### PR TITLE
Fix Twenty Twenty-Two Products by Category block item tile styling issues

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -321,6 +321,15 @@
 	}
 }
 
+.theme-twentytwentytwo {
+	.wc-block-grid__product-add-to-cart {
+		.added_to_cart {
+			margin-top: $gap-small;
+			display: block;
+		}
+	}
+}
+
 // Default screen-reader styles. Included as a fallback for themes that don't have support.
 .screen-reader-text {
 	@include visually-hidden();

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -328,6 +328,12 @@
 			display: block;
 		}
 	}
+
+	.wc-block-components-product-price {
+		ins {
+			text-decoration: none;
+		}
+	}
 }
 
 // Default screen-reader styles. Included as a fallback for themes that don't have support.


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR provides override styles for the Twenty Twenty Two theme to correctly display added to cart "View cart" call out (#5285) and sale prices to not be underlined (#5286).

This follows convention from the past where core themes were receiving patches in styles.scss via theme class namespace.

I've merged these two issues as they were very closely related and trivial in their complexity and the little potential effect on other areas of the extension.

<!-- Reference any related issues or PRs here -->
Fixes #5285 
Fixes #5286 

### Screenshots

On mobile:

![Screenshot 2022-01-31 at 19 25 34](https://user-images.githubusercontent.com/112270/151851419-10d85767-049d-4b75-82dc-55f61d480e0f.jpg)

On desktop:

![Screenshot 2022-01-31 at 19 00 24](https://user-images.githubusercontent.com/112270/151851402-18ee7c1d-2d4c-424f-a8bf-cdce9159b70b.jpg)

### Testing

### Manual Testing

How to test the changes in this Pull Request:

1. Get the [Twenty Twenty Two](https://wordpress.org/themes/twentytwentytwo/) theme
2. Create a page with Products by category block with products on sale available
3.  Visit the page
4. Confirm sale price on products on sale **is not** underlined
5. Add product to cart
6. Confirm `View cart` action is centred under the `Add to cart` button and not broken into two lines

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [✔️ ] Same as above, or
* [ ] See steps below.

### Changelog

> Fixes Twenty Twenty Two issues with sales price and added to cart "View Cart" call out styling in the "Products by Category" block
