### PR TITLE
Change tests that use the incorrect `waitForSelector` API

### DIFF
--- a/tests/e2e/specs/frontend/checkout.test.js
+++ b/tests/e2e/specs/frontend/checkout.test.js
@@ -122,8 +122,8 @@ describe( `${ block.name } Block (frontend)`, () => {
 		await shopper.goToCheckoutBlock();
 		const html = await page.content();
 
-		await page.waitForSelector( 'h1', { text: 'Checkout block' } );
-		await page.waitForSelector( 'strong', { text: 'Your cart is empty!' } );
+		expect( page ).toMatch( 'h1', { text: 'Checkoutttt block' } );
+		expect( page ).toMatch( 'strong', { text: 'Your cart is eempty!' } );
 	} );
 
 	it( 'allows customer to choose available payment methods', async () => {

--- a/tests/e2e/specs/frontend/checkout.test.js
+++ b/tests/e2e/specs/frontend/checkout.test.js
@@ -122,8 +122,10 @@ describe( `${ block.name } Block (frontend)`, () => {
 		await shopper.goToCheckoutBlock();
 		const html = await page.content();
 
-		expect( page ).toMatch( 'h1', { text: 'Checkoutttt block' } );
-		expect( page ).toMatch( 'strong', { text: 'Your cart is eempty!' } );
+		expect( page ).toMatchElement( 'h1', { text: 'Checkout block' } );
+		expect( page ).toMatchElement( 'strong', {
+			text: 'Your cart is empty!',
+		} );
 	} );
 
 	it( 'allows customer to choose available payment methods', async () => {

--- a/tests/e2e/specs/frontend/checkout.test.js
+++ b/tests/e2e/specs/frontend/checkout.test.js
@@ -122,7 +122,7 @@ describe( `${ block.name } Block (frontend)`, () => {
 		await shopper.goToCheckoutBlock();
 		const html = await page.content();
 
-		expect( page ).toMatchElement( 'h1', { text: 'Checkout block' } );
+		expect( page ).toMatchElement( 'h1', { text: 'Checkout Block' } );
 		expect( page ).toMatchElement( 'strong', {
 			text: 'Your cart is empty!',
 		} );

--- a/tests/utils/shopper.js
+++ b/tests/utils/shopper.js
@@ -19,7 +19,7 @@ export const shopper = {
 		await page.goto( checkoutBlockPermalink, {
 			waitUntil: 'networkidle0',
 		} );
-		await page.waitForSelector( 'h1', { text: 'Checkout' } );
+		await expect( page ).toMatch( 'h1', { text: 'Checkout' } );
 	},
 
 	productIsInCheckoutBlock: async ( productTitle, quantity, total ) => {
@@ -30,16 +30,16 @@ export const shopper = {
 		if ( button ) {
 			await button.click();
 		}
-		await page.waitForSelector( 'span', {
+		await expect( page ).toMatch( 'span', {
 			text: productTitle,
 		} );
-		await page.waitForSelector(
+		await expect( page ).toMatch(
 			'div.wc-block-components-order-summary-item__quantity',
 			{
 				text: quantity,
 			}
 		);
-		await page.waitForSelector(
+		await expect( page ).toMatch(
 			'span.wc-block-components-product-price__value',
 			{
 				text: total,

--- a/tests/utils/shopper.js
+++ b/tests/utils/shopper.js
@@ -19,7 +19,7 @@ export const shopper = {
 		await page.goto( checkoutBlockPermalink, {
 			waitUntil: 'networkidle0',
 		} );
-		await expect( page ).toMatch( 'h1', { text: 'Checkout' } );
+		await expect( page ).toMatchElement( 'h1', { text: 'Checkout' } );
 	},
 
 	productIsInCheckoutBlock: async ( productTitle, quantity, total ) => {
@@ -30,16 +30,16 @@ export const shopper = {
 		if ( button ) {
 			await button.click();
 		}
-		await expect( page ).toMatch( 'span', {
+		await expect( page ).toMatchElement( 'span', {
 			text: productTitle,
 		} );
-		await expect( page ).toMatch(
+		await expect( page ).toMatchElement(
 			'div.wc-block-components-order-summary-item__quantity',
 			{
 				text: quantity,
 			}
 		);
-		await expect( page ).toMatch(
+		await expect( page ).toMatchElement(
 			'span.wc-block-components-product-price__value',
 			{
 				text: total,


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
Some tests pass an option of `text` in the options object of `waitForSelector` this is not valid.

This PR will update those instanced to use `.toMatchElement` instead which does allow matching based on text.

<!-- Reference any related issues or PRs here -->
Fixes #5875

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Ensure tests pass.
2. Set some incorrect text, for example edit https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/8aa19fef1ec96a237152f84dd64fde066cb1735f/tests/e2e/specs/frontend/checkout.test.js#L125 to be wrong, and ensure tests fail.
3. Optionally push and check it fails in CI, be sure to revert the commit.