### PR TITLE
Update WooCommerce plugin slug for Block Templates

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -105,8 +105,8 @@ class BlockTemplatesController {
 		// been unhooked so won't run again.
 		add_filter( 'get_block_file_template', array( $this, 'get_single_block_template' ), 10, 3 );
 		$maybe_template = function_exists( 'gutenberg_get_block_template' ) ?
-			gutenberg_get_block_template( 'woocommerce//' . $slug, $template_type ) :
-			get_block_template( 'woocommerce//' . $slug, $template_type );
+			gutenberg_get_block_template( BlockTemplateUtils::PLUGIN_SLUG . '//' . $slug, $template_type ) :
+			get_block_template( BlockTemplateUtils::PLUGIN_SLUG . '//' . $slug, $template_type );
 
 		// Re-hook this function, it was only unhooked to stop recursion.
 		add_filter( 'pre_get_block_file_template', array( $this, 'maybe_return_blocks_template' ), 10, 3 );
@@ -270,6 +270,11 @@ class BlockTemplatesController {
 	 * @return int[]|\WP_Post[] An array of found templates.
 	 */
 	public function get_block_templates_from_db( $slugs = array(), $template_type = 'wp_template' ) {
+		// This was the previously incorrect slug used to save DB templates against.
+		// To maintain compatibility with users sites who have already customised WooCommerce block templates using this slug we have to still use it to query those.
+		// More context found here: https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5423.
+		$invalid_plugin_slug = 'woocommerce';
+
 		$check_query_args = array(
 			'post_type'      => $template_type,
 			'posts_per_page' => -1,
@@ -278,13 +283,15 @@ class BlockTemplatesController {
 				array(
 					'taxonomy' => 'wp_theme',
 					'field'    => 'name',
-					'terms'    => array( 'woocommerce', get_stylesheet() ),
+					'terms'    => array( $invalid_plugin_slug, BlockTemplateUtils::PLUGIN_SLUG, get_stylesheet() ),
 				),
 			),
 		);
+
 		if ( is_array( $slugs ) && count( $slugs ) > 0 ) {
 			$check_query_args['post_name__in'] = $slugs;
 		}
+
 		$check_query         = new \WP_Query( $check_query_args );
 		$saved_woo_templates = $check_query->posts;
 

--- a/src/Utils/BlockTemplateUtils.php
+++ b/src/Utils/BlockTemplateUtils.php
@@ -28,6 +28,15 @@ class BlockTemplateUtils {
 	);
 
 	/**
+	 * WooCommerce plugin slug
+	 *
+	 * This is used to save templates to the DB which are stored against this value in the wp_terms table.
+	 *
+	 * @var string
+	 */
+	const PLUGIN_SLUG = 'woocommerce/woocommerce';
+
+	/**
 	 * Returns an array containing the references of
 	 * the passed blocks and their inner blocks.
 	 *
@@ -119,7 +128,7 @@ class BlockTemplateUtils {
 		$template                 = new \WP_Block_Template();
 		$template->wp_id          = $post->ID;
 		$template->id             = $theme . '//' . $post->post_name;
-		$template->theme          = 'woocommerce' === $theme ? 'WooCommerce' : $theme;
+		$template->theme          = $theme;
 		$template->content        = $post->post_content;
 		$template->slug           = $post->post_name;
 		$template->source         = 'custom';
@@ -138,7 +147,10 @@ class BlockTemplateUtils {
 			}
 		}
 
-		if ( 'woocommerce' === $theme ) {
+		// We are checking 'woocommerce' to maintain legacy templates which are saved to the DB,
+		// prior to updating to use the correct slug.
+		// More information found here: https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5423.
+		if ( self::PLUGIN_SLUG === $theme || 'woocommerce' === strtolower( $theme ) ) {
 			$template->origin = 'plugin';
 		}
 
@@ -164,8 +176,8 @@ class BlockTemplateUtils {
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 		$template_content  = file_get_contents( $template_file->path );
 		$template          = new \WP_Block_Template();
-		$template->id      = $template_is_from_theme ? $theme_name . '//' . $template_file->slug : 'woocommerce//' . $template_file->slug;
-		$template->theme   = $template_is_from_theme ? $theme_name : 'WooCommerce';
+		$template->id      = $template_is_from_theme ? $theme_name . '//' . $template_file->slug : self::PLUGIN_SLUG . '//' . $template_file->slug;
+		$template->theme   = $template_is_from_theme ? $theme_name : self::PLUGIN_SLUG;
 		$template->content = self::gutenberg_inject_theme_attribute_in_content( $template_content );
 		// Plugin was agreed as a valid source value despite existing inline docs at the time of creating: https://github.com/WordPress/gutenberg/issues/36597#issuecomment-976232909.
 		$template->source         = $template_file->source ? $template_file->source : 'plugin';
@@ -196,10 +208,10 @@ class BlockTemplateUtils {
 
 		$new_template_item = array(
 			'slug'        => $template_slug,
-			'id'          => $template_is_from_theme ? $theme_name . '//' . $template_slug : 'woocommerce//' . $template_slug,
+			'id'          => $template_is_from_theme ? $theme_name . '//' . $template_slug : self::PLUGIN_SLUG . '//' . $template_slug,
 			'path'        => $template_file,
 			'type'        => $template_type,
-			'theme'       => $template_is_from_theme ? $theme_name : 'woocommerce',
+			'theme'       => $template_is_from_theme ? $theme_name : self::PLUGIN_SLUG,
 			// Plugin was agreed as a valid source value despite existing inline docs at the time of creating: https://github.com/WordPress/gutenberg/issues/36597#issuecomment-976232909.
 			'source'      => $template_is_from_theme ? 'theme' : 'plugin',
 			'title'       => self::convert_slug_to_title( $template_slug ),


### PR DESCRIPTION
#### Description

Use the correct WooCommerce plugin slug `woocommerce/woocommerce` instead of the current incorrect one `woocommerce`. However, we are maintaining the old slug until we deploy a migration script to update the DB entires.

#### Consequences of this approach

**If the site has DB entries using the old slug _and_ the new slug:**
We will have to find the `term_id` for the old slug and update all entries using it to use the _new_ slugs `term_id`.

**If the site has DB entries just using the old slug:**
We can simply update the old slug row in `wp_terms` 

From:
name: `WooCommerce` 
slug: `woocommerce`

To:
name:`woocommerce/woocommerce` 
slug: `woocommerce-woocommerce`

Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5423
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5327

### Testing

How to test the changes in this Pull Request:

Note: This is mostly regression testing.

1. **Before checking out this PR**, customise the Single Product template so you have a DB entry with the old slug.
2. Checkout this PR, ensure on the Site Editor > Templates list you are still seeing the customised template in this list and it renders correctly on the frontend, and in site editor.
3. Now customise the Product Archive template and ensure on the Site Editor > Templates list you are still seeing the customised template in this list and it renders correctly on the frontend, and in site editor.
4. Clear the customisations of the Product Archive template to ensure this functionality also works correctly.
5. Create a `archive-product.html` template in your theme and ensure this overrides the default one provided by WooCommerce. Check this also renders correctly on the frontend and within the site editor.
6. Customise the newly created `archive-product.html` provided by your theme,  ensure on the Site Editor > Templates list you are still seeing the customised template in this list and it renders correctly on the frontend, and in site editor.
7. Clear the customisations of the themes `archive-product.html` template to ensure this works correctly.
8. Check that we're now not receiving 404 network requests for WooCommerce templates on the Site Editor templates list page as described here https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5327

### Performance Impact

We are querying both the old and the new slugs for customised templates which have been saved in the database. This will be resolved later using a migration script described above in this PR.
