### PR TITLE
Handle orders that do not require payment methods without errors

### DIFF
--- a/src/StoreApi/Schemas/CheckoutSchema.php
+++ b/src/StoreApi/Schemas/CheckoutSchema.php
@@ -115,7 +115,6 @@ class CheckoutSchema extends AbstractSchema {
 				'type'        => 'string',
 				'context'     => [ 'view', 'edit' ],
 				'enum'        => wc()->payment_gateways->get_payment_gateway_ids(),
-				'required'    => true,
 			],
 			'create_account'    => [
 				'description' => __( 'Whether to create a new user account as part of order processing.', 'woo-gutenberg-products-block' ),


### PR DESCRIPTION
When an order does not require payment, the client does not send a payment method ID. Because this parameter was required in the API, it broke the request. **To fix this we can make the property optional.**

After fixing this, the validation failed because the provided payment method was blank, which resulted in an error message being thrown. **To fix this we only validate payment method if payment is required.**

Fixes #5713

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Create a coupon for 100% of the order total.
2. Add items to cart.
3. Apply the coupon. The order total should be 0 and the payment section hidden during checkout.
4. Place the order. Confirm it goes through without errors.

### Changelog

> Fixed an issue where orders would break if they did not require a payment
