### PR TITLE
Fix inconsistent spacing for checkout input fields

### DIFF
--- a/assets/js/base/components/text-input/style.scss
+++ b/assets/js/base/components/text-input/style.scss
@@ -111,6 +111,6 @@
 	}
 
 	&:only-child {
-		margin-top: 0;
+		margin-top: 1.5em;
 	}
 }


### PR DESCRIPTION
## Issue details

This PR is intended to fix this issue #5699

When displaying the `Create an account?` checkbox, the email address input field gets pushed down.

## Steps to reproduce

- Go to WooCommerce > Settings > Accounts & Privacy > Account creation > Check - Allow customers to create an account during checkout.
- Create a page and add the checkout block to it.
- Click on the email address input field.
- Enable the option `Allow shoppers to sign up for a user account during checkout` from the sidebar section.
- Notice that the email address input field gets pushed down when the checkbox becomes visible.

## Screen recording (Before)

![Screen Capture on 2022-02-02 at 14-07-43](https://user-images.githubusercontent.com/3323310/152109415-7dece974-5c66-4aac-8995-a1607a799e2d.gif)

## Expected behaviour

When displaying the `Create an account?` checkbox, the email address input field should not move.

## Screen recording (After)


https://user-images.githubusercontent.com/11503784/153187044-1446443e-6da0-474d-a140-f385b9458ad2.mov





### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
 
### Manual Testing

How to test the changes in this Pull Request:

1. Go to WooCommerce > Settings > Accounts & Privacy > Account creation > Check - Allow customers to create an account during checkout.
2. Create a page and add the checkout block to it.
3. Click on the email address input field.
4. Enable the option `Allow shoppers to sign up for a user account during checkout` from the sidebar section.
6. When displaying the `Create an account?` checkbox, the email address input field should not move.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above

### Changelog

> Fix a CSS issue with the checkout block to have consistent spacing for a checkout input field. 