### PR TITLE
Determine if we need to load the Mini Cart from the theme or WooCommerce

### DIFF
--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -377,7 +377,11 @@ class MiniCart extends AbstractBlock {
 		}
 
 		$template_part_contents = '';
-		$template_part          = BlockTemplateUtils::get_block_template( BlockTemplateUtils::PLUGIN_SLUG . '//mini-cart', 'wp_template_part' );
+
+		// Determine if we need to load the template part from the theme, or WooCommerce in that order.
+		$theme_has_mini_cart   = BlockTemplateUtils::theme_has_template_part( 'mini-cart' );
+		$template_slug_to_load = $theme_has_mini_cart ? get_stylesheet() : BlockTemplateUtils::PLUGIN_SLUG;
+		$template_part         = BlockTemplateUtils::get_block_template( $template_slug_to_load . '//mini-cart', 'wp_template_part' );
 
 		if ( $template_part && ! empty( $template_part->content ) ) {
 			$template_part_contents = do_blocks( $template_part->content );


### PR DESCRIPTION
Check if we should load the template part from the theme files or WooCommerce (in that order).

<!-- Reference any related issues or PRs here -->
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5936

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Clear any customization made to the Mini Cart template part from the Site Editor.
2. Copy the `woocommerce-gutenberg-products-block/templates/parts/mini-cart.html` to the active block theme template part folder.
3. Edit the copied template part to distinguish between it and the original. Here I change the empty cart message from `Your cart is currently empty!` to `From the theme: Your cart is currently empty!`.
4. Add the mini cart block to header.
5. Go to the frontend, ensure cart doesn't contain any product.
6. Open the Mini Cart.
7. See the original message: `From the theme: Your cart is currently empty!`. Which means that the template is loaded from the theme.
8. Customize the template part and check that the customizations are loaded.
9. Clear the customizations and then delete the mini cart file from the theme and complete the steps again checking that when the theme file does not exist we can load and customize the WooCommerce version of the Mini Cart.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
* [ ] See steps below.

1.
2.
3.
