### PR TITLE
Add to Featured Product block option to remove custom image

### DIFF
--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -31,6 +31,7 @@ import PropTypes from 'prop-types';
 import { getSetting } from '@woocommerce/settings';
 import ProductControl from '@woocommerce/editor-components/product-control';
 import ErrorPlaceholder from '@woocommerce/editor-components/error-placeholder';
+import TextToolbarButton from '@woocommerce/editor-components/text-toolbar-button';
 import { withProduct } from '@woocommerce/block-hocs';
 import { Icon, starEmpty } from '@wordpress/icons';
 
@@ -138,19 +139,29 @@ const FeaturedProduct = ( {
 						setAttributes( { contentAlign: nextAlign } );
 					} }
 				/>
-				<MediaReplaceFlow
-					mediaId={ mediaId }
-					mediaURL={ mediaSrc }
-					accept="image/*"
-					onSelect={ ( media ) => {
-						setAttributes( {
-							mediaId: media.id,
-							mediaSrc: media.url,
-						} );
-					} }
-					allowedTypes={ [ 'image' ] }
-				/>
-
+				<ToolbarGroup>
+					<MediaReplaceFlow
+						mediaId={ mediaId }
+						mediaURL={ mediaSrc }
+						accept="image/*"
+						onSelect={ ( media ) => {
+							setAttributes( {
+								mediaId: media.id,
+								mediaSrc: media.url,
+							} );
+						} }
+						allowedTypes={ [ 'image' ] }
+					/>
+					{ mediaId && mediaSrc ? (
+						<TextToolbarButton
+							onClick={ () =>
+								setAttributes( { mediaId: 0, mediaSrc: '' } )
+							}
+						>
+							{ __( 'Remove', 'woo-gutenberg-products-block' ) }
+						</TextToolbarButton>
+					) : null }
+				</ToolbarGroup>
 				<ToolbarGroup
 					controls={ [
 						{

--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -158,7 +158,7 @@ const FeaturedProduct = ( {
 								setAttributes( { mediaId: 0, mediaSrc: '' } )
 							}
 						>
-							{ __( 'Remove', 'woo-gutenberg-products-block' ) }
+							{ __( 'Reset', 'woo-gutenberg-products-block' ) }
 						</TextToolbarButton>
 					) : null }
 				</ToolbarGroup>


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This adds ability to remove custom image from Featured Product block. Removing custom image will reset it back to the default product image if available. This follows solution from #5719 which added this option to Featured Category block.

<!-- Reference any related issues or PRs here -->
Fixes #5725

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)


**UPDATE**: "Remove" label replaced with "Reset"
### Screenshots
![Screenshot 2022-02-18 at 00 02 37](https://user-images.githubusercontent.com/112270/154586939-a9802d26-a5fe-45a4-9f7a-34a74b0930b5.jpg)

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### Manual Testing

How to test the changes in this Pull Request:

1. Add a Featured Product block to a page, post, or template.
2. Add custom background media.
3. The button to remove the image should be available.
4. If clicked it should remove the custom media.
5. If the product had an image it should display it again.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
* [ ] See steps below.
### Note

misaligned "Shop Now" is an unrelated issue

### Changelog

> Featured Product block: add the ability to reset to a previously set custom background image.
