### PR TITLE
Show single express payment button in full width

### DIFF
--- a/assets/js/blocks/cart-checkout/payment-methods/express-payment/style.scss
+++ b/assets/js/blocks/cart-checkout/payment-methods/express-payment/style.scss
@@ -91,6 +91,11 @@ $border-radius: 5px;
 			width: 50%;
 		}
 
+		> li:first-child:nth-last-child(1) {
+			display: block;
+			width: 100%;
+		}
+
 		> li:nth-child(even) {
 			padding-left: $gap-smaller;
 		}

--- a/assets/js/blocks/cart-checkout/payment-methods/express-payment/style.scss
+++ b/assets/js/blocks/cart-checkout/payment-methods/express-payment/style.scss
@@ -91,7 +91,7 @@ $border-radius: 5px;
 			width: 50%;
 		}
 
-		> li:first-child:nth-last-child(1) {
+		> li:only-child {
 			display: block;
 			width: 100%;
 		}


### PR DESCRIPTION
Fixes #5593

In #5593, @LevinMedia reported that the express payment button is not displayed in full width, even when there's only one express payment button. 

I did some research and found out that this problem can be targeted using CSS3. The following code ensures that the express payment button is visible in full width, if there is only one button:

```css
.wc-block-components-express-payment--checkout {
    .wc-block-components-express-payment__event-buttons {
        li:first-child:nth-last-child(1) {
            display: block;
            width: 100%;
        }
    }
}
```

This fix relies on the CSS3 selectors `first-child` and `nth-last-child`. According to https://caniuse.com/, both elements are fully supported by all major browsers. 

https://caniuse.com/mdn-css_selectors_first-child:
<img width="1386" alt="Screen Shot 2022-01-20 at 16 14 36" src="https://user-images.githubusercontent.com/3323310/150308984-e283c5b5-50ec-4497-ad72-f45697c19fbd.png">

https://caniuse.com/mdn-css_selectors_nth-last-child:
<img width="1375" alt="Screen Shot 2022-01-20 at 16 15 17" src="https://user-images.githubusercontent.com/3323310/150309080-4a4454dd-1c90-4df7-8e78-abee0abab1d0.png">

For a handful of browsers (Opera Mini, UC Browser for Android, QQ Browser, Baidu Browser and KaiOS Browser), it's unclear if these two elements are supported. In case they're not supported, the express payment button will remain its initial width of 50%. Given that the support status is unknown and knowing that even if these elements are not supported, this PR will not introduce any breaking changes, I prefer this CSS-based solution over a React-based solution. This preference is based on keeping the code lean and readable. 

### Screenshots

<table>
<tr>
<td>Before:
<br><br>

![#5593-before](https://user-images.githubusercontent.com/3323310/150312177-1445aca7-c87c-4547-94db-285e43b91357.png)
</td>
<td>After:
<br><br>

![#5593-after](https://user-images.githubusercontent.com/3323310/150312204-4f416ebb-23da-4a41-9193-33cd95b10ce8.png)
</td>
</tr>
</table>

## Additional notes

In https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5601#pullrequestreview-858522743, @senadir asked if we cannot use `:only-child` instead of `first-child` and `nth-last-child`. As `:only-child` offers the same level of browser support, I adjusted this PR accordingly.

https://caniuse.com/mdn-css_selectors_only-child:
<img width="1375" alt="Screen Shot 2022-01-21 at 12 15 48" src="https://user-images.githubusercontent.com/3323310/150470125-12b31639-ac53-4cdd-99a7-2b673ca85685.png">

### Testing

### Manual Testing

1. Create a test page with the checkout block.
2. Install the WooCommerce Stripe Gateway plugin and enable express checkouts.
3. Go to the frontend.
4. Add a product to the cart.
5. Go to the checkout page.
6. Ensure that the express payment button is displayed in full width.
7. Install the WooCommerce Payments plugin and enable express checkouts as well. (Note: The WooCommerce Payments plugin cannot be used on a local development site.)
8. Go to the checkout page.
9. Ensure that the express payment buttons is displayed next to each other.

### User Facing Testing

* [x] Same as above

### Changelog

> Show express payment button in full width if only one express payment method is available.
