### PR TITLE
Fix typo

### DIFF
--- a/src/StoreApi/Utilities/QuantityLimits.php
+++ b/src/StoreApi/Utilities/QuantityLimits.php
@@ -93,7 +93,7 @@ final class QuantityLimits {
 		if ( ! $limits['editable'] ) {
 			return new \WP_Error(
 				'readonly_quantity',
-				__( 'This item is already in the cart and it\'s quantity cannot be edited', 'woo-gutenberg-products-block' )
+				__( 'This item is already in the cart and its quantity cannot be edited', 'woo-gutenberg-products-block' )
 			);
 		}
 


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR fixes a typo in the error thrown when an attempt to modify quantities on a readonly item is made.
 
### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Modify the cart's front-end code so you can alter the quantity of a readonly item. You need to always show the `QuantitySelector` and allow it to be used to increase the quantity of the item.
2. Add an item to the cart that is "Sold individually"
3. Try to increase the quantity and observe the API response
4. Ensure the API gives you an error with the correct spelling. (No apostrophe in `its`).


### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).

1. No user-facing steps required.

### Changelog

> Fixed a typographical error in one of the error messages returned by the API.
