### PR TITLE
Fix Global Styles for Product Image, Product Category List and Product Tag List Blocks

### DIFF
--- a/assets/js/atomic/blocks/product-elements/category-list/index.ts
+++ b/assets/js/atomic/blocks/product-elements/category-list/index.ts
@@ -33,9 +33,11 @@ const blockConfig: BlockConfiguration = {
 				text: true,
 				link: true,
 				background: false,
+				__experimentalSkipSerialization: true,
 			},
 			typography: {
 				fontSize: true,
+				__experimentalSkipSerialization: true,
 			},
 			__experimentalSelector:
 				'.wc-block-components-product-category-list',

--- a/assets/js/atomic/blocks/product-elements/category-list/index.ts
+++ b/assets/js/atomic/blocks/product-elements/category-list/index.ts
@@ -34,10 +34,12 @@ const blockConfig: BlockConfiguration = {
 				link: true,
 				background: false,
 			},
+			typography: {
+				fontSize: true,
+			},
+			__experimentalSelector:
+				'.wc-block-components-product-category-list',
 		} ),
-		typography: {
-			fontSize: true,
-		},
 	},
 	save: Save,
 	edit,

--- a/assets/js/atomic/blocks/product-elements/image/edit.js
+++ b/assets/js/atomic/blocks/product-elements/image/edit.js
@@ -14,7 +14,6 @@ import { getAdminLink } from '@woocommerce/settings';
 import Block from './block';
 import withProductSelector from '../shared/with-product-selector';
 import { BLOCK_TITLE, BLOCK_ICON } from './constants';
-import './editor.scss';
 
 const Edit = ( { attributes, setAttributes } ) => {
 	const {

--- a/assets/js/atomic/blocks/product-elements/image/editor.scss
+++ b/assets/js/atomic/blocks/product-elements/image/editor.scss
@@ -1,5 +1,0 @@
-.wp-block-woocommerce-product-image {
-	.components-disabled {
-		border-radius: inherit;
-	}
-}

--- a/assets/js/atomic/blocks/product-elements/image/style.scss
+++ b/assets/js/atomic/blocks/product-elements/image/style.scss
@@ -5,7 +5,6 @@
 	text-decoration: none;
 	display: block;
 	position: relative;
-	border-radius: inherit;
 
 	a {
 		border-radius: inherit;

--- a/assets/js/atomic/blocks/product-elements/image/supports.ts
+++ b/assets/js/atomic/blocks/product-elements/image/supports.ts
@@ -8,8 +8,9 @@ export const supports = {
 		__experimentalBorder: {
 			radius: true,
 		},
+		typography: {
+			fontSize: true,
+		},
+		__experimentalSelector: '.wc-block-components-product-image',
 	} ),
-	typography: {
-		fontSize: true,
-	},
 };

--- a/assets/js/atomic/blocks/product-elements/tag-list/supports.js
+++ b/assets/js/atomic/blocks/product-elements/tag-list/supports.js
@@ -10,8 +10,9 @@ export const supports = {
 			background: false,
 			link: true,
 		},
+		typography: {
+			fontSize: true,
+		},
+		__experimentalSelector: '.wc-block-components-product-tag-list',
 	} ),
-	typography: {
-		fontSize: true,
-	},
 };

--- a/assets/js/hooks/style-attributes.ts
+++ b/assets/js/hooks/style-attributes.ts
@@ -59,7 +59,9 @@ export const useTypographyProps = ( attributes: unknown ): WithStyle => {
 
 	return {
 		style: {
-			fontSize: attributesObject.fontSize || typography.fontSize,
+			fontSize: attributesObject.fontSize
+				? `var(--wp--preset--font-size--${ attributesObject.fontSize })`
+				: typography.fontSize,
 			lineHeight: typography.lineHeight,
 			fontWeight: typography.fontWeight,
 			textTransform: typography.textTransform,

--- a/src/BlockTypes/ProductCategoryList.php
+++ b/src/BlockTypes/ProductCategoryList.php
@@ -45,13 +45,15 @@ class ProductCategoryList extends AbstractBlock {
 		return array(
 			'color'                  =>
 			array(
-				'text'       => true,
-				'link'       => true,
-				'background' => false,
+				'text'                            => true,
+				'link'                            => true,
+				'background'                      => false,
+				'__experimentalSkipSerialization' => true,
 			),
 			'typography'             =>
 			array(
-				'fontSize' => true,
+				'fontSize'                        => true,
+				'__experimentalSkipSerialization' => true,
 			),
 			'__experimentalSelector' => '.wc-block-components-product-category-list',
 		);

--- a/src/BlockTypes/ProductCategoryList.php
+++ b/src/BlockTypes/ProductCategoryList.php
@@ -1,0 +1,60 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\BlockTypes;
+
+/**
+ * ProductCategoryList class.
+ */
+class ProductCategoryList extends AbstractBlock {
+
+	/**
+	 * Block name.
+	 *
+	 * @var string
+	 */
+	protected $block_name = 'product-category-list';
+
+	/**
+	 * API version name.
+	 *
+	 * @var string
+	 */
+	protected $api_version = '2';
+
+	/**
+	 * Get the editor script handle for this block type.
+	 *
+	 * @param string $key Data to get, or default to everything.
+	 * @return array|string;
+	 */
+	protected function get_block_type_editor_script( $key = null ) {
+		$script = [
+			'handle'       => 'wc-' . $this->block_name . '-block',
+			'path'         => $this->asset_api->get_block_asset_build_path( 'atomic-block-components/category-list' ),
+			'dependencies' => [ 'wc-blocks' ],
+		];
+		return $key ? $script[ $key ] : $script;
+	}
+
+	/**
+	 * Get block supports. Shared with the frontend.
+	 * IMPORTANT: If you change anything here, make sure to update the JS file too.
+	 *
+	 * @return array
+	 */
+	protected function get_block_type_supports() {
+		return array(
+			'color'                  =>
+			array(
+				'text'       => true,
+				'link'       => true,
+				'background' => false,
+			),
+			'typography'             =>
+			array(
+				'fontSize' => true,
+			),
+			'__experimentalSelector' => '.wc-block-components-product-category-list',
+		);
+	}
+
+}

--- a/src/BlockTypes/ProductImage.php
+++ b/src/BlockTypes/ProductImage.php
@@ -1,0 +1,58 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\BlockTypes;
+
+/**
+ * ProductImage class.
+ */
+class ProductImage extends AbstractBlock {
+
+	/**
+	 * Block name.
+	 *
+	 * @var string
+	 */
+	protected $block_name = 'product-image';
+
+	/**
+	 * API version name.
+	 *
+	 * @var string
+	 */
+	protected $api_version = '2';
+
+	/**
+	 * Get the editor script handle for this block type.
+	 *
+	 * @param string $key Data to get, or default to everything.
+	 * @return array|string;
+	 */
+	protected function get_block_type_editor_script( $key = null ) {
+		$script = [
+			'handle'       => 'wc-' . $this->block_name . '-block',
+			'path'         => $this->asset_api->get_block_asset_build_path( 'atomic-block-components/image' ),
+			'dependencies' => [ 'wc-blocks' ],
+		];
+		return $key ? $script[ $key ] : $script;
+	}
+
+	/**
+	 * Get block supports. Shared with the frontend.
+	 * IMPORTANT: If you change anything here, make sure to update the JS file too.
+	 *
+	 * @return array
+	 */
+	protected function get_block_type_supports() {
+		return array(
+			'__experimentalBorder'   =>
+			array(
+				'radius' => true,
+			),
+			'typography'             =>
+			array(
+				'fontSize' => true,
+			),
+			'__experimentalSelector' => '.wc-block-components-product-image',
+		);
+	}
+
+}

--- a/src/BlockTypes/ProductTagList.php
+++ b/src/BlockTypes/ProductTagList.php
@@ -1,0 +1,60 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\BlockTypes;
+
+/**
+ * ProductTagList class.
+ */
+class ProductTagList extends AbstractBlock {
+
+	/**
+	 * Block name.
+	 *
+	 * @var string
+	 */
+	protected $block_name = 'product-tag-list';
+
+	/**
+	 * API version name.
+	 *
+	 * @var string
+	 */
+	protected $api_version = '2';
+
+	/**
+	 * Get the editor script handle for this block type.
+	 *
+	 * @param string $key Data to get, or default to everything.
+	 * @return array|string;
+	 */
+	protected function get_block_type_editor_script( $key = null ) {
+		$script = [
+			'handle'       => 'wc-' . $this->block_name . '-block',
+			'path'         => $this->asset_api->get_block_asset_build_path( 'atomic-block-components/tag-list' ),
+			'dependencies' => [ 'wc-blocks' ],
+		];
+		return $key ? $script[ $key ] : $script;
+	}
+
+	/**
+	 * Get block supports. Shared with the frontend.
+	 * IMPORTANT: If you change anything here, make sure to update the JS file too.
+	 *
+	 * @return array
+	 */
+	protected function get_block_type_supports() {
+		return array(
+			'color'                  =>
+			array(
+				'text'       => true,
+				'background' => false,
+				'link'       => true,
+			),
+			'typography'             =>
+			array(
+				'fontSize' => true,
+			),
+			'__experimentalSelector' => '.wc-block-components-product-tag-list',
+		);
+	}
+
+}

--- a/src/BlockTypesController.php
+++ b/src/BlockTypesController.php
@@ -180,6 +180,9 @@ final class BlockTypesController {
 			'ProductSummary',
 			'ProductStockIndicator',
 			'ProductSaleBadge',
+			'ProductImage',
+			'ProductTagList',
+			'ProductCategoryList',
 		];
 
 		if ( Package::feature()->is_feature_plugin_build() ) {
@@ -232,12 +235,9 @@ final class BlockTypesController {
 	protected function get_atomic_blocks() {
 		return [
 			'product-button',
-			'product-image',
 			'product-price',
 			'product-rating',
 			'product-sku',
-			'product-category-list',
-			'product-tag-list',
 			'product-add-to-cart',
 		];
 	}


### PR DESCRIPTION
This PR fixes Global Styles for Product Image, Product Category List, and Product Tag List Blocks when they are used on `All Products` block.


The fix is pretty easy, we need to register the blocks on PHP side, in this way we can use the `__experimentalSelector` and attach the generated Global Style to a specific element in the DOM.

## Product Image
1. On `WordPress 5.9`, install and enable the `Gutenberg` plugin.
2. Install and enable the `Twenty Twenty-Two` theme.
3. Add the `All Products` block  (this block contains `Product Image`) to a post.
4. Get the focus on `Product Image` block.
5. On the right sidebar, personalize the styles of the block.
6. Go on the page and check if there are changes.
7. Reset to default using the `Reset` button from the different sections.
8. Go to Dashboard and select Appearance > Editor (beta). On top of the screen, select Home > Browser all templates > Single Post. When the page is loaded, add the block to the page.
9. On the Editor page click on the `Styles` icon on the right-top corner.
10. Verify that the `Product Image Block` is shown under the `Blocks` section. Personalize again the block.
11. Save your changes.
12. Go on the page created earlier and check if all styles are applied correctly.
13. Edit your previous post/page again.
14. Change again the styles.
15. Save your changes.
16. Check if these styles have priority over the styles from the Site Editor.

## Product Category List
1. On `WordPress 5.9`, install and enable the `Gutenberg` plugin.
2. Install and enable the `Twenty Twenty-Two` theme.
3. Add the `All Products` block  (this block contains `Product Category List`) to a post.
4. Get the focus on `Product Category List` block.
5. On the right sidebar, personalize the styles of the block.
6. Go on the page and check if there are changes.
7. Reset to default using the `Reset` button from the different sections.
8. Go to Dashboard and select Appearance > Editor (beta). On top of the screen, select Home > Browser all templates > Single Post. When the page is loaded, add the block to the page.
9. On the Editor page click on the `Styles` icon on the right-top corner.
10. Verify that the `Product Category List` is shown under the `Blocks` section. Personalize again the block.
11. Save your changes.
12. Go on the page created earlier and check if all styles are applied correctly.
13. Edit your previous post/page again.
14. Change again the styles.
15. Save your changes.
16. Check if these styles have priority over the styles from the Site Editor (except for link color).


**Due to the limitations of the global styles API, the global style link color will have a higher priority than the block style :(**


The generated global style CSS is more specific than the generated block style CSS and there is no way to change this behavior.   

![image](https://user-images.githubusercontent.com/4463174/154241244-2963637f-18c3-4a94-a720-876ab86d42f8.png)



## Product Tag List
1. On `WordPress 5.9`, install and enable the `Gutenberg` plugin.
2. Install and enable the `Twenty Twenty-Two` theme.
3. Add the `All Products` block  (this block contains `Product Tag List`) to a post.
4. Get the focus on the `Product Tag List` block.
5. On the right sidebar, personalize the styles of the block.
6. Go on the page and check if there are changes.
7. Reset to default using the `Reset` button from the different sections.
8. Go to Dashboard and select Appearance > Editor (beta). On top of the screen, select Home > Browser all templates > Single Post. When the page is loaded, add the block to the page.
9. On the Editor page click on the `Styles` icon on the right-top corner.
10. Verify that the `Product Tag List` is shown under the `Blocks` section. Personalize again the block.
11. Save your changes.
12. Go on the page created earlier and check if all styles are applied correctly.