### PR TITLE
Add margin below shipping packages in checkout

### DIFF
--- a/assets/js/base/components/cart-checkout/shipping-rates-control-package/style.scss
+++ b/assets/js/base/components/cart-checkout/shipping-rates-control-package/style.scss
@@ -1,9 +1,4 @@
 .wc-block-components-shipping-rates-control__package {
-	margin-bottom: em($gap-large);
-
-	&:last-of-type {
-		margin-bottom: 0;
-	}
 
 	.wc-block-components-panel__button {
 		margin-bottom: 0;
@@ -46,4 +41,14 @@
 .wc-block-components-shipping-rates-control__package-item:not(:last-child)::after {
 	content: ", ";
 	white-space: pre;
+}
+
+// Target the shipping selection in checkout only, the Cart block has enough spacing because of the buttons on the panel.
+.wc-block-checkout .wc-block-components-shipping-rates-control__package {
+	margin-bottom: em($gap-large);
+
+	&:last-of-type {
+		margin-bottom: 0;
+	}
+
 }

--- a/assets/js/base/components/cart-checkout/shipping-rates-control-package/style.scss
+++ b/assets/js/base/components/cart-checkout/shipping-rates-control-package/style.scss
@@ -1,4 +1,10 @@
 .wc-block-components-shipping-rates-control__package {
+	margin-bottom: em($gap-large);
+
+	&:last-of-type {
+		margin-bottom: 0;
+	}
+
 	.wc-block-components-panel__button {
 		margin-bottom: 0;
 		margin-top: 0;


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

This PR adds margin below the `wc-block-components-shipping-rates-control__package` class, but not on the last of type to prevent this from affecting the parent component's spacing.

<!-- Reference any related issues or PRs here -->
Fixes #5279

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### Screenshots

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/5656702/148422395-e039c459-fca4-4d42-8d3a-6cb04819f8ab.png) | ![image](https://user-images.githubusercontent.com/5656702/148421954-89b88d79-a8e6-43c3-9207-4d047d723bb5.png) |

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

1. Install Woo Blocks and Woo Subscriptions.
2. Add Simple subscription product with a subscription price and a signup fee.
3. Go to the front-end and add the subscription price to the cart.
4. Go to the Checkout block and look at the shipping options, notice that there is a gap between the two shipping options.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above

### Changelog

>  Fixed a styling issue in the Checkout block when an order has multiple shipping packages.
