### PR TITLE
Price Filter block: enable global style 

### DIFF
--- a/assets/js/blocks/price-filter/block.js
+++ b/assets/js/blocks/price-filter/block.js
@@ -17,6 +17,7 @@ import { getCurrencyFromPriceResponse } from '@woocommerce/price-format';
  * Internal dependencies
  */
 import usePriceConstraints from './use-price-constraints.js';
+import './style.scss';
 
 /**
  * Component displaying a price filter.

--- a/assets/js/blocks/price-filter/edit.js
+++ b/assets/js/blocks/price-filter/edit.js
@@ -2,8 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import classNames from 'classnames';
-import { InspectorControls } from '@wordpress/block-editor';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import {
 	Placeholder,
 	Disabled,
@@ -26,12 +25,13 @@ import './editor.scss';
 
 export default function ( { attributes, setAttributes } ) {
 	const {
-		className,
 		heading,
 		headingLevel,
 		showInputFields,
 		showFilterButton,
 	} = attributes;
+
+	const blockProps = useBlockProps();
 
 	const getInspectorControls = () => {
 		return (
@@ -152,16 +152,11 @@ export default function ( { attributes, setAttributes } ) {
 	);
 
 	return (
-		<>
+		<div { ...blockProps }>
 			{ blocksConfig.productCount === 0 ? (
 				noProductsPlaceholder()
 			) : (
-				<div
-					className={ classNames(
-						className,
-						'wp-block-woocommerce-price-filter'
-					) }
-				>
+				<>
 					{ getInspectorControls() }
 					<BlockTitle
 						className="wc-block-price-filter__title"
@@ -174,8 +169,8 @@ export default function ( { attributes, setAttributes } ) {
 					<Disabled>
 						<Block attributes={ attributes } isEditor={ true } />
 					</Disabled>
-				</div>
+				</>
 			) }
-		</>
+		</div>
 	);
 }

--- a/assets/js/blocks/price-filter/editor.scss
+++ b/assets/js/blocks/price-filter/editor.scss
@@ -1,14 +1,20 @@
-.components-disabled .wc-block-price-filter__range-input-wrapper .wc-block-price-filter__range-input {
-	&::-webkit-slider-thumb {
-		pointer-events: none;
-	}
-	&::-moz-range-thumb {
-		pointer-events: none;
-	}
-	&::-ms-thumb {
-		pointer-events: none;
+.wp-block-woocommerce-price-filter .components-disabled {
+	border-radius: inherit;
+	border-color: inherit;
+
+	.wc-block-price-filter__range-input-wrapper .wc-block-price-filter__range-input {
+		&::-webkit-slider-thumb {
+			pointer-events: none;
+		}
+		&::-moz-range-thumb {
+			pointer-events: none;
+		}
+		&::-ms-thumb {
+			pointer-events: none;
+		}
 	}
 }
+
 .wc-block-price-slider {
 	.components-placeholder__instructions {
 		border-bottom: 1px solid #e0e2e6;

--- a/assets/js/blocks/price-filter/index.js
+++ b/assets/js/blocks/price-filter/index.js
@@ -5,6 +5,8 @@ import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
 import classNames from 'classnames';
 import { Icon, bill } from '@woocommerce/icons';
+import { isFeaturePluginBuild } from '@woocommerce/block-settings';
+import { useBlockProps } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -12,6 +14,7 @@ import { Icon, bill } from '@woocommerce/icons';
 import edit from './edit.js';
 
 registerBlockType( 'woocommerce/price-filter', {
+	apiVersion: 2,
 	title: __( 'Filter Products by Price', 'woo-gutenberg-products-block' ),
 	icon: {
 		src: (
@@ -30,6 +33,17 @@ registerBlockType( 'woocommerce/price-filter', {
 	supports: {
 		html: false,
 		multiple: false,
+		color: {
+			text: true,
+			background: false,
+		},
+		...( isFeaturePluginBuild() && {
+			__experimentalBorder: {
+				radius: true,
+				color: true,
+				width: false,
+			},
+		} ),
 	},
 	example: {},
 	attributes: {
@@ -70,7 +84,9 @@ registerBlockType( 'woocommerce/price-filter', {
 		};
 		return (
 			<div
-				className={ classNames( 'is-loading', className ) }
+				{ ...useBlockProps.save( {
+					className: classNames( 'is-loading', className ),
+				} ) }
 				{ ...data }
 			>
 				<span

--- a/assets/js/blocks/price-filter/style.scss
+++ b/assets/js/blocks/price-filter/style.scss
@@ -1,0 +1,25 @@
+.wp-block-woocommerce-price-filter {
+	border-style: none !important;
+}
+
+.wc-block-price-slider {
+	border-radius: inherit;
+	border-color: inherit;
+}
+
+.wc-block-price-filter {
+	border-radius: inherit;
+	border-color: inherit;
+}
+
+
+.wc-block-price-filter__controls {
+	border-radius: inherit;
+	border-color: inherit;
+
+	input {
+		border-radius: inherit !important;
+		border-color: inherit !important;
+		border-style: solid;
+	}
+}


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

This PR adds support for global style for the `Price Filter block`.

Now, the user can edit the style for:
- text-color
- border (color and radius) on the input fields

## Note
Unfortunately at the current stage, global style API doesn't support the customization of the inner element instead of block wrapper, so this PR contains a hacky CSS for accomplishing the goal 

https://github.com/WordPress/gutenberg/issues/33255
https://github.com/WordPress/gutenberg/issues/32417

<!-- Reference any related issues or PRs here -->
#4965 

### Screenshots

![image](https://user-images.githubusercontent.com/4463174/149373773-0d33b44e-1abb-4acd-bf5e-c09db4c50a88.png)
*without global style*

![image](https://user-images.githubusercontent.com/4463174/149373635-74885ee0-a90a-4f6d-aab8-6cf8b59aaedc.png)
*with global style*

### Testing

### Manual Testing

Check out this branch:

1. On `WordPress 5.9`, install and enable the `Gutenberg` plugin.
2. Install and enable the `Twenty Twenty-Two` theme.
3. Add the `Price Filter block` to a post.
4. On the right sidebar, personalize the styles of the block.
5. Go on the page and check if there are changes.
6. Reset to default using the `Reset` button from the different sections. 
7. Go to Dashboard and select Appearance > Editor (beta). On top of the screen, select Home > Browser all templates > Single Post. When the page is loaded, add the block to the page.
8. On the Editor page click on the `Styles` icon on the right-top corner.
9. Verify that the `Price Filter block` is shown under the `Blocks` section. Personalize again the block.
10. Save your changes.
11. Go on the page created earlier and check if all styles are applied correctly.
12. Edit your previous post/page again.
13. Change again the styles.
14. Save your changes.
15. Check if these styles have priority over the styles from the Site Editor.

### Changelog

> Add support for the global style for the Price Filter block.
