### PR TITLE
Fix: Mini Cart global style is not applied

### DIFF
--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -455,4 +455,16 @@ class MiniCart extends AbstractBlock {
 			'display_cart_prices_including_tax' => false,
 		);
 	}
+
+	/**
+	 * Get the supports array for this block type.
+	 *
+	 * @see $this->register_block_type()
+	 * @return string;
+	 */
+	protected function get_block_type_supports() {
+		return [
+			'__experimentalSelector' => '.wc-block-mini-cart__button, .wc-block-mini-cart__badge',
+		];
+	}
 }


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #5578 

The mini cart global style isn't applied on the front-end. This PR fixes that issue by registering the `__experimentalSelector` support on the PHP side. By doing so, the global style for Mini Cart is generated correctly.

Notes:

- The style works as expected at the time it was merged, but it doesn't with the latest version of Gutenberg. I'm not aware of which change in Gutenberg or our plugin caused this issue.
- Using Xdebug, I notice that the blocks data [here](https://github.com/WordPress/gutenberg/blob/8c3b613754540afc52d0c8ea8d8b7c75bf86de74/lib/compat/wordpress-5.9/class-wp-theme-json-gutenberg.php#L518) shows all `woocommerce` blocks have `apiVersion` set to `1`. It means that we aren't registering correct metadata on the PHP side.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### Screenshots

<img width="2002" alt="Screen Shot 2022-01-24 at 17 56 53" src="https://user-images.githubusercontent.com/5423135/150770901-a8ecfa7c-e3eb-4d0a-b63e-3ff3878b3d84.png">


<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

0. Disable the Gutenberg plugin.
1. Make sure you're using WP 5.9 and a block theme (ie Twenty Twenty Two).
2. Add the Mini Cart block to header.
3. Use global style to change the background and text color of the mini cart icon.
4. See style applied on the front end.
5. Enable the Gutenberg plugin and repeat steps above.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
* [ ] See steps below.