### PR TITLE
Fix Mini Cart Edit template link

### DIFF
--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -178,7 +178,7 @@ class MiniCart extends AbstractBlock {
 			function_exists( 'wp_is_block_theme' ) &&
 			wp_is_block_theme()
 		) {
-			$theme_slug      = BlockTemplateUtils::theme_has_template_part( 'mini-cart' ) ? wp_get_theme()->get_stylesheet() : 'woocommerce';
+			$theme_slug      = BlockTemplateUtils::theme_has_template_part( 'mini-cart' ) ? wp_get_theme()->get_stylesheet() : BlockTemplateUtils::PLUGIN_SLUG;
 			$site_editor_uri = admin_url( 'site-editor.php' );
 
 			if ( version_compare( get_bloginfo( 'version' ), '5.9', '<' ) ) {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #5580 

In #5519, we update the template slug from `woocommerce` to `woocommerce/woocommerce`. The Mini Cart block still uses the old slug, that's why the edit template part link is currently broken. This PR fix that issue by using the correct theme slug.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### Screenshots
N/A. No visual change.

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Add Mini Cart block to a page.
2. Select the Mini Cart block, toggle the sidebar if needed, click on the Edit template part link.
3. See the correct template part is loaded as expected.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
* [ ] See steps below.