### PR TITLE
Prevent duplicate hooks in hook docs

### DIFF
--- a/bin/hook-docs/actions/index.js
+++ b/bin/hook-docs/actions/index.js
@@ -15,6 +15,7 @@ const {
 	returns,
 	example,
 	related,
+	files,
 } = require( '../format-hook-doc' );
 const {
 	createDocs,
@@ -52,9 +53,8 @@ const generate = ( hooks ) => {
 				...sectionWithHeading( exceptions( hookDocs ), 'Exceptions' ),
 				...sectionWithHeading( returns( hookDocs ), 'Returns' ),
 				...sectionWithHeading( example( hookDocs ), 'Example' ),
-				...sectionWithHeading( related( hookDocs ), 'Related' ),
-				{ h3: `Source` },
-				{ p: `File: [${ hook.file }](../src/${ hook.file })` },
+				...sectionWithHeading( related( hookDocs ), 'See' ),
+				...sectionWithHeading( files( hook.file ), 'Source' ),
 				{ hr: '' },
 			].filter( Boolean );
 		} ),

--- a/bin/hook-docs/data/actions.json
+++ b/bin/hook-docs/data/actions.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://raw.githubusercontent.com/johnbillion/wp-hooks-generator/0.6.1/schema.json",
+    "$schema": "https://raw.githubusercontent.com/johnbillion/wp-hooks-generator/0.7.0/schema.json",
     "hooks": [
         {
             "name": "woocommerce_add_to_cart",
@@ -59,39 +59,44 @@
                     }
                 ],
                 "long_description_html": "<p>This hook fires when an item is added to the cart. This is triggered from the Store API in this context, but WooCommerce core add to cart events trigger the same hook.</p>"
-            }
+            },
+            "args": 6
         },
         {
             "name": "woocommerce_after_main_content",
             "file": "BlockTypes/LegacyTemplate.php",
             "type": "action",
             "doc": {
-                "description": "Hook: woocommerce_after_main_content.",
-                "long_description": "",
+                "description": "Hook: woocommerce_after_main_content",
+                "long_description": "Called after rendering the main content for a product.",
                 "tags": [
                     {
-                        "name": "hooked",
-                        "content": "woocommerce_output_content_wrapper_end - 10 (outputs closing divs for the content)"
+                        "name": "see",
+                        "content": "Outputs closing DIV for the content (priority 10)",
+                        "refers": "woocommerce_output_content_wrapper_end()"
                     }
                 ],
-                "long_description_html": ""
-            }
+                "long_description_html": "<p>Called after rendering the main content for a product.</p>"
+            },
+            "args": 0
         },
         {
             "name": "woocommerce_after_main_content",
             "file": "BlockTypes/LegacyTemplate.php",
             "type": "action",
             "doc": {
-                "description": "Woocommerce_after_main_content hook.",
-                "long_description": "",
+                "description": "Hook: woocommerce_after_main_content",
+                "long_description": "Called after rendering the main content for a product.",
                 "tags": [
                     {
-                        "name": "hooked",
-                        "content": "woocommerce_output_content_wrapper_end - 10 (outputs closing divs for the content)"
+                        "name": "see",
+                        "content": "Outputs closing DIV for the content (priority 10)",
+                        "refers": "woocommerce_output_content_wrapper_end()"
                     }
                 ],
-                "long_description_html": ""
-            }
+                "long_description_html": "<p>Called after rendering the main content for a product.</p>"
+            },
+            "args": 0
         },
         {
             "name": "woocommerce_after_shop_loop",
@@ -102,12 +107,14 @@
                 "long_description": "",
                 "tags": [
                     {
-                        "name": "hooked",
-                        "content": "woocommerce_pagination - 10"
+                        "name": "see",
+                        "content": "Renders pagination (priority 10)",
+                        "refers": "woocommerce_pagination()"
                     }
                 ],
                 "long_description_html": ""
-            }
+            },
+            "args": 0
         },
         {
             "name": "woocommerce_applied_coupon",
@@ -127,7 +134,8 @@
                     }
                 ],
                 "long_description_html": ""
-            }
+            },
+            "args": 1
         },
         {
             "name": "woocommerce_archive_description",
@@ -138,60 +146,75 @@
                 "long_description": "",
                 "tags": [
                     {
-                        "name": "hooked",
-                        "content": "woocommerce_taxonomy_archive_description - 10"
+                        "name": "see",
+                        "content": "Renders the taxonomy archive description (priority 10)",
+                        "refers": "woocommerce_taxonomy_archive_description()"
                     },
                     {
-                        "name": "hooked",
-                        "content": "woocommerce_product_archive_description - 10"
+                        "name": "see",
+                        "content": "Renders the product archive description (priority 10)",
+                        "refers": "woocommerce_product_archive_description()"
                     }
                 ],
                 "long_description_html": ""
-            }
+            },
+            "args": 0
         },
         {
             "name": "woocommerce_before_main_content",
             "file": "BlockTypes/LegacyTemplate.php",
             "type": "action",
             "doc": {
-                "description": "Woocommerce_before_main_content hook.",
-                "long_description": "",
+                "description": "Hook: woocommerce_before_main_content",
+                "long_description": "Called before rendering the main content for a product.",
                 "tags": [
                     {
-                        "name": "hooked",
-                        "content": "woocommerce_output_content_wrapper - 10 (outputs opening divs for the content)"
+                        "name": "see",
+                        "content": "Outputs opening DIV for the content (priority 10)",
+                        "refers": "woocommerce_output_content_wrapper()"
                     },
                     {
-                        "name": "hooked",
-                        "content": "woocommerce_breadcrumb - 20"
+                        "name": "see",
+                        "content": "Outputs breadcrumb trail to the current product (priority 20)",
+                        "refers": "woocommerce_breadcrumb()"
+                    },
+                    {
+                        "name": "see",
+                        "content": "Outputs schema markup (priority 30)",
+                        "refers": "WC_Structured_Data::generate_website_data()"
                     }
                 ],
-                "long_description_html": ""
-            }
+                "long_description_html": "<p>Called before rendering the main content for a product.</p>"
+            },
+            "args": 0
         },
         {
             "name": "woocommerce_before_main_content",
             "file": "BlockTypes/LegacyTemplate.php",
             "type": "action",
             "doc": {
-                "description": "Hook: woocommerce_before_main_content.",
-                "long_description": "",
+                "description": "Hook: woocommerce_before_main_content",
+                "long_description": "Called before rendering the main content for a product.",
                 "tags": [
                     {
-                        "name": "hooked",
-                        "content": "woocommerce_output_content_wrapper - 10 (outputs opening divs for the content)"
+                        "name": "see",
+                        "content": "Outputs opening DIV for the content (priority 10)",
+                        "refers": "woocommerce_output_content_wrapper()"
                     },
                     {
-                        "name": "hooked",
-                        "content": "woocommerce_breadcrumb - 20"
+                        "name": "see",
+                        "content": "Outputs breadcrumb trail to the current product (priority 20)",
+                        "refers": "woocommerce_breadcrumb()"
                     },
                     {
-                        "name": "hooked",
-                        "content": "WC_Structured_Data::generate_website_data() - 30"
+                        "name": "see",
+                        "content": "Outputs schema markup (priority 30)",
+                        "refers": "WC_Structured_Data::generate_website_data()"
                     }
                 ],
-                "long_description_html": ""
-            }
+                "long_description_html": "<p>Called before rendering the main content for a product.</p>"
+            },
+            "args": 0
         },
         {
             "name": "woocommerce_before_shop_loop",
@@ -202,20 +225,24 @@
                 "long_description": "",
                 "tags": [
                     {
-                        "name": "hooked",
-                        "content": "woocommerce_output_all_notices - 10"
+                        "name": "see",
+                        "content": "Render error notices (priority 10)",
+                        "refers": "woocommerce_output_all_notices()"
                     },
                     {
-                        "name": "hooked",
-                        "content": "woocommerce_result_count - 20"
+                        "name": "see",
+                        "content": "Show number of results found (priority 20)",
+                        "refers": "woocommerce_result_count()"
                     },
                     {
-                        "name": "hooked",
-                        "content": "woocommerce_catalog_ordering - 30"
+                        "name": "see",
+                        "content": "Show form to control sort order (priority 30)",
+                        "refers": "woocommerce_catalog_ordering()"
                     }
                 ],
                 "long_description_html": ""
-            }
+            },
+            "args": 0
         },
         {
             "name": "woocommerce_blocks_cart_enqueue_data",
@@ -226,7 +253,8 @@
                 "long_description": "",
                 "tags": [],
                 "long_description_html": ""
-            }
+            },
+            "args": 0
         },
         {
             "name": "woocommerce_blocks_cart_enqueue_data",
@@ -237,7 +265,8 @@
                 "long_description": "",
                 "tags": [],
                 "long_description_html": ""
-            }
+            },
+            "args": 0
         },
         {
             "name": "woocommerce_blocks_cart_update_customer_from_request",
@@ -265,7 +294,8 @@
                     }
                 ],
                 "long_description_html": ""
-            }
+            },
+            "args": 2
         },
         {
             "name": "woocommerce_blocks_cart_update_order_from_request",
@@ -301,7 +331,8 @@
                     }
                 ],
                 "long_description_html": ""
-            }
+            },
+            "args": 2
         },
         {
             "name": "woocommerce_blocks_checkout_enqueue_data",
@@ -312,7 +343,8 @@
                 "long_description": "",
                 "tags": [],
                 "long_description_html": ""
-            }
+            },
+            "args": 0
         },
         {
             "name": "woocommerce_blocks_checkout_order_processed",
@@ -341,7 +373,8 @@
                     }
                 ],
                 "long_description_html": "<p>This hook informs extensions that $order has completed processing and is ready for payment.</p> <p>This is similar to existing core hook woocommerce_checkout_order_processed. We're using a new action:</p> <ul> <li>To keep the interface focused (only pass $order, not passing request data).</li> <li>This also explicitly indicates these orders are from checkout block/StoreAPI.</li> </ul>"
-            }
+            },
+            "args": 1
         },
         {
             "name": "woocommerce_blocks_checkout_update_order_from_request",
@@ -369,7 +402,8 @@
                     }
                 ],
                 "long_description_html": "<p>This hook gives extensions the chance to update orders based on the data in the request. This can be used in conjunction with the ExtendRestAPI class to post custom data and then process it.</p>"
-            }
+            },
+            "args": 2
         },
         {
             "name": "woocommerce_blocks_checkout_update_order_meta",
@@ -394,7 +428,8 @@
                     }
                 ],
                 "long_description_html": "<p>This hook gives extensions the chance to add or update meta data on the $order.</p> <p>This is similar to existing core hook woocommerce_checkout_update_order_meta. We're using a new action:</p> <ul> <li>To keep the interface focused (only pass $order, not passing request data).</li> <li>This also explicitly indicates these orders are from checkout block/StoreAPI.</li> </ul>"
-            }
+            },
+            "args": 1
         },
         {
             "name": "woocommerce_blocks_enqueue_cart_block_scripts_after",
@@ -405,7 +440,8 @@
                 "long_description": "",
                 "tags": [],
                 "long_description_html": ""
-            }
+            },
+            "args": 0
         },
         {
             "name": "woocommerce_blocks_enqueue_cart_block_scripts_before",
@@ -416,7 +452,8 @@
                 "long_description": "",
                 "tags": [],
                 "long_description_html": ""
-            }
+            },
+            "args": 0
         },
         {
             "name": "woocommerce_blocks_enqueue_checkout_block_scripts_after",
@@ -427,7 +464,8 @@
                 "long_description": "",
                 "tags": [],
                 "long_description_html": ""
-            }
+            },
+            "args": 0
         },
         {
             "name": "woocommerce_blocks_enqueue_checkout_block_scripts_before",
@@ -438,7 +476,8 @@
                 "long_description": "",
                 "tags": [],
                 "long_description_html": ""
-            }
+            },
+            "args": 0
         },
         {
             "name": "woocommerce_blocks_loaded",
@@ -449,7 +488,8 @@
                 "long_description": "This hook is intended to be used as a safe event hook for when the plugin has been loaded, and all dependency requirements have been met.",
                 "tags": [],
                 "long_description_html": "<p>This hook is intended to be used as a safe event hook for when the plugin has been loaded, and all dependency requirements have been met.</p>"
-            }
+            },
+            "args": 0
         },
         {
             "name": "woocommerce_blocks_{$this->registry_identifier}_registration",
@@ -469,7 +509,8 @@
                     }
                 ],
                 "long_description_html": "<p>Runs before integrations are initialized allowing new integration to be registered for use. This should be used as the primary hook for integrations to include their scripts, styles, and other code extending the blocks.</p>"
-            }
+            },
+            "args": 1
         },
         {
             "name": "woocommerce_check_cart_items",
@@ -480,7 +521,8 @@
                 "long_description": "Allow 3rd parties to validate cart items. This is a legacy hook from Woo core. This filter will be deprecated because it encourages usage of wc_add_notice. For the API we need to capture notices and convert to exceptions instead.",
                 "tags": [],
                 "long_description_html": "<p>Allow 3rd parties to validate cart items. This is a legacy hook from Woo core. This filter will be deprecated because it encourages usage of wc_add_notice. For the API we need to capture notices and convert to exceptions instead.</p>"
-            }
+            },
+            "args": 0
         },
         {
             "name": "woocommerce_created_customer",
@@ -516,7 +558,8 @@
                     }
                 ],
                 "long_description_html": "<p>This hook fires after customer accounts are created and passes the customer data.</p>"
-            }
+            },
+            "args": 3
         },
         {
             "name": "woocommerce_no_products_found",
@@ -527,12 +570,14 @@
                 "long_description": "",
                 "tags": [
                     {
-                        "name": "hooked",
-                        "content": "wc_no_products_found - 10"
+                        "name": "see",
+                        "content": "Default no products found content (priority 10)",
+                        "refers": "wc_no_products_found()"
                     }
                 ],
                 "long_description_html": ""
-            }
+            },
+            "args": 0
         },
         {
             "name": "woocommerce_register_post",
@@ -568,7 +613,8 @@
                     }
                 ],
                 "long_description_html": "<p>This hook fires before customer accounts are created and passes the form data (username, email) and an array of errors.</p> <p>This could be used to add extra validation logic and append errors to the array.</p>"
-            }
+            },
+            "args": 3
         },
         {
             "name": "woocommerce_rest_checkout_process_payment_with_context",
@@ -607,7 +653,8 @@
                     }
                 ],
                 "long_description_html": ""
-            }
+            },
+            "args": 1
         },
         {
             "name": "woocommerce_shop_loop",
@@ -618,7 +665,8 @@
                 "long_description": "",
                 "tags": [],
                 "long_description_html": ""
-            }
+            },
+            "args": 0
         },
         {
             "name": "wooocommerce_store_api_validate_add_to_cart",
@@ -646,7 +694,8 @@
                     }
                 ],
                 "long_description_html": "<p>Fire action to validate add to cart. Functions hooking into this should throw an \\Exception to prevent add to cart from happening.</p>"
-            }
+            },
+            "args": 2
         },
         {
             "name": "wooocommerce_store_api_validate_cart_item",
@@ -674,7 +723,8 @@
                     }
                 ],
                 "long_description_html": ""
-            }
+            },
+            "args": 2
         }
     ]
 }

--- a/bin/hook-docs/data/filters.json
+++ b/bin/hook-docs/data/filters.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://raw.githubusercontent.com/johnbillion/wp-hooks-generator/0.6.1/schema.json",
+    "$schema": "https://raw.githubusercontent.com/johnbillion/wp-hooks-generator/0.7.0/schema.json",
     "hooks": [
         {
             "name": "__experimental_woocommerce_blocks_add_data_attributes_to_block",
@@ -19,7 +19,8 @@
                     }
                 ],
                 "long_description_html": "<p>This hook defines which block names should have block name and attribute data- attributes appended on render.</p>"
-            }
+            },
+            "args": 1
         },
         {
             "name": "__experimental_woocommerce_blocks_add_data_attributes_to_namespace",
@@ -39,7 +40,8 @@
                     }
                 ],
                 "long_description_html": "<p>This hook defines which block namespaces should have block name and attribute <code>data-</code> attributes appended on render.</p>"
-            }
+            },
+            "args": 1
         },
         {
             "name": "__experimental_woocommerce_blocks_payment_gateway_features_list",
@@ -78,7 +80,8 @@
                     }
                 ],
                 "long_description_html": ""
-            }
+            },
+            "args": 2
         },
         {
             "name": "wc_stripe_allow_prepaid_card",
@@ -105,7 +108,8 @@
                     }
                 ],
                 "long_description_html": ""
-            }
+            },
+            "args": 1
         },
         {
             "name": "wc_stripe_display_save_payment_method_checkbox",
@@ -142,7 +146,8 @@
                     }
                 ],
                 "long_description_html": "<p>This assumes that Stripe supports <code>tokenization</code> - currently this is true, based on <a href=\"https://github.com/woocommerce/woocommerce-gateway-stripe/blob/master/includes/class-wc-gateway-stripe.php#L95\">https://github.com/woocommerce/woocommerce-gateway-stripe/blob/master/includes/class-wc-gateway-stripe.php#L95</a></p>"
-            }
+            },
+            "args": 1
         },
         {
             "name": "wc_stripe_payment_request_button_locale",
@@ -169,7 +174,8 @@
                     }
                 ],
                 "long_description_html": ""
-            }
+            },
+            "args": 1
         },
         {
             "name": "woocommerce_add_cart_item",
@@ -204,7 +210,8 @@
                     }
                 ],
                 "long_description_html": ""
-            }
+            },
+            "args": 2
         },
         {
             "name": "woocommerce_add_cart_item_data",
@@ -255,7 +262,8 @@
                     }
                 ],
                 "long_description_html": ""
-            }
+            },
+            "args": 4
         },
         {
             "name": "woocommerce_add_to_cart_sold_individually_quantity",
@@ -314,7 +322,8 @@
                     }
                 ],
                 "long_description_html": ""
-            }
+            },
+            "args": 5
         },
         {
             "name": "woocommerce_add_to_cart_validation",
@@ -377,7 +386,8 @@
                     }
                 ],
                 "long_description_html": "<p>Allow 3rd parties to validate if an item can be added to the cart. This is a legacy hook from Woo core. This filter will be deprecated because it encourages usage of wc_add_notice. For the API we need to capture notices and convert to exceptions instead.</p>"
-            }
+            },
+            "args": 5
         },
         {
             "name": "woocommerce_adjust_non_base_location_prices",
@@ -404,7 +414,8 @@
                     }
                 ],
                 "long_description_html": "<p>The woocommerce_adjust_non_base_location_prices filter can stop base taxes being taken off when dealing with out of base locations. e.g. If a product costs 10 including tax, all users will pay 10 regardless of location and taxes.</p>"
-            }
+            },
+            "args": 1
         },
         {
             "name": "woocommerce_apply_individual_use_coupon",
@@ -447,7 +458,8 @@
                     }
                 ],
                 "long_description_html": ""
-            }
+            },
+            "args": 3
         },
         {
             "name": "woocommerce_apply_with_individual_use_coupon",
@@ -498,7 +510,8 @@
                     }
                 ],
                 "long_description_html": ""
-            }
+            },
+            "args": 4
         },
         {
             "name": "woocommerce_blocks_product_grid_is_cacheable",
@@ -533,7 +546,8 @@
                     }
                 ],
                 "long_description_html": ""
-            }
+            },
+            "args": 2
         },
         {
             "name": "woocommerce_blocks_product_grid_item_html",
@@ -576,7 +590,8 @@
                     }
                 ],
                 "long_description_html": ""
-            }
+            },
+            "args": 3
         },
         {
             "name": "woocommerce_blocks_register_script_dependencies",
@@ -611,7 +626,8 @@
                     }
                 ],
                 "long_description_html": ""
-            }
+            },
+            "args": 2
         },
         {
             "name": "woocommerce_cart_contents_changed",
@@ -638,7 +654,8 @@
                     }
                 ],
                 "long_description_html": ""
-            }
+            },
+            "args": 1
         },
         {
             "name": "woocommerce_ga_disable_tracking",
@@ -658,7 +675,8 @@
                     }
                 ],
                 "long_description_html": ""
-            }
+            },
+            "args": 1
         },
         {
             "name": "woocommerce_get_item_data",
@@ -693,7 +711,8 @@
                     }
                 ],
                 "long_description_html": "<p>Filters the variation option name for custom option slugs.</p>"
-            }
+            },
+            "args": 2
         },
         {
             "name": "woocommerce_new_customer_data",
@@ -720,7 +739,8 @@
                     }
                 ],
                 "long_description_html": "<p>This hook filters customer data. It allows user data to be changed, for example, username, password, email, first name, last name, and role.</p>"
-            }
+            },
+            "args": 1
         },
         {
             "name": "woocommerce_registration_errors",
@@ -763,7 +783,8 @@
                     }
                 ],
                 "long_description_html": "<p>This hook filters registration errors. This can be used to manipulate the array of errors before they are displayed.</p>"
-            }
+            },
+            "args": 3
         },
         {
             "name": "woocommerce_shared_settings",
@@ -794,7 +815,8 @@
                     }
                 ],
                 "long_description_html": "<p>Low level hook for registration of new data late in the cycle. This is deprecated. Instead, use the data api:</p> <pre><code class=\"language-php\">Automattic\\WooCommerce\\Blocks\\Package::container()-&gt;get( Automattic\\WooCommerce\\Blocks\\Assets\\AssetDataRegistry::class )-&gt;add( $key, $value )</code></pre>"
-            }
+            },
+            "args": 1
         },
         {
             "name": "woocommerce_shipping_package_name",
@@ -837,18 +859,26 @@
                     }
                 ],
                 "long_description_html": ""
-            }
+            },
+            "args": 3
         },
         {
             "name": "woocommerce_show_page_title",
             "file": "BlockTypes/LegacyTemplate.php",
             "type": "filter",
             "doc": {
-                "description": "",
+                "description": "We need to load the scripts here because when using block templates wp_head() gets run after the block template. As a result we are trying to enqueue required scripts before we have even registered them.",
                 "long_description": "",
-                "tags": [],
+                "tags": [
+                    {
+                        "name": "see",
+                        "content": "",
+                        "refers": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5328#issuecomment-989013447"
+                    }
+                ],
                 "long_description_html": ""
-            }
+            },
+            "args": 1
         },
         {
             "name": "woocommerce_store_api_disable_nonce_check",
@@ -875,7 +905,8 @@
                     }
                 ],
                 "long_description_html": "<p>This can be used to disable the nonce check when testing API endpoints via a REST API client.</p>"
-            }
+            },
+            "args": 1
         },
         {
             "name": "woocommerce_store_api_product_quantity_limit",
@@ -910,7 +941,8 @@
                     }
                 ],
                 "long_description_html": "<p>Filters the variation option name for custom option slugs.</p>"
-            }
+            },
+            "args": 2
         },
         {
             "name": "woocommerce_variation_option_name",
@@ -961,7 +993,8 @@
                     }
                 ],
                 "long_description_html": "<p>Filters the variation option name for custom option slugs.</p>"
-            }
+            },
+            "args": 4
         }
     ]
 }

--- a/bin/hook-docs/filters/index.js
+++ b/bin/hook-docs/filters/index.js
@@ -15,6 +15,7 @@ const {
 	returns,
 	example,
 	related,
+	files,
 } = require( '../format-hook-doc' );
 const {
 	createDocs,
@@ -52,9 +53,8 @@ const generate = ( hooks ) => {
 				...sectionWithHeading( exceptions( hookDocs ), 'Exceptions' ),
 				...sectionWithHeading( returns( hookDocs ), 'Returns' ),
 				...sectionWithHeading( example( hookDocs ), 'Example' ),
-				...sectionWithHeading( related( hookDocs ), 'Related' ),
-				{ h3: `Source` },
-				{ p: `File: [${ hook.file }](../src/${ hook.file })` },
+				...sectionWithHeading( related( hookDocs ), 'See' ),
+				...sectionWithHeading( files( hook.file ), 'Source' ),
 				{ hr: '' },
 			].filter( Boolean );
 		} ),

--- a/bin/hook-docs/format-hook-doc/files.js
+++ b/bin/hook-docs/format-hook-doc/files.js
@@ -1,0 +1,11 @@
+const files = ( sources ) => {
+	return sources && sources.length
+		? {
+				ul: sources.map( ( file ) => {
+					return `[${ file }](../src/${ file })`;
+				} ),
+		  }
+		: null;
+};
+
+module.exports = { files };

--- a/bin/hook-docs/format-hook-doc/index.js
+++ b/bin/hook-docs/format-hook-doc/index.js
@@ -3,5 +3,6 @@ const { returns } = require( './returns' );
 const { example } = require( './example' );
 const { related } = require( './related' );
 const { exceptions } = require( './exceptions' );
+const { files } = require( './files' );
 
-module.exports = { params, returns, example, related, exceptions };
+module.exports = { params, returns, example, related, exceptions, files };

--- a/bin/hook-docs/format-hook-doc/related.js
+++ b/bin/hook-docs/format-hook-doc/related.js
@@ -5,7 +5,9 @@ const related = ( hookDoc ) => {
 
 	return seeDocs && seeDocs.length
 		? {
-				ul: seeDocs.map( ( { refers } ) => refers ),
+				ul: seeDocs.map( ( { refers, content = '' } ) => {
+					return content ? refers + ' - ' + content : refers;
+				} ),
 		  }
 		: null;
 };

--- a/bin/hook-docs/index.js
+++ b/bin/hook-docs/index.js
@@ -3,7 +3,7 @@
 /* eslint no-console: 0 */
 const chalk = require( 'chalk' );
 
-const groupByHook = ( hooks, hook, index, allHooks ) => {
+const groupByHook = ( hooks, hook ) => {
 	if ( hooks[ hook.name ] !== undefined ) {
 		if ( hooks[ hook.name ].file !== hook.file ) {
 			hooks[ hook.name ].file.push( hook.file );

--- a/bin/hook-docs/index.js
+++ b/bin/hook-docs/index.js
@@ -3,17 +3,37 @@
 /* eslint no-console: 0 */
 const chalk = require( 'chalk' );
 
+const groupByHook = ( hooks, hook, index, allHooks ) => {
+	if ( hooks[ hook.name ] !== undefined ) {
+		if ( hooks[ hook.name ].file !== hook.file ) {
+			hooks[ hook.name ].file.push( hook.file );
+		}
+		return hooks; // skip or return updated record.
+	}
+
+	hooks[ hook.name ] = {
+		...hook,
+		file: [ hook.file ], // Use array of files to support hooks used across the codebase.
+	};
+
+	return hooks;
+};
+
 try {
 	const { generate: generateActionDocs } = require( './actions' );
 	const { generate: generateFilterDocs } = require( './filters' );
 
 	console.log( chalk.blue( "Let's create some docs!" ) );
 
-	const actions = require( './data/actions.json' ).hooks;
-	const filters = require( './data/filters.json' ).hooks;
+	const rawActions = require( './data/actions.json' ).hooks;
+	const rawFilters = require( './data/filters.json' ).hooks;
 
-	generateActionDocs( actions );
-	generateFilterDocs( filters );
+	// Skip duplicates.
+	const actions = rawActions.reduce( groupByHook, {} );
+	const filters = rawFilters.reduce( groupByHook, {} );
+
+	generateActionDocs( Object.values( actions ) );
+	generateFilterDocs( Object.values( filters ) );
 } catch ( error ) {
 	console.log( chalk.red( error.message ) );
 }

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 		"wp-phpunit/wp-phpunit": "^5.4",
 		"woocommerce/woocommerce-sniffs": "0.1.0",
 		"yoast/phpunit-polyfills": "^1.0",
-		"johnbillion/wp-hooks-generator": "0.6.1",
+		"johnbillion/wp-hooks-generator": "^0.7.0",
 		"mockery/mockery": "^1.4"
 	},
 	"autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "35125888589aa8a4adfdb2cdbc266442",
+    "content-hash": "94edc00af416eb4f7b05b5f56548373a",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -452,16 +452,16 @@
         },
         {
             "name": "johnbillion/wp-hooks-generator",
-            "version": "0.6.1",
+            "version": "0.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/johnbillion/wp-hooks-generator.git",
-                "reference": "56f316b9716d441c4cfa35b8820dab21899dbee8"
+                "reference": "26027e46d5396afbeb5ed18b0cd6a75deb2f2996"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/johnbillion/wp-hooks-generator/zipball/56f316b9716d441c4cfa35b8820dab21899dbee8",
-                "reference": "56f316b9716d441c4cfa35b8820dab21899dbee8",
+                "url": "https://api.github.com/repos/johnbillion/wp-hooks-generator/zipball/26027e46d5396afbeb5ed18b0cd6a75deb2f2996",
+                "reference": "26027e46d5396afbeb5ed18b0cd6a75deb2f2996",
                 "shasum": ""
             },
             "require": {
@@ -469,7 +469,7 @@
                 "php": ">=7"
             },
             "require-dev": {
-                "oomphinc/composer-installers-extender": "^1.1",
+                "oomphinc/composer-installers-extender": "^2",
                 "opis/json-schema": "^1"
             },
             "bin": [
@@ -489,9 +489,15 @@
             "description": "Generates a JSON representation of the WordPress actions and filters in your code",
             "support": {
                 "issues": "https://github.com/johnbillion/wp-hooks-generator/issues",
-                "source": "https://github.com/johnbillion/wp-hooks-generator/tree/0.6.1"
+                "source": "https://github.com/johnbillion/wp-hooks-generator/tree/0.7.0"
             },
-            "time": "2020-10-31T17:46:42+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/johnbillion",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-11-10T17:22:21+00:00"
         },
         {
             "name": "johnbillion/wp-parser-lib",

--- a/docs/extensibility/actions.md
+++ b/docs/extensibility/actions.md
@@ -9,15 +9,12 @@
 
  - [woocommerce_add_to_cart](#woocommerce_add_to_cart)
  - [woocommerce_after_main_content](#woocommerce_after_main_content)
- - [woocommerce_after_main_content](#woocommerce_after_main_content-1)
  - [woocommerce_after_shop_loop](#woocommerce_after_shop_loop)
  - [woocommerce_applied_coupon](#woocommerce_applied_coupon)
  - [woocommerce_archive_description](#woocommerce_archive_description)
  - [woocommerce_before_main_content](#woocommerce_before_main_content)
- - [woocommerce_before_main_content](#woocommerce_before_main_content-1)
  - [woocommerce_before_shop_loop](#woocommerce_before_shop_loop)
  - [woocommerce_blocks_cart_enqueue_data](#woocommerce_blocks_cart_enqueue_data)
- - [woocommerce_blocks_cart_enqueue_data](#woocommerce_blocks_cart_enqueue_data-1)
  - [woocommerce_blocks_cart_update_customer_from_request](#woocommerce_blocks_cart_update_customer_from_request)
  - [woocommerce_blocks_cart_update_order_from_request](#woocommerce_blocks_cart_update_order_from_request)
  - [woocommerce_blocks_checkout_enqueue_data](#woocommerce_blocks_checkout_enqueue_data)
@@ -68,39 +65,33 @@ do_action( 'woocommerce_add_to_cart', string $cart_id, integer $product_id, inte
 ### Source
 
 
-File: [StoreApi/Utilities/CartController.php](../src/StoreApi/Utilities/CartController.php)
+ - [StoreApi/Utilities/CartController.php](../src/StoreApi/Utilities/CartController.php)
 
 ---
 
 ## woocommerce_after_main_content
 
 
-Hook: woocommerce_after_main_content.
+Hook: woocommerce_after_main_content
 
 ```php
 do_action( 'woocommerce_after_main_content' )
 ```
 
-### Source
+### Description
+
+<p>Called after rendering the main content for a product.</p>
+
+### See
 
 
-File: [BlockTypes/LegacyTemplate.php](../src/BlockTypes/LegacyTemplate.php)
-
----
-
-## woocommerce_after_main_content
-
-
-Woocommerce_after_main_content hook.
-
-```php
-do_action( 'woocommerce_after_main_content' )
-```
+ - woocommerce_output_content_wrapper_end() - Outputs closing DIV for the content (priority 10)
 
 ### Source
 
 
-File: [BlockTypes/LegacyTemplate.php](../src/BlockTypes/LegacyTemplate.php)
+ - [BlockTypes/LegacyTemplate.php](../src/BlockTypes/LegacyTemplate.php)
+ - [BlockTypes/LegacyTemplate.php](../src/BlockTypes/LegacyTemplate.php)
 
 ---
 
@@ -113,10 +104,15 @@ Hook: woocommerce_after_shop_loop.
 do_action( 'woocommerce_after_shop_loop' )
 ```
 
+### See
+
+
+ - woocommerce_pagination() - Renders pagination (priority 10)
+
 ### Source
 
 
-File: [BlockTypes/LegacyTemplate.php](../src/BlockTypes/LegacyTemplate.php)
+ - [BlockTypes/LegacyTemplate.php](../src/BlockTypes/LegacyTemplate.php)
 
 ---
 
@@ -138,7 +134,7 @@ do_action( 'woocommerce_applied_coupon', string $coupon_code )
 ### Source
 
 
-File: [StoreApi/Utilities/CartController.php](../src/StoreApi/Utilities/CartController.php)
+ - [StoreApi/Utilities/CartController.php](../src/StoreApi/Utilities/CartController.php)
 
 ---
 
@@ -151,42 +147,44 @@ Hook: woocommerce_archive_description.
 do_action( 'woocommerce_archive_description' )
 ```
 
+### See
+
+
+ - woocommerce_taxonomy_archive_description() - Renders the taxonomy archive description (priority 10)
+ - woocommerce_product_archive_description() - Renders the product archive description (priority 10)
+
 ### Source
 
 
-File: [BlockTypes/LegacyTemplate.php](../src/BlockTypes/LegacyTemplate.php)
+ - [BlockTypes/LegacyTemplate.php](../src/BlockTypes/LegacyTemplate.php)
 
 ---
 
 ## woocommerce_before_main_content
 
 
-Woocommerce_before_main_content hook.
+Hook: woocommerce_before_main_content
 
 ```php
 do_action( 'woocommerce_before_main_content' )
 ```
 
-### Source
+### Description
+
+<p>Called before rendering the main content for a product.</p>
+
+### See
 
 
-File: [BlockTypes/LegacyTemplate.php](../src/BlockTypes/LegacyTemplate.php)
-
----
-
-## woocommerce_before_main_content
-
-
-Hook: woocommerce_before_main_content.
-
-```php
-do_action( 'woocommerce_before_main_content' )
-```
+ - woocommerce_output_content_wrapper() - Outputs opening DIV for the content (priority 10)
+ - woocommerce_breadcrumb() - Outputs breadcrumb trail to the current product (priority 20)
+ - WC_Structured_Data::generate_website_data() - Outputs schema markup (priority 30)
 
 ### Source
 
 
-File: [BlockTypes/LegacyTemplate.php](../src/BlockTypes/LegacyTemplate.php)
+ - [BlockTypes/LegacyTemplate.php](../src/BlockTypes/LegacyTemplate.php)
+ - [BlockTypes/LegacyTemplate.php](../src/BlockTypes/LegacyTemplate.php)
 
 ---
 
@@ -199,10 +197,17 @@ Hook: woocommerce_before_shop_loop.
 do_action( 'woocommerce_before_shop_loop' )
 ```
 
+### See
+
+
+ - woocommerce_output_all_notices() - Render error notices (priority 10)
+ - woocommerce_result_count() - Show number of results found (priority 20)
+ - woocommerce_catalog_ordering() - Show form to control sort order (priority 30)
+
 ### Source
 
 
-File: [BlockTypes/LegacyTemplate.php](../src/BlockTypes/LegacyTemplate.php)
+ - [BlockTypes/LegacyTemplate.php](../src/BlockTypes/LegacyTemplate.php)
 
 ---
 
@@ -218,23 +223,8 @@ do_action( 'woocommerce_blocks_cart_enqueue_data' )
 ### Source
 
 
-File: [BlockTypes/MiniCart.php](../src/BlockTypes/MiniCart.php)
-
----
-
-## woocommerce_blocks_cart_enqueue_data
-
-
-Fires after cart block data is registered.
-
-```php
-do_action( 'woocommerce_blocks_cart_enqueue_data' )
-```
-
-### Source
-
-
-File: [BlockTypes/Cart.php](../src/BlockTypes/Cart.php)
+ - [BlockTypes/MiniCart.php](../src/BlockTypes/MiniCart.php)
+ - [BlockTypes/Cart.php](../src/BlockTypes/Cart.php)
 
 ---
 
@@ -257,7 +247,7 @@ do_action( 'woocommerce_blocks_cart_update_customer_from_request', \WC_Customer 
 ### Source
 
 
-File: [StoreApi/Routes/CartUpdateCustomer.php](../src/StoreApi/Routes/CartUpdateCustomer.php)
+ - [StoreApi/Routes/CartUpdateCustomer.php](../src/StoreApi/Routes/CartUpdateCustomer.php)
 
 ---
 
@@ -281,7 +271,7 @@ do_action( 'woocommerce_blocks_cart_update_order_from_request', \WC_Order $draft
 ### Source
 
 
-File: [StoreApi/Routes/AbstractCartRoute.php](../src/StoreApi/Routes/AbstractCartRoute.php)
+ - [StoreApi/Routes/AbstractCartRoute.php](../src/StoreApi/Routes/AbstractCartRoute.php)
 
 ---
 
@@ -297,7 +287,7 @@ do_action( 'woocommerce_blocks_checkout_enqueue_data' )
 ### Source
 
 
-File: [BlockTypes/Checkout.php](../src/BlockTypes/Checkout.php)
+ - [BlockTypes/Checkout.php](../src/BlockTypes/Checkout.php)
 
 ---
 
@@ -333,7 +323,7 @@ add_action( 'woocommerce_blocks_checkout_order_processed', 'my_function_callback
 ```
 
 
-### Related
+### See
 
 
  - https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3238
@@ -341,7 +331,7 @@ add_action( 'woocommerce_blocks_checkout_order_processed', 'my_function_callback
 ### Source
 
 
-File: [StoreApi/Routes/Checkout.php](../src/StoreApi/Routes/Checkout.php)
+ - [StoreApi/Routes/Checkout.php](../src/StoreApi/Routes/Checkout.php)
 
 ---
 
@@ -368,7 +358,7 @@ do_action( 'woocommerce_blocks_checkout_update_order_from_request', \WC_Order $o
 ### Source
 
 
-File: [StoreApi/Routes/Checkout.php](../src/StoreApi/Routes/Checkout.php)
+ - [StoreApi/Routes/Checkout.php](../src/StoreApi/Routes/Checkout.php)
 
 ---
 
@@ -391,7 +381,7 @@ do_action( 'woocommerce_blocks_checkout_update_order_meta', \WC_Order $order )
 | -------- | ---- | ----------- |
 | $order | \WC_Order | Order object. |
 
-### Related
+### See
 
 
  - https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3686
@@ -399,7 +389,7 @@ do_action( 'woocommerce_blocks_checkout_update_order_meta', \WC_Order $order )
 ### Source
 
 
-File: [StoreApi/Routes/Checkout.php](../src/StoreApi/Routes/Checkout.php)
+ - [StoreApi/Routes/Checkout.php](../src/StoreApi/Routes/Checkout.php)
 
 ---
 
@@ -415,7 +405,7 @@ do_action( 'woocommerce_blocks_enqueue_cart_block_scripts_after' )
 ### Source
 
 
-File: [BlockTypes/Cart.php](../src/BlockTypes/Cart.php)
+ - [BlockTypes/Cart.php](../src/BlockTypes/Cart.php)
 
 ---
 
@@ -431,7 +421,7 @@ do_action( 'woocommerce_blocks_enqueue_cart_block_scripts_before' )
 ### Source
 
 
-File: [BlockTypes/Cart.php](../src/BlockTypes/Cart.php)
+ - [BlockTypes/Cart.php](../src/BlockTypes/Cart.php)
 
 ---
 
@@ -447,7 +437,7 @@ do_action( 'woocommerce_blocks_enqueue_checkout_block_scripts_after' )
 ### Source
 
 
-File: [BlockTypes/Checkout.php](../src/BlockTypes/Checkout.php)
+ - [BlockTypes/Checkout.php](../src/BlockTypes/Checkout.php)
 
 ---
 
@@ -463,7 +453,7 @@ do_action( 'woocommerce_blocks_enqueue_checkout_block_scripts_before' )
 ### Source
 
 
-File: [BlockTypes/Checkout.php](../src/BlockTypes/Checkout.php)
+ - [BlockTypes/Checkout.php](../src/BlockTypes/Checkout.php)
 
 ---
 
@@ -483,7 +473,7 @@ do_action( 'woocommerce_blocks_loaded' )
 ### Source
 
 
-File: [Domain/Bootstrap.php](../src/Domain/Bootstrap.php)
+ - [Domain/Bootstrap.php](../src/Domain/Bootstrap.php)
 
 ---
 
@@ -509,7 +499,7 @@ do_action( 'woocommerce_blocks_{$this->registry_identifier}_registration', \Auto
 ### Source
 
 
-File: [Integrations/IntegrationRegistry.php](../src/Integrations/IntegrationRegistry.php)
+ - [Integrations/IntegrationRegistry.php](../src/Integrations/IntegrationRegistry.php)
 
 ---
 
@@ -529,7 +519,7 @@ do_action( 'woocommerce_check_cart_items' )
 ### Source
 
 
-File: [StoreApi/Utilities/CartController.php](../src/StoreApi/Utilities/CartController.php)
+ - [StoreApi/Utilities/CartController.php](../src/StoreApi/Utilities/CartController.php)
 
 ---
 
@@ -557,7 +547,7 @@ do_action( 'woocommerce_created_customer', integer $customer_id, array $new_cust
 ### Source
 
 
-File: [Domain/Services/CreateAccount.php](../src/Domain/Services/CreateAccount.php)
+ - [Domain/Services/CreateAccount.php](../src/Domain/Services/CreateAccount.php)
 
 ---
 
@@ -570,10 +560,15 @@ Hook: woocommerce_no_products_found.
 do_action( 'woocommerce_no_products_found' )
 ```
 
+### See
+
+
+ - wc_no_products_found() - Default no products found content (priority 10)
+
 ### Source
 
 
-File: [BlockTypes/LegacyTemplate.php](../src/BlockTypes/LegacyTemplate.php)
+ - [BlockTypes/LegacyTemplate.php](../src/BlockTypes/LegacyTemplate.php)
 
 ---
 
@@ -601,7 +596,7 @@ do_action( 'woocommerce_register_post', string $username, string $user_email, \W
 ### Source
 
 
-File: [Domain/Services/CreateAccount.php](../src/Domain/Services/CreateAccount.php)
+ - [Domain/Services/CreateAccount.php](../src/Domain/Services/CreateAccount.php)
 
 ---
 
@@ -629,7 +624,7 @@ do_action_ref_array( 'woocommerce_rest_checkout_process_payment_with_context', [
 ### Source
 
 
-File: [StoreApi/Routes/Checkout.php](../src/StoreApi/Routes/Checkout.php)
+ - [StoreApi/Routes/Checkout.php](../src/StoreApi/Routes/Checkout.php)
 
 ---
 
@@ -645,7 +640,7 @@ do_action( 'woocommerce_shop_loop' )
 ### Source
 
 
-File: [BlockTypes/LegacyTemplate.php](../src/BlockTypes/LegacyTemplate.php)
+ - [BlockTypes/LegacyTemplate.php](../src/BlockTypes/LegacyTemplate.php)
 
 ---
 
@@ -672,7 +667,7 @@ do_action( 'wooocommerce_store_api_validate_add_to_cart', \WC_Product $product, 
 ### Source
 
 
-File: [StoreApi/Utilities/CartController.php](../src/StoreApi/Utilities/CartController.php)
+ - [StoreApi/Utilities/CartController.php](../src/StoreApi/Utilities/CartController.php)
 
 ---
 
@@ -695,6 +690,6 @@ do_action( 'wooocommerce_store_api_validate_cart_item', \WC_Product $product, ar
 ### Source
 
 
-File: [StoreApi/Utilities/CartController.php](../src/StoreApi/Utilities/CartController.php)
+ - [StoreApi/Utilities/CartController.php](../src/StoreApi/Utilities/CartController.php)
 
 ---

--- a/docs/extensibility/filters.md
+++ b/docs/extensibility/filters.md
@@ -59,7 +59,7 @@ apply_filters( '__experimental_woocommerce_blocks_add_data_attributes_to_block',
 ### Source
 
 
-File: [BlockTypesController.php](../src/BlockTypesController.php)
+ - [BlockTypesController.php](../src/BlockTypesController.php)
 
 ---
 
@@ -85,7 +85,7 @@ apply_filters( '__experimental_woocommerce_blocks_add_data_attributes_to_namespa
 ### Source
 
 
-File: [BlockTypesController.php](../src/BlockTypesController.php)
+ - [BlockTypesController.php](../src/BlockTypesController.php)
 
 ---
 
@@ -129,7 +129,7 @@ add_filter( '__experimental_woocommerce_blocks_payment_gateway_features_list', '
 ### Source
 
 
-File: [Payments/Integrations/PayPal.php](../src/Payments/Integrations/PayPal.php)
+ - [Payments/Integrations/PayPal.php](../src/Payments/Integrations/PayPal.php)
 
 ---
 
@@ -156,7 +156,7 @@ apply_filters( 'wc_stripe_allow_prepaid_card', boolean $allow_prepaid_card )
 ### Source
 
 
-File: [Payments/Integrations/Stripe.php](../src/Payments/Integrations/Stripe.php)
+ - [Payments/Integrations/Stripe.php](../src/Payments/Integrations/Stripe.php)
 
 ---
 
@@ -184,7 +184,7 @@ apply_filters( 'wc_stripe_display_save_payment_method_checkbox', boolean $saved_
 
 `boolean` 
 
-### Related
+### See
 
 
  - https://github.com/woocommerce/woocommerce-gateway-stripe/blob/ad19168b63df86176cbe35c3e95203a245687640/includes/class-wc-gateway-stripe.php#L271
@@ -193,7 +193,7 @@ apply_filters( 'wc_stripe_display_save_payment_method_checkbox', boolean $saved_
 ### Source
 
 
-File: [Payments/Integrations/Stripe.php](../src/Payments/Integrations/Stripe.php)
+ - [Payments/Integrations/Stripe.php](../src/Payments/Integrations/Stripe.php)
 
 ---
 
@@ -220,7 +220,7 @@ apply_filters( 'wc_stripe_payment_request_button_locale', string $locale )
 ### Source
 
 
-File: [Payments/Integrations/Stripe.php](../src/Payments/Integrations/Stripe.php)
+ - [Payments/Integrations/Stripe.php](../src/Payments/Integrations/Stripe.php)
 
 ---
 
@@ -248,7 +248,7 @@ apply_filters( 'woocommerce_add_cart_item', array $cart_item_data, string $cart_
 ### Source
 
 
-File: [StoreApi/Utilities/CartController.php](../src/StoreApi/Utilities/CartController.php)
+ - [StoreApi/Utilities/CartController.php](../src/StoreApi/Utilities/CartController.php)
 
 ---
 
@@ -278,7 +278,7 @@ apply_filters( 'woocommerce_add_cart_item_data', array $cart_item_data, integer 
 ### Source
 
 
-File: [StoreApi/Utilities/CartController.php](../src/StoreApi/Utilities/CartController.php)
+ - [StoreApi/Utilities/CartController.php](../src/StoreApi/Utilities/CartController.php)
 
 ---
 
@@ -309,7 +309,7 @@ apply_filters( 'woocommerce_add_to_cart_sold_individually_quantity', integer $so
 ### Source
 
 
-File: [StoreApi/Utilities/CartController.php](../src/StoreApi/Utilities/CartController.php)
+ - [StoreApi/Utilities/CartController.php](../src/StoreApi/Utilities/CartController.php)
 
 ---
 
@@ -347,7 +347,7 @@ apply_filters( 'woocommerce_add_to_cart_validation', boolean $passed_validation,
 ### Source
 
 
-File: [StoreApi/Utilities/CartController.php](../src/StoreApi/Utilities/CartController.php)
+ - [StoreApi/Utilities/CartController.php](../src/StoreApi/Utilities/CartController.php)
 
 ---
 
@@ -378,7 +378,7 @@ apply_filters( 'woocommerce_adjust_non_base_location_prices', boolean $adjust_no
 ### Source
 
 
-File: [StoreApi/Utilities/ProductQuery.php](../src/StoreApi/Utilities/ProductQuery.php)
+ - [StoreApi/Utilities/ProductQuery.php](../src/StoreApi/Utilities/ProductQuery.php)
 
 ---
 
@@ -407,7 +407,7 @@ apply_filters( 'woocommerce_apply_individual_use_coupon', array $coupons, \WC_Co
 ### Source
 
 
-File: [StoreApi/Utilities/CartController.php](../src/StoreApi/Utilities/CartController.php)
+ - [StoreApi/Utilities/CartController.php](../src/StoreApi/Utilities/CartController.php)
 
 ---
 
@@ -437,7 +437,7 @@ apply_filters( 'woocommerce_apply_with_individual_use_coupon', boolean $apply_wi
 ### Source
 
 
-File: [StoreApi/Utilities/CartController.php](../src/StoreApi/Utilities/CartController.php)
+ - [StoreApi/Utilities/CartController.php](../src/StoreApi/Utilities/CartController.php)
 
 ---
 
@@ -465,7 +465,7 @@ apply_filters( 'woocommerce_blocks_product_grid_is_cacheable', boolean $is_cache
 ### Source
 
 
-File: [BlockTypes/AbstractProductGrid.php](../src/BlockTypes/AbstractProductGrid.php)
+ - [BlockTypes/AbstractProductGrid.php](../src/BlockTypes/AbstractProductGrid.php)
 
 ---
 
@@ -494,7 +494,7 @@ apply_filters( 'woocommerce_blocks_product_grid_item_html', string $html, array 
 ### Source
 
 
-File: [BlockTypes/AbstractProductGrid.php](../src/BlockTypes/AbstractProductGrid.php)
+ - [BlockTypes/AbstractProductGrid.php](../src/BlockTypes/AbstractProductGrid.php)
 
 ---
 
@@ -522,7 +522,7 @@ apply_filters( 'woocommerce_blocks_register_script_dependencies', array $depende
 ### Source
 
 
-File: [Assets/Api.php](../src/Assets/Api.php)
+ - [Assets/Api.php](../src/Assets/Api.php)
 
 ---
 
@@ -549,7 +549,7 @@ apply_filters( 'woocommerce_cart_contents_changed', array $cart_contents )
 ### Source
 
 
-File: [StoreApi/Utilities/CartController.php](../src/StoreApi/Utilities/CartController.php)
+ - [StoreApi/Utilities/CartController.php](../src/StoreApi/Utilities/CartController.php)
 
 ---
 
@@ -571,7 +571,7 @@ apply_filters( 'woocommerce_ga_disable_tracking', boolean $disable_tracking )
 ### Source
 
 
-File: [Domain/Services/GoogleAnalytics.php](../src/Domain/Services/GoogleAnalytics.php)
+ - [Domain/Services/GoogleAnalytics.php](../src/Domain/Services/GoogleAnalytics.php)
 
 ---
 
@@ -603,7 +603,7 @@ apply_filters( 'woocommerce_get_item_data', array $item_data, array $cart_item )
 ### Source
 
 
-File: [StoreApi/Schemas/CartItemSchema.php](../src/StoreApi/Schemas/CartItemSchema.php)
+ - [StoreApi/Schemas/CartItemSchema.php](../src/StoreApi/Schemas/CartItemSchema.php)
 
 ---
 
@@ -634,7 +634,7 @@ apply_filters( 'woocommerce_new_customer_data', array $customer_data )
 ### Source
 
 
-File: [Domain/Services/CreateAccount.php](../src/Domain/Services/CreateAccount.php)
+ - [Domain/Services/CreateAccount.php](../src/Domain/Services/CreateAccount.php)
 
 ---
 
@@ -667,7 +667,7 @@ apply_filters( 'woocommerce_registration_errors', \WP_Error $errors, string $use
 ### Source
 
 
-File: [Domain/Services/CreateAccount.php](../src/Domain/Services/CreateAccount.php)
+ - [Domain/Services/CreateAccount.php](../src/Domain/Services/CreateAccount.php)
 
 ---
 
@@ -701,7 +701,7 @@ apply_filters( 'woocommerce_shared_settings', array $data )
 ### Source
 
 
-File: [Assets/AssetDataRegistry.php](../src/Assets/AssetDataRegistry.php)
+ - [Assets/AssetDataRegistry.php](../src/Assets/AssetDataRegistry.php)
 
 ---
 
@@ -730,23 +730,28 @@ apply_filters( 'woocommerce_shipping_package_name', string $shipping_package_nam
 ### Source
 
 
-File: [StoreApi/Utilities/CartController.php](../src/StoreApi/Utilities/CartController.php)
+ - [StoreApi/Utilities/CartController.php](../src/StoreApi/Utilities/CartController.php)
 
 ---
 
 ## woocommerce_show_page_title
 
 
-
+We need to load the scripts here because when using block templates wp_head() gets run after the block template. As a result we are trying to enqueue required scripts before we have even registered them.
 
 ```php
 apply_filters( 'woocommerce_show_page_title' )
 ```
 
+### See
+
+
+ - https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5328#issuecomment-989013447
+
 ### Source
 
 
-File: [BlockTypes/LegacyTemplate.php](../src/BlockTypes/LegacyTemplate.php)
+ - [BlockTypes/LegacyTemplate.php](../src/BlockTypes/LegacyTemplate.php)
 
 ---
 
@@ -777,7 +782,7 @@ apply_filters( 'woocommerce_store_api_disable_nonce_check', boolean $disable_non
 ### Source
 
 
-File: [StoreApi/Routes/AbstractCartRoute.php](../src/StoreApi/Routes/AbstractCartRoute.php)
+ - [StoreApi/Routes/AbstractCartRoute.php](../src/StoreApi/Routes/AbstractCartRoute.php)
 
 ---
 
@@ -809,7 +814,7 @@ apply_filters( 'woocommerce_store_api_product_quantity_limit', integer $quantity
 ### Source
 
 
-File: [StoreApi/Schemas/ProductSchema.php](../src/StoreApi/Schemas/ProductSchema.php)
+ - [StoreApi/Schemas/ProductSchema.php](../src/StoreApi/Schemas/ProductSchema.php)
 
 ---
 
@@ -843,6 +848,6 @@ apply_filters( 'woocommerce_variation_option_name', string $value, null $unused,
 ### Source
 
 
-File: [StoreApi/Schemas/CartItemSchema.php](../src/StoreApi/Schemas/CartItemSchema.php)
+ - [StoreApi/Schemas/CartItemSchema.php](../src/StoreApi/Schemas/CartItemSchema.php)
 
 ---

--- a/src/BlockTypes/LegacyTemplate.php
+++ b/src/BlockTypes/LegacyTemplate.php
@@ -34,9 +34,12 @@ class LegacyTemplate extends AbstractDynamicBlock {
 			return;
 		}
 
-		// We need to load the scripts here because when using block templates wp_head() gets run after the block template.
-		// As a result we are trying to enqueue required scripts before we have even registered them.
-		// See here for more information: https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5328#issuecomment-989013447.
+		/**
+		 * We need to load the scripts here because when using block templates wp_head() gets run after the block
+		 * template. As a result we are trying to enqueue required scripts before we have even registered them.
+		 *
+		 * @see https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5328#issuecomment-989013447
+		 */
 		if ( class_exists( 'WC_Frontend_Scripts' ) ) {
 			$frontend_scripts = new \WC_Frontend_Scripts();
 			$frontend_scripts::load_scripts();
@@ -67,10 +70,13 @@ class LegacyTemplate extends AbstractDynamicBlock {
 		ob_start();
 
 		/**
-		 * Woocommerce_before_main_content hook.
+		 * Hook: woocommerce_before_main_content
 		 *
-		 * @hooked woocommerce_output_content_wrapper - 10 (outputs opening divs for the content)
-		 * @hooked woocommerce_breadcrumb - 20
+		 * Called before rendering the main content for a product.
+		 *
+		 * @see woocommerce_output_content_wrapper() Outputs opening DIV for the content (priority 10)
+		 * @see woocommerce_breadcrumb() Outputs breadcrumb trail to the current product (priority 20)
+		 * @see WC_Structured_Data::generate_website_data() Outputs schema markup (priority 30)
 		 */
 		do_action( 'woocommerce_before_main_content' );
 
@@ -82,9 +88,11 @@ class LegacyTemplate extends AbstractDynamicBlock {
 		endwhile;
 
 		/**
-		 * Woocommerce_after_main_content hook.
+		 * Hook: woocommerce_after_main_content
 		 *
-		 * @hooked woocommerce_output_content_wrapper_end - 10 (outputs closing divs for the content)
+		 * Called after rendering the main content for a product.
+		 *
+		 * @see woocommerce_output_content_wrapper_end() Outputs closing DIV for the content (priority 10)
 		 */
 		do_action( 'woocommerce_after_main_content' );
 
@@ -102,11 +110,13 @@ class LegacyTemplate extends AbstractDynamicBlock {
 		ob_start();
 
 		/**
-		 * Hook: woocommerce_before_main_content.
+		 * Hook: woocommerce_before_main_content
 		 *
-		 * @hooked woocommerce_output_content_wrapper - 10 (outputs opening divs for the content)
-		 * @hooked woocommerce_breadcrumb - 20
-		 * @hooked WC_Structured_Data::generate_website_data() - 30
+		 * Called before rendering the main content for a product.
+		 *
+		 * @see woocommerce_output_content_wrapper() Outputs opening DIV for the content (priority 10)
+		 * @see woocommerce_breadcrumb() Outputs breadcrumb trail to the current product (priority 20)
+		 * @see WC_Structured_Data::generate_website_data() Outputs schema markup (priority 30)
 		 */
 		do_action( 'woocommerce_before_main_content' );
 
@@ -120,8 +130,8 @@ class LegacyTemplate extends AbstractDynamicBlock {
 			/**
 			 * Hook: woocommerce_archive_description.
 			 *
-			 * @hooked woocommerce_taxonomy_archive_description - 10
-			 * @hooked woocommerce_product_archive_description - 10
+			 * @see woocommerce_taxonomy_archive_description() Renders the taxonomy archive description (priority 10)
+			 * @see woocommerce_product_archive_description() Renders the product archive description (priority 10)
 			 */
 			do_action( 'woocommerce_archive_description' );
 			?>
@@ -132,9 +142,9 @@ class LegacyTemplate extends AbstractDynamicBlock {
 			/**
 			 * Hook: woocommerce_before_shop_loop.
 			 *
-			 * @hooked woocommerce_output_all_notices - 10
-			 * @hooked woocommerce_result_count - 20
-			 * @hooked woocommerce_catalog_ordering - 30
+			 * @see woocommerce_output_all_notices() Render error notices (priority 10)
+			 * @see woocommerce_result_count() Show number of results found (priority 20)
+			 * @see woocommerce_catalog_ordering() Show form to control sort order (priority 30)
 			 */
 			do_action( 'woocommerce_before_shop_loop' );
 
@@ -158,22 +168,24 @@ class LegacyTemplate extends AbstractDynamicBlock {
 			/**
 			 * Hook: woocommerce_after_shop_loop.
 			 *
-			 * @hooked woocommerce_pagination - 10
+			 * @see woocommerce_pagination() Renders pagination (priority 10)
 			 */
 			do_action( 'woocommerce_after_shop_loop' );
 		} else {
 			/**
 			 * Hook: woocommerce_no_products_found.
 			 *
-			 * @hooked wc_no_products_found - 10
+			 * @see wc_no_products_found() Default no products found content (priority 10)
 			 */
 			do_action( 'woocommerce_no_products_found' );
 		}
 
 		/**
-		 * Hook: woocommerce_after_main_content.
+		 * Hook: woocommerce_after_main_content
 		 *
-		 * @hooked woocommerce_output_content_wrapper_end - 10 (outputs closing divs for the content)
+		 * Called after rendering the main content for a product.
+		 *
+		 * @see woocommerce_output_content_wrapper_end() Outputs closing DIV for the content (priority 10)
 		 */
 		do_action( 'woocommerce_after_main_content' );
 


### PR DESCRIPTION
Prevents duplicate hooks by combining them by name.

- Updates the hook documentation script
- Combines hooks by name. If hooks are called in multiple files, it collects all file names and lists all files in the doc itself.
- Updates some docblocks in LegacyTemplates class so they are consistent 

Fixes #5374

### Testing

Run `npm run build:docs` and check the output. I've updated docs with this PR.
