### PR TITLE
Fix: fatal error when page contains edited template or template part

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -144,7 +144,11 @@ class BlockTemplatesController {
 			return $template;
 		}
 
-		$available_templates = $this->get_block_templates_from_woocommerce( array( $slug ), $template_type );
+		$available_templates = $this->get_block_templates_from_woocommerce(
+			array( $slug ),
+			$this->get_block_templates_from_db( array( $slug ), $template_type ),
+			$template_type
+		);
 		return ( is_array( $available_templates ) && count( $available_templates ) > 0 )
 			? BlockTemplateUtils::gutenberg_build_template_result_from_file( $available_templates[0], $available_templates[0]->type )
 			: $template;

--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -144,7 +144,7 @@ class BlockTemplatesController {
 			return $template;
 		}
 
-		$available_templates = $this->get_block_templates( array( $slug ), $template_type );
+		$available_templates = $this->get_block_templates_from_woocommerce( array( $slug ), $template_type );
 		return ( is_array( $available_templates ) && count( $available_templates ) > 0 )
 			? BlockTemplateUtils::gutenberg_build_template_result_from_file( $available_templates[0], $available_templates[0]->type )
 			: $template;


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #5544 

This PR fixes the fatal error when the page contains the mini cart by only passing template from file to `BlockTemplateUtils::gutenberg_build_template_result_from_file()`.

#### Alternative approach

We can check for `path` on line 177th of `BlockTemplateUtils.php` and short circuit the function. But it doesn't make sense to me to let `gutenberg_build_template_result_from_file()` process template from database.

https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/9ebcea5bb7d14d7425574273bbdd8e256de998e2/src/Utils/BlockTemplateUtils.php#L177

### Testing

### Manual Testing

How to test the changes in this Pull Request:

1. Add customzied Mini Cart to the header.
2. Visit the home page.
3. Don't see error.

Or
1. Edit the single product template.
2. Visit a  product detail page on the front end
3. Don't see error.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
* [ ] See steps below.