### PR TITLE
Fix default `stockStatusOptions` in tag and attribute blocks

### DIFF
--- a/assets/js/blocks/product-category/block.js
+++ b/assets/js/blocks/product-category/block.js
@@ -190,7 +190,7 @@ class ProductByCategoryBlock extends Component {
 				</PanelBody>
 				<PanelBody
 					title={ __(
-						'Stock level',
+						'Filter by stock status',
 						'woo-gutenberg-products-block'
 					) }
 					initialOpen={ false }

--- a/assets/js/blocks/product-on-sale/block.js
+++ b/assets/js/blocks/product-on-sale/block.js
@@ -104,7 +104,7 @@ class ProductOnSaleBlock extends Component {
 				</PanelBody>
 				<PanelBody
 					title={ __(
-						'Stock level',
+						'Filter by stock status',
 						'woo-gutenberg-products-block'
 					) }
 					initialOpen={ false }

--- a/assets/js/blocks/product-tag/block.js
+++ b/assets/js/blocks/product-tag/block.js
@@ -154,7 +154,7 @@ class ProductsByTagBlock extends Component {
 				</PanelBody>
 				<PanelBody
 					title={ __(
-						'Stock level',
+						'Filter by stock status',
 						'woo-gutenberg-products-block'
 					) }
 					initialOpen={ false }

--- a/assets/js/blocks/product-tag/index.js
+++ b/assets/js/blocks/product-tag/index.js
@@ -115,7 +115,7 @@ registerBlockType( 'woocommerce/product-tag', {
 		 */
 		stockStatus: {
 			type: 'array',
-			default: getSetting( 'stockStatusOptions', [] ),
+			default: Object.keys( getSetting( 'stockStatusOptions', [] ) ),
 		},
 	},
 

--- a/assets/js/blocks/product-top-rated/block.js
+++ b/assets/js/blocks/product-top-rated/block.js
@@ -79,7 +79,7 @@ class ProductTopRatedBlock extends Component {
 				</PanelBody>
 				<PanelBody
 					title={ __(
-						'Stock level',
+						'Filter by stock status',
 						'woo-gutenberg-products-block'
 					) }
 					initialOpen={ false }

--- a/assets/js/blocks/products-by-attribute/block.js
+++ b/assets/js/blocks/products-by-attribute/block.js
@@ -104,7 +104,7 @@ class ProductsByAttributeBlock extends Component {
 				</PanelBody>
 				<PanelBody
 					title={ __(
-						'Stock level',
+						'Filter by stock status',
 						'woo-gutenberg-products-block'
 					) }
 					initialOpen={ false }

--- a/assets/js/blocks/products-by-attribute/index.js
+++ b/assets/js/blocks/products-by-attribute/index.js
@@ -121,8 +121,8 @@ registerBlockType( blockTypeName, {
 		 * Whether to display in stock, out of stock or backorder products.
 		 */
 		stockStatus: {
-			type: 'string',
-			default: getSetting( 'stockStatusOptions', [] ),
+			type: 'array',
+			default: Object.keys( getSetting( 'stockStatusOptions', [] ) ),
 		},
 	},
 

--- a/assets/js/editor-components/product-stock-control/index.tsx
+++ b/assets/js/editor-components/product-stock-control/index.tsx
@@ -3,7 +3,8 @@
  */
 import CheckboxList from '@woocommerce/base-components/checkbox-list';
 import { getSetting } from '@woocommerce/settings';
-import { useCallback, useState } from '@wordpress/element';
+import { useCallback, useState, useEffect } from '@wordpress/element';
+import { useDebounce } from 'use-debounce';
 
 export interface ProductStockControlProps {
 	value: Array< string >;
@@ -37,6 +38,12 @@ const ProductStockControl = ( {
 	// Set the initial state to the default or saved value.
 	const [ checkedOptions, setChecked ] = useState( value );
 
+	// Debounce checked options for updates.
+	const [ debouncedCheckedOptions ] = useDebounce< string[] >(
+		checkedOptions,
+		400
+	);
+
 	/**
 	 * Valid options must be in an array of [ 'value' : 'mystatus', 'label' : 'My label' ] format.
 	 * stockStatusOptions are returned as [ 'mystatus' : 'My label' ].
@@ -48,6 +55,15 @@ const ProductStockControl = ( {
 			.filter( ( status ) => !! status.label )
 			.sort( ( a, b ) => a.value.localeCompare( b.value ) )
 	);
+
+	/**
+	 * Dobounce changes to attributes based on checked items.
+	 */
+	useEffect( () => {
+		setAttributes( {
+			stockStatus: debouncedCheckedOptions,
+		} );
+	}, [ debouncedCheckedOptions, setAttributes ] );
 
 	/**
 	 * When a checkbox in the list changes, update state.
@@ -66,11 +82,8 @@ const ProductStockControl = ( {
 			}
 
 			setChecked( newChecked );
-			setAttributes( {
-				stockStatus: newChecked,
-			} );
 		},
-		[ checkedOptions, setAttributes ]
+		[ checkedOptions ]
 	);
 
 	return (

--- a/assets/js/editor-components/product-stock-control/index.tsx
+++ b/assets/js/editor-components/product-stock-control/index.tsx
@@ -4,7 +4,6 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { getSetting } from '@woocommerce/settings';
 import { useCallback, useState, useEffect } from '@wordpress/element';
-import { useDebounce } from 'use-debounce';
 import { ToggleControl } from '@wordpress/components';
 
 export interface ProductStockControlProps {
@@ -43,21 +42,15 @@ const ProductStockControl = ( {
 	// Set the initial state to the default or saved value.
 	const [ checkedOptions, setChecked ] = useState( value );
 
-	// Debounce checked options for updates.
-	const [ debouncedCheckedOptions ] = useDebounce< string[] >(
-		checkedOptions,
-		400
-	);
-
 	/**
-	 * Dobounce changes to attributes based on checked items.
+	 * Set attributes when checked items change.
+	 * Note: The blank stock status prevents all results returning when all options are unchecked.
 	 */
 	useEffect( () => {
-		// The blank stock status prevents all results returning when all options are unchecked.
 		setAttributes( {
-			stockStatus: [ '', ...debouncedCheckedOptions ],
+			stockStatus: [ '', ...checkedOptions ],
 		} );
-	}, [ debouncedCheckedOptions, setAttributes ] );
+	}, [ checkedOptions, setAttributes ] );
 
 	/**
 	 * When a checkbox in the list changes, update state.

--- a/assets/js/editor-components/product-stock-control/index.tsx
+++ b/assets/js/editor-components/product-stock-control/index.tsx
@@ -12,7 +12,7 @@ export interface ProductStockControlProps {
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
 }
 
-// Should out of stock items be hidden globally?
+// Look up whether or not out of stock items should be hidden globally.
 const hideOutOfStockItems = getSetting( 'hideOutOfStockItems', false );
 
 // Get the stock status options.
@@ -31,6 +31,15 @@ const ProductStockControl = ( {
 		? otherStockStatusOptions
 		: allStockStatusOptions;
 
+	/**
+	 * Valid options must be in an array of [ 'value' : 'mystatus', 'label' : 'My label' ] format.
+	 * stockStatusOptions are returned as [ 'mystatus' : 'My label' ].
+	 * Formatting is corrected here.
+	 */
+	const displayOptions = Object.entries( stockStatusOptions )
+		.map( ( [ slug, name ] ) => ( { value: slug, label: name } ) )
+		.filter( ( status ) => !! status.label );
+
 	// Set the initial state to the default or saved value.
 	const [ checkedOptions, setChecked ] = useState( value );
 
@@ -38,18 +47,6 @@ const ProductStockControl = ( {
 	const [ debouncedCheckedOptions ] = useDebounce< string[] >(
 		checkedOptions,
 		400
-	);
-
-	/**
-	 * Valid options must be in an array of [ 'value' : 'mystatus', 'label' : 'My label' ] format.
-	 * stockStatusOptions are returned as [ 'mystatus' : 'My label' ].
-	 * Formatting is corrected here.
-	 */
-	const [ displayOptions ] = useState(
-		Object.entries( stockStatusOptions )
-			.map( ( [ slug, name ] ) => ( { value: slug, label: name } ) )
-			.filter( ( status ) => !! status.label )
-			.sort( ( a, b ) => a.value.localeCompare( b.value ) )
 	);
 
 	/**

--- a/src/BlockTypes/AbstractProductGrid.php
+++ b/src/BlockTypes/AbstractProductGrid.php
@@ -295,15 +295,16 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 	 * @return void
 	 */
 	protected function set_stock_status_query_args( &$query_args ) {
+		$stock_statuses = array_keys( wc_get_product_stock_status_options() );
+
 		// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-		if ( isset( $this->attributes['stockStatus'] ) &&
-			( array_keys( wc_get_product_stock_status_options() ) !== $this->attributes['stockStatus'] || [] !== $this->attributes['stockStatus'] )
-		) {
+		if ( isset( $this->attributes['stockStatus'] ) && $stock_statuses !== $this->attributes['stockStatus'] ) {
 			// Reset meta_query then update with our stock status.
 			$query_args['meta_query']   = $this->meta_query;
 			$query_args['meta_query'][] = array(
-				'key'   => '_stock_status',
-				'value' => $this->attributes['stockStatus'],
+				'key'     => '_stock_status',
+				'value'   => array_merge( [ '' ], $this->attributes['stockStatus'] ),
+				'compare' => 'IN',
 			);
 		} else {
 			$query_args['meta_query'] = $this->meta_query;

--- a/src/BlockTypes/AbstractProductGrid.php
+++ b/src/BlockTypes/AbstractProductGrid.php
@@ -57,7 +57,10 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 			'align'             => $this->get_schema_align(),
 			'alignButtons'      => $this->get_schema_boolean( false ),
 			'isPreview'         => $this->get_schema_boolean( false ),
-			'stockStatus'       => array_keys( wc_get_product_stock_status_options() ),
+			'stockStatus'       => array(
+				'type'    => 'array',
+				'default' => array_keys( wc_get_product_stock_status_options() ),
+			),
 		);
 	}
 

--- a/src/BlockTypes/ProductsByAttribute.php
+++ b/src/BlockTypes/ProductsByAttribute.php
@@ -67,7 +67,10 @@ class ProductsByAttribute extends AbstractProductGrid {
 			'orderby'           => $this->get_schema_orderby(),
 			'rows'              => $this->get_schema_number( wc_get_theme_support( 'product_blocks::default_rows', 3 ) ),
 			'isPreview'         => $this->get_schema_boolean( false ),
-			'stockStatus'       => array_keys( wc_get_product_stock_status_options() ),
+			'stockStatus'       => array(
+				'type'    => 'array',
+				'default' => array_keys( wc_get_product_stock_status_options() ),
+			),
 		);
 	}
 }


### PR DESCRIPTION
There is an issue with the default value of `stockStatusOptions` in the `Products by Attribute` and `Products by tag` blocks which causes a block error when using the stock filter.

We need an array of keys, rather than objects. This PR fixes this.

Additionally, in testing we found some strange issues where preview state did not match selections. This is in part a UI issue but to improve this I've:

1. Added 400ms debounce to the controls
2. Swapped checkbox controls for toggles to indicate status
3. Made it so if all boxes are unchecked, no statuses get rendered

![Screenshot 2022-01-18 at 18 15 12](https://user-images.githubusercontent.com/90977/149995006-b103692d-77d4-4580-b7e8-d228fe44848e.png)

### Testing

How to test the changes in this Pull Request:

1. Insert `Products by Attribute` block
2. Click the `stock status` control in the inspector
3. Confirm toggles are displayed without an error.
4. Repeat for `Products by tag`

For the blocks, also check:

- Toggling stock options
- When you toggle, after a small 400ms delay the preview should update
- If you deselect all checkboxes, confirm no products are rendered
- Check the frontend. Does the product view match backend?

cc @gigitux 
