### PR TITLE
Add padding to Empty Mini Cart

### DIFF
--- a/assets/js/blocks/cart-checkout/mini-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/mini-cart/style.scss
@@ -80,8 +80,8 @@
 	display: flex;
 	flex-direction: column;
 	height: 100vh;
-	padding: 0;
 	justify-content: center;
+	padding: $gap;
 }
 
 h2.wc-block-mini-cart__title {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #5583 

### Testing

### Manual Testing

How to test the changes in this Pull Request:

1. Go to Site Editor and add the Mini Cart block somewhere.
2. Inside the empty state, add a Top Rated Products block (for example).
3. Notice there is a 16px padding between the block and the drawer borders.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
* [ ] See steps below.