### PR TITLE
Experiment: Add available_payment_methods to the API and cart data

### DIFF
--- a/assets/js/base/context/hooks/cart/use-store-cart.ts
+++ b/assets/js/base/context/hooks/cart/use-store-cart.ts
@@ -14,6 +14,7 @@ import {
 	EMPTY_CART_ERRORS,
 	EMPTY_SHIPPING_RATES,
 	EMPTY_TAX_LINES,
+	EMPTY_PAYMENT_METHODS,
 	EMPTY_PAYMENT_REQUIREMENTS,
 	EMPTY_EXTENSIONS,
 } from '@woocommerce/block-data';
@@ -113,6 +114,7 @@ export const defaultCartData: StoreCart = {
 	shippingRates: EMPTY_SHIPPING_RATES,
 	shippingRatesLoading: false,
 	cartHasCalculatedShipping: false,
+	availablePaymentMethods: EMPTY_PAYMENT_METHODS,
 	paymentRequirements: EMPTY_PAYMENT_REQUIREMENTS,
 	receiveCart: () => undefined,
 	extensions: EMPTY_EXTENSIONS,
@@ -169,6 +171,8 @@ export const useStoreCart = (
 					shippingRatesLoading: false,
 					cartHasCalculatedShipping:
 						previewCart.has_calculated_shipping,
+					availablePaymentMethods:
+						previewCart.availablePaymentMethods,
 					paymentRequirements: previewCart.paymentRequirements,
 					receiveCart:
 						typeof previewCart?.receiveCart === 'function'
@@ -229,6 +233,7 @@ export const useStoreCart = (
 				shippingRates: cartData.shippingRates,
 				shippingRatesLoading,
 				cartHasCalculatedShipping: cartData.hasCalculatedShipping,
+				availablePaymentMethods: cartData.availablePaymentMethods,
 				paymentRequirements: cartData.paymentRequirements,
 				receiveCart,
 			};

--- a/assets/js/data/constants.ts
+++ b/assets/js/data/constants.ts
@@ -11,6 +11,7 @@ export const EMPTY_CART_FEES: [  ] = [];
 export const EMPTY_CART_ITEM_ERRORS: [  ] = [];
 export const EMPTY_CART_ERRORS: [  ] = [];
 export const EMPTY_SHIPPING_RATES: [  ] = [];
+export const EMPTY_PAYMENT_METHODS: [  ] = [];
 export const EMPTY_PAYMENT_REQUIREMENTS: [  ] = [];
 export const EMPTY_EXTENSIONS: Record< string, unknown > = {};
 export const EMPTY_TAX_LINES: [  ] = [];

--- a/assets/js/payment-method-extensions/payment-methods/bacs/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/bacs/index.js
@@ -11,6 +11,8 @@ import { decodeEntities } from '@wordpress/html-entities';
  */
 import { PAYMENT_METHOD_NAME } from './constants';
 
+/** @typedef { import('@woocommerce/type-defs/hooks').StoreCart } StoreCart */
+
 const settings = getSetting( 'bacs_data', {} );
 const defaultLabel = __(
 	'Direct bank transfer',
@@ -36,6 +38,18 @@ const Label = ( props ) => {
 };
 
 /**
+ * Determine whether the gateway is available for this cart/order.
+ *
+ * @param {Object} props Incoming props for the component.
+ * @param {StoreCart} props.cart Cart Object.
+ *
+ * @return {boolean}  True if payment method should be displayed as a payment option.
+ */
+const canMakePayment = ( { cart } ) => {
+	return cart.availablePaymentMethods.includes( 'bacs' );
+};
+
+/**
  * Bank transfer (BACS) payment method config object.
  */
 const bankTransferPaymentMethod = {
@@ -43,7 +57,7 @@ const bankTransferPaymentMethod = {
 	label: <Label />,
 	content: <Content />,
 	edit: <Content />,
-	canMakePayment: () => true,
+	canMakePayment,
 	ariaLabel: label,
 	supports: {
 		features: settings?.supports ?? [],

--- a/assets/js/payment-method-extensions/payment-methods/cheque/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/cheque/index.js
@@ -11,6 +11,8 @@ import { decodeEntities } from '@wordpress/html-entities';
  */
 import { PAYMENT_METHOD_NAME } from './constants';
 
+/** @typedef { import('@woocommerce/type-defs/hooks').StoreCart } StoreCart */
+
 const settings = getSetting( 'cheque_data', {} );
 const defaultLabel = __( 'Check payment', 'woo-gutenberg-products-block' );
 const label = decodeEntities( settings.title ) || defaultLabel;
@@ -33,6 +35,18 @@ const Label = ( props ) => {
 };
 
 /**
+ * Determine whether the gateway is available for this cart/order.
+ *
+ * @param {Object} props Incoming props for the component.
+ * @param {StoreCart} props.cart Cart Object.
+ *
+ * @return {boolean}  True if payment method should be displayed as a payment option.
+ */
+const canMakePayment = ( { cart } ) => {
+	return cart.availablePaymentMethods.includes( 'cheque' );
+};
+
+/**
  * Cheque payment method config object.
  */
 const offlineChequePaymentMethod = {
@@ -40,7 +54,7 @@ const offlineChequePaymentMethod = {
 	label: <Label />,
 	content: <Content />,
 	edit: <Content />,
-	canMakePayment: () => true,
+	canMakePayment,
 	ariaLabel: label,
 	supports: {
 		features: settings?.supports ?? [],

--- a/assets/js/payment-method-extensions/payment-methods/cod/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/cod/index.js
@@ -11,6 +11,8 @@ import { decodeEntities } from '@wordpress/html-entities';
  */
 import { PAYMENT_METHOD_NAME } from './constants';
 
+/** @typedef { import('@woocommerce/type-defs/hooks').StoreCart } StoreCart */
+
 const settings = getSetting( 'cod_data', {} );
 const defaultLabel = __( 'Cash on delivery', 'woo-gutenberg-products-block' );
 const label = decodeEntities( settings.title ) || defaultLabel;
@@ -36,12 +38,17 @@ const Label = ( props ) => {
  * Determine whether COD is available for this cart/order.
  *
  * @param {Object} props Incoming props for the component.
+ * @param {StoreCart} props.cart Cart Object.
  * @param {boolean} props.cartNeedsShipping True if the cart contains any physical/shippable products.
  * @param {boolean} props.selectedShippingMethods
  *
  * @return {boolean}  True if COD payment method should be displayed as a payment option.
  */
-const canMakePayment = ( { cartNeedsShipping, selectedShippingMethods } ) => {
+const canMakePayment = ( {
+	cart,
+	cartNeedsShipping,
+	selectedShippingMethods,
+} ) => {
 	if ( ! settings.enableForVirtual && ! cartNeedsShipping ) {
 		// Store doesn't allow COD for virtual orders AND
 		// order doesn't contain any shippable products.
@@ -51,6 +58,12 @@ const canMakePayment = ( { cartNeedsShipping, selectedShippingMethods } ) => {
 	if ( ! settings.enableForShippingMethods.length ) {
 		// Store does not limit COD to specific shipping methods.
 		return true;
+	}
+
+	const available = cart.availablePaymentMethods.includes( 'cod' );
+
+	if ( ! available ) {
+		return false;
 	}
 
 	// Look for a supported shipping method in the user's selected

--- a/assets/js/payment-method-extensions/payment-methods/paypal/index.js
+++ b/assets/js/payment-method-extensions/payment-methods/paypal/index.js
@@ -11,6 +11,8 @@ import { decodeEntities } from '@wordpress/html-entities';
  */
 import { PAYMENT_METHOD_NAME } from './constants';
 
+/** @typedef { import('@woocommerce/type-defs/hooks').StoreCart } StoreCart */
+
 const settings = getSetting( 'paypal_data', {} );
 
 /**
@@ -18,6 +20,18 @@ const settings = getSetting( 'paypal_data', {} );
  */
 const Content = () => {
 	return decodeEntities( settings.description || '' );
+};
+
+/**
+ * Determine whether the gateway is available for this cart/order.
+ *
+ * @param {Object} props Incoming props for the component.
+ * @param {StoreCart} props.cart Cart Object.
+ *
+ * @return {boolean}  True if payment method should be displayed as a payment option.
+ */
+const canMakePayment = ( { cart } ) => {
+	return cart.availablePaymentMethods.includes( 'paypal' );
 };
 
 const paypalPaymentMethod = {
@@ -36,7 +50,7 @@ const paypalPaymentMethod = {
 	),
 	content: <Content />,
 	edit: <Content />,
-	canMakePayment: () => true,
+	canMakePayment,
 	ariaLabel: decodeEntities(
 		settings.title ||
 			__( 'Payment via PayPal', 'woo-gutenberg-products-block' )

--- a/assets/js/previews/cart.ts
+++ b/assets/js/previews/cart.ts
@@ -230,6 +230,7 @@ export const previewCart: CartResponse = {
 		],
 	},
 	errors: [],
+	available_payment_methods: [],
 	payment_requirements: [ 'products' ],
 	extensions: {},
 };

--- a/assets/js/types/type-defs/hooks.ts
+++ b/assets/js/types/type-defs/hooks.ts
@@ -49,6 +49,7 @@ export interface StoreCart {
 	extensions: Record< string, unknown >;
 	shippingRatesLoading: boolean;
 	cartHasCalculatedShipping: boolean;
+	availablePaymentMethods: Array< string >;
 	paymentRequirements: Array< string >;
 	receiveCart: ( cart: CartResponse ) => void;
 }

--- a/src/StoreApi/Schemas/CartSchema.php
+++ b/src/StoreApi/Schemas/CartSchema.php
@@ -116,7 +116,7 @@ class CartSchema extends AbstractSchema {
 	 */
 	public function get_properties() {
 		return [
-			'coupons'                 => [
+			'coupons'                   => [
 				'description' => __( 'List of applied cart coupons.', 'woo-gutenberg-products-block' ),
 				'type'        => 'array',
 				'context'     => [ 'view', 'edit' ],
@@ -126,7 +126,7 @@ class CartSchema extends AbstractSchema {
 					'properties' => $this->force_schema_readonly( $this->coupon_schema->get_properties() ),
 				],
 			],
-			'shipping_rates'          => [
+			'shipping_rates'            => [
 				'description' => __( 'List of available shipping rates for the cart.', 'woo-gutenberg-products-block' ),
 				'type'        => 'array',
 				'context'     => [ 'view', 'edit' ],
@@ -136,21 +136,21 @@ class CartSchema extends AbstractSchema {
 					'properties' => $this->force_schema_readonly( $this->shipping_rate_schema->get_properties() ),
 				],
 			],
-			'shipping_address'        => [
+			'shipping_address'          => [
 				'description' => __( 'Current set shipping address for the customer.', 'woo-gutenberg-products-block' ),
 				'type'        => 'object',
 				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
 				'properties'  => $this->force_schema_readonly( $this->shipping_address_schema->get_properties() ),
 			],
-			'billing_address'         => [
+			'billing_address'           => [
 				'description' => __( 'Current set billing address for the customer.', 'woo-gutenberg-products-block' ),
 				'type'        => 'object',
 				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
 				'properties'  => $this->force_schema_readonly( $this->billing_address_schema->get_properties() ),
 			],
-			'items'                   => [
+			'items'                     => [
 				'description' => __( 'List of cart items.', 'woo-gutenberg-products-block' ),
 				'type'        => 'array',
 				'context'     => [ 'view', 'edit' ],
@@ -160,37 +160,37 @@ class CartSchema extends AbstractSchema {
 					'properties' => $this->force_schema_readonly( $this->item_schema->get_properties() ),
 				],
 			],
-			'items_count'             => [
+			'items_count'               => [
 				'description' => __( 'Number of items in the cart.', 'woo-gutenberg-products-block' ),
 				'type'        => 'integer',
 				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
 			],
-			'items_weight'            => [
+			'items_weight'              => [
 				'description' => __( 'Total weight (in grams) of all products in the cart.', 'woo-gutenberg-products-block' ),
 				'type'        => 'number',
 				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
 			],
-			'needs_payment'           => [
+			'needs_payment'             => [
 				'description' => __( 'True if the cart needs payment. False for carts with only free products and no shipping costs.', 'woo-gutenberg-products-block' ),
 				'type'        => 'boolean',
 				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
 			],
-			'needs_shipping'          => [
+			'needs_shipping'            => [
 				'description' => __( 'True if the cart needs shipping. False for carts with only digital goods or stores with no shipping methods set-up.', 'woo-gutenberg-products-block' ),
 				'type'        => 'boolean',
 				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
 			],
-			'has_calculated_shipping' => [
+			'has_calculated_shipping'   => [
 				'description' => __( 'True if the cart meets the criteria for showing shipping costs, and rates have been calculated and included in the totals.', 'woo-gutenberg-products-block' ),
 				'type'        => 'boolean',
 				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
 			],
-			'fees'                    => [
+			'fees'                      => [
 				'description' => __( 'List of cart fees.', 'woo-gutenberg-products-block' ),
 				'type'        => 'array',
 				'context'     => [ 'view', 'edit' ],
@@ -200,7 +200,7 @@ class CartSchema extends AbstractSchema {
 					'properties' => $this->force_schema_readonly( $this->fee_schema->get_properties() ),
 				],
 			],
-			'totals'                  => [
+			'totals'                    => [
 				'description' => __( 'Cart total amounts provided using the smallest unit of the currency.', 'woo-gutenberg-products-block' ),
 				'type'        => 'object',
 				'context'     => [ 'view', 'edit' ],
@@ -300,7 +300,7 @@ class CartSchema extends AbstractSchema {
 					]
 				),
 			],
-			'errors'                  => [
+			'errors'                    => [
 				'description' => __( 'List of cart item errors, for example, items in the cart which are out of stock.', 'woo-gutenberg-products-block' ),
 				'type'        => 'array',
 				'context'     => [ 'view', 'edit' ],
@@ -310,13 +310,19 @@ class CartSchema extends AbstractSchema {
 					'properties' => $this->force_schema_readonly( $this->error_schema->get_properties() ),
 				],
 			],
-			'payment_requirements'    => [
+			'available_payment_methods' => [
+				'description' => __( 'List of available payment gateways that can be used to process the order.', 'woo-gutenberg-products-block' ),
+				'type'        => 'array',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
+			'payment_requirements'      => [
 				'description' => __( 'List of required payment gateway features to process the order.', 'woo-gutenberg-products-block' ),
 				'type'        => 'array',
 				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
 			],
-			self::EXTENDING_KEY       => $this->get_extended_schema( self::IDENTIFIER ),
+			self::EXTENDING_KEY         => $this->get_extended_schema( self::IDENTIFIER ),
 		];
 	}
 
@@ -341,18 +347,18 @@ class CartSchema extends AbstractSchema {
 		$shipping_packages = $has_calculated_shipping ? $controller->get_shipping_packages() : [];
 
 		return [
-			'coupons'                 => $this->get_item_responses_from_schema( $this->coupon_schema, $cart->get_applied_coupons() ),
-			'shipping_rates'          => $this->get_item_responses_from_schema( $this->shipping_rate_schema, $shipping_packages ),
-			'shipping_address'        => $this->shipping_address_schema->get_item_response( wc()->customer ),
-			'billing_address'         => $this->billing_address_schema->get_item_response( wc()->customer ),
-			'items'                   => $this->get_item_responses_from_schema( $this->item_schema, $cart->get_cart() ),
-			'items_count'             => $cart->get_cart_contents_count(),
-			'items_weight'            => wc_get_weight( $cart->get_cart_contents_weight(), 'g' ),
-			'needs_payment'           => $cart->needs_payment(),
-			'needs_shipping'          => $cart->needs_shipping(),
-			'has_calculated_shipping' => $has_calculated_shipping,
-			'fees'                    => $this->get_item_responses_from_schema( $this->fee_schema, $cart->get_fees() ),
-			'totals'                  => (object) $this->prepare_currency_response(
+			'coupons'                   => $this->get_item_responses_from_schema( $this->coupon_schema, $cart->get_applied_coupons() ),
+			'shipping_rates'            => $this->get_item_responses_from_schema( $this->shipping_rate_schema, $shipping_packages ),
+			'shipping_address'          => $this->shipping_address_schema->get_item_response( wc()->customer ),
+			'billing_address'           => $this->billing_address_schema->get_item_response( wc()->customer ),
+			'items'                     => $this->get_item_responses_from_schema( $this->item_schema, $cart->get_cart() ),
+			'items_count'               => $cart->get_cart_contents_count(),
+			'items_weight'              => wc_get_weight( $cart->get_cart_contents_weight(), 'g' ),
+			'needs_payment'             => $cart->needs_payment(),
+			'needs_shipping'            => $cart->needs_shipping(),
+			'has_calculated_shipping'   => $has_calculated_shipping,
+			'fees'                      => $this->get_item_responses_from_schema( $this->fee_schema, $cart->get_fees() ),
+			'totals'                    => (object) $this->prepare_currency_response(
 				[
 					'total_items'        => $this->prepare_money_response( $cart->get_subtotal(), wc_get_price_decimals() ),
 					'total_items_tax'    => $this->prepare_money_response( $cart->get_subtotal_tax(), wc_get_price_decimals() ),
@@ -369,9 +375,10 @@ class CartSchema extends AbstractSchema {
 					'tax_lines'          => $this->get_tax_lines( $cart ),
 				]
 			),
-			'errors'                  => $cart_errors,
-			'payment_requirements'    => $this->extend->get_payment_requirements(),
-			self::EXTENDING_KEY       => $this->get_extended_data( self::IDENTIFIER ),
+			'errors'                    => $cart_errors,
+			'available_payment_methods' => array_keys( WC()->payment_gateways->get_available_payment_gateways() ),
+			'payment_requirements'      => $this->extend->get_payment_requirements(),
+			self::EXTENDING_KEY         => $this->get_extended_data( self::IDENTIFIER ),
 		];
 	}
 


### PR DESCRIPTION
This attempts to solve the problem in #5388 by adding `available_payment_methods` to the cart response data with the current list of available payment method IDs.

Payment methods are registered if `enabled` in settings. This enqueues the scripts for Blocks. 

This script is not aware of the `woocommerce_available_payment_gateways` filter, so to handle this we need to check if a method is available via its `canMakePayment` callback. 

So `canMakePayment` knows which methods are available, I've updated the cart data to include a list of available payment method IDs which are surfaced to gateways.

### Testing

Use a snippet like this:

```
add_filter(
	'woocommerce_available_payment_gateways',
	function( $methods ) {
		if ( wc()->cart->get_total( 'edit' ) < 100 ) {
			unset( $methods['bacs'] );
		}
		return $methods;
	}
);
```

Make a free shipping and flat rate shipping method costing $50. Add $60 of items to the cart. Toggle between free shipping and flat rate shipping so the totals change. BACS should only be available when free shipping is checked.