### PR TITLE
Add Shopping Button Inner block

### DIFF
--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/index.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/index.tsx
@@ -7,3 +7,4 @@ import './mini-cart-title-block';
 import './mini-cart-items-block';
 import './mini-cart-products-table-block';
 import './mini-cart-footer-block';
+import './mini-cart-shopping-button-block';

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-shopping-button-block/block.json
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-shopping-button-block/block.json
@@ -1,0 +1,26 @@
+{
+	"name": "woocommerce/mini-cart-shopping-button-block",
+	"version": "1.0.0",
+	"title": "Mini Cart Shopping Button",
+	"description": "Block that displays the shopping button for the Mini Cart block.",
+	"category": "woocommerce",
+	"supports": {
+		"align": false,
+		"html": false,
+		"multiple": false,
+		"reusable": false,
+		"inserter": true 
+	},
+	"attributes": {
+		"lock": {
+			"type": "object",
+			"default": {
+				"remove": false,
+				"move": false 
+			}
+		}
+	},
+	"parent": [ "woocommerce/empty-mini-cart-contents-block" ],
+	"textdomain": "woo-gutenberg-products-block",
+	"apiVersion": 2
+}

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-shopping-button-block/block.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-shopping-button-block/block.tsx
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { SHOP_URL } from '@woocommerce/block-settings';
+
+/**
+ * Internal dependencies
+ */
+
+const Block = (): JSX.Element | null => {
+	if ( ! SHOP_URL ) {
+		return null;
+	}
+
+	return (
+		<div className="wp-block-button aligncenter is-style-outline">
+			<a className="wp-block-button__link" href={ SHOP_URL }>
+				{ __( 'Start shopping', 'woo-gutenberg-products-block' ) }
+			</a>
+		</div>
+	);
+};
+
+export default Block;

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-shopping-button-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-shopping-button-block/edit.tsx
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import { useBlockProps } from '@wordpress/block-editor';
+import Noninteractive from '@woocommerce/base-components/noninteractive';
+
+/**
+ * Internal dependencies
+ */
+import Block from './block';
+
+export const Edit = (): JSX.Element => {
+	const blockProps = useBlockProps();
+
+	return (
+		<div { ...blockProps }>
+			<Noninteractive>
+				<Block />
+			</Noninteractive>
+		</div>
+	);
+};
+
+export const Save = (): JSX.Element => {
+	return <div { ...useBlockProps.save() }></div>;
+};

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-shopping-button-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-shopping-button-block/index.tsx
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import { Icon, bookmark } from '@woocommerce/icons';
+import { registerFeaturePluginBlockType } from '@woocommerce/block-settings';
+
+/**
+ * Internal dependencies
+ */
+import { Edit, Save } from './edit';
+import metadata from './block.json';
+
+registerFeaturePluginBlockType( metadata, {
+	icon: {
+		src: (
+			<Icon
+				srcElement={ bookmark }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
+	},
+	edit: Edit,
+	save: Save,
+} );

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/register-components.ts
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/register-components.ts
@@ -13,6 +13,7 @@ import miniCartTitleMetadata from './mini-cart-title-block/block.json';
 import miniCartProductsTableMetadata from './mini-cart-products-table-block/block.json';
 import miniCartFooterMetadata from './mini-cart-footer-block/block.json';
 import miniCartItemsMetadata from './mini-cart-items-block/block.json';
+import miniCartShoppingButtonMetadata from './mini-cart-shopping-button-block/block.json';
 
 // Modify webpack publicPath at runtime based on location of WordPress Plugin.
 // eslint-disable-next-line no-undef,camelcase
@@ -68,6 +69,15 @@ registerCheckoutBlock( {
 	component: lazy( () =>
 		import(
 			/* webpackChunkName: "mini-cart-contents-block/footer" */ './mini-cart-footer-block/block'
+		)
+	),
+} );
+
+registerCheckoutBlock( {
+	metadata: miniCartShoppingButtonMetadata,
+	component: lazy( () =>
+		import(
+			/* webpackChunkName: "mini-cart-contents-block/shopping-button" */ './mini-cart-shopping-button-block/block'
 		)
 	),
 } );

--- a/assets/js/blocks/cart-checkout/mini-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/mini-cart/style.scss
@@ -155,3 +155,14 @@ h2.wc-block-mini-cart__title {
 		margin-top: $gap;
 	}
 }
+
+.wc-block-mini-cart__shopping-button {
+	display: flex;
+	justify-content: center;
+
+	a {
+		border: 2px solid;
+		padding: $gap-small $gap-large;
+		text-decoration: none;
+	}
+}

--- a/templates/parts/mini-cart.html
+++ b/templates/parts/mini-cart.html
@@ -29,15 +29,9 @@
 		</p>
 		<!-- /wp:paragraph -->
 
-		<!-- wp:buttons -->
-		<div class="wp-block-buttons">
-			<!-- wp:button {"align":"center","className":"is-style-outline"} -->
-			<div class="wp-block-button aligncenter is-style-outline">
-				<a href="/" class="wp-block-button__link">Start shopping</a>
-			</div>
-			<!-- /wp:button -->
-		</div>
-		<!-- /wp:buttons -->
+		<!-- wp:woocommerce/mini-cart-shopping-button-block -->
+		<div class="wp-block-woocommerce-mini-cart-shopping-button-block"></div>
+		<!-- /wp:woocommerce/mini-cart-shopping-button-block -->
 	</div>
 	<!-- /wp:woocommerce/empty-mini-cart-contents-block -->
 </div>


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #5582 

Previously, the `Start shopping` button in the Mini Cart template part is a Button block with the link set to the root domain. The reason for this is: we use the template part file as the starter template for the Mini Cart Drawer, so the root domain (`/`) makes the most sense to be the default URL of the shopping button.

This PR links the correct shop page to the shopping button by creating a new inner block that pulls the `SHOP_URL` from the WC settings. The Shopping Button block can be moved and deleted just like a normal block.

The block is styled as an outline button. The button style and alignment can't be changed. If store owners need more styling options, they should replace the block with a `Button` block.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### Screenshots
N/A. No visual change was introduced.
<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Install and activate Gutenberg plugin.
2. Clear any customizations to the Mini Cart block.
3. Add Mini Cart block to a page.
4. On the front end, ensure the cart is empty.
5. Open the Mini Cart, see the Shopping button link to the correct Shop page.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
* [ ] See steps below.