### PR TITLE
Update version numbers in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/---bug-report.md
+++ b/.github/ISSUE_TEMPLATE/---bug-report.md
@@ -1,13 +1,15 @@
 ---
 name: "\U0001F41E Bug report"
 about: Let us know if something isn't working as you expect it to.
-labels: "type: bug" 
+labels: 'type: bug'
 ---
 
 ## Describe the bug
+
 A clear and concise description of what the bug is.
 
 ## To reproduce
+
 Steps to reproduce the behavior:
 
 1. Go to '...'
@@ -16,30 +18,37 @@ Steps to reproduce the behavior:
 4. See error
 
 ## Expected behavior
+
 A clear and concise description of what you expected to happen.
 
 ## Screenshots
+
 If applicable, add screenshots to help explain your problem.
 
 ## Environment
+
 ### WordPress (please complete the following information):
-* Core version: [e.g. 5.0.3]
-* Gutenberg version (if installed): [e.g. 4.8.0]
-* WooCommerce version: [e.g. 3.5.3]
-* WooCommerce Blocks version: [e.g. 1.3.1]
-* Site language:
-* Any other plugins installed:
+
+-   Core version: [e.g. 5.9]
+-   Gutenberg version (if installed): [e.g. 12.0.0]
+-   WooCommerce version: [e.g. 6.1]
+-   WooCommerce Blocks version: [e.g. 7.0.0]
+-   Site language:
+-   Any other plugins installed:
 
 ### Desktop (please complete the following information):
-* OS: [e.g. macOS, Windows]
-* Browser [e.g. chrome, safari]
-* Version [e.g. 22]
+
+-   OS: [e.g. macOS, Windows]
+-   Browser [e.g. chrome, safari]
+-   Version [e.g. 22]
 
 ### Smartphone (please complete the following information):
-* Device: [e.g. iPhone6]
-* OS: [e.g. iOS8.1]
-* Browser [e.g. stock browser, safari]
-* Version [e.g. 22]
+
+-   Device: [e.g. iPhone6]
+-   OS: [e.g. iOS8.1]
+-   Browser [e.g. stock browser, safari]
+-   Version [e.g. 22]
 
 ## Additional context
+
 Add any other context about the problem here.


### PR DESCRIPTION
I noticed that the version numbers used as examples in the Bug report template are really old, so  just updating to the latest(ish) ones. #nitpick