### PR TITLE
Update PR assignment automation to match new Team Kirigami name

### DIFF
--- a/.github/automate-team-review-assignment-config.yml
+++ b/.github/automate-team-review-assignment-config.yml
@@ -9,9 +9,9 @@ when:
         - rubik-fp-squad
   - author:
       teamIs:
-        - rubik-fse-squad
+        - kirigami
       ignore:
         nameIs:
     assign:
       teams:
-        - rubik-fse-squad
+        - kirigami


### PR DESCRIPTION
The name of the `rubik-fse-squad` GitHub team has been changed to `rubik`, so we need to update the PR review assignment automation too.