### PR TITLE
Switch to correct view if inner block is selected

### DIFF
--- a/assets/js/blocks/cart-checkout/cart/edit.js
+++ b/assets/js/blocks/cart-checkout/cart/edit.js
@@ -46,6 +46,19 @@ const ALLOWED_BLOCKS = [
 	'woocommerce/empty-cart-block',
 ];
 
+const views = [
+	{
+		view: 'woocommerce/filled-cart-block',
+		label: __( 'Filled Cart', 'woo-gutenberg-products-block' ),
+		icon: <Icon srcElement={ filledCart } />,
+	},
+	{
+		view: 'woocommerce/empty-cart-block',
+		label: __( 'Empty Cart', 'woo-gutenberg-products-block' ),
+		icon: <Icon srcElement={ removeCart } />,
+	},
+];
+
 const BlockSettings = ( { attributes, setAttributes } ) => {
 	const { hasDarkControls } = attributes;
 	const { currentPostId } = useEditorContext();
@@ -104,18 +117,7 @@ export const Edit = ( { className, attributes, setAttributes, clientId } ) => {
 	const { hasDarkControls } = attributes;
 	const { currentView, component: ViewSwitcherComponent } = useViewSwitcher(
 		clientId,
-		[
-			{
-				view: 'woocommerce/filled-cart-block',
-				label: __( 'Filled Cart', 'woo-gutenberg-products-block' ),
-				icon: <Icon srcElement={ filledCart } />,
-			},
-			{
-				view: 'woocommerce/empty-cart-block',
-				label: __( 'Empty Cart', 'woo-gutenberg-products-block' ),
-				icon: <Icon srcElement={ removeCart } />,
-			},
-		]
+		views
 	);
 	const defaultTemplate = [
 		[ 'woocommerce/filled-cart-block', {}, [] ],

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/edit.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/edit.tsx
@@ -22,6 +22,20 @@ const ALLOWED_BLOCKS = [
 	'woocommerce/filled-mini-cart-contents-block',
 	'woocommerce/empty-mini-cart-contents-block',
 ];
+
+const views = [
+	{
+		view: 'woocommerce/filled-mini-cart-contents-block',
+		label: __( 'Filled Mini Cart', 'woo-gutenberg-products-block' ),
+		icon: <Icon srcElement={ filledCart } />,
+	},
+	{
+		view: 'woocommerce/empty-mini-cart-contents-block',
+		label: __( 'Empty Mini Cart', 'woo-gutenberg-products-block' ),
+		icon: <Icon srcElement={ removeCart } />,
+	},
+];
+
 interface Props {
 	clientId: string;
 }
@@ -36,18 +50,7 @@ const Edit = ( { clientId }: Props ): ReactElement => {
 
 	const { currentView, component: ViewSwitcherComponent } = useViewSwitcher(
 		clientId,
-		[
-			{
-				view: 'woocommerce/filled-mini-cart-contents-block',
-				label: __( 'Filled Mini Cart', 'woo-gutenberg-products-block' ),
-				icon: <Icon srcElement={ filledCart } />,
-			},
-			{
-				view: 'woocommerce/empty-mini-cart-contents-block',
-				label: __( 'Empty Mini Cart', 'woo-gutenberg-products-block' ),
-				icon: <Icon srcElement={ removeCart } />,
-			},
-		]
+		views
 	);
 
 	useForcedLayout( {

--- a/assets/js/blocks/cart-checkout/shared/use-view-switcher.tsx
+++ b/assets/js/blocks/cart-checkout/shared/use-view-switcher.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
+import { useState, useEffect } from '@wordpress/element';
 import { useDispatch, select } from '@wordpress/data';
 import { ToolbarGroup, ToolbarDropdownMenu } from '@wordpress/components';
 import { Icon, eye } from '@woocommerce/icons';
@@ -23,8 +23,47 @@ export const useViewSwitcher = (
 } => {
 	const initialView = views[ 0 ];
 	const [ currentView, setCurrentView ] = useState( initialView );
+	const viewNames = views.map( ( { view } ) => view );
 	const { selectBlock } = useDispatch( 'core/block-editor' );
-	const { getBlock } = select( blockEditorStore );
+	const {
+		getBlock,
+		getSelectedBlockClientId,
+		getBlockParentsByBlockName,
+	} = select( blockEditorStore );
+	const selectedBlockClientId = getSelectedBlockClientId();
+
+	useEffect( () => {
+		const parentBlockIds = getBlockParentsByBlockName(
+			selectedBlockClientId,
+			viewNames
+		);
+
+		if ( parentBlockIds.length !== 1 ) {
+			return;
+		}
+		const parentBlock = getBlock( parentBlockIds[ 0 ] );
+
+		if ( currentView.view === parentBlock.name ) {
+			return;
+		}
+
+		const filteredViews = views.filter(
+			( { view } ) => view === parentBlock.name
+		);
+
+		if ( filteredViews.length !== 1 ) {
+			return;
+		}
+
+		setCurrentView( filteredViews[ 0 ] );
+	}, [
+		getBlockParentsByBlockName,
+		selectedBlockClientId,
+		viewNames,
+		getBlock,
+		currentView.view,
+		views,
+	] );
 
 	const ViewSwitcherComponent = (
 		<ToolbarGroup>

--- a/assets/js/blocks/cart-checkout/shared/use-view-switcher.tsx
+++ b/assets/js/blocks/cart-checkout/shared/use-view-switcher.tsx
@@ -23,7 +23,6 @@ export const useViewSwitcher = (
 } => {
 	const initialView = views[ 0 ];
 	const [ currentView, setCurrentView ] = useState( initialView );
-	const viewNames = views.map( ( { view } ) => view );
 	const { selectBlock } = useDispatch( 'core/block-editor' );
 	const {
 		getBlock,
@@ -33,6 +32,7 @@ export const useViewSwitcher = (
 	const selectedBlockClientId = getSelectedBlockClientId();
 
 	useEffect( () => {
+		const viewNames = views.map( ( { view } ) => view );
 		const parentBlockIds = getBlockParentsByBlockName(
 			selectedBlockClientId,
 			viewNames
@@ -59,7 +59,6 @@ export const useViewSwitcher = (
 	}, [
 		getBlockParentsByBlockName,
 		selectedBlockClientId,
-		viewNames,
 		getBlock,
 		currentView.view,
 		views,


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #5351

This PR watches for the change of current selected block then switch the current view of the view switcher if an inner block is selected.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Insert or edit the Cart block.
2. Open the block navigation list panel.
3. Given the current view is the Filled Cart.
4. Select an inner block of Empty Cart.
5. See the view changes to Empty.
6. Repeat all steps above to test Mini Cart Contents block.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
* [ ] See steps below.

### Changelog

> Cart block: switch to correct view if inner block is selected.