### PR TITLE
Remove lazy loading on core components

### DIFF
--- a/assets/js/blocks/cart-checkout/cart/inner-blocks/register-components.ts
+++ b/assets/js/blocks/cart-checkout/cart/inner-blocks/register-components.ts
@@ -21,77 +21,41 @@ import cartOrderSummaryMetadata from './cart-order-summary-block/block.json';
 import cartTotalsMetadata from './cart-totals-block/block.json';
 import cartProceedToCheckoutMetadata from './proceed-to-checkout-block/block.json';
 import cartAcceptedPaymentMethodsMetadata from './cart-accepted-payment-methods-block/block.json';
-
-registerCheckoutBlock( {
-	metadata: filledCartMetadata,
-	component: lazy( () =>
-		import(
-			/* webpackChunkName: "cart-blocks/filled-cart" */ './filled-cart-block/frontend'
-		)
-	),
-} );
+import emptyCartComponent from './empty-cart-block/frontend';
+import filledCartComponent from './filled-cart-block/frontend';
+import cartItemsComponent from './cart-items-block/frontend';
+import cartLineItemsComponent from './cart-line-items-block/block';
+import cartTotalsComponent from './cart-totals-block/frontend';
+import cartOrderSummaryComponent from './cart-order-summary-block/frontend';
 
 registerCheckoutBlock( {
 	metadata: emptyCartMetadata,
-	component: lazy( () =>
-		import(
-			/* webpackChunkName: "cart-blocks/empty-cart" */ './empty-cart-block/frontend'
-		)
-	),
+	component: emptyCartComponent,
 } );
 
 registerCheckoutBlock( {
 	metadata: filledCartMetadata,
-	component: lazy( () =>
-		import(
-			/* webpackChunkName: "cart-blocks/filled-cart" */ './filled-cart-block/frontend'
-		)
-	),
-} );
-
-registerCheckoutBlock( {
-	metadata: emptyCartMetadata,
-	component: lazy( () =>
-		import(
-			/* webpackChunkName: "cart-blocks/empty-cart" */ './empty-cart-block/frontend'
-		)
-	),
+	component: filledCartComponent,
 } );
 
 registerCheckoutBlock( {
 	metadata: cartItemsMetadata,
-	component: lazy( () =>
-		import(
-			/* webpackChunkName: "cart-blocks/items" */ './cart-items-block/frontend'
-		)
-	),
+	component: cartItemsComponent,
 } );
 
 registerCheckoutBlock( {
 	metadata: cartLineItemsMetadata,
-	component: lazy( () =>
-		import(
-			/* webpackChunkName: "cart-blocks/line-items" */ './cart-line-items-block/block'
-		)
-	),
+	component: cartLineItemsComponent,
 } );
 
 registerCheckoutBlock( {
 	metadata: cartTotalsMetadata,
-	component: lazy( () =>
-		import(
-			/* webpackChunkName: "cart-blocks/totals" */ './cart-totals-block/frontend'
-		)
-	),
+	component: cartTotalsComponent,
 } );
 
 registerCheckoutBlock( {
 	metadata: cartOrderSummaryMetadata,
-	component: lazy( () =>
-		import(
-			/* webpackChunkName: "cart-blocks/order-summary" */ './cart-order-summary-block/frontend'
-		)
-	),
+	component: cartOrderSummaryComponent,
 } );
 
 registerCheckoutBlock( {

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/register-components.ts
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/register-components.ts
@@ -24,15 +24,17 @@ import checkoutShippingAddressMetadata from './checkout-shipping-address-block/b
 import checkoutShippingMethodsMetadata from './checkout-shipping-methods-block/block.json';
 import checkoutTermsMetadata from './checkout-terms-block/block.json';
 import checkoutTotalsMetadata from './checkout-totals-block/block.json';
+import checkoutFieldsComponent from './checkout-fields-block/frontend';
+import checkoutContactInformationComponent from './checkout-contact-information-block/frontend';
+import checkoutShippingAddressComponent from './checkout-shipping-address-block/frontend';
+import checkoutActionsComponent from './checkout-actions-block/frontend';
+import checkoutOrderSummaryComponent from './checkout-order-summary-block/block';
+import checkoutTotalsComponent from './checkout-totals-block/frontend';
 
 // @todo When forcing all blocks at once, they will append based on the order they are registered. Introduce formal sorting param.
 registerCheckoutBlock( {
 	metadata: checkoutFieldsMetadata,
-	component: lazy( () =>
-		import(
-			/* webpackChunkName: "checkout-blocks/fields" */ './checkout-fields-block/frontend'
-		)
-	),
+	component: checkoutFieldsComponent,
 } );
 
 registerCheckoutBlock( {
@@ -46,20 +48,12 @@ registerCheckoutBlock( {
 
 registerCheckoutBlock( {
 	metadata: checkoutContactInformationMetadata,
-	component: lazy( () =>
-		import(
-			/* webpackChunkName: "checkout-blocks/contact-information" */ './checkout-contact-information-block/frontend'
-		)
-	),
+	component: checkoutContactInformationComponent,
 } );
 
 registerCheckoutBlock( {
 	metadata: checkoutShippingAddressMetadata,
-	component: lazy( () =>
-		import(
-			/* webpackChunkName: "checkout-blocks/shipping-address" */ './checkout-shipping-address-block/frontend'
-		)
-	),
+	component: checkoutShippingAddressComponent,
 } );
 
 registerCheckoutBlock( {
@@ -109,27 +103,15 @@ registerCheckoutBlock( {
 
 registerCheckoutBlock( {
 	metadata: checkoutActionsMetadata,
-	component: lazy( () =>
-		import(
-			/* webpackChunkName: "checkout-blocks/actions" */ './checkout-actions-block/frontend'
-		)
-	),
+	component: checkoutActionsComponent,
 } );
 
 registerCheckoutBlock( {
 	metadata: checkoutTotalsMetadata,
-	component: lazy( () =>
-		import(
-			/* webpackChunkName: "checkout-blocks/totals" */ './checkout-totals-block/frontend'
-		)
-	),
+	component: checkoutTotalsComponent,
 } );
 
 registerCheckoutBlock( {
 	metadata: checkoutOrderSummaryMetadata,
-	component: lazy( () =>
-		import(
-			/* webpackChunkName: "checkout-blocks/order-summary" */ './checkout-order-summary-block/block'
-		)
-	),
+	component: checkoutOrderSummaryComponent,
 } );


### PR DESCRIPTION
The Cart and Checkout blocks' loading placeholders disappear before the blocks are fully loaded. This is in part due to lazy loading of components which can add a visible delay while the script is loaded from the server.

To mitigate this problem we should ensure that the core components of the checkout **which always render** are not lazy-loaded, reserving lazy loading for optional components, or components that don't need to be visible straight away.

Fixes #5011

This was split from https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5026

Components that should not lazy load:

- Wrapper components that contain other blocks (cart and checkout main area/sidebar)
- Mandatory interactive components (address fields and form steps)
- Other required components (cart items)

#### Testing

To test the skeleton before DOM and react is finished loading:

- Open dev tools network panel
- Set the speed to 3g or something slow
- View a page containing the cart and checkout blocks

You will see the skeleton loading view, and once loaded, the components will replace them.

#### Performance Impact

The bundle size may increase due to removing some lazy loading components, but the perceived speed should be improved because the cart and checkout blocks will render faster without an obvious delay.

#### Changelog

> Improve the cart and checkout loading states.
