### PR TITLE
Fix: Shopping Button block: undefined icon break the Site Editor

### DIFF
--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-shopping-button-block/block.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-shopping-button-block/block.tsx
@@ -14,8 +14,8 @@ const Block = (): JSX.Element | null => {
 	}
 
 	return (
-		<div className="wp-block-button aligncenter is-style-outline">
-			<a className="wp-block-button__link" href={ SHOP_URL }>
+		<div className="wc-block-mini-cart__shopping-button">
+			<a href={ SHOP_URL }>
 				{ __( 'Start shopping', 'woo-gutenberg-products-block' ) }
 			</a>
 		</div>

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-shopping-button-block/index.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-shopping-button-block/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Icon, bookmark } from '@woocommerce/icons';
+import { Icon, button } from '@wordpress/icons';
 import { registerFeaturePluginBlockType } from '@woocommerce/block-settings';
 
 /**
@@ -14,7 +14,7 @@ registerFeaturePluginBlockType( metadata, {
 	icon: {
 		src: (
 			<Icon
-				srcElement={ bookmark }
+				icon={ button }
 				className="wc-block-editor-components-block-icon"
 			/>
 		),


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #5858 

This PR fixes the Icon issue of the Shopping Button that breaks the Site Editor by following #5599 to use WordPress `<Icon>` component and button icon.

This also corrects the button markup and classes, which is left from https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5614.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### Screenshots

<img width="1392" alt="image" src="https://user-images.githubusercontent.com/5423135/154194176-02b13c70-82b8-44cc-8fe2-53d08d8097eb.png">

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Edit the Mini Cart template part.
2. Toggle the Block lists navigation.
3. See no error.
4. Select the Mini Cart Shopping Button.
5. See no error.
### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
* [ ] See steps below.