### PR TITLE
Fix All Products Block Tests due to incorrect Stock Filter addition

### DIFF
--- a/assets/js/blocks/product-category/block.js
+++ b/assets/js/blocks/product-category/block.js
@@ -18,6 +18,7 @@ import GridContentControl from '@woocommerce/editor-components/grid-content-cont
 import GridLayoutControl from '@woocommerce/editor-components/grid-layout-control';
 import ProductCategoryControl from '@woocommerce/editor-components/product-category-control';
 import ProductOrderbyControl from '@woocommerce/editor-components/product-orderby-control';
+import ProductStockControl from '@woocommerce/editor-components/product-stock-control';
 import { gridBlockPreview } from '@woocommerce/resource-previews';
 import { Icon, folder } from '@woocommerce/icons';
 import { getSetting } from '@woocommerce/settings';
@@ -119,6 +120,7 @@ class ProductByCategoryBlock extends Component {
 			orderby,
 			rows,
 			alignButtons,
+			stockStatus,
 		} = attributes;
 
 		return (
@@ -184,6 +186,18 @@ class ProductByCategoryBlock extends Component {
 					<ProductOrderbyControl
 						setAttributes={ setAttributes }
 						value={ orderby }
+					/>
+				</PanelBody>
+				<PanelBody
+					title={ __(
+						'Stock level',
+						'woo-gutenberg-products-block'
+					) }
+					initialOpen={ false }
+				>
+					<ProductStockControl
+						setAttributes={ setAttributes }
+						value={ stockStatus }
 					/>
 				</PanelBody>
 			</InspectorControls>

--- a/assets/js/blocks/products/attributes.js
+++ b/assets/js/blocks/products/attributes.js
@@ -18,7 +18,6 @@ export const defaults = {
 	orderby: 'date',
 	layoutConfig: DEFAULT_PRODUCT_LIST_LAYOUT,
 	isPreview: false,
-	stockStatus: 'any',
 };
 
 export const attributes = {
@@ -64,13 +63,5 @@ export const attributes = {
 	isPreview: {
 		type: 'boolean',
 		default: false,
-	},
-
-	/**
-	 * Whether to display in stock, out of stock or backorder products.
-	 */
-	stockStatus: {
-		type: 'string',
-		default: 'any',
 	},
 };

--- a/assets/js/blocks/products/edit.js
+++ b/assets/js/blocks/products/edit.js
@@ -2,8 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { PanelBody, ToggleControl, SelectControl } from '@wordpress/components';
-import ProductStockControl from '@woocommerce/editor-components/product-stock-control';
+import { ToggleControl, SelectControl } from '@wordpress/components';
 
 export const getSharedContentControls = ( attributes, setAttributes ) => {
 	const { contentVisibility } = attributes;
@@ -28,65 +27,48 @@ export const getSharedContentControls = ( attributes, setAttributes ) => {
 
 export const getSharedListControls = ( attributes, setAttributes ) => {
 	return (
-		<div>
-			<SelectControl
-				label={ __(
-					'Order Products By',
-					'woo-gutenberg-products-block'
-				) }
-				value={ attributes.orderby }
-				options={ [
-					{
-						label: __(
-							'Default sorting (menu order)',
-							'woo-gutenberg-products-block'
-						),
-						value: 'menu_order',
-					},
-					{
-						label: __(
-							'Popularity',
-							'woo-gutenberg-products-block'
-						),
-						value: 'popularity',
-					},
-					{
-						label: __(
-							'Average rating',
-							'woo-gutenberg-products-block'
-						),
-						value: 'rating',
-					},
-					{
-						label: __( 'Latest', 'woo-gutenberg-products-block' ),
-						value: 'date',
-					},
-					{
-						label: __(
-							'Price: low to high',
-							'woo-gutenberg-products-block'
-						),
-						value: 'price',
-					},
-					{
-						label: __(
-							'Price: high to low',
-							'woo-gutenberg-products-block'
-						),
-						value: 'price-desc',
-					},
-				] }
-				onChange={ ( orderby ) => setAttributes( { orderby } ) }
-			/>
-			<PanelBody
-				title={ __( 'Stock level', 'woo-gutenberg-products-block' ) }
-				initialOpen={ false }
-			>
-				<ProductStockControl
-					setAttributes={ setAttributes }
-					value={ attributes.stockStatus }
-				/>
-			</PanelBody>
-		</div>
+		<SelectControl
+			label={ __( 'Order Products By', 'woo-gutenberg-products-block' ) }
+			value={ attributes.orderby }
+			options={ [
+				{
+					label: __(
+						'Default sorting (menu order)',
+						'woo-gutenberg-products-block'
+					),
+					value: 'menu_order',
+				},
+				{
+					label: __( 'Popularity', 'woo-gutenberg-products-block' ),
+					value: 'popularity',
+				},
+				{
+					label: __(
+						'Average rating',
+						'woo-gutenberg-products-block'
+					),
+					value: 'rating',
+				},
+				{
+					label: __( 'Latest', 'woo-gutenberg-products-block' ),
+					value: 'date',
+				},
+				{
+					label: __(
+						'Price: low to high',
+						'woo-gutenberg-products-block'
+					),
+					value: 'price',
+				},
+				{
+					label: __(
+						'Price: high to low',
+						'woo-gutenberg-products-block'
+					),
+					value: 'price-desc',
+				},
+			] }
+			onChange={ ( orderby ) => setAttributes( { orderby } ) }
+		/>
 	);
 };


### PR DESCRIPTION
https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4943 added a Stock Filter option to our product grid blocks, but we accidentally applied this to the All Products block which broke tests.

This PR fixes the mistake by removing the option from the All Products block, and adds the missing control to the Products by Category block which was also missed. 

### Testing

Please ensure tests pass before merging.

How to test the changes in this Pull Request:

1. Create an All Products Block. 
2. Confirm it renders and there is no "stock filter" control in the inspector/editor.
3. Create a Products By Category Block.
2. Confirm it renders and there is a "stock filter" control in the inspector/editor.
