### PR TITLE
Fix New Block Inserter Overlaps

### DIFF
--- a/assets/js/blocks/checkout/form-step/editor.scss
+++ b/assets/js/blocks/checkout/form-step/editor.scss
@@ -1,6 +1,6 @@
 
 .wc-block-checkout__additional_fields {
-	margin: 1.5em 0 -1.5em;
+	margin: 1.5em 0 0;
 }
 .wc-block-components-checkout-step__description-placeholder {
 	opacity: 0.5;


### PR DESCRIPTION


<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
When the Show step number attribute is unchecked, the new block inserter will not get overlapped with the title of the next block at the bottom.
<!-- Reference any related issues or PRs here -->
Fixes #5849





### Screenshots

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/11503784/154746685-d70c66f6-95b5-47f5-882d-d56d0b82ae4f.png) | <img width="529" alt="image" src="https://user-images.githubusercontent.com/11503784/154746824-0059bf20-86ec-4f70-85ba-b1cc96bbfee3.png"> |



### Testing

### Manual Testing

How to test the changes in this Pull Request:

1. Add the Checkout block.
2. Click on any inner block (Shipping address) and uncheck the Show step number attribute.
3. The new block inserter at the bottom of the block should not overlap with the title of the next block (Shipping options).
### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above



### Changelog

> Fix new block inserter overlaps
