### PR TITLE
Pass context information about parent block to the existing Slots

### DIFF
--- a/assets/js/base/components/cart-checkout/shipping-rates-control/index.tsx
+++ b/assets/js/base/components/cart-checkout/shipping-rates-control/index.tsx
@@ -81,6 +81,7 @@ interface ShippingRatesControlProps {
 	shippingRatesLoading: boolean;
 	noResultsMessage: ReactElement;
 	renderOption: PackageRateRenderOption;
+	context: 'wc/cart' | 'wc/checkout';
 }
 /**
  * Renders the shipping rates control element.
@@ -92,6 +93,7 @@ interface ShippingRatesControlProps {
  * @param {boolean} [props.collapsible] If true, when multiple packages are rendered they can be toggled open and closed.
  * @param {ReactElement} props.noResultsMessage Rendered when there are no packages.
  * @param {Function} [props.renderOption] Function to render a shipping rate.
+ * @param {string} [props.context] String indicating in which block the component is rendered
  */
 const ShippingRatesControl = ( {
 	shippingRates,
@@ -100,6 +102,7 @@ const ShippingRatesControl = ( {
 	collapsible = false,
 	noResultsMessage,
 	renderOption,
+	context,
 }: ShippingRatesControlProps ): JSX.Element => {
 	useEffect( () => {
 		if ( shippingRatesLoading ) {
@@ -161,6 +164,7 @@ const ShippingRatesControl = ( {
 		components: {
 			ShippingRatesControlPackage,
 		},
+		context,
 	};
 	const { isEditor } = useEditorContext();
 

--- a/assets/js/base/components/cart-checkout/shipping-rates-control/index.tsx
+++ b/assets/js/base/components/cart-checkout/shipping-rates-control/index.tsx
@@ -81,7 +81,7 @@ interface ShippingRatesControlProps {
 	shippingRatesLoading: boolean;
 	noResultsMessage: ReactElement;
 	renderOption: PackageRateRenderOption;
-	context: 'wc/cart' | 'wc/checkout';
+	context: 'woocommerce/cart' | 'woocommerce/checkout';
 }
 /**
  * Renders the shipping rates control element.
@@ -93,7 +93,7 @@ interface ShippingRatesControlProps {
  * @param {boolean} [props.collapsible] If true, when multiple packages are rendered they can be toggled open and closed.
  * @param {ReactElement} props.noResultsMessage Rendered when there are no packages.
  * @param {Function} [props.renderOption] Function to render a shipping rate.
- * @param {string} [props.context] String indicating in which block the component is rendered
+ * @param {string} [props.context] String equal to the block name where the Slot is rendered
  */
 const ShippingRatesControl = ( {
 	shippingRates,

--- a/assets/js/base/components/cart-checkout/totals/shipping/shipping-rate-selector.js
+++ b/assets/js/base/components/cart-checkout/totals/shipping/shipping-rate-selector.js
@@ -40,7 +40,7 @@ const ShippingRateSelector = ( {
 				}
 				shippingRates={ shippingRates }
 				shippingRatesLoading={ shippingRatesLoading }
-				context="wc/cart"
+				context="woocommerce/cart"
 			/>
 		</fieldset>
 	);

--- a/assets/js/base/components/cart-checkout/totals/shipping/shipping-rate-selector.js
+++ b/assets/js/base/components/cart-checkout/totals/shipping/shipping-rate-selector.js
@@ -40,6 +40,7 @@ const ShippingRateSelector = ( {
 				}
 				shippingRates={ shippingRates }
 				shippingRatesLoading={ shippingRatesLoading }
+				context="wc/cart"
 			/>
 		</fieldset>
 	);

--- a/assets/js/blocks/cart-checkout/cart/inner-blocks/cart-order-summary-block/block.tsx
+++ b/assets/js/blocks/cart-checkout/cart/inner-blocks/cart-order-summary-block/block.tsx
@@ -56,11 +56,13 @@ const Block = ( {
 	const slotFillProps = {
 		extensions,
 		cart,
+		context: 'wc/cart',
 	};
 
 	const discountsSlotFillProps = {
 		extensions,
 		cart,
+		context: 'wc/cart',
 	};
 
 	return (

--- a/assets/js/blocks/cart-checkout/cart/inner-blocks/cart-order-summary-block/block.tsx
+++ b/assets/js/blocks/cart-checkout/cart/inner-blocks/cart-order-summary-block/block.tsx
@@ -56,13 +56,13 @@ const Block = ( {
 	const slotFillProps = {
 		extensions,
 		cart,
-		context: 'wc/cart',
+		context: 'woocommerce/cart',
 	};
 
 	const discountsSlotFillProps = {
 		extensions,
 		cart,
-		context: 'wc/cart',
+		context: 'woocommerce/cart',
 	};
 
 	return (

--- a/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-block/block.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-block/block.tsx
@@ -54,6 +54,7 @@ const Block = ( {
 	const slotFillProps = {
 		extensions,
 		cart,
+		context: 'wc/checkout',
 	};
 
 	return (

--- a/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-block/block.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-block/block.tsx
@@ -54,7 +54,7 @@ const Block = ( {
 	const slotFillProps = {
 		extensions,
 		cart,
-		context: 'wc/checkout',
+		context: 'woocommerce/checkout',
 	};
 
 	return (

--- a/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/block.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/block.tsx
@@ -103,6 +103,7 @@ const Block = (): JSX.Element | null => {
 					renderOption={ renderShippingRatesControlOption }
 					shippingRates={ shippingRates }
 					shippingRatesLoading={ shippingRatesLoading }
+					context="wc/checkout"
 				/>
 			) }
 		</>

--- a/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/block.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/block.tsx
@@ -103,7 +103,7 @@ const Block = (): JSX.Element | null => {
 					renderOption={ renderShippingRatesControlOption }
 					shippingRates={ shippingRates }
 					shippingRatesLoading={ shippingRatesLoading }
-					context="wc/checkout"
+					context="woocommerce/checkout"
 				/>
 			) }
 		</>

--- a/docs/extensibility/available-slot-fills.md
+++ b/docs/extensibility/available-slot-fills.md
@@ -2,29 +2,37 @@
 
 This document presents the list of available Slots that you can use for adding your custom content (Fill):
 
-- [ExperimentalOrderMeta](#experimentalordermeta)
-- [ExperimentalOrderShippingPackages](#experimentalordershippingpackages)
-- [ExperimentalDiscountsMeta](#experimentaldiscountsmeta)
+-   [ExperimentalOrderMeta](#experimentalordermeta)
+-   [ExperimentalOrderShippingPackages](#experimentalordershippingpackages)
+-   [ExperimentalDiscountsMeta](#experimentaldiscountsmeta)
 
-***
+---
 
 If you want to add a new SlotFill component, check the [Checkout - Slot Fill document](../../packages/checkout/slot/README.md). To read more about Slot and Fill, check the [Slot and Fill document](./slot-fills.md).
 
 **Note About Naming:** Slots that are prefixed with `Experimental` are experimental and subject to change or remove. Once they graduate from the experimental stage, the naming would change and the `Experimental` prefix would be dropped.
 Check the [Feature Gating document](../blocks/feature-flags-and-experimental-interfaces.md) from more information.
 
-
 ## ExperimentalOrderMeta
+
 This Slot renders below the Checkout summary section and above the "Proceed to Checkout" button in the Cart.
 
-<img width="1135" alt="image" src="https://user-images.githubusercontent.com/6165348/118398683-a0202700-b651-11eb-8a4f-cd8b6ebff53f.png">
+Cart:
+
+<img width="865" alt="Screenshot 2022-02-17 at 16 42 33" src="https://user-images.githubusercontent.com/1628454/154517779-117bb4e4-568e-413c-904c-855fc3450dfa.png">
+
+Checkout:
+
+<img width="1233" alt="image" src="https://user-images.githubusercontent.com/6165348/118399133-90094700-b653-11eb-8ff0-c917947c199f.png">
 
 ### Passed parameters
 
-- `cart`: `wc/store/cart` data but in `camelCase` instead of `snake_case`. [Object breakdown.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/c00da597efe4c16fcf5481c213d8052ec5df3766/assets/js/type-defs/cart.ts#L172-L188)
-- `extensions`: external data registered by third-party developers using `ExtendRestAPI`. If you used `ExtendRestAPI` on `wc/store/cart` you would find your data under your namespace here.
+-   `cart`: `wc/store/cart` data but in `camelCase` instead of `snake_case`. [Object breakdown.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/c00da597efe4c16fcf5481c213d8052ec5df3766/assets/js/type-defs/cart.ts#L172-L188)
+-   `extensions`: external data registered by third-party developers using `ExtendRestAPI`. If you used `ExtendRestAPI` on `wc/store/cart` you would find your data under your namespace here.
+-   `context`, equal to `wc/cart` or `wc/checkout` depending on which Block the fill is rendered in
 
 ## ExperimentalOrderShippingPackages
+
 This slot renders inside the shipping step of Checkout and inside the shipping options in Cart.
 
 Cart:
@@ -37,17 +45,19 @@ Checkout:
 
 ### Passed parameters
 
-- `collapsible`: `Boolean` If a shipping package panel should be collapsible or not, this is false in Checkout and true in Cart.
-- `collapse`: `Boolean` If a panel should be collapsed by default, this is true if there's more than 1 fill registered (Core Shipping options are registered as a fill and they're counted).
-- `showItems`: `Boolean` If we should show the content of each package, this is true if there's more than 1 fill registered (Core Shipping options are registered as a fill and they're counted).
-- `noResultsMessage`: A React element that you can render if there are no shipping options.
-- `renderOption`: a render function that takes a rate object and returns a render option.
-- `cart`: `wc/store/cart` data but in `camelCase` instead of `snake_case`. [Object breakdown.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/c00da597efe4c16fcf5481c213d8052ec5df3766/assets/js/type-defs/cart.ts#L172-L188)
-- `extensions`: external data registered by third-party developers using `ExtendRestAPI`, if you used `ExtendRestAPI` on `wc/store/cart` you would find your data under your namespace here.
-- `components`: an object containing components you can use to render your own shipping rates, it contains `ShippingRatesControlPackage`.
+-   `collapsible`: `Boolean` If a shipping package panel should be collapsible or not, this is false in Checkout and true in Cart.
+-   `collapse`: `Boolean` If a panel should be collapsed by default, this is true if there's more than 1 fill registered (Core Shipping options are registered as a fill and they're counted).
+-   `showItems`: `Boolean` If we should show the content of each package, this is true if there's more than 1 fill registered (Core Shipping options are registered as a fill and they're counted).
+-   `noResultsMessage`: A React element that you can render if there are no shipping options.
+-   `renderOption`: a render function that takes a rate object and returns a render option.
+-   `cart`: `wc/store/cart` data but in `camelCase` instead of `snake_case`. [Object breakdown.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/c00da597efe4c16fcf5481c213d8052ec5df3766/assets/js/type-defs/cart.ts#L172-L188)
+-   `extensions`: external data registered by third-party developers using `ExtendRestAPI`, if you used `ExtendRestAPI` on `wc/store/cart` you would find your data under your namespace here.
+-   `components`: an object containing components you can use to render your own shipping rates, it contains `ShippingRatesControlPackage`.
+-   `context`, equal to `wc/cart` or `wc/checkout` depending on which Block the fill is rendered in
 
 ## ExperimentalDiscountsMeta
-This slot renders below the `CouponCode` input. 
+
+This slot renders below the `CouponCode` input.
 
 Cart:
 <img alt="Cart showing ExperimentalDiscountsMeta location" src="https://user-images.githubusercontent.com/5656702/122774218-ea27a880-d2a0-11eb-9450-11f119567f26.png" />
@@ -56,14 +66,15 @@ Checkout:
 <img alt="Checkout showing ExperimentalDiscountsMeta location" src="https://user-images.githubusercontent.com/5656702/122779606-efd3bd00-d2a5-11eb-8c84-6525eca5d704.png" />
 
 ### Passed paramters
-- `cart`: `wc/store/cart` data but in `camelCase` instead of `snake_case`. [Object breakdown.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/c00da597efe4c16fcf5481c213d8052ec5df3766/assets/js/type-defs/cart.ts#L172-L188)
-- `extensions`: external data registered by third-party developers using `ExtendRestAPI`, if you used `ExtendRestAPI` on `wc/store/cart` you would find your data under your namespace here.
 
-<!-- FEEDBACK -->
----
+-   `cart`: `wc/store/cart` data but in `camelCase` instead of `snake_case`. [Object breakdown.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/c00da597efe4c16fcf5481c213d8052ec5df3766/assets/js/type-defs/cart.ts#L172-L188)
+-   `extensions`: external data registered by third-party developers using `ExtendRestAPI`, if you used `ExtendRestAPI` on `wc/store/cart` you would find your data under your namespace here.
+-   `context`, equal to `wc/cart` or `wc/checkout` depending on which Block the fill is rendered in
+
+## <!-- FEEDBACK -->
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/extensibility/available-slot-fills.md)
-<!-- /FEEDBACK -->
 
+<!-- /FEEDBACK -->

--- a/docs/extensibility/available-slot-fills.md
+++ b/docs/extensibility/available-slot-fills.md
@@ -19,11 +19,11 @@ This Slot renders below the Checkout summary section and above the "Proceed to C
 
 Cart:
 
-<img width="865" alt="Screenshot 2022-02-17 at 16 42 33" src="https://user-images.githubusercontent.com/1628454/154517779-117bb4e4-568e-413c-904c-855fc3450dfa.png">
+<img width="865" alt="Example of ExperimentalOrderMeta in the Cart block" src="https://user-images.githubusercontent.com/1628454/154517779-117bb4e4-568e-413c-904c-855fc3450dfa.png">
 
 Checkout:
 
-<img width="1233" alt="image" src="https://user-images.githubusercontent.com/6165348/118399133-90094700-b653-11eb-8ff0-c917947c199f.png">
+<img width="860" alt="Example of ExperimentalOrderMeta in the Checkout block" src="https://user-images.githubusercontent.com/1628454/154697224-de245182-6783-4914-81ba-1dbcf77292eb.png">
 
 ### Passed parameters
 
@@ -37,11 +37,11 @@ This slot renders inside the shipping step of Checkout and inside the shipping o
 
 Cart:
 
-<img width="1151" alt="image" src="https://user-images.githubusercontent.com/6165348/118399054-2b4dec80-b653-11eb-94a0-989e2e6e362a.png">
+<img width="1151" alt="Example of ExperimentalOrderShippingPackages in the Cart block" src="https://user-images.githubusercontent.com/6165348/118399054-2b4dec80-b653-11eb-94a0-989e2e6e362a.png">
 
 Checkout:
 
-<img width="1233" alt="image" src="https://user-images.githubusercontent.com/6165348/118399133-90094700-b653-11eb-8ff0-c917947c199f.png">
+<img width="1233" alt="Example of ExperimentalOrderShippingPackages in the Checkout block" src="https://user-images.githubusercontent.com/6165348/118399133-90094700-b653-11eb-8ff0-c917947c199f.png">
 
 ### Passed parameters
 

--- a/docs/extensibility/available-slot-fills.md
+++ b/docs/extensibility/available-slot-fills.md
@@ -29,7 +29,7 @@ Checkout:
 
 -   `cart`: `wc/store/cart` data but in `camelCase` instead of `snake_case`. [Object breakdown.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/c00da597efe4c16fcf5481c213d8052ec5df3766/assets/js/type-defs/cart.ts#L172-L188)
 -   `extensions`: external data registered by third-party developers using `ExtendRestAPI`. If you used `ExtendRestAPI` on `wc/store/cart` you would find your data under your namespace here.
--   `context`, equal to `wc/cart` or `wc/checkout` depending on which Block the fill is rendered in
+-   `context`, equal to the name of the Block in which the fill is rendered: `woocommerce/cart` or `woocommerce/checkout`
 
 ## ExperimentalOrderShippingPackages
 
@@ -53,7 +53,7 @@ Checkout:
 -   `cart`: `wc/store/cart` data but in `camelCase` instead of `snake_case`. [Object breakdown.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/c00da597efe4c16fcf5481c213d8052ec5df3766/assets/js/type-defs/cart.ts#L172-L188)
 -   `extensions`: external data registered by third-party developers using `ExtendRestAPI`, if you used `ExtendRestAPI` on `wc/store/cart` you would find your data under your namespace here.
 -   `components`: an object containing components you can use to render your own shipping rates, it contains `ShippingRatesControlPackage`.
--   `context`, equal to `wc/cart` or `wc/checkout` depending on which Block the fill is rendered in
+-   `context`, equal to the name of the Block in which the fill is rendered: `woocommerce/cart` or `woocommerce/checkout`
 
 ## ExperimentalDiscountsMeta
 
@@ -69,7 +69,7 @@ Checkout:
 
 -   `cart`: `wc/store/cart` data but in `camelCase` instead of `snake_case`. [Object breakdown.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/c00da597efe4c16fcf5481c213d8052ec5df3766/assets/js/type-defs/cart.ts#L172-L188)
 -   `extensions`: external data registered by third-party developers using `ExtendRestAPI`, if you used `ExtendRestAPI` on `wc/store/cart` you would find your data under your namespace here.
--   `context`, equal to `wc/cart` or `wc/checkout` depending on which Block the fill is rendered in
+-   `context`, equal to the name of the Block in which the fill is rendered: `woocommerce/cart` or `woocommerce/checkout`
 
 ## <!-- FEEDBACK -->
 

--- a/docs/extensibility/slot-fills.md
+++ b/docs/extensibility/slot-fills.md
@@ -21,7 +21,7 @@ The `ExperimentalOrderMeta` will automatically pass props to its top level child
 
 -   `cart` which contains cart data
 -   `extensions` which contains data registered with `ExtendRestAPI` in `wc/store/cart` endpoint
--   `context`, equal to `wc/cart` or `wc/checkout` depending on which Block the fill is rendered in
+-   `context`, equal to the name of the Block in which the fill is rendered: `woocommerce/cart` or `woocommerce/checkout`
 
 ```jsx
 const { registerPlugin } = wp.plugins;

--- a/docs/extensibility/slot-fills.md
+++ b/docs/extensibility/slot-fills.md
@@ -1,6 +1,7 @@
 # Slot and Fill
 
 ## The problem
+
 You added custom data to the [Store API](./extend-rest-api-add-data.md). You changed several strings using [Checkout filters](./available-filters.md). Now you want to render your own components in specific places in the Cart and Checkout.
 
 ## Solution
@@ -15,22 +16,26 @@ Slot and Fill use WordPress' API, and you can learn more about how they work in 
 
 ## Basic Usage
 
-`ExperimentalOrderMeta` is a fill that will render in a slot below the order summary section in the Cart and Checkout blocks.
-The `ExperimentalOrderMeta` will automatically pass props to its top level child: `cart` which contains cart data, and `extensions` which contains data registered with `ExtendRestAPI` in `wc/store/cart` endpoint.
+`ExperimentalOrderMeta` is a fill that will render in a slot below the Order summary section in the Cart and Checkout blocks.
+The `ExperimentalOrderMeta` will automatically pass props to its top level child:
+
+-   `cart` which contains cart data
+-   `extensions` which contains data registered with `ExtendRestAPI` in `wc/store/cart` endpoint
+-   `context`, equal to `wc/cart` or `wc/checkout` depending on which Block the fill is rendered in
 
 ```jsx
 const { registerPlugin } = wp.plugins;
 const { ExperimentalOrderMeta } = wc.blocksCheckout;
 
 const MyCustomComponent = ( { cart, extensions } ) => {
-	return <div className='my-component'>Hello WooCommerce</div>
-}
+	return <div className="my-component">Hello WooCommerce</div>;
+};
 
 const render = () => {
 	return (
-			<ExperimentalOrderMeta>
-				<MyCustomComponent />
-			</ExperimentalOrderMeta>
+		<ExperimentalOrderMeta>
+			<MyCustomComponent />
+		</ExperimentalOrderMeta>
 	);
 };
 
@@ -47,13 +52,13 @@ In the above example, we're using `registerPlugin`. This plugin will take our co
 You use `registerPlugin` to feed in your plugin namespace, your component `render`, and the scope of your `registerPlugin`. The value of scope should always be `woocommerce-checkout`.
 
 ## Requirements
+
 For this to work, your script must be enqueued after Cart and Checkout. You can follow the [IntegrationInterface](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/50f9b3e8d012f425d318908cc13d9c601d97bd68/docs/extensibility/integration-interface.md) documentation for enqueueing your script.
 
-<!-- FEEDBACK -->
----
+## <!-- FEEDBACK -->
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/extensibility/slot-fills.md)
-<!-- /FEEDBACK -->
 
+<!-- /FEEDBACK -->

--- a/packages/checkout/components/discounts-meta/index.js
+++ b/packages/checkout/components/discounts-meta/index.js
@@ -16,7 +16,7 @@ const {
 	Slot: DiscountsMetaSlot,
 } = createSlotFill( slotName );
 
-const Slot = ( { className, extensions, cart } ) => {
+const Slot = ( { className, extensions, cart, context } ) => {
 	const { fills } = useSlot( slotName );
 	return (
 		hasValidFills( fills ) && (
@@ -26,7 +26,7 @@ const Slot = ( { className, extensions, cart } ) => {
 						className,
 						'wc-block-components-discounts-meta'
 					) }
-					fillProps={ { extensions, cart } }
+					fillProps={ { extensions, cart, context } }
 				/>
 			</TotalsWrapper>
 		)

--- a/packages/checkout/components/order-meta/index.js
+++ b/packages/checkout/components/order-meta/index.js
@@ -15,7 +15,7 @@ const { Fill: ExperimentalOrderMeta, Slot: OrderMetaSlot } = createSlotFill(
 	slotName
 );
 
-const Slot = ( { className, extensions, cart } ) => {
+const Slot = ( { className, extensions, cart, context } ) => {
 	const { fills } = useSlot( slotName );
 	return (
 		hasValidFills( fills ) && (
@@ -25,7 +25,7 @@ const Slot = ( { className, extensions, cart } ) => {
 						className,
 						'wc-block-components-order-meta'
 					) }
-					fillProps={ { extensions, cart } }
+					fillProps={ { extensions, cart, context } }
 				/>
 			</TotalsWrapper>
 		)

--- a/packages/checkout/components/order-shipping-packages/index.js
+++ b/packages/checkout/components/order-shipping-packages/index.js
@@ -22,6 +22,7 @@ const Slot = ( {
 	extensions,
 	cart,
 	components,
+	context,
 } ) => {
 	const { fills } = useSlot( slotName );
 	const hasMultiplePackages = fills.length > 1;
@@ -40,6 +41,7 @@ const Slot = ( {
 				extensions,
 				cart,
 				components,
+				context,
 			} }
 		/>
 	);


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR passes context information about containing block to the existing Slots and updates the Slots documentation to reflect the changes.
<!-- Reference any related issues or PRs here -->
Fixes #5854 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

#### Other Checks

- [x] I've updated [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) for any feature flags or experimental interfaces implemented in this pull request.
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.


### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Checkout this branch
2. Install the WooCommerce Subscription extension
3. Create a Subscription product and add it to cart
4. Use the React Components dev tools to test that the ExperimentalOrderShippingPackages and ExperimentalOrderMeta pass the correct context value: `wc/cart` for the Fills in the Cart block and `wc/checkout` for the Fills in the Checkout block.
5. Install the WC Points and Reward extension and add some points to the user
6. Use the React Components dev tools to test that the `ExperimentalDiscountsMeta` passes the correct context value: `wc/cart` for the Fills in the Cart block and `wc/checkout` for the Fills in the Checkout block.
### User Facing Testing
* [x] Don't include this PR in the Release notes



<!-- If you can, add the appropriate labels -->

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Pass context information about containing block to the existing Slots
