### PR TITLE
Remove the unused get_skeleton_inline_script method

### DIFF
--- a/src/BlockTypes/AbstractBlock.php
+++ b/src/BlockTypes/AbstractBlock.php
@@ -374,37 +374,4 @@ abstract class AbstractBlock {
 			wp_enqueue_script( $this->get_block_type_script( 'handle' ) );
 		}
 	}
-
-	/**
-	 * Script to append the correct sizing class to a block skeleton.
-	 *
-	 * @return string
-	 */
-	protected function get_skeleton_inline_script() {
-		return "<script>
-			var containers = document.querySelectorAll( 'div.wc-block-skeleton' );
-
-			if ( containers.length ) {
-				Array.prototype.forEach.call( containers, function( el, i ) {
-					var w = el.offsetWidth;
-					var classname = '';
-
-					if ( w > 700 )
-						classname = 'is-large';
-					else if ( w > 520 )
-						classname = 'is-medium';
-					else if ( w > 400 )
-						classname = 'is-small';
-					else
-						classname = 'is-mobile';
-
-					if ( ! el.classList.contains( classname ) )  {
-						el.classList.add( classname );
-					}
-
-					el.classList.remove( 'hidden' );
-				} );
-			}
-		</script>";
-	}
 }


### PR DESCRIPTION
Removes an unused method (`get_skeleton_inline_script`). This was not being used anywhere and was protected, so is not part of the public API.

Code review only; does not require specific testing steps or a changelog entry.

Split from https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5026