### PR TITLE
Limit API response based on what is updated

### DIFF
--- a/assets/js/data/cart/reducers.ts
+++ b/assets/js/data/cart/reducers.ts
@@ -70,6 +70,7 @@ const reducer: Reducer< CartState > = (
 					...state,
 					errors: EMPTY_CART_ERRORS,
 					cartData: {
+						...state.cartData,
 						...action.response,
 					},
 				};

--- a/src/StoreApi/Routes/CartUpdateCustomer.php
+++ b/src/StoreApi/Routes/CartUpdateCustomer.php
@@ -122,7 +122,7 @@ class CartUpdateCustomer extends AbstractCartRoute {
 
 		$this->calculate_totals();
 
-		return rest_ensure_response( $this->schema->get_item_response( $cart ) );
+		return rest_ensure_response( $this->schema->get_item_response( $cart, [ 'shipping_address', 'billing_address' ] ) );
 	}
 
 	/**

--- a/src/Utils/ArrayUtils.php
+++ b/src/Utils/ArrayUtils.php
@@ -1,6 +1,8 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\Utils;
 
+use \Exception;
+
 /**
  * ArrayUtils class used for custom functions to operate on arrays
  */
@@ -32,5 +34,26 @@ class ArrayUtils {
 			);
 		}
 		return $last;
+	}
+
+	/**
+	 * A utility function to remove items from an array based on their key.
+	 *
+	 * @param array    $array The array to remove items from.
+	 * @param string[] $keys_to_remove The keys of the items that should be removed from the array.
+	 *
+	 * @return array Returns the array with keys removed.
+	 * @throws Exception Throws when either the original array, or keys to remove is not an array.
+	 */
+	public static function remove_keys( $array, $keys_to_remove ) {
+		if ( ! is_array( $keys_to_remove ) || ! is_array( $array ) ) {
+			throw new Exception( '$array and $keys_to_remove must both be arrays.' );
+		}
+		foreach ( $keys_to_remove as $key_to_remove ) {
+			if ( isset( $array[ $key_to_remove ] ) ) {
+				unset( $array[ $key_to_remove ] );
+			}
+		}
+		return $array;
 	}
 }


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR will add a utility function to remove items from arrays based on their key (in `ArrayUtils.php`) and will also specify some keys to be omitted on the `CartUpdateCustomer (/wc/store/cart/update-customer)` route. Specifically it will omit `billing_address` and `shipping_address` from the response.

The reason we want to do this is because: now we've removed local state, and we're now using the data store to drive the data in the checkout form, when the user is typing, the `UPDATE_CUSTOMER_DATA` action pushes the new address data to the server. The server then responds with the cart object, which includes `shipping_address` and `billing_address` - when the new cart is received, in the `RECEIVE_CART` action, any changes to the address data since _sending_ the request will be overwritten by the response.

<!-- Reference any related issues or PRs here -->
Fixes #5747

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Type into either address field on the Checkout block, update the city/postcode/country.
2. Ensure the address does not revert to a previous one while typing.
3. Keep typing, but slow your rate down to 1 character per second, or similar, ensure the form contents do not switch back and forth while you type.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
* [ ] See steps below.

