### PR TITLE
Disable font-size for the Featured Category block #5681

### DIFF
--- a/assets/js/blocks/featured-category/index.js
+++ b/assets/js/blocks/featured-category/index.js
@@ -40,9 +40,6 @@ registerBlockType( 'woocommerce/featured-category', {
 		align: [ 'wide', 'full' ],
 		html: false,
 		color: true,
-		typography: {
-			fontSize: true,
-		},
 		...( isFeaturePluginBuild() && {
 			__experimentalBorder: {
 				color: true,

--- a/assets/js/blocks/featured-category/style.scss
+++ b/assets/js/blocks/featured-category/style.scss
@@ -1,5 +1,5 @@
 .wp-block-woocommerce-featured-category {
-	background-color: #000;
+	background-color: $gray-900;
 	border-color: transparent;
 	color: #fff;
 	overflow: hidden;
@@ -70,7 +70,6 @@
 	.wc-block-featured-category__price,
 	.wc-block-featured-category__link {
 		color: inherit;
-		font-size: inherit;
 		width: 100%;
 		padding: 0 48px 16px 48px;
 		z-index: 1;
@@ -81,7 +80,6 @@
 
 		div {
 			color: inherit;
-			font-size: inherit;
 		}
 
 		&::before {
@@ -91,7 +89,6 @@
 
 	.wc-block-featured-category__description {
 		color: inherit;
-		font-size: inherit;
 		p {
 			margin: 0;
 		}


### PR DESCRIPTION
The implementation of the font size with the Global Styles API has changed the default design of the Featured Category block.

This PR disables the possibility to change the font size with the Global Styles API and restore the old and correct default design.

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #5681 


### Screenshots

![image](https://user-images.githubusercontent.com/4463174/151832176-fe784992-4c89-4d26-ad5d-c9d5b2e1051a.png)
*Featured Category Block using the TT1 Block Theme with the correct default design*
### Testing

### Manual Testing

How to test the changes in this Pull Request:

Check out this branch

1. Be sure to activate a block theme and have WordPress 5.9 or WordPress 5.8 with Gutenberg enabled.
2. Open the editor and add the `Feature Category` Block.
3. Check that description and title have different font size and look equal to the attached image.

