### PR TITLE
Fix Search Product placeholder's contrast

### DIFF
--- a/assets/css/abstracts/_colors.scss
+++ b/assets/css/abstracts/_colors.scss
@@ -7,7 +7,7 @@ $low-stock-color: $alert-yellow;
 $in-stock-color: $alert-green;
 $discount-color: $alert-green;
 
-$placeholder-color: var(--global--color-primary, $gray-200);
+$placeholder-color: var(--global--color-primary, $gray-700);
 $input-border-gray: #50575e;
 $input-border-dark: rgba(255, 255, 255, 0.4);
 $input-disabled-dark: rgba(255, 255, 255, 0.3);

--- a/assets/css/abstracts/_mixins.scss
+++ b/assets/css/abstracts/_mixins.scss
@@ -6,6 +6,10 @@ $fontSizes: (
 	"larger": 2,
 );
 
+$placeholders: "-webkit-input-placeholder",
+	"-moz-placeholder",
+	"-ms-input-placeholder";
+
 // Maps a named font-size to its predefined size. Units default to em, but can
 // be changed using the multiplier parameter.
 @mixin font-size($sizeName, $multiplier: 1em) {
@@ -215,4 +219,30 @@ $fontSizes: (
 
 	$hex: str-slice(ie-hex-str($color), 4);
 	@return "%23" + unquote("#{$hex}");
+}
+
+@mixin placeholder-auto-prefixer {
+	@each $placeholder in $placeholders {
+		@if $placeholder == "-webkit-input-placeholder" {
+			::#{$placeholder} {
+				@content;
+			}
+		}
+		@else if $placeholder == "-moz-placeholder" {
+			// FF 18-
+			:#{$placeholder} {
+				@content;
+			}
+
+			// FF 19+
+			::#{$placeholder} {
+				@content;
+			}
+		}
+		@else {
+			:#{$placeholder} {
+				@content;
+			}
+		}
+	}
 }

--- a/assets/css/abstracts/_mixins.scss
+++ b/assets/css/abstracts/_mixins.scss
@@ -6,10 +6,6 @@ $fontSizes: (
 	"larger": 2,
 );
 
-$placeholders: "-webkit-input-placeholder",
-	"-moz-placeholder",
-	"-ms-input-placeholder";
-
 // Maps a named font-size to its predefined size. Units default to em, but can
 // be changed using the multiplier parameter.
 @mixin font-size($sizeName, $multiplier: 1em) {
@@ -219,30 +215,4 @@ $placeholders: "-webkit-input-placeholder",
 
 	$hex: str-slice(ie-hex-str($color), 4);
 	@return "%23" + unquote("#{$hex}");
-}
-
-@mixin placeholder-auto-prefixer {
-	@each $placeholder in $placeholders {
-		@if $placeholder == "-webkit-input-placeholder" {
-			::#{$placeholder} {
-				@content;
-			}
-		}
-		@else if $placeholder == "-moz-placeholder" {
-			// FF 18-
-			:#{$placeholder} {
-				@content;
-			}
-
-			// FF 19+
-			::#{$placeholder} {
-				@content;
-			}
-		}
-		@else {
-			:#{$placeholder} {
-				@content;
-			}
-		}
-	}
 }

--- a/assets/js/blocks/product-search/style.scss
+++ b/assets/js/blocks/product-search/style.scss
@@ -1,8 +1,4 @@
 .wc-block-product-search {
-	@include placeholder-auto-prefixer {
-		color: $placeholder-color;
-	}
-
 	.wc-block-product-search__fields {
 		display: flex;
 	}
@@ -10,6 +6,11 @@
 		padding: 6px 8px;
 		line-height: 1.8;
 		flex-grow: 1;
+
+		&::placeholder,
+		input::placeholder {
+			color: $placeholder-color;
+		}
 	}
 	.wc-block-product-search__button {
 		display: flex;

--- a/assets/js/blocks/product-search/style.scss
+++ b/assets/js/blocks/product-search/style.scss
@@ -1,4 +1,8 @@
 .wc-block-product-search {
+	@include placeholder-auto-prefixer {
+		color: $placeholder-color;
+	}
+
 	.wc-block-product-search__fields {
 		display: flex;
 	}


### PR DESCRIPTION
It was reported in this issue: #1683, that the placeholder of the Product Search block doesn't have enough contrast.

After looking further into it, I discovered the following:

- In the editor mode, we don't have the contrast issue anymore, but we are relying on the colors set by the WordPress core for our placeholders (e.g. we are getting our placeholder colors from `/wp-includes/css/dist/components/style.css` & `/wp-admin/css/forms.css`).
- In the preview or the live version mode of our Product Search block, the default placeholder color of the browser is applied instead. The reason for that is the class name change of the input element.

### Issue

The issue here is that we shouldn't rely on the CSS applied by the WordPress core to style our blocks on the editor mode, and we shouldn't rely on the browser default styles either.
For example, in this case, the latest version of the Safari browser is applying the following placeholder color: `#A9A9A9` while the background is white, and this combination is failing every contrast test:
[https://webaim.org/resources/contrastchecker/?fcolor=A9A9A9&bcolor=FFFFFF](https://webaim.org/resources/contrastchecker/?fcolor=A9A9A9&bcolor=FFFFFF)

![image](https://user-images.githubusercontent.com/14235870/148474523-040a6f2a-530d-45e8-87ca-69274d45c320.png)

### Fix

Set a placeholder color that passes the contrast test for the Product Search block.

### Another approach

While inspecting the codebase of the WooCommerce Blocks it seems that we aren't setting any default colors for our placeholders in all of our blocks. 
A better solution would have been setting a default placeholder color globally instead of fixing this issue for the Product Search alone. But, since I'm not yet familiar with this product and to be safe I choose the latter option.

### Testing

### Manual Testing
The theme used for this test: "Twenty Twenty-One".

1. Checkout the branch
2. Create a test page.
3. Add the "Search Product" block.
4. Publish the page
5. Check the live version of this page on different browsers (e.g. Chrome, Safari, etc.)
6. Inspect the search input and check that our WooCommerce Blocks plugin is applying its own placeholder color (in wc-blocks-style.css).
7. Test contrast on this [contrast checker](https://webaim.org/resources/contrastchecker/) tool by providing the placeholder's color. It should pass on white background.

### Changelog

> Fix the default placeholder color contrast for the Product Search block

