### PR TITLE
Convert token to string when setting the active payment method

### DIFF
--- a/assets/js/base/context/providers/cart-checkout/payment-methods/payment-method-data-context.tsx
+++ b/assets/js/base/context/providers/cart-checkout/payment-methods/payment-method-data-context.tsx
@@ -195,14 +195,14 @@ export const PaymentMethodDataProvider = ( {
 			)[ 0 ] || undefined;
 
 		if ( customerPaymentMethod ) {
-			const token = customerPaymentMethod.tokenId;
+			const token = customerPaymentMethod.tokenId.toString();
 			const paymentMethodSlug = customerPaymentMethod.method.gateway;
 			const savedTokenKey = `wc-${ paymentMethodSlug }-payment-token`;
 
 			dispatchActions.setActivePaymentMethod( paymentMethodSlug, {
 				token,
 				payment_method: paymentMethodSlug,
-				[ savedTokenKey ]: token.toString(),
+				[ savedTokenKey ]: token,
 				isSavedToken: true,
 			} );
 			return;


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
For cards saved during the checkout process, the payment_data token is being put through as an integer since 6.6.0 because of the changes introduced by [this PR](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5350/files)
This PR fixes this issue by converting the token to string when dispatching the setActivePaymentMethod.


<!-- Reference any related issues or PRs here -->
Fixes #5522

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->






### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. On your site make sure you have Stripe set up
2. Create a new customer user for your website
3. Log in with that user and add a product to the Cart block
4. In the Checkout block pay with a Stripe card and select `Save payment information to my account for future purchases.`
5. Successfully place the order
6. Do another purchase and make sure to select the saved card as a payment method
7. Notice that you can successfully place the order and no  `payment_data[0] [value] is not of type string.boolean.` error is showed.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or



Additionally perform a quick smoke test to the Checkout block:
- pay with an express method
- notice that your Shipping details are prefilled after your first order



### Changelog

> Convert token to string when setting the active payment method
