### PR TITLE
Mini Cart Contents block improvements

### DIFF
--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/empty-mini-cart-contents-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/empty-mini-cart-contents-block/edit.tsx
@@ -1,40 +1,39 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
-import { innerBlockAreas } from '@woocommerce/blocks-checkout';
-import type { TemplateArray } from '@wordpress/blocks';
 import { useEditorContext } from '@woocommerce/base-context';
+import { getBlockTypes } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
-import { useForcedLayout, getAllowedBlocks } from '../../../shared';
 
-export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
+const excludedBlocks = [
+	'woocommerce/mini-cart',
+	'core/template-part',
+	'core/post-template',
+	'core/comment-template',
+];
+
+export const Edit = (): JSX.Element => {
 	const blockProps = useBlockProps();
-	const allowedBlocks = getAllowedBlocks( innerBlockAreas.EMPTY_MINI_CART );
 	const { currentView } = useEditorContext();
+	const allowedBlocks = [
+		...getBlockTypes()
+			.filter( ( block ) => {
+				if ( excludedBlocks.includes( block.name ) ) {
+					return false;
+				}
 
-	const defaultTemplate = ( [
-		[
-			'core/heading',
-			{
-				content: __(
-					'Empty mini cart content',
-					'woo-gutenberg-products-block'
-				),
-				level: 2,
-			},
-		],
-	].filter( Boolean ) as unknown ) as TemplateArray;
+				if ( block.parent && block.parent.length > 0 ) {
+					return false;
+				}
 
-	useForcedLayout( {
-		clientId,
-		registeredBlocks: allowedBlocks,
-		defaultTemplate,
-	} );
+				return true;
+			} )
+			.map( ( { name } ) => name ),
+	];
 
 	return (
 		<div
@@ -44,8 +43,7 @@ export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 			}
 		>
 			<InnerBlocks
-				template={ defaultTemplate }
-				templateLock={ false }
+				allowedBlocks={ allowedBlocks }
 				renderAppender={ InnerBlocks.ButtonBlockAppender }
 			/>
 		</div>

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/empty-mini-cart-contents-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/empty-mini-cart-contents-block/edit.tsx
@@ -9,7 +9,7 @@ import { getBlockTypes } from '@wordpress/blocks';
  * Internal dependencies
  */
 
-const excludedBlocks = [
+const EXCLUDED_BLOCKS: readonly string[] = [
 	'woocommerce/mini-cart',
 	'core/template-part',
 	'core/post-template',
@@ -19,21 +19,15 @@ const excludedBlocks = [
 export const Edit = (): JSX.Element => {
 	const blockProps = useBlockProps();
 	const { currentView } = useEditorContext();
-	const allowedBlocks = [
-		...getBlockTypes()
-			.filter( ( block ) => {
-				if ( excludedBlocks.includes( block.name ) ) {
-					return false;
-				}
+	const allowedBlocks = getBlockTypes()
+		.filter( ( block ) => {
+			if ( EXCLUDED_BLOCKS.includes( block.name ) ) {
+				return false;
+			}
 
-				if ( block.parent && block.parent.length > 0 ) {
-					return false;
-				}
-
-				return true;
-			} )
-			.map( ( { name } ) => name ),
-	];
+			return true;
+		} )
+		.map( ( { name } ) => name );
 
 	return (
 		<div

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/empty-mini-cart-contents-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/empty-mini-cart-contents-block/edit.tsx
@@ -11,9 +11,16 @@ import { getBlockTypes } from '@wordpress/blocks';
 
 const EXCLUDED_BLOCKS: readonly string[] = [
 	'woocommerce/mini-cart',
-	'core/template-part',
+	'woocommerce/single-product',
 	'core/post-template',
 	'core/comment-template',
+	'core/query-pagination',
+	'core/comments-query-loop',
+	'core/post-comments-form',
+	'core/post-comments-link',
+	'core/post-comments-count',
+	'core/comments-pagination',
+	'core/post-navigation-link',
 ];
 
 export const Edit = (): JSX.Element => {
@@ -22,6 +29,16 @@ export const Edit = (): JSX.Element => {
 	const allowedBlocks = getBlockTypes()
 		.filter( ( block ) => {
 			if ( EXCLUDED_BLOCKS.includes( block.name ) ) {
+				return false;
+			}
+
+			// Exclude child blocks of EXCLUDED_BLOCKS.
+			if (
+				block.parent &&
+				block.parent.filter( ( value ) =>
+					EXCLUDED_BLOCKS.includes( value )
+				).length > 0
+			) {
 				return false;
 			}
 

--- a/assets/js/blocks/cart-checkout/shared/use-view-switcher.tsx
+++ b/assets/js/blocks/cart-checkout/shared/use-view-switcher.tsx
@@ -14,6 +14,10 @@ interface View {
 	icon: string | JSX.Element;
 }
 
+function getView( viewName: string, views: View[] ) {
+	return views.find( ( view ) => view.view === viewName );
+}
+
 export const useViewSwitcher = (
 	clientId: string,
 	views: View[]
@@ -32,7 +36,25 @@ export const useViewSwitcher = (
 	const selectedBlockClientId = getSelectedBlockClientId();
 
 	useEffect( () => {
+		const selectedBlock = getBlock( selectedBlockClientId );
+
+		if ( ! selectedBlock ) {
+			return;
+		}
+
+		if ( currentView.view === selectedBlock.name ) {
+			return;
+		}
+
 		const viewNames = views.map( ( { view } ) => view );
+
+		if ( viewNames.includes( selectedBlock.name ) ) {
+			const newView = getView( selectedBlock.name, views );
+			if ( newView ) {
+				return setCurrentView( newView );
+			}
+		}
+
 		const parentBlockIds = getBlockParentsByBlockName(
 			selectedBlockClientId,
 			viewNames
@@ -47,15 +69,11 @@ export const useViewSwitcher = (
 			return;
 		}
 
-		const filteredViews = views.filter(
-			( { view } ) => view === parentBlock.name
-		);
+		const newView = getView( parentBlock.name, views );
 
-		if ( filteredViews.length !== 1 ) {
-			return;
+		if ( newView ) {
+			setCurrentView( newView );
 		}
-
-		setCurrentView( filteredViews[ 0 ] );
 	}, [
 		getBlockParentsByBlockName,
 		selectedBlockClientId,


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #5445

This PR:

- Limits blocks can be added to the empty view of the Mini Cart Contents block.
- Removes the forced layout of the empty view.
- Switchs to the correct view if the view block is selected.

### Testing

How to test the changes in this Pull Request:

1. Edit the Mini Cart template part using the Site Editor.
2. Open the Block Navigation.
3. Select the Empty Mini Cart Contents block.
4. See the view is updated accordingly.
5. Try removing all blocks inside the empty view.
6. See the all blocks can be removed.
7. Try adding a block to empty view.
8. See Mini Cart block isn't in the blocks list.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
