### PR TITLE
initialize_session if it does not yet exist before calling the sessio…

### DIFF
--- a/src/StoreApi/Utilities/DraftOrderTrait.php
+++ b/src/StoreApi/Utilities/DraftOrderTrait.php
@@ -13,6 +13,9 @@ trait DraftOrderTrait {
 	 * @return integer
 	 */
 	protected function get_draft_order_id() {
+		if ( ! wc()->session ) {
+			wc()->initialize_session();
+		}
 		return wc()->session->get( 'store_api_draft_order', 0 );
 	}
 
@@ -22,6 +25,9 @@ trait DraftOrderTrait {
 	 * @param integer $order_id Draft order ID.
 	 */
 	protected function set_draft_order_id( $order_id ) {
+		if ( ! wc()->session ) {
+			wc()->initialize_session();
+		}
 		wc()->session->set( 'store_api_draft_order', $order_id );
 	}
 


### PR DESCRIPTION
Bug introduced in https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5406

cc @gigitux 

The code that finds the quantity limits also looks up remaining stock. This relies on knowing if a draft order exists in session, and it's ID.

WooCommerce does not initalize the session on all routes. We do it manually on cart routes here: https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/src/StoreApi/Routes/AbstractCartRoute.php#L68 But product routes won't do this.

To fix, we just need to see if `session` exists, and if not, initialize it.

We can skip the changelog entry if this ships before next release.

### Testing

How to test the changes in this Pull Request:

Try this before and after to confirm you see the issue.

1. Add all products block to a page
2. Edit one of the displayed products. Make it stock managed, and set stock to 20.
3. View all products block. Before this patch, the block will break (render error). 