### PR TITLE
Fix inconsistent HTML of rating section

### DIFF
--- a/assets/js/atomic/blocks/product-elements/rating/block.js
+++ b/assets/js/atomic/blocks/product-elements/rating/block.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import PropTypes from 'prop-types';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import classnames from 'classnames';
 import {
 	useInnerBlockLayoutContext,
@@ -41,6 +41,21 @@ const Block = ( { className } ) => {
 		rating
 	);
 
+	const reviews = getRatingCount( product );
+	const ratingHTML = {
+		__html: sprintf(
+			/* translators: %1$s is referring to the average rating value, %2$s is referring to the number of ratings */
+			_n(
+				'Rated %1$s out of 5 based on %2$s customer rating',
+				'Rated %1$s out of 5 based on %2$s customer ratings',
+				reviews,
+				'woo-gutenberg-products-block'
+			),
+			sprintf( '<strong class="rating">%f</strong>', rating ),
+			sprintf( '<span class="rating">%d</span>', reviews )
+		),
+	};
+
 	return (
 		<div
 			className={ classnames(
@@ -59,7 +74,10 @@ const Block = ( { className } ) => {
 				role="img"
 				aria-label={ ratingText }
 			>
-				<span style={ starStyle }>{ ratingText }</span>
+				<span
+					style={ starStyle }
+					dangerouslySetInnerHTML={ ratingHTML }
+				/>
 			</div>
 		</div>
 	);
@@ -69,6 +87,12 @@ const getAverageRating = ( product ) => {
 	const rating = parseFloat( product.average_rating );
 
 	return Number.isFinite( rating ) && rating > 0 ? rating : 0;
+};
+
+const getRatingCount = ( product ) => {
+	const count = parseInt( product.review_count, 10 );
+
+	return Number.isFinite( count ) && count > 0 ? count : 0;
 };
 
 Block.propTypes = {

--- a/assets/js/base/components/reviews/review-list-item/index.js
+++ b/assets/js/base/components/reviews/review-list-item/index.js
@@ -124,6 +124,13 @@ function getReviewRating( review ) {
 		__( 'Rated %f out of 5', 'woo-gutenberg-products-block' ),
 		rating
 	);
+	const ratingHTML = {
+		__html: sprintf(
+			/* translators: %s is referring to the average rating value */
+			__( 'Rated %s out of 5', 'woo-gutenberg-products-block' ),
+			sprintf( '<strong class="rating">%f</strong>', rating )
+		),
+	};
 	return (
 		<div className="wc-block-review-list-item__rating wc-block-components-review-list-item__rating">
 			<div
@@ -131,7 +138,10 @@ function getReviewRating( review ) {
 				role="img"
 				aria-label={ ratingText }
 			>
-				<span style={ starStyle }>{ ratingText }</span>
+				<span
+					style={ starStyle }
+					dangerouslySetInnerHTML={ ratingHTML }
+				/>
 			</div>
 		</div>
 	);


### PR DESCRIPTION
Fixes #1916

#### Notes

In #1916, @dashkevych reported that the underlying HTML code of the rating sections is inconsistent. To solve this issue, I checked which of the current blocks is showing the rating section.

| Block                 | Rating type |
| --------------------- | ----------- |
| All Products          | 1           |
| All Reviews           | 2           |
| Best Selling Products | 3           |
| Hand-picked Products  | 3           |
| Newest Products       | 3           |
| On Sale Products      | 3           |
| Products by Attribute | 3           |
| Products by Category  | 3           |
| Products by Tag       | 3           |
| Reviews by Category   | 2           |
| Reviews by Product    | 2           |
| Single Product        | 1           |
| Top Rated Products    | 3           |

1. `assets/js/atomic/product-elements/rating/block.js`
2. `assets/js/base/components/reviews/review-list-item/index.js`
3. `src/BlockTypes/AbstractProductGrid.php`

Rating type 3 shows the correct HTML code and is defined in:

https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/b72efda06f68d1caa5ab225bfb057489cf92ecd8/src/BlockTypes/AbstractProductGrid.php#L559-L564

This part calls the following WooCommerce core functions:

https://github.com/woocommerce/woocommerce/blob/159ceb3f3548c7d04140b9c8f48236b6afd36fee/plugins/woocommerce/includes/wc-template-functions.php#L3540-L3582

Rating type 1 shows the incorrect HTML code and is defined in:

https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/b72efda06f68d1caa5ab225bfb057489cf92ecd8/assets/js/atomic/blocks/product-elements/rating/block.js#L44-L65

Rating type 2 also shows the incorrect HTML code and is defined in:

https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/b72efda06f68d1caa5ab225bfb057489cf92ecd8/assets/js/base/components/reviews/review-list-item/index.js#L127-L137

Rating types 1 and 2 have a slightly different logic. While rating type 1 shows individual ratings, rating type 2 shows all the average rating per product. Therefore, their final structure is slightly different.

### Screenshots

#### Rating type 1 - before

```html
<div class="wc-block-components-product-rating wc-block-grid__product-rating">
  <div
    class="wc-block-components-product-rating__stars wc-block-grid__product-rating__stars"
    role="img"
    aria-label="Rated 4.33 out of 5"
  >
    <span style="width: 86.6%;">Rated 4.33 out of 5</span>
  </div>
</div>
```

#### Rating type 1 - after

```html
<div class="wc-block-components-product-rating wc-block-grid__product-rating">
  <div
    class="wc-block-components-product-rating__stars wc-block-grid__product-rating__stars"
    role="img"
    aria-label="Rated 4.33 out of 5"
  >
    <span style="width: 86.6%;">
      Rated
      <strong class="rating">4.33</strong>
      out of 5 based on
      <span class="rating">3</span>
      customer ratings
    </span>
  </div>
</div>
```

#### Rating type 2 - before

```html
<div class="wc-block-review-list-item__rating wc-block-components-review-list-item__rating">
  <div
    class="wc-block-review-list-item__rating__stars wc-block-components-review-list-item__rating__stars"
    role="img"
    aria-label="Rated 4 out of 5"
  >
    <span style="width: 80%;">Rated 4 out of 5</span>
  </div>
</div>
```

#### Rating type 2 - after

```html
<div class="wc-block-review-list-item__rating wc-block-components-review-list-item__rating">
  <div
    class="wc-block-review-list-item__rating__stars wc-block-components-review-list-item__rating__stars"
    role="img"
    aria-label="Rated 4 out of 5"
  >
    <span style="width: 80%;">
      Rated
      <strong class="rating">4</strong>
      out of 5
    </span>
  </div>
</div>
```

### Testing

### Manual Testing

#### Rating type 1 - Single rating

1. Create a test page and add a rating type 1 block to it, e.g. the `All Products` block.
2. Ensure to have one product with one rating.
3. Look up that product in the `All Products` block on the frontend.
4. Inspect the HTML code of the rating section.
5. Ensure that the HTML code is displayed as mentioned in the screenshot section and the singular translation is visible.

#### Rating type 1 - Multiple ratings

1. Create a test page and add a rating type 1 block to it, e.g. the `All Products` block.
2. Ensure to have one product with multiple ratings.
3. Look up that product in the `All Products` block on the frontend.
4. Inspect the HTML code of the rating section.
5. Ensure that the HTML code is displayed as mentioned in the screenshot section and the plural translation is visible.

#### Rating type 2 - Single rating

1. Create a test page and add a rating type 2 block to it, e.g. the `All Reviews` block.
2. Ensure to at least one product with a rating.
3. Look up that product in the `All Reviews` block on the frontend.
4. Inspect the HTML code of the rating section.
5. Ensure that the HTML code is displayed as mentioned in the screenshot section.

### User Facing Testing

- [x] Same as above

<!-- If you can, add the appropriate labels -->

### Changelog

> Use consistent HTML code for all rating sections, so that screen readers pronounce the rating correctly.
