### PR TITLE
Update testing instructions for missing PRs in 6.6.0

### DIFF
--- a/docs/testing/releases/660.md
+++ b/docs/testing/releases/660.md
@@ -110,3 +110,39 @@ This requires Stripe and a saved payment method.
 2. Verify that both the Cart, the Filled Cart and the Empty Cart only show the alignment options None and Wide width.
 3. Create a test page with the checkout block.
 4. Verify that only the alignment options None and Wide width are available.
+
+### Fix saving WooCommerce templates in WP 5.9 beta 3 ([5408](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5408))
+
+1. With WP 5.9 beta 3 and Gutenberg disabled, go to Appearance > Editor.
+2. Edit one of the WooCommerce templates and try to save it.
+3. Verify the template is saved without errors.
+4. Repeat the process with Gutenberg enabled and verify it works as well.
+
+### Fix required scripts not loading for WC block templates. ([5346](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5346))
+
+1. Install a Block Theme such as [TT1](https://en-gb.wordpress.org/themes/tt1-blocks/) and the [Gutenberg plugin](https://wordpress.org/plugins/gutenberg/).
+2. Load the product page of a variable product.
+3. Change some of the options (such as colour) on the variable product and check that the image in the product gallery updates to show the correct image for that variant.
+4. Clicking "Add to cart" should successfully add the product to the cart.
+
+### Fix reverting WC templates. ([5342](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5342))
+
+1. With WC 6.0 or later, Gutenberg and a block theme installed, go to Appearance > Editor.
+2. Go to the Templates page and edit one of the WooCommerce templates (ie: Single Product Page).
+3. In the frontend, verify the changes you just saved are applied.
+4. Go back to the Templates page and press on _Clear Customizations_ of the template you just edited.
+5. Verify there is no error and the changes have been reverted in the frontend.
+6. Repeat the steps above with WP 5.9 beta without Gutenberg enabled.
+
+### Fix WC templates loading for WP 5.9 without Gutenberg plugin. ([5335](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5335))
+
+1. Make sure you have WP 5.9 or above.
+2. Install a Block Theme such as [TT1](https://en-gb.wordpress.org/themes/tt1-blocks/).
+3. Make sure you can load the list of Block Templates in the Appearance > Site Editor
+
+### Make it so WooCommerce template names are not editable ([5385](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5385))
+
+1. With WC 6.0 beta 3 and a block theme installed, go to Appearance > Editor.
+2. Go to the Templates page and edit one of the WooCommerce templates (ie: Single Product Page).
+3. Save and refresh the page.
+4. Verify the template name is not editable.

--- a/readme.txt
+++ b/readme.txt
@@ -97,6 +97,11 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 - Fixed a case where payments could fail after validation errors when using saved cards. ([5350](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5350))
 - Add error handling for network errors during checkout. ([5341](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5341))
 - Fix cart and checkout margin problem by removing the full-width option. ([5315](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5315))
+- Fix saving WooCommerce templates in WP 5.9 beta 3 ([5408](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5408))
+- Fix You attempted to edit an item that doesn't exist error on WordPress 5.8 ([5425](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5425))
+- Fix required scripts not loading for WC block templates. ([5346](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5346))
+- Fix reverting WC templates. ([5342](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5342))
+- Fix WC templates loading for WP 5.9 without Gutenberg plugin. ([5335](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5335))
 
 #### Various
 
@@ -106,6 +111,8 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 - Fix validation error handling after using browser autofill. ([5373](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5373))
 - Update loading skeleton animations. ([5362](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5362))
 - Add error handling to `get_routes_from_namespace` method. ([5319](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5319))
+- Make it so WooCommerce template names are not editable ([5385](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5385))
+
 
 = 6.5.0 - 2021-12-06 =
 


### PR DESCRIPTION
Added the missing PRs from release 6.6.0 to the testing notes and readme changelog.