### PR TITLE
Revert "Remove extra padding for cart sidebar to fix visual regression bug"

### DIFF
--- a/assets/js/blocks/cart-checkout/cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/style.scss
@@ -238,6 +238,13 @@ table.wc-block-cart-items {
 		}
 	}
 
+	.wc-block-cart__sidebar {
+		& > div:not(.wc-block-components-totals-wrapper) {
+			margin-left: $gap;
+			margin-right: $gap;
+		}
+	}
+
 	.wc-block-components-radio-control__input {
 		left: 0;
 	}


### PR DESCRIPTION
Reverts woocommerce/woocommerce-gutenberg-products-block#5247

When reading the initial PR the comments containing further discussion didn't load so I didn't see there was a conversation ongoing. I was over zealous with the merge button!