### PR TITLE
Prefetch cart and checkout block assets when cart has contents

### DIFF
--- a/src/AssetsController.php
+++ b/src/AssetsController.php
@@ -35,6 +35,7 @@ final class AssetsController {
 	 */
 	protected function init() {
 		add_action( 'init', array( $this, 'register_assets' ) );
+		add_filter( 'wp_resource_hints', array( $this, 'add_resource_hints' ), 10, 2 );
 		add_action( 'body_class', array( $this, 'add_theme_body_class' ), 1 );
 		add_action( 'admin_body_class', array( $this, 'add_theme_body_class' ), 1 );
 		add_action( 'admin_enqueue_scripts', array( $this, 'update_block_style_dependencies' ), 20 );
@@ -74,6 +75,100 @@ final class AssetsController {
 			};
 			",
 			'before'
+		);
+	}
+
+	/**
+	 * Defines resource hints to help speed up the loading of some critical blocks.
+	 *
+	 * These will not impact page loading times negatively because they are loaded once the current page is idle.
+	 *
+	 * @param array  $urls          URLs to print for resource hints. Each URL is an array of resource attributes, or a URL string.
+	 * @param string $relation_type The relation type the URLs are printed. Possible values: preconnect, dns-prefetch, prefetch, prerender.
+	 * @return array URLs to print for resource hints.
+	 */
+	public function add_resource_hints( $urls, $relation_type ) {
+		if ( ! Package::feature()->is_feature_plugin_build() ) {
+			return $urls;
+		}
+
+		// We only need to prefetch when the cart has contents.
+		if ( ! in_array( $relation_type, [ 'prefetch', 'prerender' ], true ) || 0 === WC()->cart->get_cart_contents_count() ) {
+			return $urls;
+		}
+
+		$resources         = [];
+		$is_block_cart     = has_block( 'woocommerce/cart' );
+		$is_block_checkout = has_block( 'woocommerce/checkout' );
+
+		if ( 'prefetch' === $relation_type ) {
+			if ( ! $is_block_cart ) {
+				$resources = array_merge( $resources, $this->get_block_asset_resource_hints( 'cart-frontend' ) );
+			}
+
+			if ( ! $is_block_checkout ) {
+				$resources = array_merge( $resources, $this->get_block_asset_resource_hints( 'checkout-frontend' ) );
+			}
+
+			$urls = array_merge(
+				$urls,
+				array_map(
+					function( $src ) {
+						return array(
+							'href' => $src,
+							'as'   => 'script',
+						);
+					},
+					array_unique( array_filter( $resources ) )
+				)
+			);
+		}
+
+		if ( 'prerender' === $relation_type && $is_block_cart ) {
+			$checkout_page_id  = wc_get_page_id( 'checkout' );
+			$checkout_page_url = $checkout_page_id ? get_permalink( $checkout_page_id ) : '';
+			if ( $checkout_page_url ) {
+				$urls[] = $checkout_page_url;
+			}
+		}
+
+		return $urls;
+	}
+
+	/**
+	 * Get resource hint for a block by name.
+	 *
+	 * @param string $filename Block filename.
+	 * @return array
+	 */
+	private function get_block_asset_resource_hints( $filename = '' ) {
+		if ( ! $filename ) {
+			return [];
+		}
+		$script_data = $this->api->get_script_data(
+			$this->api->get_block_asset_build_path( $filename )
+		);
+		return array_merge( [ add_query_arg( 'ver', $script_data['version'], $script_data['src'] ) ], $this->get_script_dependency_src_array( $script_data['dependencies'] ) );
+	}
+
+	/**
+	 * Get the src of all script dependencies (handles).
+	 *
+	 * @param array $dependencies Array of dependency handles.
+	 * @return string[] Array of src strings.
+	 */
+	private function get_script_dependency_src_array( array $dependencies ) {
+		$wp_scripts = wp_scripts();
+		return array_reduce(
+			$dependencies,
+			function( $src, $handle ) use ( $wp_scripts ) {
+				if ( isset( $wp_scripts->registered[ $handle ] ) ) {
+					$src[] = add_query_arg( 'ver', $wp_scripts->registered[ $handle ]->ver, $wp_scripts->registered[ $handle ]->src );
+					$src   = array_merge( $src, $this->get_script_dependency_src_array( $wp_scripts->registered[ $handle ]->deps ) );
+				}
+				return $src;
+			},
+			[]
 		);
 	}
 

--- a/src/AssetsController.php
+++ b/src/AssetsController.php
@@ -88,12 +88,14 @@ final class AssetsController {
 	 * @return array URLs to print for resource hints.
 	 */
 	public function add_resource_hints( $urls, $relation_type ) {
-		if ( ! Package::feature()->is_feature_plugin_build() ) {
+		if ( ! Package::feature()->is_feature_plugin_build() || ! in_array( $relation_type, [ 'prefetch', 'prerender' ], true ) ) {
 			return $urls;
 		}
 
 		// We only need to prefetch when the cart has contents.
-		if ( ! in_array( $relation_type, [ 'prefetch', 'prerender' ], true ) || 0 === WC()->cart->get_cart_contents_count() ) {
+		$cart = wc()->cart;
+
+		if ( ! $cart || ! $cart instanceof \WC_Cart || 0 === $cart->get_cart_contents_count() ) {
 			return $urls;
 		}
 


### PR DESCRIPTION
This PR implements resource hinting for cart and checkout scripts when we can predict the customer will be visiting those pages during the current session. It essentially pre-caches block assets in the background when the page is idle so that when the customer lands on the cart and checkout pages, the block scripts can be loaded from cache.

Fixes #2207

cc @senadir 

See:
- https://3perf.com/blog/link-rels/
- https://medium.com/reloading/preload-prefetch-and-priorities-in-chrome-776165961bbf

The new rules include:

1. Cart has contents, not on the cart page = Load cart block assets
2. Cart has contents, not on checkout page = Load checkout assets
3. Cart has contents, viewing the cart page = Prerender the checkout page

Case 3 uses the `prerender` attribute which is not supported in all browsers, but is by Chrome. It does not actually render the page or run JS, but it does pre-load all assets and resources on the page. See https://developers.google.com/web/updates/2018/07/nostate-prefetch

### Testing

### Manual Testing

How to test the changes in this Pull Request:

1. Clear website cache.
2. Go to the homepage with nothing in your cart.
3. View source. Look for `rel='prefetch'` rules. Cart and checkout will not be there.
4. Go to the shop page and add something to the cart.
5. Go back to the homepage.
6. View source. Look for `rel='prefetch'` rules:

![Screenshot 2022-01-12 at 13 17 57](https://user-images.githubusercontent.com/90977/149147708-009cf5fa-46fa-4cbb-80c6-6fe7f0cd5607.png)

If you open network tools at this point and then visit the cart page, you should see the majority of scripts are loaded from cache.

### User Facing Testing

Users cannot see these changes in an obvious way, so smoke testing should be performed only of the checkout flow.

### Performance Impact

For first time visitors to the cart and checkout pages, this should increase the page loading times due to assets being retrieved from cache rather than the server.

### Changelog

> Add resource hinting for cart and checkout blocks to improve first time performance.
