### PR TITLE
Fix `You attempted to edit an item that doesn't exist` error on WordPress 5.8

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -92,9 +92,10 @@ class BlockTemplatesController {
 
 		// Check if the theme has a saved version of this template before falling back to the woo one. Please note how
 		// the slug has not been modified at this point, we're still using the default one passed to this hook.
-		$maybe_template = function_exists( 'get_block_template' ) ?
-			get_block_template( $id, $template_type ) :
-			gutenberg_get_block_template( $id, $template_type );
+		$maybe_template = function_exists( 'gutenberg_get_block_template' ) ?
+			gutenberg_get_block_template( $id, $template_type ) :
+			get_block_template( $id, $template_type );
+
 		if ( null !== $maybe_template ) {
 			add_filter( 'pre_get_block_file_template', array( $this, 'maybe_return_blocks_template' ), 10, 3 );
 			return $maybe_template;
@@ -103,9 +104,9 @@ class BlockTemplatesController {
 		// Theme-based template didn't exist, try switching the theme to woocommerce and try again. This function has
 		// been unhooked so won't run again.
 		add_filter( 'get_block_file_template', array( $this, 'get_single_block_template' ), 10, 3 );
-		$maybe_template = function_exists( 'get_block_template' ) ?
-			get_block_template( 'woocommerce//' . $slug, $template_type ) :
-			gutenberg_get_block_template( 'woocommerce//' . $slug, $template_type );
+		$maybe_template = function_exists( 'gutenberg_get_block_template' ) ?
+			gutenberg_get_block_template( 'woocommerce//' . $slug, $template_type ) :
+			get_block_template( 'woocommerce//' . $slug, $template_type );
 
 		// Re-hook this function, it was only unhooked to stop recursion.
 		add_filter( 'pre_get_block_file_template', array( $this, 'maybe_return_blocks_template' ), 10, 3 );


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4463174/146914469-40a94ae0-db29-4829-b98a-b0b8a8952d30.png)

This PR fixes the error `You attempted to edit an item that doesn't exist. Perhaps it was deleted?` on WordPress 5.8 when the user wants to edit a template.

### Manual Testing

How to test the changes in this Pull Request:

Check out this branch. We need to test this PR on WordPress 5.8 and WordPress 5.9 to be sure that we are not introducing any regression.

## WordPress 5.8

Be sure that you are using a block theme and you have installed WooCommerce and Gutenberg plugins.

1. Open the FSE editor
2. From the sidebar on the left click on `Templates`.
3. Click on one of these templates `Product Category Page`, `Product Archive Page`, `Product Archive Page` or `Single Product Page`.
4. Edit the template and save it.
5. Go back (not refresh the page, because you will reproduce a knowledge bug #5426).
6. Reopen the same template and check if the changes are still there.
7. Check if the template works correctly on the frontend side too.

## WordPress 5.9 - without GB

Be sure that you are using a block theme and you have installed WooCommerce WITHOUT GB plugin.

1. Open the FSE editor
2. From the sidebar on the left click on `Templates`.
3. Click on one of these templates `Product Category Page`, `Product Archive Page`, `Product Archive Page` or `Single Product Page`.
4. Edit the template and save it.
5. Go back (not refresh the page, because you will reproduce a knowledge bug #5426).
6. Reopen the same template and check if the changes are still there.
7. Check if the template works correctly on the frontend side too.

## WordPress 5.9 - with GB

Be sure that you are using a block theme and you have installed WooCommerce and Gutenberg plugins.

1. Open the FSE editor
2. From the sidebar on the left click on `Templates`.
3. Click on one of these templates `Product Category Page`, `Product Archive Page`, `Product Archive Page` or `Single Product Page`.
4. Edit the template and save it.
5. Go back (not refresh the page, because you will reproduce a knowledge bug #5426).
6. Reopen the same template and check if the changes are still there.
7. Check if the template works correctly on FE side too.

### Changelog

> Fixed error reporting block templates do not exist after editing WooCommerce templates on WP 5.8
