### PR TITLE
Don't show shipping price when no options are available

### DIFF
--- a/assets/js/base/components/cart-checkout/totals/shipping/index.tsx
+++ b/assets/js/base/components/cart-checkout/totals/shipping/index.tsx
@@ -90,10 +90,15 @@ const NoShippingPlaceholder = ( {
 	if ( ! showCalculator ) {
 		return (
 			<em>
-				{ __(
-					'Calculated during checkout',
-					'woo-gutenberg-products-block'
-				) }
+				{ isCheckout
+					? __(
+							'No shipping options available',
+							'woo-gutenberg-products-block'
+					  )
+					: __(
+							'Calculated during checkout',
+							'woo-gutenberg-products-block'
+					  ) }
 			</em>
 		);
 	}

--- a/assets/js/base/components/cart-checkout/totals/shipping/index.tsx
+++ b/assets/js/base/components/cart-checkout/totals/shipping/index.tsx
@@ -77,6 +77,7 @@ const ShippingAddress = ( {
 interface NoShippingPlaceholderProps {
 	showCalculator: boolean;
 	isShippingCalculatorOpen: boolean;
+	isCheckout?: boolean;
 	setIsShippingCalculatorOpen: CalculatorButtonProps[ 'setIsShippingCalculatorOpen' ];
 }
 
@@ -84,6 +85,7 @@ const NoShippingPlaceholder = ( {
 	showCalculator,
 	isShippingCalculatorOpen,
 	setIsShippingCalculatorOpen,
+	isCheckout = false,
 }: NoShippingPlaceholderProps ): ReactElement => {
 	if ( ! showCalculator ) {
 		return (
@@ -113,6 +115,7 @@ export interface TotalShippingProps {
 	showCalculator?: boolean; //Whether to display the rate selector below the shipping total.
 	showRateSelector?: boolean; // Whether to show shipping calculator or not.
 	className?: string;
+	isCheckout?: boolean;
 }
 
 export const TotalsShipping = ( {
@@ -120,6 +123,7 @@ export const TotalsShipping = ( {
 	values,
 	showCalculator = true,
 	showRateSelector = true,
+	isCheckout = false,
 	className,
 }: TotalShippingProps ): ReactElement => {
 	const [ isShippingCalculatorOpen, setIsShippingCalculatorOpen ] = useState(

--- a/assets/js/base/components/cart-checkout/totals/shipping/index.tsx
+++ b/assets/js/base/components/cart-checkout/totals/shipping/index.tsx
@@ -167,32 +167,29 @@ export const TotalsShipping = ( {
 			<TotalsItem
 				label={ __( 'Shipping', 'woo-gutenberg-products-block' ) }
 				value={
-					cartHasCalculatedShipping ? (
+					hasRates && cartHasCalculatedShipping ? (
 						totalShippingValue
 					) : (
 						<NoShippingPlaceholder
 							showCalculator={ showCalculator }
+							isCheckout={ isCheckout }
 							{ ...calculatorButtonProps }
 						/>
 					)
 				}
 				description={
-					<>
-						{ cartHasCalculatedShipping && (
-							<>
-								<ShippingVia
-									selectedShippingRates={
-										selectedShippingRates
-									}
-								/>
-								<ShippingAddress
-									shippingAddress={ shippingAddress }
-									showCalculator={ showCalculator }
-									{ ...calculatorButtonProps }
-								/>
-							</>
-						) }
-					</>
+					hasRates && cartHasCalculatedShipping ? (
+						<>
+							<ShippingVia
+								selectedShippingRates={ selectedShippingRates }
+							/>
+							<ShippingAddress
+								shippingAddress={ shippingAddress }
+								showCalculator={ showCalculator }
+								{ ...calculatorButtonProps }
+							/>
+						</>
+					) : null
 				}
 				currency={ currency }
 			/>

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-order-summary-block/block.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-order-summary-block/block.tsx
@@ -84,6 +84,7 @@ const Block = ( {
 			{ needsShipping && (
 				<TotalsWrapper>
 					<TotalsShipping
+						isCheckout={ true }
 						showCalculator={ false }
 						showRateSelector={ false }
 						values={ cartTotals }


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR will add a prop called `isCheckout` to the `NoShippingPlaceholder` and `TotalsShipping` components. This will allow us to determine whether the component is being rendered as part of the Checkout block or the Cart block.

It also adds a check to the `TotalsShipping` component to check if there are any rates available for the order. If there are no rates then the price should not be displayed.

Following the change to hide the price if there are no rates, the component would show `Calculated at checkout` if no rates were available which is confusing when the customer is actually on the Checkout block. Instead I added a new error message to be shown instead.

<!-- Reference any related issues or PRs here -->
Fixes #5378

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### Screenshots

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/5656702/147132243-bd42c69c-415b-45d6-9e7f-ebd02e1c0ab9.png) | ![image](https://user-images.githubusercontent.com/5656702/147132055-1efbd023-f99c-4651-bccc-5608ddc7ba7a.png) |

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Go to WooCommerce > Settings > Shipping and remove all shipping methods, including shipping methods for `Locations not covered by your other zones`.
2. Add a shipping zone for a specific country, for example USA.
3. Add some methods to this zone, free shipping and flat rate are fine.
4. Add some items to the cart.
5. Go to the Cart.
6. Check you can still use the shipping calculator.
7. Check that the shipping rates show when using a USA address.
8. Check the error shows when using an address from another country, e.g. UK.
9. Go to the Checkout block.
10. Notice the shipping subtotal does not contain a price if your address is in an invalid country.
11. Change country on the Checkout form.
12. Notice that a shipping price is only shown when the address is in a valid country.
13. Try changing country back and forth and selecting different shipping rates.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above

<!-- If you can, add the appropriate labels -->


### Changelog

> Prevent a 0 value shipping price being shown in the Checkout if no shipping methods are available.