### PR TITLE
Default all product images to "cropped" and actual image width

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -22,7 +22,8 @@
 
 	img {
 		height: auto;
-		width: 100%;
+		width: auto;
+		max-width: 100%;
 
 		&[hidden] {
 			display: none;

--- a/assets/js/blocks/products/base-utils.js
+++ b/assets/js/blocks/products/base-utils.js
@@ -2,7 +2,7 @@
  * The default layout built from the default template.
  */
 export const DEFAULT_PRODUCT_LIST_LAYOUT = [
-	[ 'woocommerce/product-image' ],
+	[ 'woocommerce/product-image', { imageSizing: 'cropped' } ],
 	[ 'woocommerce/product-title' ],
 	[ 'woocommerce/product-price' ],
 	[ 'woocommerce/product-rating' ],


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR fixes a bug where images with different aspect ratios would not align properly. This is because the all products block displays the full image rather than the thumbnail by default. By displaying the thumbnail or "cropped" version of the product image, we are respecting the WooCommerce image settings (in Appearance -> Customize -> WooCommerce -> Product Images) and make sure images are cropped to size and align properly within the grid. 

The users are still free to change this by editing the All Products block and setting the image sizing to "Full Size"

Displaying thumbnails instead of full size images introduced a new problem. The thumbnails are smaller than the full size image, so it's now possible for the thumbnails to pixelate as they are rendered at a bigger size than their actual size. To solve this I chnaged `width: auto` and `max-width: 100%` to make sure the images are rendered at their actual size, but never break out of their container.

Further discussion in [this P2 post](pca54o-2R1-p2)
<!-- Reference any related issues or PRs here -->
Fixes #5398

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### Testing

How to test the changes in this Pull Request:

*Before checking out this branch, make sure you have a page with the "All Products" block saved.*

1. Add a product with a portrait image ([example you can use](https://user-images.githubusercontent.com/3966773/149120479-b266c2b1-ac13-48e6-944b-6785cd7ee4a9.jpeg)
)), and one with a landscape image ([example you can use](https://user-images.githubusercontent.com/3966773/149120600-f6e0ef32-16e1-46ec-bd0f-575fc8a658c6.jpeg))
2. Edit the existing page with the All Products block that you had before you checked out this branch. Edit the block, select the image. In the sidebar, under "Block" tab, the "Image Sizing" setting should be "Full Size". This confirms existing blocks are not affected.
3. Visit the page with this block on the front end. Sort by "latest" so that the two new products you added are visible. Notice the aspect ratios of these are different and cause the other items out of alignment.
4. Add the All Products block to a new page and save it. 
5. Edit the All products block, select the image. In the sidebar, under "Block" tab, the "Image Sizing" setting should have "Cropped" selected.
6. Visit this page on the front end and sort by "latest" so that the two new products you added are visible.
7. All product images should be the same aspect ratio and align within the grid.
8. Go to Appearance -> Customize -> WooCommerce -> Product Images and set a custom aspect ratio (for example, 16:9).
9. Visit the all products page again. All product images should be rendered with this new aspect ratio.

<!-- If you can, add the appropriate labels -->

### Performance Impact
This should increase performance slightly as smaller images are loaded

### Changelog

> All Products block displays thumbnails.