### PR TITLE
Add Testing Details In Contributors Guide

### DIFF
--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -130,10 +130,6 @@ This will use the `.prettierrc.js` file in the root folder of the Blocks plugin 
 You’ll find a handful of scripts in `package.json` that performs the automated tests and linting. You can run the following commands to execute automated tests in your terminal:
 
 - JS tests: `npm run test`
-- End-to-End `tests:npm run test:e2e` 
-- PHP tests: `npm run test:php` 
-
-You can also use [Docker](https://www.docker.com/) to run end-to-end or php tests.
 
 - Run `npm run wp-env` command to setup the development environment in Docker.
 

--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -125,6 +125,19 @@ To use Prettier, you should install the [Prettier - Code formatter](https://mark
 
 This will use the `.prettierrc.js` file in the root folder of the Blocks plugin repository and the version of Prettier that is installed in the root `node_modules` folder.
 
+## Testing
+
+You’ll find a handful of scripts in `package.json` that performs the automated tests and linting. You can run the following commands to execute automated tests in your terminal:
+
+- JS tests: `npm run test`
+- End-to-End `tests:npm run test:e2e` 
+- PHP tests: `npm run test:php` 
+
+You can also use [Docker](https://www.docker.com/) to run end-to-end or php tests.
+
+- Run `npm run wp-env` command to setup the development environment in Docker.
+
+
 <!-- FEEDBACK -->
 ---
 

--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -137,6 +137,7 @@ You can also use [Docker](https://www.docker.com/) to run end-to-end or php test
 
 - Run `npm run wp-env` command to setup the development environment in Docker.
 
+To find out more about how to run automated JavaScript tests, check out the documentation on [JavaScript Testing](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/contributors/javascript-testing.md).
 
 <!-- FEEDBACK -->
 ---


### PR DESCRIPTION
Fixes #5878

This PR adds the testing details in the [Getting Started Contributors Guide](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/contributors/getting-started.md).

### Testing

Read the [Getting Started Contributors Guide](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/contributors/getting-started.md) and make sure testing steps are added correctly.