### PR TITLE
fix regression for Twenty Twenty-Two with sale prices being underlined

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -329,7 +329,8 @@
 		}
 	}
 
-	.wc-block-components-product-price {
+	.wc-block-components-product-price,
+	.wc-block-grid__product-price {
 		ins {
 			text-decoration: none;
 		}


### PR DESCRIPTION
class name on price container in Product by * blocks changed from `wc-block-components-product-price` to `wc-block-grid__product-price`.

This affects trunk only so shouldn't require changelog entry.

Fixes #5286

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### Manual Testing

How to test the changes in this Pull Request:

1. On Twenty Twenty-Two theme 
2. On a page add Products by (something) block
3. Make sure it has a product on sale
4. Make sure product sale price is not underlined

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
* [ ] See steps below.

