### PR TITLE
Mini Cart: only display the editing link to users with site editing permission

### DIFF
--- a/assets/js/blocks/cart-checkout/mini-cart/edit.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart/edit.tsx
@@ -12,12 +12,10 @@ import type { ReactElement } from 'react';
 import { formatPrice } from '@woocommerce/price-format';
 import { CartCheckoutCompatibilityNotice } from '@woocommerce/editor-components/compatibility-notices';
 import { PanelBody, ExternalLink, ToggleControl } from '@wordpress/components';
-import { addQueryArgs } from '@wordpress/url';
-import { ADMIN_URL, getSetting } from '@woocommerce/settings';
+import { getSetting } from '@woocommerce/settings';
 import { __ } from '@wordpress/i18n';
 import { positionCenter, positionRight, positionLeft } from '@wordpress/icons';
 import classnames from 'classnames';
-import { isString } from '@woocommerce/types';
 import Noninteractive from '@woocommerce/base-components/noninteractive';
 
 /**
@@ -56,9 +54,10 @@ const MiniCartBlock = ( {
 		} ),
 	} );
 
-	const themeSlug = getSetting( 'themeSlug', '' );
-
-	const isBlockTheme = getSetting( 'isBlockTheme', false );
+	const templatePartEditUri = getSetting(
+		'templatePartEditUri',
+		''
+	) as string;
 
 	/**
 	 * @todo Replace `getColorClassName` and manual style manipulation with
@@ -139,31 +138,21 @@ const MiniCartBlock = ( {
 						}
 					/>
 				</PanelBody>
-				{ isBlockTheme &&
-					isString( themeSlug ) &&
-					themeSlug.length > 0 && (
-						<PanelBody
-							title={ __(
-								'Template Editor',
+				{ templatePartEditUri && (
+					<PanelBody
+						title={ __(
+							'Template Editor',
+							'woo-gutenberg-products-block'
+						) }
+					>
+						<ExternalLink href={ templatePartEditUri }>
+							{ __(
+								'Edit template part',
 								'woo-gutenberg-products-block'
 							) }
-						>
-							<ExternalLink
-								href={ addQueryArgs(
-									`${ ADMIN_URL }site-editor.php`,
-									{
-										postId: `${ themeSlug }//mini-cart`,
-										postType: 'wp_template_part',
-									}
-								) }
-							>
-								{ __(
-									'Edit template part',
-									'woo-gutenberg-products-block'
-								) }
-							</ExternalLink>
-						</PanelBody>
-					) }
+						</ExternalLink>
+					</PanelBody>
+				) }
 			</InspectorControls>
 			<Noninteractive>
 				<button

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -171,25 +171,37 @@ class MiniCart extends AbstractBlock {
 			true
 		);
 
-		$this->asset_data_registry->add(
-			'themeSlug',
-			BlockTemplateUtils::theme_has_template_part( 'mini-cart' ) ? wp_get_theme()->get_stylesheet() : 'woocommerce',
-			''
-		);
+		$template_part_edit_uri = '';
 
-		if ( function_exists( 'wp_is_block_theme' ) ) {
-			$this->asset_data_registry->add(
-				'isBlockTheme',
-				wp_is_block_theme(),
-				true
-			);
-		} else {
-			$this->asset_data_registry->add(
-				'isBlockTheme',
-				false,
-				true
+		if (
+			current_user_can( 'edit_theme_options' ) &&
+			function_exists( 'wp_is_block_theme' ) &&
+			wp_is_block_theme()
+		) {
+			$theme_slug      = BlockTemplateUtils::theme_has_template_part( 'mini-cart' ) ? wp_get_theme()->get_stylesheet() : 'woocommerce';
+			$site_editor_uri = admin_url( 'site-editor.php' );
+
+			if ( version_compare( get_bloginfo( 'version' ), '5.9', '<' ) ) {
+				$site_editor_uri = add_query_arg(
+					array( 'page' => 'gutenberg-edit-site' ),
+					admin_url( 'themes.php' )
+				);
+			}
+
+			$template_part_edit_uri = add_query_arg(
+				array(
+					'postId'   => sprintf( '%s//%s', $theme_slug, 'mini-cart' ),
+					'postType' => 'wp_template_part',
+				),
+				$site_editor_uri
 			);
 		}
+
+		$this->asset_data_registry->add(
+			'templatePartEditUri',
+			$template_part_edit_uri,
+			''
+		);
 
 		/**
 		 * Fires after cart block data is registered.


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #5359

Instead of passing the theme slug and the theme type as we're doing, this PR prepares the full edit URI for the Mini Cart template part in the editor then passes it to the block editor. By doing so, we can check for the current user permission and WP version then pass the appropriate value to the editor. On the editor site, we just need to check for one variable, which makes our code more readable.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Switch to a user with the Editor role.
2. Edit a page containing Mini Cart block.
3. Select the Mini Cart block, don't see the edit template part link.
4. Switch to an admin account.
5. Edit a page containing Mini Cart block.
6. Select the Mini Cart block, see the edit template part link.
7. Switch to a non-block theme.
8. Edit a page containing Mini Cart block.
9. Select the Mini Cart block, don't see the edit template part link.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
* [ ] See steps below.