### PR TITLE
Add wc-block-mini-cart__contents class for the Mini Cart block

### DIFF
--- a/assets/js/blocks/cart-checkout/mini-cart-contents/editor.scss
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/editor.scss
@@ -1,4 +1,4 @@
-.editor-styles-wrapper .wp-block-woocommerce-mini-cart-contents {
+.editor-styles-wrapper .wc-block-mini-cart__contents {
 	max-width: 480px;
 	/* We need to override the margin top here to simulate the layout of
 	the mini cart contents on the front end. */

--- a/assets/js/blocks/cart-checkout/mini-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/mini-cart/style.scss
@@ -75,7 +75,7 @@
 }
 
 // @todo Review the class naming convention for Mini Cart inner blocks.
-.wp-block-woocommerce-mini-cart-contents {
+.wc-block-mini-cart__contents {
 	background: #fff;
 	box-sizing: border-box;
 	display: flex;

--- a/assets/js/blocks/cart-checkout/mini-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/mini-cart/style.scss
@@ -74,7 +74,6 @@
 	}
 }
 
-// @todo Review the class naming convention for Mini Cart inner blocks.
 .wc-block-mini-cart__contents {
 	background: #fff;
 	box-sizing: border-box;

--- a/templates/parts/mini-cart.html
+++ b/templates/parts/mini-cart.html
@@ -1,4 +1,4 @@
-<!-- wp:woocommerce/mini-cart-contents {"align":"center","className":"wc-block-mini-cart__contents"} -->
+<!-- wp:woocommerce/mini-cart-contents {"className":"wc-block-mini-cart__contents"} -->
 <div class="wp-block-woocommerce-mini-cart-contents wc-block-mini-cart__contents">
 	<!-- wp:woocommerce/filled-mini-cart-contents-block -->
 	<div class="wp-block-woocommerce-filled-mini-cart-contents-block">

--- a/templates/parts/mini-cart.html
+++ b/templates/parts/mini-cart.html
@@ -1,5 +1,5 @@
-<!-- wp:woocommerce/mini-cart-contents -->
-<div class="wp-block-woocommerce-mini-cart-contents">
+<!-- wp:woocommerce/mini-cart-contents {"align":"center","className":"wc-block-mini-cart__contents"} -->
+<div class="wp-block-woocommerce-mini-cart-contents wc-block-mini-cart__contents">
 	<!-- wp:woocommerce/filled-mini-cart-contents-block -->
 	<div class="wp-block-woocommerce-filled-mini-cart-contents-block">
 		<!-- wp:woocommerce/mini-cart-title-block -->


### PR DESCRIPTION
This PR adds `wc-block-mini-cart__contents` class for the Mini Cart block wrapper.


<!-- Reference any related issues or PRs here -->
Fixes #5418 



### Testing
### Manual Testing

How to test the changes in this Pull Request:

1. Active `Storefront` theme and add Mini Cart block as a widget.
2. Go on frontend side and open the Mini Cart block.
3. Check that the main wrapper of Mini Cart block has `wc-block-mini-cart__contents` class.
