### PR TITLE
Revert theme name

### DIFF
--- a/src/Utils/BlockTemplateUtils.php
+++ b/src/Utils/BlockTemplateUtils.php
@@ -117,7 +117,6 @@ class BlockTemplateUtils {
 		}
 
 		if ( 'woocommerce' === $theme ) {
-			$template->theme  = 'woocommerce/woocommerce';
 			$template->origin = 'plugin';
 		}
 
@@ -138,7 +137,7 @@ class BlockTemplateUtils {
 		$template_content         = file_get_contents( $template_file->path );
 		$template                 = new \WP_Block_Template();
 		$template->id             = 'woocommerce//' . $template_file->slug;
-		$template->theme          = 'woocommerce/woocommerce';
+		$template->theme          = 'WooCommerce';
 		$template->content        = self::gutenberg_inject_theme_attribute_in_content( $template_content );
 		$template->source         = 'plugin';
 		$template->slug           = $template_file->slug;


### PR DESCRIPTION
After some investigation, we discovered that #5375 introduces a bug on saving template (#5399). So we need partial revert #5375. This PR revert some changes and fixed the new bug.

### Testing
### Manual Testing

How to test the changes in this Pull Request:

Check out this branch. Be sure that you have: `WordPress 5.9`, `Gutenberg trunk version`, `WooCommerce 6.0.0`, and `WooCommerce Blocks trunk` 

1. Go to `Template Page` on `Full Site Editor`.
2. Click on one of the `WooCommerce template` like `Single Product Page`.
3. Add a new block (be sure that you don't add it on the header or footer group).
4. Save.
5. Refresh, and check that your changes are still there.
6. Check that your changes are visible on frontend side too.


#### Important

This PR reintroduce #5375 
