### PR TITLE
Fix Sass warnings for  Slash as Division seen when building the project

### DIFF
--- a/assets/js/base/components/reviews/review-list-item/style.scss
+++ b/assets/js/base/components/reviews/review-list-item/style.scss
@@ -140,7 +140,7 @@
 }
 
 .wc-block-components-review-list-item__product + .wc-block-components-review-list-item__author + .wc-block-components-review-list-item__published-date {
-	padding-left: $gap/2;
+	padding-left: $gap*0.5;
 	position: relative;
 
 	&::before {

--- a/assets/js/blocks/cart-checkout/mini-cart/quantity-badge/style.scss
+++ b/assets/js/blocks/cart-checkout/mini-cart/quantity-badge/style.scss
@@ -13,10 +13,10 @@
 	display: flex;
 	font-size: 0.875em;
 	font-weight: 600;
-	height: em(20px)/0.875;
+	height: math.div(em(20px), 0.875);
 	justify-content: center;
-	margin-left: em(-10px)/0.875;
-	min-width: em(20px)/0.875;
+	margin-left: math.div(em(-10px), 0.875);
+	min-width: math.div(em(20px), 0.875);
 	padding: 0 em($gap-smallest);
 	transform: translateY(-50%);
 	white-space: nowrap;


### PR DESCRIPTION
A quick PR that fixes the deprecation warnings seen when building the project which really annoyed me.

```
Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($gap, 2) or calc($gap / 2)

More info and automated migrator: https://sass-lang.com/d/slash-div

    ╷
143 │     padding-left: $gap/2;
    │                   ^^^^^^
```

The [solution](https://sass-lang.com/documentation/breaking-changes/slash-div#automatic-migration) was easy so I went ahead and fixed it on the spot:

### How to test
- checkout the branch and run `npm run start` notice there is no warning in the terminal
- check the look and feel of the Mini Cart