### PR TITLE
Disable quantity selector and remove item link if item is a synced force sell

### DIFF
--- a/assets/js/blocks/cart-checkout/cart/cart-line-items-table/cart-line-item-row.tsx
+++ b/assets/js/blocks/cart-checkout/cart/cart-line-items-table/cart-line-item-row.tsx
@@ -200,6 +200,12 @@ const CartLineItemRow = forwardRef< HTMLTableRowElement, CartLineItemRowProps >(
 			validation: productPriceValidation,
 		} );
 
+		// If this item is set as a Sync Force Sell (by the Woocommerce Force Sells plugin).
+		// we want to disable the quantity selector and remove item link
+		const isSyncForcedItem = !! itemData.find(
+			( item ) => item?.name === 'Linked to'
+		);
+
 		return (
 			<tr
 				className={ classnames(
@@ -288,7 +294,9 @@ const CartLineItemRow = forwardRef< HTMLTableRowElement, CartLineItemRowProps >(
 							{ ! soldIndividually &&
 								!! quantityLimits.editable && (
 									<QuantitySelector
-										disabled={ isPendingDelete }
+										disabled={
+											isPendingDelete || isSyncForcedItem
+										}
 										quantity={ quantity }
 										minimum={ quantityLimits.minimum }
 										maximum={ quantityLimits.maximum }
@@ -326,7 +334,7 @@ const CartLineItemRow = forwardRef< HTMLTableRowElement, CartLineItemRowProps >(
 										)
 									);
 								} }
-								disabled={ isPendingDelete }
+								disabled={ isPendingDelete || isSyncForcedItem }
 							>
 								{ __(
 									'Remove item',


### PR DESCRIPTION
This solves an [integration issue with the WooCommerce Force Sells plugin](57-gh-woocommerce/woocommerce-force-sells). When a product is forced to sync to another product, the user should not be able to change the quantity or remove the linked product. This PR disables those options for a sync forced product. 

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes  57-gh-woocommerce/woocommerce-force-sells

### Screenshots

| Before | After |
| ----- | ------ |
| ![Screenshot 2022-02-08 at 17 22 23](https://user-images.githubusercontent.com/3966773/153041294-9c4e77cc-eefd-4767-8356-11759a8fc86e.png) | ![Screenshot 2022-02-08 at 17 21 54](https://user-images.githubusercontent.com/3966773/153041384-9ca0f7ad-8705-4d3f-af9c-1df3862fa9f5.png) |


### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Add the [WooCommerce Blocks plugin](https://wordpress.org/plugins/woo-gutenberg-products-block/).
2. Create a test page with the cart block.
3. Go to `product A` and add `product B` as `Synced Force Sells` product.
4. Go to the frontend and add `product A` to the cart.
5. Go to the test page with the cart block.
6. You should not be able to adjust the quantity or remove `product B`

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above

### Changelog

> Fix an integration issue with WooCommerce Force Sells plugin where a user could modify a sync forced product in the Cart block.