### PR TITLE
Fix: Mini Cart template part editor height

### DIFF
--- a/assets/js/blocks/cart-checkout/mini-cart-contents/edit.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/edit.tsx
@@ -44,6 +44,12 @@ interface Props {
 
 const Edit = ( { clientId }: Props ): ReactElement => {
 	const blockProps = useBlockProps( {
+		/**
+		 * This is a workaround for the Site Editor to calculate the
+		 * correct height of the Mini Cart template part on the first load.
+		 *
+		 * @see https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5825
+		 */
 		style: {
 			minHeight: '100vh',
 		},

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/edit.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/edit.tsx
@@ -43,7 +43,11 @@ interface Props {
 }
 
 const Edit = ( { clientId }: Props ): ReactElement => {
-	const blockProps = useBlockProps();
+	const blockProps = useBlockProps( {
+		style: {
+			minHeight: '100vh',
+		},
+	} );
 
 	const defaultTemplate = [
 		[ 'woocommerce/filled-mini-cart-contents-block', {}, [] ],


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #5813 

When a template part is loaded, Gutenberg set the height of the editor area using `iframe.contentDocument.documentElement.scrollHeight`, at this point, the editor CSS hasn't been loaded yet, which causes the issue in #5813. If we switch to edit another template, then switch back to edit the Mini Cart template part, the height is correct because, at that point, the CSS had been loaded.

This PR uses the inline style to set the height of the Mini Cart Contents block so Gutenberg can calculate the correct height when loading the template part.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### Screenshots
<img width="1392" alt="image" src="https://user-images.githubusercontent.com/5423135/153803889-9864a65c-077c-4395-bc80-5d876c6dd451.png">

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Go to Site Editor.
2. From the W icon, select Template Parts, then select Mini Cart.
3. See the height of the editor area expanded to the remaining browser height.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
* [ ] See steps below.