### PR TITLE
Remove “Page” suffix from template titles

### DIFF
--- a/src/Utils/BlockTemplateUtils.php
+++ b/src/Utils/BlockTemplateUtils.php
@@ -216,13 +216,13 @@ class BlockTemplateUtils {
 	public static function convert_slug_to_title( $template_slug ) {
 		switch ( $template_slug ) {
 			case 'single-product':
-				return __( 'Single Product Page', 'woo-gutenberg-products-block' );
+				return __( 'Single Product', 'woo-gutenberg-products-block' );
 			case 'archive-product':
-				return __( 'Product Archive Page', 'woo-gutenberg-products-block' );
+				return __( 'Product Archive', 'woo-gutenberg-products-block' );
 			case 'taxonomy-product_cat':
-				return __( 'Product Category Page', 'woo-gutenberg-products-block' );
+				return __( 'Product Category', 'woo-gutenberg-products-block' );
 			case 'taxonomy-product_tag':
-				return __( 'Product Tag Page', 'woo-gutenberg-products-block' );
+				return __( 'Product Tag', 'woo-gutenberg-products-block' );
 			default:
 				// Replace all hyphens and underscores with spaces.
 				return ucwords( preg_replace( '/[\-_]/', ' ', $template_slug ) );


### PR DESCRIPTION
Removes the “Page” suffix from WooCommerce templates.

Fixes #5280


### Screenshots

Before:

![144097099-33106abd-ce98-49c4-a301-a057ffa15673](https://user-images.githubusercontent.com/1847066/147007820-f15472b5-cf38-4622-a6db-4e789cd68b78.png)

After:

<img width="962" alt="Screen Shot 2021-12-21 at 23 51 28" src="https://user-images.githubusercontent.com/1847066/147007837-164d19e1-a6ad-4626-bd25-121ac5e92b3b.png">

### Manual Testing

How to test the changes in this Pull Request:

1. Go to Appearence > Editor
2. Select “Browse all templates” from the dropdown menu
3. Verify that the suffix is gone

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above

### Changelog
> Remove the “Page” suffix from template titles