### PR TITLE
Add font-style and font-weight support for the Product Categories List block

### DIFF
--- a/assets/js/atomic/blocks/product-elements/category-list/index.ts
+++ b/assets/js/atomic/blocks/product-elements/category-list/index.ts
@@ -37,6 +37,9 @@ const blockConfig: BlockConfiguration = {
 			},
 			typography: {
 				fontSize: true,
+				lineHeight: true,
+				__experimentalFontStyle: true,
+				__experimentalFontWeight: true,
 				__experimentalSkipSerialization: true,
 			},
 			__experimentalSelector:

--- a/src/BlockTypes/ProductCategoryList.php
+++ b/src/BlockTypes/ProductCategoryList.php
@@ -53,6 +53,8 @@ class ProductCategoryList extends AbstractBlock {
 			'typography'             =>
 			array(
 				'fontSize'                        => true,
+				'__experimentalFontStyle'         => true,
+				'__experimentalFontWeight'        => true,
 				'__experimentalSkipSerialization' => true,
 			),
 			'__experimentalSelector' => '.wc-block-components-product-category-list',


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

This PR adds support for margin customization on the Global Style.

<!-- Reference any related issues or PRs here -->
Fixes #5670

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### Testing
### Manual Testing

How to test the changes in this Pull Request:

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

This PR adds support for global style for the `Product Categories List` block.

Now, the user can edit the style for:
- margin


<!-- Reference any related issues or PRs here -->
#5670

### Screenshots

![image](https://user-images.githubusercontent.com/4463174/155370400-de48417e-4a42-46a2-990e-cd95ac0d6f27.png)
*without global style*

![image](https://user-images.githubusercontent.com/4463174/155370571-ac58a3e0-927d-4d4c-a4c0-a0df04884298.png)
*with global style*

### Testing

### Manual Testing

Check out this branch:

1. Use `WordPress 5.9`.
2. Install and enable the `Twenty Twenty-Two` theme.
3. Add the `All Products` block  (this block contains the `Product Categories List` block) to a post.
4. Get the focus on the `Product Categories List` block.
5. On the right sidebar, personalize the font style.
6. Go on the page and check if there are changes.
7. Reset to default using the `Reset` button from the different sections.
8. On the Editor page click on the `Styles` icon on the right-top corner.
9. Verify that the `Product Categories List` is shown under the `Blocks` section. Personalize again the font style.
10. Save your changes.
11. Go on the page created earlier and check if all styles are applied correctly.
12. Edit your previous post/page again.
13. Change again the styles.
14. Save your changes.
15. Check if these styles have priority over the styles from the Site Editor.
