### PR TITLE
Fix Product Category List element not visible on All Products block item edit

### DIFF
--- a/assets/js/previews/products.js
+++ b/assets/js/previews/products.js
@@ -34,6 +34,14 @@ export const previewProducts = [
 			},
 		],
 		average_rating: 5,
+		categories: [
+			{
+				id: 1,
+				name: 'Decor',
+				slug: 'decor',
+				link: 'https://example.org',
+			},
+		],
 		review_count: 1,
 		prices: {
 			currency_code: 'GBP',


### PR DESCRIPTION

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
Item edit relied on data from `@woocommerce/resource-previews` productsPreview which was missing mock data for product category. 

<!-- Reference any related issues or PRs here -->
Fixes #5674

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### Screenshots
![Screenshot 2022-02-01 at 11 06 47](https://user-images.githubusercontent.com/112270/151950663-5bce112d-1421-4f8a-af19-a8f35a9ec447.jpg)

### Testing

### Manual Testing

How to test the changes in this Pull Request:
Steps to reproduce the behavior:

1. Go to post/page editor.
2. Add All Products block.
3. Click on the pencil to edit the single product view.
4. Add the Product Category List block.
5. `Categories: Decor` should be visible

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [ ] Same as above, or
* [ ] See steps below.

1. One can verify if category is visible on published page but user facing was working ok before 

<!-- If you can, add the appropriate labels -->

### Changelog

> Fixed adding Product Category List element to All Products block item edit would not be visible in edit preview.
