### PR TITLE
Fix ReadMore component's maxLines prop reactivity

### DIFF
--- a/assets/js/base/components/read-more/index.tsx
+++ b/assets/js/base/components/read-more/index.tsx
@@ -111,6 +111,29 @@ class ReadMore extends Component< ReadMoreProps, ReadMoreState > {
 	}
 
 	componentDidMount(): void {
+		this.setSummary();
+	}
+
+	componentDidUpdate( prevProps: ReadMoreProps ): void {
+		if (
+			prevProps.maxLines !== this.props.maxLines ||
+			prevProps.children !== this.props.children
+		) {
+			/**
+			 * if maxLines or content changed we need to reset the state to
+			 * initial values so that summary can be calculated again
+			 */
+			this.setState(
+				{
+					clampEnabled: null,
+					summary: '.',
+				},
+				this.setSummary
+			);
+		}
+	}
+
+	setSummary(): void {
 		if ( this.props.children ) {
 			const { maxLines, ellipsis } = this.props;
 


### PR DESCRIPTION
when changing property value of `maxLines` component would not
update until remounted or reloaded with new settings

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

I've extracted setSummary as a component method and set it up so that it fires initially on `componentDidMount` and on `componentDidUpdate` if component `children` or `maxLines` change.

<!-- Reference any related issues or PRs here -->
Fixes #5299

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. start storybook `npm run storybook`
2. Go to http://localhost:6006/?path=/story/woocommerce-blocks-base-components-readmore--default
3. In storybook Controls tab change value for `maxLines`, while on this branch it should update the state of the view without the need to reload as mentioned on #5299 

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).

Controls for changing `maxLines` are not exposed in block settings so the only thing to test is that the block still works, currently, the issue was only visible in the storybook.

1. Edit one of the page templates and insert All Reviews block
2. Go to a product and create product with very long reviews, like 3 paragraphs of  
```Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.```
3. See that the component behaves as intended.


<!-- If you can, add the appropriate labels -->

### Changelog

> Fix ReadMore component's maxLines prop reactivity
