### PR TITLE
Loading animation: change from pulse to swipe

### DIFF
--- a/assets/css/abstracts/_mixins.scss
+++ b/assets/css/abstracts/_mixins.scss
@@ -12,32 +12,56 @@ $fontSizes: (
 	font-size: map-get($fontSizes, $sizeName) * $multiplier;
 }
 
-@keyframes loading-fade {
+@keyframes spinner__animation {
 	0% {
-		opacity: 0.7;
-	}
-	50% {
-		opacity: 1;
+		animation-timing-function: cubic-bezier(0.5856, 0.0703, 0.4143, 0.9297);
+		transform: rotate(0deg);
 	}
 	100% {
-		opacity: 0.7;
+		transform: rotate(360deg);
+	}
+}
+
+@keyframes loading__animation {
+	100% {
+		transform: translateX(100%);
 	}
 }
 
 // Adds animation to placeholder section
 @mixin placeholder() {
-	animation: loading-fade 1.2s ease-in-out infinite;
-	background-color: $placeholder-color !important;
-	color: $placeholder-color !important;
 	outline: 0 !important;
 	border: 0 !important;
-	box-shadow: none;
+	background-color: #ebebeb !important;
+	color: transparent !important;
+	width: 100%;
+	border-radius: 0.25rem;
+	display: block;
+	line-height: 1;
+	position: relative !important;
+	overflow: hidden !important;
+	max-width: 100% !important;
 	pointer-events: none;
-	max-width: 100%;
+	box-shadow: none;
+	z-index: 1; /* Necessary for overflow: hidden to work correctly in Safari */
 
 	// Forces direct descendants to keep layout but lose visibility.
 	> * {
 		visibility: hidden;
+	}
+
+	&::after {
+		content: " ";
+		display: block;
+		position: absolute;
+		left: 0;
+		right: 0;
+		top: 0;
+		height: 100%;
+		background-repeat: no-repeat;
+		background-image: linear-gradient(90deg, #ebebeb, #f5f5f5, #ebebeb);
+		transform: translateX(-100%);
+		animation: loading__animation 1.5s ease-in-out infinite;
 	}
 
 	@media screen and (prefers-reduced-motion: reduce) {
@@ -46,7 +70,7 @@ $fontSizes: (
 }
 
 @mixin force-content() {
-	&::after {
+	&::before {
 		content: "\00a0";
 	}
 }

--- a/assets/js/base/components/spinner/style.scss
+++ b/assets/js/base/components/spinner/style.scss
@@ -22,16 +22,6 @@
 		border-radius: 50%;
 		border: 0.2em solid currentColor;
 		border-left-color: transparent;
-		animation: wc-block-components-spinner__animation 1s infinite linear;
-	}
-}
-
-@keyframes wc-block-components-spinner__animation {
-	0% {
-		animation-timing-function: cubic-bezier(0.5856, 0.0703, 0.4143, 0.9297);
-		transform: rotate(0deg);
-	}
-	100% {
-		transform: rotate(360deg);
+		animation: spinner__animation 1s infinite linear;
 	}
 }


### PR DESCRIPTION
Pulled from https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5026

I updated the pulsing animation to a 'loading' swipe type animation, based on a Skeleton component I've been using. The pulse was a little too subtle and the swipe seems to better represent that loading is progressing. No issue for this one, just something I thought looked better :)

### Screenshots

| Before      | After |
| ----------- | ----------- |
| ![2021-12-10 13 07 27](https://user-images.githubusercontent.com/90977/145578986-8ff4a905-fdca-4a06-8755-3a640522c08f.gif)      | ![2021-12-10 13 06 41](https://user-images.githubusercontent.com/90977/145578994-88c9bf21-99e0-41a5-9fff-ed983c7cd53e.gif)       |

### Changelog

> Update loading skeleton animations
