### PR TITLE
Fix: Empty Mini Cart contents overflow issue

### DIFF
--- a/assets/js/blocks/cart-checkout/mini-cart-contents/editor.scss
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/editor.scss
@@ -41,4 +41,16 @@
 		box-shadow: inset 0 0 0 1px;
 		color: inherit;
 	}
+
+	.wp-block-woocommerce-empty-mini-cart-contents-block {
+		overflow-y: unset;
+		padding: 0;
+
+		> .block-editor-inner-blocks {
+			max-height: 100vh;
+			overflow-y: auto;
+			box-sizing: border-box;
+			padding: $gap-largest $gap $gap;
+		}
+	}
 }

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/empty-mini-cart-contents-block/block.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/empty-mini-cart-contents-block/block.tsx
@@ -1,5 +1,0 @@
-const Block = ( { children }: { children: JSX.Element } ): JSX.Element => {
-	return <>{ children }</>;
-};
-
-export default Block;

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/empty-mini-cart-contents-block/frontend.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/empty-mini-cart-contents-block/frontend.tsx
@@ -20,7 +20,11 @@ const EmptyMiniCartContentsBlock = ( {
 		return null;
 	}
 
-	return <>{ children }</>;
+	return (
+		<div className="wp-block-woocommerce-empty-mini-cart-contents-block">
+			{ children }
+		</div>
+	);
 };
 
 export default EmptyMiniCartContentsBlock;

--- a/assets/js/blocks/cart-checkout/mini-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/mini-cart/style.scss
@@ -87,6 +87,7 @@
 
 .wp-block-woocommerce-empty-mini-cart-contents-block {
 	overflow-y: auto;
+	padding: $gap-largest $gap $gap;
 }
 
 h2.wc-block-mini-cart__title {

--- a/assets/js/blocks/cart-checkout/mini-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/mini-cart/style.scss
@@ -65,6 +65,7 @@
 
 		button {
 			color: inherit;
+			z-index: 9999;
 		}
 
 		svg {
@@ -82,6 +83,10 @@
 	height: 100vh;
 	padding: 0;
 	justify-content: center;
+}
+
+.wp-block-woocommerce-empty-mini-cart-contents-block {
+	overflow-y: auto;
 }
 
 h2.wc-block-mini-cart__title {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #5584, fixes #5583 

This PR fixes the overflow issue of the Empty Mini Cart contents by adding a wrapper for its inner blocks. This PR also fixes the padding issue of the Empty Mini Cart Contents, set the same padding as the Filled view. Because the wrapper is need for the padding, this PR fixes two PRs at once.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Add Mini Cart block to Header.
2. Edit Mini Cart the template part content.
3. Add Top Rated Products block to Empty Mini Cart Contents.
4. Make it have 6 rows.
5. Notice the block contents are scrollable, all inner blocks are still selectable and editable.
6. On the front end, see inner blocks of the Empty Mini Cart Contents are scrollable too.
7. See the Empty Mini Cart Contents block has the same padding as the filled one.
### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
* [ ] See steps below.