### PR TITLE
Fix: Ensure `shopper.goToBlockPage` works with any theme

### DIFF
--- a/tests/utils/shopper.js
+++ b/tests/utils/shopper.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { shopper as wcShopper } from '@woocommerce/e2e-utils';
-import { createURL } from '@wordpress/e2e-test-utils';
 
 /**
  * Internal dependencies
@@ -49,11 +48,9 @@ export const shopper = {
 	},
 
 	goToBlockPage: async ( title ) => {
-		await page.goto( createURL( '/' ), { waitUntil: 'networkidle0' } );
-
-		await expect( page ).toClick( '.nav-menu a', { text: title } );
-
-		await page.waitForNavigation();
+		await page.goto( await getBlockPagePermalink( title ), {
+			waitUntil: 'networkidle0',
+		} );
 
 		await expect( page ).toMatchElement( 'h1', { text: title } );
 	},


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Relates #5913 

The `shopper.goToBlockPage` was created with the assumption that the test environment is always using the Storefront theme, we use that assumption to [speed up the test](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5877#pullrequestreview-887416788). #5913 shows that the test environment doesn't always use Storefront.

While we need to investigate why the Storefront theme doesn't active for the test environment, I think it's better for a utility to work with any theme. 

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

See the GH Actions passing (Running the E2E tests locally doesn't have any issue. Only tests on GH Actions are failing. )