### PR TITLE
Trigger validation on change if the input is not focussed 

### DIFF
--- a/assets/js/base/components/button/index.tsx
+++ b/assets/js/base/components/button/index.tsx
@@ -15,6 +15,9 @@ interface ButtonProps extends WPButton.ButtonProps {
 	className?: string;
 	showSpinner?: boolean;
 	children?: ReactNode;
+	disabled?: boolean;
+	onClick?: ( e: React.MouseEvent< HTMLButtonElement, MouseEvent > ) => void;
+	type?: 'input' | 'submit';
 }
 
 /**

--- a/assets/js/base/components/cart-checkout/address-form/address-form.tsx
+++ b/assets/js/base/components/cart-checkout/address-form/address-form.tsx
@@ -57,28 +57,27 @@ const validateShippingCountry = (
 };
 
 interface AddressFormProps {
-	id: string;
+	// Id for component.
+	id?: string;
+	// Unique id for form.
 	instanceId: string;
+	// Array of fields in form.
 	fields: ( keyof AddressFields )[];
-	fieldConfig: Record< keyof AddressFields, Partial< AddressField > >;
+	// Field configuration for fields in form.
+	fieldConfig?: Record< keyof AddressFields, Partial< AddressField > >;
+	// Function to all for an form onChange event.
 	onChange: ( newValue: EnteredAddress ) => void;
-	type: AddressType;
+	// Type of form.
+	type?: AddressType;
+	// Values for fields.
 	values: EnteredAddress;
 }
+
 /**
  * Checkout address form.
- *
- * @param {Object} props Incoming props for component.
- * @param {string} props.id Id for component.
- * @param {Array}  props.fields Array of fields in form.
- * @param {Object} props.fieldConfig Field configuration for fields in form.
- * @param {string} props.instanceId Unique id for form.
- * @param {function(any):any} props.onChange Function to all for an form onChange event.
- * @param {string} props.type Type of form.
- * @param {Object} props.values Values for fields.
  */
 const AddressForm = ( {
-	id,
+	id = '',
 	fields = ( Object.keys(
 		defaultAddressFields
 	) as unknown ) as ( keyof AddressFields )[],


### PR DESCRIPTION
This PR fixes #5130 and replaces the fix for #4495.

When browser autofill triggers, from what I can tell with logging, onChange events are fired. However, validation occurs onBlur and this is not fired for autofilled inputs.

Because we can track the onChange event, we can ensure that validation runs (in the background) on non-focused fields.

@senadir this replaces your event handling fix. Does it make more sense to you?

### Testing

How to test the changes in this Pull Request:

1. In a clean browser session with no address, add an item to the cart
2. Go to Cart block
3. Open shipping calculator.
4. Autofill an address.
5. Click update
6. You should see no inline validation errors

### Changelog

> Fix validation error handling after using browser autofill
