### PR TITLE
Correctly load JS translations from WC core

### DIFF
--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -205,7 +205,7 @@ function woocommerce_blocks_get_i18n_data_json( $translations, $file, $handle, $
 JS;
 
 	// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.NoExplicitVersion
-	wp_register_script( $handle_filename, '', array(), false, true );
+	wp_register_script( $handle_filename, '', array( 'wp-i18n' ), false, true );
 	wp_enqueue_script( $handle_filename );
 	wp_add_inline_script(
 		$handle_filename,

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -172,7 +172,8 @@ function woocommerce_blocks_get_i18n_data_json( $translations, $file, $handle, $
 		return $translations;
 	}
 
-	$handle_filename = basename( $wp_scripts->registered[ $handle ]->src );
+	$handle_src      = explode( '/build/', $wp_scripts->registered[ $handle ]->src );
+	$handle_filename = $handle_src[1];
 	$locale          = determine_locale();
 	$lang_dir        = WP_LANG_DIR . '/plugins';
 
@@ -203,7 +204,13 @@ function woocommerce_blocks_get_i18n_data_json( $translations, $file, $handle, $
 	} )( "{$domain}", {$json_translations} );
 JS;
 
-	printf( "<script type='text/javascript'>\n%s\n</script>\n", $output ); // phpcs:ignore
+	// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.NoExplicitVersion
+	wp_register_script( $handle_filename, '', array(), false, true );
+	wp_enqueue_script( $handle_filename );
+	wp_add_inline_script(
+		$handle_filename,
+		$output
+	);
 
 	// Finally, short circuit the pre_load_script_translations hook by returning
 	// the translation JSON from the feature plugin, if it exists so this hook


### PR DESCRIPTION
While doing some testing, I noticed translations of JS files were not correctly loaded in some locales. The locale needed to have the strings translated in WC core but not in WC Blocks.

### Manual Testing

1. Go to Settings > General > Language (`/wp-admin/options-general.php`) and select a language which has WC core translation at 100% but WC Blocks' at 0%. (I tested with `Català`).
2. Go to the updates screen (`/wp-admin/update-core.php`), scroll down and update the language translations.
3. Visit the Cart or Checkout block in the frontend and verify the texts are translated.

Before | After
--- | ---
![imatge](https://user-images.githubusercontent.com/3616980/154985999-0ac2210b-29c3-4085-8dad-218496ab7734.png) | ![imatge](https://user-images.githubusercontent.com/3616980/154985945-fa7add28-1e99-418e-b342-d120277640a9.png)

4. Switch to a language where WC core translations already exist (ie: `Deutsch`, `Español` or `Français`) and verify translations are still loaded correctly (you will need to go to the updates screen again).

### Changelog

> Fix loading WC core translations in locales where WC Blocks is not localized for some strings.
