### PR TITLE
Fix: Mini Cart block: divide contents into three inner blocks

### DIFF
--- a/assets/js/blocks/cart-checkout/mini-cart-contents/edit.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/edit.tsx
@@ -16,6 +16,7 @@ import type { TemplateArray } from '@wordpress/blocks';
  * Internal dependencies
  */
 import { useViewSwitcher, useForcedLayout } from '../shared';
+import './editor.scss';
 
 // Array of allowed block names.
 const ALLOWED_BLOCKS = [

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/editor.scss
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/editor.scss
@@ -1,0 +1,18 @@
+.wp-block-woocommerce-mini-cart-contents {
+	max-width: 512px;
+	margin: 0 auto;
+}
+
+.wp-block-woocommerce-filled-mini-cart-contents-block {
+	.block-editor-block-list__layout {
+		display: flex;
+		flex-direction: column;
+		height: calc(100vh - 2 * $gap-largest);
+	}
+}
+
+.wp-block-woocommerce-mini-cart-products-table-block {
+	flex-grow: 1;
+	flex-shrink: 1;
+	margin-bottom: auto;
+}

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/editor.scss
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/editor.scss
@@ -7,7 +7,7 @@
 	.block-editor-block-list__layout {
 		display: flex;
 		flex-direction: column;
-		height: calc(100vh - 2 * $gap-largest);
+		min-height: calc(100vh - 2 * $gap-largest);
 	}
 }
 

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/editor.scss
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/editor.scss
@@ -1,5 +1,5 @@
 .wp-block-woocommerce-mini-cart-contents {
-	max-width: 512px;
+	max-width: 480px;
 	margin: 0 auto;
 }
 
@@ -12,7 +12,5 @@
 }
 
 .wp-block-woocommerce-mini-cart-products-table-block {
-	flex-grow: 1;
-	flex-shrink: 1;
 	margin-bottom: auto;
 }

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/index.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/index.tsx
@@ -36,6 +36,9 @@ const settings = {
 		reusable: false,
 		inserter: false,
 		__experimentalExposeControlsToChildren: true,
+		color: {
+			text: false,
+		},
 	},
 	attributes: {
 		isPreview: {
@@ -48,6 +51,17 @@ const settings = {
 			default: {
 				remove: true,
 				move: true,
+			},
+		},
+		backgroundColor: {
+			type: 'string',
+		},
+		style: {
+			type: 'object',
+			default: {
+				color: {
+					background: '#ffffff',
+				},
 			},
 		},
 	},

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/index.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/index.tsx
@@ -53,17 +53,6 @@ const settings = {
 				move: true,
 			},
 		},
-		backgroundColor: {
-			type: 'string',
-		},
-		style: {
-			type: 'object',
-			default: {
-				color: {
-					background: '#ffffff',
-				},
-			},
-		},
 	},
 	example: {
 		attributes: {

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/filled-mini-cart-contents-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/filled-mini-cart-contents-block/edit.tsx
@@ -19,6 +19,7 @@ export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 	const defaultTemplate = ( [
 		[ 'woocommerce/mini-cart-title-block', {} ],
 		[ 'woocommerce/mini-cart-products-table-block', {} ],
+		[ 'woocommerce/mini-cart-footer-block', {} ],
 	].filter( Boolean ) as unknown ) as TemplateArray;
 
 	useForcedLayout( {

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/filled-mini-cart-contents-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/filled-mini-cart-contents-block/edit.tsx
@@ -4,7 +4,8 @@
 import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
 import { innerBlockAreas } from '@woocommerce/blocks-checkout';
 import type { TemplateArray } from '@wordpress/blocks';
-import { useEditorContext } from '@woocommerce/base-context';
+import { EditorProvider, useEditorContext } from '@woocommerce/base-context';
+import { previewCart } from '@woocommerce/resource-previews';
 
 /**
  * Internal dependencies
@@ -35,11 +36,16 @@ export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 				currentView !== 'woocommerce/filled-mini-cart-contents-block'
 			}
 		>
-			<InnerBlocks
-				template={ defaultTemplate }
-				allowedBlocks={ allowedBlocks }
-				templateLock="insert"
-			/>
+			<EditorProvider
+				currentView={ currentView }
+				previewData={ { previewCart } }
+			>
+				<InnerBlocks
+					template={ defaultTemplate }
+					allowedBlocks={ allowedBlocks }
+					templateLock="insert"
+				/>
+			</EditorProvider>
 		</div>
 	);
 };

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/filled-mini-cart-contents-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/filled-mini-cart-contents-block/edit.tsx
@@ -18,6 +18,7 @@ export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 
 	const defaultTemplate = ( [
 		[ 'woocommerce/mini-cart-title-block', {} ],
+		[ 'woocommerce/mini-cart-products-table-block', {} ],
 	].filter( Boolean ) as unknown ) as TemplateArray;
 
 	useForcedLayout( {

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/filled-mini-cart-contents-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/filled-mini-cart-contents-block/edit.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
 import { innerBlockAreas } from '@woocommerce/blocks-checkout';
 import type { TemplateArray } from '@wordpress/blocks';
@@ -18,16 +17,7 @@ export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 	const { currentView } = useEditorContext();
 
 	const defaultTemplate = ( [
-		[
-			'core/heading',
-			{
-				content: __(
-					'Filled mini cart content',
-					'woo-gutenberg-products-block'
-				),
-				level: 2,
-			},
-		],
+		[ 'woocommerce/mini-cart-title-block', {} ],
 	].filter( Boolean ) as unknown ) as TemplateArray;
 
 	useForcedLayout( {
@@ -44,6 +34,7 @@ export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 			}
 		>
 			<InnerBlocks
+				template={ defaultTemplate }
 				allowedBlocks={ allowedBlocks }
 				templateLock="insert"
 			/>

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/filled-mini-cart-contents-block/frontend.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/filled-mini-cart-contents-block/frontend.tsx
@@ -1,91 +1,20 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
-import {
-	usePaymentMethods,
-	useStoreCart,
-} from '@woocommerce/base-context/hooks';
-import { TotalsItem } from '@woocommerce/blocks-checkout';
-import { CART_URL, CHECKOUT_URL } from '@woocommerce/block-settings';
-import Button from '@woocommerce/base-components/button';
-import { PaymentMethodDataProvider } from '@woocommerce/base-context';
-import { getIconsFromPaymentMethods } from '@woocommerce/base-utils';
-import PaymentMethodIcons from '@woocommerce/base-components/cart-checkout/payment-method-icons';
-import { getCurrencyFromPriceResponse } from '@woocommerce/price-format';
-import { getSetting } from '@woocommerce/settings';
+import { useStoreCart } from '@woocommerce/base-context/hooks';
 
-/**
- * Internal dependencies
- */
-import CartLineItemsTable from '../../../cart/cart-line-items-table';
-
-const PaymentMethodIconsElement = (): JSX.Element => {
-	const { paymentMethods } = usePaymentMethods();
-	return (
-		<PaymentMethodIcons
-			icons={ getIconsFromPaymentMethods( paymentMethods ) }
-		/>
-	);
-};
-
-type FilledMiniCartContentsBlockProps = {
+const FilledMiniCartContentsBlock = ( {
+	children,
+}: {
 	children: JSX.Element | JSX.Element[];
-};
+} ): JSX.Element | null => {
+	const { cartItems } = useStoreCart();
 
-const FilledMiniCartContentsBlock = ( {}: FilledMiniCartContentsBlockProps ): JSX.Element | null => {
-	const { cartItems, cartIsLoading, cartTotals } = useStoreCart();
-	const subTotal = getSetting( 'displayCartPricesIncludingTax', false )
-		? parseInt( cartTotals.total_items, 10 ) +
-		  parseInt( cartTotals.total_items_tax, 10 )
-		: parseInt( cartTotals.total_items, 10 );
-
-	if ( cartIsLoading || cartItems.length === 0 ) {
+	if ( cartItems.length === 0 ) {
 		return null;
 	}
 
-	return (
-		<>
-			<div className="wc-block-mini-cart__items">
-				<CartLineItemsTable
-					lineItems={ cartItems }
-					isLoading={ cartIsLoading }
-				/>
-			</div>
-			<div className="wc-block-mini-cart__footer">
-				<TotalsItem
-					className="wc-block-mini-cart__footer-subtotal"
-					currency={ getCurrencyFromPriceResponse( cartTotals ) }
-					label={ __( 'Subtotal', 'woo-gutenberg-products-block' ) }
-					value={ subTotal }
-					description={ __(
-						'Shipping, taxes, and discounts calculated at checkout.',
-						'woo-gutenberg-products-block'
-					) }
-				/>
-				<div className="wc-block-mini-cart__footer-actions">
-					<Button
-						className="wc-block-mini-cart__footer-cart"
-						href={ CART_URL }
-					>
-						{ __( 'View my cart', 'woo-gutenberg-products-block' ) }
-					</Button>
-					<Button
-						className="wc-block-mini-cart__footer-checkout"
-						href={ CHECKOUT_URL }
-					>
-						{ __(
-							'Go to checkout',
-							'woo-gutenberg-products-block'
-						) }
-					</Button>
-				</div>
-				<PaymentMethodDataProvider>
-					<PaymentMethodIconsElement />
-				</PaymentMethodDataProvider>
-			</div>
-		</>
-	);
+	return <>{ children }</>;
 };
 
 export default FilledMiniCartContentsBlock;

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/index.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/index.tsx
@@ -4,3 +4,4 @@
 import './empty-mini-cart-contents-block';
 import './filled-mini-cart-contents-block';
 import './mini-cart-title-block';
+import './mini-cart-products-table-block';

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/index.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/index.tsx
@@ -5,3 +5,4 @@ import './empty-mini-cart-contents-block';
 import './filled-mini-cart-contents-block';
 import './mini-cart-title-block';
 import './mini-cart-products-table-block';
+import './mini-cart-footer-block';

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/index.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/index.tsx
@@ -3,3 +3,4 @@
  */
 import './empty-mini-cart-contents-block';
 import './filled-mini-cart-contents-block';
+import './mini-cart-title-block';

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-footer-block/block.json
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-footer-block/block.json
@@ -1,7 +1,7 @@
 {
 	"name": "woocommerce/mini-cart-footer-block",
 	"version": "1.0.0",
-	"title": "Mini Cart Contents Title",
+	"title": "Mini Cart Footer",
 	"description": "Block that display the footer of the Mini Cart block.",
 	"category": "woocommerce",
 	"supports": {

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-footer-block/block.json
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-footer-block/block.json
@@ -2,7 +2,7 @@
 	"name": "woocommerce/mini-cart-footer-block",
 	"version": "1.0.0",
 	"title": "Mini Cart Footer",
-	"description": "Block that display the footer of the Mini Cart block.",
+	"description": "Block that displays the footer of the Mini Cart block.",
 	"category": "woocommerce",
 	"supports": {
 		"align": false,

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-footer-block/block.json
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-footer-block/block.json
@@ -1,0 +1,26 @@
+{
+	"name": "woocommerce/mini-cart-footer-block",
+	"version": "1.0.0",
+	"title": "Mini Cart Contents Title",
+	"description": "Block that display the footer of the Mini Cart block.",
+	"category": "woocommerce",
+	"supports": {
+		"align": false,
+		"html": false,
+		"multiple": false,
+		"reusable": false,
+		"inserter": false
+	},
+	"attributes": {
+		"lock": {
+			"type": "object",
+			"default": {
+				"remove": true,
+				"move": true
+			}
+		}
+	},
+	"parent": [ "woocommerce/filled-mini-cart-contents-block" ],
+	"textdomain": "woo-gutenberg-products-block",
+	"apiVersion": 2
+}

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-footer-block/block.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-footer-block/block.tsx
@@ -1,9 +1,66 @@
 /**
  * External dependencies
  */
+import { __ } from '@wordpress/i18n';
+import { TotalsItem } from '@woocommerce/blocks-checkout';
+import { getCurrencyFromPriceResponse } from '@woocommerce/price-format';
+import {
+	usePaymentMethods,
+	useStoreCart,
+} from '@woocommerce/base-context/hooks';
+import PaymentMethodIcons from '@woocommerce/base-components/cart-checkout/payment-method-icons';
+import { getIconsFromPaymentMethods } from '@woocommerce/base-utils';
+import { getSetting } from '@woocommerce/settings';
+import { CART_URL, CHECKOUT_URL } from '@woocommerce/block-settings';
+import Button from '@woocommerce/base-components/button';
+import { PaymentMethodDataProvider } from '@woocommerce/base-context';
+
+const PaymentMethodIconsElement = (): JSX.Element => {
+	const { paymentMethods } = usePaymentMethods();
+	return (
+		<PaymentMethodIcons
+			icons={ getIconsFromPaymentMethods( paymentMethods ) }
+		/>
+	);
+};
 
 const Block = (): JSX.Element => {
-	return <h2 className="mini-cart-footer-block">Mini cart footer</h2>;
+	const { cartTotals } = useStoreCart();
+	const subTotal = getSetting( 'displayCartPricesIncludingTax', false )
+		? parseInt( cartTotals.total_items, 10 ) +
+		  parseInt( cartTotals.total_items_tax, 10 )
+		: parseInt( cartTotals.total_items, 10 );
+	return (
+		<div className="wc-block-mini-cart__footer">
+			<TotalsItem
+				className="wc-block-mini-cart__footer-subtotal"
+				currency={ getCurrencyFromPriceResponse( cartTotals ) }
+				label={ __( 'Subtotal', 'woo-gutenberg-products-block' ) }
+				value={ subTotal }
+				description={ __(
+					'Shipping, taxes, and discounts calculated at checkout.',
+					'woo-gutenberg-products-block'
+				) }
+			/>
+			<div className="wc-block-mini-cart__footer-actions">
+				<Button
+					className="wc-block-mini-cart__footer-cart"
+					href={ CART_URL }
+				>
+					{ __( 'View my cart', 'woo-gutenberg-products-block' ) }
+				</Button>
+				<Button
+					className="wc-block-mini-cart__footer-checkout"
+					href={ CHECKOUT_URL }
+				>
+					{ __( 'Go to checkout', 'woo-gutenberg-products-block' ) }
+				</Button>
+			</div>
+			<PaymentMethodDataProvider>
+				<PaymentMethodIconsElement />
+			</PaymentMethodDataProvider>
+		</div>
+	);
 };
 
 export default Block;

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-footer-block/block.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-footer-block/block.tsx
@@ -1,0 +1,9 @@
+/**
+ * External dependencies
+ */
+
+const Block = (): JSX.Element => {
+	return <h2 className="mini-cart-footer-block">Mini cart footer</h2>;
+};
+
+export default Block;

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-footer-block/block.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-footer-block/block.tsx
@@ -43,18 +43,25 @@ const Block = (): JSX.Element => {
 				) }
 			/>
 			<div className="wc-block-mini-cart__footer-actions">
-				<Button
-					className="wc-block-mini-cart__footer-cart"
-					href={ CART_URL }
-				>
-					{ __( 'View my cart', 'woo-gutenberg-products-block' ) }
-				</Button>
-				<Button
-					className="wc-block-mini-cart__footer-checkout"
-					href={ CHECKOUT_URL }
-				>
-					{ __( 'Go to checkout', 'woo-gutenberg-products-block' ) }
-				</Button>
+				{ CART_URL && (
+					<Button
+						className="wc-block-mini-cart__footer-cart"
+						href={ CART_URL }
+					>
+						{ __( 'View my cart', 'woo-gutenberg-products-block' ) }
+					</Button>
+				) }
+				{ CHECKOUT_URL && (
+					<Button
+						className="wc-block-mini-cart__footer-checkout"
+						href={ CHECKOUT_URL || '' }
+					>
+						{ __(
+							'Go to checkout',
+							'woo-gutenberg-products-block'
+						) }
+					</Button>
+				) }
 			</div>
 			<PaymentMethodDataProvider>
 				<PaymentMethodIconsElement />

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-footer-block/block.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-footer-block/block.tsx
@@ -54,7 +54,7 @@ const Block = (): JSX.Element => {
 				{ CHECKOUT_URL && (
 					<Button
 						className="wc-block-mini-cart__footer-checkout"
-						href={ CHECKOUT_URL || '' }
+						href={ CHECKOUT_URL }
 					>
 						{ __(
 							'Go to checkout',

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-footer-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-footer-block/edit.tsx
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import { useBlockProps } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import Block from './block';
+
+export const Edit = (): JSX.Element => {
+	const blockProps = useBlockProps();
+
+	return (
+		<div { ...blockProps }>
+			<Block />
+		</div>
+	);
+};

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-footer-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-footer-block/edit.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { useBlockProps } from '@wordpress/block-editor';
+import Noninteractive from '@woocommerce/base-components/noninteractive';
 
 /**
  * Internal dependencies
@@ -13,7 +14,9 @@ export const Edit = (): JSX.Element => {
 
 	return (
 		<div { ...blockProps }>
-			<Block />
+			<Noninteractive>
+				<Block />
+			</Noninteractive>
 		</div>
 	);
 };

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-footer-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-footer-block/index.tsx
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import { Icon, bookmark } from '@woocommerce/icons';
+import { registerFeaturePluginBlockType } from '@woocommerce/block-settings';
+
+/**
+ * Internal dependencies
+ */
+import { Edit } from './edit';
+import metadata from './block.json';
+
+registerFeaturePluginBlockType( metadata, {
+	icon: {
+		src: (
+			<Icon
+				srcElement={ bookmark }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
+	},
+	edit: Edit,
+} );

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-footer-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-footer-block/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Icon, bookmark } from '@woocommerce/icons';
+import { Icon, card } from '@woocommerce/icons';
 import { registerFeaturePluginBlockType } from '@woocommerce/block-settings';
 
 /**
@@ -14,7 +14,7 @@ registerFeaturePluginBlockType( metadata, {
 	icon: {
 		src: (
 			<Icon
-				srcElement={ bookmark }
+				srcElement={ card }
 				className="wc-block-editor-components-block-icon"
 			/>
 		),

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-products-table-block/block.json
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-products-table-block/block.json
@@ -1,8 +1,8 @@
 {
-	"name": "woocommerce/mini-cart-title-block",
+	"name": "woocommerce/mini-cart-products-table-block",
 	"version": "1.0.0",
 	"title": "Mini Cart Contents Title",
-	"description": "Block that display the title of the Mini Cart block.",
+	"description": "Block that display the products table of the Mini Cart block.",
 	"category": "woocommerce",
 	"supports": {
 		"align": false,

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-products-table-block/block.json
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-products-table-block/block.json
@@ -1,7 +1,7 @@
 {
 	"name": "woocommerce/mini-cart-products-table-block",
 	"version": "1.0.0",
-	"title": "Mini Cart Contents Title",
+	"title": "Mini Cart Products Table",
 	"description": "Block that display the products table of the Mini Cart block.",
 	"category": "woocommerce",
 	"supports": {

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-products-table-block/block.json
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-products-table-block/block.json
@@ -2,7 +2,7 @@
 	"name": "woocommerce/mini-cart-products-table-block",
 	"version": "1.0.0",
 	"title": "Mini Cart Products Table",
-	"description": "Block that display the products table of the Mini Cart block.",
+	"description": "Block that displays the products table of the Mini Cart block.",
 	"category": "woocommerce",
 	"supports": {
 		"align": false,

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-products-table-block/block.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-products-table-block/block.tsx
@@ -1,12 +1,22 @@
 /**
  * External dependencies
  */
+import { useStoreCart } from '@woocommerce/base-context/hooks';
+
+/**
+ * Internal dependencies
+ */
+import CartLineItemsTable from '../../../cart/cart-line-items-table';
 
 const Block = (): JSX.Element => {
+	const { cartItems, cartIsLoading } = useStoreCart();
 	return (
-		<h2 className="mini-cart-products-table-block">
-			Mini cart products table
-		</h2>
+		<div className="wc-block-mini-cart__items">
+			<CartLineItemsTable
+				lineItems={ cartItems }
+				isLoading={ cartIsLoading }
+			/>
+		</div>
 	);
 };
 

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-products-table-block/block.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-products-table-block/block.tsx
@@ -1,0 +1,13 @@
+/**
+ * External dependencies
+ */
+
+const Block = (): JSX.Element => {
+	return (
+		<h2 className="mini-cart-products-table-block">
+			Mini cart products table
+		</h2>
+	);
+};
+
+export default Block;

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-products-table-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-products-table-block/edit.tsx
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import { useBlockProps } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import Block from './block';
+
+export const Edit = (): JSX.Element => {
+	const blockProps = useBlockProps();
+
+	return (
+		<div { ...blockProps }>
+			<Block />
+		</div>
+	);
+};

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-products-table-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-products-table-block/edit.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { useBlockProps } from '@wordpress/block-editor';
+import Noninteractive from '@woocommerce/base-components/noninteractive';
 
 /**
  * Internal dependencies
@@ -13,7 +14,9 @@ export const Edit = (): JSX.Element => {
 
 	return (
 		<div { ...blockProps }>
-			<Block />
+			<Noninteractive>
+				<Block />
+			</Noninteractive>
 		</div>
 	);
 };

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-products-table-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-products-table-block/index.tsx
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import { Icon, bookmark } from '@woocommerce/icons';
+import { registerFeaturePluginBlockType } from '@woocommerce/block-settings';
+
+/**
+ * Internal dependencies
+ */
+import { Edit } from './edit';
+import metadata from './block.json';
+
+registerFeaturePluginBlockType( metadata, {
+	icon: {
+		src: (
+			<Icon
+				srcElement={ bookmark }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
+	},
+	edit: Edit,
+} );

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-products-table-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-products-table-block/index.tsx
@@ -11,13 +11,11 @@ import { Edit } from './edit';
 import metadata from './block.json';
 
 registerFeaturePluginBlockType( metadata, {
-	icon: {
-		src: (
-			<Icon
-				srcElement={ list }
-				className="wc-block-editor-components-block-icon"
-			/>
-		),
-	},
+	icon: (
+		<Icon
+			srcElement={ list }
+			className="wc-block-editor-components-block-icon"
+		/>
+	)
 	edit: Edit,
 } );

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-products-table-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-products-table-block/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Icon, bookmark } from '@woocommerce/icons';
+import { Icon, list } from '@woocommerce/icons';
 import { registerFeaturePluginBlockType } from '@woocommerce/block-settings';
 
 /**
@@ -14,7 +14,7 @@ registerFeaturePluginBlockType( metadata, {
 	icon: {
 		src: (
 			<Icon
-				srcElement={ bookmark }
+				srcElement={ list }
 				className="wc-block-editor-components-block-icon"
 			/>
 		),

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-products-table-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-products-table-block/index.tsx
@@ -16,6 +16,6 @@ registerFeaturePluginBlockType( metadata, {
 			srcElement={ list }
 			className="wc-block-editor-components-block-icon"
 		/>
-	)
+	),
 	edit: Edit,
 } );

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-title-block/block.json
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-title-block/block.json
@@ -1,7 +1,7 @@
 {
 	"name": "woocommerce/mini-cart-title-block",
 	"version": "1.0.0",
-	"title": "Mini Cart Contents Title",
+	"title": "Mini Cart Title",
 	"description": "Block that display the title of the Mini Cart block.",
 	"category": "woocommerce",
 	"supports": {

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-title-block/block.json
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-title-block/block.json
@@ -2,7 +2,7 @@
 	"name": "woocommerce/mini-cart-title-block",
 	"version": "1.0.0",
 	"title": "Mini Cart Title",
-	"description": "Block that display the title of the Mini Cart block.",
+	"description": "Block that displays the title of the Mini Cart block.",
 	"category": "woocommerce",
 	"supports": {
 		"align": false,

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-title-block/block.json
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-title-block/block.json
@@ -1,0 +1,26 @@
+{
+	"name": "woocommerce/mini-cart-title-block",
+	"version": "1.0.0",
+	"title": "Mini Cart Contents Title",
+	"description": "Block that display the title of the mini cart content.",
+	"category": "woocommerce",
+	"supports": {
+		"align": false,
+		"html": false,
+		"multiple": false,
+		"reusable": false,
+		"inserter": false
+	},
+	"attributes": {
+		"lock": {
+			"type": "object",
+			"default": {
+				"remove": true,
+				"move": true
+			}
+		}
+	},
+	"parent": [ "woocommerce/filled-mini-cart-contents-block" ],
+	"textdomain": "woo-gutenberg-products-block",
+	"apiVersion": 2
+}

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-title-block/block.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-title-block/block.tsx
@@ -1,0 +1,9 @@
+/**
+ * External dependencies
+ */
+
+const Block = (): JSX.Element => {
+	return <h2 className="mini-cart-title-block">Mini cart title</h2>;
+};
+
+export default Block;

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-title-block/block.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-title-block/block.tsx
@@ -1,9 +1,27 @@
 /**
  * External dependencies
  */
+import { sprintf, _n, __ } from '@wordpress/i18n';
+import { useStoreCart } from '@woocommerce/base-context/hooks';
 
 const Block = (): JSX.Element => {
-	return <h2 className="mini-cart-title-block">Mini cart title</h2>;
+	const { cartItemsCount, cartIsLoading } = useStoreCart();
+	return (
+		<h2 className="mini-cart-title-block">
+			{ cartIsLoading
+				? __( 'Your cart', 'woo-gutenberg-products-block' )
+				: sprintf(
+						/* translators: %d is the count of items in the cart. */
+						_n(
+							'Your cart (%d item)',
+							'Your cart (%d items)',
+							cartItemsCount,
+							'woo-gutenberg-products-block'
+						),
+						cartItemsCount
+				  ) }
+		</h2>
+	);
 };
 
 export default Block;

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-title-block/block.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-title-block/block.tsx
@@ -4,10 +4,17 @@
 import { sprintf, _n, __ } from '@wordpress/i18n';
 import { useStoreCart } from '@woocommerce/base-context/hooks';
 
+/**
+ * Internal dependencies
+ */
+
 const Block = (): JSX.Element => {
 	const { cartItemsCount, cartIsLoading } = useStoreCart();
+	/**
+	 * @todo Allow the user to edit the title of the mini cart.
+	 */
 	return (
-		<h2 className="mini-cart-title-block">
+		<h2 className="wc-block-mini-cart__title">
 			{ cartIsLoading
 				? __( 'Your cart', 'woo-gutenberg-products-block' )
 				: sprintf(

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-title-block/block.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-title-block/block.tsx
@@ -10,9 +10,6 @@ import { useStoreCart } from '@woocommerce/base-context/hooks';
 
 const Block = (): JSX.Element => {
 	const { cartItemsCount, cartIsLoading } = useStoreCart();
-	/**
-	 * @todo Allow the user to edit the title of the mini cart.
-	 */
 	return (
 		<h2 className="wc-block-mini-cart__title">
 			{ cartIsLoading

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-title-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-title-block/edit.tsx
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import { useBlockProps } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import Block from './block';
+
+export const Edit = (): JSX.Element => {
+	const blockProps = useBlockProps();
+
+	return (
+		<div { ...blockProps }>
+			<Block />
+		</div>
+	);
+};

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-title-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-title-block/index.tsx
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import { Icon, bookmark } from '@woocommerce/icons';
+import { registerFeaturePluginBlockType } from '@woocommerce/block-settings';
+
+/**
+ * Internal dependencies
+ */
+import { Edit } from './edit';
+import metadata from './block.json';
+
+registerFeaturePluginBlockType( metadata, {
+	icon: {
+		src: (
+			<Icon
+				srcElement={ bookmark }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
+	},
+	edit: Edit,
+} );

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/register-components.ts
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/register-components.ts
@@ -9,6 +9,7 @@ import { lazy } from '@wordpress/element';
  */
 import emptyMiniCartContentsMetadata from './empty-mini-cart-contents-block/block.json';
 import filledMiniCartMetadata from './filled-mini-cart-contents-block/block.json';
+import miniCartContentsTitleMetadata from './mini-cart-title-block/block.json';
 
 // Modify webpack publicPath at runtime based on location of WordPress Plugin.
 // eslint-disable-next-line no-undef,camelcase
@@ -28,6 +29,15 @@ registerCheckoutBlock( {
 	component: lazy( () =>
 		import(
 			/* webpackChunkName: "mini-cart-contents-block/empty-cart" */ './empty-mini-cart-contents-block/frontend'
+		)
+	),
+} );
+
+registerCheckoutBlock( {
+	metadata: miniCartContentsTitleMetadata,
+	component: lazy( () =>
+		import(
+			/* webpackChunkName: "mini-cart-contents-block/title" */ './mini-cart-title-block/block'
 		)
 	),
 } );

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/register-components.ts
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/register-components.ts
@@ -9,7 +9,8 @@ import { lazy } from '@wordpress/element';
  */
 import emptyMiniCartContentsMetadata from './empty-mini-cart-contents-block/block.json';
 import filledMiniCartMetadata from './filled-mini-cart-contents-block/block.json';
-import miniCartContentsTitleMetadata from './mini-cart-title-block/block.json';
+import miniCartTitleMetadata from './mini-cart-title-block/block.json';
+import miniCartProductsTableMetadata from './mini-cart-products-table-block/block.json';
 
 // Modify webpack publicPath at runtime based on location of WordPress Plugin.
 // eslint-disable-next-line no-undef,camelcase
@@ -34,10 +35,19 @@ registerCheckoutBlock( {
 } );
 
 registerCheckoutBlock( {
-	metadata: miniCartContentsTitleMetadata,
+	metadata: miniCartTitleMetadata,
 	component: lazy( () =>
 		import(
 			/* webpackChunkName: "mini-cart-contents-block/title" */ './mini-cart-title-block/block'
+		)
+	),
+} );
+
+registerCheckoutBlock( {
+	metadata: miniCartProductsTableMetadata,
+	component: lazy( () =>
+		import(
+			/* webpackChunkName: "mini-cart-contents-block/products-table" */ './mini-cart-products-table-block/block'
 		)
 	),
 } );

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/register-components.ts
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/register-components.ts
@@ -11,6 +11,7 @@ import emptyMiniCartContentsMetadata from './empty-mini-cart-contents-block/bloc
 import filledMiniCartMetadata from './filled-mini-cart-contents-block/block.json';
 import miniCartTitleMetadata from './mini-cart-title-block/block.json';
 import miniCartProductsTableMetadata from './mini-cart-products-table-block/block.json';
+import miniCartFooterMetadata from './mini-cart-footer-block/block.json';
 
 // Modify webpack publicPath at runtime based on location of WordPress Plugin.
 // eslint-disable-next-line no-undef,camelcase
@@ -48,6 +49,15 @@ registerCheckoutBlock( {
 	component: lazy( () =>
 		import(
 			/* webpackChunkName: "mini-cart-contents-block/products-table" */ './mini-cart-products-table-block/block'
+		)
+	),
+} );
+
+registerCheckoutBlock( {
+	metadata: miniCartFooterMetadata,
+	component: lazy( () =>
+		import(
+			/* webpackChunkName: "mini-cart-contents-block/footer" */ './mini-cart-footer-block/block'
 		)
 	),
 } );

--- a/assets/js/blocks/cart-checkout/mini-cart/block.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart/block.tsx
@@ -190,7 +190,11 @@ const MiniCartBlock = ( {
 				} }
 				slideIn={ ! skipSlideIn }
 			>
-				<div ref={ contentsRef }>
+				<div
+					className="wc-block-mini-cart__template-part"
+					ref={ contentsRef }
+				>
+					{ /* @todo The `div` wrapper of RawHTML isn't removed on the front end. */ }
 					<RawHTML>{ contents }</RawHTML>
 				</div>
 			</Drawer>

--- a/assets/js/blocks/cart-checkout/mini-cart/block.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart/block.tsx
@@ -19,7 +19,7 @@ import {
 	useEffect,
 	useState,
 } from '@wordpress/element';
-import { sprintf, _n, __ } from '@wordpress/i18n';
+import { sprintf, _n } from '@wordpress/i18n';
 import classnames from 'classnames';
 /**
  * Internal dependencies
@@ -183,20 +183,7 @@ const MiniCartBlock = ( {
 						'is-loading': cartIsLoading,
 					}
 				) }
-				title={
-					cartIsLoading
-						? __( 'Your cart', 'woo-gutenberg-products-block' )
-						: sprintf(
-								/* translators: %d is the count of items in the cart. */
-								_n(
-									'Your cart (%d item)',
-									'Your cart (%d items)',
-									cartItemsCount,
-									'woo-gutenberg-products-block'
-								),
-								cartItemsCount
-						  )
-				}
+				title=""
 				isOpen={ isOpen }
 				onClose={ () => {
 					setIsOpen( false );

--- a/assets/js/blocks/cart-checkout/mini-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/mini-cart/style.scss
@@ -82,7 +82,6 @@
 	box-sizing: border-box;
 	display: flex;
 	flex-direction: column;
-	height: 100%;
 	height: 100vh;
 	padding: $gap-largest $gap;
 }

--- a/assets/js/blocks/cart-checkout/mini-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/mini-cart/style.scss
@@ -54,14 +54,14 @@
 	font-size: 1rem;
 
 	.components-modal__content {
-		box-sizing: border-box;
-		display: flex;
-		flex-direction: column;
-		height: 100%;
+		padding: 0;
+		position: relative;
 	}
 
 	.components-modal__header {
-		margin: $gap 0 0;
+		position: absolute;
+		top: $gap-largest;
+		right: $gap;
 	}
 
 	.wc-block-mini-cart__items {
@@ -76,15 +76,14 @@
 	}
 }
 
-.wc-block-mini-cart__template-part {
-	flex-grow: 1;
-}
-
 // @todo Review the class naming convention for Mini Cart inner blocks.
 .wp-block-woocommerce-mini-cart-contents {
+	box-sizing: border-box;
 	display: flex;
 	flex-direction: column;
 	height: 100%;
+	height: 100vh;
+	padding: $gap-largest $gap;
 }
 
 .wc-block-mini-cart__title {

--- a/assets/js/blocks/cart-checkout/mini-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/mini-cart/style.scss
@@ -78,6 +78,7 @@
 
 // @todo Review the class naming convention for Mini Cart inner blocks.
 .wp-block-woocommerce-mini-cart-contents {
+	background: #fff;
 	box-sizing: border-box;
 	display: flex;
 	flex-direction: column;

--- a/assets/js/blocks/cart-checkout/mini-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/mini-cart/style.scss
@@ -87,7 +87,7 @@
 }
 
 .wc-block-mini-cart__title {
-	font-size: xx-large;
+	@include font-size(large);
 	margin-top: 0;
 }
 

--- a/assets/js/blocks/cart-checkout/mini-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/mini-cart/style.scss
@@ -61,7 +61,7 @@
 	}
 
 	.components-modal__header {
-		margin: $gap 0;
+		margin: $gap 0 0;
 	}
 
 	.wc-block-mini-cart__items {
@@ -74,6 +74,22 @@
 			content: none;
 		}
 	}
+}
+
+.wc-block-mini-cart__template-part {
+	flex-grow: 1;
+}
+
+// @todo Review the class naming convention for Mini Cart inner blocks.
+.wp-block-woocommerce-mini-cart-contents {
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+}
+
+.wc-block-mini-cart__title {
+	font-size: xx-large;
+	margin-top: 0;
 }
 
 .wc-block-mini-cart__footer {

--- a/assets/js/blocks/cart-checkout/mini-cart/test/block.js
+++ b/assets/js/blocks/cart-checkout/mini-cart/test/block.js
@@ -71,7 +71,6 @@ describe( 'Testing Mini Cart', () => {
 			fireEvent.click( screen.getByLabelText( /items/i ) );
 		} );
 
-		expect( screen.getByText( /Your cart/i ) ).toBeInTheDocument();
 		expect( fetchMock ).toHaveBeenCalledTimes( 1 );
 		// ["`select` control in `@wordpress/data-controls` is deprecated. Please use built-in `resolveSelect` control in `@wordpress/data` instead."]
 		expect( console ).toHaveWarned();
@@ -86,7 +85,6 @@ describe( 'Testing Mini Cart', () => {
 			fireEvent.click( screen.getByLabelText( /items/i ) );
 		} );
 
-		expect( screen.getByText( /0 items/i ) ).toBeInTheDocument();
 		expect( fetchMock ).toHaveBeenCalledTimes( 1 );
 	} );
 

--- a/packages/checkout/blocks-registry/types.ts
+++ b/packages/checkout/blocks-registry/types.ts
@@ -20,7 +20,7 @@ export enum innerBlockAreas {
 	CART_TOTALS = 'woocommerce/cart-totals-block',
 	MINI_CART = 'woocommerce/mini-cart-contents',
 	EMPTY_MINI_CART = 'woocommerce/empty-mini-cart-contents-block',
-	FILLED_MINI_CART = 'woocommerce/filled-mini-cart-content-block',
+	FILLED_MINI_CART = 'woocommerce/filled-mini-cart-contents-block',
 }
 
 interface CheckoutBlockOptionsMetadata extends Partial< BlockConfiguration > {

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -397,9 +397,7 @@ class MiniCart extends AbstractBlock {
 				<div class="components-modal__frame wc-block-components-drawer">
 					<div class="components-modal__content">
 						<div class="components-modal__header">
-							<div class="components-modal__header-heading-container">
-								<h1 id="components-modal-header-1" class="components-modal__header-heading">' . wp_kses_post( $title ) . '</h1>
-							</div>
+							<div class="components-modal__header-heading-container"></div>
 						</div>
 						<div class="wc-block-mini-cart__template-part">'
 						. wp_kses_post( $template_part_contents ) .

--- a/templates/block-template-parts/mini-cart.html
+++ b/templates/block-template-parts/mini-cart.html
@@ -1,13 +1,19 @@
 <!-- wp:woocommerce/mini-cart-contents -->
-<div class="wp-block-woocommerce-mini-cart-contents"><!-- wp:woocommerce/filled-mini-cart-contents-block -->
-<div class="wp-block-woocommerce-filled-mini-cart-contents-block"><!-- wp:heading -->
-<h2 id="filled-mini-cart-content">Filled mini cart content</h2>
-<!-- /wp:heading --></div>
-<!-- /wp:woocommerce/filled-mini-cart-contents-block -->
+<div class="wp-block-woocommerce-mini-cart-contents">
+	<!-- wp:woocommerce/filled-mini-cart-contents-block -->
+	<div class="wp-block-woocommerce-filled-mini-cart-contents-block">
+		<!-- wp:woocommerce/mini-cart-title-block /-->
+		<!-- wp:woocommerce/mini-cart-products-table-block /-->
+		<!-- wp:woocommerce/mini-cart-footer-block /-->
+	</div>
+	<!-- /wp:woocommerce/filled-mini-cart-contents-block -->
 
-<!-- wp:woocommerce/empty-mini-cart-contents-block -->
-<div class="wp-block-woocommerce-empty-mini-cart-contents-block"><!-- wp:heading -->
-<h2 id="empty-mini-cart-content">Empty mini cart content</h2>
-<!-- /wp:heading --></div>
-<!-- /wp:woocommerce/empty-mini-cart-contents-block --></div>
+	<!-- wp:woocommerce/empty-mini-cart-contents-block -->
+	<div class="wp-block-woocommerce-empty-mini-cart-contents-block">
+		<!-- wp:heading -->
+		<h2 id="empty-mini-cart-content">Empty mini cart content</h2>
+		<!-- /wp:heading -->
+	</div>
+	<!-- /wp:woocommerce/empty-mini-cart-contents-block -->
+</div>
 <!-- /wp:woocommerce/mini-cart-contents -->

--- a/templates/block-template-parts/mini-cart.html
+++ b/templates/block-template-parts/mini-cart.html
@@ -1,5 +1,5 @@
 <!-- wp:woocommerce/mini-cart-contents -->
-<div class="wp-block-woocommerce-mini-cart-contents has-background" style="background-color:#ffffff">
+<div class="wp-block-woocommerce-mini-cart-contents">
 	<!-- wp:woocommerce/filled-mini-cart-contents-block -->
 	<div class="wp-block-woocommerce-filled-mini-cart-contents-block">
 		<!-- wp:woocommerce/mini-cart-title-block /-->

--- a/templates/block-template-parts/mini-cart.html
+++ b/templates/block-template-parts/mini-cart.html
@@ -1,5 +1,5 @@
 <!-- wp:woocommerce/mini-cart-contents -->
-<div class="wp-block-woocommerce-mini-cart-contents">
+<div class="wp-block-woocommerce-mini-cart-contents has-background" style="background-color:#ffffff">
 	<!-- wp:woocommerce/filled-mini-cart-contents-block -->
 	<div class="wp-block-woocommerce-filled-mini-cart-contents-block">
 		<!-- wp:woocommerce/mini-cart-title-block /-->


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #4855 

This PR:
- Splits the filled mini cart contents into three inner blocks: Mini Cart Title, Mini Cart Products Table, and Mini Cart Footer.
- Renders filled Mini Cart contents block in the editor.
- Removes the `<Drawer>` title.
- Adds background support to the mini cart content block.
- Updates `mini-cart` template part file.
- Updates markup in the `MiniCartContents.php` to match with the component.
- Sets a maximum width for the Mini Cart Contents block in the Site Editor.
- Blocks interactive for Mini Cart Products Table and Footer blocks.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### Screenshots

<details>
<summary>Click to expand</summary>

#### Editor
![image](https://user-images.githubusercontent.com/5423135/146174085-3f7fa6cf-a682-43b4-8643-549c0e93ce00.png)

#### Front end
![image](https://user-images.githubusercontent.com/5423135/146174322-b7e53817-a1d8-48eb-97bc-1f07d0fcde3a.png)

</details>

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Delete all customized mini-cart template parts in `/wp-admin/edit.php?post_type=wp_template_part`.
2. Delete the theme's mini-cart template part file.
3. Edit the Mini Cart template: Site Editor > Template Parts > Mini Cart.
4. See no error.
5. See the content of the filled mini cart renders in the editor.
6. Select the mini cart content block.
7. Set the background color.
8. See it works in the editor.
9. Save the change, see the background color works on the front end.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
* [ ] See steps below.