### PR TITLE
Move is-loading` class removal to render callback

### DIFF
--- a/assets/js/base/utils/render-frontend.tsx
+++ b/assets/js/base/utils/render-frontend.tsx
@@ -62,7 +62,12 @@ export const renderBlock = <
 				{ Block && <Block { ...props } attributes={ attributes } /> }
 			</Suspense>
 		</BlockErrorBoundary>,
-		container
+		container,
+		() => {
+			if ( container.classList ) {
+				container.classList.remove( 'is-loading' );
+			}
+		}
 	);
 };
 
@@ -108,7 +113,6 @@ const renderBlockInContainers = <
 			...el.dataset,
 			...( props.attributes || {} ),
 		};
-		el.classList.remove( 'is-loading' );
 
 		renderBlock( {
 			Block,


### PR DESCRIPTION
This is a minor change pulled from https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5026/files.

Currently, the `is-loading` class is removed when we're traversing the DOM and replacing HTML elements with React Components. While not noticeable, this is really too early. We should remove the `is-loading` class once the component has been rendered, and to do this, we just need to add a render callback function. 

[Render docs are here.](https://reactjs.org/docs/react-dom.html#render)

> If the optional callback is provided, it will be executed after the component is rendered or updated.

#### Testing

Just smoke test that blocks (cart and checkout) render on the frontend.