### PR TITLE
Introduce new cart/order validation hooks

### DIFF
--- a/docs/examples/validate-cart.md
+++ b/docs/examples/validate-cart.md
@@ -1,0 +1,19 @@
+```php
+// The action callback function.
+function my_function_callback( $cart ) {
+  // Validate the $cart object and throw a RouteException. For example, to create an error if the cart contains more than 10 items:
+  if ( $cart->get_cart_contents_count() > 10 ) {
+    throw new Automattic\WooCommerce\Blocks\StoreApi\Routes\RouteException( 'my_exception_code', 'Too many cart items!' );
+  }
+}
+
+add_action( '__experimental_woocommerce_store_api_validate_cart', 'my_function_callback', 10 );
+```
+<!-- FEEDBACK -->
+---
+
+[We're hiring!](https://woocommerce.com/careers/) Come work with us!
+
+🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/examples/checkout-order-processed.md)
+<!-- /FEEDBACK -->
+

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -310,18 +310,6 @@ class Checkout extends AbstractCartRoute {
 			$this->order_controller->update_order_from_cart( $this->order );
 		}
 
-		// Confirm order is valid before proceeding further.
-		if ( ! $this->order instanceof \WC_Order ) {
-			throw new RouteException(
-				'woocommerce_rest_checkout_missing_order',
-				__( 'Unable to create order', 'woo-gutenberg-products-block' ),
-				500
-			);
-		}
-
-		// Store order ID to session.
-		$this->set_draft_order_id( $this->order->get_id() );
-
 		/**
 		 * Fires when the Checkout Block/Store API updates an order's meta data.
 		 *
@@ -365,6 +353,18 @@ class Checkout extends AbstractCartRoute {
 		 */
 		do_action( 'woocommerce_blocks_checkout_update_order_meta', $this->order );
 
+		// Confirm order is valid before proceeding further.
+		if ( ! $this->order instanceof \WC_Order ) {
+			throw new RouteException(
+				'woocommerce_rest_checkout_missing_order',
+				__( 'Unable to create order', 'woo-gutenberg-products-block' ),
+				500
+			);
+		}
+
+		// Store order ID to session.
+		$this->set_draft_order_id( $this->order->get_id() );
+
 		/**
 		 * Try to reserve stock for the order.
 		 *
@@ -382,14 +382,6 @@ class Checkout extends AbstractCartRoute {
 				$e->getCode()
 			);
 		}
-
-		/**
-		 * Fire action after draft order creation/update.
-		 * Functions hooking into this can throw a \RouteException to force the checkout block into an error state that prevents access to its contents.
-		 *
-		 * @param \WC_Order $order Order object.
-		 */
-		do_action( 'wooocommerce_blocks_draft_order_updated', $this->order );
 	}
 
 	/**

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -310,6 +310,18 @@ class Checkout extends AbstractCartRoute {
 			$this->order_controller->update_order_from_cart( $this->order );
 		}
 
+		// Confirm order is valid before proceeding further.
+		if ( ! $this->order instanceof \WC_Order ) {
+			throw new RouteException(
+				'woocommerce_rest_checkout_missing_order',
+				__( 'Unable to create order', 'woo-gutenberg-products-block' ),
+				500
+			);
+		}
+
+		// Store order ID to session.
+		$this->set_draft_order_id( $this->order->get_id() );
+
 		/**
 		 * Fires when the Checkout Block/Store API updates an order's meta data.
 		 *
@@ -353,18 +365,6 @@ class Checkout extends AbstractCartRoute {
 		 */
 		do_action( 'woocommerce_blocks_checkout_update_order_meta', $this->order );
 
-		// Confirm order is valid before proceeding further.
-		if ( ! $this->order instanceof \WC_Order ) {
-			throw new RouteException(
-				'woocommerce_rest_checkout_missing_order',
-				__( 'Unable to create order', 'woo-gutenberg-products-block' ),
-				500
-			);
-		}
-
-		// Store order ID to session.
-		$this->set_draft_order_id( $this->order->get_id() );
-
 		/**
 		 * Try to reserve stock for the order.
 		 *
@@ -382,6 +382,14 @@ class Checkout extends AbstractCartRoute {
 				$e->getCode()
 			);
 		}
+
+		/**
+		 * Fire action after draft order creation/update.
+		 * Functions hooking into this can throw a \RouteException to force the checkout block into an error state that prevents access to its contents.
+		 *
+		 * @param \WC_Order $order Order object.
+		 */
+		do_action( 'wooocommerce_blocks_draft_order_updated', $this->order );
 	}
 
 	/**

--- a/src/StoreApi/Routes/Checkout.php
+++ b/src/StoreApi/Routes/Checkout.php
@@ -341,6 +341,7 @@ class Checkout extends AbstractCartRoute {
 		 * Fires when the Checkout Block/Store API updates an order's meta data.
 		 *
 		 * This hook gives extensions the chance to add or update meta data on the $order.
+		 * Throwing an exception from a callback attached to this action will make the Checkout Block render in a warning state, effectively preventing checkout.
 		 *
 		 * This is similar to existing core hook woocommerce_checkout_update_order_meta.
 		 * We're using a new action:

--- a/src/StoreApi/Schemas/CartSchema.php
+++ b/src/StoreApi/Schemas/CartSchema.php
@@ -411,6 +411,7 @@ class CartSchema extends AbstractSchema {
 		try {
 			/**
 			 * Fire action to validate cart. Functions hooking into this should throw a \RouteException.
+			 * @example See docs/examples/validate-cart.md
 			 *
 			 * @param \WC_Cart $cart Cart object.
 			 */

--- a/src/StoreApi/Schemas/CartSchema.php
+++ b/src/StoreApi/Schemas/CartSchema.php
@@ -419,7 +419,8 @@ class CartSchema extends AbstractSchema {
 			$cart_errors[] = new WP_Error( $error->getErrorCode(), $error->getMessage() );
 		}
 
-		$cart_errors = array_filter( array_merge( $cart_errors, $item_errors, $coupon_errors ),
+		$cart_errors = array_filter(
+			array_merge( $cart_errors, $item_errors, $coupon_errors ),
 			function ( WP_Error $error ) {
 				return $error->has_errors();
 			}

--- a/src/StoreApi/Schemas/CartSchema.php
+++ b/src/StoreApi/Schemas/CartSchema.php
@@ -414,7 +414,7 @@ class CartSchema extends AbstractSchema {
 			 *
 			 * @param \WC_Cart $cart Cart object.
 			 */
-			do_action( 'wooocommerce_store_api_validate_cart', $cart );
+			do_action( '__experimental_wooocommerce_store_api_validate_cart', $cart );
 		} catch ( RouteException $error ) {
 			$cart_errors[] = new WP_Error( $error->getErrorCode(), $error->getMessage() );
 		}

--- a/src/StoreApi/Schemas/CartSchema.php
+++ b/src/StoreApi/Schemas/CartSchema.php
@@ -414,7 +414,7 @@ class CartSchema extends AbstractSchema {
 			 *
 			 * @param \WC_Cart $cart Cart object.
 			 */
-			do_action( '__experimental_wooocommerce_store_api_validate_cart', $cart );
+			do_action( '__experimental_woocommerce_store_api_validate_cart', $cart );
 		} catch ( RouteException $error ) {
 			$cart_errors[] = new WP_Error( $error->getErrorCode(), $error->getMessage() );
 		}

--- a/src/StoreApi/Schemas/CartSchema.php
+++ b/src/StoreApi/Schemas/CartSchema.php
@@ -404,14 +404,27 @@ class CartSchema extends AbstractSchema {
 	 */
 	protected function get_cart_errors( $cart ) {
 		$controller    = new CartController();
-		$item_errors   = array_filter(
-			$controller->get_cart_item_errors(),
+		$cart_errors   = [];
+		$item_errors   = $controller->get_cart_item_errors();
+		$coupon_errors = $controller->get_cart_coupon_errors();
+
+		try {
+			/**
+			 * Fire action to validate cart. Functions hooking into this should throw a \RouteException.
+			 *
+			 * @param \WC_Cart $cart Cart object.
+			 */
+			do_action( 'wooocommerce_store_api_validate_cart', $cart );
+		} catch ( RouteException $error ) {
+			$cart_errors[] = new WP_Error( $error->getErrorCode(), $error->getMessage() );
+		}
+
+		$cart_errors = array_filter( array_merge( $cart_errors, $item_errors, $coupon_errors ),
 			function ( WP_Error $error ) {
 				return $error->has_errors();
 			}
 		);
-		$coupon_errors = $controller->get_cart_coupon_errors();
 
-		return array_values( array_map( [ $this->error_schema, 'get_item_response' ], array_merge( $item_errors, $coupon_errors ) ) );
+		return array_values( array_map( [ $this->error_schema, 'get_item_response' ], $cart_errors ) );
 	}
 }


### PR DESCRIPTION
While diving deeper into Cart/Checkout Error Handling, we found that

- The Store API provides an <code>errors</code> field as the "canonical" way to pass cart errors to front-end consumers.
- The presence of <code>errors</code> does not prevent access to the contents of the Checkout Block. To prevent access to the Checkout Block, developers must throw <a href="https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/1c478e60acb805733be04c5ca4c9f2d2443f7551/src/StoreApi/Routes/Checkout.php#L122">[an Exception here](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/1c478e60acb805733be04c5ca4c9f2d2443f7551/src/StoreApi/Routes/Checkout.php#L122)</a>. 
- If <code>errors</code> have been added to the cart response via the <code>wooocommerce_store_api_validate_cart_item</code> <a href="https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/1c478e60acb805733be04c5ca4c9f2d2443f7551/src/StoreApi/Utilities/CartController.php#L577">[action](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/1c478e60acb805733be04c5ca4c9f2d2443f7551/src/StoreApi/Utilities/CartController.php#L577)</a>, they are not rendered in the Checkout block.

So far so good! This is a great architecture that gives developers a lot of flexibility to:

- determine if their own errors should prevent access to the checkout block;
- decide how to display/consume `errors` in the checkout block.

To better serve extensibility needs:

- Developers will need a way to add cart `errors` that replaces the legacy `woocommerce_check_cart_items` hook. Such a way does not seem to exist right now.
- We need to make it clear to developers that the presence of `errors` does not automatically prevent access to the Checkout block. Going forward, they are responsible for determining if their errors should trigger this behavior in the front-end. On our side, we need to make this clearer in the code, and ideally also provide a hook for this purpose.

This PR:

1. Introduces a new `wooocommerce_store_api_validate_cart` action, which can be used by third party developers to add extra 'errors' in cart route responses. This is meant to function as a replacement of the legacy `woocommerce_check_cart_items` hook.
2. Introduces a new `wooocommerce_blocks_draft_order_updated` action. This new action can be used to modify the finalized draft order object. Additionally, developers can use it to throw a RouteException in order to prevent access to the checkout block, instead of the `woocommerce_blocks_checkout_update_order_meta` (naming more aligned with intent!).

Finally the PR also shuffles some existing code that checks the order instance and sets the draft order ID before the `woocommerce_blocks_checkout_update_order_meta` gets fired.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] I've updated [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) for any feature flags or experimental interfaces implemented in this pull request.
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### Testing

#### Automated Tests
* [x] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [ ] E2E tests

### User Facing Testing

None.


### Changelog

> Introduced `wooocommerce_store_api_validate_cart` and `wooocommerce_blocks_draft_order_updated` actions.
