### PR TITLE
Set focus on Empty Mini Cart Contents Block

### DIFF
--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/empty-mini-cart-contents-block/frontend.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/empty-mini-cart-contents-block/frontend.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { useStoreCart } from '@woocommerce/base-context/hooks';
+import { useEffect, useRef } from 'react';
 
 /**
  * Internal dependencies
@@ -16,12 +17,22 @@ const EmptyMiniCartContentsBlock = ( {
 }: EmptyMiniCartContentsBlockProps ): JSX.Element | null => {
 	const { cartItems, cartIsLoading } = useStoreCart();
 
+	const elementRef = useRef< HTMLDivElement >( null );
+
+	useEffect( () => {
+		elementRef.current?.focus();
+	} );
+
 	if ( cartIsLoading || cartItems.length > 0 ) {
 		return null;
 	}
 
 	return (
-		<div className="wp-block-woocommerce-empty-mini-cart-contents-block">
+		<div
+			tabIndex={ 0 }
+			ref={ elementRef }
+			className="wp-block-woocommerce-empty-mini-cart-contents-block"
+		>
 			{ children }
 		</div>
 	);

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/empty-mini-cart-contents-block/frontend.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/empty-mini-cart-contents-block/frontend.tsx
@@ -20,8 +20,10 @@ const EmptyMiniCartContentsBlock = ( {
 	const elementRef = useRef< HTMLDivElement >( null );
 
 	useEffect( () => {
-		elementRef.current?.focus();
-	} );
+		if ( cartItems.length === 0 && ! cartIsLoading ) {
+			elementRef.current?.focus();
+		}
+	}, [ cartItems, cartIsLoading ] );
 
 	if ( cartIsLoading || cartItems.length > 0 ) {
 		return null;
@@ -29,7 +31,7 @@ const EmptyMiniCartContentsBlock = ( {
 
 	return (
 		<div
-			tabIndex={ 0 }
+			tabIndex={ -1 }
 			ref={ elementRef }
 			className="wp-block-woocommerce-empty-mini-cart-contents-block"
 		>


### PR DESCRIPTION
This PR set the focus on the Empty Mini Cart Contents element: in this way when the user clicks outside the drawer, this latter will close.

Without this PR when the Empty Mini Cart Contents Block is rendered after removing the last product, the active element is the body. This causes that [these callbacks](https://github.com/WordPress/gutenberg/blob/c86a198597fa6d237699b7883bd9de8d1663bbd0/packages/components/src/modal/index.js#L74) aren't being called.


<!-- Reference any related issues or PRs here -->
Fixes #4618

### Manual Testing

How to test the changes in this Pull Request:

Check out this branch

1. Create a post or page and add a Mini Cart block.
2. Add a Product to the cart.
3. Visit that post or page in the front and click on the Mini Cart button.
4. Remove the product.
5. Click on the overlay and check that the drawer will close.

