### PR TITLE
Remove hover effect from disabled Mini Cart button

### DIFF
--- a/assets/js/blocks/cart-checkout/mini-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/mini-cart/style.scss
@@ -24,7 +24,7 @@
 	font-weight: 400;
 	padding: em($gap-small) em($gap-smaller);
 
-	&:hover {
+	&:hover:not([disabled]) {
 		opacity: 0.6;
 	}
 }


### PR DESCRIPTION
Removes the `:hover` effect from the Mini Cart button when it's disabled.

### Manual Testing

1. Go to Appearance > Site Editor and add the Mini Cart block to the header.
2. Go to the Cart or Checkout page and hover the Mini Cart block.
3. Verify the button has no `:hover` effect.

Before | After
--- | ---
![Kooha-02-21-2022-16-27-38](https://user-images.githubusercontent.com/3616980/154984761-aed874ee-3bd4-43df-9595-1c6fe67b5bab.gif) | ![Kooha-02-21-2022-16-27-00](https://user-images.githubusercontent.com/3616980/154984661-845636f5-0243-42b4-b314-76d346d0a076.gif)
