### PR TITLE
Spread metadata to allow default attributes to work when loading Checkout block in frontend

### DIFF
--- a/assets/js/blocks/checkout/frontend.tsx
+++ b/assets/js/blocks/checkout/frontend.tsx
@@ -17,11 +17,12 @@ import { renderParentBlock } from '@woocommerce/atomic-utils';
 import './inner-blocks/register-components';
 import Block from './block';
 import { blockName, blockAttributes } from './attributes';
+import metadata from './block.json';
 
 const getProps = ( el: Element ) => {
 	return {
 		attributes: getValidBlockAttributes(
-			blockAttributes,
+			{ ...metadata.attributes, ...blockAttributes },
 			/* eslint-disable @typescript-eslint/no-explicit-any */
 			( el instanceof HTMLElement ? el.dataset : {} ) as any
 		),


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR ensures default attributes from metadata are passed to the front end block.

<!-- Reference any related issues or PRs here -->
Fixes #5723

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Add the Checkout block and select the Shipping Address in the editor.
2. Change the settings (try a few different, random settings) in the sidebar and ensure the block changes as expected.
3. Save the block and load it on the front-end and ensure the block is rendered as you expect based on the attributes you saved.
4. Go back to the editor and select the Checkout block as a whole, set the "Dark mode inputs" option to true.
5. Load the block in the front-end again and ensure the dark mode inputs are being used.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
* [ ] See steps below.

<!-- If you can, add the appropriate labels -->

### Changelog

> Fixed an issue where default block attributes were not being passed to the Checkout block correctly.
