### PR TITLE
Fix 404 HTTP error for Product Title, Product Summary, and Product Stock indicator blocks

### DIFF
--- a/src/BlockTypes/ProductStockIndicator.php
+++ b/src/BlockTypes/ProductStockIndicator.php
@@ -21,6 +21,21 @@ class ProductStockIndicator extends AbstractBlock {
 	protected $api_version = '2';
 
 	/**
+	 * Get the editor script handle for this block type.
+	 *
+	 * @param string $key Data to get, or default to everything.
+	 * @return array|string;
+	 */
+	protected function get_block_type_editor_script( $key = null ) {
+		$script = [
+			'handle'       => 'wc-' . $this->block_name . '-block',
+			'path'         => $this->asset_api->get_block_asset_build_path( 'atomic-block-components/stock-indicator' ),
+			'dependencies' => [ 'wc-blocks' ],
+		];
+		return $key ? $script[ $key ] : $script;
+	}
+
+	/**
 	 * Get block supports. Shared with the frontend.
 	 * IMPORTANT: If you change anything here, make sure to update the JS file too.
 	 *

--- a/src/BlockTypes/ProductSummary.php
+++ b/src/BlockTypes/ProductSummary.php
@@ -21,6 +21,21 @@ class ProductSummary extends AbstractBlock {
 	protected $api_version = '2';
 
 	/**
+	 * Get the editor script handle for this block type.
+	 *
+	 * @param string $key Data to get, or default to everything.
+	 * @return array|string;
+	 */
+	protected function get_block_type_editor_script( $key = null ) {
+		$script = [
+			'handle'       => 'wc-' . $this->block_name . '-block',
+			'path'         => $this->asset_api->get_block_asset_build_path( 'atomic-block-components/summary' ),
+			'dependencies' => [ 'wc-blocks' ],
+		];
+		return $key ? $script[ $key ] : $script;
+	}
+
+	/**
 	 * Get block supports. Shared with the frontend.
 	 * IMPORTANT: If you change anything here, make sure to update the JS file too.
 	 *

--- a/src/BlockTypes/ProductTitle.php
+++ b/src/BlockTypes/ProductTitle.php
@@ -21,6 +21,21 @@ class ProductTitle extends AbstractBlock {
 	protected $api_version = '2';
 
 	/**
+	 * Get the editor script handle for this block type.
+	 *
+	 * @param string $key Data to get, or default to everything.
+	 * @return array|string;
+	 */
+	protected function get_block_type_editor_script( $key = null ) {
+		$script = [
+			'handle'       => 'wc-' . $this->block_name . '-block',
+			'path'         => $this->asset_api->get_block_asset_build_path( 'atomic-block-components/title' ),
+			'dependencies' => [ 'wc-blocks' ],
+		];
+		return $key ? $script[ $key ] : $script;
+	}
+
+	/**
 	 * Get block supports. Shared with the frontend.
 	 * IMPORTANT: If you change anything here, make sure to update the JS file too.
 	 *


### PR DESCRIPTION
This PR fixes 404 HTTP errors related to the Product Title, Product Summary, and Product Stock indicator blocks when the user loads the widget page or the FSE page.


<!-- Reference any related issues or PRs here -->
Fixes #5648

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->


<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### Testing

#### Automated Tests
### Manual Testing

How to test the changes in this Pull Request:

Check out this branch:

1. Open the dev console and select the network tab.
2. Go on `wp-admin/widgets.php` or `wp-admin/site-editor.php` (available only if a block theme is active).
3. Check that there aren't 404 HTTP errors related to Product Title, Product Summary, and Product Stock Indicator blocks