### PR TITLE
Fix custom templates with fallback being incorrectly attributed

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -175,16 +175,10 @@ class BlockTemplatesController {
 		// @todo: Add apply_filters to _gutenberg_get_template_files() in Gutenberg to prevent duplication of logic.
 		foreach ( $template_files as $template_file ) {
 
-			// Avoid adding the same template if it's already in the array of $query_result.
-			if (
-				array_filter(
-					$query_result,
-					function( $query_result_template ) use ( $template_file ) {
-						return $query_result_template->slug === $template_file->slug &&
-								$query_result_template->theme === $template_file->theme;
-					}
-				)
-			) {
+			// If we have a template which is eligible for a fallback, we need to explicitly tell Gutenberg that
+			// it has a theme file (because it is using the fallback template file). And then `continue` to avoid
+			// adding duplicates.
+			if ( BlockTemplateUtils::confirm_theme_file_when_fallback_is_available( $query_result, $template_file ) ) {
 				continue;
 			}
 
@@ -348,14 +342,7 @@ class BlockTemplatesController {
 			}
 
 			// If the theme has an archive-product.html template, but not a taxonomy-product_cat.html template let's use the themes archive-product.html template.
-			if ( 'taxonomy-product_cat' === $template_slug && ! BlockTemplateUtils::theme_has_template( 'taxonomy-product_cat' ) && BlockTemplateUtils::theme_has_template( 'archive-product' ) ) {
-				$template_file = get_stylesheet_directory() . '/' . self::TEMPLATES_DIR_NAME . '/archive-product.html';
-				$templates[]   = BlockTemplateUtils::create_new_block_template_object( $template_file, $template_type, $template_slug, true );
-				continue;
-			}
-
-			// If the theme has an archive-product.html template, but not a taxonomy-product_tag.html template let's use the themes archive-product.html template.
-			if ( 'taxonomy-product_tag' === $template_slug && ! BlockTemplateUtils::theme_has_template( 'taxonomy-product_tag' ) && BlockTemplateUtils::theme_has_template( 'archive-product' ) ) {
+			if ( BlockTemplateUtils::template_is_eligible_for_product_archive_fallback( $template_slug ) ) {
 				$template_file = get_stylesheet_directory() . '/' . self::TEMPLATES_DIR_NAME . '/archive-product.html';
 				$templates[]   = BlockTemplateUtils::create_new_block_template_object( $template_file, $template_type, $template_slug, true );
 				continue;

--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -178,7 +178,7 @@ class BlockTemplatesController {
 			// If we have a template which is eligible for a fallback, we need to explicitly tell Gutenberg that
 			// it has a theme file (because it is using the fallback template file). And then `continue` to avoid
 			// adding duplicates.
-			if ( BlockTemplateUtils::confirm_theme_file_when_fallback_is_available( $query_result, $template_file ) ) {
+			if ( BlockTemplateUtils::set_has_theme_file_if_fallback_is_available( $query_result, $template_file ) ) {
 				continue;
 			}
 

--- a/src/Utils/BlockTemplateUtils.php
+++ b/src/Utils/BlockTemplateUtils.php
@@ -317,7 +317,7 @@ class BlockTemplateUtils {
 	 * @return boolean
 	 */
 	public static function set_has_theme_file_if_fallback_is_available( $query_result, $template ) {
-		foreach ( $query_result as $query_result_template ) {
+		foreach ( $query_result as &$query_result_template ) {
 			if (
 				$query_result_template->slug === $template->slug
 				&& $query_result_template->theme === $template->theme

--- a/src/Utils/BlockTemplateUtils.php
+++ b/src/Utils/BlockTemplateUtils.php
@@ -317,7 +317,7 @@ class BlockTemplateUtils {
 	 * @return boolean
 	 */
 	public static function set_has_theme_file_if_fallback_is_available( $query_result, $template ) {
-		foreach ( $query_result as $i => &$query_result_template ) {
+		foreach ( $query_result as $query_result_template ) {
 			if (
 				$query_result_template->slug === $template->slug
 				&& $query_result_template->theme === $template->theme

--- a/src/Utils/BlockTemplateUtils.php
+++ b/src/Utils/BlockTemplateUtils.php
@@ -294,15 +294,9 @@ class BlockTemplateUtils {
 	public static function template_is_eligible_for_product_archive_fallback( $template_slug ) {
 		$eligible_for_fallbacks = array( 'taxonomy-product_cat', 'taxonomy-product_tag' );
 
-		if (
-			in_array( $template_slug, $eligible_for_fallbacks, true )
+		return in_array( $template_slug, $eligible_for_fallbacks, true )
 			&& ! self::theme_has_template( $template_slug )
-			&& self::theme_has_template( 'archive-product' )
-		) {
-			return true;
-		}
-
-		return false;
+			&& self::theme_has_template( 'archive-product' );
 	}
 
 	/**
@@ -322,32 +316,18 @@ class BlockTemplateUtils {
 	 *
 	 * @return boolean
 	 */
-	public static function confirm_theme_file_when_fallback_is_available( $query_result, $template ) {
-		$template_with_fallback_idx = null;
-		$is_duplicate               = false;
-
-		array_walk(
-			$query_result,
-			function( $query_result_template, $idx ) use ( $template, &$template_with_fallback_idx, &$is_duplicate ) {
-				if (
-					$query_result_template->slug === $template->slug
-					&& $query_result_template->theme === $template->theme
-				) {
-					$is_duplicate = true;
-
-					if ( self::template_is_eligible_for_product_archive_fallback( $template->slug ) ) {
-						$template_with_fallback_idx = $idx;
-					}
+	public static function set_has_theme_file_if_fallback_is_available( $query_result, $template ) {
+		foreach ( $query_result as $i => &$query_result_template ) {
+			if (
+				$query_result_template->slug === $template->slug
+				&& $query_result_template->theme === $template->theme
+			) {
+				if ( self::template_is_eligible_for_product_archive_fallback( $template->slug ) ) {
+					$query_result_template->has_theme_file = true;
 				}
-			}
-		);
 
-		if ( $is_duplicate ) {
-			if ( is_int( $template_with_fallback_idx ) ) {
-				$query_result[ $template_with_fallback_idx ]->has_theme_file = true;
+				return true;
 			}
-
-			return true;
 		}
 
 		return false;

--- a/src/Utils/BlockTemplateUtils.php
+++ b/src/Utils/BlockTemplateUtils.php
@@ -324,22 +324,29 @@ class BlockTemplateUtils {
 	 */
 	public static function confirm_theme_file_when_fallback_is_available( $query_result, $template ) {
 		$template_with_fallback_idx = null;
+		$is_duplicate               = false;
 
 		array_walk(
 			$query_result,
-			function( $query_result_template, $idx ) use ( $template, &$template_with_fallback_idx ) {
+			function( $query_result_template, $idx ) use ( $template, &$template_with_fallback_idx, &$is_duplicate ) {
 				if (
 					$query_result_template->slug === $template->slug
 					&& $query_result_template->theme === $template->theme
-					&& self::template_is_eligible_for_product_archive_fallback( $template->slug )
 				) {
+					$is_duplicate = true;
+
+					if ( self::template_is_eligible_for_product_archive_fallback( $template->slug ) ) {
 						$template_with_fallback_idx = $idx;
+					}
 				}
 			}
 		);
 
-		if ( is_int( $template_with_fallback_idx ) ) {
-			$query_result[ $template_with_fallback_idx ]->has_theme_file = true;
+		if ( $is_duplicate ) {
+			if ( is_int( $template_with_fallback_idx ) ) {
+				$query_result[ $template_with_fallback_idx ]->has_theme_file = true;
+			}
+
 			return true;
 		}
 


### PR DESCRIPTION
Category and tags templates can fallback to the generic archive if, e.g., the theme provides one for the latter but not for the former (#5380). However, since Gutenberg is not aware of this fallback mechanism, it would incorrectly attribute the custom template
to the user instead of the theme.

Here we are explicitly setting the `has_theme_file` to make sure Gutenberg knows we do, in fact, have a theme fail (if not what it expects).

Fixes #5441

## Testing

### Manual Testing

#### How to test the changes in this Pull Request:

1. Install and enable the `Gutenberg` plugin.
2. Install and enable the `TT1 Blocks` theme.
3. Add an `archive-product.html`. This is because we are using the themes archive-product.html file for the category and tag templates as they're typically the same.
4. Go to the templates list within the Site Editor
5. You will see now that `Product Archive`, `Product Category` and `Product Tag` are added by the theme.
6. Customize the `Product Category` template and save it.
7. Navigate back to the templates list within the Site Editor. You will notice under the "Added By" column it should say your theme along with a theme icon.
8. Notice that these templates render in the Site Editor, and on the front-end as expected with and without customizations.

#### Regression testing

**Note:** The logic of all these steps is a bit convoluted, so doing some regression tests is advised for the following scenarios:

1. If you put product taxonomy template(s) in the theme, please check that these are used over the themes `product-archive.html` on both the frontend and in the site editor. Please also check these are customizable and render as expected.
2. If no Woo related templates are in the theme, check it uses the templates from Woo Blocks as expected, on both the frontend and in the site editor. Please also check these are customizable and render as expected.
4. If you put a taxonomy template(s) in the theme, it doesn't appear twice in the template list.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above

### Changelog

> Fix custom templates with fallback to archive being incorrectly attributed to the user in the editor instead of the parent theme.
