### PR TITLE
Add tests for phone field on Checkout block

### DIFF
--- a/assets/js/blocks/cart-checkout/checkout/phone-number/test/index.js
+++ b/assets/js/blocks/cart-checkout/checkout/phone-number/test/index.js
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+
+import { render, findByLabelText } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import PhoneNumber from '../index';
+
+describe( 'Phone number', () => {
+	it( 'Renders an input field with type tel', async () => {
+		const { container } = render(
+			<PhoneNumber
+				id={ 'shipping-phone' }
+				isRequired={ true }
+				onChange={ () => null }
+				value={ '' }
+			/>
+		);
+		const input = await findByLabelText( container, 'Phone' );
+		expect( input.getAttribute( 'type' ) ).toEqual( 'tel' );
+	} );
+	it( 'Renders (optional) in the label if the field is not marked as required', async () => {
+		const { container } = render(
+			<PhoneNumber
+				id={ 'shipping-phone' }
+				isRequired={ false }
+				onChange={ () => null }
+				value={ '' }
+			/>
+		);
+		const input = await findByLabelText( container, 'Phone (optional)' );
+		expect( input ).toBeTruthy();
+	} );
+} );


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR adds some tests for the phone field.

It tests the input having a type of `tel` and that the label is updated to show the field is optional if `required` is false.

The component is pretty basic and is driven by `ValidatedTextInput` so further testing of this specific component isn't needed.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Check JS unit tests pass

### User Facing Testing
There are no user-facing tests required for this.

<!-- If you can, add the appropriate labels -->

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Skipping
