### PR TITLE
Revert "Change tests that use the incorrect `waitForSelector` API (#5932)

### DIFF
--- a/tests/e2e/specs/frontend/checkout.test.js
+++ b/tests/e2e/specs/frontend/checkout.test.js
@@ -122,10 +122,8 @@ describe( `${ block.name } Block (frontend)`, () => {
 		await shopper.goToCheckoutBlock();
 		const html = await page.content();
 
-		expect( page ).toMatchElement( 'h1', { text: 'Checkout Block' } );
-		expect( page ).toMatchElement( 'strong', {
-			text: 'Your cart is empty!',
-		} );
+		await page.waitForSelector( 'h1', { text: 'Checkout block' } );
+		await page.waitForSelector( 'strong', { text: 'Your cart is empty!' } );
 	} );
 
 	it( 'allows customer to choose available payment methods', async () => {

--- a/tests/utils/shopper.js
+++ b/tests/utils/shopper.js
@@ -19,7 +19,7 @@ export const shopper = {
 		await page.goto( checkoutBlockPermalink, {
 			waitUntil: 'networkidle0',
 		} );
-		await expect( page ).toMatchElement( 'h1', { text: 'Checkout' } );
+		await page.waitForSelector( 'h1', { text: 'Checkout' } );
 	},
 
 	productIsInCheckoutBlock: async ( productTitle, quantity, total ) => {
@@ -30,16 +30,16 @@ export const shopper = {
 		if ( button ) {
 			await button.click();
 		}
-		await expect( page ).toMatchElement( 'span', {
+		await page.waitForSelector( 'span', {
 			text: productTitle,
 		} );
-		await expect( page ).toMatchElement(
+		await page.waitForSelector(
 			'div.wc-block-components-order-summary-item__quantity',
 			{
 				text: quantity,
 			}
 		);
-		await expect( page ).toMatchElement(
+		await page.waitForSelector(
 			'span.wc-block-components-product-price__value',
 			{
 				text: total,


### PR DESCRIPTION
This reverts commit 9493e9fc26c49d1f701cc5573a7ced78c8f5b005. This reverts PR #5932

This has apparently introduced some flakiness in E2E tests, so we will revert while we figure out why.

### Testing instructions
Please ensure tests go green.
