### PR TITLE
Fix: Exclude Mini Cart and other blocks inside the Mini Cart Contents block

### DIFF
--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/allowed-blocks.ts
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/allowed-blocks.ts
@@ -5,7 +5,11 @@ import { getBlockTypes } from '@wordpress/blocks';
 
 const EXCLUDED_BLOCKS: readonly string[] = [
 	'woocommerce/mini-cart',
+	'woocommerce/checkout',
+	'woocommerce/cart',
 	'woocommerce/single-product',
+	'woocommerce/cart-totals-block',
+	'woocommerce/checkout-fields-block',
 	'core/post-template',
 	'core/comment-template',
 	'core/query-pagination',

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/allowed-blocks.ts
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/allowed-blocks.ts
@@ -17,22 +17,23 @@ const EXCLUDED_BLOCKS: readonly string[] = [
 	'core/post-navigation-link',
 ];
 
-export const allowedBlocks = getBlockTypes()
-	.filter( ( block ) => {
-		if ( EXCLUDED_BLOCKS.includes( block.name ) ) {
-			return false;
-		}
+export const getMiniCartAllowedBlocks = (): string[] =>
+	getBlockTypes()
+		.filter( ( block ) => {
+			if ( EXCLUDED_BLOCKS.includes( block.name ) ) {
+				return false;
+			}
 
-		// Exclude child blocks of EXCLUDED_BLOCKS.
-		if (
-			block.parent &&
-			block.parent.filter( ( value ) =>
-				EXCLUDED_BLOCKS.includes( value )
-			).length > 0
-		) {
-			return false;
-		}
+			// Exclude child blocks of EXCLUDED_BLOCKS.
+			if (
+				block.parent &&
+				block.parent.filter( ( value ) =>
+					EXCLUDED_BLOCKS.includes( value )
+				).length > 0
+			) {
+				return false;
+			}
 
-		return true;
-	} )
-	.map( ( { name } ) => name );
+			return true;
+		} )
+		.map( ( { name } ) => name );

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/allowed-blocks.ts
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/allowed-blocks.ts
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import { getBlockTypes } from '@wordpress/blocks';
+
+const EXCLUDED_BLOCKS: readonly string[] = [
+	'woocommerce/mini-cart',
+	'woocommerce/single-product',
+	'core/post-template',
+	'core/comment-template',
+	'core/query-pagination',
+	'core/comments-query-loop',
+	'core/post-comments-form',
+	'core/post-comments-link',
+	'core/post-comments-count',
+	'core/comments-pagination',
+	'core/post-navigation-link',
+];
+
+export const allowedBlocks = getBlockTypes()
+	.filter( ( block ) => {
+		if ( EXCLUDED_BLOCKS.includes( block.name ) ) {
+			return false;
+		}
+
+		// Exclude child blocks of EXCLUDED_BLOCKS.
+		if (
+			block.parent &&
+			block.parent.filter( ( value ) =>
+				EXCLUDED_BLOCKS.includes( value )
+			).length > 0
+		) {
+			return false;
+		}
+
+		return true;
+	} )
+	.map( ( { name } ) => name );

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/empty-mini-cart-contents-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/empty-mini-cart-contents-block/edit.tsx
@@ -7,7 +7,7 @@ import { useEditorContext } from '@woocommerce/base-context';
 /**
  * Internal dependencies
  */
-import { allowedBlocks } from '../allowed-blocks';
+import { getMiniCartAllowedBlocks } from '../allowed-blocks';
 
 export const Edit = (): JSX.Element => {
 	const blockProps = useBlockProps();
@@ -21,7 +21,7 @@ export const Edit = (): JSX.Element => {
 			}
 		>
 			<InnerBlocks
-				allowedBlocks={ allowedBlocks }
+				allowedBlocks={ getMiniCartAllowedBlocks() }
 				renderAppender={ InnerBlocks.ButtonBlockAppender }
 			/>
 		</div>

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/empty-mini-cart-contents-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/empty-mini-cart-contents-block/edit.tsx
@@ -3,48 +3,15 @@
  */
 import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
 import { useEditorContext } from '@woocommerce/base-context';
-import { getBlockTypes } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
-
-const EXCLUDED_BLOCKS: readonly string[] = [
-	'woocommerce/mini-cart',
-	'woocommerce/single-product',
-	'core/post-template',
-	'core/comment-template',
-	'core/query-pagination',
-	'core/comments-query-loop',
-	'core/post-comments-form',
-	'core/post-comments-link',
-	'core/post-comments-count',
-	'core/comments-pagination',
-	'core/post-navigation-link',
-];
+import { allowedBlocks } from '../allowed-blocks';
 
 export const Edit = (): JSX.Element => {
 	const blockProps = useBlockProps();
 	const { currentView } = useEditorContext();
-	const allowedBlocks = getBlockTypes()
-		.filter( ( block ) => {
-			if ( EXCLUDED_BLOCKS.includes( block.name ) ) {
-				return false;
-			}
-
-			// Exclude child blocks of EXCLUDED_BLOCKS.
-			if (
-				block.parent &&
-				block.parent.filter( ( value ) =>
-					EXCLUDED_BLOCKS.includes( value )
-				).length > 0
-			) {
-				return false;
-			}
-
-			return true;
-		} )
-		.map( ( { name } ) => name );
 
 	return (
 		<div

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/filled-mini-cart-contents-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/filled-mini-cart-contents-block/edit.tsx
@@ -14,7 +14,7 @@ import { useForcedLayout, getAllowedBlocks } from '../../../shared';
 
 export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 	const blockProps = useBlockProps();
-	const allowedBlocks = getAllowedBlocks( innerBlockAreas.EMPTY_MINI_CART );
+	const allowedBlocks = getAllowedBlocks( innerBlockAreas.FILLED_MINI_CART );
 	const { currentView } = useEditorContext();
 
 	const defaultTemplate = ( [

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-items-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-items-block/edit.tsx
@@ -7,7 +7,7 @@ import type { TemplateArray } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import { allowedBlocks } from '../allowed-blocks';
+import { getMiniCartAllowedBlocks } from '../allowed-blocks';
 
 export const Edit = (): JSX.Element => {
 	const blockProps = useBlockProps();
@@ -22,7 +22,7 @@ export const Edit = (): JSX.Element => {
 				template={ defaultTemplate }
 				renderAppender={ InnerBlocks.ButtonBlockAppender }
 				templateLock={ false }
-				allowedBlocks={ allowedBlocks }
+				allowedBlocks={ getMiniCartAllowedBlocks() }
 			/>
 		</div>
 	);

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-items-block/edit.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-items-block/edit.tsx
@@ -7,6 +7,7 @@ import type { TemplateArray } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
+import { allowedBlocks } from '../allowed-blocks';
 
 export const Edit = (): JSX.Element => {
 	const blockProps = useBlockProps();
@@ -21,6 +22,7 @@ export const Edit = (): JSX.Element => {
 				template={ defaultTemplate }
 				renderAppender={ InnerBlocks.ButtonBlockAppender }
 				templateLock={ false }
+				allowedBlocks={ allowedBlocks }
 			/>
 		</div>
 	);


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #5579 

This PR excludes the Mini Cart block and other blocks from the appender of the Mini Cart Items `<InnerBlocks>`. We've already excluded the same set of blocks for the Empty Mini Cart Contents. This PR moves the logic excluding blocks from the empty view into its own file and imports it into the Empty Mini Carts Contents and Mini Cart Items block.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### Screenshots

![149791757-062e21fb-7e7e-4280-a864-21502de9288d](https://user-images.githubusercontent.com/5423135/150716453-88254d20-33d7-42bf-8a58-75a1f9bf5068.png)


<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Go to Appearance > Editor > Template Parts.
2. Edit the Mini Cart block template part and try to insert a block inside it.
3. Don't see the Mini Cart block.


### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
* [ ] See steps below.