### PR TITLE
Fix conflict between Storybook and `@emotion/styled@11.x`

### DIFF
--- a/storybook/webpack.config.js
+++ b/storybook/webpack.config.js
@@ -26,6 +26,8 @@ const aliases = Object.keys( tsConfig.compilerOptions.paths ).reduce(
 	{}
 );
 
+const pathToModule = ( module ) => path.join( __dirname, module );
+
 module.exports = ( { config: storybookConfig } ) => {
 	const wooBlocksConfig = getMainConfig( { alias: getAlias() } );
 	const wooStylingConfig = getStylingConfig();
@@ -42,6 +44,7 @@ module.exports = ( { config: storybookConfig } ) => {
 		'wordpress-components': require.resolve(
 			'../node_modules/wordpress-components'
 		),
+		'@emotion/styled': pathToModule( '../node_modules/@emotion/styled' ),
 	};
 	storybookConfig.module.rules.push(
 		{


### PR DESCRIPTION
Resolve the alias for `@emotion/styled` to the root of the module in Storybook WebPack config.

Fixes #5353

### Manual Testing

How to test the changes in this Pull Request:

1. Run `npm run storybook`
2. Confirm that the Storybook server gets run and that you can access the stories at [http://localhost:6006](http://localhost:6006)

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
