### PR TITLE
Reformatted prettier files

### DIFF
--- a/assets/js/base/hooks/tsconfig.json
+++ b/assets/js/base/hooks/tsconfig.json
@@ -1,6 +1,6 @@
 {
-  "extends": "../../../../tsconfig.base.json",
-  "compilerOptions": {},
-  "include": [ ".", "../../type-defs/**.ts", "../utils/index.js" ],
-  "exclude": [ "**/test/**" ]
+	"extends": "../../../../tsconfig.base.json",
+	"compilerOptions": {},
+	"include": [ ".", "../../type-defs/**.ts", "../utils/index.js" ],
+	"exclude": [ "**/test/**" ]
 }

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-products-table-block/block.json
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-products-table-block/block.json
@@ -16,7 +16,7 @@
 			"type": "object",
 			"default": {
 				"remove": true,
-				"move": false 
+				"move": false
 			}
 		}
 	},

--- a/bin/hook-docs/data/actions.json
+++ b/bin/hook-docs/data/actions.json
@@ -1,730 +1,676 @@
 {
-    "$schema": "https://raw.githubusercontent.com/johnbillion/wp-hooks-generator/0.7.0/schema.json",
-    "hooks": [
-        {
-            "name": "woocommerce_add_to_cart",
-            "file": "StoreApi/Utilities/CartController.php",
-            "type": "action",
-            "doc": {
-                "description": "Fires when an item is added to the cart.",
-                "long_description": "This hook fires when an item is added to the cart. This is triggered from the Store API in this context, but WooCommerce core add to cart events trigger the same hook.",
-                "tags": [
-                    {
-                        "name": "param",
-                        "content": "ID of the item in the cart.",
-                        "types": [
-                            "string"
-                        ],
-                        "variable": "$cart_id"
-                    },
-                    {
-                        "name": "param",
-                        "content": "ID of the product added to the cart.",
-                        "types": [
-                            "integer"
-                        ],
-                        "variable": "$product_id"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Quantity of the item added to the cart.",
-                        "types": [
-                            "integer"
-                        ],
-                        "variable": "$request_quantity"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Variation ID of the product added to the cart.",
-                        "types": [
-                            "integer"
-                        ],
-                        "variable": "$variation_id"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Array of variation data.",
-                        "types": [
-                            "array"
-                        ],
-                        "variable": "$variation"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Array of other cart item data.",
-                        "types": [
-                            "array"
-                        ],
-                        "variable": "$cart_item_data"
-                    }
-                ],
-                "long_description_html": "<p>This hook fires when an item is added to the cart. This is triggered from the Store API in this context, but WooCommerce core add to cart events trigger the same hook.</p>"
-            },
-            "args": 6
-        },
-        {
-            "name": "woocommerce_after_main_content",
-            "file": "BlockTypes/LegacyTemplate.php",
-            "type": "action",
-            "doc": {
-                "description": "Hook: woocommerce_after_main_content",
-                "long_description": "Called after rendering the main content for a product.",
-                "tags": [
-                    {
-                        "name": "see",
-                        "content": "Outputs closing DIV for the content (priority 10)",
-                        "refers": "woocommerce_output_content_wrapper_end()"
-                    }
-                ],
-                "long_description_html": "<p>Called after rendering the main content for a product.</p>"
-            },
-            "args": 0
-        },
-        {
-            "name": "woocommerce_after_main_content",
-            "file": "BlockTypes/LegacyTemplate.php",
-            "type": "action",
-            "doc": {
-                "description": "Hook: woocommerce_after_main_content",
-                "long_description": "Called after rendering the main content for a product.",
-                "tags": [
-                    {
-                        "name": "see",
-                        "content": "Outputs closing DIV for the content (priority 10)",
-                        "refers": "woocommerce_output_content_wrapper_end()"
-                    }
-                ],
-                "long_description_html": "<p>Called after rendering the main content for a product.</p>"
-            },
-            "args": 0
-        },
-        {
-            "name": "woocommerce_after_shop_loop",
-            "file": "BlockTypes/LegacyTemplate.php",
-            "type": "action",
-            "doc": {
-                "description": "Hook: woocommerce_after_shop_loop.",
-                "long_description": "",
-                "tags": [
-                    {
-                        "name": "see",
-                        "content": "Renders pagination (priority 10)",
-                        "refers": "woocommerce_pagination()"
-                    }
-                ],
-                "long_description_html": ""
-            },
-            "args": 0
-        },
-        {
-            "name": "woocommerce_applied_coupon",
-            "file": "StoreApi/Utilities/CartController.php",
-            "type": "action",
-            "doc": {
-                "description": "Fires after a coupon has been applied to the cart.",
-                "long_description": "",
-                "tags": [
-                    {
-                        "name": "param",
-                        "content": "The coupon code that was applied.",
-                        "types": [
-                            "string"
-                        ],
-                        "variable": "$coupon_code"
-                    }
-                ],
-                "long_description_html": ""
-            },
-            "args": 1
-        },
-        {
-            "name": "woocommerce_archive_description",
-            "file": "BlockTypes/LegacyTemplate.php",
-            "type": "action",
-            "doc": {
-                "description": "Hook: woocommerce_archive_description.",
-                "long_description": "",
-                "tags": [
-                    {
-                        "name": "see",
-                        "content": "Renders the taxonomy archive description (priority 10)",
-                        "refers": "woocommerce_taxonomy_archive_description()"
-                    },
-                    {
-                        "name": "see",
-                        "content": "Renders the product archive description (priority 10)",
-                        "refers": "woocommerce_product_archive_description()"
-                    }
-                ],
-                "long_description_html": ""
-            },
-            "args": 0
-        },
-        {
-            "name": "woocommerce_before_main_content",
-            "file": "BlockTypes/LegacyTemplate.php",
-            "type": "action",
-            "doc": {
-                "description": "Hook: woocommerce_before_main_content",
-                "long_description": "Called before rendering the main content for a product.",
-                "tags": [
-                    {
-                        "name": "see",
-                        "content": "Outputs opening DIV for the content (priority 10)",
-                        "refers": "woocommerce_output_content_wrapper()"
-                    },
-                    {
-                        "name": "see",
-                        "content": "Outputs breadcrumb trail to the current product (priority 20)",
-                        "refers": "woocommerce_breadcrumb()"
-                    },
-                    {
-                        "name": "see",
-                        "content": "Outputs schema markup (priority 30)",
-                        "refers": "WC_Structured_Data::generate_website_data()"
-                    }
-                ],
-                "long_description_html": "<p>Called before rendering the main content for a product.</p>"
-            },
-            "args": 0
-        },
-        {
-            "name": "woocommerce_before_main_content",
-            "file": "BlockTypes/LegacyTemplate.php",
-            "type": "action",
-            "doc": {
-                "description": "Hook: woocommerce_before_main_content",
-                "long_description": "Called before rendering the main content for a product.",
-                "tags": [
-                    {
-                        "name": "see",
-                        "content": "Outputs opening DIV for the content (priority 10)",
-                        "refers": "woocommerce_output_content_wrapper()"
-                    },
-                    {
-                        "name": "see",
-                        "content": "Outputs breadcrumb trail to the current product (priority 20)",
-                        "refers": "woocommerce_breadcrumb()"
-                    },
-                    {
-                        "name": "see",
-                        "content": "Outputs schema markup (priority 30)",
-                        "refers": "WC_Structured_Data::generate_website_data()"
-                    }
-                ],
-                "long_description_html": "<p>Called before rendering the main content for a product.</p>"
-            },
-            "args": 0
-        },
-        {
-            "name": "woocommerce_before_shop_loop",
-            "file": "BlockTypes/LegacyTemplate.php",
-            "type": "action",
-            "doc": {
-                "description": "Hook: woocommerce_before_shop_loop.",
-                "long_description": "",
-                "tags": [
-                    {
-                        "name": "see",
-                        "content": "Render error notices (priority 10)",
-                        "refers": "woocommerce_output_all_notices()"
-                    },
-                    {
-                        "name": "see",
-                        "content": "Show number of results found (priority 20)",
-                        "refers": "woocommerce_result_count()"
-                    },
-                    {
-                        "name": "see",
-                        "content": "Show form to control sort order (priority 30)",
-                        "refers": "woocommerce_catalog_ordering()"
-                    }
-                ],
-                "long_description_html": ""
-            },
-            "args": 0
-        },
-        {
-            "name": "woocommerce_blocks_cart_enqueue_data",
-            "file": "BlockTypes/MiniCart.php",
-            "type": "action",
-            "doc": {
-                "description": "Fires after cart block data is registered.",
-                "long_description": "",
-                "tags": [],
-                "long_description_html": ""
-            },
-            "args": 0
-        },
-        {
-            "name": "woocommerce_blocks_cart_enqueue_data",
-            "file": "BlockTypes/Cart.php",
-            "type": "action",
-            "doc": {
-                "description": "Fires after cart block data is registered.",
-                "long_description": "",
-                "tags": [],
-                "long_description_html": ""
-            },
-            "args": 0
-        },
-        {
-            "name": "woocommerce_blocks_cart_update_customer_from_request",
-            "file": "StoreApi/Routes/CartUpdateCustomer.php",
-            "type": "action",
-            "doc": {
-                "description": "Fires when the Checkout Block/Store API updates a customer from the API request data.",
-                "long_description": "",
-                "tags": [
-                    {
-                        "name": "param",
-                        "content": "Customer object.",
-                        "types": [
-                            "\\WC_Customer"
-                        ],
-                        "variable": "$customer"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Full details about the request.",
-                        "types": [
-                            "\\WP_REST_Request"
-                        ],
-                        "variable": "$request"
-                    }
-                ],
-                "long_description_html": ""
-            },
-            "args": 2
-        },
-        {
-            "name": "woocommerce_blocks_cart_update_order_from_request",
-            "file": "StoreApi/Routes/AbstractCartRoute.php",
-            "type": "action",
-            "doc": {
-                "description": "Fires when the order is synced with cart data from a cart route.",
-                "long_description": "",
-                "tags": [
-                    {
-                        "name": "param",
-                        "content": "Order object.",
-                        "types": [
-                            "\\WC_Order"
-                        ],
-                        "variable": "$draft_order"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Customer object.",
-                        "types": [
-                            "\\WC_Customer"
-                        ],
-                        "variable": "$customer"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Full details about the request.",
-                        "types": [
-                            "\\WP_REST_Request"
-                        ],
-                        "variable": "$request"
-                    }
-                ],
-                "long_description_html": ""
-            },
-            "args": 2
-        },
-        {
-            "name": "woocommerce_blocks_checkout_enqueue_data",
-            "file": "BlockTypes/Checkout.php",
-            "type": "action",
-            "doc": {
-                "description": "Fires after checkout block data is registered.",
-                "long_description": "",
-                "tags": [],
-                "long_description_html": ""
-            },
-            "args": 0
-        },
-        {
-            "name": "woocommerce_blocks_checkout_order_processed",
-            "file": "StoreApi/Routes/Checkout.php",
-            "type": "action",
-            "doc": {
-                "description": "Fires before an order is processed by the Checkout Block/Store API.",
-                "long_description": "This hook informs extensions that $order has completed processing and is ready for payment.\n This is similar to existing core hook woocommerce_checkout_order_processed. We're using a new action: - To keep the interface focused (only pass $order, not passing request data). - This also explicitly indicates these orders are from checkout block/StoreAPI.",
-                "tags": [
-                    {
-                        "name": "see",
-                        "content": "",
-                        "refers": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3238"
-                    },
-                    {
-                        "name": "example",
-                        "content": "docs/examples/checkout-order-processed.md"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Order object.",
-                        "types": [
-                            "\\WC_Order"
-                        ],
-                        "variable": "$order"
-                    }
-                ],
-                "long_description_html": "<p>This hook informs extensions that $order has completed processing and is ready for payment.</p> <p>This is similar to existing core hook woocommerce_checkout_order_processed. We're using a new action:</p> <ul> <li>To keep the interface focused (only pass $order, not passing request data).</li> <li>This also explicitly indicates these orders are from checkout block/StoreAPI.</li> </ul>"
-            },
-            "args": 1
-        },
-        {
-            "name": "woocommerce_blocks_checkout_update_order_from_request",
-            "file": "StoreApi/Routes/Checkout.php",
-            "type": "action",
-            "doc": {
-                "description": "Fires when the Checkout Block/Store API updates an order's from the API request data.",
-                "long_description": "This hook gives extensions the chance to update orders based on the data in the request. This can be used in conjunction with the ExtendRestAPI class to post custom data and then process it.",
-                "tags": [
-                    {
-                        "name": "param",
-                        "content": "Order object.",
-                        "types": [
-                            "\\WC_Order"
-                        ],
-                        "variable": "$order"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Full details about the request.",
-                        "types": [
-                            "\\WP_REST_Request"
-                        ],
-                        "variable": "$request"
-                    }
-                ],
-                "long_description_html": "<p>This hook gives extensions the chance to update orders based on the data in the request. This can be used in conjunction with the ExtendRestAPI class to post custom data and then process it.</p>"
-            },
-            "args": 2
-        },
-        {
-            "name": "woocommerce_blocks_checkout_update_order_meta",
-            "file": "StoreApi/Routes/Checkout.php",
-            "type": "action",
-            "doc": {
-                "description": "Fires when the Checkout Block/Store API updates an order's meta data.",
-                "long_description": "This hook gives extensions the chance to add or update meta data on the $order.\n This is similar to existing core hook woocommerce_checkout_update_order_meta. We're using a new action: - To keep the interface focused (only pass $order, not passing request data). - This also explicitly indicates these orders are from checkout block/StoreAPI.",
-                "tags": [
-                    {
-                        "name": "see",
-                        "content": "",
-                        "refers": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3686"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Order object.",
-                        "types": [
-                            "\\WC_Order"
-                        ],
-                        "variable": "$order"
-                    }
-                ],
-                "long_description_html": "<p>This hook gives extensions the chance to add or update meta data on the $order.</p> <p>This is similar to existing core hook woocommerce_checkout_update_order_meta. We're using a new action:</p> <ul> <li>To keep the interface focused (only pass $order, not passing request data).</li> <li>This also explicitly indicates these orders are from checkout block/StoreAPI.</li> </ul>"
-            },
-            "args": 1
-        },
-        {
-            "name": "woocommerce_blocks_enqueue_cart_block_scripts_after",
-            "file": "BlockTypes/Cart.php",
-            "type": "action",
-            "doc": {
-                "description": "Fires after cart block scripts are enqueued.",
-                "long_description": "",
-                "tags": [],
-                "long_description_html": ""
-            },
-            "args": 0
-        },
-        {
-            "name": "woocommerce_blocks_enqueue_cart_block_scripts_before",
-            "file": "BlockTypes/Cart.php",
-            "type": "action",
-            "doc": {
-                "description": "Fires before cart block scripts are enqueued.",
-                "long_description": "",
-                "tags": [],
-                "long_description_html": ""
-            },
-            "args": 0
-        },
-        {
-            "name": "woocommerce_blocks_enqueue_checkout_block_scripts_after",
-            "file": "BlockTypes/Checkout.php",
-            "type": "action",
-            "doc": {
-                "description": "Fires after checkout block scripts are enqueued.",
-                "long_description": "",
-                "tags": [],
-                "long_description_html": ""
-            },
-            "args": 0
-        },
-        {
-            "name": "woocommerce_blocks_enqueue_checkout_block_scripts_before",
-            "file": "BlockTypes/Checkout.php",
-            "type": "action",
-            "doc": {
-                "description": "Fires before checkout block scripts are enqueued.",
-                "long_description": "",
-                "tags": [],
-                "long_description_html": ""
-            },
-            "args": 0
-        },
-        {
-            "name": "woocommerce_blocks_loaded",
-            "file": "Domain/Bootstrap.php",
-            "type": "action",
-            "doc": {
-                "description": "Fires after WooCommerce Blocks plugin has loaded.",
-                "long_description": "This hook is intended to be used as a safe event hook for when the plugin has been loaded, and all dependency requirements have been met.",
-                "tags": [],
-                "long_description_html": "<p>This hook is intended to be used as a safe event hook for when the plugin has been loaded, and all dependency requirements have been met.</p>"
-            },
-            "args": 0
-        },
-        {
-            "name": "woocommerce_blocks_{$this->registry_identifier}_registration",
-            "file": "Integrations/IntegrationRegistry.php",
-            "type": "action",
-            "doc": {
-                "description": "Fires when the IntegrationRegistry is initialized.",
-                "long_description": "Runs before integrations are initialized allowing new integration to be registered for use. This should be used as the primary hook for integrations to include their scripts, styles, and other code extending the blocks.",
-                "tags": [
-                    {
-                        "name": "param",
-                        "content": "Instance of the IntegrationRegistry class which exposes the IntegrationRegistry::register() method.",
-                        "types": [
-                            "\\Automattic\\WooCommerce\\Blocks\\Integrations\\IntegrationRegistry"
-                        ],
-                        "variable": "$this"
-                    }
-                ],
-                "long_description_html": "<p>Runs before integrations are initialized allowing new integration to be registered for use. This should be used as the primary hook for integrations to include their scripts, styles, and other code extending the blocks.</p>"
-            },
-            "args": 1
-        },
-        {
-            "name": "woocommerce_check_cart_items",
-            "file": "StoreApi/Utilities/CartController.php",
-            "type": "action",
-            "doc": {
-                "description": "Fires when cart items are being validated.",
-                "long_description": "Allow 3rd parties to validate cart items. This is a legacy hook from Woo core. This filter will be deprecated because it encourages usage of wc_add_notice. For the API we need to capture notices and convert to exceptions instead.",
-                "tags": [],
-                "long_description_html": "<p>Allow 3rd parties to validate cart items. This is a legacy hook from Woo core. This filter will be deprecated because it encourages usage of wc_add_notice. For the API we need to capture notices and convert to exceptions instead.</p>"
-            },
-            "args": 0
-        },
-        {
-            "name": "woocommerce_created_customer",
-            "file": "Domain/Services/CreateAccount.php",
-            "type": "action",
-            "doc": {
-                "description": "Fires after a customer account has been registered.",
-                "long_description": "This hook fires after customer accounts are created and passes the customer data.",
-                "tags": [
-                    {
-                        "name": "param",
-                        "content": "New customer (user) ID.",
-                        "types": [
-                            "integer"
-                        ],
-                        "variable": "$customer_id"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Array of customer (user) data.",
-                        "types": [
-                            "array"
-                        ],
-                        "variable": "$new_customer_data"
-                    },
-                    {
-                        "name": "param",
-                        "content": "The generated password for the account.",
-                        "types": [
-                            "string"
-                        ],
-                        "variable": "$password_generated"
-                    }
-                ],
-                "long_description_html": "<p>This hook fires after customer accounts are created and passes the customer data.</p>"
-            },
-            "args": 3
-        },
-        {
-            "name": "woocommerce_no_products_found",
-            "file": "BlockTypes/LegacyTemplate.php",
-            "type": "action",
-            "doc": {
-                "description": "Hook: woocommerce_no_products_found.",
-                "long_description": "",
-                "tags": [
-                    {
-                        "name": "see",
-                        "content": "Default no products found content (priority 10)",
-                        "refers": "wc_no_products_found()"
-                    }
-                ],
-                "long_description_html": ""
-            },
-            "args": 0
-        },
-        {
-            "name": "woocommerce_register_post",
-            "file": "Domain/Services/CreateAccount.php",
-            "type": "action",
-            "doc": {
-                "description": "Fires before a customer account is registered.",
-                "long_description": "This hook fires before customer accounts are created and passes the form data (username, email) and an array of errors.\n This could be used to add extra validation logic and append errors to the array.",
-                "tags": [
-                    {
-                        "name": "param",
-                        "content": "Customer username.",
-                        "types": [
-                            "string"
-                        ],
-                        "variable": "$username"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Customer email address.",
-                        "types": [
-                            "string"
-                        ],
-                        "variable": "$user_email"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Error object.",
-                        "types": [
-                            "\\WP_Error"
-                        ],
-                        "variable": "$errors"
-                    }
-                ],
-                "long_description_html": "<p>This hook fires before customer accounts are created and passes the form data (username, email) and an array of errors.</p> <p>This could be used to add extra validation logic and append errors to the array.</p>"
-            },
-            "args": 3
-        },
-        {
-            "name": "woocommerce_rest_checkout_process_payment_with_context",
-            "file": "StoreApi/Routes/Checkout.php",
-            "type": "action_reference",
-            "doc": {
-                "description": "Process payment with context.",
-                "long_description": "",
-                "tags": [
-                    {
-                        "name": "hook",
-                        "content": "woocommerce_rest_checkout_process_payment_with_context"
-                    },
-                    {
-                        "name": "throws",
-                        "content": "If there is an error taking payment, an \\Exception object can be thrown with an error message.",
-                        "types": [
-                            "\\Exception"
-                        ]
-                    },
-                    {
-                        "name": "param",
-                        "content": "Holds context for the payment, including order ID and payment method.",
-                        "types": [
-                            "\\Automattic\\WooCommerce\\Blocks\\Payments\\PaymentContext"
-                        ],
-                        "variable": "$context"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Result object for the transaction.",
-                        "types": [
-                            "\\Automattic\\WooCommerce\\Blocks\\Payments\\PaymentResult"
-                        ],
-                        "variable": "$payment_result"
-                    }
-                ],
-                "long_description_html": ""
-            },
-            "args": 1
-        },
-        {
-            "name": "woocommerce_shop_loop",
-            "file": "BlockTypes/LegacyTemplate.php",
-            "type": "action",
-            "doc": {
-                "description": "Hook: woocommerce_shop_loop.",
-                "long_description": "",
-                "tags": [],
-                "long_description_html": ""
-            },
-            "args": 0
-        },
-        {
-            "name": "wooocommerce_store_api_validate_add_to_cart",
-            "file": "StoreApi/Utilities/CartController.php",
-            "type": "action",
-            "doc": {
-                "description": "Fires during validation when adding an item to the cart via the Store API.",
-                "long_description": "Fire action to validate add to cart. Functions hooking into this should throw an \\Exception to prevent add to cart from happening.",
-                "tags": [
-                    {
-                        "name": "param",
-                        "content": "Product object being added to the cart.",
-                        "types": [
-                            "\\WC_Product"
-                        ],
-                        "variable": "$product"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Add to cart request params including id, quantity, and variation attributes.",
-                        "types": [
-                            "array"
-                        ],
-                        "variable": "$request"
-                    }
-                ],
-                "long_description_html": "<p>Fire action to validate add to cart. Functions hooking into this should throw an \\Exception to prevent add to cart from happening.</p>"
-            },
-            "args": 2
-        },
-        {
-            "name": "wooocommerce_store_api_validate_cart_item",
-            "file": "StoreApi/Utilities/CartController.php",
-            "type": "action",
-            "doc": {
-                "description": "Fire action to validate add to cart. Functions hooking into this should throw an \\Exception to prevent add to cart from occurring.",
-                "long_description": "",
-                "tags": [
-                    {
-                        "name": "param",
-                        "content": "Product object being added to the cart.",
-                        "types": [
-                            "\\WC_Product"
-                        ],
-                        "variable": "$product"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Cart item array.",
-                        "types": [
-                            "array"
-                        ],
-                        "variable": "$cart_item"
-                    }
-                ],
-                "long_description_html": ""
-            },
-            "args": 2
-        }
-    ]
+	"$schema": "https://raw.githubusercontent.com/johnbillion/wp-hooks-generator/0.7.0/schema.json",
+	"hooks": [
+		{
+			"name": "woocommerce_add_to_cart",
+			"file": "StoreApi/Utilities/CartController.php",
+			"type": "action",
+			"doc": {
+				"description": "Fires when an item is added to the cart.",
+				"long_description": "This hook fires when an item is added to the cart. This is triggered from the Store API in this context, but WooCommerce core add to cart events trigger the same hook.",
+				"tags": [
+					{
+						"name": "param",
+						"content": "ID of the item in the cart.",
+						"types": [ "string" ],
+						"variable": "$cart_id"
+					},
+					{
+						"name": "param",
+						"content": "ID of the product added to the cart.",
+						"types": [ "integer" ],
+						"variable": "$product_id"
+					},
+					{
+						"name": "param",
+						"content": "Quantity of the item added to the cart.",
+						"types": [ "integer" ],
+						"variable": "$request_quantity"
+					},
+					{
+						"name": "param",
+						"content": "Variation ID of the product added to the cart.",
+						"types": [ "integer" ],
+						"variable": "$variation_id"
+					},
+					{
+						"name": "param",
+						"content": "Array of variation data.",
+						"types": [ "array" ],
+						"variable": "$variation"
+					},
+					{
+						"name": "param",
+						"content": "Array of other cart item data.",
+						"types": [ "array" ],
+						"variable": "$cart_item_data"
+					}
+				],
+				"long_description_html": "<p>This hook fires when an item is added to the cart. This is triggered from the Store API in this context, but WooCommerce core add to cart events trigger the same hook.</p>"
+			},
+			"args": 6
+		},
+		{
+			"name": "woocommerce_after_main_content",
+			"file": "BlockTypes/LegacyTemplate.php",
+			"type": "action",
+			"doc": {
+				"description": "Hook: woocommerce_after_main_content",
+				"long_description": "Called after rendering the main content for a product.",
+				"tags": [
+					{
+						"name": "see",
+						"content": "Outputs closing DIV for the content (priority 10)",
+						"refers": "woocommerce_output_content_wrapper_end()"
+					}
+				],
+				"long_description_html": "<p>Called after rendering the main content for a product.</p>"
+			},
+			"args": 0
+		},
+		{
+			"name": "woocommerce_after_main_content",
+			"file": "BlockTypes/LegacyTemplate.php",
+			"type": "action",
+			"doc": {
+				"description": "Hook: woocommerce_after_main_content",
+				"long_description": "Called after rendering the main content for a product.",
+				"tags": [
+					{
+						"name": "see",
+						"content": "Outputs closing DIV for the content (priority 10)",
+						"refers": "woocommerce_output_content_wrapper_end()"
+					}
+				],
+				"long_description_html": "<p>Called after rendering the main content for a product.</p>"
+			},
+			"args": 0
+		},
+		{
+			"name": "woocommerce_after_shop_loop",
+			"file": "BlockTypes/LegacyTemplate.php",
+			"type": "action",
+			"doc": {
+				"description": "Hook: woocommerce_after_shop_loop.",
+				"long_description": "",
+				"tags": [
+					{
+						"name": "see",
+						"content": "Renders pagination (priority 10)",
+						"refers": "woocommerce_pagination()"
+					}
+				],
+				"long_description_html": ""
+			},
+			"args": 0
+		},
+		{
+			"name": "woocommerce_applied_coupon",
+			"file": "StoreApi/Utilities/CartController.php",
+			"type": "action",
+			"doc": {
+				"description": "Fires after a coupon has been applied to the cart.",
+				"long_description": "",
+				"tags": [
+					{
+						"name": "param",
+						"content": "The coupon code that was applied.",
+						"types": [ "string" ],
+						"variable": "$coupon_code"
+					}
+				],
+				"long_description_html": ""
+			},
+			"args": 1
+		},
+		{
+			"name": "woocommerce_archive_description",
+			"file": "BlockTypes/LegacyTemplate.php",
+			"type": "action",
+			"doc": {
+				"description": "Hook: woocommerce_archive_description.",
+				"long_description": "",
+				"tags": [
+					{
+						"name": "see",
+						"content": "Renders the taxonomy archive description (priority 10)",
+						"refers": "woocommerce_taxonomy_archive_description()"
+					},
+					{
+						"name": "see",
+						"content": "Renders the product archive description (priority 10)",
+						"refers": "woocommerce_product_archive_description()"
+					}
+				],
+				"long_description_html": ""
+			},
+			"args": 0
+		},
+		{
+			"name": "woocommerce_before_main_content",
+			"file": "BlockTypes/LegacyTemplate.php",
+			"type": "action",
+			"doc": {
+				"description": "Hook: woocommerce_before_main_content",
+				"long_description": "Called before rendering the main content for a product.",
+				"tags": [
+					{
+						"name": "see",
+						"content": "Outputs opening DIV for the content (priority 10)",
+						"refers": "woocommerce_output_content_wrapper()"
+					},
+					{
+						"name": "see",
+						"content": "Outputs breadcrumb trail to the current product (priority 20)",
+						"refers": "woocommerce_breadcrumb()"
+					},
+					{
+						"name": "see",
+						"content": "Outputs schema markup (priority 30)",
+						"refers": "WC_Structured_Data::generate_website_data()"
+					}
+				],
+				"long_description_html": "<p>Called before rendering the main content for a product.</p>"
+			},
+			"args": 0
+		},
+		{
+			"name": "woocommerce_before_main_content",
+			"file": "BlockTypes/LegacyTemplate.php",
+			"type": "action",
+			"doc": {
+				"description": "Hook: woocommerce_before_main_content",
+				"long_description": "Called before rendering the main content for a product.",
+				"tags": [
+					{
+						"name": "see",
+						"content": "Outputs opening DIV for the content (priority 10)",
+						"refers": "woocommerce_output_content_wrapper()"
+					},
+					{
+						"name": "see",
+						"content": "Outputs breadcrumb trail to the current product (priority 20)",
+						"refers": "woocommerce_breadcrumb()"
+					},
+					{
+						"name": "see",
+						"content": "Outputs schema markup (priority 30)",
+						"refers": "WC_Structured_Data::generate_website_data()"
+					}
+				],
+				"long_description_html": "<p>Called before rendering the main content for a product.</p>"
+			},
+			"args": 0
+		},
+		{
+			"name": "woocommerce_before_shop_loop",
+			"file": "BlockTypes/LegacyTemplate.php",
+			"type": "action",
+			"doc": {
+				"description": "Hook: woocommerce_before_shop_loop.",
+				"long_description": "",
+				"tags": [
+					{
+						"name": "see",
+						"content": "Render error notices (priority 10)",
+						"refers": "woocommerce_output_all_notices()"
+					},
+					{
+						"name": "see",
+						"content": "Show number of results found (priority 20)",
+						"refers": "woocommerce_result_count()"
+					},
+					{
+						"name": "see",
+						"content": "Show form to control sort order (priority 30)",
+						"refers": "woocommerce_catalog_ordering()"
+					}
+				],
+				"long_description_html": ""
+			},
+			"args": 0
+		},
+		{
+			"name": "woocommerce_blocks_cart_enqueue_data",
+			"file": "BlockTypes/MiniCart.php",
+			"type": "action",
+			"doc": {
+				"description": "Fires after cart block data is registered.",
+				"long_description": "",
+				"tags": [],
+				"long_description_html": ""
+			},
+			"args": 0
+		},
+		{
+			"name": "woocommerce_blocks_cart_enqueue_data",
+			"file": "BlockTypes/Cart.php",
+			"type": "action",
+			"doc": {
+				"description": "Fires after cart block data is registered.",
+				"long_description": "",
+				"tags": [],
+				"long_description_html": ""
+			},
+			"args": 0
+		},
+		{
+			"name": "woocommerce_blocks_cart_update_customer_from_request",
+			"file": "StoreApi/Routes/CartUpdateCustomer.php",
+			"type": "action",
+			"doc": {
+				"description": "Fires when the Checkout Block/Store API updates a customer from the API request data.",
+				"long_description": "",
+				"tags": [
+					{
+						"name": "param",
+						"content": "Customer object.",
+						"types": [ "\\WC_Customer" ],
+						"variable": "$customer"
+					},
+					{
+						"name": "param",
+						"content": "Full details about the request.",
+						"types": [ "\\WP_REST_Request" ],
+						"variable": "$request"
+					}
+				],
+				"long_description_html": ""
+			},
+			"args": 2
+		},
+		{
+			"name": "woocommerce_blocks_cart_update_order_from_request",
+			"file": "StoreApi/Routes/AbstractCartRoute.php",
+			"type": "action",
+			"doc": {
+				"description": "Fires when the order is synced with cart data from a cart route.",
+				"long_description": "",
+				"tags": [
+					{
+						"name": "param",
+						"content": "Order object.",
+						"types": [ "\\WC_Order" ],
+						"variable": "$draft_order"
+					},
+					{
+						"name": "param",
+						"content": "Customer object.",
+						"types": [ "\\WC_Customer" ],
+						"variable": "$customer"
+					},
+					{
+						"name": "param",
+						"content": "Full details about the request.",
+						"types": [ "\\WP_REST_Request" ],
+						"variable": "$request"
+					}
+				],
+				"long_description_html": ""
+			},
+			"args": 2
+		},
+		{
+			"name": "woocommerce_blocks_checkout_enqueue_data",
+			"file": "BlockTypes/Checkout.php",
+			"type": "action",
+			"doc": {
+				"description": "Fires after checkout block data is registered.",
+				"long_description": "",
+				"tags": [],
+				"long_description_html": ""
+			},
+			"args": 0
+		},
+		{
+			"name": "woocommerce_blocks_checkout_order_processed",
+			"file": "StoreApi/Routes/Checkout.php",
+			"type": "action",
+			"doc": {
+				"description": "Fires before an order is processed by the Checkout Block/Store API.",
+				"long_description": "This hook informs extensions that $order has completed processing and is ready for payment.\n This is similar to existing core hook woocommerce_checkout_order_processed. We're using a new action: - To keep the interface focused (only pass $order, not passing request data). - This also explicitly indicates these orders are from checkout block/StoreAPI.",
+				"tags": [
+					{
+						"name": "see",
+						"content": "",
+						"refers": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3238"
+					},
+					{
+						"name": "example",
+						"content": "docs/examples/checkout-order-processed.md"
+					},
+					{
+						"name": "param",
+						"content": "Order object.",
+						"types": [ "\\WC_Order" ],
+						"variable": "$order"
+					}
+				],
+				"long_description_html": "<p>This hook informs extensions that $order has completed processing and is ready for payment.</p> <p>This is similar to existing core hook woocommerce_checkout_order_processed. We're using a new action:</p> <ul> <li>To keep the interface focused (only pass $order, not passing request data).</li> <li>This also explicitly indicates these orders are from checkout block/StoreAPI.</li> </ul>"
+			},
+			"args": 1
+		},
+		{
+			"name": "woocommerce_blocks_checkout_update_order_from_request",
+			"file": "StoreApi/Routes/Checkout.php",
+			"type": "action",
+			"doc": {
+				"description": "Fires when the Checkout Block/Store API updates an order's from the API request data.",
+				"long_description": "This hook gives extensions the chance to update orders based on the data in the request. This can be used in conjunction with the ExtendRestAPI class to post custom data and then process it.",
+				"tags": [
+					{
+						"name": "param",
+						"content": "Order object.",
+						"types": [ "\\WC_Order" ],
+						"variable": "$order"
+					},
+					{
+						"name": "param",
+						"content": "Full details about the request.",
+						"types": [ "\\WP_REST_Request" ],
+						"variable": "$request"
+					}
+				],
+				"long_description_html": "<p>This hook gives extensions the chance to update orders based on the data in the request. This can be used in conjunction with the ExtendRestAPI class to post custom data and then process it.</p>"
+			},
+			"args": 2
+		},
+		{
+			"name": "woocommerce_blocks_checkout_update_order_meta",
+			"file": "StoreApi/Routes/Checkout.php",
+			"type": "action",
+			"doc": {
+				"description": "Fires when the Checkout Block/Store API updates an order's meta data.",
+				"long_description": "This hook gives extensions the chance to add or update meta data on the $order.\n This is similar to existing core hook woocommerce_checkout_update_order_meta. We're using a new action: - To keep the interface focused (only pass $order, not passing request data). - This also explicitly indicates these orders are from checkout block/StoreAPI.",
+				"tags": [
+					{
+						"name": "see",
+						"content": "",
+						"refers": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3686"
+					},
+					{
+						"name": "param",
+						"content": "Order object.",
+						"types": [ "\\WC_Order" ],
+						"variable": "$order"
+					}
+				],
+				"long_description_html": "<p>This hook gives extensions the chance to add or update meta data on the $order.</p> <p>This is similar to existing core hook woocommerce_checkout_update_order_meta. We're using a new action:</p> <ul> <li>To keep the interface focused (only pass $order, not passing request data).</li> <li>This also explicitly indicates these orders are from checkout block/StoreAPI.</li> </ul>"
+			},
+			"args": 1
+		},
+		{
+			"name": "woocommerce_blocks_enqueue_cart_block_scripts_after",
+			"file": "BlockTypes/Cart.php",
+			"type": "action",
+			"doc": {
+				"description": "Fires after cart block scripts are enqueued.",
+				"long_description": "",
+				"tags": [],
+				"long_description_html": ""
+			},
+			"args": 0
+		},
+		{
+			"name": "woocommerce_blocks_enqueue_cart_block_scripts_before",
+			"file": "BlockTypes/Cart.php",
+			"type": "action",
+			"doc": {
+				"description": "Fires before cart block scripts are enqueued.",
+				"long_description": "",
+				"tags": [],
+				"long_description_html": ""
+			},
+			"args": 0
+		},
+		{
+			"name": "woocommerce_blocks_enqueue_checkout_block_scripts_after",
+			"file": "BlockTypes/Checkout.php",
+			"type": "action",
+			"doc": {
+				"description": "Fires after checkout block scripts are enqueued.",
+				"long_description": "",
+				"tags": [],
+				"long_description_html": ""
+			},
+			"args": 0
+		},
+		{
+			"name": "woocommerce_blocks_enqueue_checkout_block_scripts_before",
+			"file": "BlockTypes/Checkout.php",
+			"type": "action",
+			"doc": {
+				"description": "Fires before checkout block scripts are enqueued.",
+				"long_description": "",
+				"tags": [],
+				"long_description_html": ""
+			},
+			"args": 0
+		},
+		{
+			"name": "woocommerce_blocks_loaded",
+			"file": "Domain/Bootstrap.php",
+			"type": "action",
+			"doc": {
+				"description": "Fires after WooCommerce Blocks plugin has loaded.",
+				"long_description": "This hook is intended to be used as a safe event hook for when the plugin has been loaded, and all dependency requirements have been met.",
+				"tags": [],
+				"long_description_html": "<p>This hook is intended to be used as a safe event hook for when the plugin has been loaded, and all dependency requirements have been met.</p>"
+			},
+			"args": 0
+		},
+		{
+			"name": "woocommerce_blocks_{$this->registry_identifier}_registration",
+			"file": "Integrations/IntegrationRegistry.php",
+			"type": "action",
+			"doc": {
+				"description": "Fires when the IntegrationRegistry is initialized.",
+				"long_description": "Runs before integrations are initialized allowing new integration to be registered for use. This should be used as the primary hook for integrations to include their scripts, styles, and other code extending the blocks.",
+				"tags": [
+					{
+						"name": "param",
+						"content": "Instance of the IntegrationRegistry class which exposes the IntegrationRegistry::register() method.",
+						"types": [
+							"\\Automattic\\WooCommerce\\Blocks\\Integrations\\IntegrationRegistry"
+						],
+						"variable": "$this"
+					}
+				],
+				"long_description_html": "<p>Runs before integrations are initialized allowing new integration to be registered for use. This should be used as the primary hook for integrations to include their scripts, styles, and other code extending the blocks.</p>"
+			},
+			"args": 1
+		},
+		{
+			"name": "woocommerce_check_cart_items",
+			"file": "StoreApi/Utilities/CartController.php",
+			"type": "action",
+			"doc": {
+				"description": "Fires when cart items are being validated.",
+				"long_description": "Allow 3rd parties to validate cart items. This is a legacy hook from Woo core. This filter will be deprecated because it encourages usage of wc_add_notice. For the API we need to capture notices and convert to exceptions instead.",
+				"tags": [],
+				"long_description_html": "<p>Allow 3rd parties to validate cart items. This is a legacy hook from Woo core. This filter will be deprecated because it encourages usage of wc_add_notice. For the API we need to capture notices and convert to exceptions instead.</p>"
+			},
+			"args": 0
+		},
+		{
+			"name": "woocommerce_created_customer",
+			"file": "Domain/Services/CreateAccount.php",
+			"type": "action",
+			"doc": {
+				"description": "Fires after a customer account has been registered.",
+				"long_description": "This hook fires after customer accounts are created and passes the customer data.",
+				"tags": [
+					{
+						"name": "param",
+						"content": "New customer (user) ID.",
+						"types": [ "integer" ],
+						"variable": "$customer_id"
+					},
+					{
+						"name": "param",
+						"content": "Array of customer (user) data.",
+						"types": [ "array" ],
+						"variable": "$new_customer_data"
+					},
+					{
+						"name": "param",
+						"content": "The generated password for the account.",
+						"types": [ "string" ],
+						"variable": "$password_generated"
+					}
+				],
+				"long_description_html": "<p>This hook fires after customer accounts are created and passes the customer data.</p>"
+			},
+			"args": 3
+		},
+		{
+			"name": "woocommerce_no_products_found",
+			"file": "BlockTypes/LegacyTemplate.php",
+			"type": "action",
+			"doc": {
+				"description": "Hook: woocommerce_no_products_found.",
+				"long_description": "",
+				"tags": [
+					{
+						"name": "see",
+						"content": "Default no products found content (priority 10)",
+						"refers": "wc_no_products_found()"
+					}
+				],
+				"long_description_html": ""
+			},
+			"args": 0
+		},
+		{
+			"name": "woocommerce_register_post",
+			"file": "Domain/Services/CreateAccount.php",
+			"type": "action",
+			"doc": {
+				"description": "Fires before a customer account is registered.",
+				"long_description": "This hook fires before customer accounts are created and passes the form data (username, email) and an array of errors.\n This could be used to add extra validation logic and append errors to the array.",
+				"tags": [
+					{
+						"name": "param",
+						"content": "Customer username.",
+						"types": [ "string" ],
+						"variable": "$username"
+					},
+					{
+						"name": "param",
+						"content": "Customer email address.",
+						"types": [ "string" ],
+						"variable": "$user_email"
+					},
+					{
+						"name": "param",
+						"content": "Error object.",
+						"types": [ "\\WP_Error" ],
+						"variable": "$errors"
+					}
+				],
+				"long_description_html": "<p>This hook fires before customer accounts are created and passes the form data (username, email) and an array of errors.</p> <p>This could be used to add extra validation logic and append errors to the array.</p>"
+			},
+			"args": 3
+		},
+		{
+			"name": "woocommerce_rest_checkout_process_payment_with_context",
+			"file": "StoreApi/Routes/Checkout.php",
+			"type": "action_reference",
+			"doc": {
+				"description": "Process payment with context.",
+				"long_description": "",
+				"tags": [
+					{
+						"name": "hook",
+						"content": "woocommerce_rest_checkout_process_payment_with_context"
+					},
+					{
+						"name": "throws",
+						"content": "If there is an error taking payment, an \\Exception object can be thrown with an error message.",
+						"types": [ "\\Exception" ]
+					},
+					{
+						"name": "param",
+						"content": "Holds context for the payment, including order ID and payment method.",
+						"types": [
+							"\\Automattic\\WooCommerce\\Blocks\\Payments\\PaymentContext"
+						],
+						"variable": "$context"
+					},
+					{
+						"name": "param",
+						"content": "Result object for the transaction.",
+						"types": [
+							"\\Automattic\\WooCommerce\\Blocks\\Payments\\PaymentResult"
+						],
+						"variable": "$payment_result"
+					}
+				],
+				"long_description_html": ""
+			},
+			"args": 1
+		},
+		{
+			"name": "woocommerce_shop_loop",
+			"file": "BlockTypes/LegacyTemplate.php",
+			"type": "action",
+			"doc": {
+				"description": "Hook: woocommerce_shop_loop.",
+				"long_description": "",
+				"tags": [],
+				"long_description_html": ""
+			},
+			"args": 0
+		},
+		{
+			"name": "wooocommerce_store_api_validate_add_to_cart",
+			"file": "StoreApi/Utilities/CartController.php",
+			"type": "action",
+			"doc": {
+				"description": "Fires during validation when adding an item to the cart via the Store API.",
+				"long_description": "Fire action to validate add to cart. Functions hooking into this should throw an \\Exception to prevent add to cart from happening.",
+				"tags": [
+					{
+						"name": "param",
+						"content": "Product object being added to the cart.",
+						"types": [ "\\WC_Product" ],
+						"variable": "$product"
+					},
+					{
+						"name": "param",
+						"content": "Add to cart request params including id, quantity, and variation attributes.",
+						"types": [ "array" ],
+						"variable": "$request"
+					}
+				],
+				"long_description_html": "<p>Fire action to validate add to cart. Functions hooking into this should throw an \\Exception to prevent add to cart from happening.</p>"
+			},
+			"args": 2
+		},
+		{
+			"name": "wooocommerce_store_api_validate_cart_item",
+			"file": "StoreApi/Utilities/CartController.php",
+			"type": "action",
+			"doc": {
+				"description": "Fire action to validate add to cart. Functions hooking into this should throw an \\Exception to prevent add to cart from occurring.",
+				"long_description": "",
+				"tags": [
+					{
+						"name": "param",
+						"content": "Product object being added to the cart.",
+						"types": [ "\\WC_Product" ],
+						"variable": "$product"
+					},
+					{
+						"name": "param",
+						"content": "Cart item array.",
+						"types": [ "array" ],
+						"variable": "$cart_item"
+					}
+				],
+				"long_description_html": ""
+			},
+			"args": 2
+		}
+	]
 }

--- a/bin/hook-docs/data/filters.json
+++ b/bin/hook-docs/data/filters.json
@@ -1,951 +1,794 @@
 {
-    "$schema": "https://raw.githubusercontent.com/johnbillion/wp-hooks-generator/0.7.0/schema.json",
-    "hooks": [
-        {
-            "name": "__experimental_woocommerce_blocks_add_data_attributes_to_block",
-            "file": "BlockTypesController.php",
-            "type": "filter",
-            "doc": {
-                "description": "Filters the list of allowed Block Names",
-                "long_description": "This hook defines which block names should have block name and attribute data- attributes appended on render.",
-                "tags": [
-                    {
-                        "name": "param",
-                        "content": "List of namespaces.",
-                        "types": [
-                            "array"
-                        ],
-                        "variable": "$allowed_namespaces"
-                    }
-                ],
-                "long_description_html": "<p>This hook defines which block names should have block name and attribute data- attributes appended on render.</p>"
-            },
-            "args": 1
-        },
-        {
-            "name": "__experimental_woocommerce_blocks_add_data_attributes_to_namespace",
-            "file": "BlockTypesController.php",
-            "type": "filter",
-            "doc": {
-                "description": "Filters the list of allowed block namespaces.",
-                "long_description": "This hook defines which block namespaces should have block name and attribute `data-` attributes appended on render.",
-                "tags": [
-                    {
-                        "name": "param",
-                        "content": "List of namespaces.",
-                        "types": [
-                            "array"
-                        ],
-                        "variable": "$allowed_namespaces"
-                    }
-                ],
-                "long_description_html": "<p>This hook defines which block namespaces should have block name and attribute <code>data-</code> attributes appended on render.</p>"
-            },
-            "args": 1
-        },
-        {
-            "name": "__experimental_woocommerce_blocks_payment_gateway_features_list",
-            "file": "Payments/Integrations/PayPal.php",
-            "type": "filter",
-            "doc": {
-                "description": "Filter to control what features are available for each payment gateway.",
-                "long_description": "",
-                "tags": [
-                    {
-                        "name": "example",
-                        "content": "docs/examples/payment-gateways-features-list.md"
-                    },
-                    {
-                        "name": "param",
-                        "content": "List of supported features.",
-                        "types": [
-                            "array"
-                        ],
-                        "variable": "$features"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Gateway name.",
-                        "types": [
-                            "string"
-                        ],
-                        "variable": "$name"
-                    },
-                    {
-                        "name": "return",
-                        "content": "Updated list of supported features.",
-                        "types": [
-                            "array"
-                        ]
-                    }
-                ],
-                "long_description_html": ""
-            },
-            "args": 2
-        },
-        {
-            "name": "woocommerce_add_cart_item",
-            "file": "StoreApi/Utilities/CartController.php",
-            "type": "filter",
-            "doc": {
-                "description": "Filters the item being added to the cart.",
-                "long_description": "",
-                "tags": [
-                    {
-                        "name": "param",
-                        "content": "Array of cart item data being added to the cart.",
-                        "types": [
-                            "array"
-                        ],
-                        "variable": "$cart_item_data"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Id of the item in the cart.",
-                        "types": [
-                            "string"
-                        ],
-                        "variable": "$cart_id"
-                    },
-                    {
-                        "name": "return",
-                        "content": "Updated cart item data.",
-                        "types": [
-                            "array"
-                        ]
-                    }
-                ],
-                "long_description_html": ""
-            },
-            "args": 2
-        },
-        {
-            "name": "woocommerce_add_cart_item_data",
-            "file": "StoreApi/Utilities/CartController.php",
-            "type": "filter",
-            "doc": {
-                "description": "Filter cart item data for add to cart requests.",
-                "long_description": "",
-                "tags": [
-                    {
-                        "name": "param",
-                        "content": "Array of other cart item data.",
-                        "types": [
-                            "array"
-                        ],
-                        "variable": "$cart_item_data"
-                    },
-                    {
-                        "name": "param",
-                        "content": "ID of the product added to the cart.",
-                        "types": [
-                            "integer"
-                        ],
-                        "variable": "$product_id"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Variation ID of the product added to the cart.",
-                        "types": [
-                            "integer"
-                        ],
-                        "variable": "$variation_id"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Quantity of the item added to the cart.",
-                        "types": [
-                            "integer"
-                        ],
-                        "variable": "$quantity"
-                    },
-                    {
-                        "name": "return",
-                        "content": "",
-                        "types": [
-                            "array"
-                        ]
-                    }
-                ],
-                "long_description_html": ""
-            },
-            "args": 4
-        },
-        {
-            "name": "woocommerce_add_to_cart_sold_individually_quantity",
-            "file": "StoreApi/Utilities/CartController.php",
-            "type": "filter",
-            "doc": {
-                "description": "Filter sold individually quantity for add to cart requests.",
-                "long_description": "",
-                "tags": [
-                    {
-                        "name": "param",
-                        "content": "Defaults to 1.",
-                        "types": [
-                            "integer"
-                        ],
-                        "variable": "$sold_individually_quantity"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Quantity of the item added to the cart.",
-                        "types": [
-                            "integer"
-                        ],
-                        "variable": "$quantity"
-                    },
-                    {
-                        "name": "param",
-                        "content": "ID of the product added to the cart.",
-                        "types": [
-                            "integer"
-                        ],
-                        "variable": "$product_id"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Variation ID of the product added to the cart.",
-                        "types": [
-                            "integer"
-                        ],
-                        "variable": "$variation_id"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Array of other cart item data.",
-                        "types": [
-                            "array"
-                        ],
-                        "variable": "$cart_item_data"
-                    },
-                    {
-                        "name": "return",
-                        "content": "",
-                        "types": [
-                            "integer"
-                        ]
-                    }
-                ],
-                "long_description_html": ""
-            },
-            "args": 5
-        },
-        {
-            "name": "woocommerce_add_to_cart_validation",
-            "file": "StoreApi/Utilities/CartController.php",
-            "type": "filter",
-            "doc": {
-                "description": "Filters if an item being added to the cart passed validation checks.",
-                "long_description": "Allow 3rd parties to validate if an item can be added to the cart. This is a legacy hook from Woo core. This filter will be deprecated because it encourages usage of wc_add_notice. For the API we need to capture notices and convert to exceptions instead.",
-                "tags": [
-                    {
-                        "name": "deprecated",
-                        "content": ""
-                    },
-                    {
-                        "name": "param",
-                        "content": "True if the item passed validation.",
-                        "types": [
-                            "boolean"
-                        ],
-                        "variable": "$passed_validation"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Product ID being validated.",
-                        "types": [
-                            "integer"
-                        ],
-                        "variable": "$product_id"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Quantity added to the cart.",
-                        "types": [
-                            "integer"
-                        ],
-                        "variable": "$quantity"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Variation ID being added to the cart.",
-                        "types": [
-                            "integer"
-                        ],
-                        "variable": "$variation_id"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Variation data.",
-                        "types": [
-                            "array"
-                        ],
-                        "variable": "$variation"
-                    },
-                    {
-                        "name": "return",
-                        "content": "",
-                        "types": [
-                            "boolean"
-                        ]
-                    }
-                ],
-                "long_description_html": "<p>Allow 3rd parties to validate if an item can be added to the cart. This is a legacy hook from Woo core. This filter will be deprecated because it encourages usage of wc_add_notice. For the API we need to capture notices and convert to exceptions instead.</p>"
-            },
-            "args": 5
-        },
-        {
-            "name": "woocommerce_adjust_non_base_location_prices",
-            "file": "StoreApi/Utilities/ProductQuery.php",
-            "type": "filter",
-            "doc": {
-                "description": "Filters if taxes should be removed from locations outside the store base location.",
-                "long_description": "The woocommerce_adjust_non_base_location_prices filter can stop base taxes being taken off when dealing with out of base locations. e.g. If a product costs 10 including tax, all users will pay 10 regardless of location and taxes.",
-                "tags": [
-                    {
-                        "name": "param",
-                        "content": "True by default.",
-                        "types": [
-                            "boolean"
-                        ],
-                        "variable": "$adjust_non_base_location_prices"
-                    },
-                    {
-                        "name": "return",
-                        "content": "",
-                        "types": [
-                            "boolean"
-                        ]
-                    }
-                ],
-                "long_description_html": "<p>The woocommerce_adjust_non_base_location_prices filter can stop base taxes being taken off when dealing with out of base locations. e.g. If a product costs 10 including tax, all users will pay 10 regardless of location and taxes.</p>"
-            },
-            "args": 1
-        },
-        {
-            "name": "woocommerce_apply_individual_use_coupon",
-            "file": "StoreApi/Utilities/CartController.php",
-            "type": "filter",
-            "doc": {
-                "description": "Filter coupons to remove when applying an individual use coupon.",
-                "long_description": "",
-                "tags": [
-                    {
-                        "name": "param",
-                        "content": "Array of coupons to remove from the cart.",
-                        "types": [
-                            "array"
-                        ],
-                        "variable": "$coupons"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Coupon object applied to the cart.",
-                        "types": [
-                            "\\WC_Coupon"
-                        ],
-                        "variable": "$coupon"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Array of applied coupons already applied to the cart.",
-                        "types": [
-                            "array"
-                        ],
-                        "variable": "$applied_coupons"
-                    },
-                    {
-                        "name": "return",
-                        "content": "",
-                        "types": [
-                            "array"
-                        ]
-                    }
-                ],
-                "long_description_html": ""
-            },
-            "args": 3
-        },
-        {
-            "name": "woocommerce_apply_with_individual_use_coupon",
-            "file": "StoreApi/Utilities/CartController.php",
-            "type": "filter",
-            "doc": {
-                "description": "Filters if a coupon can be applied alongside other individual use coupons.",
-                "long_description": "",
-                "tags": [
-                    {
-                        "name": "param",
-                        "content": "Defaults to false.",
-                        "types": [
-                            "boolean"
-                        ],
-                        "variable": "$apply_with_individual_use_coupon"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Coupon object applied to the cart.",
-                        "types": [
-                            "\\WC_Coupon"
-                        ],
-                        "variable": "$coupon"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Individual use coupon already applied to the cart.",
-                        "types": [
-                            "\\WC_Coupon"
-                        ],
-                        "variable": "$individual_use_coupon"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Array of applied coupons already applied to the cart.",
-                        "types": [
-                            "array"
-                        ],
-                        "variable": "$applied_coupons"
-                    },
-                    {
-                        "name": "return",
-                        "content": "",
-                        "types": [
-                            "boolean"
-                        ]
-                    }
-                ],
-                "long_description_html": ""
-            },
-            "args": 4
-        },
-        {
-            "name": "woocommerce_blocks_product_grid_is_cacheable",
-            "file": "BlockTypes/AbstractProductGrid.php",
-            "type": "filter",
-            "doc": {
-                "description": "Filters whether or not the product grid is cacheable.",
-                "long_description": "",
-                "tags": [
-                    {
-                        "name": "param",
-                        "content": "The list of script dependencies.",
-                        "types": [
-                            "boolean"
-                        ],
-                        "variable": "$is_cacheable"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Query args for the products query passed to BlocksWpQuery.",
-                        "types": [
-                            "array"
-                        ],
-                        "variable": "$query_args"
-                    },
-                    {
-                        "name": "return",
-                        "content": "True to enable cache, false to disable cache.",
-                        "types": [
-                            "array"
-                        ]
-                    }
-                ],
-                "long_description_html": ""
-            },
-            "args": 2
-        },
-        {
-            "name": "woocommerce_blocks_product_grid_item_html",
-            "file": "BlockTypes/AbstractProductGrid.php",
-            "type": "filter",
-            "doc": {
-                "description": "Filters the HTML for products in the grid.",
-                "long_description": "",
-                "tags": [
-                    {
-                        "name": "param",
-                        "content": "Product grid item HTML.",
-                        "types": [
-                            "string"
-                        ],
-                        "variable": "$html"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Product data passed to the template.",
-                        "types": [
-                            "array"
-                        ],
-                        "variable": "$data"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Product object.",
-                        "types": [
-                            "\\WC_Product"
-                        ],
-                        "variable": "$product"
-                    },
-                    {
-                        "name": "return",
-                        "content": "Updated product grid item HTML.",
-                        "types": [
-                            "string"
-                        ]
-                    }
-                ],
-                "long_description_html": ""
-            },
-            "args": 3
-        },
-        {
-            "name": "woocommerce_blocks_register_script_dependencies",
-            "file": "Assets/Api.php",
-            "type": "filter",
-            "doc": {
-                "description": "Filters the list of script dependencies.",
-                "long_description": "",
-                "tags": [
-                    {
-                        "name": "param",
-                        "content": "The list of script dependencies.",
-                        "types": [
-                            "array"
-                        ],
-                        "variable": "$dependencies"
-                    },
-                    {
-                        "name": "param",
-                        "content": "The script's handle.",
-                        "types": [
-                            "string"
-                        ],
-                        "variable": "$handle"
-                    },
-                    {
-                        "name": "return",
-                        "content": "",
-                        "types": [
-                            "array"
-                        ]
-                    }
-                ],
-                "long_description_html": ""
-            },
-            "args": 2
-        },
-        {
-            "name": "woocommerce_cart_contents_changed",
-            "file": "StoreApi/Utilities/CartController.php",
-            "type": "filter",
-            "doc": {
-                "description": "Filters the entire cart contents when the cart changes.",
-                "long_description": "",
-                "tags": [
-                    {
-                        "name": "param",
-                        "content": "Array of all cart items.",
-                        "types": [
-                            "array"
-                        ],
-                        "variable": "$cart_contents"
-                    },
-                    {
-                        "name": "return",
-                        "content": "Updated array of all cart items.",
-                        "types": [
-                            "array"
-                        ]
-                    }
-                ],
-                "long_description_html": ""
-            },
-            "args": 1
-        },
-        {
-            "name": "woocommerce_ga_disable_tracking",
-            "file": "Domain/Services/GoogleAnalytics.php",
-            "type": "filter",
-            "doc": {
-                "description": "Filter to disable Google Analytics tracking.",
-                "long_description": "",
-                "tags": [
-                    {
-                        "name": "param",
-                        "content": "If true, tracking will be disabled.",
-                        "types": [
-                            "boolean"
-                        ],
-                        "variable": "$disable_tracking"
-                    }
-                ],
-                "long_description_html": ""
-            },
-            "args": 1
-        },
-        {
-            "name": "woocommerce_get_item_data",
-            "file": "StoreApi/Schemas/CartItemSchema.php",
-            "type": "filter",
-            "doc": {
-                "description": "Filters cart item data.",
-                "long_description": "Filters the variation option name for custom option slugs.",
-                "tags": [
-                    {
-                        "name": "param",
-                        "content": "Cart item data. Empty by default.",
-                        "types": [
-                            "array"
-                        ],
-                        "variable": "$item_data"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Cart item array.",
-                        "types": [
-                            "array"
-                        ],
-                        "variable": "$cart_item"
-                    },
-                    {
-                        "name": "return",
-                        "content": "",
-                        "types": [
-                            "array"
-                        ]
-                    }
-                ],
-                "long_description_html": "<p>Filters the variation option name for custom option slugs.</p>"
-            },
-            "args": 2
-        },
-        {
-            "name": "woocommerce_new_customer_data",
-            "file": "Domain/Services/CreateAccount.php",
-            "type": "filter",
-            "doc": {
-                "description": "Filters customer data before a customer account is registered.",
-                "long_description": "This hook filters customer data. It allows user data to be changed, for example, username, password, email, first name, last name, and role.",
-                "tags": [
-                    {
-                        "name": "param",
-                        "content": "An array of customer (user) data.",
-                        "types": [
-                            "array"
-                        ],
-                        "variable": "$customer_data"
-                    },
-                    {
-                        "name": "return",
-                        "content": "",
-                        "types": [
-                            "array"
-                        ]
-                    }
-                ],
-                "long_description_html": "<p>This hook filters customer data. It allows user data to be changed, for example, username, password, email, first name, last name, and role.</p>"
-            },
-            "args": 1
-        },
-        {
-            "name": "woocommerce_registration_errors",
-            "file": "Domain/Services/CreateAccount.php",
-            "type": "filter",
-            "doc": {
-                "description": "Filters registration errors before a customer account is registered.",
-                "long_description": "This hook filters registration errors. This can be used to manipulate the array of errors before they are displayed.",
-                "tags": [
-                    {
-                        "name": "param",
-                        "content": "Error object.",
-                        "types": [
-                            "\\WP_Error"
-                        ],
-                        "variable": "$errors"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Customer username.",
-                        "types": [
-                            "string"
-                        ],
-                        "variable": "$username"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Customer email address.",
-                        "types": [
-                            "string"
-                        ],
-                        "variable": "$user_email"
-                    },
-                    {
-                        "name": "return",
-                        "content": "",
-                        "types": [
-                            "\\WP_Error"
-                        ]
-                    }
-                ],
-                "long_description_html": "<p>This hook filters registration errors. This can be used to manipulate the array of errors before they are displayed.</p>"
-            },
-            "args": 3
-        },
-        {
-            "name": "woocommerce_shared_settings",
-            "file": "Assets/AssetDataRegistry.php",
-            "type": "filter",
-            "doc": {
-                "description": "Filters the array of shared settings.",
-                "long_description": "Low level hook for registration of new data late in the cycle. This is deprecated. Instead, use the data api:\n ```php Automattic\\WooCommerce\\Blocks\\Package::container()->get( Automattic\\WooCommerce\\Blocks\\Assets\\AssetDataRegistry::class )->add( $key, $value ) ```",
-                "tags": [
-                    {
-                        "name": "deprecated",
-                        "content": ""
-                    },
-                    {
-                        "name": "param",
-                        "content": "Settings data.",
-                        "types": [
-                            "array"
-                        ],
-                        "variable": "$data"
-                    },
-                    {
-                        "name": "return",
-                        "content": "",
-                        "types": [
-                            "array"
-                        ]
-                    }
-                ],
-                "long_description_html": "<p>Low level hook for registration of new data late in the cycle. This is deprecated. Instead, use the data api:</p> <pre><code class=\"language-php\">Automattic\\WooCommerce\\Blocks\\Package::container()-&gt;get( Automattic\\WooCommerce\\Blocks\\Assets\\AssetDataRegistry::class )-&gt;add( $key, $value )</code></pre>"
-            },
-            "args": 1
-        },
-        {
-            "name": "woocommerce_shipping_package_name",
-            "file": "StoreApi/Utilities/CartController.php",
-            "type": "filter",
-            "doc": {
-                "description": "Filters the shipping package name.",
-                "long_description": "",
-                "tags": [
-                    {
-                        "name": "param",
-                        "content": "Shipping package name.",
-                        "types": [
-                            "string"
-                        ],
-                        "variable": "$shipping_package_name"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Shipping package ID.",
-                        "types": [
-                            "string"
-                        ],
-                        "variable": "$package_id"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Shipping package from WooCommerce.",
-                        "types": [
-                            "array"
-                        ],
-                        "variable": "$package"
-                    },
-                    {
-                        "name": "return",
-                        "content": "Shipping package name.",
-                        "types": [
-                            "string"
-                        ]
-                    }
-                ],
-                "long_description_html": ""
-            },
-            "args": 3
-        },
-        {
-            "name": "woocommerce_show_page_title",
-            "file": "BlockTypes/LegacyTemplate.php",
-            "type": "filter",
-            "doc": {
-                "description": "We need to load the scripts here because when using block templates wp_head() gets run after the block template. As a result we are trying to enqueue required scripts before we have even registered them.",
-                "long_description": "",
-                "tags": [
-                    {
-                        "name": "see",
-                        "content": "",
-                        "refers": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5328#issuecomment-989013447"
-                    }
-                ],
-                "long_description_html": ""
-            },
-            "args": 1
-        },
-        {
-            "name": "woocommerce_store_api_disable_nonce_check",
-            "file": "StoreApi/Routes/AbstractCartRoute.php",
-            "type": "filter",
-            "doc": {
-                "description": "Filters the Store API nonce check.",
-                "long_description": "This can be used to disable the nonce check when testing API endpoints via a REST API client.",
-                "tags": [
-                    {
-                        "name": "param",
-                        "content": "If true, nonce checks will be disabled.",
-                        "types": [
-                            "boolean"
-                        ],
-                        "variable": "$disable_nonce_check"
-                    },
-                    {
-                        "name": "return",
-                        "content": "",
-                        "types": [
-                            "boolean"
-                        ]
-                    }
-                ],
-                "long_description_html": "<p>This can be used to disable the nonce check when testing API endpoints via a REST API client.</p>"
-            },
-            "args": 1
-        },
-        {
-            "name": "woocommerce_store_api_product_quantity_limit",
-            "file": "StoreApi/Utilities/QuantityLimits.php",
-            "type": "filter",
-            "doc": {
-                "description": "Filters the quantity limit for a product being added to the cart via the Store API.",
-                "long_description": "Filters the variation option name for custom option slugs.",
-                "tags": [
-                    {
-                        "name": "param",
-                        "content": "Quantity limit which defaults to 99 unless sold individually.",
-                        "types": [
-                            "integer"
-                        ],
-                        "variable": "$quantity_limit"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Product instance.",
-                        "types": [
-                            "\\WC_Product"
-                        ],
-                        "variable": "$product"
-                    },
-                    {
-                        "name": "return",
-                        "content": "",
-                        "types": [
-                            "integer"
-                        ]
-                    }
-                ],
-                "long_description_html": "<p>Filters the variation option name for custom option slugs.</p>"
-            },
-            "args": 2
-        },
-        {
-            "name": "woocommerce_store_api_product_quantity_{$value_type}",
-            "file": "StoreApi/Utilities/QuantityLimits.php",
-            "type": "filter",
-            "doc": {
-                "description": "Filters the quantity minimum for a cart item in Store API. This allows extensions to control the minimum qty of items already within the cart.",
-                "long_description": "The suffix of the hook will vary depending on the value being filtered. For example, minimum, maximum, multiple_of, editable.",
-                "tags": [
-                    {
-                        "name": "param",
-                        "content": "The value being filtered.",
-                        "types": [
-                            "mixed"
-                        ],
-                        "variable": "$value"
-                    },
-                    {
-                        "name": "param",
-                        "content": "The product object.",
-                        "types": [
-                            "\\WC_Product"
-                        ],
-                        "variable": "$product"
-                    },
-                    {
-                        "name": "param",
-                        "content": "The cart item if the product exists in the cart, or null.",
-                        "types": [
-                            "array",
-                            "null"
-                        ],
-                        "variable": "$cart_item"
-                    },
-                    {
-                        "name": "return",
-                        "content": "",
-                        "types": [
-                            "mixed"
-                        ]
-                    }
-                ],
-                "long_description_html": "<p>The suffix of the hook will vary depending on the value being filtered. For example, minimum, maximum, multiple_of, editable.</p>"
-            },
-            "args": 3
-        },
-        {
-            "name": "woocommerce_variation_option_name",
-            "file": "StoreApi/Schemas/CartItemSchema.php",
-            "type": "filter",
-            "doc": {
-                "description": "Filters the variation option name.",
-                "long_description": "Filters the variation option name for custom option slugs.",
-                "tags": [
-                    {
-                        "name": "param",
-                        "content": "The name to display.",
-                        "types": [
-                            "string"
-                        ],
-                        "variable": "$value"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Unused because this is not a variation taxonomy.",
-                        "types": [
-                            "null"
-                        ],
-                        "variable": "$unused"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Taxonomy or product attribute name.",
-                        "types": [
-                            "string"
-                        ],
-                        "variable": "$taxonomy"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Product data.",
-                        "types": [
-                            "\\WC_Product"
-                        ],
-                        "variable": "$product"
-                    },
-                    {
-                        "name": "return",
-                        "content": "",
-                        "types": [
-                            "string"
-                        ]
-                    }
-                ],
-                "long_description_html": "<p>Filters the variation option name for custom option slugs.</p>"
-            },
-            "args": 4
-        }
-    ]
+	"$schema": "https://raw.githubusercontent.com/johnbillion/wp-hooks-generator/0.7.0/schema.json",
+	"hooks": [
+		{
+			"name": "__experimental_woocommerce_blocks_add_data_attributes_to_block",
+			"file": "BlockTypesController.php",
+			"type": "filter",
+			"doc": {
+				"description": "Filters the list of allowed Block Names",
+				"long_description": "This hook defines which block names should have block name and attribute data- attributes appended on render.",
+				"tags": [
+					{
+						"name": "param",
+						"content": "List of namespaces.",
+						"types": [ "array" ],
+						"variable": "$allowed_namespaces"
+					}
+				],
+				"long_description_html": "<p>This hook defines which block names should have block name and attribute data- attributes appended on render.</p>"
+			},
+			"args": 1
+		},
+		{
+			"name": "__experimental_woocommerce_blocks_add_data_attributes_to_namespace",
+			"file": "BlockTypesController.php",
+			"type": "filter",
+			"doc": {
+				"description": "Filters the list of allowed block namespaces.",
+				"long_description": "This hook defines which block namespaces should have block name and attribute `data-` attributes appended on render.",
+				"tags": [
+					{
+						"name": "param",
+						"content": "List of namespaces.",
+						"types": [ "array" ],
+						"variable": "$allowed_namespaces"
+					}
+				],
+				"long_description_html": "<p>This hook defines which block namespaces should have block name and attribute <code>data-</code> attributes appended on render.</p>"
+			},
+			"args": 1
+		},
+		{
+			"name": "__experimental_woocommerce_blocks_payment_gateway_features_list",
+			"file": "Payments/Integrations/PayPal.php",
+			"type": "filter",
+			"doc": {
+				"description": "Filter to control what features are available for each payment gateway.",
+				"long_description": "",
+				"tags": [
+					{
+						"name": "example",
+						"content": "docs/examples/payment-gateways-features-list.md"
+					},
+					{
+						"name": "param",
+						"content": "List of supported features.",
+						"types": [ "array" ],
+						"variable": "$features"
+					},
+					{
+						"name": "param",
+						"content": "Gateway name.",
+						"types": [ "string" ],
+						"variable": "$name"
+					},
+					{
+						"name": "return",
+						"content": "Updated list of supported features.",
+						"types": [ "array" ]
+					}
+				],
+				"long_description_html": ""
+			},
+			"args": 2
+		},
+		{
+			"name": "woocommerce_add_cart_item",
+			"file": "StoreApi/Utilities/CartController.php",
+			"type": "filter",
+			"doc": {
+				"description": "Filters the item being added to the cart.",
+				"long_description": "",
+				"tags": [
+					{
+						"name": "param",
+						"content": "Array of cart item data being added to the cart.",
+						"types": [ "array" ],
+						"variable": "$cart_item_data"
+					},
+					{
+						"name": "param",
+						"content": "Id of the item in the cart.",
+						"types": [ "string" ],
+						"variable": "$cart_id"
+					},
+					{
+						"name": "return",
+						"content": "Updated cart item data.",
+						"types": [ "array" ]
+					}
+				],
+				"long_description_html": ""
+			},
+			"args": 2
+		},
+		{
+			"name": "woocommerce_add_cart_item_data",
+			"file": "StoreApi/Utilities/CartController.php",
+			"type": "filter",
+			"doc": {
+				"description": "Filter cart item data for add to cart requests.",
+				"long_description": "",
+				"tags": [
+					{
+						"name": "param",
+						"content": "Array of other cart item data.",
+						"types": [ "array" ],
+						"variable": "$cart_item_data"
+					},
+					{
+						"name": "param",
+						"content": "ID of the product added to the cart.",
+						"types": [ "integer" ],
+						"variable": "$product_id"
+					},
+					{
+						"name": "param",
+						"content": "Variation ID of the product added to the cart.",
+						"types": [ "integer" ],
+						"variable": "$variation_id"
+					},
+					{
+						"name": "param",
+						"content": "Quantity of the item added to the cart.",
+						"types": [ "integer" ],
+						"variable": "$quantity"
+					},
+					{
+						"name": "return",
+						"content": "",
+						"types": [ "array" ]
+					}
+				],
+				"long_description_html": ""
+			},
+			"args": 4
+		},
+		{
+			"name": "woocommerce_add_to_cart_sold_individually_quantity",
+			"file": "StoreApi/Utilities/CartController.php",
+			"type": "filter",
+			"doc": {
+				"description": "Filter sold individually quantity for add to cart requests.",
+				"long_description": "",
+				"tags": [
+					{
+						"name": "param",
+						"content": "Defaults to 1.",
+						"types": [ "integer" ],
+						"variable": "$sold_individually_quantity"
+					},
+					{
+						"name": "param",
+						"content": "Quantity of the item added to the cart.",
+						"types": [ "integer" ],
+						"variable": "$quantity"
+					},
+					{
+						"name": "param",
+						"content": "ID of the product added to the cart.",
+						"types": [ "integer" ],
+						"variable": "$product_id"
+					},
+					{
+						"name": "param",
+						"content": "Variation ID of the product added to the cart.",
+						"types": [ "integer" ],
+						"variable": "$variation_id"
+					},
+					{
+						"name": "param",
+						"content": "Array of other cart item data.",
+						"types": [ "array" ],
+						"variable": "$cart_item_data"
+					},
+					{
+						"name": "return",
+						"content": "",
+						"types": [ "integer" ]
+					}
+				],
+				"long_description_html": ""
+			},
+			"args": 5
+		},
+		{
+			"name": "woocommerce_add_to_cart_validation",
+			"file": "StoreApi/Utilities/CartController.php",
+			"type": "filter",
+			"doc": {
+				"description": "Filters if an item being added to the cart passed validation checks.",
+				"long_description": "Allow 3rd parties to validate if an item can be added to the cart. This is a legacy hook from Woo core. This filter will be deprecated because it encourages usage of wc_add_notice. For the API we need to capture notices and convert to exceptions instead.",
+				"tags": [
+					{
+						"name": "deprecated",
+						"content": ""
+					},
+					{
+						"name": "param",
+						"content": "True if the item passed validation.",
+						"types": [ "boolean" ],
+						"variable": "$passed_validation"
+					},
+					{
+						"name": "param",
+						"content": "Product ID being validated.",
+						"types": [ "integer" ],
+						"variable": "$product_id"
+					},
+					{
+						"name": "param",
+						"content": "Quantity added to the cart.",
+						"types": [ "integer" ],
+						"variable": "$quantity"
+					},
+					{
+						"name": "param",
+						"content": "Variation ID being added to the cart.",
+						"types": [ "integer" ],
+						"variable": "$variation_id"
+					},
+					{
+						"name": "param",
+						"content": "Variation data.",
+						"types": [ "array" ],
+						"variable": "$variation"
+					},
+					{
+						"name": "return",
+						"content": "",
+						"types": [ "boolean" ]
+					}
+				],
+				"long_description_html": "<p>Allow 3rd parties to validate if an item can be added to the cart. This is a legacy hook from Woo core. This filter will be deprecated because it encourages usage of wc_add_notice. For the API we need to capture notices and convert to exceptions instead.</p>"
+			},
+			"args": 5
+		},
+		{
+			"name": "woocommerce_adjust_non_base_location_prices",
+			"file": "StoreApi/Utilities/ProductQuery.php",
+			"type": "filter",
+			"doc": {
+				"description": "Filters if taxes should be removed from locations outside the store base location.",
+				"long_description": "The woocommerce_adjust_non_base_location_prices filter can stop base taxes being taken off when dealing with out of base locations. e.g. If a product costs 10 including tax, all users will pay 10 regardless of location and taxes.",
+				"tags": [
+					{
+						"name": "param",
+						"content": "True by default.",
+						"types": [ "boolean" ],
+						"variable": "$adjust_non_base_location_prices"
+					},
+					{
+						"name": "return",
+						"content": "",
+						"types": [ "boolean" ]
+					}
+				],
+				"long_description_html": "<p>The woocommerce_adjust_non_base_location_prices filter can stop base taxes being taken off when dealing with out of base locations. e.g. If a product costs 10 including tax, all users will pay 10 regardless of location and taxes.</p>"
+			},
+			"args": 1
+		},
+		{
+			"name": "woocommerce_apply_individual_use_coupon",
+			"file": "StoreApi/Utilities/CartController.php",
+			"type": "filter",
+			"doc": {
+				"description": "Filter coupons to remove when applying an individual use coupon.",
+				"long_description": "",
+				"tags": [
+					{
+						"name": "param",
+						"content": "Array of coupons to remove from the cart.",
+						"types": [ "array" ],
+						"variable": "$coupons"
+					},
+					{
+						"name": "param",
+						"content": "Coupon object applied to the cart.",
+						"types": [ "\\WC_Coupon" ],
+						"variable": "$coupon"
+					},
+					{
+						"name": "param",
+						"content": "Array of applied coupons already applied to the cart.",
+						"types": [ "array" ],
+						"variable": "$applied_coupons"
+					},
+					{
+						"name": "return",
+						"content": "",
+						"types": [ "array" ]
+					}
+				],
+				"long_description_html": ""
+			},
+			"args": 3
+		},
+		{
+			"name": "woocommerce_apply_with_individual_use_coupon",
+			"file": "StoreApi/Utilities/CartController.php",
+			"type": "filter",
+			"doc": {
+				"description": "Filters if a coupon can be applied alongside other individual use coupons.",
+				"long_description": "",
+				"tags": [
+					{
+						"name": "param",
+						"content": "Defaults to false.",
+						"types": [ "boolean" ],
+						"variable": "$apply_with_individual_use_coupon"
+					},
+					{
+						"name": "param",
+						"content": "Coupon object applied to the cart.",
+						"types": [ "\\WC_Coupon" ],
+						"variable": "$coupon"
+					},
+					{
+						"name": "param",
+						"content": "Individual use coupon already applied to the cart.",
+						"types": [ "\\WC_Coupon" ],
+						"variable": "$individual_use_coupon"
+					},
+					{
+						"name": "param",
+						"content": "Array of applied coupons already applied to the cart.",
+						"types": [ "array" ],
+						"variable": "$applied_coupons"
+					},
+					{
+						"name": "return",
+						"content": "",
+						"types": [ "boolean" ]
+					}
+				],
+				"long_description_html": ""
+			},
+			"args": 4
+		},
+		{
+			"name": "woocommerce_blocks_product_grid_is_cacheable",
+			"file": "BlockTypes/AbstractProductGrid.php",
+			"type": "filter",
+			"doc": {
+				"description": "Filters whether or not the product grid is cacheable.",
+				"long_description": "",
+				"tags": [
+					{
+						"name": "param",
+						"content": "The list of script dependencies.",
+						"types": [ "boolean" ],
+						"variable": "$is_cacheable"
+					},
+					{
+						"name": "param",
+						"content": "Query args for the products query passed to BlocksWpQuery.",
+						"types": [ "array" ],
+						"variable": "$query_args"
+					},
+					{
+						"name": "return",
+						"content": "True to enable cache, false to disable cache.",
+						"types": [ "array" ]
+					}
+				],
+				"long_description_html": ""
+			},
+			"args": 2
+		},
+		{
+			"name": "woocommerce_blocks_product_grid_item_html",
+			"file": "BlockTypes/AbstractProductGrid.php",
+			"type": "filter",
+			"doc": {
+				"description": "Filters the HTML for products in the grid.",
+				"long_description": "",
+				"tags": [
+					{
+						"name": "param",
+						"content": "Product grid item HTML.",
+						"types": [ "string" ],
+						"variable": "$html"
+					},
+					{
+						"name": "param",
+						"content": "Product data passed to the template.",
+						"types": [ "array" ],
+						"variable": "$data"
+					},
+					{
+						"name": "param",
+						"content": "Product object.",
+						"types": [ "\\WC_Product" ],
+						"variable": "$product"
+					},
+					{
+						"name": "return",
+						"content": "Updated product grid item HTML.",
+						"types": [ "string" ]
+					}
+				],
+				"long_description_html": ""
+			},
+			"args": 3
+		},
+		{
+			"name": "woocommerce_blocks_register_script_dependencies",
+			"file": "Assets/Api.php",
+			"type": "filter",
+			"doc": {
+				"description": "Filters the list of script dependencies.",
+				"long_description": "",
+				"tags": [
+					{
+						"name": "param",
+						"content": "The list of script dependencies.",
+						"types": [ "array" ],
+						"variable": "$dependencies"
+					},
+					{
+						"name": "param",
+						"content": "The script's handle.",
+						"types": [ "string" ],
+						"variable": "$handle"
+					},
+					{
+						"name": "return",
+						"content": "",
+						"types": [ "array" ]
+					}
+				],
+				"long_description_html": ""
+			},
+			"args": 2
+		},
+		{
+			"name": "woocommerce_cart_contents_changed",
+			"file": "StoreApi/Utilities/CartController.php",
+			"type": "filter",
+			"doc": {
+				"description": "Filters the entire cart contents when the cart changes.",
+				"long_description": "",
+				"tags": [
+					{
+						"name": "param",
+						"content": "Array of all cart items.",
+						"types": [ "array" ],
+						"variable": "$cart_contents"
+					},
+					{
+						"name": "return",
+						"content": "Updated array of all cart items.",
+						"types": [ "array" ]
+					}
+				],
+				"long_description_html": ""
+			},
+			"args": 1
+		},
+		{
+			"name": "woocommerce_ga_disable_tracking",
+			"file": "Domain/Services/GoogleAnalytics.php",
+			"type": "filter",
+			"doc": {
+				"description": "Filter to disable Google Analytics tracking.",
+				"long_description": "",
+				"tags": [
+					{
+						"name": "param",
+						"content": "If true, tracking will be disabled.",
+						"types": [ "boolean" ],
+						"variable": "$disable_tracking"
+					}
+				],
+				"long_description_html": ""
+			},
+			"args": 1
+		},
+		{
+			"name": "woocommerce_get_item_data",
+			"file": "StoreApi/Schemas/CartItemSchema.php",
+			"type": "filter",
+			"doc": {
+				"description": "Filters cart item data.",
+				"long_description": "Filters the variation option name for custom option slugs.",
+				"tags": [
+					{
+						"name": "param",
+						"content": "Cart item data. Empty by default.",
+						"types": [ "array" ],
+						"variable": "$item_data"
+					},
+					{
+						"name": "param",
+						"content": "Cart item array.",
+						"types": [ "array" ],
+						"variable": "$cart_item"
+					},
+					{
+						"name": "return",
+						"content": "",
+						"types": [ "array" ]
+					}
+				],
+				"long_description_html": "<p>Filters the variation option name for custom option slugs.</p>"
+			},
+			"args": 2
+		},
+		{
+			"name": "woocommerce_new_customer_data",
+			"file": "Domain/Services/CreateAccount.php",
+			"type": "filter",
+			"doc": {
+				"description": "Filters customer data before a customer account is registered.",
+				"long_description": "This hook filters customer data. It allows user data to be changed, for example, username, password, email, first name, last name, and role.",
+				"tags": [
+					{
+						"name": "param",
+						"content": "An array of customer (user) data.",
+						"types": [ "array" ],
+						"variable": "$customer_data"
+					},
+					{
+						"name": "return",
+						"content": "",
+						"types": [ "array" ]
+					}
+				],
+				"long_description_html": "<p>This hook filters customer data. It allows user data to be changed, for example, username, password, email, first name, last name, and role.</p>"
+			},
+			"args": 1
+		},
+		{
+			"name": "woocommerce_registration_errors",
+			"file": "Domain/Services/CreateAccount.php",
+			"type": "filter",
+			"doc": {
+				"description": "Filters registration errors before a customer account is registered.",
+				"long_description": "This hook filters registration errors. This can be used to manipulate the array of errors before they are displayed.",
+				"tags": [
+					{
+						"name": "param",
+						"content": "Error object.",
+						"types": [ "\\WP_Error" ],
+						"variable": "$errors"
+					},
+					{
+						"name": "param",
+						"content": "Customer username.",
+						"types": [ "string" ],
+						"variable": "$username"
+					},
+					{
+						"name": "param",
+						"content": "Customer email address.",
+						"types": [ "string" ],
+						"variable": "$user_email"
+					},
+					{
+						"name": "return",
+						"content": "",
+						"types": [ "\\WP_Error" ]
+					}
+				],
+				"long_description_html": "<p>This hook filters registration errors. This can be used to manipulate the array of errors before they are displayed.</p>"
+			},
+			"args": 3
+		},
+		{
+			"name": "woocommerce_shared_settings",
+			"file": "Assets/AssetDataRegistry.php",
+			"type": "filter",
+			"doc": {
+				"description": "Filters the array of shared settings.",
+				"long_description": "Low level hook for registration of new data late in the cycle. This is deprecated. Instead, use the data api:\n ```php Automattic\\WooCommerce\\Blocks\\Package::container()->get( Automattic\\WooCommerce\\Blocks\\Assets\\AssetDataRegistry::class )->add( $key, $value ) ```",
+				"tags": [
+					{
+						"name": "deprecated",
+						"content": ""
+					},
+					{
+						"name": "param",
+						"content": "Settings data.",
+						"types": [ "array" ],
+						"variable": "$data"
+					},
+					{
+						"name": "return",
+						"content": "",
+						"types": [ "array" ]
+					}
+				],
+				"long_description_html": "<p>Low level hook for registration of new data late in the cycle. This is deprecated. Instead, use the data api:</p> <pre><code class=\"language-php\">Automattic\\WooCommerce\\Blocks\\Package::container()-&gt;get( Automattic\\WooCommerce\\Blocks\\Assets\\AssetDataRegistry::class )-&gt;add( $key, $value )</code></pre>"
+			},
+			"args": 1
+		},
+		{
+			"name": "woocommerce_shipping_package_name",
+			"file": "StoreApi/Utilities/CartController.php",
+			"type": "filter",
+			"doc": {
+				"description": "Filters the shipping package name.",
+				"long_description": "",
+				"tags": [
+					{
+						"name": "param",
+						"content": "Shipping package name.",
+						"types": [ "string" ],
+						"variable": "$shipping_package_name"
+					},
+					{
+						"name": "param",
+						"content": "Shipping package ID.",
+						"types": [ "string" ],
+						"variable": "$package_id"
+					},
+					{
+						"name": "param",
+						"content": "Shipping package from WooCommerce.",
+						"types": [ "array" ],
+						"variable": "$package"
+					},
+					{
+						"name": "return",
+						"content": "Shipping package name.",
+						"types": [ "string" ]
+					}
+				],
+				"long_description_html": ""
+			},
+			"args": 3
+		},
+		{
+			"name": "woocommerce_show_page_title",
+			"file": "BlockTypes/LegacyTemplate.php",
+			"type": "filter",
+			"doc": {
+				"description": "We need to load the scripts here because when using block templates wp_head() gets run after the block template. As a result we are trying to enqueue required scripts before we have even registered them.",
+				"long_description": "",
+				"tags": [
+					{
+						"name": "see",
+						"content": "",
+						"refers": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5328#issuecomment-989013447"
+					}
+				],
+				"long_description_html": ""
+			},
+			"args": 1
+		},
+		{
+			"name": "woocommerce_store_api_disable_nonce_check",
+			"file": "StoreApi/Routes/AbstractCartRoute.php",
+			"type": "filter",
+			"doc": {
+				"description": "Filters the Store API nonce check.",
+				"long_description": "This can be used to disable the nonce check when testing API endpoints via a REST API client.",
+				"tags": [
+					{
+						"name": "param",
+						"content": "If true, nonce checks will be disabled.",
+						"types": [ "boolean" ],
+						"variable": "$disable_nonce_check"
+					},
+					{
+						"name": "return",
+						"content": "",
+						"types": [ "boolean" ]
+					}
+				],
+				"long_description_html": "<p>This can be used to disable the nonce check when testing API endpoints via a REST API client.</p>"
+			},
+			"args": 1
+		},
+		{
+			"name": "woocommerce_store_api_product_quantity_limit",
+			"file": "StoreApi/Utilities/QuantityLimits.php",
+			"type": "filter",
+			"doc": {
+				"description": "Filters the quantity limit for a product being added to the cart via the Store API.",
+				"long_description": "Filters the variation option name for custom option slugs.",
+				"tags": [
+					{
+						"name": "param",
+						"content": "Quantity limit which defaults to 99 unless sold individually.",
+						"types": [ "integer" ],
+						"variable": "$quantity_limit"
+					},
+					{
+						"name": "param",
+						"content": "Product instance.",
+						"types": [ "\\WC_Product" ],
+						"variable": "$product"
+					},
+					{
+						"name": "return",
+						"content": "",
+						"types": [ "integer" ]
+					}
+				],
+				"long_description_html": "<p>Filters the variation option name for custom option slugs.</p>"
+			},
+			"args": 2
+		},
+		{
+			"name": "woocommerce_store_api_product_quantity_{$value_type}",
+			"file": "StoreApi/Utilities/QuantityLimits.php",
+			"type": "filter",
+			"doc": {
+				"description": "Filters the quantity minimum for a cart item in Store API. This allows extensions to control the minimum qty of items already within the cart.",
+				"long_description": "The suffix of the hook will vary depending on the value being filtered. For example, minimum, maximum, multiple_of, editable.",
+				"tags": [
+					{
+						"name": "param",
+						"content": "The value being filtered.",
+						"types": [ "mixed" ],
+						"variable": "$value"
+					},
+					{
+						"name": "param",
+						"content": "The product object.",
+						"types": [ "\\WC_Product" ],
+						"variable": "$product"
+					},
+					{
+						"name": "param",
+						"content": "The cart item if the product exists in the cart, or null.",
+						"types": [ "array", "null" ],
+						"variable": "$cart_item"
+					},
+					{
+						"name": "return",
+						"content": "",
+						"types": [ "mixed" ]
+					}
+				],
+				"long_description_html": "<p>The suffix of the hook will vary depending on the value being filtered. For example, minimum, maximum, multiple_of, editable.</p>"
+			},
+			"args": 3
+		},
+		{
+			"name": "woocommerce_variation_option_name",
+			"file": "StoreApi/Schemas/CartItemSchema.php",
+			"type": "filter",
+			"doc": {
+				"description": "Filters the variation option name.",
+				"long_description": "Filters the variation option name for custom option slugs.",
+				"tags": [
+					{
+						"name": "param",
+						"content": "The name to display.",
+						"types": [ "string" ],
+						"variable": "$value"
+					},
+					{
+						"name": "param",
+						"content": "Unused because this is not a variation taxonomy.",
+						"types": [ "null" ],
+						"variable": "$unused"
+					},
+					{
+						"name": "param",
+						"content": "Taxonomy or product attribute name.",
+						"types": [ "string" ],
+						"variable": "$taxonomy"
+					},
+					{
+						"name": "param",
+						"content": "Product data.",
+						"types": [ "\\WC_Product" ],
+						"variable": "$product"
+					},
+					{
+						"name": "return",
+						"content": "",
+						"types": [ "string" ]
+					}
+				],
+				"long_description_html": "<p>Filters the variation option name for custom option slugs.</p>"
+			},
+			"args": 4
+		}
+	]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,10 @@
 	"labels": [ "type: dependencies", "skip-changelog" ],
 	"packageRules": [
 		{
-			"packageNames": [ "automattic/jetpack-autoloader", "composer/installers" ],
+			"packageNames": [
+				"automattic/jetpack-autoloader",
+				"composer/installers"
+			],
 			"rangeStrategy": "bump"
 		},
 		{

--- a/tests/e2e/config/custom-matchers/__fixtures__/best-selling-products.fixture.json
+++ b/tests/e2e/config/custom-matchers/__fixtures__/best-selling-products.fixture.json
@@ -1,1 +1,4 @@
-{"title":"Best Selling Products Block","pageContent":"<!-- wp:woocommerce/product-best-sellers /-->"}
+{
+	"title": "Best Selling Products Block",
+	"pageContent": "<!-- wp:woocommerce/product-best-sellers /-->"
+}

--- a/tests/e2e/config/custom-matchers/__fixtures__/featured-category.fixture.json
+++ b/tests/e2e/config/custom-matchers/__fixtures__/featured-category.fixture.json
@@ -1,1 +1,4 @@
-{"title":"Featured Category Block","pageContent":"<!-- wp:woocommerce/featured-category /-->"}
+{
+	"title": "Featured Category Block",
+	"pageContent": "<!-- wp:woocommerce/featured-category /-->"
+}

--- a/tests/e2e/config/custom-matchers/__fixtures__/hand-picked-products.fixture.json
+++ b/tests/e2e/config/custom-matchers/__fixtures__/hand-picked-products.fixture.json
@@ -1,1 +1,4 @@
-{"title":"Hand-picked Products Block","pageContent":"<!-- wp:woocommerce/handpicked-products /-->"}
+{
+	"title": "Hand-picked Products Block",
+	"pageContent": "<!-- wp:woocommerce/handpicked-products /-->"
+}

--- a/tests/e2e/config/custom-matchers/__fixtures__/newest-products.fixture.json
+++ b/tests/e2e/config/custom-matchers/__fixtures__/newest-products.fixture.json
@@ -1,1 +1,4 @@
-{"title":"Newest Products Block","pageContent":"<!-- wp:woocommerce/product-new /-->"}
+{
+	"title": "Newest Products Block",
+	"pageContent": "<!-- wp:woocommerce/product-new /-->"
+}

--- a/tests/e2e/config/custom-matchers/__fixtures__/product-categories-list.fixture.json
+++ b/tests/e2e/config/custom-matchers/__fixtures__/product-categories-list.fixture.json
@@ -1,1 +1,4 @@
-{"title":"Product Categories List Block","pageContent":"<!-- wp:woocommerce/product-categories /-->"}
+{
+	"title": "Product Categories List Block",
+	"pageContent": "<!-- wp:woocommerce/product-categories /-->"
+}

--- a/tests/e2e/config/custom-matchers/__fixtures__/top-rated-products.fixture.json
+++ b/tests/e2e/config/custom-matchers/__fixtures__/top-rated-products.fixture.json
@@ -1,1 +1,4 @@
-{"title":"Top Rated Products Block","pageContent":"<!-- wp:woocommerce/product-top-rated /-->"}
+{
+	"title": "Top Rated Products Block",
+	"pageContent": "<!-- wp:woocommerce/product-top-rated /-->"
+}

--- a/tests/js/jest.config.json
+++ b/tests/js/jest.config.json
@@ -51,5 +51,5 @@
 		"^.+\\.(js|ts|tsx)$": "<rootDir>/tests/js/jestPreprocess.js"
 	},
 	"verbose": true,
-	"moduleFileExtensions": ["js", "jsx", "ts", "tsx", "json", "node"]
+	"moduleFileExtensions": [ "js", "jsx", "ts", "tsx", "json", "node" ]
 }


### PR DESCRIPTION
A lot of people have been having problems with `prettier` errors on the pre-commit hook. I ran `npm run reformat-files` and it looks like a few files weren't formatted properly so I've committed the formatting changes here. 


It would  be useful if a few people could check this to make sure i doesn't cause any problems for anyone. 

To test: 
1. Checkout the branch
2. Run `npm install`
3. Make a commit anywhere in `js/assets` folder.
4. You should not get any prettier or es-lint errors.

