### PR TITLE
Add ensureCleanAttributes back and run only if E2E tests are running locally

### DIFF
--- a/tests/e2e/config/setup.js
+++ b/tests/e2e/config/setup.js
@@ -35,6 +35,7 @@ module.exports = async ( globalConfig ) => {
 		// We only want to run ensureCleanAttributes when running locally, and not in CI.
 		// This env variable should not exist on someone's local machine
 		if ( ! process.env.GITHUB_RUN_ID ) {
+			console.log( 'cleaning attributes' );
 			await ensureCleanAttributes();
 		}
 		/**

--- a/tests/e2e/config/setup.js
+++ b/tests/e2e/config/setup.js
@@ -35,7 +35,6 @@ module.exports = async ( globalConfig ) => {
 		// We only want to run ensureCleanAttributes when running locally, and not in CI.
 		// This env variable should not exist on someone's local machine
 		if ( ! process.env.GITHUB_RUN_ID ) {
-			console.log( 'cleaning attributes' );
 			await ensureCleanAttributes();
 		}
 		/**

--- a/tests/e2e/config/setup.js
+++ b/tests/e2e/config/setup.js
@@ -17,6 +17,7 @@ import {
 	createShippingZones,
 	createBlockPages,
 	enablePaymentGateways,
+	ensureCleanAttributes,
 	createProductAttributes,
 } from '../fixtures/fixture-loaders';
 
@@ -30,6 +31,12 @@ module.exports = async ( globalConfig ) => {
 		await setupSettings();
 		const pages = await createBlockPages();
 
+		// Check if there's a github actions run ID set in the environment variables.
+		// We only want to run ensureCleanAttributes when running locally, and not in CI.
+		// This env variable should not exist on someone's local machine
+		if ( ! process.env.GITHUB_RUN_ID ) {
+			await ensureCleanAttributes();
+		}
 		/**
 		 * Promise.all will return an array of all promises resolved values.
 		 * Some functions like setupSettings and enablePaymentGateways resolve

--- a/tests/e2e/fixtures/fixture-loaders.js
+++ b/tests/e2e/fixtures/fixture-loaders.js
@@ -353,6 +353,20 @@ const deleteBlockPages = ( ids ) => {
 };
 
 /**
+ * Ensure attributes are removed from the site before setting up. This exists in case
+ * the teardown didn't happen properly for any reason. This function exists mostly as a
+ * dev-ex improvement tool while working on tests.
+ *
+ * @return {Promise<void>}
+ */
+const ensureCleanAttributes = async () => {
+	const attributeIds = await WooCommerce.get( 'products/attributes' );
+	await deleteProductAttributes(
+		attributeIds.data.map( ( attribute ) => attribute.id )
+	);
+};
+
+/**
  * Create Products attributes and terms.
  *
  * @param {Object[]} fixture An array of objects describing our data, defaults
@@ -407,6 +421,7 @@ const deleteProductAttributes = ( ids ) => {
 module.exports = {
 	createProductAttributes,
 	deleteProductAttributes,
+	ensureCleanAttributes,
 	setupSettings,
 	setupPageSettings,
 	createTaxes,


### PR DESCRIPTION
This PR will add the `ensureCleanAttributes` function back, but this time it will only run locally and not in CI.

It was removed from https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4562#discussion_r688413063 because of concerns about running this code unnecessarily.

While it is still a useful function for testing locally, we can keep it but just skip running it if the tests are running in CI. To determine whether they are we can check an environment variable that is set by GitHub actions. I chose `GITHUB_RUN_ID`.

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #5410

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Force a commit that includes a console log in this conditional
https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/7301aac85852e91ff3296480096167d01c5f89a9/tests/e2e/config/setup.js#L37-L39
2. Check the output of the E2E tests action, ensure you can't see your console logged text.


### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [ ] Same as above, or
* [ ] See steps below.

This does not need user-facing testing to be carried out.

<!-- If you can, add the appropriate labels -->

### Performance Impact
When running locally, there will be a (very) minor performance decrease while the attributes are deleted, when running in CI there should be no change.

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Add suggested changelog entry here.
