### PR TITLE
Fix spelling of two action hooks in Store API

### DIFF
--- a/bin/hook-docs/data/actions.json
+++ b/bin/hook-docs/data/actions.json
@@ -669,7 +669,7 @@
             "args": 0
         },
         {
-            "name": "wooocommerce_store_api_validate_add_to_cart",
+            "name": "woocommerce_store_api_validate_add_to_cart",
             "file": "StoreApi/Utilities/CartController.php",
             "type": "action",
             "doc": {
@@ -698,7 +698,7 @@
             "args": 2
         },
         {
-            "name": "wooocommerce_store_api_validate_cart_item",
+            "name": "woocommerce_store_api_validate_cart_item",
             "file": "StoreApi/Utilities/CartController.php",
             "type": "action",
             "doc": {

--- a/docs/extensibility/actions.md
+++ b/docs/extensibility/actions.md
@@ -33,8 +33,8 @@
  - [woocommerce_register_post](#woocommerce_register_post)
  - [woocommerce_rest_checkout_process_payment_with_context](#woocommerce_rest_checkout_process_payment_with_context)
  - [woocommerce_shop_loop](#woocommerce_shop_loop)
- - [wooocommerce_store_api_validate_add_to_cart](#wooocommerce_store_api_validate_add_to_cart)
- - [wooocommerce_store_api_validate_cart_item](#wooocommerce_store_api_validate_cart_item)
+ - [woocommerce_store_api_validate_add_to_cart](#woocommerce_store_api_validate_add_to_cart)
+ - [woocommerce_store_api_validate_cart_item](#woocommerce_store_api_validate_cart_item)
 
 ---
 

--- a/docs/extensibility/available-slot-fills.md
+++ b/docs/extensibility/available-slot-fills.md
@@ -71,10 +71,11 @@ Checkout:
 -   `extensions`: external data registered by third-party developers using `ExtendRestAPI`, if you used `ExtendRestAPI` on `wc/store/cart` you would find your data under your namespace here.
 -   `context`, equal to the name of the Block in which the fill is rendered: `woocommerce/cart` or `woocommerce/checkout`
 
-## <!-- FEEDBACK -->
+<!-- FEEDBACK -->
+---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/extensibility/available-slot-fills.md)
-
 <!-- /FEEDBACK -->
+

--- a/docs/extensibility/slot-fills.md
+++ b/docs/extensibility/slot-fills.md
@@ -55,10 +55,11 @@ You use `registerPlugin` to feed in your plugin namespace, your component `rende
 
 For this to work, your script must be enqueued after Cart and Checkout. You can follow the [IntegrationInterface](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/50f9b3e8d012f425d318908cc13d9c601d97bd68/docs/extensibility/integration-interface.md) documentation for enqueueing your script.
 
-## <!-- FEEDBACK -->
+<!-- FEEDBACK -->
+---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/extensibility/slot-fills.md)
-
 <!-- /FEEDBACK -->
+

--- a/src/StoreApi/Utilities/CartController.php
+++ b/src/StoreApi/Utilities/CartController.php
@@ -602,7 +602,7 @@ class CartController {
 			'wooocommerce_store_api_validate_cart_item',
 			array(
 				$product,
-				$request,
+				$cart_item,
 			),
 			'7.1.0',
 			'woocommerce_store_api_validate_cart_item',

--- a/src/StoreApi/Utilities/CartController.php
+++ b/src/StoreApi/Utilities/CartController.php
@@ -263,13 +263,31 @@ class CartController {
 		/**
 		 * Fires during validation when adding an item to the cart via the Store API.
 		 *
+		 * @param \WC_Product $product Product object being added to the cart.
+		 * @param array       $request Add to cart request params including id, quantity, and variation attributes.
+		 * @deprecated 7.1.0 Use woocommerce_store_api_validate_add_to_cart instead.
+		 */
+		wc_do_deprecated_action(
+			'wooocommerce_store_api_validate_add_to_cart',
+			array(
+				$product,
+				$request,
+			),
+			'7.1.0',
+			'woocommerce_store_api_validate_add_to_cart',
+			'This action was deprecated in WooCommerce Blocks version 7.1.0. Please use woocommerce_store_api_validate_add_to_cart instead.'
+		);
+
+		/**
+		 * Fires during validation when adding an item to the cart via the Store API.
+		 *
 		 * Fire action to validate add to cart. Functions hooking into this should throw an \Exception to prevent
 		 * add to cart from happening.
 		 *
 		 * @param \WC_Product $product Product object being added to the cart.
 		 * @param array       $request Add to cart request params including id, quantity, and variation attributes.
 		 */
-		do_action( 'wooocommerce_store_api_validate_add_to_cart', $product, $request );
+		do_action( 'woocommerce_store_api_validate_add_to_cart', $product, $request );
 	}
 
 	/**
@@ -578,8 +596,27 @@ class CartController {
 		 *
 		 * @param \WC_Product $product Product object being added to the cart.
 		 * @param array       $cart_item Cart item array.
+		 * @deprecated 7.1.0 Use woocommerce_store_api_validate_cart_item instead.
 		 */
-		do_action( 'wooocommerce_store_api_validate_cart_item', $product, $cart_item );
+		wc_do_deprecated_action(
+			'wooocommerce_store_api_validate_cart_item',
+			array(
+				$product,
+				$request,
+			),
+			'7.1.0',
+			'woocommerce_store_api_validate_cart_item',
+			'This action was deprecated in WooCommerce Blocks version 7.1.0. Please use woocommerce_store_api_validate_cart_item instead.'
+		);
+
+		/**
+		 * Fire action to validate add to cart. Functions hooking into this should throw an \Exception to prevent
+		 * add to cart from occurring.
+		 *
+		 * @param \WC_Product $product Product object being added to the cart.
+		 * @param array       $cart_item Cart item array.
+		 */
+		do_action( 'woocommerce_store_api_validate_cart_item', $product, $cart_item );
 	}
 
 	/**

--- a/src/StoreApi/docs/guiding-principles.md
+++ b/src/StoreApi/docs/guiding-principles.md
@@ -127,10 +127,11 @@ Non-breaking changes are always permitted without the need to increase the API v
 
 The version will not increase for bug fixes unless the scope of the bug causes a backwards-incompatible change. Fixes would not be rolled back to past API versions with the exception of security issues that require backporting.
 
-## <!-- FEEDBACK -->
+<!-- FEEDBACK -->
+---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./src/StoreApi/docs/guiding-principles.md)
-
 <!-- /FEEDBACK -->
+


### PR DESCRIPTION
Corrects:

- `wooocommerce_store_api_validate_add_to_cart` -> `woocommerce_store_api_validate_add_to_cart`
- `wooocommerce_store_api_validate_cart_item` -> `woocommerce_store_api_validate_cart_item`

Implements `wc_do_deprecated_action` for backwards compatibility with the incorrect hook names.

Fixes #5884

### Testing

This is a rename so there is nothing to test here.

### Changelog

> Fixed typo in `wooocommerce_store_api_validate_add_to_cart` and `wooocommerce_store_api_validate_cart_item` hook names.
