### PR TITLE
Remove deprecated data controls in favour of those from the `@wordpress/data` package

### DIFF
--- a/assets/js/base/context/providers/cart-checkout/payment-methods/test/payment-method-data-context.js
+++ b/assets/js/base/context/providers/cart-checkout/payment-methods/test/payment-method-data-context.js
@@ -208,9 +208,6 @@ describe( 'Testing Payment Method Data Context Provider', () => {
 			);
 			expect( activePaymentMethod ).not.toBeNull();
 		} );
-
-		// ["`select` control in `@wordpress/data-controls` is deprecated. Please use built-in `resolveSelect` control in `@wordpress/data` instead."]
-		expect( console ).toHaveWarned();
 	} );
 } );
 

--- a/assets/js/blocks/cart-checkout/cart/test/block.js
+++ b/assets/js/blocks/cart-checkout/cart/test/block.js
@@ -83,7 +83,9 @@ describe( 'Testing cart', () => {
 	} );
 
 	it( 'renders cart if there are items in the cart', async () => {
-		render( <CartBlock /> );
+		act( () => {
+			render( <CartBlock /> );
+		} );
 		await waitFor( () => expect( fetchMock ).toHaveBeenCalled() );
 		expect(
 			screen.getByText( /Proceed to Checkout/i )
@@ -96,7 +98,9 @@ describe( 'Testing cart', () => {
 		allSettings.displayCartPricesIncludingTax = false;
 		// The criteria for showing the Taxes section is:
 		// Display prices during basket and checkout: 'Excluding tax'.
-		render( <CartBlock /> );
+		act( () => {
+			render( <CartBlock /> );
+		} );
 
 		await waitFor( () => expect( fetchMock ).toHaveBeenCalled() );
 		expect( screen.getByText( /Tax/i ) ).toBeInTheDocument();
@@ -108,7 +112,9 @@ describe( 'Testing cart', () => {
 		// The criteria for showing the lines in the Taxes section is:
 		// Display prices during basket and checkout: 'Excluding tax'.
 		// Display tax totals: 'Itemized';
-		render( <CartBlock /> );
+		act( () => {
+			render( <CartBlock /> );
+		} );
 		await waitFor( () => expect( fetchMock ).toHaveBeenCalled() );
 		expect( screen.getByText( /Sales tax/i ) ).toBeInTheDocument();
 	} );
@@ -141,7 +147,9 @@ describe( 'Testing cart', () => {
 				return Promise.resolve( '' );
 			} );
 		} );
-		render( <CartBlock /> );
+		act( () => {
+			render( <CartBlock /> );
+		} );
 
 		await waitFor( () => expect( fetchMock ).toHaveBeenCalled() );
 		expect( screen.getByText( /Empty Cart/i ) ).toBeInTheDocument();
@@ -173,7 +181,9 @@ describe( 'Testing cart', () => {
 				return Promise.resolve( JSON.stringify( cart ) );
 			}
 		} );
-		render( <CartBlock /> );
+		act( () => {
+			render( <CartBlock /> );
+		} );
 
 		await waitFor( () => expect( fetchMock ).toHaveBeenCalled() );
 		expect( screen.getAllByRole( 'cell' )[ 1 ] ).toHaveTextContent( '16€' );
@@ -191,7 +201,9 @@ describe( 'Testing cart', () => {
 			],
 		};
 		const itemName = cart.items[ 0 ].name;
-		render( <CartBlock /> );
+		act( () => {
+			render( <CartBlock /> );
+		} );
 
 		await waitFor( () => expect( fetchMock ).toHaveBeenCalled() );
 		const quantityInput = screen.getByLabelText(

--- a/assets/js/blocks/cart-checkout/cart/test/block.js
+++ b/assets/js/blocks/cart-checkout/cart/test/block.js
@@ -90,8 +90,6 @@ describe( 'Testing cart', () => {
 		).toBeInTheDocument();
 
 		expect( fetchMock ).toHaveBeenCalledTimes( 1 );
-		// ["`select` control in `@wordpress/data-controls` is deprecated. Please use built-in `resolveSelect` control in `@wordpress/data` instead."]
-		expect( console ).toHaveWarned();
 	} );
 
 	it( 'Contains a Taxes section if Core options are set to show it', async () => {
@@ -133,13 +131,15 @@ describe( 'Testing cart', () => {
 	} );
 
 	it( 'renders empty cart if there are no items in the cart', async () => {
-		fetchMock.mockResponse( ( req ) => {
-			if ( req.url.match( /wc\/store\/v1\/cart/ ) ) {
-				return Promise.resolve(
-					JSON.stringify( defaultCartState.cartData )
-				);
-			}
-			return Promise.resolve( '' );
+		act( () => {
+			fetchMock.mockResponse( ( req ) => {
+				if ( req.url.match( /wc\/store\/v1\/cart/ ) ) {
+					return Promise.resolve(
+						JSON.stringify( defaultCartState.cartData )
+					);
+				}
+				return Promise.resolve( '' );
+			} );
 		} );
 		render( <CartBlock /> );
 

--- a/assets/js/blocks/cart-checkout/mini-cart/test/block.js
+++ b/assets/js/blocks/cart-checkout/mini-cart/test/block.js
@@ -72,8 +72,6 @@ describe( 'Testing Mini Cart', () => {
 		} );
 
 		expect( fetchMock ).toHaveBeenCalledTimes( 1 );
-		// ["`select` control in `@wordpress/data-controls` is deprecated. Please use built-in `resolveSelect` control in `@wordpress/data` instead."]
-		expect( console ).toHaveWarned();
 	} );
 
 	it( 'renders empty cart if there are no items in the cart', async () => {

--- a/assets/js/blocks/cart-checkout/payment-methods/test/payment-methods.js
+++ b/assets/js/blocks/cart-checkout/payment-methods/test/payment-methods.js
@@ -99,8 +99,6 @@ describe( 'PaymentMethods', () => {
 			// creates an extra `div` with the notice contents used for a11y.
 			expect( noPaymentMethods.length ).toBeGreaterThanOrEqual( 1 );
 		} );
-		// ["`select` control in `@wordpress/data-controls` is deprecated. Please use built-in `resolveSelect` control in `@wordpress/data` instead."]
-		expect( console ).toHaveWarned();
 	} );
 
 	test( 'selecting new payment method', async () => {

--- a/assets/js/data/cart/actions.ts
+++ b/assets/js/data/cart/actions.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { select } from '@wordpress/data-controls';
 import type {
 	Cart,
 	CartResponse,
@@ -12,6 +11,7 @@ import type {
 import { camelCase, mapKeys } from 'lodash';
 import type { AddToCartEventDetail } from '@woocommerce/type-defs/events';
 import { BillingAddress, ShippingAddress } from '@woocommerce/settings';
+import { controls } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -416,7 +416,11 @@ export function* changeCartItemQuantity(
 	quantity: number
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- unclear how to represent multiple different yields as type
 ): Generator< unknown, void, any > {
-	const cartItem = yield select( CART_STORE_KEY, 'getCartItem', cartItemKey );
+	const cartItem = yield controls.select(
+		CART_STORE_KEY,
+		'getCartItem',
+		cartItemKey
+	);
 	if ( cartItem?.quantity === quantity ) {
 		return;
 	}

--- a/assets/js/data/cart/actions.ts
+++ b/assets/js/data/cart/actions.ts
@@ -416,7 +416,7 @@ export function* changeCartItemQuantity(
 	quantity: number
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- unclear how to represent multiple different yields as type
 ): Generator< unknown, void, any > {
-	const cartItem = yield controls.select(
+	const cartItem = yield controls.resolveSelect(
 		CART_STORE_KEY,
 		'getCartItem',
 		cartItemKey

--- a/assets/js/data/cart/resolvers.ts
+++ b/assets/js/data/cart/resolvers.ts
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { select, apiFetch } from '@wordpress/data-controls';
+import { apiFetch } from '@wordpress/data-controls';
+import { controls } from '@wordpress/data';
 import { CartResponse, Cart } from '@woocommerce/types';
 
 /**
@@ -32,5 +33,5 @@ export function* getCartData(): Generator< unknown, void, CartResponse > {
  * Resolver for retrieving cart totals.
  */
 export function* getCartTotals(): Generator< unknown, void, Cart > {
-	yield select( STORE_KEY, 'getCartData' );
+	yield controls.select( STORE_KEY, 'getCartData' );
 }

--- a/assets/js/data/cart/resolvers.ts
+++ b/assets/js/data/cart/resolvers.ts
@@ -33,5 +33,5 @@ export function* getCartData(): Generator< unknown, void, CartResponse > {
  * Resolver for retrieving cart totals.
  */
 export function* getCartTotals(): Generator< unknown, void, Cart > {
-	yield controls.select( STORE_KEY, 'getCartData' );
+	yield controls.resolveSelect( STORE_KEY, 'getCartData' );
 }

--- a/assets/js/data/collections/resolvers.js
+++ b/assets/js/data/collections/resolvers.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { select, dispatch } from '@wordpress/data-controls';
+import { controls } from '@wordpress/data';
 import { addQueryArgs } from '@wordpress/url';
 
 /**
@@ -18,13 +18,16 @@ import { apiFetchWithHeaders } from '../shared-controls';
  * @param {number} timestamp Last update timestamp.
  */
 function* invalidateModifiedCollection( timestamp ) {
-	const lastModified = yield select( STORE_KEY, 'getCollectionLastModified' );
+	const lastModified = yield controls.select(
+		STORE_KEY,
+		'getCollectionLastModified'
+	);
 
 	if ( ! lastModified ) {
-		yield dispatch( STORE_KEY, 'receiveLastModified', timestamp );
+		yield controls.dispatch( STORE_KEY, 'receiveLastModified', timestamp );
 	} else if ( timestamp > lastModified ) {
-		yield dispatch( STORE_KEY, 'invalidateResolutionForStore' );
-		yield dispatch( STORE_KEY, 'receiveLastModified', timestamp );
+		yield controls.dispatch( STORE_KEY, 'invalidateResolutionForStore' );
+		yield controls.dispatch( STORE_KEY, 'receiveLastModified', timestamp );
 	}
 }
 
@@ -37,7 +40,7 @@ function* invalidateModifiedCollection( timestamp ) {
  * @param {Array}  ids
  */
 export function* getCollection( namespace, resourceName, query, ids ) {
-	const route = yield select(
+	const route = yield controls.select(
 		SCHEMA_STORE_KEY,
 		'getRoute',
 		namespace,
@@ -104,6 +107,6 @@ export function* getCollectionHeader(
 	const args = [ namespace, resourceName, query, ids ].filter(
 		( arg ) => typeof arg !== 'undefined'
 	);
-	//we call this simply to do any resolution of the collection if necessary.
-	yield select( STORE_KEY, 'getCollection', ...args );
+	// we call this simply to do any resolution of the collection if necessary.
+	yield controls.select( STORE_KEY, 'getCollection', ...args );
 }

--- a/assets/js/data/collections/resolvers.js
+++ b/assets/js/data/collections/resolvers.js
@@ -108,5 +108,5 @@ export function* getCollectionHeader(
 		( arg ) => typeof arg !== 'undefined'
 	);
 	// we call this simply to do any resolution of the collection if necessary.
-	yield controls.select( STORE_KEY, 'getCollection', ...args );
+	yield controls.resolveSelect( STORE_KEY, 'getCollection', ...args );
 }

--- a/assets/js/data/collections/resolvers.js
+++ b/assets/js/data/collections/resolvers.js
@@ -18,7 +18,7 @@ import { apiFetchWithHeaders } from '../shared-controls';
  * @param {number} timestamp Last update timestamp.
  */
 function* invalidateModifiedCollection( timestamp ) {
-	const lastModified = yield controls.select(
+	const lastModified = yield controls.resolveSelect(
 		STORE_KEY,
 		'getCollectionLastModified'
 	);
@@ -40,7 +40,7 @@ function* invalidateModifiedCollection( timestamp ) {
  * @param {Array}  ids
  */
 export function* getCollection( namespace, resourceName, query, ids ) {
-	const route = yield controls.select(
+	const route = yield controls.resolveSelect(
 		SCHEMA_STORE_KEY,
 		'getRoute',
 		namespace,

--- a/assets/js/data/collections/test/resolvers.js
+++ b/assets/js/data/collections/test/resolvers.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { select } from '@wordpress/data-controls';
+import { controls } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -12,7 +12,7 @@ import { STORE_KEY as SCHEMA_STORE_KEY } from '../../schema/constants';
 import { STORE_KEY } from '../constants';
 import { apiFetchWithHeaders } from '../../shared-controls';
 
-jest.mock( '@wordpress/data-controls' );
+jest.mock( '@wordpress/data' );
 
 describe( 'getCollection', () => {
 	describe( 'yields with expected responses', () => {
@@ -27,7 +27,7 @@ describe( 'getCollection', () => {
 		test( 'with getRoute call invoked to retrieve route', () => {
 			rewind();
 			fulfillment.next();
-			expect( select ).toHaveBeenCalledWith(
+			expect( controls.select ).toHaveBeenCalledWith(
 				SCHEMA_STORE_KEY,
 				'getRoute',
 				testArgs[ 0 ],
@@ -133,7 +133,12 @@ describe( 'getCollectionHeader', () => {
 		rewind( 'x-wp-total', '/wc/blocks', 'products' );
 		const { value } = fulfillment.next();
 		expect( value ).toEqual(
-			select( STORE_KEY, 'getCollection', '/wc/blocks', 'products' )
+			controls.select(
+				STORE_KEY,
+				'getCollection',
+				'/wc/blocks',
+				'products'
+			)
 		);
 	} );
 	it( 'yields expected select control when called with all args', () => {
@@ -147,7 +152,7 @@ describe( 'getCollectionHeader', () => {
 		rewind( ...args );
 		const { value } = fulfillment.next();
 		expect( value ).toEqual(
-			select(
+			controls.select(
 				STORE_KEY,
 				'/wc/blocks',
 				'products/attributes',

--- a/assets/js/data/collections/test/resolvers.js
+++ b/assets/js/data/collections/test/resolvers.js
@@ -27,7 +27,7 @@ describe( 'getCollection', () => {
 		test( 'with getRoute call invoked to retrieve route', () => {
 			rewind();
 			fulfillment.next();
-			expect( controls.select ).toHaveBeenCalledWith(
+			expect( controls.resolveSelect ).toHaveBeenCalledWith(
 				SCHEMA_STORE_KEY,
 				'getRoute',
 				testArgs[ 0 ],
@@ -133,7 +133,7 @@ describe( 'getCollectionHeader', () => {
 		rewind( 'x-wp-total', '/wc/blocks', 'products' );
 		const { value } = fulfillment.next();
 		expect( value ).toEqual(
-			controls.select(
+			controls.resolveSelect(
 				STORE_KEY,
 				'getCollection',
 				'/wc/blocks',
@@ -152,7 +152,7 @@ describe( 'getCollectionHeader', () => {
 		rewind( ...args );
 		const { value } = fulfillment.next();
 		expect( value ).toEqual(
-			controls.select(
+			controls.resolveSelect(
 				STORE_KEY,
 				'/wc/blocks',
 				'products/attributes',

--- a/assets/js/data/schema/resolvers.js
+++ b/assets/js/data/schema/resolvers.js
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { select, apiFetch } from '@wordpress/data-controls';
+import { apiFetch } from '@wordpress/data-controls';
+import { controls } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -20,7 +21,7 @@ import { STORE_KEY } from './constants';
 export function* getRoute( namespace ) {
 	// we call this simply to do any resolution of all endpoints if necessary.
 	// allows for jit population of routes for a given namespace.
-	yield select( STORE_KEY, 'getRoutes', namespace );
+	yield controls.select( STORE_KEY, 'getRoutes', namespace );
 }
 
 /**

--- a/assets/js/data/schema/resolvers.js
+++ b/assets/js/data/schema/resolvers.js
@@ -21,7 +21,7 @@ import { STORE_KEY } from './constants';
 export function* getRoute( namespace ) {
 	// we call this simply to do any resolution of all endpoints if necessary.
 	// allows for jit population of routes for a given namespace.
-	yield controls.select( STORE_KEY, 'getRoutes', namespace );
+	yield controls.resolveSelect( STORE_KEY, 'getRoutes', namespace );
 }
 
 /**

--- a/assets/js/data/schema/test/resolvers.js
+++ b/assets/js/data/schema/test/resolvers.js
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import { select, apiFetch } from '@wordpress/data-controls';
+import { apiFetch } from '@wordpress/data-controls';
+import { controls } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -11,12 +12,13 @@ import { receiveRoutes } from '../actions';
 import { STORE_KEY } from '../constants';
 
 jest.mock( '@wordpress/data-controls' );
+jest.mock( '@wordpress/data' );
 
 describe( 'getRoute', () => {
 	it( 'yields select control response', () => {
 		const fulfillment = getRoute( 'wc/blocks' );
 		fulfillment.next();
-		expect( select ).toHaveBeenCalledWith(
+		expect( controls.select ).toHaveBeenCalledWith(
 			STORE_KEY,
 			'getRoutes',
 			'wc/blocks'

--- a/assets/js/data/schema/test/resolvers.js
+++ b/assets/js/data/schema/test/resolvers.js
@@ -18,7 +18,7 @@ describe( 'getRoute', () => {
 	it( 'yields select control response', () => {
 		const fulfillment = getRoute( 'wc/blocks' );
 		fulfillment.next();
-		expect( controls.select ).toHaveBeenCalledWith(
+		expect( controls.resolveSelect ).toHaveBeenCalledWith(
 			STORE_KEY,
 			'getRoutes',
 			'wc/blocks'


### PR DESCRIPTION
Removes usage of the deprecated functions `select` and `dispatch` imported from `@wordpress/data-controls` ([deprecated here](https://github.com/WordPress/gutenberg/pull/26509)) and replaces them with `controls.select` and `controls.dispatch` from the `@wordpress/data` package.  

Fixes #5339

Questions from the issue:

> What version of WordPress is the replacement available?

The switch to `@wordpress/data` happened in Gutenberg 9.2, which was part of [WordPress 5.6](https://developer.wordpress.org/block-editor/contributors/versions-in-wordpress/), but controls existed before then. 

> Is the deprecated implementation in Woo Blocks in code that is exposed to users via Woo Core?

Yes, it's part of schema and collections data-stores, used by All Products block.

> What version of WordPress does Woo Core still require as minimum support and does that fall in the appropriate range?

The `controls` export existed in WordPress 5.6 ([see here](https://github.com/WordPress/WordPress/blob/5.6/wp-includes/js/dist/data.js)). This is the min supported version of Woo core.

Blocks min support is 5.8. Both are satisfied.

### Testing

How to test the changes in this Pull Request:

1. Smoke test changing quantities of items in the cart
2. Smoke test All Products block and add to cart buttons within that block
3. Smoke test All Products block with Filter Blocks

JS tests must also pass. I removed the deprecation assertions from those.

### Changelog

> Remove deprecated data controls in favour of those from the `@wordpress/data` package
