### PR TITLE
Restore correct font style when the block is loaded in the editor

### DIFF
--- a/assets/js/atomic/blocks/product-elements/title/block.tsx
+++ b/assets/js/atomic/blocks/product-elements/title/block.tsx
@@ -3,7 +3,10 @@
  */
 import classnames from 'classnames';
 import { HTMLAttributes } from 'react';
-import { useProductDataContext } from '@woocommerce/shared-context';
+import {
+	useInnerBlockLayoutContext,
+	useProductDataContext,
+} from '@woocommerce/shared-context';
 import { isFeaturePluginBuild } from '@woocommerce/block-settings';
 import { withProductDataContext } from '@woocommerce/shared-hocs';
 import ProductName from '@woocommerce/base-components/product-name';
@@ -58,6 +61,7 @@ export const Block = ( props: Props ): JSX.Element => {
 		align,
 	} = props;
 
+	const { parentClassName } = useInnerBlockLayoutContext();
 	const { product } = useProductDataContext();
 	const { dispatchStoreEvent } = useStoreEvents();
 
@@ -74,6 +78,7 @@ export const Block = ( props: Props ): JSX.Element => {
 					colorProps.className,
 					'wc-block-components-product-title',
 					{
+						[ `${ parentClassName }__product-title` ]: parentClassName,
 						[ `wc-block-components-product-title--align-${ align }` ]:
 							align && isFeaturePluginBuild(),
 					}
@@ -99,6 +104,7 @@ export const Block = ( props: Props ): JSX.Element => {
 				colorProps.className,
 				'wc-block-components-product-title',
 				{
+					[ `${ parentClassName }__product-title` ]: parentClassName,
 					[ `wc-block-components-product-title--align-${ align }` ]:
 						align && isFeaturePluginBuild(),
 				}

--- a/assets/js/atomic/blocks/product-elements/title/editor.scss
+++ b/assets/js/atomic/blocks/product-elements/title/editor.scss
@@ -1,3 +1,13 @@
 .editor-styles-wrapper a.wc-block-components-product-name {
 	color: inherit;
 }
+
+.editor-styles-wrapper .wc-block-components-product-title {
+	margin-top: 0;
+	margin-bottom: $gap-small;
+	line-height: 1.5;
+	font-weight: 700;
+	padding: 0;
+	display: block;
+	font-size: inherit;
+}


### PR DESCRIPTION
#5595 has introduced a different font style for the `Product Title block` when the `All Product block` is loaded in the editor.
This PR restores the correct font style.

### Screenshots
![image](https://user-images.githubusercontent.com/4463174/150203711-c41f01d9-10a3-4c12-ad30-d737766f5f8a.png)
*#5595 introduce a different font style from our current style*

![image](https://user-images.githubusercontent.com/4463174/150203842-aa4c9d02-4a9b-4b9e-b9c6-72d4b04b0d97.png)
*this PR restores the correct style*


How to test the changes in this Pull Request:

1.  Upgrade to `WordPress 5.9`.
2.  Install and enable the `Twenty Twenty-Two` theme.
3.  Add the `All Product Block` (this block contains `Product Title block`) to a post. Check that the font style looks like the second image.
4.  Click on the pencil to edit the block and get the focus on the `Product Title block`.
5.  On the right sidebar, personalize the styles of the block.
6.  Check that the changes are applied to the block in the editor.
7.  Go to Dashboard and select Appearance > Editor (beta). On top of the screen, select Home > Browser all templates > Single Post. When the page is loaded, add the block to the page. Click on the pencil to edit the block, add the `Product Title block`.
8. On the Editor page click on the `Styles` icon on the right-top corner.
9. Verify that the `Product Title block` is shown under the `Blocks` section. Personalize the block.
10. Check that the changes are applied to the block in the editor.
