### PR TITLE
Change `curl` example calls to use `sh` code block

### DIFF
--- a/src/StoreApi/README.md
+++ b/src/StoreApi/README.md
@@ -4,7 +4,7 @@
 
 Example of a valid API request using cURL:
 
-```http
+```sh
 curl "https://example-store.com/wp-json/wc/store/v1/products"
 ```
 
@@ -87,7 +87,7 @@ If collections contain many results, they may be paginated. When listing resourc
 
 In the example below, we list 20 products per page and return page 2.
 
-```http
+```sh
 curl "https://example-store.com/wp-json/wc/store/v1/products?page=2&per_page=20"
 ```
 

--- a/src/StoreApi/docs/cart-coupons.md
+++ b/src/StoreApi/docs/cart-coupons.md
@@ -14,7 +14,7 @@ GET /cart/coupons
 
 There are no parameters required for this endpoint.
 
-```http
+```sh
 curl "https://example-store.com/wp-json/wc/store/v1/cart/coupons"
 ```
 
@@ -64,7 +64,7 @@ GET /cart/coupons/:code
 | :-------- | :----- | :------: | :---------------------------------------------- |
 | `code`    | string |   Yes    | The coupon code of the cart coupon to retrieve. |
 
-```http
+```sh
 curl "https://example-store.com/wp-json/wc/store/v1/cart/coupons/20off"
 ```
 
@@ -100,7 +100,7 @@ POST /cart/coupons/
 | :-------- | :----- | :------: | :--------------------------------------------- |
 | `code`    | string |   Yes    | The coupon code you wish to apply to the cart. |
 
-```http
+```sh
 curl --request POST https://example-store.com/wp-json/wc/store/v1/cart/coupons?code=20off
 ```
 
@@ -136,7 +136,7 @@ DELETE /cart/coupons/:code
 | :-------- | :----- | :------: | :------------------------------------------------ |
 | `code`    | string |   Yes    | The coupon code you wish to remove from the cart. |
 
-```http
+```sh
 curl --request DELETE https://example-store.com/wp-json/wc/store/v1/cart/coupons/20off
 ```
 
@@ -150,7 +150,7 @@ DELETE /cart/coupons/
 
 There are no parameters required for this endpoint.
 
-```http
+```sh
 curl --request DELETE https://example-store.com/wp-json/wc/store/v1/cart/coupons
 ```
 

--- a/src/StoreApi/docs/cart-items.md
+++ b/src/StoreApi/docs/cart-items.md
@@ -14,7 +14,7 @@ GET /cart/items
 
 There are no parameters required for this endpoint.
 
-```http
+```sh
 curl "https://example-store.com/wp-json/wc/store/v1/cart/items"
 ```
 
@@ -193,7 +193,7 @@ GET /cart/items/:key
 | :-------- | :----- | :------: | :------------------------------------ |
 | `key`     | string |   Yes    | The key of the cart item to retrieve. |
 
-```http
+```sh
 curl "https://example-store.com/wp-json/wc/store/v1/cart/items/e369853df766fa44e1ed0ff613f563bd"
 ```
 
@@ -294,7 +294,7 @@ POST /cart/items/
 | `quantity`  | integer |   Yes    | Quantity of this item in the cart.                                                                   |
 | `variation` | array   |   Yes    | Chosen attributes (for variations) containing an array of objects with keys `attribute` and `value`. |
 
-```http
+```sh
 curl --request POST https://example-store.com/wp-json/wc/store/v1/cart/items?id=100&quantity=1
 ```
 
@@ -313,7 +313,7 @@ PUT /cart/items/:key
 | `key`      | string  |   Yes    | The key of the cart item to edit.  |
 | `quantity` | integer |   Yes    | Quantity of this item in the cart. |
 
-```http
+```sh
 curl --request PUT https://example-store.com/wp-json/wc/store/v1/cart/items/e369853df766fa44e1ed0ff613f563bd?quantity=10
 ```
 
@@ -331,7 +331,7 @@ DELETE /cart/items/:key
 | :-------- | :----- | :------: | :-------------------------------- |
 | `key`     | string |   Yes    | The key of the cart item to edit. |
 
-```http
+```sh
 curl --request DELETE https://example-store.com/wp-json/wc/store/v1/cart/items/e369853df766fa44e1ed0ff613f563bd
 ```
 
@@ -345,7 +345,7 @@ DELETE /cart/items/
 
 There are no parameters required for this endpoint.
 
-```http
+```sh
 curl --request DELETE https://example-store.com/wp-json/wc/store/v1/cart/items
 ```
 

--- a/src/StoreApi/docs/cart.md
+++ b/src/StoreApi/docs/cart.md
@@ -302,7 +302,7 @@ GET /cart
 
 There are no parameters required for this endpoint.
 
-```http
+```sh
 curl "https://example-store.com/wp-json/wc/store/v1/cart"
 ```
 
@@ -324,7 +324,7 @@ POST /cart/add-item
 | `quantity`  | integer |   Yes    | Quantity of this item in the cart.                                                                   |
 | `variation` | array   |   Yes    | Chosen attributes (for variations) containing an array of objects with keys `attribute` and `value`. |
 
-```http
+```sh
 curl --header "X-WC-Store-API-Nonce: 12345" --request POST https://example-store.com/wp-json/wc/store/v1/cart/add-item?id=100&quantity=1
 ```
 
@@ -344,7 +344,7 @@ POST /cart/remove-item
 | :-------- | :----- | :------: | :-------------------------------- |
 | `key`     | string |   Yes    | The key of the cart item to edit. |
 
-```http
+```sh
 curl --header "X-WC-Store-API-Nonce: 12345" --request POST https://example-store.com/wp-json/wc/store/v1/cart/remove-item?key=e369853df766fa44e1ed0ff613f563bd
 ```
 
@@ -365,7 +365,7 @@ POST /cart/update-item
 | `key`      | string  |   Yes    | The key of the cart item to edit.  |
 | `quantity` | integer |   Yes    | Quantity of this item in the cart. |
 
-```http
+```sh
 curl --header "X-WC-Store-API-Nonce: 12345" --request POST https://example-store.com/wp-json/wc/store/v1/cart/update-item?key=e369853df766fa44e1ed0ff613f563bd&quantity=10
 ```
 
@@ -385,7 +385,7 @@ POST /cart/apply-coupon/
 | :-------- | :----- | :------: | :--------------------------------------------- |
 | `code`    | string |   Yes    | The coupon code you wish to apply to the cart. |
 
-```http
+```sh
 curl --header "X-WC-Store-API-Nonce: 12345" --request POST https://example-store.com/wp-json/wc/store/v1/cart/apply-coupon?code=20off
 ```
 
@@ -405,7 +405,7 @@ POST /cart/remove-coupon/
 | :-------- | :----- | :------: | :------------------------------------------------ |
 | `code`    | string |   Yes    | The coupon code you wish to remove from the cart. |
 
-```http
+```sh
 curl --header "X-WC-Store-API-Nonce: 12345" --request POST https://example-store.com/wp-json/wc/store/v1/cart/remove-coupon?code=20off
 ```
 
@@ -461,7 +461,7 @@ POST /cart/select-shipping-rate
 | `package_id` | integer |  string  | yes                                 | The ID of the shipping package within the cart. |
 | `rate_id`    | string  |   yes    | The chosen rate ID for the package. |
 
-```http
+```sh
 curl --header "X-WC-Store-API-Nonce: 12345" --request POST /cart/select-shipping-rate?package_id=1&rate_id=flat_rate:1
 ```
 

--- a/src/StoreApi/docs/checkout.md
+++ b/src/StoreApi/docs/checkout.md
@@ -19,7 +19,7 @@ GET /wc/store/v1/checkout
 
 There are no parameters required for this endpoint.
 
-```http
+```sh
 curl --header "X-WC-Store-API-Nonce: 12345" --request GET https://example-store.com/wp-json/wc/store/v1/checkout
 ```
 
@@ -84,7 +84,7 @@ POST /wc/store/v1/checkout
 | `payment_method`   | string  |   Yes    | The ID of the payment method being used to process the payment.     |
 | `payment_data`     | array   |    No    | Data to pass through to the payment method when processing payment. |
 
-```http
+```sh
 curl --header "X-WC-Store-API-Nonce: 12345" --request POST https://example-store.com/wp-json/wc/store/v1/checkout?payment_method=paypal&payment_data[0][key]=test-key&payment_data[0][value]=test-value
 ```
 

--- a/src/StoreApi/docs/nonce-tokens.md
+++ b/src/StoreApi/docs/nonce-tokens.md
@@ -17,7 +17,7 @@ Nonce tokens are included with the request headers. Create a request header name
 
 **Example:**
 
-```http
+```sh
 curl --header "X-WC-Store-API-Nonce: 12345" --request GET https://example-store.com/wp-json/wc/store/v1/checkout
 ```
 

--- a/src/StoreApi/docs/product-attribute-terms.md
+++ b/src/StoreApi/docs/product-attribute-terms.md
@@ -11,7 +11,7 @@ GET /products/attributes/:id/terms&orderby=slug
 | `order`   | string  |    no    | Order ascending or descending. Allowed values: `asc`, `desc`                  |
 | `orderby` | string  |    no    | Sort collection by object attribute. Allowed values: `name`, `slug`, `count`. |
 
-```http
+```sh
 curl "https://example-store.com/wp-json/wc/store/v1/products/attributes/1/terms"
 ```
 

--- a/src/StoreApi/docs/product-attributes.md
+++ b/src/StoreApi/docs/product-attributes.md
@@ -11,7 +11,7 @@ GET /products/attributes
 
 There are no parameters required for this endpoint.
 
-```http
+```sh
 curl "https://example-store.com/wp-json/wc/store/v1/products/attributes"
 ```
 
@@ -50,7 +50,7 @@ GET /products/attributes/:id
 | :-------- | :------ | :------: | :----------------------------------- |
 | `id`      | integer |   Yes    | The ID of the attribute to retrieve. |
 
-```http
+```sh
 curl "https://example-store.com/wp-json/wc/store/v1/products/attributes/1"
 ```
 

--- a/src/StoreApi/docs/product-collection-data.md
+++ b/src/StoreApi/docs/product-collection-data.md
@@ -17,7 +17,7 @@ GET /products/collection-data?calculate_rating_counts=true
 
 **In addition to the above attributes**, all product list attributes are supported. This allows you to get data for a certain subset of products. See [the products API list products section](products.md#list-products) for the full list.
 
-```http
+```sh
 curl "https://example-store.com/wp-json/wc/store/v1/products/collection-data?calculate_price_range=true&calculate_attribute_counts=pa_size,pa_color&calculate_rating_counts=true"
 ```
 

--- a/src/StoreApi/docs/products.md
+++ b/src/StoreApi/docs/products.md
@@ -64,7 +64,7 @@ GET /products?return_rating_counts=true
 | `catalog_visibility` | string  |    no    | Determines if hidden or visible catalog products are shown. Allowed values: `any`, `visible`, `catalog`, `search`, `hidden`                                               |
 | `rating`             | boolean |    no    | Limit result set to products with a certain average rating.                                                                                                               |
 
-```http
+```sh
 curl "https://example-store.com/wp-json/wc/store/v1/products"
 ```
 
@@ -132,7 +132,7 @@ GET /products/:id
 | :-------- | :------ | :------: | :--------------------------------- |
 | `id`      | integer |   Yes    | The ID of the product to retrieve. |
 
-```http
+```sh
 curl "https://example-store.com/wp-json/wc/store/v1/products/34"
 ```
 


### PR DESCRIPTION
Change curl examples 'code block's language' from `http` to `sh` to solve github marking the examples as syntactically incorrect