### PR TITLE
Keep top margin for create account section in editor

### DIFF
--- a/assets/js/blocks/checkout/inner-blocks/checkout-terms-block/editor.scss
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-terms-block/editor.scss
@@ -14,6 +14,10 @@
 
 .wc-block-components-checkbox {
 	margin-top: 0;
+
+	&.wc-block-checkout__create-account {
+		margin-top: 1em;
+	}
 }
 
 .wc-block-checkout__terms_notice .components-notice__action {


### PR DESCRIPTION
In #5191, we've adjusted the T&C checkbox position. This change lead to the fact that the top margin of the create account section disappeared. This PR aims to correct this regression.

### Screenshots

<table>
<tr>
<td>Before:
<br><br>

![fix-before](https://user-images.githubusercontent.com/3323310/150910955-97d4fb04-a619-40ce-8758-32ba4aa90bb0.png)
</td>
<td>After:
<br><br>

![fix-after](https://user-images.githubusercontent.com/3323310/150910947-7e54c5cc-6f65-4eb9-8a9b-16328d0af2c1.png)
</td>
</tr>
</table>

### Testing

1. Create a test page and add the checkout block.
2. Click on email address field.
3. Open settings sidebar.
4. Activate `Account Options » Allow shoppers to sign up for a user account during checkout`.
5. Verify that the `Create an account?` section has sufficient top margin.

### User Facing Testing

* [x] Same as above

### Changelog

> Fix alignment issue with the "create account" section on the checkout block in the editor
