### PR TITLE
Fix global style for Product Summary block, Product Stock Indicator block, and Product Title block

### DIFF
--- a/assets/js/atomic/blocks/product-elements/stock-indicator/supports.js
+++ b/assets/js/atomic/blocks/product-elements/stock-indicator/supports.js
@@ -14,4 +14,5 @@ export const supports = {
 	typography: {
 		fontSize: true,
 	},
+	__experimentalSelector: '.wc-block-components-product-stock-indicator',
 };

--- a/assets/js/atomic/blocks/product-elements/stock-indicator/supports.js
+++ b/assets/js/atomic/blocks/product-elements/stock-indicator/supports.js
@@ -10,9 +10,9 @@ export const supports = {
 			background: false,
 			link: false,
 		},
+		typography: {
+			fontSize: true,
+		},
+		__experimentalSelector: '.wc-block-components-product-stock-indicator',
 	} ),
-	typography: {
-		fontSize: true,
-	},
-	__experimentalSelector: '.wc-block-components-product-stock-indicator',
 };

--- a/assets/js/atomic/blocks/product-elements/summary/edit.js
+++ b/assets/js/atomic/blocks/product-elements/summary/edit.js
@@ -10,6 +10,7 @@ import { useBlockProps } from '@wordpress/block-editor';
 import Block from './block';
 import withProductSelector from '../shared/with-product-selector';
 import { BLOCK_TITLE, BLOCK_ICON } from './constants';
+import './editor.scss';
 
 const Edit = ( { attributes } ) => {
 	const blockProps = useBlockProps();

--- a/assets/js/atomic/blocks/product-elements/summary/editor.scss
+++ b/assets/js/atomic/blocks/product-elements/summary/editor.scss
@@ -1,0 +1,5 @@
+.wc-block-components-product-summary {
+	p {
+		font-size: inherit;
+	}
+}

--- a/assets/js/atomic/blocks/product-elements/summary/supports.js
+++ b/assets/js/atomic/blocks/product-elements/summary/supports.js
@@ -10,9 +10,9 @@ export const supports = {
 			background: false,
 			link: false,
 		},
+		typography: {
+			fontSize: true,
+		},
+		__experimentalSelector: '.wc-block-components-product-summary',
 	} ),
-	typography: {
-		fontSize: true,
-	},
-	__experimentalSelector: '.wc-block-components-product-summary',
 };

--- a/assets/js/atomic/blocks/product-elements/summary/supports.js
+++ b/assets/js/atomic/blocks/product-elements/summary/supports.js
@@ -14,4 +14,5 @@ export const supports = {
 	typography: {
 		fontSize: true,
 	},
+	__experimentalSelector: '.wc-block-components-product-summary',
 };

--- a/assets/js/atomic/blocks/product-elements/title/block.tsx
+++ b/assets/js/atomic/blocks/product-elements/title/block.tsx
@@ -75,6 +75,7 @@ export const Block = ( props: Props ): JSX.Element => {
 				headingLevel={ headingLevel }
 				className={ classnames(
 					className,
+					colorProps.className,
 					'wc-block-components-product-title',
 					{
 						[ `${ parentClassName }__product-title` ]: parentClassName,
@@ -82,34 +83,6 @@ export const Block = ( props: Props ): JSX.Element => {
 							align && isFeaturePluginBuild(),
 					}
 				) }
-			/>
-		);
-	}
-
-	return (
-		<TagName
-			headingLevel={ headingLevel }
-			className={ classnames(
-				className,
-				'wc-block-components-product-title',
-				{
-					[ `${ parentClassName }__product-title` ]: parentClassName,
-					[ `wc-block-components-product-title--align-${ align }` ]:
-						align && isFeaturePluginBuild(),
-				}
-			) }
-		>
-			<ProductName
-				className={ colorProps.className }
-				disabled={ ! showProductLink }
-				name={ product.name }
-				permalink={ product.permalink }
-				rel={ showProductLink ? 'nofollow' : '' }
-				onClick={ () => {
-					dispatchStoreEvent( 'product-view-link', {
-						product,
-					} );
-				} }
 				style={
 					isFeaturePluginBuild()
 						? {
@@ -119,6 +92,43 @@ export const Block = ( props: Props ): JSX.Element => {
 						  }
 						: {}
 				}
+			/>
+		);
+	}
+
+	return (
+		<TagName
+			headingLevel={ headingLevel }
+			className={ classnames(
+				className,
+				colorProps.className,
+				'wc-block-components-product-title',
+				{
+					[ `${ parentClassName }__product-title` ]: parentClassName,
+					[ `wc-block-components-product-title--align-${ align }` ]:
+						align && isFeaturePluginBuild(),
+				}
+			) }
+			style={
+				isFeaturePluginBuild()
+					? {
+							...spacingProps.style,
+							...typographyProps.style,
+							...colorProps.style,
+					  }
+					: {}
+			}
+		>
+			<ProductName
+				disabled={ ! showProductLink }
+				name={ product.name }
+				permalink={ product.permalink }
+				rel={ showProductLink ? 'nofollow' : '' }
+				onClick={ () => {
+					dispatchStoreEvent( 'product-view-link', {
+						product,
+					} );
+				} }
 			/>
 		</TagName>
 	);

--- a/assets/js/atomic/blocks/product-elements/title/block.tsx
+++ b/assets/js/atomic/blocks/product-elements/title/block.tsx
@@ -3,10 +3,7 @@
  */
 import classnames from 'classnames';
 import { HTMLAttributes } from 'react';
-import {
-	useInnerBlockLayoutContext,
-	useProductDataContext,
-} from '@woocommerce/shared-context';
+import { useProductDataContext } from '@woocommerce/shared-context';
 import { isFeaturePluginBuild } from '@woocommerce/block-settings';
 import { withProductDataContext } from '@woocommerce/shared-hocs';
 import ProductName from '@woocommerce/base-components/product-name';
@@ -61,7 +58,6 @@ export const Block = ( props: Props ): JSX.Element => {
 		align,
 	} = props;
 
-	const { parentClassName } = useInnerBlockLayoutContext();
 	const { product } = useProductDataContext();
 	const { dispatchStoreEvent } = useStoreEvents();
 
@@ -78,7 +74,6 @@ export const Block = ( props: Props ): JSX.Element => {
 					colorProps.className,
 					'wc-block-components-product-title',
 					{
-						[ `${ parentClassName }__product-title` ]: parentClassName,
 						[ `wc-block-components-product-title--align-${ align }` ]:
 							align && isFeaturePluginBuild(),
 					}
@@ -104,7 +99,6 @@ export const Block = ( props: Props ): JSX.Element => {
 				colorProps.className,
 				'wc-block-components-product-title',
 				{
-					[ `${ parentClassName }__product-title` ]: parentClassName,
 					[ `wc-block-components-product-title--align-${ align }` ]:
 						align && isFeaturePluginBuild(),
 				}

--- a/assets/js/atomic/blocks/product-elements/title/index.ts
+++ b/assets/js/atomic/blocks/product-elements/title/index.ts
@@ -50,6 +50,7 @@ const blockConfig: BlockConfiguration = {
 					__experimentalSkipSerialization: true,
 				},
 			} ),
+			__experimentalSelector: '.wc-block-components-product-title',
 		} ),
 	},
 };

--- a/assets/js/atomic/blocks/product-elements/title/style.scss
+++ b/assets/js/atomic/blocks/product-elements/title/style.scss
@@ -1,22 +1,24 @@
-.wp-block-woocommerce-product-title {
-	width: fit-content;
-}
-
 .wc-block-components-product-title {
 	margin-top: 0;
 	margin-bottom: $gap-small;
-}
-.wc-block-grid .wc-block-components-product-title {
 	line-height: 1.5;
 	font-weight: 700;
 	padding: 0;
-	color: inherit;
-	font-size: inherit;
 	display: block;
+	font-size: inherit;
+
+	a {
+		color: inherit;
+		font-size: inherit;
+	}
+
 }
 
-.wc-block-components-product-name {
-	color: inherit;
+.wc-block-grid {
+	line-height: 1.5;
+	font-weight: 700;
+	padding: 0;
+	display: block;
 }
 
 .is-loading {

--- a/src/BlockTypes/ProductStockIndicator.php
+++ b/src/BlockTypes/ProductStockIndicator.php
@@ -1,0 +1,46 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\BlockTypes;
+
+/**
+ * ProductStockIndicator class.
+ */
+class ProductStockIndicator extends AbstractBlock {
+
+	/**
+	 * Block name.
+	 *
+	 * @var string
+	 */
+	protected $block_name = 'product-stock-indicator';
+
+	/**
+	 * API version name.
+	 *
+	 * @var string
+	 */
+	protected $api_version = '2';
+
+	/**
+	 * Get block supports. Shared with the frontend.
+	 * IMPORTANT: If you change anything here, make sure to update the JS file too.
+	 *
+	 * @return array
+	 */
+	protected function get_block_type_supports() {
+		return array(
+			'color'                  =>
+			array(
+				'link'  => false,
+				'background' => false,
+				'text' => true,
+
+			),
+			'typography'             =>
+			array(
+				'fontSize'   => true,
+			),
+			'__experimentalSelector' => '.wc-block-components-product-stock-indicator',
+		);
+	}
+
+}

--- a/src/BlockTypes/ProductStockIndicator.php
+++ b/src/BlockTypes/ProductStockIndicator.php
@@ -30,14 +30,13 @@ class ProductStockIndicator extends AbstractBlock {
 		return array(
 			'color'                  =>
 			array(
-				'link'  => false,
+				'link'       => false,
 				'background' => false,
-				'text' => true,
-
+				'text'       => true,
 			),
 			'typography'             =>
 			array(
-				'fontSize'   => true,
+				'fontSize' => true,
 			),
 			'__experimentalSelector' => '.wc-block-components-product-stock-indicator',
 		);

--- a/src/BlockTypes/ProductSummary.php
+++ b/src/BlockTypes/ProductSummary.php
@@ -1,0 +1,46 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\BlockTypes;
+
+/**
+ * ProductSummary class.
+ */
+class ProductSummary extends AbstractBlock {
+
+	/**
+	 * Block name.
+	 *
+	 * @var string
+	 */
+	protected $block_name = 'product-summary';
+
+	/**
+	 * API version name.
+	 *
+	 * @var string
+	 */
+	protected $api_version = '2';
+
+	/**
+	 * Get block supports. Shared with the frontend.
+	 * IMPORTANT: If you change anything here, make sure to update the JS file too.
+	 *
+	 * @return array
+	 */
+	protected function get_block_type_supports() {
+		return array(
+			'color'                  =>
+			array(
+				'link'  => true,
+				'background' => false,
+				'text' => true,
+
+			),
+			'typography'             =>
+			array(
+				'fontSize'   => true,
+			),
+			'__experimentalSelector' => '.wc-block-components-product-summary',
+		);
+	}
+
+}

--- a/src/BlockTypes/ProductSummary.php
+++ b/src/BlockTypes/ProductSummary.php
@@ -30,14 +30,13 @@ class ProductSummary extends AbstractBlock {
 		return array(
 			'color'                  =>
 			array(
-				'link'  => true,
+				'link'       => true,
 				'background' => false,
-				'text' => true,
-
+				'text'       => true,
 			),
 			'typography'             =>
 			array(
-				'fontSize'   => true,
+				'fontSize' => true,
 			),
 			'__experimentalSelector' => '.wc-block-components-product-summary',
 		);

--- a/src/BlockTypes/ProductTitle.php
+++ b/src/BlockTypes/ProductTitle.php
@@ -35,7 +35,6 @@ class ProductTitle extends AbstractBlock {
 				'link'                            => false,
 				'text'                            => true,
 				'__experimentalSkipSerialization' => true,
-
 			),
 			'typography'             =>
 			array(
@@ -44,7 +43,6 @@ class ProductTitle extends AbstractBlock {
 				'__experimentalFontWeight'    => true,
 				'__experimentalTextTransform' => true,
 				'__experimentalFontFamily'    => true,
-
 			),
 			'spacing'                =>
 			array(

--- a/src/BlockTypes/ProductTitle.php
+++ b/src/BlockTypes/ProductTitle.php
@@ -1,0 +1,58 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\BlockTypes;
+
+/**
+ * ProductTitle class.
+ */
+class ProductTitle extends AbstractBlock {
+
+	/**
+	 * Block name.
+	 *
+	 * @var string
+	 */
+	protected $block_name = 'product-title';
+
+	/**
+	 * API version name.
+	 *
+	 * @var string
+	 */
+	protected $api_version = '2';
+
+	/**
+	 * Get block supports. Shared with the frontend.
+	 * IMPORTANT: If you change anything here, make sure to update the JS file too.
+	 *
+	 * @return array
+	 */
+	protected function get_block_type_supports() {
+		return array(
+			'color'                  =>
+			array(
+				'gradients'  => true,
+				'background' => true,
+				'link' 	 => false,
+				'text' => true,
+				'__experimentalSkipSerialization' => true,
+
+			),
+			'typography'             =>
+			array(
+				'fontSize'   => true,
+				'lineHeight' => true,
+				'__experimentalFontWeight' => true,
+				'__experimentalTextTransform' => true,
+				'__experimentalFontFamily' => true,
+
+			),
+			'spacing'                =>
+			array(
+				'margin'                         => true,
+				'__experimentalSkipSerialization' => true,
+			),
+			'__experimentalSelector' => '.wc-block-components-product-title',
+		);
+	}
+
+}

--- a/src/BlockTypes/ProductTitle.php
+++ b/src/BlockTypes/ProductTitle.php
@@ -30,25 +30,25 @@ class ProductTitle extends AbstractBlock {
 		return array(
 			'color'                  =>
 			array(
-				'gradients'  => true,
-				'background' => true,
-				'link' 	 => false,
-				'text' => true,
+				'gradients'                       => true,
+				'background'                      => true,
+				'link'                            => false,
+				'text'                            => true,
 				'__experimentalSkipSerialization' => true,
 
 			),
 			'typography'             =>
 			array(
-				'fontSize'   => true,
-				'lineHeight' => true,
-				'__experimentalFontWeight' => true,
+				'fontSize'                    => true,
+				'lineHeight'                  => true,
+				'__experimentalFontWeight'    => true,
 				'__experimentalTextTransform' => true,
-				'__experimentalFontFamily' => true,
+				'__experimentalFontFamily'    => true,
 
 			),
 			'spacing'                =>
 			array(
-				'margin'                         => true,
+				'margin'                          => true,
 				'__experimentalSkipSerialization' => true,
 			),
 			'__experimentalSelector' => '.wc-block-components-product-title',

--- a/src/BlockTypesController.php
+++ b/src/BlockTypesController.php
@@ -175,6 +175,9 @@ final class BlockTypesController {
 			'StockFilter',
 			'ActiveFilters',
 			'LegacyTemplate',
+			'ProductTitle',
+			'ProductSummary',
+			'ProductStockIndicator'
 		];
 
 		if ( Package::feature()->is_feature_plugin_build() ) {
@@ -216,17 +219,14 @@ final class BlockTypesController {
 	 */
 	protected function get_atomic_blocks() {
 		return [
-			'product-title',
 			'product-button',
 			'product-image',
 			'product-price',
 			'product-rating',
 			'product-sale-badge',
-			'product-summary',
 			'product-sku',
 			'product-category-list',
 			'product-tag-list',
-			'product-stock-indicator',
 			'product-add-to-cart',
 		];
 	}

--- a/src/BlockTypesController.php
+++ b/src/BlockTypesController.php
@@ -177,7 +177,7 @@ final class BlockTypesController {
 			'LegacyTemplate',
 			'ProductTitle',
 			'ProductSummary',
-			'ProductStockIndicator'
+			'ProductStockIndicator',
 		];
 
 		if ( Package::feature()->is_feature_plugin_build() ) {


### PR DESCRIPTION
This PR fixes the global style for `Product Summary block`, `Product Stock Indicator block`, and `Product Title block` when these blocks are used in the `All Products` block.

This code register the `Product Summary block`, `Product Stock Indicator block`, and `Product Title` block on the PHP side. This is necessary for using the `__experimentalSelector` from global style API.


### Screenshots

![image](https://user-images.githubusercontent.com/4463174/150109795-33a56976-95b2-44ac-90df-ca6c201f9ee6.png)
*with global style*

![image](https://user-images.githubusercontent.com/4463174/150110049-7ae8e6ed-f3f3-4fd3-95b9-f76f90884afc.png)
*without global style*

### Testing

### Manual Testing

How to test the changes in this Pull Request:

1.  Upgrade to `WordPress 5.9`.
2.  Install and enable the `Twenty Twenty-Two` theme.
3.  Add the `All Product Block` (this block contains `Stock Indicator block`) to a post.
4.  Click on the pencil to edit the block, add the `Stock Indicator Block` and get the focus on the `Stock Indicator block`.
5.  On the right sidebar, personalize the styles of the block.
6.  Go on the page and check if there are changes.
7.  Reset to default using the `Reset` button from the different sections.
8.  Go to Dashboard and select Appearance > Editor (beta). On top of the screen, select Home > Browser all templates > Single Post. When the page is loaded, add the block to the page. Click on the pencil to edit the block, add the `Stock Indicator Block`.
9.  On the Editor page click on the `Styles` icon on the right-top corner.
10. Verify that the `Stock Indicator block` is shown under the `Blocks` section. Personalize the block.
11. Save your changes.
12. Go on the page created earlier and check if all styles are applied correctly.
13. Edit your previous post/page again.
14. Change again the styles.
15. Save your changes.
16. Check if these styles have priority over the styles from the Site Editor.

Repeat from 4th point for `Product Summary Block` and `Product Title Block`.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above
