### PR TITLE
Update testing instructions for 6.8.0 and 6.9.0 releases

### DIFF
--- a/docs/testing/releases/680.md
+++ b/docs/testing/releases/680.md
@@ -28,63 +28,6 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 2. Open Appearance > Editor > Templates.
 3. Make sure all the templates and parts appear correctly. WooCommerce templates that should be available: `Archive Product`, `Single Product`, `Product Category` and `Product Tag`. WooCommerce template-parts that should be available `Mini Cart`.
 
-### FSE: Add support for the global style for the Stock Indicator block. ([5525](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5525))
-
-1.  Upgrade to `WordPress 5.9`.
-2.  Install and enable the `Twenty Twenty-Two` theme.
-3.  Add the `All Product Block` (this block contains `Stock Indicator block`) to a post.
-4.  Click on the pencil to edit the block, add the `Stock Indicator Block` and get the focus on the `Stock Indicator block`.
-5.  On the right sidebar, personalize the styles of the block.
-6.  Go on the page and check if there are changes.
-7.  Reset to default using the `Reset` button from the different sections.
-8.  Go to Dashboard and select Appearance > Editor (beta). On top of the screen, select Home > Browser all templates > Single Post. When the page is loaded, add the block to the page. Click on the pencil to edit the block, add the `Stock Indicator Block`.
-9.  On the Editor page click on the `Styles` icon on the right-top corner.
-10. Verify that the `Stock Indicator block` is shown under the `Blocks` section. Personalize the block.
-11. Save your changes.
-12. Go on the page created earlier and check if all styles are applied correctly.
-13. Edit your previous post/page again.
-14. Change again the styles.
-15. Save your changes.
-16. Check if these styles have priority over the styles from the Site Editor.
-
-### FSE: Add support for the global style for the Summary Product block. ([5524](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5524))
-
-1.  Upgrade to `WordPress 5.9`.
-2.  Install and enable the `Twenty Twenty-Two` theme.
-3.  Add the `All Product Block` (this block contains `Summary Product block`) to a post.
-4.  Click on the pencil to edit the block, add the `Summary Product block` and get the focus on the `Summary Product block`.
-5.  On the right sidebar, personalize the styles of the block.
-6.  Go on the page and check if there are changes.
-7.  Reset to default using the `Reset` button from the different sections.
-8.  Go to Dashboard and select Appearance > Editor (beta). On top of the screen, select Home > Browser all templates > Single Post. When the page is loaded, add the block to the page. Click on the pencil to edit the block, add the `Summary Product block`.
-9.  On the Editor page click on the `Styles` icon on the right-top corner.
-10. Verify that the `Summary Product block` is shown under the `Blocks` section. Personalize the block.
-11. Save your changes.
-12. Go on the page created earlier and check if all styles are applied correctly.
-13. Edit your previous post/page again.
-14. Change again the styles.
-15. Save your changes.
-16. Check if these styles have priority over the styles from the Site Editor.
-
-### FSE: Add support for the global style for the Product Title block. ([5515](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5515))
-
-1.  Upgrade to `WordPress 5.9`.
-2.  Install and enable the `Twenty Twenty-Two` theme.
-3.  Add the `All Product Block` (this block contains `Product Title block`) to a post.
-4.  Click on the pencil to edit the block, add the `Product Title block` and get the focus on the `Product Title block`.
-5.  On the right sidebar, personalize the styles of the block.
-6.  Go on the page and check if there are changes.
-7.  Reset to default using the `Reset` button from the different sections.
-8.  Go to Dashboard and select Appearance > Editor (beta). On top of the screen, select Home > Browser all templates > Single Post. When the page is loaded, add the block to the page. Click on the pencil to edit the block, add the `Product Title block`.
-9.  On the Editor page click on the `Styles` icon on the right-top corner.
-10. Verify that the `Product Title block` is shown under the `Blocks` section. Personalize the block.
-11. Save your changes.
-12. Go on the page created earlier and check if all styles are applied correctly.
-13. Edit your previous post/page again.
-14. Change again the styles.
-15. Save your changes.
-16. Check if these styles have priority over the styles from the Site Editor.
-
 ### FSE: Add support for the wide and full alignment for the legacy template block. ([5433](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5433))
 
 1. Activate the Gutenberg plugin (or use WordPress 5.9). Select a block theme e.g. TT1 Blocks.
@@ -176,6 +119,65 @@ Install the [Stripe Payment Method Extension](https://github.com/woocommerce/woo
 2. Go to checkout.
 3. Select Stripe Credit Card extension and make a payment. Do so while logged in and save the card to your account.
 4. Repeat checkout with a saved card.
+
+## Experimental blocks only
+
+### FSE: Add support for the global style for the Product Title block. ([5515](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5515))
+
+1.  Upgrade to `WordPress 5.9`.
+2.  Install and enable the `Twenty Twenty-Two` theme.
+3.  Add the `All Product Block` (this block contains `Product Title block`) to a post.
+4.  Click on the pencil to edit the block, add the `Product Title block` and get the focus on the `Product Title block`.
+5.  On the right sidebar, personalize the styles of the block.
+6.  Go on the page and check if there are changes.
+7.  Reset to default using the `Reset` button from the different sections.
+8.  Go to Dashboard and select Appearance > Editor (beta). On top of the screen, select Home > Browser all templates > Single Post. When the page is loaded, add the block to the page. Click on the pencil to edit the block, add the `Product Title block`.
+9.  On the Editor page click on the `Styles` icon on the right-top corner.
+10. Verify that the `Product Title block` is shown under the `Blocks` section. Personalize the block.
+11. Save your changes.
+12. Go on the page created earlier and check if all styles are applied correctly.
+13. Edit your previous post/page again.
+14. Change again the styles.
+15. Save your changes.
+16. Check if these styles have priority over the styles from the Site Editor.
+
+### FSE: Add support for the global style for the Stock Indicator block. ([5525](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5525))
+
+1.  Upgrade to `WordPress 5.9`.
+2.  Install and enable the `Twenty Twenty-Two` theme.
+3.  Add the `All Product Block` (this block contains `Stock Indicator block`) to a post.
+4.  Click on the pencil to edit the block, add the `Stock Indicator Block` and get the focus on the `Stock Indicator block`.
+5.  On the right sidebar, personalize the styles of the block.
+6.  Go on the page and check if there are changes.
+7.  Reset to default using the `Reset` button from the different sections.
+8.  Go to Dashboard and select Appearance > Editor (beta). On top of the screen, select Home > Browser all templates > Single Post. When the page is loaded, add the block to the page. Click on the pencil to edit the block, add the `Stock Indicator Block`.
+9.  On the Editor page click on the `Styles` icon on the right-top corner.
+10. Verify that the `Stock Indicator block` is shown under the `Blocks` section. Personalize the block.
+11. Save your changes.
+12. Go on the page created earlier and check if all styles are applied correctly.
+13. Edit your previous post/page again.
+14. Change again the styles.
+15. Save your changes.
+16. Check if these styles have priority over the styles from the Site Editor.
+
+### FSE: Add support for the global style for the Summary Product block. ([5524](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5524))
+
+1.  Upgrade to `WordPress 5.9`.
+2.  Install and enable the `Twenty Twenty-Two` theme.
+3.  Add the `All Product Block` (this block contains `Summary Product block`) to a post.
+4.  Click on the pencil to edit the block, add the `Summary Product block` and get the focus on the `Summary Product block`.
+5.  On the right sidebar, personalize the styles of the block.
+6.  Go on the page and check if there are changes.
+7.  Reset to default using the `Reset` button from the different sections.
+8.  Go to Dashboard and select Appearance > Editor (beta). On top of the screen, select Home > Browser all templates > Single Post. When the page is loaded, add the block to the page. Click on the pencil to edit the block, add the `Summary Product block`.
+9.  On the Editor page click on the `Styles` icon on the right-top corner.
+10. Verify that the `Summary Product block` is shown under the `Blocks` section. Personalize the block.
+11. Save your changes.
+12. Go on the page created earlier and check if all styles are applied correctly.
+13. Edit your previous post/page again.
+14. Change again the styles.
+15. Save your changes.
+16. Check if these styles have priority over the styles from the Site Editor.
 
 ## <!-- FEEDBACK -->
 

--- a/docs/testing/releases/680.md
+++ b/docs/testing/releases/680.md
@@ -2,7 +2,7 @@
 
 Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.com/woocommerce/woocommerce-gutenberg-products-block/files/7903801/woocommerce-gutenberg-products-block.zip)
 
-## Feature Plugin
+## WC Core
 
 ### FSE: Add support for the global style for the Price Filter block. ([5559](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5559))
 
@@ -98,27 +98,6 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 You should test these steps at least one between `Product Category Page`, `Product Archive Page` and `Product Tag Page`.
 You should test `Single Product Page`.
 
-### Hold stock for 60mins if the order is pending payment. ([5546](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5546))
-
-1.  Edit an item and ensure it has inventory enabled.
-2.  Successfully place an order.
-
-### Fix duplicated checkout error notices. ([5476](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5476))
-
-1. Make sure you're using the Blocks checkout and an payment method configurate (for example Stripe).
-2. Add 1 or more products to your cart.
-3. Go to the blocks checkout page
-4. Pay through the credit card form with a card that will be declined, e.g. 4000 0000 0000 0002.
-5. Ensure that only one error notice is displayed
-
-### Store API and Cart block now support defining a quantity stepper and a minimum quantity. ([5406](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5406))
-
-1. Smoke test adding items to cart and changing quantity, either via the + and - buttons, or directly via the input.
-2. Edit a product and make it "sold individually"
-3. Confirm that no quantity box shows on the cart page for this product
-4. Edit a product and set stock to 6, no backorders.
-5. Confirm that you can only have 6 maximum for this product.
-
 ### Added controls to product grid blocks for filtering by stock levels. ([4943](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4943))
 
 1. Create a new post.
@@ -140,6 +119,41 @@ You should test `Single Product Page`.
 9. Go to Appearance > Customize > WooCommerce > Product Images and set a custom aspect ratio (for example, 16:9).
 10. Visit the all products page again. All product images should be rendered with this new aspect ratio.
 
+### Filter Products By Price block: Don't allow to insert negative values on inputs. ([5123](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5123))
+
+1. Create a post and add `All Products` block and add `Filter Products by Price` block.
+2. Save the post.
+3. Go to the page having all the above block added.
+
+Check that:
+
+-   the user can't insert in both inputs a negative number.
+-   the user can't insert on input left a number that is greater than input on the right.
+-   if the user inserts on the input on the right a number that is lower than input on the left, the component sets to 0 the minimum price.
+
+## Feature Plugin only
+
+### Hold stock for 60mins if the order is pending payment. ([5546](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5546))
+
+1.  Edit an item and ensure it has inventory enabled.
+2.  Successfully place an order.
+
+### Fix duplicated checkout error notices. ([5476](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5476))
+
+1. Make sure you're using the Blocks checkout and an payment method configurate (for example Stripe).
+2. Add 1 or more products to your cart.
+3. Go to the blocks checkout page
+4. Pay through the credit card form with a card that will be declined, e.g. 4000 0000 0000 0002.
+5. Ensure that only one error notice is displayed
+
+### Store API and Cart block now support defining a quantity stepper and a minimum quantity. ([5406](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5406))
+
+1. Smoke test adding items to cart and changing quantity, either via the + and - buttons, or directly via the input.
+2. Edit a product and make it "sold individually"
+3. Confirm that no quantity box shows on the cart page for this product
+4. Edit a product and set stock to 6, no backorders.
+5. Confirm that you can only have 6 maximum for this product.
+
 ### Fixed a styling issue in the Checkout block when an order has multiple shipping packages. ([5529](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5529))
 
 1. Install `Woo Subscriptions`.
@@ -154,18 +168,6 @@ You should test `Single Product Page`.
 3. Go to Cart and see the input to redeem points is showing
 4. The text input should be inline with the "Apply Discount" button
 
-### Filter Products By Price block: Don't allow to insert negative values on inputs. ([5123](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5123))
-
-1. Create a post and add `All Products` block and add `Filter Products by Price` block.
-2. Save the post.
-3. Go to the page having all the above block added.
-
-Check that:
-
--   the user can't insert in both inputs a negative number.
--   the user can't insert on input left a number that is greater than input on the right.
--   if the user inserts on the input on the right a number that is lower than input on the left, the component sets to 0 the minimum price.
-
 ### Remove Stripe Payment Method Integration (which is now part of the Stripe Payment Method extension itself). ([5449](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5449))
 
 Install the [Stripe Payment Method Extension](https://github.com/woocommerce/woocommerce-gateway-stripe/), activate it, enable it and test it works by:
@@ -175,11 +177,10 @@ Install the [Stripe Payment Method Extension](https://github.com/woocommerce/woo
 3. Select Stripe Credit Card extension and make a payment. Do so while logged in and save the card to your account.
 4. Repeat checkout with a saved card.
 
-<!-- FEEDBACK -->
----
+## <!-- FEEDBACK -->
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/680.md)
-<!-- /FEEDBACK -->
 
+<!-- /FEEDBACK -->

--- a/docs/testing/releases/690.md
+++ b/docs/testing/releases/690.md
@@ -2,7 +2,7 @@
 
 Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.com/woocommerce/woocommerce-gutenberg-products-block/files/7980490/woocommerce-gutenberg-products-block.zip)
 
-## Feature Plugin
+## WC Core
 
 ### FSE: Revert "Allow LegacyTemplate block to be reinserted, only on WooCommerce block templates.". ([5643](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5643))
 
@@ -36,6 +36,8 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 2. Open Appearance > Editor > Templates Parts.
 3. Check that Mini Cart template is NOT visible.
 
+## Feature Plugin only
+
 ### Show express payment button in full width if only one express payment method is available. ([5601](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5601))
 
 1. Create a test page with the checkout block.
@@ -62,11 +64,12 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 3. Open settings sidebar.
 4. Activate Account Options » Allow shoppers to sign up for a user account during checkout.
 5. Verify that the Create an account? section has [sufficient top margin](https://user-images.githubusercontent.com/3323310/150910947-7e54c5cc-6f65-4eb9-8a9b-16328d0af2c1.png) as opposed to [being crammed](https://user-images.githubusercontent.com/3323310/150910955-97d4fb04-a619-40ce-8758-32ba4aa90bb0.png).
-<!-- FEEDBACK -->
+ <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/690.md)
-<!-- /FEEDBACK -->
 
+<!-- /FEEDBACK -->


### PR DESCRIPTION
Some minor changes to the testing instructions for the 6.8.0 and 6.9.0 releases to enable WC peeps to discern what to test a bit better for the WC 6.3.0 release.

### To test:
- Check that everything listed under "WC Core" is work that will be included in core, and anything under "Feature Plugin only" will only be included for users with this plugin active