### PR TITLE
Prevent Redirect URL leaking between payment gateways

### DIFF
--- a/assets/js/base/context/providers/cart-checkout/checkout-state/index.tsx
+++ b/assets/js/base/context/providers/cart-checkout/checkout-state/index.tsx
@@ -148,12 +148,9 @@ export const CheckoutStateProvider = ( {
 				const paymentResult = getPaymentResultFromCheckoutResponse(
 					response
 				);
-
-				if ( paymentResult.redirectUrl ) {
-					dispatch(
-						actions.setRedirectUrl( paymentResult.redirectUrl )
-					);
-				}
+				dispatch(
+					actions.setRedirectUrl( paymentResult?.redirectUrl || '' )
+				);
 				dispatch( actions.setProcessingResponse( paymentResult ) );
 				dispatch( actions.setAfterProcessing() );
 			},
@@ -302,6 +299,7 @@ export const CheckoutStateProvider = ( {
 							// the last observer response always "wins" for success.
 							successResponse = response;
 						}
+
 						if (
 							isErrorResponse( response ) ||
 							isFailResponse( response )
@@ -331,8 +329,7 @@ export const CheckoutStateProvider = ( {
 							dispatch( actions.setHasError( true ) );
 						}
 					} else {
-						// nothing hooked in had any response type so let's just
-						// consider successful
+						// nothing hooked in had any response type so let's just consider successful.
 						dispatch( actions.setComplete() );
 					}
 				} );

--- a/assets/js/base/context/providers/cart-checkout/checkout-state/reducer.ts
+++ b/assets/js/base/context/providers/cart-checkout/checkout-state/reducer.ts
@@ -57,11 +57,8 @@ export const reducer = (
 					? {
 							...state,
 							status: STATUS.COMPLETE,
-							// @todo Investigate why redirectURL could be non-truthy and whether this would cause a bug if multiple gateways were used for payment e.g. 1st set the redirect URL but failed, and then the 2nd did not provide a redirect URL and succeeded.
 							redirectUrl:
-								data !== undefined &&
-								typeof data.redirectUrl === 'string' &&
-								data.redirectUrl
+								typeof data?.redirectUrl === 'string'
 									? data.redirectUrl
 									: state.redirectUrl,
 					  }

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -505,6 +505,11 @@ class Checkout extends AbstractCartRoute {
 			if ( ! $payment_result instanceof PaymentResult ) {
 				throw new RouteException( 'woocommerce_rest_checkout_invalid_payment_result', __( 'Invalid payment result received from payment method.', 'woo-gutenberg-products-block' ), 500 );
 			}
+
+			// Ensure redirect is set to avoid being stuck on the payment page.
+			if ( 'success' === $payment_result->status && empty( $payment_result->redirect_url ) ) {
+				$payment_result->set_redirect_url( $this->order->get_checkout_order_received_url() );
+			}
 		} catch ( \Exception $e ) {
 			throw new RouteException( 'woocommerce_rest_checkout_process_payment_error', $e->getMessage(), 400 );
 		}

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -505,11 +505,6 @@ class Checkout extends AbstractCartRoute {
 			if ( ! $payment_result instanceof PaymentResult ) {
 				throw new RouteException( 'woocommerce_rest_checkout_invalid_payment_result', __( 'Invalid payment result received from payment method.', 'woo-gutenberg-products-block' ), 500 );
 			}
-
-			// Ensure redirect is set to avoid being stuck on the payment page.
-			if ( 'success' === $payment_result->status && empty( $payment_result->redirect_url ) ) {
-				$payment_result->set_redirect_url( $this->order->get_checkout_order_received_url() );
-			}
 		} catch ( \Exception $e ) {
 			throw new RouteException( 'woocommerce_rest_checkout_process_payment_error', $e->getMessage(), 400 );
 		}


### PR DESCRIPTION
This PR prevents (due to implementation error) redirect URLs being shared between different payment gateways.

Fixes #4224

### Testing

How to test the changes in this Pull Request:

You'll need to modify 2 gateways to test this. 

*plugins/woocommerce/includes/gateways/cheque/class-wc-gateway-cheque.php*

Replace the return statement to be:

```
return [
			'result'   => 'success',
		];
```

*plugins/woocommerce/includes/gateways/bacs/class-wc-gateway-bacs.php*

Change the `process_payment` method to contain only:

```
return array(
			'result'   => 'fail',
			'redirect' => $this->get_return_url( $order ),
		);
```

Now if you add something to cart, and go to checkout you can test this case.

1. Try first paying with BACS. Payment will fail. Notice this returned a redirect.
2. Now switch payment method and pay with Cheque.
3. Before this patch, Cheque would redirect to the URL provided by BACS. After this patch, checkout will not redirect.

### User Facing Testing

Smoke test payments on the checkout page (using BACS should suffice).

### Changelog

> Prevent redirect URLs being incorrectly shared between payment gateways.
