### PR TITLE
Fix modified block templates to have a user friendly Plugin name.

### DIFF
--- a/src/Utils/BlockTemplateUtils.php
+++ b/src/Utils/BlockTemplateUtils.php
@@ -98,7 +98,7 @@ class BlockTemplateUtils {
 		$template                 = new \WP_Block_Template();
 		$template->wp_id          = $post->ID;
 		$template->id             = $theme . '//' . $post->post_name;
-		$template->theme          = $theme;
+		$template->theme          = 'woocommerce' === $theme ? 'WooCommerce' : $theme;
 		$template->content        = $post->post_content;
 		$template->slug           = $post->post_name;
 		$template->source         = 'custom';
@@ -109,6 +109,7 @@ class BlockTemplateUtils {
 		$template->has_theme_file = $has_theme_file;
 		$template->is_custom      = false;
 		$template->post_types     = array(); // Don't appear in any Edit Post template selector dropdown.
+
 		if ( 'wp_template_part' === $post->post_type ) {
 			$type_terms = get_the_terms( $post, 'wp_template_part_area' );
 			if ( ! is_wp_error( $type_terms ) && false !== $type_terms ) {


### PR DESCRIPTION
Ensure the Added By template column value is user friendly for modified WooCommerce block templates.

### Screenshots

Before:

![Screenshot 2021-12-20 at 14 17 35](https://user-images.githubusercontent.com/8639742/146781091-1fb8e392-6e69-43e6-a1a6-f9a94cf0481d.png)

After:

![Screenshot 2021-12-20 at 14 16 56](https://user-images.githubusercontent.com/8639742/146781012-aaec4e1b-1453-4f3a-93d3-2edae28c50ca.png)

### Testing

### Manual Testing

How to test the changes in this Pull Request:

1. Modify one of the WooCommerce block templates via the Site Editor. Save it.
2. Load the templates screen and ensure the Added By column value says `WooCommerce` and not `woocommerce`
3. Ensure the modified version of the template loads in the Site Editor and on the frontend.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
* [ ] See steps below.

1.
2.
3.

### Changelog

> Added By template column value is user friendly for modified WooCommerce block templates.
