### PR TITLE
Fix id generation for template from file #5399

### DIFF
--- a/src/Utils/BlockTemplateUtils.php
+++ b/src/Utils/BlockTemplateUtils.php
@@ -133,12 +133,14 @@ class BlockTemplateUtils {
 	 * @return \WP_Block_Template Template.
 	 */
 	public static function gutenberg_build_template_result_from_file( $template_file, $template_type ) {
+		$theme = 'woocommerce/woocommerce';
+
 		$template_file = (object) $template_file;
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 		$template_content         = file_get_contents( $template_file->path );
 		$template                 = new \WP_Block_Template();
-		$template->id             = 'woocommerce//' . $template_file->slug;
-		$template->theme          = 'woocommerce/woocommerce';
+		$template->theme          = $theme;
+		$template->id             = $theme . '//' . $template_file->slug;
 		$template->content        = self::gutenberg_inject_theme_attribute_in_content( $template_content );
 		$template->source         = 'plugin';
 		$template->slug           = $template_file->slug;


### PR DESCRIPTION
[In according with the function `get_block_template`](https://github.com/WordPress/WordPress/blob/master/wp-includes/block-template-utils.php#L768-L786), the system gets the `theme` value from the `id`. In the previous implementation, the id was `woocommerce//${slug}`.  So the calculated theme was `woocommerce`. The problem was that the theme value for our template is `woocommerce/woocommerce`. So the query could not find the post and it loaded always the template from the file.


This pr fixes the generation id. Now the id is `woocommerce/wocoomerce//${slug}`.


## Question
Are we sure that it is the best solution to adopt `woocommerce/woocommerce` like theme value? 
From what I understand GB and our code work a lot with the id (for example with `explode` PHP function).
It can be tricky for potential future regexes, but also for debugging work with an id like this `woocommerce/wocoomerce//${slug}`



<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #5399 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### Testing

### Manual Testing

How to test the changes in this Pull Request:
Check out this branch. Be sure that you have: `WordPress 5.9`, `Gutenberg trunk version`, `WooCommerce 6.0.0`, and `WooCommerce Blocks trunk` 

1. Go to `Template Page` on `Full Site Editor`.
2. Click on one of the `WooCommerce template` like `Single Product Page`.
3. Add a new block (be sure that you don't add it on the header or footer group).
4. Save.
5. Refresh, and check that your changes are still there.
