### PR TITLE
Fix duplicated error notices

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-payment-block/block.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-payment-block/block.tsx
@@ -1,8 +1,6 @@
 /**
  * External dependencies
  */
-import { StoreNoticesProvider } from '@woocommerce/base-context';
-import { useEmitResponse } from '@woocommerce/base-context/hooks';
 
 /**
  * Internal dependencies
@@ -10,13 +8,7 @@ import { useEmitResponse } from '@woocommerce/base-context/hooks';
 import { PaymentMethods } from '../../../payment-methods';
 
 const Block = (): JSX.Element | null => {
-	const { noticeContexts } = useEmitResponse();
-
-	return (
-		<StoreNoticesProvider context={ noticeContexts.PAYMENTS }>
-			<PaymentMethods />
-		</StoreNoticesProvider>
-	);
+	return <PaymentMethods />;
 };
 
 export default Block;

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-payment-block/frontend.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-payment-block/frontend.tsx
@@ -2,13 +2,10 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { useStoreCart, useEmitResponse } from '@woocommerce/base-context/hooks';
+import { useStoreCart } from '@woocommerce/base-context/hooks';
 import { withFilteredAttributes } from '@woocommerce/shared-hocs';
 import { FormStep } from '@woocommerce/base-components/cart-checkout';
-import {
-	useCheckoutContext,
-	StoreNoticesProvider,
-} from '@woocommerce/base-context';
+import { useCheckoutContext } from '@woocommerce/base-context';
 
 /**
  * Internal dependencies
@@ -31,7 +28,6 @@ const FrontendBlock = ( {
 } ) => {
 	const { isProcessing: checkoutIsProcessing } = useCheckoutContext();
 	const { cartNeedsPayment } = useStoreCart();
-	const { noticeContexts } = useEmitResponse();
 
 	if ( ! cartNeedsPayment ) {
 		return null;
@@ -48,9 +44,7 @@ const FrontendBlock = ( {
 			description={ description }
 			showStepNumber={ showStepNumber }
 		>
-			<StoreNoticesProvider context={ noticeContexts.PAYMENTS }>
-				<Block />
-			</StoreNoticesProvider>
+			<Block />
 			{ children }
 		</FormStep>
 	);

--- a/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-payment-block/frontend.tsx
+++ b/assets/js/blocks/cart-checkout/checkout/inner-blocks/checkout-payment-block/frontend.tsx
@@ -2,10 +2,13 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { useStoreCart } from '@woocommerce/base-context/hooks';
+import { useStoreCart, useEmitResponse } from '@woocommerce/base-context/hooks';
 import { withFilteredAttributes } from '@woocommerce/shared-hocs';
 import { FormStep } from '@woocommerce/base-components/cart-checkout';
-import { useCheckoutContext } from '@woocommerce/base-context';
+import {
+	useCheckoutContext,
+	StoreNoticesProvider,
+} from '@woocommerce/base-context';
 
 /**
  * Internal dependencies
@@ -28,6 +31,7 @@ const FrontendBlock = ( {
 } ) => {
 	const { isProcessing: checkoutIsProcessing } = useCheckoutContext();
 	const { cartNeedsPayment } = useStoreCart();
+	const { noticeContexts } = useEmitResponse();
 
 	if ( ! cartNeedsPayment ) {
 		return null;
@@ -44,7 +48,9 @@ const FrontendBlock = ( {
 			description={ description }
 			showStepNumber={ showStepNumber }
 		>
-			<Block />
+			<StoreNoticesProvider context={ noticeContexts.PAYMENTS }>
+				<Block />
+			</StoreNoticesProvider>
 			{ children }
 		</FormStep>
 	);


### PR DESCRIPTION
`StoreNoticeProvider` is already being used within `Block` component. This PR proposes its removal from `FrontendBlock` to prevent duplicate error notices mentioned in  #5475 . I am not quite sure if it should rather be removed from the (child) `Block` component instead.  

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #5475 


<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### Screenshots

**Before**
![image](https://user-images.githubusercontent.com/41606954/141514500-4803d148-6a73-4ea5-aefd-a24f9a6cbc7b.png)

**After**
![Screen Shot 2021-12-30 at 12 15 43 PM](https://user-images.githubusercontent.com/6216000/147777983-9f54e997-0fbb-40fa-a01c-ac3648d34965.png)


### Testing

How to test the changes in this Pull Request:


1. Make sure you're using the Blocks checkout and WCPay.
2. Enable UPE from WCPay Dev Tools
2. Add 1 or more products to your cart.
3. Go to the blocks checkout page
4. Pay through the credit card form with a card that will be declined, e.g. 4000 0000 0000 0002.
5. Ensure that only one error notice is displayed 

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above

### Changelog

> Fix duplicated checkout error notices.
