### PR TITLE
Rename templates to more e-commerce friendly names

### DIFF
--- a/src/Utils/BlockTemplateUtils.php
+++ b/src/Utils/BlockTemplateUtils.php
@@ -264,11 +264,11 @@ class BlockTemplateUtils {
 			case 'single-product':
 				return __( 'Single Product', 'woo-gutenberg-products-block' );
 			case 'archive-product':
-				return __( 'Product Archive', 'woo-gutenberg-products-block' );
+				return __( 'Product Catalog', 'woo-gutenberg-products-block' );
 			case 'taxonomy-product_cat':
-				return __( 'Product Category', 'woo-gutenberg-products-block' );
+				return __( 'Products by Category', 'woo-gutenberg-products-block' );
 			case 'taxonomy-product_tag':
-				return __( 'Product Tag', 'woo-gutenberg-products-block' );
+				return __( 'Products by Tag', 'woo-gutenberg-products-block' );
 			default:
 				// Replace all hyphens and underscores with spaces.
 				return ucwords( preg_replace( '/[\-_]/', ' ', $template_slug ) );

--- a/tests/e2e/specs/backend/__snapshots__/site-editing-templates.test.js.snap
+++ b/tests/e2e/specs/backend/__snapshots__/site-editing-templates.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Store Editing Templates Product Archive block template should contain the "WooCommerce Product Archive Block" legacy template 1`] = `
+exports[`Store Editing Templates Product Catalog block template should contain the "WooCommerce Product Grid Block" legacy template 1`] = `
 "<!-- wp:template-part {\\"slug\\":\\"header\\",\\"theme\\":\\"emptytheme\\"} /-->
 
 <!-- wp:group {\\"layout\\":{\\"inherit\\":true}} -->
@@ -10,7 +10,7 @@ exports[`Store Editing Templates Product Archive block template should contain t
 <!-- wp:template-part {\\"slug\\":\\"footer\\",\\"theme\\":\\"emptytheme\\"} /-->"
 `;
 
-exports[`Store Editing Templates Product Category block template should contain the "WooCommerce Product Taxonomy Block" legacy template 1`] = `
+exports[`Store Editing Templates Product by Category block template should contain the "WooCommerce Product Taxonomy Block" legacy template 1`] = `
 "<!-- wp:template-part {\\"slug\\":\\"header\\",\\"theme\\":\\"emptytheme\\"} /-->
 
 <!-- wp:group {\\"layout\\":{\\"inherit\\":true}} -->
@@ -20,7 +20,7 @@ exports[`Store Editing Templates Product Category block template should contain 
 <!-- wp:template-part {\\"slug\\":\\"footer\\",\\"theme\\":\\"emptytheme\\"} /-->"
 `;
 
-exports[`Store Editing Templates Product Tag block template should contain the "WooCommerce Product Taxonomy Block" legacy template 1`] = `
+exports[`Store Editing Templates Products by Tag block template should contain the "WooCommerce Product Taxonomy Block" legacy template 1`] = `
 "<!-- wp:template-part {\\"slug\\":\\"header\\",\\"theme\\":\\"emptytheme\\"} /-->
 
 <!-- wp:group {\\"layout\\":{\\"inherit\\":true}} -->

--- a/tests/e2e/specs/backend/site-editing-templates.test.js
+++ b/tests/e2e/specs/backend/site-editing-templates.test.js
@@ -404,7 +404,7 @@ describe( 'Store Editing Templates', () => {
 
 	describe( 'Products by Tag block template', () => {
 		it( 'default template from WooCommerce Blocks is available on an FSE theme', async () => {
-			const EXPECTED_TEMPLATE = defaultTemplateProps( 'Product Tag' );
+			const EXPECTED_TEMPLATE = defaultTemplateProps( 'Products by Tag' );
 
 			await goToSiteEditor( '?postType=wp_template' );
 

--- a/tests/e2e/specs/backend/site-editing-templates.test.js
+++ b/tests/e2e/specs/backend/site-editing-templates.test.js
@@ -213,9 +213,9 @@ describe( 'Store Editing Templates', () => {
 		} );
 	} );
 
-	describe( 'Product Archive block template', () => {
+	describe( 'Product Catalog block template', () => {
 		it( 'default template from WooCommerce Blocks is available on an FSE theme', async () => {
-			const EXPECTED_TEMPLATE = defaultTemplateProps( 'Product Archive' );
+			const EXPECTED_TEMPLATE = defaultTemplateProps( 'Product Catalog' );
 
 			await goToSiteEditor( '?postType=wp_template' );
 
@@ -234,7 +234,7 @@ describe( 'Store Editing Templates', () => {
 			}
 		} );
 
-		it( 'should contain the "WooCommerce Product Archive Block" legacy template', async () => {
+		it( 'should contain the "WooCommerce Product Grid Block" legacy template', async () => {
 			const templateQuery = addQueryArgs( '', {
 				postId: 'woocommerce/woocommerce//archive-product',
 				postType: 'wp_template',
@@ -255,7 +255,7 @@ describe( 'Store Editing Templates', () => {
 
 		it( 'should show the action menu if the template has been customized by the user', async () => {
 			const EXPECTED_TEMPLATE = {
-				...defaultTemplateProps( 'Product Archive' ),
+				...defaultTemplateProps( 'Product Catalog' ),
 				hasActions: true,
 			};
 
@@ -308,10 +308,10 @@ describe( 'Store Editing Templates', () => {
 		} );
 	} );
 
-	describe( 'Product Category block template', () => {
+	describe( 'Product by Category block template', () => {
 		it( 'default template from WooCommerce Blocks is available on an FSE theme', async () => {
 			const EXPECTED_TEMPLATE = defaultTemplateProps(
-				'Product Category'
+				'Products by Category'
 			);
 
 			await goToSiteEditor( '?postType=wp_template' );
@@ -353,7 +353,7 @@ describe( 'Store Editing Templates', () => {
 
 		it( 'should show the action menu if the template has been customized by the user', async () => {
 			const EXPECTED_TEMPLATE = {
-				...defaultTemplateProps( 'Product Category' ),
+				...defaultTemplateProps( 'Products by Category' ),
 				hasActions: true,
 			};
 
@@ -402,7 +402,7 @@ describe( 'Store Editing Templates', () => {
 		} );
 	} );
 
-	describe( 'Product Tag block template', () => {
+	describe( 'Products by Tag block template', () => {
 		it( 'default template from WooCommerce Blocks is available on an FSE theme', async () => {
 			const EXPECTED_TEMPLATE = defaultTemplateProps( 'Product Tag' );
 
@@ -445,7 +445,7 @@ describe( 'Store Editing Templates', () => {
 
 		it( 'should show the action menu if the template has been customized by the user', async () => {
 			const EXPECTED_TEMPLATE = {
-				...defaultTemplateProps( 'Product Tag' ),
+				...defaultTemplateProps( 'Products by Tag' ),
 				hasActions: true,
 			};
 

--- a/tests/e2e/specs/frontend/legacy-template-blocks.test.js
+++ b/tests/e2e/specs/frontend/legacy-template-blocks.test.js
@@ -74,7 +74,7 @@ describe( 'Legacy Template blocks', () => {
 		} );
 	} );
 
-	describe( 'Product Category block', () => {
+	describe( 'Product by Category block', () => {
 		it( 'renders a list of products with their count, pagination and the category title', async () => {
 			const CATEGORY_NAME = 'Uncategorized';
 			const { productArchivePage } = SELECTORS;
@@ -112,7 +112,7 @@ describe( 'Legacy Template blocks', () => {
 		} );
 	} );
 
-	describe( 'Product Tag block', () => {
+	describe( 'Products by Tag block', () => {
 		it( 'renders a list of products with their count, pagination and the tag title', async () => {
 			const TAG_NAME = 'Newest';
 			const { productArchivePage } = SELECTORS;

--- a/tests/e2e/specs/frontend/legacy-template-blocks.test.js
+++ b/tests/e2e/specs/frontend/legacy-template-blocks.test.js
@@ -74,7 +74,7 @@ describe( 'Legacy Template blocks', () => {
 		} );
 	} );
 
-	describe( 'Product by Category block', () => {
+	describe( 'Products by Category block', () => {
 		it( 'renders a list of products with their count, pagination and the category title', async () => {
 			const CATEGORY_NAME = 'Uncategorized';
 			const { productArchivePage } = SELECTORS;


### PR DESCRIPTION
It was suggested that we change the names of our templates to better reflect the user/merchant understanding of their store experience. Names like “archive” are associated with blogging/press and definitely not with products, so this PR addresses that.

<!-- Reference any related issues or PRs here -->
Fixes #5891

### Testing

#### Automated Tests
* [x] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests

### Manual Testing

How to test the changes in this Pull Request:

1. Open the site editor
2. Ascertain that template names appear on the list according to the following table:

Old Title | New Title
-- | --
Product Archive | Product Catalog
Product Tag | Products by Tag
Product Category | Products by Category
Single Product | _no change_

### Changelog

> Renamed WooCommerce block templates to more e-commerce related names
