### PR TITLE
Fix extra network request on cart

### DIFF
--- a/assets/js/base/context/hooks/use-customer-data.ts
+++ b/assets/js/base/context/hooks/use-customer-data.ts
@@ -95,26 +95,6 @@ export const useCustomerData = (): {
 		shippingAddress: initialShippingAddress,
 	} );
 
-	// We only want to update the local state once, otherwise the data on the checkout page gets overwritten
-	// with the initial state of the addresses here
-	const [ hasCustomerDataSynced, setHasCustomerDataSynced ] = useState<
-		boolean
-	>( false );
-
-	if (
-		! hasCustomerDataSynced &&
-		shouldUpdateAddressStore(
-			customerData.shippingAddress,
-			initialShippingAddress
-		)
-	) {
-		setCustomerData( {
-			billingData: initialBillingAddress,
-			shippingAddress: initialShippingAddress,
-		} );
-		setHasCustomerDataSynced( true );
-	}
-
 	// Store values last sent to the server in a ref to avoid requests unless important fields are changed.
 	const previousCustomerData = useRef< CustomerData >( customerData );
 


### PR DESCRIPTION
[PR5129](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5129) introduced an extra unnecessary network request to update customer data when the cart is mounted. Initially, the local state `customerData` was out of sync with the cart store. The code removed in this PR was added in the previous PR to keep the local state and the cart in sync. While this would still be nice, it's not necessary and introduces an extra network request.

### Manual Testing

How to test the changes in this Pull Request:

1. Load the cart page
2. There should be no requests (batch or otherwise) to update customer data once the cart is mounted

### Changelog

> Fixed a performance issue with the cart by preventing an extra network request on mount.
