### PR TITLE
Fix initial population of address data in `useCustomerData` hook

### DIFF
--- a/assets/js/base/context/hooks/use-checkout-address.js
+++ b/assets/js/base/context/hooks/use-checkout-address.js
@@ -27,7 +27,7 @@ export const useCheckoutAddress = () => {
 	} = useCustomerDataContext();
 
 	const currentShippingAsBilling = useRef( shippingAsBilling );
-	const previousBillingData = useRef( billingData );
+	const previousBillingData = useRef();
 
 	/**
 	 * Sets shipping address data, and also billing if using the same address.
@@ -71,7 +71,7 @@ export const useCheckoutAddress = () => {
 					email,
 					/* eslint-enable no-unused-vars */
 					...billingAddress
-				} = previousBillingData.current;
+				} = previousBillingData.current || billingData;
 
 				setBillingData( {
 					...billingAddress,

--- a/assets/js/base/context/hooks/use-store-notices.ts
+++ b/assets/js/base/context/hooks/use-store-notices.ts
@@ -30,7 +30,7 @@ type WPNotice = {
 type NoticeOptions = {
 	id: string;
 	type?: string;
-	isDismissible: boolean;
+	isDismissible?: boolean;
 };
 
 type NoticeCreator = ( text: string, noticeProps: NoticeOptions ) => void;
@@ -39,7 +39,7 @@ export const useStoreNotices = (): {
 	notices: WPNotice[];
 	hasNoticesOfType: ( type: string ) => boolean;
 	removeNotices: ( status: string | null ) => void;
-	removeNotice: ( id: string, context: string ) => void;
+	removeNotice: ( id: string, context?: string ) => void;
 	addDefaultNotice: NoticeCreator;
 	addErrorNotice: NoticeCreator;
 	addWarningNotice: NoticeCreator;


### PR DESCRIPTION
Fixes the issue [described here](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5456#issuecomment-1002825206) where address fields are blank on mount. Traced back to this change: https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5394

While we don't want to update the server on the initial mount, we do need to sync initial address data with the cart once that's finished initialising. I believe this PR fixes both cases.

1. Changes `useCustomerData` so it tracks when the cart is finished loading, and then initialized itself with the updated address.
2. Added inline documentation to `useCustomerData` to make it easier to maintain.
3. Updated `useCustomerData` to use `useDebounceCallback` which is more easy to follow than debouncing several values.
2. Fixes a small issue in `useCheckoutAddress` which was also tracking the initial empty address.

Fixes #5456

### Testing

To avoid further regressions we need to test against all related issues.

1. While logged in, with a customer than has checked out before, visit the checkout page
2. Confirm shipping address fields are populated
3. Toggle the "different billing address' box. Confirm billing fields are populated.
4. Open the network inspector in browser tools
5. Repeat the test above. Open the checkout page. Confirm there are no extra requests to the `batch/` endpoint once the address data is populated.
6. Change an address field such as state or country. Confirm the cart sends a request to the server after a small 1000ms delay.
7. Smoke test the full checkout flow

### Changelog

> Fixed an issue where the checkout address fields would be blank for logged in customers
