### PR TITLE
Add to cart button ignored redirect to cart setting

### DIFF
--- a/assets/js/atomic/blocks/product-elements/button/block.js
+++ b/assets/js/atomic/blocks/product-elements/button/block.js
@@ -9,6 +9,8 @@ import {
 	useStoreAddToCart,
 } from '@woocommerce/base-context/hooks';
 import { decodeEntities } from '@wordpress/html-entities';
+import { CART_URL } from '@woocommerce/block-settings';
+import { getSetting } from '@woocommerce/settings';
 import {
 	useInnerBlockLayoutContext,
 	useProductDataContext,
@@ -101,6 +103,12 @@ const AddToCartButton = ( { product } ) => {
 			dispatchStoreEvent( 'cart-add-item', {
 				product,
 			} );
+			// redirect to cart if the setting to redirect to the cart page
+			// on cart add item is enabled
+			const { cartRedirectAfterAdd } = getSetting( 'productsSettings' );
+			if ( cartRedirectAfterAdd ) {
+				window.location.href = CART_URL;
+			}
 		};
 	}
 

--- a/src/Assets/AssetDataRegistry.php
+++ b/src/Assets/AssetDataRegistry.php
@@ -89,6 +89,7 @@ class AssetDataRegistry {
 			'locale'             => $this->get_locale_data(),
 			'orderStatuses'      => $this->get_order_statuses(),
 			'placeholderImgSrc'  => wc_placeholder_img_src(),
+			'productsSettings'   => $this->get_products_settings(),
 			'siteTitle'          => get_bloginfo( 'name' ),
 			'storePages'         => $this->get_store_pages(),
 			'wcAssetUrl'         => plugins_url( 'assets/', WC_PLUGIN_FILE ),
@@ -149,6 +150,19 @@ class AssetDataRegistry {
 				'terms'     => wc_terms_and_conditions_page_id(),
 			]
 		);
+	}
+
+	/**
+	 * Get product related settings.
+	 *
+	 * Note: For the time being we are exposing only the settings that are used by blocks.
+	 *
+	 * @return array
+	 */
+	protected function get_products_settings() {
+		return [
+			'cartRedirectAfterAdd' => get_option( 'woocommerce_cart_redirect_after_add' ) === 'yes',
+		];
 	}
 
 	/**


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This fixes issue where All Products (and all other blocks) where Add to Cart button was present were ignoring the *Redirect to Cart after item added* setting was enabled.

We expose WooCommerce products settings in `wcSettings`

For the time being we expose only what is used by the blocks
which is `cartRedirectAfterAdd`. In the future more can be added
as needed. Setting is accessible via `getSetting( 'productsSettings' )`.

We namespace the settings under productsSettigns to reflect
the domain and how settings are organised in Woo admin and to
inform that this is an object with more settings within.

This setting normally was available **only** if AJAX add to cart was set
as a JS global `wc_add_to_cart_params.cart_redirect_after_add`.
By accessing the option directly we ensure it’s exposed
to blocks regardless of if AJAX option is enabled. 

This adds the redirect directly on the AddToCartButton after successful
add to cart action and it follows convention that redirects or other side
effects shouldn’t happen as part of the action but rather be part of the
control that triggers such flow.

<!-- Reference any related issues or PRs here -->
Fixes #1766 

### Manual Testing

How to test the changes in this Pull Request:

1. Go to WooCommerce Settings > Products > General and toggle *Redirect to the cart page after successful addition*
2. Add All Blocks and/or other products blocks. 
3. Hit the *Add to Cart* button
4. If setting is enabled you should be automatically redirected to the cart

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
* [ ] See steps below.

### Changelog

> Add to Cart button on Products listing blocks will respect the "Redirect to the cart page after successful addition" setting
