### PR TITLE
Limit CSS styles to WooCommerce Block icons only

### DIFF
--- a/assets/css/editor.scss
+++ b/assets/css/editor.scss
@@ -45,6 +45,18 @@
 	}
 }
 
+svg.wc-block-editor-components-block-icon {
+	color: rgb(127, 84, 179);
+}
+
+.block-editor-list-view-leaf.is-selected {
+	.block-editor-list-view-block-contents {
+		svg.wc-block-editor-components-block-icon {
+			color: currentColor;
+		}
+	}
+}
+
 // Selectors with extra specificity to override some editor styles.
 .woocommerce-search-list__list.woocommerce-search-list__list {
 	box-sizing: border-box;

--- a/assets/css/editor.scss
+++ b/assets/css/editor.scss
@@ -46,7 +46,7 @@
 }
 
 svg.wc-block-editor-components-block-icon {
-	color: rgb(127, 84, 179);
+	color: $studio-woocommerce-purple-50;
 }
 
 .block-editor-list-view-leaf.is-selected {

--- a/assets/js/atomic/blocks/product-elements/add-to-cart/constants.js
+++ b/assets/js/atomic/blocks/product-elements/add-to-cart/constants.js
@@ -5,7 +5,12 @@ import { __ } from '@wordpress/i18n';
 import { cart, Icon } from '@woocommerce/icons';
 
 export const BLOCK_TITLE = __( 'Add to Cart', 'woo-gutenberg-products-block' );
-export const BLOCK_ICON = <Icon srcElement={ cart } />;
+export const BLOCK_ICON = (
+	<Icon
+		srcElement={ cart }
+		className="wc-block-editor-components-block-icon"
+	/>
+);
 export const BLOCK_DESCRIPTION = __(
 	'Displays an add to cart button. Optionally displays other add to cart form elements.',
 	'woo-gutenberg-products-block'

--- a/assets/js/atomic/blocks/product-elements/add-to-cart/index.js
+++ b/assets/js/atomic/blocks/product-elements/add-to-cart/index.js
@@ -18,10 +18,7 @@ import {
 const blockConfig = {
 	title,
 	description,
-	icon: {
-		src: icon,
-		foreground: '#7f54b3',
-	},
+	icon: { src: icon },
 	edit,
 	attributes,
 };

--- a/assets/js/atomic/blocks/product-elements/button/constants.js
+++ b/assets/js/atomic/blocks/product-elements/button/constants.js
@@ -8,7 +8,12 @@ export const BLOCK_TITLE = __(
 	'Add to Cart Button',
 	'woo-gutenberg-products-block'
 );
-export const BLOCK_ICON = <Icon srcElement={ cart } />;
+export const BLOCK_ICON = (
+	<Icon
+		srcElement={ cart }
+		className="wc-block-editor-components-block-icon"
+	/>
+);
 export const BLOCK_DESCRIPTION = __(
 	'Display a call to action button which either adds the product to the cart, or links to the product page.',
 	'woo-gutenberg-products-block'

--- a/assets/js/atomic/blocks/product-elements/button/index.js
+++ b/assets/js/atomic/blocks/product-elements/button/index.js
@@ -18,10 +18,7 @@ import {
 const blockConfig = {
 	title,
 	description,
-	icon: {
-		src: icon,
-		foreground: '#7f54b3',
-	},
+	icon: { src: icon },
 	attributes,
 	edit,
 };

--- a/assets/js/atomic/blocks/product-elements/category-list/constants.tsx
+++ b/assets/js/atomic/blocks/product-elements/category-list/constants.tsx
@@ -8,7 +8,12 @@ export const BLOCK_TITLE: string = __(
 	'Product Category List',
 	'woo-gutenberg-products-block'
 );
-export const BLOCK_ICON: JSX.Element = <Icon srcElement={ folder } />;
+export const BLOCK_ICON: JSX.Element = (
+	<Icon
+		srcElement={ folder }
+		className="wc-block-editor-components-block-icon"
+	/>
+);
 export const BLOCK_DESCRIPTION: string = __(
 	'Display a list of categories belonging to a product.',
 	'woo-gutenberg-products-block'

--- a/assets/js/atomic/blocks/product-elements/category-list/index.ts
+++ b/assets/js/atomic/blocks/product-elements/category-list/index.ts
@@ -20,10 +20,7 @@ const blockConfig: BlockConfiguration = {
 	...sharedConfig,
 	title,
 	description,
-	icon: {
-		src: icon,
-		foreground: '#7f54b3',
-	},
+	icon: { src: icon },
 	attributes,
 	edit,
 };

--- a/assets/js/atomic/blocks/product-elements/image/constants.js
+++ b/assets/js/atomic/blocks/product-elements/image/constants.js
@@ -8,7 +8,12 @@ export const BLOCK_TITLE = __(
 	'Product Image',
 	'woo-gutenberg-products-block'
 );
-export const BLOCK_ICON = <Icon srcElement={ image } />;
+export const BLOCK_ICON = (
+	<Icon
+		srcElement={ image }
+		className="wc-block-editor-components-block-icon"
+	/>
+);
 export const BLOCK_DESCRIPTION = __(
 	'Display the main product image',
 	'woo-gutenberg-products-block'

--- a/assets/js/atomic/blocks/product-elements/image/index.js
+++ b/assets/js/atomic/blocks/product-elements/image/index.js
@@ -18,10 +18,7 @@ import {
 const blockConfig = {
 	title,
 	description,
-	icon: {
-		src: icon,
-		foreground: '#7f54b3',
-	},
+	icon: { src: icon },
 	attributes,
 	edit,
 };

--- a/assets/js/atomic/blocks/product-elements/price/constants.js
+++ b/assets/js/atomic/blocks/product-elements/price/constants.js
@@ -8,7 +8,12 @@ export const BLOCK_TITLE = __(
 	'Product Price',
 	'woo-gutenberg-products-block'
 );
-export const BLOCK_ICON = <Icon srcElement={ bill } />;
+export const BLOCK_ICON = (
+	<Icon
+		srcElement={ bill }
+		className="wc-block-editor-components-block-icon"
+	/>
+);
 export const BLOCK_DESCRIPTION = __(
 	'Display the price of a product.',
 	'woo-gutenberg-products-block'

--- a/assets/js/atomic/blocks/product-elements/price/index.js
+++ b/assets/js/atomic/blocks/product-elements/price/index.js
@@ -18,10 +18,7 @@ import {
 const blockConfig = {
 	title,
 	description,
-	icon: {
-		src: icon,
-		foreground: '#7f54b3',
-	},
+	icon: { src: icon },
 	attributes,
 	edit,
 };

--- a/assets/js/atomic/blocks/product-elements/rating/constants.js
+++ b/assets/js/atomic/blocks/product-elements/rating/constants.js
@@ -8,7 +8,12 @@ export const BLOCK_TITLE = __(
 	'Product Rating',
 	'woo-gutenberg-products-block'
 );
-export const BLOCK_ICON = <Icon srcElement={ star } />;
+export const BLOCK_ICON = (
+	<Icon
+		srcElement={ star }
+		className="wc-block-editor-components-block-icon"
+	/>
+);
 export const BLOCK_DESCRIPTION = __(
 	'Display the average rating of a product.',
 	'woo-gutenberg-products-block'

--- a/assets/js/atomic/blocks/product-elements/rating/index.js
+++ b/assets/js/atomic/blocks/product-elements/rating/index.js
@@ -18,10 +18,7 @@ import {
 const blockConfig = {
 	title,
 	description,
-	icon: {
-		src: icon,
-		foreground: '#7f54b3',
-	},
+	icon: { src: icon },
 	attributes,
 	edit,
 };

--- a/assets/js/atomic/blocks/product-elements/sale-badge/constants.js
+++ b/assets/js/atomic/blocks/product-elements/sale-badge/constants.js
@@ -8,7 +8,12 @@ export const BLOCK_TITLE = __(
 	'On-Sale Badge',
 	'woo-gutenberg-products-block'
 );
-export const BLOCK_ICON = <Icon srcElement={ tag } />;
+export const BLOCK_ICON = (
+	<Icon
+		srcElement={ tag }
+		className="wc-block-editor-components-block-icon"
+	/>
+);
 export const BLOCK_DESCRIPTION = __(
 	'Displays an on-sale badge if the product is on-sale.',
 	'woo-gutenberg-products-block'

--- a/assets/js/atomic/blocks/product-elements/sale-badge/index.js
+++ b/assets/js/atomic/blocks/product-elements/sale-badge/index.js
@@ -18,10 +18,7 @@ import {
 const blockConfig = {
 	title,
 	description,
-	icon: {
-		src: icon,
-		foreground: '#7f54b3',
-	},
+	icon: { src: icon },
 	supports: {
 		html: false,
 	},

--- a/assets/js/atomic/blocks/product-elements/shared/config.tsx
+++ b/assets/js/atomic/blocks/product-elements/shared/config.tsx
@@ -19,8 +19,12 @@ const sharedConfig: Omit< BlockConfiguration, 'attributes' | 'title' > = {
 	category: 'woocommerce-product-elements',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
 	icon: {
-		src: <Icon srcElement={ grid } />,
-		foreground: '#7f54b3',
+		src: (
+			<Icon
+				srcElement={ grid }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	supports: {
 		html: false,

--- a/assets/js/atomic/blocks/product-elements/sku/constants.js
+++ b/assets/js/atomic/blocks/product-elements/sku/constants.js
@@ -5,7 +5,12 @@ import { __ } from '@wordpress/i18n';
 import { barcode, Icon } from '@woocommerce/icons';
 
 export const BLOCK_TITLE = __( 'Product SKU', 'woo-gutenberg-products-block' );
-export const BLOCK_ICON = <Icon srcElement={ barcode } />;
+export const BLOCK_ICON = (
+	<Icon
+		srcElement={ barcode }
+		className="wc-block-editor-components-block-icon"
+	/>
+);
 export const BLOCK_DESCRIPTION = __(
 	'Display the SKU of a product.',
 	'woo-gutenberg-products-block'

--- a/assets/js/atomic/blocks/product-elements/sku/index.js
+++ b/assets/js/atomic/blocks/product-elements/sku/index.js
@@ -18,10 +18,7 @@ import {
 const blockConfig = {
 	title,
 	description,
-	icon: {
-		src: icon,
-		foreground: '#7f54b3',
-	},
+	icon: { src: icon },
 	attributes,
 	edit,
 };

--- a/assets/js/atomic/blocks/product-elements/stock-indicator/constants.js
+++ b/assets/js/atomic/blocks/product-elements/stock-indicator/constants.js
@@ -8,7 +8,12 @@ export const BLOCK_TITLE = __(
 	'Product Stock Indicator',
 	'woo-gutenberg-products-block'
 );
-export const BLOCK_ICON = <Icon srcElement={ box } />;
+export const BLOCK_ICON = (
+	<Icon
+		srcElement={ box }
+		className="wc-block-editor-components-block-icon"
+	/>
+);
 export const BLOCK_DESCRIPTION = __(
 	'Display product stock status.',
 	'woo-gutenberg-products-block'

--- a/assets/js/atomic/blocks/product-elements/stock-indicator/index.js
+++ b/assets/js/atomic/blocks/product-elements/stock-indicator/index.js
@@ -18,10 +18,7 @@ import {
 const blockConfig = {
 	title,
 	description,
-	icon: {
-		src: icon,
-		foreground: '#7f54b3',
-	},
+	icon: { src: icon },
 	attributes,
 	edit,
 };

--- a/assets/js/atomic/blocks/product-elements/summary/constants.js
+++ b/assets/js/atomic/blocks/product-elements/summary/constants.js
@@ -8,7 +8,12 @@ export const BLOCK_TITLE = __(
 	'Product Summary',
 	'woo-gutenberg-products-block'
 );
-export const BLOCK_ICON = <Icon srcElement={ notes } />;
+export const BLOCK_ICON = (
+	<Icon
+		srcElement={ notes }
+		className="wc-block-editor-components-block-icon"
+	/>
+);
 export const BLOCK_DESCRIPTION = __(
 	'Display a short description about a product.',
 	'woo-gutenberg-products-block'

--- a/assets/js/atomic/blocks/product-elements/summary/index.js
+++ b/assets/js/atomic/blocks/product-elements/summary/index.js
@@ -18,10 +18,7 @@ import {
 const blockConfig = {
 	title,
 	description,
-	icon: {
-		src: icon,
-		foreground: '#7f54b3',
-	},
+	icon: { src: icon },
 	attributes,
 	edit,
 };

--- a/assets/js/atomic/blocks/product-elements/tag-list/constants.js
+++ b/assets/js/atomic/blocks/product-elements/tag-list/constants.js
@@ -8,7 +8,12 @@ export const BLOCK_TITLE = __(
 	'Product Tag List',
 	'woo-gutenberg-products-block'
 );
-export const BLOCK_ICON = <Icon srcElement={ tag } />;
+export const BLOCK_ICON = (
+	<Icon
+		srcElement={ tag }
+		className="wc-block-editor-components-block-icon"
+	/>
+);
 export const BLOCK_DESCRIPTION = __(
 	'Display a list of tags belonging to a product.',
 	'woo-gutenberg-products-block'

--- a/assets/js/atomic/blocks/product-elements/tag-list/index.js
+++ b/assets/js/atomic/blocks/product-elements/tag-list/index.js
@@ -18,10 +18,7 @@ import {
 const blockConfig = {
 	title,
 	description,
-	icon: {
-		src: icon,
-		foreground: '#7f54b3',
-	},
+	icon: { src: icon },
 	attributes,
 	edit,
 };

--- a/assets/js/atomic/blocks/product-elements/title/constants.tsx
+++ b/assets/js/atomic/blocks/product-elements/title/constants.tsx
@@ -8,7 +8,12 @@ export const BLOCK_TITLE: string = __(
 	'Product Title',
 	'woo-gutenberg-products-block'
 );
-export const BLOCK_ICON: JSX.Element = <Icon srcElement={ bookmark } />;
+export const BLOCK_ICON: JSX.Element = (
+	<Icon
+		srcElement={ bookmark }
+		className="wc-block-editor-components-block-icon"
+	/>
+);
 export const BLOCK_DESCRIPTION: string = __(
 	'Display the title of a product.',
 	'woo-gutenberg-products-block'

--- a/assets/js/atomic/blocks/product-elements/title/index.ts
+++ b/assets/js/atomic/blocks/product-elements/title/index.ts
@@ -21,10 +21,7 @@ const blockConfig: BlockConfiguration = {
 	apiVersion: 2,
 	title,
 	description,
-	icon: {
-		src: icon,
-		foreground: '#7f54b3',
-	},
+	icon: { src: icon },
 	attributes,
 	edit,
 	supports: isFeaturePluginBuild()

--- a/assets/js/blocks/active-filters/index.js
+++ b/assets/js/blocks/active-filters/index.js
@@ -14,8 +14,12 @@ import edit from './edit.js';
 registerBlockType( 'woocommerce/active-filters', {
 	title: __( 'Active Product Filters', 'woo-gutenberg-products-block' ),
 	icon: {
-		src: <Icon srcElement={ toggle } />,
-		foreground: '#7f54b3',
+		src: (
+			<Icon
+				srcElement={ toggle }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],

--- a/assets/js/blocks/attribute-filter/index.js
+++ b/assets/js/blocks/attribute-filter/index.js
@@ -14,8 +14,12 @@ import edit from './edit.js';
 registerBlockType( 'woocommerce/attribute-filter', {
 	title: __( 'Filter Products by Attribute', 'woo-gutenberg-products-block' ),
 	icon: {
-		src: <Icon srcElement={ server } />,
-		foreground: '#7f54b3',
+		src: (
+			<Icon
+				srcElement={ server }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],

--- a/assets/js/blocks/cart-checkout/cart/index.js
+++ b/assets/js/blocks/cart-checkout/cart/index.js
@@ -21,8 +21,12 @@ import './inner-blocks';
 const settings = {
 	title: __( 'Cart', 'woo-gutenberg-products-block' ),
 	icon: {
-		src: <Icon srcElement={ cart } />,
-		foreground: '#7f54b3',
+		src: (
+			<Icon
+				srcElement={ cart }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],

--- a/assets/js/blocks/cart-checkout/cart/inner-blocks/cart-accepted-payment-methods-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/cart/inner-blocks/cart-accepted-payment-methods-block/index.tsx
@@ -12,8 +12,12 @@ import metadata from './block.json';
 
 registerFeaturePluginBlockType( metadata, {
 	icon: {
-		src: <Icon srcElement={ card } />,
-		foreground: '#874FB9',
+		src: (
+			<Icon
+				srcElement={ card }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	edit: Edit,
 	save: Save,

--- a/assets/js/blocks/cart-checkout/cart/inner-blocks/cart-express-payment-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/cart/inner-blocks/cart-express-payment-block/index.tsx
@@ -12,8 +12,12 @@ import metadata from './block.json';
 
 registerFeaturePluginBlockType( metadata, {
 	icon: {
-		src: <Icon srcElement={ card } />,
-		foreground: '#7f54b3',
+		src: (
+			<Icon
+				srcElement={ card }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	edit: Edit,
 	save: Save,

--- a/assets/js/blocks/cart-checkout/cart/inner-blocks/cart-items-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/cart/inner-blocks/cart-items-block/index.tsx
@@ -12,8 +12,12 @@ import metadata from './block.json';
 
 registerFeaturePluginBlockType( metadata, {
 	icon: {
-		src: <Icon icon={ column } />,
-		foreground: '#7f54b3',
+		src: (
+			<Icon
+				icon={ column }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	edit: Edit,
 	save: Save,

--- a/assets/js/blocks/cart-checkout/cart/inner-blocks/cart-line-items-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/cart/inner-blocks/cart-line-items-block/index.tsx
@@ -12,8 +12,12 @@ import metadata from './block.json';
 
 registerFeaturePluginBlockType( metadata, {
 	icon: {
-		src: <Icon icon={ column } />,
-		foreground: '#7f54b3',
+		src: (
+			<Icon
+				icon={ column }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	edit: Edit,
 	save: Save,

--- a/assets/js/blocks/cart-checkout/cart/inner-blocks/cart-order-summary-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/cart/inner-blocks/cart-order-summary-block/index.tsx
@@ -13,8 +13,12 @@ import metadata from './block.json';
 
 registerFeaturePluginBlockType( metadata, {
 	icon: {
-		src: <Icon srcElement={ totals } />,
-		foreground: '#7f54b3',
+		src: (
+			<Icon
+				srcElement={ totals }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	attributes,
 	edit: Edit,

--- a/assets/js/blocks/cart-checkout/cart/inner-blocks/cart-totals-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/cart/inner-blocks/cart-totals-block/index.tsx
@@ -12,8 +12,12 @@ import metadata from './block.json';
 
 registerFeaturePluginBlockType( metadata, {
 	icon: {
-		src: <Icon icon={ column } />,
-		foreground: '#7f54b3',
+		src: (
+			<Icon
+				icon={ column }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	edit: Edit,
 	save: Save,

--- a/assets/js/blocks/cart-checkout/cart/inner-blocks/empty-cart-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/cart/inner-blocks/empty-cart-block/index.tsx
@@ -12,8 +12,12 @@ import metadata from './block.json';
 
 registerFeaturePluginBlockType( metadata, {
 	icon: {
-		src: <Icon srcElement={ removeCart } />,
-		foreground: '#7f54b3',
+		src: (
+			<Icon
+				srcElement={ removeCart }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	edit: Edit,
 	save: Save,

--- a/assets/js/blocks/cart-checkout/cart/inner-blocks/filled-cart-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/cart/inner-blocks/filled-cart-block/index.tsx
@@ -12,8 +12,12 @@ import metadata from './block.json';
 
 registerFeaturePluginBlockType( metadata, {
 	icon: {
-		src: <Icon srcElement={ filledCart } />,
-		foreground: '#7f54b3',
+		src: (
+			<Icon
+				srcElement={ filledCart }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	edit: Edit,
 	save: Save,

--- a/assets/js/blocks/cart-checkout/cart/inner-blocks/proceed-to-checkout-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/cart/inner-blocks/proceed-to-checkout-block/index.tsx
@@ -13,8 +13,12 @@ import metadata from './block.json';
 
 registerFeaturePluginBlockType( metadata, {
 	icon: {
-		src: <Icon icon={ button } />,
-		foreground: '#7f54b3',
+		src: (
+			<Icon
+				icon={ button }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	attributes,
 	edit: Edit,

--- a/assets/js/blocks/cart-checkout/checkout/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/index.tsx
@@ -17,8 +17,12 @@ import './inner-blocks';
 const settings = {
 	title: __( 'Checkout', 'woo-gutenberg-products-block' ),
 	icon: {
-		src: <Icon srcElement={ fields } />,
-		foreground: '#7f54b3',
+		src: (
+			<Icon
+				srcElement={ fields }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-actions-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-actions-block/index.tsx
@@ -13,8 +13,12 @@ import metadata from './block.json';
 
 registerFeaturePluginBlockType( metadata, {
 	icon: {
-		src: <Icon icon={ button } />,
-		foreground: '#7f54b3',
+		src: (
+			<Icon
+				icon={ button }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	attributes,
 	edit: Edit,

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-billing-address-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-billing-address-block/index.tsx
@@ -13,8 +13,12 @@ import metadata from './block.json';
 
 registerFeaturePluginBlockType( metadata, {
 	icon: {
-		src: <Icon srcElement={ address } />,
-		foreground: '#7f54b3',
+		src: (
+			<Icon
+				srcElement={ address }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	attributes,
 	edit: Edit,

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-contact-information-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-contact-information-block/index.tsx
@@ -13,8 +13,12 @@ import metadata from './block.json';
 
 registerFeaturePluginBlockType( metadata, {
 	icon: {
-		src: <Icon srcElement={ contact } />,
-		foreground: '#7f54b3',
+		src: (
+			<Icon
+				srcElement={ contact }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	attributes,
 	edit: Edit,

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-express-payment-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-express-payment-block/index.tsx
@@ -12,8 +12,12 @@ import metadata from './block.json';
 
 registerFeaturePluginBlockType( metadata, {
 	icon: {
-		src: <Icon srcElement={ card } />,
-		foreground: '#7f54b3',
+		src: (
+			<Icon
+				srcElement={ card }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	edit: Edit,
 	save: Save,

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-fields-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-fields-block/index.tsx
@@ -12,8 +12,12 @@ import metadata from './block.json';
 
 registerFeaturePluginBlockType( metadata, {
 	icon: {
-		src: <Icon icon={ column } />,
-		foreground: '#7f54b3',
+		src: (
+			<Icon
+				icon={ column }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	edit: Edit,
 	save: Save,

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-order-note-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-order-note-block/index.tsx
@@ -12,8 +12,12 @@ import metadata from './block.json';
 
 registerFeaturePluginBlockType( metadata, {
 	icon: {
-		src: <Icon srcElement={ notes } />,
-		foreground: '#7f54b3',
+		src: (
+			<Icon
+				srcElement={ notes }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	edit: Edit,
 	save: Save,

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-order-summary-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-order-summary-block/index.tsx
@@ -13,8 +13,12 @@ import metadata from './block.json';
 
 registerFeaturePluginBlockType( metadata, {
 	icon: {
-		src: <Icon srcElement={ totals } />,
-		foreground: '#7f54b3',
+		src: (
+			<Icon
+				srcElement={ totals }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	attributes,
 	edit: Edit,

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-payment-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-payment-block/index.tsx
@@ -13,8 +13,12 @@ import metadata from './block.json';
 
 registerFeaturePluginBlockType( metadata, {
 	icon: {
-		src: <Icon srcElement={ card } />,
-		foreground: '#7f54b3',
+		src: (
+			<Icon
+				srcElement={ card }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	attributes,
 	edit: Edit,

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-shipping-address-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-shipping-address-block/index.tsx
@@ -13,8 +13,12 @@ import metadata from './block.json';
 
 registerFeaturePluginBlockType( metadata, {
 	icon: {
-		src: <Icon srcElement={ address } />,
-		foreground: '#7f54b3',
+		src: (
+			<Icon
+				srcElement={ address }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	attributes,
 	edit: Edit,

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-shipping-methods-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-shipping-methods-block/index.tsx
@@ -13,8 +13,12 @@ import metadata from './block.json';
 
 registerFeaturePluginBlockType( metadata, {
 	icon: {
-		src: <Icon srcElement={ truck } />,
-		foreground: '#7f54b3',
+		src: (
+			<Icon
+				srcElement={ truck }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	attributes,
 	edit: Edit,

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-terms-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-terms-block/index.tsx
@@ -11,8 +11,12 @@ import metadata from './block.json';
 
 registerFeaturePluginBlockType( metadata, {
 	icon: {
-		src: <Icon srcElement={ asterisk } />,
-		foreground: '#7f54b3',
+		src: (
+			<Icon
+				srcElement={ asterisk }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	edit: Edit,
 	save: Save,

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-totals-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-totals-block/index.tsx
@@ -12,8 +12,12 @@ import metadata from './block.json';
 
 registerFeaturePluginBlockType( metadata, {
 	icon: {
-		src: <Icon icon={ column } />,
-		foreground: '#7f54b3',
+		src: (
+			<Icon
+				icon={ column }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	edit: Edit,
 	save: Save,

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/index.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/index.tsx
@@ -15,8 +15,12 @@ const settings = {
 	apiVersion: 2,
 	title: __( 'Mini Cart Contents', 'woo-gutenberg-products-block' ),
 	icon: {
-		src: <Icon srcElement={ cart } />,
-		foreground: '#7f54b3',
+		src: (
+			<Icon
+				srcElement={ cart }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/empty-mini-cart-contents-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/empty-mini-cart-contents-block/index.tsx
@@ -12,8 +12,12 @@ import metadata from './block.json';
 
 registerFeaturePluginBlockType( metadata, {
 	icon: {
-		src: <Icon srcElement={ removeCart } />,
-		foreground: '#7f54b3',
+		src: (
+			<Icon
+				srcElement={ removeCart }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	edit: Edit,
 	save: Save,

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/filled-mini-cart-contents-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/filled-mini-cart-contents-block/index.tsx
@@ -12,8 +12,12 @@ import metadata from './block.json';
 
 registerFeaturePluginBlockType( metadata, {
 	icon: {
-		src: <Icon srcElement={ filledCart } />,
-		foreground: '#7f54b3',
+		src: (
+			<Icon
+				srcElement={ filledCart }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	edit: Edit,
 	save: Save,

--- a/assets/js/blocks/cart-checkout/mini-cart/index.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart/index.tsx
@@ -14,8 +14,12 @@ const settings = {
 	apiVersion: 2,
 	title: __( 'Mini Cart', 'woo-gutenberg-products-block' ),
 	icon: {
-		src: <Icon srcElement={ cart } />,
-		foreground: '#7f54b3',
+		src: (
+			<Icon
+				srcElement={ cart }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],

--- a/assets/js/blocks/featured-category/index.js
+++ b/assets/js/blocks/featured-category/index.js
@@ -21,8 +21,12 @@ import { example } from './example';
 registerBlockType( 'woocommerce/featured-category', {
 	title: __( 'Featured Category', 'woo-gutenberg-products-block' ),
 	icon: {
-		src: <Icon srcElement={ folderStarred } />,
-		foreground: '#7f54b3',
+		src: (
+			<Icon
+				srcElement={ folderStarred }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],

--- a/assets/js/blocks/featured-product/index.js
+++ b/assets/js/blocks/featured-product/index.js
@@ -21,8 +21,12 @@ import Block from './block';
 registerBlockType( 'woocommerce/featured-product', {
 	title: __( 'Featured Product', 'woo-gutenberg-products-block' ),
 	icon: {
-		src: <Icon srcElement={ star } />,
-		foreground: '#7f54b3',
+		src: (
+			<Icon
+				srcElement={ star }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],

--- a/assets/js/blocks/handpicked-products/index.js
+++ b/assets/js/blocks/handpicked-products/index.js
@@ -15,8 +15,12 @@ import Block from './block';
 registerBlockType( 'woocommerce/handpicked-products', {
 	title: __( 'Hand-picked Products', 'woo-gutenberg-products-block' ),
 	icon: {
-		src: <Icon srcElement={ widgets } />,
-		foreground: '#7f54b3',
+		src: (
+			<Icon
+				srcElement={ widgets }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	category: 'woocommerce',
 	keywords: [

--- a/assets/js/blocks/price-filter/index.js
+++ b/assets/js/blocks/price-filter/index.js
@@ -14,8 +14,12 @@ import edit from './edit.js';
 registerBlockType( 'woocommerce/price-filter', {
 	title: __( 'Filter Products by Price', 'woo-gutenberg-products-block' ),
 	icon: {
-		src: <Icon srcElement={ bill } />,
-		foreground: '#7f54b3',
+		src: (
+			<Icon
+				srcElement={ bill }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],

--- a/assets/js/blocks/product-best-sellers/index.js
+++ b/assets/js/blocks/product-best-sellers/index.js
@@ -17,8 +17,12 @@ import sharedAttributes, {
 registerBlockType( 'woocommerce/product-best-sellers', {
 	title: __( 'Best Selling Products', 'woo-gutenberg-products-block' ),
 	icon: {
-		src: <Icon srcElement={ stonks } />,
-		foreground: '#7f54b3',
+		src: (
+			<Icon
+				srcElement={ stonks }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],

--- a/assets/js/blocks/product-categories/index.js
+++ b/assets/js/blocks/product-categories/index.js
@@ -17,8 +17,12 @@ registerBlockType( 'woocommerce/product-categories', {
 	apiVersion: 2,
 	title: __( 'Product Categories List', 'woo-gutenberg-products-block' ),
 	icon: {
-		src: <Icon srcElement={ list } />,
-		foreground: '#7f54b3',
+		src: (
+			<Icon
+				srcElement={ list }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],

--- a/assets/js/blocks/product-category/index.js
+++ b/assets/js/blocks/product-category/index.js
@@ -21,8 +21,12 @@ import sharedAttributes, {
 registerBlockType( 'woocommerce/product-category', {
 	title: __( 'Products by Category', 'woo-gutenberg-products-block' ),
 	icon: {
-		src: <Icon srcElement={ folder } />,
-		foreground: '#7f54b3',
+		src: (
+			<Icon
+				srcElement={ folder }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],

--- a/assets/js/blocks/product-new/index.js
+++ b/assets/js/blocks/product-new/index.js
@@ -17,8 +17,12 @@ import sharedAttributes, {
 registerBlockType( 'woocommerce/product-new', {
 	title: __( 'Newest Products', 'woo-gutenberg-products-block' ),
 	icon: {
-		src: <Icon srcElement={ exclamation } />,
-		foreground: '#7f54b3',
+		src: (
+			<Icon
+				srcElement={ exclamation }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],

--- a/assets/js/blocks/product-on-sale/index.js
+++ b/assets/js/blocks/product-on-sale/index.js
@@ -17,8 +17,12 @@ import sharedAttributes, {
 registerBlockType( 'woocommerce/product-on-sale', {
 	title: __( 'On Sale Products', 'woo-gutenberg-products-block' ),
 	icon: {
-		src: <Icon srcElement={ tag } />,
-		foreground: '#7f54b3',
+		src: (
+			<Icon
+				srcElement={ tag }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],

--- a/assets/js/blocks/product-search/index.js
+++ b/assets/js/blocks/product-search/index.js
@@ -49,8 +49,12 @@ const attributes = {
 registerBlockType( 'woocommerce/product-search', {
 	title: __( 'Product Search', 'woo-gutenberg-products-block' ),
 	icon: {
-		src: <Icon srcElement={ search } />,
-		foreground: '#7f54b3',
+		src: (
+			<Icon
+				srcElement={ search }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],

--- a/assets/js/blocks/product-tag/index.js
+++ b/assets/js/blocks/product-tag/index.js
@@ -18,8 +18,12 @@ import Block from './block';
 registerBlockType( 'woocommerce/product-tag', {
 	title: __( 'Products by Tag', 'woo-gutenberg-products-block' ),
 	icon: {
-		src: <Icon srcElement={ more } />,
-		foreground: '#7f54b3',
+		src: (
+			<Icon
+				srcElement={ more }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],

--- a/assets/js/blocks/product-top-rated/index.js
+++ b/assets/js/blocks/product-top-rated/index.js
@@ -19,8 +19,12 @@ const blockTypeName = 'woocommerce/product-top-rated';
 registerBlockType( blockTypeName, {
 	title: __( 'Top Rated Products', 'woo-gutenberg-products-block' ),
 	icon: {
-		src: <Icon srcElement={ thumbUp } />,
-		foreground: '#7f54b3',
+		src: (
+			<Icon
+				srcElement={ thumbUp }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],

--- a/assets/js/blocks/products-by-attribute/index.js
+++ b/assets/js/blocks/products-by-attribute/index.js
@@ -17,8 +17,12 @@ const blockTypeName = 'woocommerce/products-by-attribute';
 registerBlockType( blockTypeName, {
 	title: __( 'Products by Attribute', 'woo-gutenberg-products-block' ),
 	icon: {
-		src: <Icon srcElement={ tags } />,
-		foreground: '#7f54b3',
+		src: (
+			<Icon
+				srcElement={ tags }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],

--- a/assets/js/blocks/products/all-products/index.js
+++ b/assets/js/blocks/products/all-products/index.js
@@ -17,8 +17,12 @@ import { getBlockClassName } from '../utils.js';
 export const blockSettings = {
 	title: __( 'All Products', 'woo-gutenberg-products-block' ),
 	icon: {
-		src: <Icon srcElement={ grid } />,
-		foreground: '#7f54b3',
+		src: (
+			<Icon
+				srcElement={ grid }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],

--- a/assets/js/blocks/reviews/all-reviews/index.js
+++ b/assets/js/blocks/reviews/all-reviews/index.js
@@ -22,8 +22,12 @@ registerBlockType( 'woocommerce/all-reviews', {
 	apiVersion: 2,
 	title: __( 'All Reviews', 'woo-gutenberg-products-block' ),
 	icon: {
-		src: <Icon srcElement={ discussion } />,
-		foreground: '#7f54b3',
+		src: (
+			<Icon
+				srcElement={ discussion }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],

--- a/assets/js/blocks/reviews/reviews-by-category/index.js
+++ b/assets/js/blocks/reviews/reviews-by-category/index.js
@@ -20,8 +20,12 @@ registerBlockType( 'woocommerce/reviews-by-category', {
 	apiVersion: 2,
 	title: __( 'Reviews by Category', 'woo-gutenberg-products-block' ),
 	icon: {
-		src: <Icon srcElement={ review } />,
-		foreground: '#7f54b3',
+		src: (
+			<Icon
+				srcElement={ review }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],

--- a/assets/js/blocks/reviews/reviews-by-product/index.js
+++ b/assets/js/blocks/reviews/reviews-by-product/index.js
@@ -20,8 +20,12 @@ registerBlockType( 'woocommerce/reviews-by-product', {
 	apiVersion: 2,
 	title: __( 'Reviews by Product', 'woo-gutenberg-products-block' ),
 	icon: {
-		src: <Icon srcElement={ comment } />,
-		foreground: '#7f54b3',
+		src: (
+			<Icon
+				srcElement={ comment }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],

--- a/assets/js/blocks/single-product/constants.js
+++ b/assets/js/blocks/single-product/constants.js
@@ -10,7 +10,12 @@ export const BLOCK_TITLE = __(
 	'Single Product',
 	'woo-gutenberg-products-block'
 );
-export const BLOCK_ICON = <Icon srcElement={ reader } />;
+export const BLOCK_ICON = (
+	<Icon
+		srcElement={ reader }
+		className="wc-block-editor-components-block-icon"
+	/>
+);
 export const BLOCK_DESCRIPTION = __(
 	'Display a single product.',
 	'woo-gutenberg-products-block'

--- a/assets/js/blocks/single-product/index.js
+++ b/assets/js/blocks/single-product/index.js
@@ -21,7 +21,6 @@ const settings = {
 	title: BLOCK_TITLE,
 	icon: {
 		src: BLOCK_ICON,
-		foreground: '#7f54b3',
 	},
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],

--- a/assets/js/blocks/stock-filter/index.js
+++ b/assets/js/blocks/stock-filter/index.js
@@ -14,8 +14,12 @@ import edit from './edit.js';
 registerBlockType( 'woocommerce/stock-filter', {
 	title: __( 'Filter Products by Stock', 'woo-gutenberg-products-block' ),
 	icon: {
-		src: <Icon srcElement={ server } />,
-		foreground: '#7f54b3',
+		src: (
+			<Icon
+				srcElement={ server }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -29,6 +29,11 @@ setCategories( [
 			'WooCommerce Product Elements',
 			'woo-gutenberg-products-block'
 		),
-		icon: <Icon srcElement={ atom } style={ { fill: '#7f54b3' } } />,
+		icon: (
+			<Icon
+				srcElement={ atom }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
 	},
 ] );


### PR DESCRIPTION
Fixes #5355

### Notes

At the moment, when selecting a block within the List View (Mac: `control + option + o`), the icon remains purple (`#7F54B3`). With the blue background color (`#007CBA`), the contrast ratio of the icon drops to 1.2:1 (see https://webaim.org/resources/contrastchecker/ or https://color.adobe.com/create/color-contrast-analyzer). This PR is doing the following things:

1. Remove the hard-coded foreground color.
2. Add a CSS class to all icons.
3. Add CSS styles for the unselected and the selected state. 

---

Initially, I thought about adding the CSS class to the `<Icon>` component itself rather than the individual elements. However, we're also using icons without a defined color, such as the `eye` icon within the `ViewSwitcherComponent`. Therefore, I decided to add the CSS classes to the affected icons itself.

### Testing

1. Create a test page.
2. Add all blocks of this plugin to the test page.
3. Open the List View (Mac: `control + option + o`).
4. Click on each block.
5. Verify that, before selecting a block, the icon color is purple, and the text color is black.
6. Verify that, when selecting a block, both the icon color and the text color is white.

### User Facing Testing

* [x] Same as above