### PR TITLE
Mini Cart Block contents: Remove item border bottom

### DIFF
--- a/assets/js/blocks/cart-checkout/cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/style.scss
@@ -179,7 +179,6 @@ table.wc-block-cart-items {
 			display: none;
 		}
 		.wc-block-cart-items__row {
-			@include with-translucent-border( 0 0 1px );
 			display: grid;
 			grid-template-columns: 80px 132px;
 			padding: $gap 0;
@@ -262,6 +261,18 @@ table.wc-block-cart-items {
 
 	.wc-block-cart__payment-options {
 		padding: $gap 0 0;
+	}
+}
+
+// Remove the border from cart items inside the Mini Cart drawer
+// https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5679
+.is-medium,
+.is-small,
+.is-mobile:not(.wc-block-mini-cart__drawer) {
+	table.wc-block-cart-items {
+		.wc-block-cart-items__row {
+			@include with-translucent-border( 0 0 1px );
+		}
 	}
 }
 

--- a/assets/js/blocks/cart-checkout/cart/style.scss
+++ b/assets/js/blocks/cart-checkout/cart/style.scss
@@ -178,6 +178,11 @@ table.wc-block-cart-items {
 		.wc-block-cart-item__remove-link {
 			display: none;
 		}
+		&:not(.wc-block-mini-cart-items) {
+			.wc-block-cart-items__row {
+				@include with-translucent-border( 0 0 1px );
+			}
+		}
 		.wc-block-cart-items__row {
 			display: grid;
 			grid-template-columns: 80px 132px;
@@ -261,18 +266,6 @@ table.wc-block-cart-items {
 
 	.wc-block-cart__payment-options {
 		padding: $gap 0 0;
-	}
-}
-
-// Remove the border from cart items inside the Mini Cart drawer
-// https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5679
-.is-medium,
-.is-small,
-.is-mobile:not(.wc-block-mini-cart__drawer) {
-	table.wc-block-cart-items {
-		.wc-block-cart-items__row {
-			@include with-translucent-border( 0 0 1px );
-		}
 	}
 }
 

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-products-table-block/block.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-products-table-block/block.tsx
@@ -15,6 +15,7 @@ const Block = (): JSX.Element => {
 			<CartLineItemsTable
 				lineItems={ cartItems }
 				isLoading={ cartIsLoading }
+				className="wc-block-mini-cart-items"
 			/>
 		</div>
 	);

--- a/assets/js/blocks/cart-checkout/mini-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/mini-cart/style.scss
@@ -112,10 +112,6 @@ h2.wc-block-mini-cart__title {
 			padding-top: $gap-smaller;
 			padding-bottom: $gap-smaller;
 
-			&::after {
-				border-bottom-width: 0 !important;
-			}
-
 			&:last-child::after {
 				content: none;
 			}

--- a/assets/js/blocks/cart-checkout/mini-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/mini-cart/style.scss
@@ -100,7 +100,7 @@ h2.wc-block-mini-cart__title {
 	flex-direction: column;
 	flex-grow: 1;
 	overflow-y: hidden;
-	padding: 0 $gap;
+	padding: $gap $gap 0;
 
 	.wc-block-mini-cart__products-table {
 		margin-bottom: auto;
@@ -108,8 +108,17 @@ h2.wc-block-mini-cart__title {
 		overflow-y: auto;
 		padding-right: $gap;
 
-		.wc-block-cart-items__row:last-child::after {
-			content: none;
+		.wc-block-cart-items__row {
+			padding-top: $gap-smaller;
+			padding-bottom: $gap-smaller;
+
+			&::after {
+				border-bottom-width: 0 !important;
+			}
+
+			&:last-child::after {
+				content: none;
+			}
 		}
 	}
 }


### PR DESCRIPTION
Remove the item border-bottom, inside of the Mini Cart block contents.

I'm not a huge fan of using `!important` but didn't see a clean way to overwrite the core styles.

<!-- Reference any related issues or PRs here -->
Fixes #5679 

### Screenshots

Before:
<img width="1304" alt="Products_–_kirigami" src="https://user-images.githubusercontent.com/905781/152891863-0d663064-12ae-476b-a13d-9f032a7e91a4.png">

After:
<img width="1307" alt="Products_–_kirigami" src="https://user-images.githubusercontent.com/905781/152891776-c505c811-5a62-4fcd-a6bb-ed545c9885a7.png">

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Active `Storefront` theme and add the Mini Cart Block as a widget.
2. Go on `/shop` page and add a product.
3. Confirm that the flyout mini cart items don't have a border

### User Facing Testing

* [x] Same as above

