### PR TITLE
Fix: Category block products display when `All selected categories` is selected

### DIFF
--- a/src/BlockTypes/AbstractProductGrid.php
+++ b/src/BlockTypes/AbstractProductGrid.php
@@ -240,7 +240,6 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 				'taxonomy'         => 'product_cat',
 				'terms'            => $categories,
 				'field'            => 'term_id',
-				'operator'         => 'all' === $this->attributes['catOperator'] ? 'AND' : 'IN',
 
 				/*
 				 * When cat_operator is AND, the children categories should be excluded,


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR will try and fix https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/3085 where, when more than one category is selected and `All selected categories` option is set, we get an incorrect number of products displayed.

The proposed fix looks at the operator taxonomy query for filtering the product results:
1. The `AND` operator means that the matching products need to be in all the categories selected
2. The `IN` operator means that the matching products can be in any categories selected

I would think that 1. is not desired and that can be replaced with `IN`, and since the default operator value is `IN`, then that can be removed altogether.

<!-- Reference any related issues or PRs here -->
Fixes woocommerce/woocommerce#42676

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

There are no changes at the accessibility level since the PR does not affect any stylings.

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] I've updated [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) for any feature flags or experimental interfaces implemented in this pull request.
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<img width="1248" alt="Screenshot 2022-01-07 at 10 00 12" src="https://user-images.githubusercontent.com/537751/148511710-44318c0d-fad9-43b9-9ce2-1164f717aa92.png">

<img width="890" alt="Screenshot 2022-01-07 at 10 00 55" src="https://user-images.githubusercontent.com/537751/148511720-aee4e667-cf8d-4727-b5fb-fc2f425cfdb3.png">

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Install WooCommerce Blocks and WooCommerce core
2. Install WooCommerce [sample data](https://woocommerce.com/document/importing-woocommerce-sample-data/)
3. In my setup, it seems the `woocommerce/packages/woocommerce-blocks/src/BlockTypes/AbstractProductGrid.php` took precedence on load, so copy also the original file from `woocommerce-gutenberg-products-block/src/BlockTypes/AbstractProductGrid.php` to that one
4. Create a new Post
5. Select Products by Category block
6. Select 2 or more categories
7. Select the `All selected categories`
8. Check the frontend results display count, the result should only shows products assigned to those specific categories with child categories excluded

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
* [ ] See steps below.


<!-- If you can, add the appropriate labels -->

### Performance Impact

No performance impact was estimated.

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Fix the Products by Category block showing the incorrect number of products when `All selected categories` is selected
