### PR TITLE
Fix: Mini Cart: Default content for empty state

### DIFF
--- a/assets/js/blocks/cart-checkout/mini-cart-contents/editor.scss
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/editor.scss
@@ -1,6 +1,8 @@
 .wp-block-woocommerce-mini-cart-contents {
 	max-width: 480px;
-	margin: 0 auto;
+	/* We need to override the margin top here to simulate the layout of
+	the mini cart contents on the front end. */
+	margin: 0 auto !important;
 }
 
 .wp-block-woocommerce-filled-mini-cart-contents-block {

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/editor.scss
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/editor.scss
@@ -1,13 +1,13 @@
 .wp-block-woocommerce-mini-cart-contents {
 	max-width: 480px;
-	margin: 0 auto;
+	margin: 0 auto !important;
 }
 
 .wp-block-woocommerce-filled-mini-cart-contents-block {
 	.block-editor-block-list__layout {
 		display: flex;
 		flex-direction: column;
-		min-height: calc(100vh - 2 * $gap-largest);
+		min-height: 100vh;
 	}
 }
 

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/editor.scss
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/editor.scss
@@ -1,6 +1,6 @@
 .wp-block-woocommerce-mini-cart-contents {
 	max-width: 480px;
-	margin: 0 auto !important;
+	margin: 0 auto;
 }
 
 .wp-block-woocommerce-filled-mini-cart-contents-block {

--- a/assets/js/blocks/cart-checkout/mini-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/mini-cart/style.scss
@@ -66,9 +66,8 @@
 
 	.wc-block-mini-cart__items {
 		flex-grow: 1;
-		margin-right: -$gap;
 		overflow-y: auto;
-		padding-right: $gap;
+		padding: 0 $gap;
 
 		.wc-block-cart-items__row:last-child::after {
 			content: none;
@@ -83,21 +82,18 @@
 	display: flex;
 	flex-direction: column;
 	height: 100vh;
-	padding: $gap-largest $gap;
+	padding: 0;
+	justify-content: center;
 }
 
 .wc-block-mini-cart__title {
 	@include font-size(large);
-	margin-top: 0;
+	margin: $gap-largest $gap 0;
 }
 
 .wc-block-mini-cart__footer {
 	border-top: 1px solid $gray-300;
-	margin-bottom: -$gap-largest;
-	margin-left: -$gap;
-	margin-right: -$gap;
-	padding: $gap-large;
-
+	padding: $gap-large $gap;
 }
 
 .wc-block-components-totals-item.wc-block-mini-cart__footer-subtotal {

--- a/templates/block-template-parts/mini-cart.html
+++ b/templates/block-template-parts/mini-cart.html
@@ -10,9 +10,21 @@
 
 	<!-- wp:woocommerce/empty-mini-cart-contents-block -->
 	<div class="wp-block-woocommerce-empty-mini-cart-contents-block">
-		<!-- wp:heading -->
-		<h2 id="empty-mini-cart-content">Empty mini cart content</h2>
-		<!-- /wp:heading -->
+		<!-- wp:paragraph {"align":"center"} -->
+		<p class="has-text-align-center">
+			<strong>Your cart is currently empty!</strong>
+		</p>
+		<!-- /wp:paragraph -->
+
+		<!-- wp:buttons -->
+		<div class="wp-block-buttons">
+			<!-- wp:button {"align":"center","className":"is-style-outline"} -->
+			<div class="wp-block-button aligncenter is-style-outline">
+				<a href="/" class="wp-block-button__link">Start shopping</a>
+			</div>
+			<!-- /wp:button -->
+		</div>
+		<!-- /wp:buttons -->
 	</div>
 	<!-- /wp:woocommerce/empty-mini-cart-contents-block -->
 </div>


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #5377 

This PR updates the default empty view of the Mini Cart Contents blocks and fixes some minor styling issues.

### Screenshots

![image](https://user-images.githubusercontent.com/5423135/146782513-158d5c64-06bb-4346-828e-e5169a2c2a06.png)

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### Testing

### Manual Testing

How to test the changes in this Pull Request:

1. Make sure the active block theme doesn't have a `mini-cart` template part.
2. Delete all customizations of the Mini Cart template part.
3. On the front-end, remove all products from the cart.
4. Open the Mini Cart, see the empty view that matches with the screenshot above.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
* [ ] See steps below.