### PR TITLE
Fix Mini Cart doesn't update data 

### DIFF
--- a/assets/js/base/context/providers/add-to-cart-form/form/submit/index.js
+++ b/assets/js/base/context/providers/add-to-cart-form/form/submit/index.js
@@ -13,6 +13,7 @@ import { useAddToCartFormContext } from '../../form-state';
 import { useValidationContext } from '../../../validation';
 import { useStoreCart } from '../../../../hooks/cart/use-store-cart';
 import { useStoreNotices } from '../../../../hooks/use-store-notices';
+import { triggerAddedToCartEvent } from '@woocommerce/base-utils';
 
 /**
  * FormSubmit.
@@ -107,6 +108,7 @@ const FormSubmit = () => {
 					} else {
 						receiveCart( response );
 					}
+					triggerAddedToCartEvent( { preserveCartData: true } );
 					dispatchActions.setAfterProcessing( response );
 					setIsSubmitting( false );
 				} );

--- a/assets/js/base/context/providers/add-to-cart-form/form/submit/index.js
+++ b/assets/js/base/context/providers/add-to-cart-form/form/submit/index.js
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import triggerFetch from '@wordpress/api-fetch';
 import { useEffect, useCallback, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
+import { triggerAddedToCartEvent } from '@woocommerce/base-utils';
 
 /**
  * Internal dependencies
@@ -13,7 +14,6 @@ import { useAddToCartFormContext } from '../../form-state';
 import { useValidationContext } from '../../../validation';
 import { useStoreCart } from '../../../../hooks/cart/use-store-cart';
 import { useStoreNotices } from '../../../../hooks/use-store-notices';
-import { triggerAddedToCartEvent } from '@woocommerce/base-utils';
 
 /**
  * FormSubmit.

--- a/src/BlockTypes/AllProducts.php
+++ b/src/BlockTypes/AllProducts.php
@@ -27,6 +27,7 @@ class AllProducts extends AbstractBlock {
 		$this->asset_data_registry->add( 'min_rows', wc_get_theme_support( 'product_blocks::min_rows', 1 ), true );
 		$this->asset_data_registry->add( 'max_rows', wc_get_theme_support( 'product_blocks::max_rows', 6 ), true );
 		$this->asset_data_registry->add( 'default_rows', wc_get_theme_support( 'product_blocks::default_rows', 3 ), true );
+		$this->hydrate_from_api();
 	}
 
 	/**

--- a/src/BlockTypes/AllProducts.php
+++ b/src/BlockTypes/AllProducts.php
@@ -30,6 +30,13 @@ class AllProducts extends AbstractBlock {
 	}
 
 	/**
+	 * Hydrate the All Product block with data from the API.
+	 */
+	protected function hydrate_from_api() {
+		$this->asset_data_registry->hydrate_api_request( '/wc/store/cart' );
+	}
+
+	/**
 	 * Register script and style assets for the block type before it is registered.
 	 *
 	 * This registers the scripts; it does not enqueue them.

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -107,8 +107,6 @@ class MiniCart extends AbstractBlock {
 
 		// Hydrate the following data depending on admin or frontend context.
 		if ( ! is_admin() && ! WC()->is_rest_api_request() ) {
-			$this->hydrate_from_api();
-
 			$label_info = $this->get_tax_label();
 
 			$this->tax_label                         = $label_info['tax_label'];

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -210,13 +210,6 @@ class MiniCart extends AbstractBlock {
 	}
 
 	/**
-	 * Hydrate the cart block with data from the API.
-	 */
-	protected function hydrate_from_api() {
-		$this->asset_data_registry->hydrate_api_request( '/wc/store/cart' );
-	}
-
-	/**
 	 * Returns the script data given its handle.
 	 *
 	 * @param string $handle Handle of the script.

--- a/src/BlockTypes/SingleProduct.php
+++ b/src/BlockTypes/SingleProduct.php
@@ -39,11 +39,12 @@ class SingleProduct extends AbstractBlock {
 	}
 
 	/**
-	 * Hydrate the cart block with data from the API.
+	 * Hydrate the Single Product block with data from the API.
 	 *
 	 * @param int $product_id ID of the product.
 	 */
 	protected function hydrate_from_api( int $product_id ) {
 		$this->asset_data_registry->hydrate_api_request( "/wc/store/products/$product_id" );
+		$this->asset_data_registry->hydrate_api_request( '/wc/store/cart' );
 	}
 }


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

This PR removes API hydration for the Mini Cart block. This is because when the user opens the mini cart should have always the last data from the backend.

I noticed that removing the API hydration even if the Mini Cart block didn't open, the client did fetch requests to `/wc/store/cart`. This happened when I did some tests with `Single Product` and `All Product` blocks. Obviously, this is the wrong behavior because we wanted to prevent doing requests if we could avoid them.

I discovered that the provider `StoreNoticesProvider` triggers the fetch request to `/wc/store/cart` due to `useStoreEvent` hook that call `useStoreCart` hook (https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/51d7eaef4ed7f122698466249e47ab72ddeccc01/assets/js/base/context/providers/store-notices/context.js/#L66)

`StoreNoticesProvider` is used by `Single Product` and `All Product` blocks. So I added API hydration for these two blocks.

I guess that we should refactor `useStoreEvent` hook to avoid this problem for the next blocks.


<!-- Reference any related issues or PRs here -->
Fixes #5729


### Testing
### Manual Testing

How to test the changes in this Pull Request:

Check out this branch

1. Active `StoreFront` theme and add `Mini Cart` block as a widget.
2. Create two pages/posts with `Single Product` block and the other one with `All Product` block. Save them.
3. Check that the cart is empty.
4. Go on `/shop` page and add a product.
5. Check that the Mini Cart updates correctly.
6. Empty the cart. 
7. Open the network tab from Dev Tools.
8. Go on the created pages/post and check that the browser doesn't fetch `/wc/store/cart`
9. Add a product for both pages and check that the Mini Cart updates correctly.

