### PR TITLE
Remove validateOnMount in favour of validation on state change

### DIFF
--- a/assets/js/base/components/cart-checkout/totals/coupon/index.tsx
+++ b/assets/js/base/components/cart-checkout/totals/coupon/index.tsx
@@ -104,7 +104,6 @@ export const TotalsCoupon = ( {
 							onChange={ ( newCouponValue ) => {
 								setCouponValue( newCouponValue );
 							} }
-							validateOnMount={ false }
 							focusOnMount={ true }
 							showError={ false }
 						/>

--- a/assets/js/base/components/text-input/validated-text-input.tsx
+++ b/assets/js/base/components/text-input/validated-text-input.tsx
@@ -119,6 +119,7 @@ const ValidatedTextInput = ( {
 		) {
 			validateInput( true );
 		}
+		// We need to track value even if it is not directly used so we know when it changes.
 	}, [ value, validateInput ] );
 
 	// Remove validation errors when unmounted.

--- a/assets/js/base/components/text-input/validated-text-input.tsx
+++ b/assets/js/base/components/text-input/validated-text-input.tsx
@@ -2,13 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	useCallback,
-	useRef,
-	useEffect,
-	useLayoutEffect,
-	useState,
-} from 'react';
+import { useCallback, useRef, useEffect, useState } from 'react';
 import classnames from 'classnames';
 import {
 	ValidationInputError,
@@ -106,7 +100,7 @@ const ValidatedTextInput = ( {
 	 *
 	 * If the input is in pristine state, focus the element.
 	 */
-	useLayoutEffect( () => {
+	useEffect( () => {
 		if ( isPristine && focusOnMount ) {
 			inputRef.current?.focus();
 		}
@@ -119,7 +113,7 @@ const ValidatedTextInput = ( {
 	 * Runs validation on state change if the current element is not in focus. This is because autofilled elements do not
 	 * trigger the blur() event, and so values can be validated in the background if the state changes elsewhere.
 	 */
-	useLayoutEffect( () => {
+	useEffect( () => {
 		if (
 			inputRef.current?.ownerDocument?.activeElement !== inputRef.current
 		) {


### PR DESCRIPTION
Fixes an issue where the input validation may break if there is a value on page load. Caused in part by a conflict with existing code, state, and https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5373 

To replicate:

- Whilst logged in with customer data,
- Go to checkout. Note that some address fields should be pre-filled.
- Hit place order without interacting with fields
- Errors will show below populated fields

### Testing

How to test the changes in this Pull Request:

- Whilst logged in go to checkout.
- Note that some address fields should be pre-filled with customer data. If they are not, go to admin and fill out profile data for your address then repeat the test.
- Hit place order without interacting with address fields
- No errors should be shown below filled fields.