### PR TITLE
Load MiniCart template part using the correct template ID

### DIFF
--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -377,7 +377,7 @@ class MiniCart extends AbstractBlock {
 		}
 
 		$template_part_contents = '';
-		$template_part          = BlockTemplateUtils::get_block_template( get_stylesheet() . '//mini-cart', 'wp_template_part' );
+		$template_part          = BlockTemplateUtils::get_block_template( BlockTemplateUtils::PLUGIN_SLUG . '//mini-cart', 'wp_template_part' );
 
 		if ( $template_part && ! empty( $template_part->content ) ) {
 			$template_part_contents = do_blocks( $template_part->content );


### PR DESCRIPTION
Previously we were loading the MiniCart template part using `get_stylesheet() . '//mini-cart'` which would be `twentytwentytwo//mini-cart`. This is wrong as the Mini Cart should have the WooCommerce slug. I've updated this now so it should evaluate `woocommerce/woocommerce//mini-cart` like the rest of the templates.

<!-- Reference any related issues or PRs here -->
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5883

### Manual Testing

How to test the changes in this Pull Request:

1. Before checking out this PR clear all Mini Cart customizations
2. Checkout this PR
3. Check Mini Cart renders correctly inside the Site Editor and on the frontend
4. Make some customizations and save them.
5. Check Mini Cart renders the customizations inside the Site Editor and on the frontend correctly.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
* [ ] See steps below.

1.
2.
3.
