### PR TITLE
Shopper → Checkout → Can choose shipping option

### DIFF
--- a/bin/wp-env-config.sh
+++ b/bin/wp-env-config.sh
@@ -18,5 +18,6 @@ wp rewrite flush
 wp core version --extra
 wp plugin list
 wp theme activate storefront
+wp wc customer update 1 --user=1 --billing='{"first_name":"John","last_name":"Doe","company":"Automattic","country":"US","address_1":"addr 1","address_2":"addr 2","city":"San Francisco","state":"CA","postcode":"94107","phone":"123456789"}' --shipping='{"first_name":"John","last_name":"Doe","company":"Automattic","country":"US","address_1":"addr 1","address_2":"addr 2","city":"San Francisco","state":"CA","postcode":"94107","phone":"123456789"}'
 
 exit $EXIT_CODE

--- a/tests/e2e/fixtures/fixture-data.js
+++ b/tests/e2e/fixtures/fixture-data.js
@@ -344,6 +344,30 @@ const Shipping = () => [
 			},
 		],
 	},
+	{
+		name: 'US',
+		locations: [
+			{
+				code: 'US',
+			},
+		],
+		methods: [
+			{
+				method_id: 'flat_rate',
+				settings: {
+					title: 'Normal Shipping',
+					cost: '20.00',
+				},
+			},
+			{
+				method_id: 'free_shipping',
+				settings: {
+					title: 'Free Shipping',
+					cost: '00.00',
+				},
+			},
+		],
+	},
 ];
 
 /**

--- a/tests/e2e/specs/shopper/checkout-shipping.test.js
+++ b/tests/e2e/specs/shopper/checkout-shipping.test.js
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import { merchant } from '@woocommerce/e2e-utils';
+
+/**
+ * Internal dependencies
+ */
+import { shopper } from '../../../utils';
+
+const productName = '128GB USB Stick';
+const freeShippingName = 'Free Shipping';
+const freeShippingPrice = '$0.00';
+const normalShippingName = 'Normal Shipping';
+const normalShippingPrice = '$20.00';
+
+if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 )
+	// eslint-disable-next-line jest/no-focused-tests
+	test.only( 'Skipping Checkout tests', () => {} );
+
+describe( `Shopper → Checkout → Can choose shipping option`, () => {
+	beforeAll( async () => {
+		await merchant.login();
+	} );
+
+	afterAll( async () => {
+		await merchant.logout();
+	} );
+
+	it( 'allows customer to choose free shipping', async () => {
+		await shopper.goToShop();
+		await shopper.addToCartFromShopPage( productName );
+		await shopper.block.goToCheckout();
+		await shopper.block.selectAndVerifyShippingOption(
+			freeShippingName,
+			freeShippingPrice
+		);
+		await shopper.block.placeOrder();
+		await page.waitForTimeout( 2000 );
+		await expect( page ).toMatch( 'Order received' );
+		await expect( page ).toMatch( freeShippingName );
+	} );
+
+	it( 'allows customer to choose flat rate shipping', async () => {
+		await shopper.goToShop();
+		await shopper.addToCartFromShopPage( productName );
+		await shopper.block.goToCheckout();
+		await shopper.block.selectAndVerifyShippingOption(
+			normalShippingName,
+			normalShippingPrice
+		);
+		await shopper.block.placeOrder();
+		await page.waitForTimeout( 2000 );
+		await expect( page ).toMatch( 'Order received' );
+		await expect( page ).toMatch( normalShippingName );
+	} );
+} );

--- a/tests/utils/shopper.js
+++ b/tests/utils/shopper.js
@@ -274,5 +274,24 @@ export const shopper = {
 				page.waitForNavigation( { waitUntil: 'networkidle0' } ),
 			] );
 		},
+
+		selectAndVerifyShippingOption: async (
+			shippingName,
+			shippingPrice
+		) => {
+			await expect( page ).toClick(
+				'.wc-block-components-radio-control__label',
+				{
+					text: shippingName,
+				}
+			);
+			await page.waitForTimeout( 1000 );
+			await expect( page ).toMatchElement(
+				'.wc-block-components-totals-shipping .wc-block-formatted-money-amount',
+				{
+					text: shippingPrice,
+				}
+			);
+		},
 	},
 };


### PR DESCRIPTION
Fixes #5781

### Notes

This PR adds e2e tests to verify that a shopper can choose the shipping options (`Normal Shipping ` and `Free Shipping`) on the checkout block.

### Testing

#### Automated Tests
* [x] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests

### Manual Testing

1. Check out this PR.
2. Start Docker Desktop.
3. Run `npm run wp-env destroy && npm run wp-env start` to start a fresh e2e environment.
4. Run `npm run test:e2e -- tests/e2e/specs/shopper/checkout-shipping.test.js` to run only this test case.
5. Run `npm run test:e2e` to run the whole test suite.