### PR TITLE
Set the origin of custom templates to 'plugin' and fix plugin name on REST requests

### DIFF
--- a/src/Utils/BlockTemplateUtils.php
+++ b/src/Utils/BlockTemplateUtils.php
@@ -117,6 +117,7 @@ class BlockTemplateUtils {
 		}
 
 		if ( 'woocommerce' === $theme ) {
+			$template->theme  = 'woocommerce/woocommerce';
 			$template->origin = 'plugin';
 		}
 
@@ -137,7 +138,7 @@ class BlockTemplateUtils {
 		$template_content         = file_get_contents( $template_file->path );
 		$template                 = new \WP_Block_Template();
 		$template->id             = 'woocommerce//' . $template_file->slug;
-		$template->theme          = 'WooCommerce';
+		$template->theme          = 'woocommerce/woocommerce';
 		$template->content        = self::gutenberg_inject_theme_attribute_in_content( $template_content );
 		$template->source         = 'plugin';
 		$template->slug           = $template_file->slug;

--- a/src/Utils/BlockTemplateUtils.php
+++ b/src/Utils/BlockTemplateUtils.php
@@ -116,6 +116,10 @@ class BlockTemplateUtils {
 			}
 		}
 
+		if ( 'woocommerce' === $theme ) {
+			$template->origin = 'plugin';
+		}
+
 		return $template;
 	}
 


### PR DESCRIPTION
Fixes #5327.

Templates that had been edited by the user were considered as being theme templates even though they are plugin templates. This PR fixes that setting the `origin` to `plugin` in those cases.

This PR also fixes the plugin name, after some investigation I found it must be in the form `woocommerce/woocommerce`.

### Manual Testing

1. Go to Appearance > Site Editor > Templates.
2. If you haven't edited any of the WooCommerce templates, edit one and go back to the Templates list.
3. Verify the WooCommerce edited template has the plugin icon (plug) instead of the theme icon (icon of a webpage).
4. Verify it shows the plugin name as `WooCommerce` instead of `woocommerce` (notice the capital letters).
5. Verify there were no 404 calls made when loading the page.

| Before | After |
| --- | --- |
| ![imatge](https://user-images.githubusercontent.com/3616980/145828161-1f384b2c-f778-460e-830f-2fb78c52c331.png) | ![imatge](https://user-images.githubusercontent.com/3616980/145827705-0395ff46-6728-4094-bbc9-e9173dc865d7.png) |

Note: This PR introduces a regression, the 'blue' circle on top of the icon indicating that it has been customized by the user does not appear when the origin is a plugin. I think that's a bug in Gutenberg and I created a PR in that repo: https://github.com/WordPress/gutenberg/pull/37329.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
* [ ] See steps below.

### Changelog

> Site Editor template list: Fix wrong icon displayed on WooCommerce templates after they have been edited.
