### PR TITLE
Ensure screenshots can be attached in jest html report

### DIFF
--- a/tests/e2e/config/environment.js
+++ b/tests/e2e/config/environment.js
@@ -8,15 +8,14 @@ class E2EEnvironment extends PuppeteerEnvironment {
 	async handleTestEvent( event ) {
 		if (
 			event.name === 'test_fn_failure' ||
-			event.asyncError !== undefined
+			event.name === 'hook_failure'
 		) {
 			const attach = await this.global.page.screenshot();
-			console.log( 'taking screenshot' );
 			await addAttach( {
 				attach,
 				description: 'Full Page Screenshot',
 				context: this.global,
-				bufferFormat: 'utf8',
+				bufferFormat: 'png',
 			} );
 		}
 	}

--- a/tests/e2e/config/environment.js
+++ b/tests/e2e/config/environment.js
@@ -6,7 +6,10 @@ const { addAttach } = require( 'jest-html-reporters/helper' );
 
 class E2EEnvironment extends PuppeteerEnvironment {
 	async handleTestEvent( event ) {
-		if ( event.name === 'test_fn_failure' ) {
+		if (
+			event.name === 'test_fn_failure' ||
+			event.asyncError !== undefined
+		) {
 			const attach = await this.global.page.screenshot();
 			console.log( 'taking screenshot' );
 			await addAttach( {

--- a/tests/e2e/config/environment.js
+++ b/tests/e2e/config/environment.js
@@ -10,7 +10,10 @@ class E2EEnvironment extends PuppeteerEnvironment {
 			event.name === 'test_fn_failure' ||
 			event.name === 'hook_failure'
 		) {
-			const attach = await this.global.page.screenshot();
+			console.log( event );
+			const attach = await this.global.page.screenshot( {
+				fullPage: event.name !== 'hook_failure',
+			} );
 			await addAttach( {
 				attach,
 				description: 'Full Page Screenshot',

--- a/tests/e2e/config/environment.js
+++ b/tests/e2e/config/environment.js
@@ -10,7 +10,6 @@ class E2EEnvironment extends PuppeteerEnvironment {
 			event.name === 'test_fn_failure' ||
 			event.name === 'hook_failure'
 		) {
-			console.log( event );
 			const attach = await this.global.page.screenshot( {
 				fullPage: event.name !== 'hook_failure',
 			} );

--- a/tests/e2e/config/environment.js
+++ b/tests/e2e/config/environment.js
@@ -7,8 +7,13 @@ const { addAttach } = require( 'jest-html-reporters/helper' );
 class E2EEnvironment extends PuppeteerEnvironment {
 	async handleTestEvent( event ) {
 		if ( event.name === 'test_fn_failure' ) {
-			const data = await this.global.page.screenshot();
-			await addAttach( data, 'Full Page Screenshot', this.global );
+			const attach = await this.global.page.screenshot();
+			await addAttach( {
+				attach,
+				description: 'Full Page Screenshot',
+				context: this.global,
+				bufferFormat: 'utf8',
+			} );
 		}
 	}
 }

--- a/tests/e2e/config/environment.js
+++ b/tests/e2e/config/environment.js
@@ -8,6 +8,7 @@ class E2EEnvironment extends PuppeteerEnvironment {
 	async handleTestEvent( event ) {
 		if ( event.name === 'test_fn_failure' ) {
 			const attach = await this.global.page.screenshot();
+			console.log( 'taking screenshot' );
 			await addAttach( {
 				attach,
 				description: 'Full Page Screenshot',

--- a/tests/e2e/specs/frontend/checkout.test.js
+++ b/tests/e2e/specs/frontend/checkout.test.js
@@ -50,7 +50,7 @@ describe( `${ block.name } Block (frontend)`, () => {
 		// Set base location with state CA.
 		await expect( page ).toSelect(
 			'select[name="woocommerce_default_country"]',
-			'United States (US) — Caliifornia'
+			'United States (US) — California'
 		);
 		// Sell to all countries
 		await expect( page ).toSelect(

--- a/tests/e2e/specs/frontend/checkout.test.js
+++ b/tests/e2e/specs/frontend/checkout.test.js
@@ -50,7 +50,7 @@ describe( `${ block.name } Block (frontend)`, () => {
 		// Set base location with state CA.
 		await expect( page ).toSelect(
 			'select[name="woocommerce_default_country"]',
-			'United States (US) — California'
+			'United States (US) — Caliifornia'
 		);
 		// Sell to all countries
 		await expect( page ).toSelect(


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
The signature for attaching images via `addAttach` in `jest-html-reporters` was changed here https://github.com/Hazyzh/jest-html-reporters/commit/ad7dd8c2486114e09b78781a38b2e51903ea19e8 and now accepts  an object.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Push a commit here that will cause the e2e tests to error, for example change the state on this line to one that doesn't exist.
https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/35c5161a3e95901a1668f4360d5ae0227986a117/tests/e2e/specs/frontend/checkout.test.js#L50-L53
2. When e2e tests finish running, go to the artifacts section of the job and download the zip file.
3. Open the report, and ensure there's an image of the screen captures on the failing test.
4. Revert the bad commit.

Alternatively, view the artifacts from here: https://github.com/woocommerce/woocommerce-gutenberg-products-block/actions/runs/1886571707 and see the report

### User Facing Testing
No user-facing testing required.
