### PR TITLE
Remove text decorations from product filtering blocks items

### DIFF
--- a/assets/js/blocks/attribute-filter/style.scss
+++ b/assets/js/blocks/attribute-filter/style.scss
@@ -11,8 +11,6 @@
 		width: 100%;
 
 		li {
-			text-decoration: underline;
-
 			label {
 				cursor: pointer;
 			}

--- a/assets/js/blocks/stock-filter/style.scss
+++ b/assets/js/blocks/stock-filter/style.scss
@@ -5,8 +5,6 @@
 		margin: 0;
 
 		li {
-			text-decoration: underline;
-
 			label {
 				cursor: pointer;
 			}


### PR DESCRIPTION
Fixes #5290

### Screenshots

<table>
<tr>
<td>Before:
<br><br>

![#5290-before](https://user-images.githubusercontent.com/3323310/146129258-794efe6d-b73d-4d33-a7f6-421e0ecaad3f.png)
</td>
<td>After:
<br><br>

![#5290-after](https://user-images.githubusercontent.com/3323310/146129264-df7a0531-286c-4316-ab22-5605735d6e26.png)
</td>
</tr>
</table>

### Testing

1. Check out this PR.
2. Create a test page.
3. Add the `Filter Products by Attribute`, `Filter Products by Stock` and `All Products` blocks to it.
4. Look up the test page in the frontend.
5. Verify that the options within the `Filter Products by Attribute` and `Filter Products by Stock` blocks are not underlined.

### User Facing Testing

* [x] Same as above

### Changelog

> Remove text decorations from product filtering blocks items
