### PR TITLE
Use text indent in input fields instead of padding

### DIFF
--- a/assets/js/base/components/text-input/style.scss
+++ b/assets/js/base/components/text-input/style.scss
@@ -44,7 +44,8 @@
 	input[type="email"] {
 		@include font-size(regular);
 		background-color: #fff;
-		padding: em($gap-small) $gap;
+		padding: em($gap-small) 0;
+		text-indent: $gap;
 		border-radius: 4px;
 		border: 1px solid $input-border-gray;
 		width: 100%;
@@ -91,7 +92,7 @@
 	&.is-active input[type="text"],
 	&.is-active input[type="number"],
 	&.is-active input[type="email"] {
-		padding: em($gap-large) 0 em($gap-smallest) $gap;
+		padding: em($gap-large) 0 em($gap-smallest);
 	}
 
 	&.has-error input {


### PR DESCRIPTION
Small improvement to input fields on checkout for when they contain long longs of text which prevents awkward cut-off on the left side. 

Inspired by https://twitter.com/drwpow/status/1496896451041021971?s=21

### Screenshots

Before:
![Screenshot 2022-02-25 at 12 50 37](https://user-images.githubusercontent.com/90977/155718305-688b9454-cdef-42d6-8bcf-ae4c06cd24be.png)

After:
![Screenshot 2022-02-25 at 12 50 11](https://user-images.githubusercontent.com/90977/155718329-76868228-7d23-4fc4-a38b-e9926d20684a.png)

### Testing

How to test the changes in this Pull Request:

1. Go to checkout
2. Enter a long string of text inside a field
3. Confirm it does not cut off on the left or right side and matches the screetshots above.

### Changelog

> Tweak input field styling to prevent cut-off
