### PR TITLE
Add correct class to Legacy Template block icon

### DIFF
--- a/assets/js/blocks/legacy-template/index.tsx
+++ b/assets/js/blocks/legacy-template/index.tsx
@@ -57,7 +57,9 @@ const Edit = ( { attributes }: Props ) => {
 
 registerBlockType( 'woocommerce/legacy-template', {
 	title: __( 'WooCommerce Legacy Template', 'woo-gutenberg-products-block' ),
-	icon: <Icon icon={ box } color="#7f54b3" />,
+	icon: (
+		<Icon icon={ box } className="wc-block-editor-components-block-icon" />
+	),
 	category: 'woocommerce',
 	apiVersion: 2,
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],


### PR DESCRIPTION
We forgot to add the correct class name to this icon. :slightly_smiling_face: 

### Manual Testing

1. With a block theme, go to Appearance > Editor.
2. Modify one of the WooCommerce templates.
3. In the editor, open the List view and select the WooCommerce Legacy Template block.
4. Verify the icon changes to white.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
* [ ] See steps below.
