### PR TITLE
Enable Mini Cart template-parts only for experimental builds 

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -362,12 +362,14 @@ class BlockTemplatesController {
 	 * @param array $slugs An array of slugs to retrieve templates for.
 	 * @param array $template_type wp_template or wp_template_part.
 	 *
-	 * @return array
+	 * @return array WP_Block_Template[] An array of block template objects.
 	 */
 	public function get_block_templates( $slugs = array(), $template_type = 'wp_template' ) {
 		$templates_from_db  = $this->get_block_templates_from_db( $slugs, $template_type );
 		$templates_from_woo = $this->get_block_templates_from_woocommerce( $slugs, $templates_from_db, $template_type );
-		return array_merge( $templates_from_db, $templates_from_woo );
+		$templates          = array_merge( $templates_from_db, $templates_from_woo );
+		return BlockTemplateUtils::filter_block_templates_by_feature_flag( $templates );
+
 	}
 
 	/**

--- a/src/Domain/Services/FeatureGating.php
+++ b/src/Domain/Services/FeatureGating.php
@@ -137,4 +137,32 @@ class FeatureGating {
 	public function is_test_environment() {
 		return self::TEST_ENVIRONMENT === $this->environment;
 	}
+
+	/**
+	 * Returns core flag value.
+	 *
+	 * @return number
+	 */
+	public static function get_core_flag() {
+		return self::CORE_FLAG;
+	}
+
+	/**
+	 * Returns feature plugin flag value.
+	 *
+	 * @return number
+	 */
+	public static function get_feature_plugin_flag() {
+		return self::FEATURE_PLUGIN_FLAG;
+	}
+
+	/**
+	 * Returns experimental flag value.
+	 *
+	 * @return number
+	 */
+	public static function get_experimental_flag() {
+		return self::EXPERIMENTAL_FLAG;
+	}
+
 }


### PR DESCRIPTION
Enable `Mini Cart` template parts only for experimental builds.

**NOTE:** This PR will be included in release `6.7.3`.

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #5598

### Testing
### Manual Testing
How to test the changes in this Pull Request:

Check out this branch

1. Install Gutenberg (or use WordPress 5.9) and select a block theme e.g. `TT1 Blocks`.
2. Open Appearance > Editor > Templates Parts.
3. Check that `Mini Cart` template is visible.
4. Build a production version (`npm run package-plugin:deploy`).
5. Install the zip.
6. Open Appearance > Editor > Templates Parts.
7. Check that `Mini Cart` template is NOT visible.
### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
 
1. Install Gutenberg (or use WordPress 5.9) and select a block theme e.g. `TT1 Blocks`.
2. Open Appearance > Editor > Templates Parts.
3. Check that `Mini Cart` template is NOT visible.

## Changelog
> Enable Mini Cart template-parts only for experimental builds