### PR TITLE
Ensure that the translation of the "Proceed to Checkout" button is working.

### DIFF
--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -209,7 +209,7 @@ class Cart extends AbstractBlock {
 			'cart-blocks/line-items',
 			'cart-blocks/order-summary',
 			'cart-blocks/order-summary--checkout-blocks/billing-address--checkout-blocks/shipping-address',
-			'cart-blocks/checkout-button-frontend.js',
+			'cart-blocks/checkout-button',
 			'cart-blocks/express-payment',
 		];
 		$chunks = preg_filter( '/$/', '-frontend', $blocks );


### PR DESCRIPTION
Fixes #5452

### Notes

At the moment, the translation of the "Proceed to Checkout" button is not working due to referring to an incorrect lazy loading file.

### Screenshots

<table>
<tr>
<td valign="top">Before:
<br><br>

![#5452-before](https://user-images.githubusercontent.com/3323310/147332014-9d76312d-a0a4-4682-94fa-5fbed6957380.png)
</td>
<td valign="top">After:
<br><br>

![#5452-after](https://user-images.githubusercontent.com/3323310/147332020-48140705-4b7f-44e4-b967-0459424a33cd.png)
</td>
</tr>
</table>

### Testing

1. Create a test page and add the Cart block.
2. Go to `/wp-admin/options-general.php` and change the site language to `Norsk bokmål`.
3. Go to `/wp-admin/update-core.php` and update the translations.
4. Go to the front-end, add a product to cart and visit the Cart block.
5. See that the "Proceed to Checkout" button is now translated.

### User Facing Testing

* [x] Same as above

### Changelog

> Ensure that the translation of the "Proceed to Checkout" button is working.

