### PR TITLE
Mini Cart Contents: Support link and text colors

### DIFF
--- a/assets/js/atomic/blocks/product-elements/title/editor.scss
+++ b/assets/js/atomic/blocks/product-elements/title/editor.scss
@@ -1,3 +1,3 @@
-.editor-styles-wrapper a.wc-block-components-product-name {
+.editor-styles-wrapper .wc-block-components-product-title a.wc-block-components-product-name {
 	color: inherit;
 }

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/editor.scss
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/editor.scss
@@ -36,4 +36,9 @@
 	table.wc-block-cart-items {
 		color: inherit;
 	}
+
+	.block-editor-button-block-appender {
+		box-shadow: inset 0 0 0 1px;
+		color: inherit;
+	}
 }

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/editor.scss
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/editor.scss
@@ -1,35 +1,39 @@
-.wp-block-woocommerce-mini-cart-contents {
+.editor-styles-wrapper .wp-block-woocommerce-mini-cart-contents {
 	max-width: 480px;
 	/* We need to override the margin top here to simulate the layout of
 	the mini cart contents on the front end. */
 	margin: 0 auto !important;
-}
 
-.wp-block-woocommerce-filled-mini-cart-contents-block > .block-editor-inner-blocks > .block-editor-block-list__layout {
-	display: flex;
-	flex-direction: column;
-	min-height: 100vh;
-}
-
-.wp-block-woocommerce-mini-cart-items-block {
-	display: grid;
-	flex-grow: 1;
-	margin-bottom: $gap;
-	padding: 0 $gap;
-
-	> .block-editor-inner-blocks > .block-editor-block-list__layout {
+	.wp-block-woocommerce-filled-mini-cart-contents-block > .block-editor-inner-blocks > .block-editor-block-list__layout {
 		display: flex;
 		flex-direction: column;
-		height: 100%;
+		min-height: 100vh;
 	}
-}
 
-.wp-block-woocommerce-mini-cart-products-table-block {
-	margin-bottom: auto;
-	margin-top: $gap;
-}
+	.wp-block-woocommerce-mini-cart-items-block {
+		display: grid;
+		flex-grow: 1;
+		margin-bottom: $gap;
+		padding: 0 $gap;
 
-.editor-styles-wrapper h2.wc-block-mini-cart__title {
-	@include font-size(larger);
-	margin: $gap-largest $gap 0;
+		> .block-editor-inner-blocks > .block-editor-block-list__layout {
+			display: flex;
+			flex-direction: column;
+			height: 100%;
+		}
+	}
+
+	.wp-block-woocommerce-mini-cart-products-table-block {
+		margin-bottom: auto;
+		margin-top: $gap;
+	}
+
+	h2.wc-block-mini-cart__title {
+		@include font-size(larger);
+		margin: $gap-largest $gap 0;
+	}
+
+	table.wc-block-cart-items {
+		color: inherit;
+	}
 }

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/index.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/index.tsx
@@ -36,7 +36,7 @@ const settings = {
 		reusable: false,
 		inserter: false,
 		color: {
-			text: false,
+			link: true,
 		},
 	},
 	attributes: {

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-footer-block/block.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-footer-block/block.tsx
@@ -24,7 +24,12 @@ const PaymentMethodIconsElement = (): JSX.Element => {
 	);
 };
 
-const Block = (): JSX.Element => {
+interface Props {
+	color?: string;
+	backgroundColor?: string;
+}
+
+const Block = ( { color, backgroundColor }: Props ): JSX.Element => {
 	const { cartTotals } = useStoreCart();
 	const subTotal = getSetting( 'displayCartPricesIncludingTax', false )
 		? parseInt( cartTotals.total_items, 10 ) +
@@ -47,6 +52,10 @@ const Block = (): JSX.Element => {
 					<Button
 						className="wc-block-mini-cart__footer-cart"
 						href={ CART_URL }
+						style={ {
+							color,
+							borderColor: color,
+						} }
 					>
 						{ __( 'View my cart', 'woo-gutenberg-products-block' ) }
 					</Button>
@@ -55,6 +64,11 @@ const Block = (): JSX.Element => {
 					<Button
 						className="wc-block-mini-cart__footer-checkout"
 						href={ CHECKOUT_URL }
+						style={ {
+							color: backgroundColor,
+							borderColor: color,
+							backgroundColor: color,
+						} }
 					>
 						{ __(
 							'Go to checkout',

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-footer-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-footer-block/edit.tsx
@@ -3,19 +3,40 @@
  */
 import { useBlockProps } from '@wordpress/block-editor';
 import Noninteractive from '@woocommerce/base-components/noninteractive';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import Block from './block';
+import { blockName as miniCartContentsBlockName } from '../../attributes';
+import { useColorProps } from '../../../../../hooks/style-attributes';
 
-export const Edit = (): JSX.Element => {
+export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 	const blockProps = useBlockProps();
+
+	const parentAttributes = useSelect( ( select ) => {
+		const { getBlockAttributes, getBlockParentsByBlockName } = select(
+			'core/block-editor'
+		);
+		const parentBlockIds = getBlockParentsByBlockName(
+			clientId,
+			miniCartContentsBlockName
+		);
+
+		if ( parentBlockIds.length !== 1 ) {
+			return {};
+		}
+
+		return getBlockAttributes( parentBlockIds[ 0 ] );
+	} );
+
+	const parentColorProps = useColorProps( parentAttributes );
 
 	return (
 		<div { ...blockProps }>
 			<Noninteractive>
-				<Block />
+				<Block { ...parentColorProps.style } />
 			</Noninteractive>
 		</div>
 	);

--- a/assets/js/blocks/cart-checkout/mini-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/mini-cart/style.scss
@@ -62,24 +62,13 @@
 		position: absolute;
 		top: $gap-largest;
 		right: $gap;
-	}
 
-	.wc-block-mini-cart__items {
-		display: flex;
-		flex-direction: column;
-		flex-grow: 1;
-		overflow-y: hidden;
-		padding: 0 $gap;
-	}
+		button {
+			color: inherit;
+		}
 
-	.wc-block-mini-cart__products-table {
-		margin-bottom: auto;
-		margin-right: -$gap;
-		overflow-y: auto;
-		padding-right: $gap;
-
-		.wc-block-cart-items__row:last-child::after {
-			content: none;
+		svg {
+			fill: currentColor;
 		}
 	}
 }
@@ -100,50 +89,69 @@ h2.wc-block-mini-cart__title {
 	margin: $gap-largest $gap 0;
 }
 
+.wc-block-mini-cart__items {
+	display: flex;
+	flex-direction: column;
+	flex-grow: 1;
+	overflow-y: hidden;
+	padding: 0 $gap;
+
+	.wc-block-mini-cart__products-table {
+		margin-bottom: auto;
+		margin-right: -$gap;
+		overflow-y: auto;
+		padding-right: $gap;
+
+		.wc-block-cart-items__row:last-child::after {
+			content: none;
+		}
+	}
+}
+
 .wc-block-mini-cart__footer {
 	border-top: 1px solid $gray-300;
 	padding: $gap-large $gap;
-}
 
-.wc-block-components-totals-item.wc-block-mini-cart__footer-subtotal {
-	font-weight: 600;
-	margin-bottom: $gap;
-
-	.wc-block-components-totals-item__description {
-		display: none;
-		font-size: 0.75em;
-		font-weight: 400;
-
-		@media only screen and (min-width: 480px) {
-			display: unset;
-		}
-	}
-}
-
-.wc-block-mini-cart__footer-actions {
-	display: flex;
-	gap: $gap;
-
-	.wc-block-mini-cart__footer-cart.wc-block-components-button {
-		background-color: transparent;
-		border: 1px solid $gray-900;
-		color: $gray-900;
-		display: none;
-		flex-grow: 1;
+	.wc-block-components-totals-item.wc-block-mini-cart__footer-subtotal {
 		font-weight: 600;
+		margin-bottom: $gap;
 
-		@media only screen and (min-width: 480px) {
-			display: inline-flex;
+		.wc-block-components-totals-item__description {
+			display: none;
+			font-size: 0.75em;
+			font-weight: 400;
+
+			@media only screen and (min-width: 480px) {
+				display: unset;
+			}
 		}
 	}
 
-	.wc-block-mini-cart__footer-checkout {
-		border: 1px solid $gray-900;
-		flex-grow: 1;
-		font-weight: 600;
-	}
-}
+	.wc-block-mini-cart__footer-actions {
+		display: flex;
+		gap: $gap;
 
-.wc-block-mini-cart__footer .wc-block-components-payment-method-icons {
-	margin-top: $gap;
+		.wc-block-mini-cart__footer-cart.wc-block-components-button {
+			background-color: transparent;
+			border: 1px solid $gray-900;
+			color: $gray-900;
+			display: none;
+			flex-grow: 1;
+			font-weight: 600;
+
+			@media only screen and (min-width: 480px) {
+				display: inline-flex;
+			}
+		}
+
+		.wc-block-mini-cart__footer-checkout {
+			border: 1px solid $gray-900;
+			flex-grow: 1;
+			font-weight: 600;
+		}
+	}
+
+	.wc-block-components-payment-method-icons {
+		margin-top: $gap;
+	}
 }

--- a/src/BlockTypes/MiniCartContents.php
+++ b/src/BlockTypes/MiniCartContents.php
@@ -5,6 +5,7 @@ use Automattic\WooCommerce\Blocks\Package;
 use Automattic\WooCommerce\Blocks\Assets;
 use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
 use Automattic\WooCommerce\Blocks\StoreApi\Utilities\CartController;
+use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
 
 /**
  * Mini Cart class.
@@ -64,5 +65,82 @@ class MiniCartContents extends AbstractBlock {
 		}
 
 		return $content;
+	}
+
+	/**
+	 * Enqueue frontend assets for this block, just in time for rendering.
+	 *
+	 * @param array $attributes  Any attributes that currently are available from the block.
+	 */
+	protected function enqueue_assets( array $attributes ) {
+		parent::enqueue_assets( $attributes );
+		$text_color = StyleAttributesUtils::get_text_color_class_and_style( $attributes );
+		$bg_color   = StyleAttributesUtils::get_background_color_class_and_style( $attributes );
+
+		$styles = array(
+			array(
+				'selector'   => '.wc-block-mini-cart__drawer .components-modal__header',
+				'properties' => array(
+					array(
+						'property' => 'color',
+						'value'    => $text_color ? $text_color['value'] : false,
+					),
+				),
+			),
+			array(
+				'selector'   => '.wc-block-mini-cart__footer .wc-block-mini-cart__footer-actions .wc-block-mini-cart__footer-cart.wc-block-components-button',
+				'properties' => array(
+					array(
+						'property' => 'color',
+						'value'    => $text_color ? $text_color['value'] : false,
+					),
+					array(
+						'property' => 'border-color',
+						'value'    => $text_color ? $text_color['value'] : false,
+					),
+				),
+			),
+			array(
+				'selector'   => '.wc-block-mini-cart__footer .wc-block-mini-cart__footer-actions .wc-block-mini-cart__footer-checkout',
+				'properties' => array(
+					array(
+						'property' => 'color',
+						'value'    => $bg_color ? $bg_color['value'] : false,
+					),
+					array(
+						'property' => 'border-color',
+						'value'    => $text_color ? $text_color['value'] : false,
+					),
+					array(
+						'property' => 'background-color',
+						'value'    => $text_color ? $text_color['value'] : false,
+					),
+				),
+			),
+		);
+
+		$parsed_style = '';
+
+		foreach ( $styles as $style ) {
+			$properties = array_filter(
+				$style['properties'],
+				function( $property ) {
+					return $property['value'];
+				}
+			);
+
+			if ( ! empty( $properties ) ) {
+				$parsed_style .= $style['selector'] . '{' . PHP_EOL;
+				foreach ( $properties as $property ) {
+					$parsed_style .= $property['property'] . ':' . $property['value'] . ';' . PHP_EOL;
+				}
+				$parsed_style .= '}' . PHP_EOL;
+			}
+		}
+
+		wp_add_inline_style(
+			'wc-blocks-style',
+			$parsed_style
+		);
 	}
 }

--- a/src/Utils/StyleAttributesUtils.php
+++ b/src/Utils/StyleAttributesUtils.php
@@ -58,11 +58,13 @@ class StyleAttributesUtils {
 			return array(
 				'class' => sprintf( 'has-text-color has-%s-color', $text_color ),
 				'style' => null,
+				'value' => self::get_preset_value( $text_color ),
 			);
 		} elseif ( $custom_text_color ) {
 			return array(
 				'class' => null,
 				'style' => sprintf( 'color: %s;', $custom_text_color ),
+				'value' => $custom_text_color,
 			);
 		}
 		return null;
@@ -92,12 +94,14 @@ class StyleAttributesUtils {
 			$parsed_named_link_color = substr( $link_color, $index_named_link_color + 1 );
 			return array(
 				'class' => null,
-				'style' => sprintf( 'color: %s;', $parsed_named_link_color ),
+				'style' => sprintf( 'color: %s;', self::get_preset_value( $parsed_named_link_color ) ),
+				'value' => self::get_preset_value( $parsed_named_link_color ),
 			);
 		} else {
 			return array(
 				'class' => null,
 				'style' => sprintf( 'color: %s;', $link_color ),
+				'value' => $link_color,
 			);
 		}
 	}
@@ -144,11 +148,13 @@ class StyleAttributesUtils {
 			return array(
 				'class' => sprintf( 'has-background has-%s-background-color', $background_color ),
 				'style' => null,
+				'value' => self::get_preset_value( $background_color ),
 			);
 		} elseif ( '' !== $custom_background_color ) {
 			return array(
 				'class' => null,
 				'style' => sprintf( 'background-color: %s;', $custom_background_color ),
+				'value' => $custom_background_color,
 			);
 		}
 		return null;
@@ -283,5 +289,16 @@ class StyleAttributesUtils {
 		$classes_and_styles = self::get_classes_and_styles_by_attributes( $attributes, $properties );
 
 		return $classes_and_styles['styles'];
+	}
+
+	/**
+	 * Get CSS value for color preset.
+	 *
+	 * @param string $preset_name Preset name.
+	 *
+	 * @return string CSS value for color preset.
+	 */
+	public static function get_preset_value( $preset_name ) {
+		return "var(--wp--preset--color--$preset_name)";
 	}
 }


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #5413. Replaces #5443 

This PR adds text and link color support to the Mini Cart Contents block. Users only need to change three colors of the Mini Cart Contents block then inner blocks get styled correctly based on those colors.

#### Limitations
- The global style doesn't work. Because we only have one Mini Cart template part, its block style is basically the global style. AFAIK, we can't opt-out a block from global style, so Mini Cart Contents still appears in the Global Style blocks list.

### Screenshots

<details>
<summary>Details</summary>

<img width="1616" alt="Screen Shot 2022-01-14 at 21 08 10" src="https://user-images.githubusercontent.com/5423135/149528491-bf0ac825-250f-4915-90d8-87e0fe108ff5.png">
<img width="1417" alt="Screen Shot 2022-01-14 at 20 27 22" src="https://user-images.githubusercontent.com/5423135/149527873-07a1827d-a12f-463b-9e70-925068044bca.png">
<img width="1417" alt="Screen Shot 2022-01-14 at 20 27 31" src="https://user-images.githubusercontent.com/5423135/149527837-254ebc36-5a54-4ee6-b525-19f4af7d26d4.png">

</details>

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### Testing

### Manual Testing

How to test the changes in this Pull Request:

1. Edit the Mini Cart template part.
2. Select Mini Cart Contents block.
3. Change background, text, and link colors.
4. See the color of inner blocks change accordingly.
5. Save the template part. See the colors applied on the front end.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
* [ ] See steps below.