### PR TITLE
Account for products without variations in the On Sale Products block

### DIFF
--- a/src/BlockTypes/AbstractProductGrid.php
+++ b/src/BlockTypes/AbstractProductGrid.php
@@ -363,14 +363,16 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 		$variation_ids_by_parent = array_column( $product_variations, 'product_id', 'variation_id' );
 		$all_variation_meta_data = [];
 
-		if ( ! empty( $prime_variation_ids ) ) {
-			$all_variation_meta_data = $wpdb->get_results(
-				$wpdb->prepare(
-					"SELECT post_id as variation_id, meta_key as attribute_key, meta_value as attribute_value FROM {$wpdb->postmeta} WHERE post_id IN (" . implode( ',', array_map( 'esc_sql', $prime_variation_ids ) ) . ') AND meta_key LIKE %s',
-					$wpdb->esc_like( 'attribute_' ) . '%'
-				)
-			);
+		if ( empty( $prime_variation_ids ) ) {
+			return;
 		}
+		
+		$all_variation_meta_data = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT post_id as variation_id, meta_key as attribute_key, meta_value as attribute_value FROM {$wpdb->postmeta} WHERE post_id IN (" . implode( ',', array_map( 'esc_sql', $prime_variation_ids ) ) . ') AND meta_key LIKE %s',
+				$wpdb->esc_like( 'attribute_' ) . '%'
+			)
+		);
 		// phpcs:enable
 		// Prepare the data to cache by indexing by the parent product.
 		$primed_data = array_reduce(

--- a/src/BlockTypes/AbstractProductGrid.php
+++ b/src/BlockTypes/AbstractProductGrid.php
@@ -366,7 +366,7 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 		if ( empty( $prime_variation_ids ) ) {
 			return;
 		}
-		
+
 		$all_variation_meta_data = $wpdb->get_results(
 			$wpdb->prepare(
 				"SELECT post_id as variation_id, meta_key as attribute_key, meta_value as attribute_value FROM {$wpdb->postmeta} WHERE post_id IN (" . implode( ',', array_map( 'esc_sql', $prime_variation_ids ) ) . ') AND meta_key LIKE %s',

--- a/src/BlockTypes/AbstractProductGrid.php
+++ b/src/BlockTypes/AbstractProductGrid.php
@@ -361,14 +361,17 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 		$product_variations      = $wpdb->get_results( "SELECT ID as variation_id, post_parent as product_id from {$wpdb->posts} WHERE post_parent IN ( " . implode( ',', $prime_product_ids ) . ' )', ARRAY_A );
 		$prime_variation_ids     = array_column( $product_variations, 'variation_id' );
 		$variation_ids_by_parent = array_column( $product_variations, 'product_id', 'variation_id' );
-		$all_variation_meta_data = $wpdb->get_results(
-			$wpdb->prepare(
-				"SELECT post_id as variation_id, meta_key as attribute_key, meta_value as attribute_value FROM {$wpdb->postmeta} WHERE post_id IN (" . implode( ',', array_map( 'esc_sql', $prime_variation_ids ) ) . ') AND meta_key LIKE %s',
-				$wpdb->esc_like( 'attribute_' ) . '%'
-			)
-		);
-		// phpcs:enable
+		$all_variation_meta_data = [];
 
+		if ( ! empty( $prime_variation_ids ) ) {
+			$all_variation_meta_data = $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT post_id as variation_id, meta_key as attribute_key, meta_value as attribute_value FROM {$wpdb->postmeta} WHERE post_id IN (" . implode( ',', array_map( 'esc_sql', $prime_variation_ids ) ) . ') AND meta_key LIKE %s',
+					$wpdb->esc_like( 'attribute_' ) . '%'
+				)
+			);
+		}
+		// phpcs:enable
 		// Prepare the data to cache by indexing by the parent product.
 		$primed_data = array_reduce(
 			$all_variation_meta_data,

--- a/src/BlockTypes/AbstractProductGrid.php
+++ b/src/BlockTypes/AbstractProductGrid.php
@@ -361,7 +361,6 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 		$product_variations      = $wpdb->get_results( "SELECT ID as variation_id, post_parent as product_id from {$wpdb->posts} WHERE post_parent IN ( " . implode( ',', $prime_product_ids ) . ' )', ARRAY_A );
 		$prime_variation_ids     = array_column( $product_variations, 'variation_id' );
 		$variation_ids_by_parent = array_column( $product_variations, 'product_id', 'variation_id' );
-		$all_variation_meta_data = [];
 
 		if ( empty( $prime_variation_ids ) ) {
 			return;


### PR DESCRIPTION
This PR accounts for the case when no product variations are present in the blocks that use the `prime_product_variations` function

<!-- Reference any related issues or PRs here -->
Fixes #5417

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->




### Testing

### Manual Testing

How to test the changes in this Pull Request:

On a store with no products store

1. Add 2 simple products on sale and publish them
2. Go to a test page and add the On Sale Products block.
3. Visit the page on the front-end.
4. Notice that no MySQL error is present in Query Monitor.




### Changelog

> Account for products without variations in the On Sale Products block
