### PR TITLE
Make it so WooCommerce template names are not editable

### DIFF
--- a/src/Utils/BlockTemplateUtils.php
+++ b/src/Utils/BlockTemplateUtils.php
@@ -107,7 +107,7 @@ class BlockTemplateUtils {
 		$template->title          = $post->post_title;
 		$template->status         = $post->post_status;
 		$template->has_theme_file = $has_theme_file;
-		$template->is_custom      = true;
+		$template->is_custom      = false;
 		$template->post_types     = array(); // Don't appear in any Edit Post template selector dropdown.
 		if ( 'wp_template_part' === $post->post_type ) {
 			$type_terms = get_the_terms( $post, 'wp_template_part_area' );
@@ -147,7 +147,7 @@ class BlockTemplateUtils {
 		$template->status         = 'publish';
 		$template->has_theme_file = true;
 		$template->origin         = 'plugin';
-		$template->is_custom      = false; // Templates loaded from the filesystem aren't custom, ones that have been edited and loaded from the DB are.
+		$template->is_custom      = false;
 		$template->post_types     = array(); // Don't appear in any Edit Post template selector dropdown.
 		$template->area           = 'uncategorized';
 		return $template;

--- a/src/Utils/BlockTemplateUtils.php
+++ b/src/Utils/BlockTemplateUtils.php
@@ -140,7 +140,6 @@ class BlockTemplateUtils {
 		$template->id             = 'woocommerce//' . $template_file->slug;
 		$template->theme          = 'woocommerce/woocommerce';
 		$template->content        = self::gutenberg_inject_theme_attribute_in_content( $template_content );
-		$template->source         = 'plugin';
 		$template->slug           = $template_file->slug;
 		$template->type           = $template_type;
 		$template->title          = ! empty( $template_file->title ) ? $template_file->title : self::convert_slug_to_title( $template_file->slug );


### PR DESCRIPTION
Fixes #5281.

It turns out that [`is_custom`](https://github.com/WordPress/gutenberg/blob/8eb1f341285362f6a131fcba81a8d054b6b5b5c5/lib/compat/wordpress-5.9/class-gutenberg-block-template.php#L100-L105) in a template object means that it's a template created by the user, not a template from the theme/plugin edited by the user. So in WooCommerce template we always have to set it to `false`.

In this PR I also removed this line:
```PHP
$template->source = 'plugin';
```
according to the [comment docs](https://github.com/WordPress/gutenberg/blob/8eb1f341285362f6a131fcba81a8d054b6b5b5c5/lib/compat/wordpress-5.9/class-gutenberg-block-template.php#L63-L68), `$source` can only have two values: `theme` or `custom`. So I think it's better to leave it blank, so it uses the default value (`theme`).

### Manual Testing

1. With WC 6.0 beta 3 and a block theme installed, go to Appearance > Editor.
2. Go to the Templates page and edit one of the WooCommerce templates (ie: Single Product Page).
3. Save and refresh the page.
4. Verify the template name is not editable.

| Before | After |
| --- | --- |
| ![imatge](https://user-images.githubusercontent.com/3616980/146168974-41761b71-47a2-4634-9af2-0848ca2103d6.png) | ![imatge](https://user-images.githubusercontent.com/3616980/146168879-f1ebd3f5-187e-42cd-8aa0-bf74cfbd410e.png) |

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
* [ ] See steps below.

### Changelog

> Avoid WooCommerce template names being editable.
