### PR TITLE
Fix reverting customisations by refactoring pre_get_block_file_template

### DIFF
--- a/src/Utils/BlockTemplateUtils.php
+++ b/src/Utils/BlockTemplateUtils.php
@@ -40,6 +40,16 @@ class BlockTemplateUtils {
 	const PLUGIN_SLUG = 'woocommerce/woocommerce';
 
 	/**
+	 * Deprecated WooCommerce plugin slug
+	 *
+	 * For supporting users who have customized templates under the incorrect plugin slug during the first release.
+	 * More context found here: https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5423.
+	 *
+	 * @var string
+	 */
+	const DEPRECATED_PLUGIN_SLUG = 'woocommerce';
+
+	/**
 	 * Returns an array containing the references of
 	 * the passed blocks and their inner blocks.
 	 *
@@ -153,7 +163,7 @@ class BlockTemplateUtils {
 		// We are checking 'woocommerce' to maintain legacy templates which are saved to the DB,
 		// prior to updating to use the correct slug.
 		// More information found here: https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5423.
-		if ( self::PLUGIN_SLUG === $theme || 'woocommerce' === strtolower( $theme ) ) {
+		if ( self::PLUGIN_SLUG === $theme || self::DEPRECATED_PLUGIN_SLUG === strtolower( $theme ) ) {
 			$template->origin = 'plugin';
 		}
 

--- a/src/Utils/BlockTemplateUtils.php
+++ b/src/Utils/BlockTemplateUtils.php
@@ -163,12 +163,12 @@ class BlockTemplateUtils {
 	/**
 	 * Build a unified template object based on a theme file.
 	 *
-	 * @param array $template_file Theme file.
-	 * @param array $template_type wp_template or wp_template_part.
+	 * @param array|object $template_file Theme file.
+	 * @param string       $template_type wp_template or wp_template_part.
 	 *
 	 * @return \WP_Block_Template Template.
 	 */
-	public static function gutenberg_build_template_result_from_file( $template_file, $template_type ) {
+	public static function build_template_result_from_file( $template_file, $template_type ) {
 		$template_file = (object) $template_file;
 
 		// If the theme has an archive-products.html template but does not have product taxonomy templates


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5704

### Description

* Refactor and rename the callback for `pre_get_block_file_template` in BlockTemplateController.
* Drop the `gutenberg_` prefix from `gutenberg_create_new_block_template_object` as it's confusing and unncessary.
* Remove `get_single_block_template` as it's no longer being used.
* Moved deprecated plugin slug `woocommerce` into a const value alongside the correct one.
* I have discovered this issue (https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5799) when testing this PR myself which already exists in `trunk` and the latest version of WooCommerce (6.2 at the time of writing)

### Context

There are two methods used to get block templates in Gutenberg, they are `get_block_template` and `get_block_file_template`.

* `get_block_template` - Will query the database for a customised post, and if one does not exist it will then call `get_block_file_template`
* `get_block_file_template` - Will load the template from the themes file system and return a `WP_Template` object.

When we revert a template, we pass specific query params with the request which lands us [here](https://github.com/WordPress/WordPress/blob/master/wp-includes/rest-api/endpoints/class-wp-rest-templates-controller.php#L242) calling the `get_block_file_template`. This will ultimately fail because of [this check](https://github.com/WordPress/WordPress/blob/22c9355e2dede8a53910f2ed075f6bda33698255/wp-includes/block-template-utils.php#L847-L850) as `$theme` for our template is `woocommerce/woocommerce` which does not equal `wp_get_theme()->get_stylesheet()` which would be the active themes id (e.g. `twentytwentytwo`). This was happening because we were using cores method recursively on itself (but removing hooks so we didn't end up with an infinite loop), and core does not currently account for templates being loaded from plugins like WooCommerce, only themes. So we needed to refactor this.

With all of the above in mind we can conclude that `pre_get_block_file_template` filter only runs when its retrieving the original block template file `WP_Template` object from the filesystem (within `get_block_file_template`). Knowing this I have refactored the callback to only do this for our block templates, but to also consider the edge case of a theme having a `product-archive.html` template file only, which would also be used for Product Category and Tag templates.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Ensure you have the latest WooCommerce, WordPress 5.9 and a block theme so that the FSE feature is enabled.
2. Go to Appearance > Editor and load Single Product template, customize the content and save the template.
3. In a separate tab ensure these changes are represented on the frontend, be careful _not_ to reload the current tab.
4. Back in your Site Editor tab, using the navigation please navigate back to All Templates view. In the list of templates your customized Single Product template should indicate it has been customized.
5. Click the three dots on the right of this template and click "Clear Customizations" and wait until the action has been complete.
6. Click "Single Product" again to go back into this template, check that all customizations have been cleared.
7. In a separate tab ensure these changes are represented on the frontend, be careful _not_ to reload the current tab.
8. Now in your Site Editor tab make another customization in this template and save it. Then using the navigation please navigate back to All Templates view. In the list of templates your customized Single Product template should indicate it has been customized.
9. Now click "Single Product" again to go back into the Site Editor, check that these customizations are showing still in the Site Editor.
10. Click the downward chevron in the top bar next to the block template title. It should show a "Clear Customizations" option here, click this and check that all customizations are reverted.
11. Now add a WooCommerce template (e.g. `single-product.html`) into your theme or download and install [this version of TwentyTwentyTwo](https://github.com/woocommerce/woocommerce-gutenberg-products-block/files/8036005/twentytwentytwo.zip) and test steps 1-10 again.

**Please also do some regression testing of your own around the feature with and without WooCommerce templates within the theme as this is a significant refactor to fix this bug and we don't have the luxury of a test suite as of yet.**

**Video of testing steps**

https://user-images.githubusercontent.com/8639742/153071379-45672296-67d4-464b-90f9-cba218285bd5.mp4

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
* [ ] See steps below.

1.
2.
3.

### Changelog

> Fixed an issue where clear customizations functionality was not working for WooCommerce templates.
