### PR TITLE
Allow LegacyTemplate block to be reinserted, only on WooCommerce block templates.

### DIFF
--- a/assets/js/blocks/legacy-template/constants.ts
+++ b/assets/js/blocks/legacy-template/constants.ts
@@ -9,13 +9,6 @@ type TemplateAttributes = {
 };
 
 export const TEMPLATES: Record< string, TemplateAttributes > = {
-	default: {
-		title: __(
-			'WooCommerce Legacy Template',
-			'woo-gutenberg-products-block'
-		),
-		placeholder: 'any',
-	},
 	'single-product': {
 		title: __(
 			'WooCommerce Single Product Block',

--- a/assets/js/blocks/legacy-template/constants.ts
+++ b/assets/js/blocks/legacy-template/constants.ts
@@ -3,7 +3,19 @@
  */
 import { __ } from '@wordpress/i18n';
 
-export const TEMPLATES: Record< string, Record< string, string > > = {
+type TemplateAttributes = {
+	title: string;
+	placeholder: string;
+};
+
+export const TEMPLATES: Record< string, TemplateAttributes > = {
+	default: {
+		title: __(
+			'WooCommerce Legacy Template',
+			'woo-gutenberg-products-block'
+		),
+		placeholder: 'any',
+	},
 	'single-product': {
 		title: __(
 			'WooCommerce Single Product Block',

--- a/assets/js/blocks/legacy-template/constants.ts
+++ b/assets/js/blocks/legacy-template/constants.ts
@@ -3,10 +3,10 @@
  */
 import { __ } from '@wordpress/i18n';
 
-type TemplateAttributes = {
-	title: string;
-	placeholder: string;
-};
+/**
+ * Internal dependencies
+ */
+import { TemplateAttributes } from './types';
 
 export const TEMPLATES: Record< string, TemplateAttributes > = {
 	'single-product': {

--- a/assets/js/blocks/legacy-template/index.tsx
+++ b/assets/js/blocks/legacy-template/index.tsx
@@ -18,21 +18,20 @@ import { TEMPLATES } from './constants';
 interface Props {
 	attributes: {
 		template: string;
+		title: string;
+		placeholder: string;
 	};
 }
 
 const Edit = ( { attributes }: Props ) => {
 	const blockProps = useBlockProps();
-	const templateTitle =
-		TEMPLATES[ attributes.template ]?.title ?? attributes.template;
-	const templatePlaceholder =
-		TEMPLATES[ attributes.template ]?.placeholder ?? 'fallback';
+	const { title, placeholder } = attributes;
 
 	return (
 		<div { ...blockProps }>
 			<Placeholder
 				icon={ box }
-				label={ templateTitle }
+				label={ title }
 				className="wp-block-woocommerce-legacy-template__placeholder"
 			>
 				<div className="wp-block-woocommerce-legacy-template__placeholder-copy">
@@ -55,15 +54,15 @@ const Edit = ( { attributes }: Props ) => {
 								'This is an editor placeholder for the %s. On your store this will be replaced by the template and display with your product image(s), title, price, etc. You can move this placeholder around and add further blocks around it to extend the template.',
 								'woo-gutenberg-products-block'
 							),
-							templateTitle
+							title
 						) }
 					</p>
 				</div>
 				<div className="wp-block-woocommerce-legacy-template__placeholder-wireframe">
 					<img
 						className="wp-block-woocommerce-legacy-template__placeholder-image"
-						src={ `${ WC_BLOCKS_IMAGE_URL }template-placeholders/${ templatePlaceholder }.svg` }
-						alt={ templateTitle }
+						src={ `${ WC_BLOCKS_IMAGE_URL }template-placeholders/${ placeholder }.svg` }
+						alt={ title }
 					/>
 				</div>
 			</Placeholder>
@@ -77,16 +76,19 @@ const unsubscribe = subscribe( () => {
 	const store = select( 'core/edit-site' );
 	templateId = store.getEditedPostId();
 
-	if ( templateId !== undefined ) {
+	if ( templateId ) {
 		unsubscribe();
 		const currentTemplateSlug = templateId?.split( '//' )[ 1 ];
+		// We only want this block to be available for use in specified WooCommerce templates.
 		const eligibleForInserter =
 			TEMPLATES[ currentTemplateSlug ] !== undefined;
-		const blockTitle =
+		const title =
 			TEMPLATES[ currentTemplateSlug ]?.title ?? currentTemplateSlug;
+		const placeholder =
+			TEMPLATES[ currentTemplateSlug ]?.placeholder ?? 'fallback';
 
 		registerBlockType( 'woocommerce/legacy-template', {
-			title: blockTitle,
+			title,
 			icon: (
 				<Icon
 					icon={ box }
@@ -119,6 +121,14 @@ const unsubscribe = subscribe( () => {
 				template: {
 					type: 'string',
 					default: currentTemplateSlug,
+				},
+				title: {
+					type: 'string',
+					default: title,
+				},
+				placeholder: {
+					type: 'string',
+					default: placeholder,
 				},
 			},
 			edit: Edit,

--- a/assets/js/blocks/legacy-template/index.tsx
+++ b/assets/js/blocks/legacy-template/index.tsx
@@ -87,6 +87,18 @@ const Edit = ( { attributes, setAttributes }: Props ) => {
 	);
 };
 
+function isEligibleForInserter() {
+	try {
+		const queryString = window.location.search;
+		const urlParams = new URLSearchParams( queryString );
+		const currentTemplateId = urlParams.get( 'postId' ) || '';
+		const currentTemplateParts = currentTemplateId.split( '//' );
+		return TEMPLATES[ currentTemplateParts[ 1 ] ] !== undefined;
+	} catch ( err ) {
+		return false;
+	}
+}
+
 registerBlockType( 'woocommerce/legacy-template', {
 	title: __( 'WooCommerce Legacy Template', 'woo-gutenberg-products-block' ),
 	icon: (
@@ -104,7 +116,7 @@ registerBlockType( 'woocommerce/legacy-template', {
 		html: false,
 		multiple: false,
 		reusable: false,
-		inserter: true,
+		inserter: isEligibleForInserter(),
 	},
 	example: {
 		attributes: {

--- a/assets/js/blocks/legacy-template/index.tsx
+++ b/assets/js/blocks/legacy-template/index.tsx
@@ -75,7 +75,7 @@ let templateId: string | undefined;
 
 const unsubscribe = subscribe( () => {
 	const store = select( 'core/edit-site' );
-	templateId = store.getEditedPostId();
+	templateId = store?.getEditedPostId();
 
 	if ( templateId ) {
 		unsubscribe();

--- a/assets/js/blocks/legacy-template/index.tsx
+++ b/assets/js/blocks/legacy-template/index.tsx
@@ -7,6 +7,8 @@ import { useBlockProps } from '@wordpress/block-editor';
 import { Placeholder } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { box, Icon } from '@wordpress/icons';
+import { useEffect } from 'react';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -18,14 +20,30 @@ interface Props {
 	attributes: {
 		template: string;
 	};
+	setAttributes: ( attributes: Record< string, unknown > ) => void;
 }
 
-const Edit = ( { attributes }: Props ) => {
+const Edit = ( { attributes, setAttributes }: Props ) => {
 	const blockProps = useBlockProps();
 	const templateTitle =
 		TEMPLATES[ attributes.template ]?.title ?? attributes.template;
 	const templatePlaceholder =
 		TEMPLATES[ attributes.template ]?.placeholder ?? 'fallback';
+
+	const templateId = useSelect( ( select ) => {
+		const store = select( 'core/edit-site' );
+		return store.getEditedPostId();
+	} );
+
+	useEffect( () => {
+		if ( attributes.template === 'any' && typeof templateId === 'string' ) {
+			const templateParts = templateId.split( '//' );
+			setAttributes( {
+				template: templateParts[ 1 ],
+			} );
+		}
+	}, [ templateId ] );
+
 	return (
 		<div { ...blockProps }>
 			<Placeholder
@@ -86,7 +104,7 @@ registerBlockType( 'woocommerce/legacy-template', {
 		html: false,
 		multiple: false,
 		reusable: false,
-		inserter: false,
+		inserter: true,
 	},
 	example: {
 		attributes: {

--- a/assets/js/blocks/legacy-template/index.tsx
+++ b/assets/js/blocks/legacy-template/index.tsx
@@ -75,6 +75,13 @@ let templateId: string | undefined;
 
 const unsubscribe = subscribe( () => {
 	const store = select( 'core/edit-site' );
+
+	if ( ! store ) {
+		// The store will only exist in the Site Editor so we need to unsubscribe and early return for Posts / Pages.
+		unsubscribe();
+		return;
+	}
+
 	templateId = store?.getEditedPostId();
 
 	if ( templateId ) {

--- a/assets/js/blocks/legacy-template/index.tsx
+++ b/assets/js/blocks/legacy-template/index.tsx
@@ -14,6 +14,7 @@ import { box, Icon } from '@wordpress/icons';
  */
 import './editor.scss';
 import { TEMPLATES } from './constants';
+import { getMatchingTemplateData } from './utils';
 
 interface Props {
 	attributes: {
@@ -79,13 +80,14 @@ const unsubscribe = subscribe( () => {
 	if ( templateId ) {
 		unsubscribe();
 		const currentTemplateSlug = templateId?.split( '//' )[ 1 ];
+		const templateData = getMatchingTemplateData(
+			TEMPLATES,
+			currentTemplateSlug
+		);
 		// We only want this block to be available for use in specified WooCommerce templates.
-		const eligibleForInserter =
-			TEMPLATES[ currentTemplateSlug ] !== undefined;
-		const title =
-			TEMPLATES[ currentTemplateSlug ]?.title ?? currentTemplateSlug;
-		const placeholder =
-			TEMPLATES[ currentTemplateSlug ]?.placeholder ?? 'fallback';
+		const eligibleForInserter = templateData !== null;
+		const title = templateData?.title ?? currentTemplateSlug;
+		const placeholder = templateData?.placeholder ?? 'fallback';
 
 		registerBlockType( 'woocommerce/legacy-template', {
 			title,

--- a/assets/js/blocks/legacy-template/test/utils.ts
+++ b/assets/js/blocks/legacy-template/test/utils.ts
@@ -1,0 +1,86 @@
+/**
+ * Internal dependencies
+ */
+import { beginsWith, getMatchingTemplateData } from '../utils';
+
+export const TEMPLATES = {
+	'single-product': {
+		title: 'WooCommerce Single Product Block',
+		placeholder: 'single-product',
+	},
+	'archive-product': {
+		title: 'WooCommerce Product Grid Block',
+		placeholder: 'archive-product',
+	},
+	'taxonomy-product_cat': {
+		title: 'WooCommerce Product Taxonomy Block',
+		placeholder: 'archive-product',
+	},
+	'taxonomy-product_tag': {
+		title: 'WooCommerce Product Tag Block',
+		placeholder: 'archive-product',
+	},
+};
+
+describe( 'beginsWith', () => {
+	it( 'should return true for matching first part of a given string', () => {
+		expect(
+			beginsWith(
+				'taxonomy-product_tag',
+				'taxonomy-product_tag-clothing'
+			)
+		).toBe( true );
+		expect(
+			beginsWith(
+				'taxonomy-product_cat',
+				'taxonomy-product_cat-winter-collection'
+			)
+		).toBe( true );
+	} );
+
+	it( 'should return false if first part of a given string does not match', () => {
+		expect(
+			beginsWith(
+				'taxonomy-product_tag',
+				'taxonomies-product_tag-clothing'
+			)
+		).toBe( false );
+		expect(
+			beginsWith(
+				'taxonomy-product_cat',
+				'taxonomy-products_cat-winter-collection'
+			)
+		).toBe( false );
+		expect(
+			beginsWith(
+				'taxonomy-product_tag',
+				'taxonomy-product_cat-winter-collection'
+			)
+		).toBe( false );
+	} );
+} );
+
+describe( 'getMatchingTemplateData', () => {
+	it( 'should return template data if a correct match has been found', () => {
+		expect(
+			getMatchingTemplateData(
+				TEMPLATES,
+				'taxonomy-product_cat-winter-collection'
+			)
+		).toBe( TEMPLATES[ 'taxonomy-product_cat' ] );
+
+		expect( getMatchingTemplateData( TEMPLATES, 'single-product' ) ).toBe(
+			TEMPLATES[ 'single-product' ]
+		);
+
+		expect(
+			getMatchingTemplateData( TEMPLATES, 'taxonomy-product_tag' )
+		).toBe( TEMPLATES[ 'taxonomy-product_tag' ] );
+	} );
+
+	it( 'should return null if given template slug does not match any of the expected options', () => {
+		expect(
+			getMatchingTemplateData( TEMPLATES, 'slug-does-not-match' )
+		).toBe( null );
+	} );
+} );

--- a/assets/js/blocks/legacy-template/test/utils.ts
+++ b/assets/js/blocks/legacy-template/test/utils.ts
@@ -2,25 +2,7 @@
  * Internal dependencies
  */
 import { getMatchingTemplateData } from '../utils';
-
-export const TEMPLATES = {
-	'single-product': {
-		title: 'WooCommerce Single Product Block',
-		placeholder: 'single-product',
-	},
-	'archive-product': {
-		title: 'WooCommerce Product Grid Block',
-		placeholder: 'archive-product',
-	},
-	'taxonomy-product_cat': {
-		title: 'WooCommerce Product Taxonomy Block',
-		placeholder: 'archive-product',
-	},
-	'taxonomy-product_tag': {
-		title: 'WooCommerce Product Tag Block',
-		placeholder: 'archive-product',
-	},
-};
+import { TEMPLATES } from '../constants';
 
 describe( 'getMatchingTemplateData', () => {
 	it( 'should return template data if a correct match has been found', () => {

--- a/assets/js/blocks/legacy-template/test/utils.ts
+++ b/assets/js/blocks/legacy-template/test/utils.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { beginsWith, getMatchingTemplateData } from '../utils';
+import { getMatchingTemplateData } from '../utils';
 
 export const TEMPLATES = {
 	'single-product': {
@@ -21,44 +21,6 @@ export const TEMPLATES = {
 		placeholder: 'archive-product',
 	},
 };
-
-describe( 'beginsWith', () => {
-	it( 'should return true for matching first part of a given string', () => {
-		expect(
-			beginsWith(
-				'taxonomy-product_tag',
-				'taxonomy-product_tag-clothing'
-			)
-		).toBe( true );
-		expect(
-			beginsWith(
-				'taxonomy-product_cat',
-				'taxonomy-product_cat-winter-collection'
-			)
-		).toBe( true );
-	} );
-
-	it( 'should return false if first part of a given string does not match', () => {
-		expect(
-			beginsWith(
-				'taxonomy-product_tag',
-				'taxonomies-product_tag-clothing'
-			)
-		).toBe( false );
-		expect(
-			beginsWith(
-				'taxonomy-product_cat',
-				'taxonomy-products_cat-winter-collection'
-			)
-		).toBe( false );
-		expect(
-			beginsWith(
-				'taxonomy-product_tag',
-				'taxonomy-product_cat-winter-collection'
-			)
-		).toBe( false );
-	} );
-} );
 
 describe( 'getMatchingTemplateData', () => {
 	it( 'should return template data if a correct match has been found', () => {

--- a/assets/js/blocks/legacy-template/types.ts
+++ b/assets/js/blocks/legacy-template/types.ts
@@ -1,0 +1,4 @@
+export type TemplateAttributes = {
+	title: string;
+	placeholder: string;
+};

--- a/assets/js/blocks/legacy-template/utils.ts
+++ b/assets/js/blocks/legacy-template/utils.ts
@@ -1,0 +1,24 @@
+/**
+ * Internal dependencies
+ */
+import { TemplateAttributes } from './types';
+
+export function beginsWith( needle: string, haystack: string ): boolean {
+	return haystack.substr( 0, needle.length ) === needle;
+}
+
+export function getMatchingTemplateData(
+	templates: Record< string, TemplateAttributes >,
+	slug: string
+): TemplateAttributes | null {
+	const templateSlugs = Object.keys( templates );
+	const matchingSlugs = templateSlugs.filter( ( templateSlug ) =>
+		beginsWith( templateSlug, slug )
+	);
+
+	if ( matchingSlugs.length === 0 ) {
+		return null;
+	}
+
+	return templates[ matchingSlugs[ 0 ] ];
+}

--- a/assets/js/blocks/legacy-template/utils.ts
+++ b/assets/js/blocks/legacy-template/utils.ts
@@ -13,7 +13,7 @@ export function getMatchingTemplateData(
 ): TemplateAttributes | null {
 	const templateSlugs = Object.keys( templates );
 	const matchingSlugs = templateSlugs.filter( ( templateSlug ) =>
-		beginsWith( templateSlug, slug )
+		slug.startsWith( templateSlug )
 	);
 
 	if ( matchingSlugs.length === 0 ) {


### PR DESCRIPTION
#### Description

Allow the WooCommece Legacy Template block to be reinserted if it's deleted, and also only make it eligible to be inserted on the WooCommerce templates: `archive-product.html`, `single-product`, `taxonomy-product_cat`, `taxonomy-product_tag`

<!-- Reference any related issues or PRs here -->
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5193

### Testing

### Manual Testing

How to test the changes in this Pull Request:

1. Ensure you have an FSE theme enabled such as TT1 blocks
2. Load each WooCommerce block template, remove the Legacy Template block and reinsert it.
3. Ensure this loads correctly on the frontend for each template.
4. Load a block template in the Site Editor which _is not_ from WooCommerce
5. Add a category specific template to your theme such as `taxonomy-product_cat-clothing.html` and test you can load, remove and re-add the block to this.
6. Check that you are **not** able to insert the WooCommerce Legacy Template block

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above

### Changelog

> Allow users to reinsert the WooCommerce Legacy Template block in their block template if it is a WooCommerce block template.
