### PR TITLE
Avoid calling plugin_dir_url a lot

### DIFF
--- a/src/Domain/Package.php
+++ b/src/Domain/Package.php
@@ -28,6 +28,13 @@ class Package {
 	private $path;
 
 	/**
+	 * Holds locally the plugin_dir_url to avoid recomputing it.
+	 *
+	 * @var string
+	 */
+	private $plugin_dir_url;
+
+	/**
 	 * Holds the feature gating class instance.
 	 *
 	 * @var FeatureGating
@@ -45,6 +52,9 @@ class Package {
 		$this->version        = $version;
 		$this->path           = $plugin_path;
 		$this->feature_gating = $feature_gating;
+
+		// Append index.php so WP does not return the parent directory.
+		$this->plugin_dir_url = plugin_dir_url( $this->path . '/index.php' );
 	}
 
 	/**
@@ -77,8 +87,7 @@ class Package {
 	 * @return string
 	 */
 	public function get_url( $relative_url = '' ) {
-		// Append index.php so WP does not return the parent directory.
-		return plugin_dir_url( $this->path . '/index.php' ) . $relative_url;
+		return $this->plugin_dir_url . $relative_url;
 	}
 
 	/**


### PR DESCRIPTION
Hello,
I've spent a bit of time optimizing my Wordpress + Woocommerce install. I've noticed that Automattic\WooCommerce\Blocks\Domain\Package->get_url() is called quite a few times (79 times on my installation), and recomputes plugin_dir_url each time.
This patch caches it in a static variable. It is a little improvement, but makes this function responsible for about 71 microseconds instead of 3.5 milliseconds, so I suppose it's something :)

Hope this helps.

Callstack before:
![image](https://user-images.githubusercontent.com/1016317/155084966-0a0cfb66-4ecc-4a05-a6a9-991ecb1cc140.png)

Callstack after:
![image](https://user-images.githubusercontent.com/1016317/155085018-79d35bdb-67d3-410b-aec9-b7ddb87b77d4.png)


### Testing instructions
Visit some pages containing blocks and ensure they load correctly. Check you can still add blocks in the block editor.

### Changelog
Cache plugin_dir_url instead of recomputing it dozens of times.
