### PR TITLE
Fix All Products block pagination not showing up

### DIFF
--- a/assets/js/base/context/hooks/use-store-products.ts
+++ b/assets/js/base/context/hooks/use-store-products.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Query, ProductResponseItem, isString } from '@woocommerce/types';
+import { Query, ProductResponseItem } from '@woocommerce/types';
 /**
  * Internal dependencies
  */
@@ -45,7 +45,7 @@ export const useStoreProducts = (
 	} );
 	return {
 		products: products as ProductResponseItem[], // TODO: Remove this once getCollection selector and resolver is converted to TS.
-		totalProducts: parseInt( isString( totalProducts ).toString(), 10 ),
+		totalProducts: parseInt( totalProducts as string, 10 ),
 		productsLoading,
 	};
 };


### PR DESCRIPTION
After converting `useStoreProducts()` to TypeScript (see [#5668](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5668/files#diff-badb52abe6c3543682e0a447fe296a3bbbee37d80b05d5e6e79685963e76b860R48)), it looks like `totalProducts` was always `NaN`. That caused the All Products block not to show the pagination. This PR is a quick fix for that, there might be a better way to fix it with TS. :slightly_smiling_face: 

cc @sunyatasattva heads-up that this is a blocker for 7.0.

### Screenshots

![imatge](https://user-images.githubusercontent.com/3616980/154061030-0d2799c7-06f5-47ab-b899-cd05712f5ed3.png)

### Manual Testing

1. Make sure you have at least 9 products in your store.
2. Add the All Products block.
3. Verify the pagination is shown and you can navigate from one page to another.