### PR TITLE
Mini Cart Block: The color of the badge reflects the global style

### DIFF
--- a/assets/js/blocks/cart-checkout/mini-cart/index.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart/index.tsx
@@ -36,6 +36,7 @@ const settings = {
 			 * to add color classes and style to the wrapper.
 			 */
 			__experimentalSkipSerialization: true,
+			background: false,
 		},
 		/**
 		 * We need this experimental flag because we don't want to style the

--- a/assets/js/blocks/cart-checkout/mini-cart/quantity-badge/style.scss
+++ b/assets/js/blocks/cart-checkout/mini-cart/quantity-badge/style.scss
@@ -9,7 +9,7 @@
 	border: 0.15em solid;
 	border-radius: 1em;
 	box-sizing: border-box;
-	color: #000;
+	color: inherit;
 	display: flex;
 	font-size: 0.875em;
 	font-weight: 600;


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

With this PR, the color of the badge of Mini Cart Block will reflect the global style.

This PR also disables the ability to customize the background because it shouldn't be possible.



<!-- Reference any related issues or PRs here -->
Fixes #4965 


### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->
![image](https://user-images.githubusercontent.com/4463174/147925799-532ae454-702e-4b10-9d85-63109e4424e5.png)
*before this PR* 

![image](https://user-images.githubusercontent.com/4463174/147925832-370acdbf-9e4b-4556-9832-b3e3d1fda86d.png)
*with this PR*



### Manual Testing

How to test the changes in this PR:

Check out this branch:

1. Install and enable `Gutenberg` plugin.
2. Install and enable `TT1 Blocks` theme.
3. Add the `Mini Cart Block`.
4. Verify you can change ONLY the text color.
5. Save.
6. Go on the page and check if there are changes.
7. Reset to default.
8. Go to Dashboard and select Appearance > Editor (beta).
9. Click on the Global styles icon .
10. Verify the `Mini Cart Block` is shown and you can tweak its styles.
11. Save 
12. Go on the page created earlier and check if all styles are applied correctly.
10. Edit the previous post/page again.
11. Change again text color.
12. Save.
13. Check if these styles have priority over the styles from the Site editor.



