### PR TITLE
Update item quantity if server result is different from client

### DIFF
--- a/assets/js/base/context/hooks/cart/use-store-cart-item-quantity.ts
+++ b/assets/js/base/context/hooks/cart/use-store-cart-item-quantity.ts
@@ -66,6 +66,9 @@ export const useStoreCartItemQuantity = (
 		storeKey
 	);
 
+	// Update local state when server updates.
+	useEffect( () => setQuantity( cartItemQuantity ), [ cartItemQuantity ] );
+
 	// Track when things are already pending updates.
 	const isPending = useSelect(
 		( select ) => {

--- a/assets/js/blocks/cart-checkout/cart/test/block.js
+++ b/assets/js/blocks/cart-checkout/cart/test/block.js
@@ -178,4 +178,31 @@ describe( 'Testing cart', () => {
 		await waitFor( () => expect( fetchMock ).toHaveBeenCalled() );
 		expect( screen.getAllByRole( 'cell' )[ 1 ] ).toHaveTextContent( '16€' );
 	} );
+
+	it( 'updates quantity when changed in server', async () => {
+		const cart = {
+			...previewCart,
+			// Make it so there is only one item to simplify things.
+			items: [
+				{
+					...previewCart.items[ 0 ],
+					quantity: 5,
+				},
+			],
+		};
+		const itemName = cart.items[ 0 ].name;
+		render( <CartBlock /> );
+
+		await waitFor( () => expect( fetchMock ).toHaveBeenCalled() );
+		const quantityInput = screen.getByLabelText(
+			`Quantity of ${ itemName } in your cart.`
+		);
+		expect( quantityInput.value ).toBe( '2' );
+
+		act( () => {
+			dispatch( storeKey ).receiveCart( cart );
+		} );
+
+		expect( quantityInput.value ).toBe( '5' );
+	} );
 } );

--- a/assets/js/data/cart/actions.ts
+++ b/assets/js/data/cart/actions.ts
@@ -393,11 +393,10 @@ export function* changeCartItemQuantity(
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- unclear how to represent multiple different yields as type
 ): Generator< unknown, void, any > {
 	const cartItem = yield select( CART_STORE_KEY, 'getCartItem', cartItemKey );
-	yield itemIsPendingQuantity( cartItemKey );
-
 	if ( cartItem?.quantity === quantity ) {
 		return;
 	}
+	yield itemIsPendingQuantity( cartItemKey );
 	try {
 		const { response } = yield apiFetchWithHeaders( {
 			path: '/wc/store/cart/update-item',


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
Our cart's quantity input (as well as our checkout inputs) have a data direction issues, they only bubble up updates, but don't take updates from the server, meaning once the input mounts, its internal state will not reset, even if the server returns a different result.

Such systemic issues are fixed in two ways:
- Having a useEffect that watch the server state and update the local state accordingly (what we did here).
- Having the local state and server state be the same thing (what `react-query` uses) so you update the cache you have while you wait for the server to respond. This was complicated to do in this PR, and would probably need an additional action. It's worth exploring nevertheless.

<!-- Reference any related issues or PRs here -->
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5239


How to test the changes in this Pull Request:
You can test this with two methods, `recieveCart` and server updates.

1. Copy the code in #5239 into the bottom of `woocommerce-gutenberg-products-block.php`
2. Add two products, Hoodie and Belt to your cart.
3. Updating once quantity should update the other when the server responds.

1. Add an item to your cart, go to cart.
2. In console, run this code:
```js
const cartData = wp.data.select('wc/store/cart').getCartData()
wp.data.dispatch('wc/store/cart').changeCartItemQuantity(cartData.items[0].key, 5)
```
It should update your item quantity to 5.

### Changelog

> Respect implicit quantity updates coming from server or directly from data stores.
