### PR TITLE
Global Styles support for Product Price block

### DIFF
--- a/assets/js/atomic/blocks/product-elements/price/attributes.js
+++ b/assets/js/atomic/blocks/product-elements/price/attributes.js
@@ -13,31 +13,7 @@ let blockAttributes = {
 if ( isFeaturePluginBuild() ) {
 	blockAttributes = {
 		...blockAttributes,
-		align: {
-			type: 'string',
-		},
-		fontSize: {
-			type: 'string',
-		},
-		customFontSize: {
-			type: 'number',
-		},
-		saleFontSize: {
-			type: 'string',
-		},
-		customSaleFontSize: {
-			type: 'number',
-		},
-		color: {
-			type: 'string',
-		},
-		saleColor: {
-			type: 'string',
-		},
-		customColor: {
-			type: 'string',
-		},
-		customSaleColor: {
+		textAlign: {
 			type: 'string',
 		},
 	};

--- a/assets/js/atomic/blocks/product-elements/price/block.js
+++ b/assets/js/atomic/blocks/product-elements/price/block.js
@@ -80,6 +80,9 @@ const Block = ( props ) => {
 			maxPrice={ prices?.price_range?.max_amount }
 			// This is the regular or original price when the `price` value is a sale price.
 			regularPrice={ prices.regular_price }
+			regularPriceClassName={ classnames( {
+				[ `${ parentClassName }__product-price__regular` ]: parentClassName,
+			} ) }
 		/>
 	);
 };

--- a/assets/js/atomic/blocks/product-elements/price/block.js
+++ b/assets/js/atomic/blocks/product-elements/price/block.js
@@ -9,111 +9,72 @@ import {
 	useInnerBlockLayoutContext,
 	useProductDataContext,
 } from '@woocommerce/shared-context';
-import { getColorClassName, getFontSizeClass } from '@wordpress/block-editor';
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
 import { withProductDataContext } from '@woocommerce/shared-hocs';
+
+/**
+ * Internal dependencies
+ */
+import {
+	useColorProps,
+	useTypographyProps,
+} from '../../../../hooks/style-attributes';
 
 /**
  * Product Price Block Component.
  *
  * @param {Object} props                          Incoming props.
  * @param {string} [props.className]              CSS Class name for the component.
- * @param {string} [props.align]                  Text alignment.
+ * @param {string} [props.textAlign]              Text alignment.
  * @param {string} [props.fontSize]               Normal Price font size name.
- * @param {number} [props.customFontSize]         Normal Price custom font size.
- * @param {string} [props.saleFontSize]           Original Price font size name.
- * @param {number} [props.customSaleFontSize]     Original Price custom font size.
  * @param {string} [props.color]                  Normal Price text color.
- * @param {string} [props.customColor]            Normal Price custom text color.
- * @param {string} [props.saleColor]              Original Price text color.
- * @param {string} [props.customSaleColor]        Original Price custom text color.
  * context will be used if this is not provided.
  * @return {*} The component.
  */
-const Block = ( {
-	className,
-	align,
-	fontSize,
-	customFontSize,
-	saleFontSize,
-	customSaleFontSize,
-	color,
-	customColor,
-	saleColor,
-	customSaleColor,
-} ) => {
+const Block = ( props ) => {
+	const { className, textAlign } = props;
 	const { parentClassName } = useInnerBlockLayoutContext();
 	const { product } = useProductDataContext();
 
-	const wrapperClassName = classnames( className, {
+	const colorProps = useColorProps( props );
+	const typographyProps = useTypographyProps( props );
+
+	const wrapperClassName = classnames( className, colorProps.className, {
 		[ `${ parentClassName }__product-price` ]: parentClassName,
 	} );
 
-	if ( ! product.id ) {
-		return <ProductPrice align={ align } className={ wrapperClassName } />;
-	}
-
-	const colorClass = getColorClassName( 'color', color );
-	const fontSizeClass = getFontSizeClass( fontSize );
-	const saleColorClass = getColorClassName( 'color', saleColor );
-	const saleFontSizeClass = getFontSizeClass( saleFontSize );
-
-	const classes = classnames( {
-		'has-text-color': color || customColor,
-		'has-font-size': fontSize || customFontSize,
-		[ colorClass ]: colorClass,
-		[ fontSizeClass ]: fontSizeClass,
-	} );
-
-	const saleClasses = classnames( {
-		'has-text-color': saleColor || customSaleColor,
-		'has-font-size': saleFontSize || customSaleFontSize,
-		[ saleColorClass ]: saleColorClass,
-		[ saleFontSizeClass ]: saleFontSizeClass,
-	} );
-
 	const style = {
-		color: customColor,
-		fontSize: customFontSize,
+		...typographyProps.style,
+		...colorProps.style,
 	};
 
-	const saleStyle = {
-		color: customSaleColor,
-		fontSize: customSaleFontSize,
-	};
+	if ( ! product.id ) {
+		return (
+			<ProductPrice align={ textAlign } className={ wrapperClassName } />
+		);
+	}
 
 	const prices = product.prices;
 	const currency = getCurrencyFromPriceResponse( prices );
 	const isOnSale = prices.price !== prices.regular_price;
-	const priceClassName = isOnSale
-		? classnames( {
-				[ `${ parentClassName }__product-price__value` ]: parentClassName,
-				[ saleClasses ]: isFeaturePluginBuild(),
-		  } )
-		: classnames( {
-				[ `${ parentClassName }__product-price__value` ]: parentClassName,
-				[ classes ]: isFeaturePluginBuild(),
-		  } );
-	const priceStyle = isOnSale ? saleStyle : style;
+	const priceClassName = classnames( {
+		[ `${ parentClassName }__product-price__value` ]: parentClassName,
+		[ `${ parentClassName }__product-price__value--on-sale` ]: isOnSale,
+	} );
 
 	return (
 		<ProductPrice
-			align={ align }
+			align={ textAlign }
 			className={ wrapperClassName }
+			priceStyle={ style }
+			regularPriceStyle={ style }
+			priceClassName={ priceClassName }
 			currency={ currency }
 			price={ prices.price }
-			priceClassName={ priceClassName }
-			priceStyle={ isFeaturePluginBuild() ? priceStyle : {} }
 			// Range price props
 			minPrice={ prices?.price_range?.min_amount }
 			maxPrice={ prices?.price_range?.max_amount }
 			// This is the regular or original price when the `price` value is a sale price.
 			regularPrice={ prices.regular_price }
-			regularPriceClassName={ classnames( {
-				[ `${ parentClassName }__product-price__regular` ]: parentClassName,
-				[ classes ]: isFeaturePluginBuild(),
-			} ) }
-			regularPriceStyle={ isFeaturePluginBuild() ? style : {} }
 		/>
 	);
 };
@@ -121,15 +82,11 @@ const Block = ( {
 Block.propTypes = {
 	className: PropTypes.string,
 	product: PropTypes.object,
-	align: PropTypes.string,
+	textAlign: PropTypes.oneOf( [ 'left', 'right', 'center' ] ),
 	fontSize: PropTypes.string,
-	customFontSize: PropTypes.number,
-	saleFontSize: PropTypes.string,
-	customSaleFontSize: PropTypes.number,
+	fontWidth: PropTypes.string,
+	fontStyle: PropTypes.string,
 	color: PropTypes.string,
-	customColor: PropTypes.string,
-	saleColor: PropTypes.string,
-	customSaleColor: PropTypes.string,
 };
 
 export default withProductDataContext( Block );

--- a/assets/js/atomic/blocks/product-elements/price/block.js
+++ b/assets/js/atomic/blocks/product-elements/price/block.js
@@ -38,9 +38,14 @@ const Block = ( props ) => {
 	const colorProps = useColorProps( props );
 	const typographyProps = useTypographyProps( props );
 
-	const wrapperClassName = classnames( className, colorProps.className, {
-		[ `${ parentClassName }__product-price` ]: parentClassName,
-	} );
+	const wrapperClassName = classnames(
+		'wc-block-components-product-price',
+		className,
+		colorProps.className,
+		{
+			[ `${ parentClassName }__product-price` ]: parentClassName,
+		}
+	);
 
 	const style = {
 		...typographyProps.style,

--- a/assets/js/atomic/blocks/product-elements/price/edit.js
+++ b/assets/js/atomic/blocks/product-elements/price/edit.js
@@ -1,19 +1,18 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { PanelBody, BaseControl } from '@wordpress/components';
-import { compose } from '@wordpress/compose';
-import {
-	InspectorControls,
-	BlockControls,
-	AlignmentToolbar,
-	withColors,
-	ColorPalette,
-	FontSizePicker,
-	withFontSizes,
-} from '@wordpress/block-editor';
 import { isFeaturePluginBuild } from '@woocommerce/block-settings';
+import {
+	AlignmentToolbar,
+	BlockControls,
+	useBlockProps,
+} from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+
+/**
+ *
+ */
+
 /**
  * Internal dependencies
  */
@@ -21,113 +20,32 @@ import Block from './block';
 import withProductSelector from '../shared/with-product-selector';
 import { BLOCK_TITLE, BLOCK_ICON } from './constants';
 
-const TextControl = ( {
-	fontSize,
-	setFontSize,
-	color,
-	setColor,
-	colorLabel,
-} ) => (
-	<>
-		<FontSizePicker value={ fontSize.size } onChange={ setFontSize } />
-		{ /* ColorPalette doesn't accept an id. */
-		/* eslint-disable-next-line @wordpress/no-base-control-with-label-without-id */ }
-		<BaseControl label={ colorLabel }>
-			<ColorPalette
-				value={ color.color }
-				onChange={ setColor }
-				label={ __( 'Color', 'woo-gutenberg-products-block' ) }
-			/>
-		</BaseControl>
-	</>
-);
-const PriceEdit = ( {
-	fontSize,
-	saleFontSize,
-	setFontSize,
-	setSaleFontSize,
-	color,
-	saleColor,
-	setColor,
-	setSaleColor,
-	attributes,
-	setAttributes,
-} ) => {
-	const { align } = attributes;
+const PriceEdit = ( { attributes, setAttributes } ) => {
+	const blockProps = useBlockProps();
 	return (
 		<>
-			{ isFeaturePluginBuild() && (
-				<BlockControls>
+			<BlockControls>
+				{ isFeaturePluginBuild() && (
 					<AlignmentToolbar
-						value={ align }
-						onChange={ ( nextAlign ) => {
-							setAttributes( { align: nextAlign } );
+						value={ attributes.textAlign }
+						onChange={ ( newAlign ) => {
+							setAttributes( { textAlign: newAlign } );
 						} }
 					/>
-				</BlockControls>
-			) }
-			<InspectorControls>
-				{ isFeaturePluginBuild() && (
-					<>
-						<PanelBody
-							title={ __(
-								'Price',
-								'woo-gutenberg-products-block'
-							) }
-						>
-							<TextControl
-								color={ color }
-								setColor={ setColor }
-								fontSize={ fontSize }
-								setFontSize={ setFontSize }
-								colorLabel={ __(
-									'Color',
-									'woo-gutenberg-products-block'
-								) }
-							/>
-						</PanelBody>
-						<PanelBody
-							title={ __(
-								'Sale price',
-								'woo-gutenberg-products-block'
-							) }
-						>
-							<TextControl
-								color={ saleColor }
-								setColor={ setSaleColor }
-								fontSize={ saleFontSize }
-								setFontSize={ setSaleFontSize }
-								colorLabel={ __(
-									'Color',
-									'woo-gutenberg-products-block'
-								) }
-							/>
-						</PanelBody>
-					</>
 				) }
-			</InspectorControls>
-			<Block { ...attributes } />
+			</BlockControls>
+			<div { ...blockProps }>
+				<Block { ...attributes } />
+			</div>
 		</>
 	);
 };
 
-const Price = isFeaturePluginBuild()
-	? compose( [
-			withFontSizes( 'fontSize' ),
-			withFontSizes( 'saleFontSize' ),
-			withFontSizes( 'originalFontSize' ),
-			withColors( 'color', { textColor: 'color' } ),
-			withColors( 'saleColor', { textColor: 'saleColor' } ),
-			withColors( 'originalColor', { textColor: 'originalColor' } ),
-			withProductSelector( {
-				icon: BLOCK_ICON,
-				label: BLOCK_TITLE,
-				description: __(
-					'Choose a product to display its price.',
-					'woo-gutenberg-products-block'
-				),
-			} ),
-	  ] )( PriceEdit )
-	: PriceEdit;
-
-export default Price;
+export default withProductSelector( {
+	icon: BLOCK_ICON,
+	label: BLOCK_TITLE,
+	description: __(
+		'Choose a product to display its price.',
+		'woo-gutenberg-products-block'
+	),
+} )( PriceEdit );

--- a/assets/js/atomic/blocks/product-elements/price/index.js
+++ b/assets/js/atomic/blocks/product-elements/price/index.js
@@ -27,8 +27,8 @@ const blockConfig = {
 	edit,
 	save: Save,
 	supports: {
+		...sharedConfig.supports,
 		...( isFeaturePluginBuild() && {
-			...sharedConfig.supports,
 			color: {
 				text: true,
 				background: false,

--- a/assets/js/atomic/blocks/product-elements/price/index.js
+++ b/assets/js/atomic/blocks/product-elements/price/index.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { isFeaturePluginBuild } from '@woocommerce/block-settings';
 import { registerBlockType } from '@wordpress/blocks';
 
 /**
@@ -8,6 +9,7 @@ import { registerBlockType } from '@wordpress/blocks';
  */
 import sharedConfig from '../shared/config';
 import edit from './edit';
+import { Save } from './save';
 import attributes from './attributes';
 import {
 	BLOCK_TITLE as title,
@@ -16,14 +18,31 @@ import {
 } from './constants';
 
 const blockConfig = {
+	...sharedConfig,
+	apiVersion: 2,
 	title,
 	description,
 	icon: { src: icon },
 	attributes,
 	edit,
+	save: Save,
+	supports: {
+		...( isFeaturePluginBuild() && {
+			...sharedConfig.supports,
+			color: {
+				text: true,
+				background: false,
+				link: false,
+				__experimentalSkipSerialization: true,
+			},
+			typography: {
+				fontSize: true,
+				__experimentalFontWeight: true,
+				__experimentalFontStyle: true,
+				__experimentalSkipSerialization: true,
+			},
+		} ),
+	},
 };
 
-registerBlockType( 'woocommerce/product-price', {
-	...sharedConfig,
-	...blockConfig,
-} );
+registerBlockType( 'woocommerce/product-price', blockConfig );

--- a/assets/js/atomic/blocks/product-elements/price/index.js
+++ b/assets/js/atomic/blocks/product-elements/price/index.js
@@ -41,6 +41,7 @@ const blockConfig = {
 				__experimentalFontStyle: true,
 				__experimentalSkipSerialization: true,
 			},
+			__experimentalSelector: '.wc-block-components-product-price',
 		} ),
 	},
 };

--- a/assets/js/atomic/blocks/product-elements/price/save.tsx
+++ b/assets/js/atomic/blocks/product-elements/price/save.tsx
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import { useBlockProps } from '@wordpress/block-editor';
+import classnames from 'classnames';
+
+type Props = {
+	attributes: Record< string, unknown > & {
+		className?: string;
+	};
+};
+
+export const Save = ( { attributes }: Props ): JSX.Element => {
+	return (
+		<div
+			{ ...useBlockProps.save( {
+				className: classnames( 'is-loading', attributes.className ),
+			} ) }
+		/>
+	);
+};

--- a/src/BlockTypes/ProductPrice.php
+++ b/src/BlockTypes/ProductPrice.php
@@ -1,0 +1,62 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\BlockTypes;
+
+/**
+ * ProductPrice class.
+ */
+class ProductPrice extends AbstractBlock {
+
+	/**
+	 * Block name.
+	 *
+	 * @var string
+	 */
+	protected $block_name = 'product-price';
+
+	/**
+	 * API version name.
+	 *
+	 * @var string
+	 */
+	protected $api_version = '2';
+
+	/**
+	 * Get the editor script handle for this block type.
+	 *
+	 * @param string $key Data to get, or default to everything.
+	 * @return array|string;
+	 */
+	protected function get_block_type_editor_script( $key = null ) {
+		$script = [
+			'handle'       => 'wc-' . $this->block_name . '-block',
+			'path'         => $this->asset_api->get_block_asset_build_path( 'atomic-block-components/price' ),
+			'dependencies' => [ 'wc-blocks' ],
+		];
+		return $key ? $script[ $key ] : $script;
+	}
+
+	/**
+	 * Get block supports. Shared with the frontend.
+	 * IMPORTANT: If you change anything here, make sure to update the JS file too.
+	 *
+	 * @return array
+	 */
+	protected function get_block_type_supports() {
+		return array(
+			'color'                  =>
+			array(
+				'text'       => true,
+				'background' => true,
+				'link'       => false,
+			),
+			'typography'             =>
+			array(
+				'fontSize'                 => true,
+				'__experimentalFontWeight' => true,
+				'__experimentalFontStyle'  => true,
+			),
+			'__experimentalSelector' => '.wc-block-components-product-price',
+		);
+	}
+
+}

--- a/src/BlockTypesController.php
+++ b/src/BlockTypesController.php
@@ -237,7 +237,6 @@ final class BlockTypesController {
 	 */
 	protected function get_atomic_blocks() {
 		return [
-			'product-price',
 			'product-sku',
 			'product-add-to-cart',
 		];

--- a/src/BlockTypesController.php
+++ b/src/BlockTypesController.php
@@ -177,6 +177,7 @@ final class BlockTypesController {
 			'ActiveFilters',
 			'LegacyTemplate',
 			'ProductTitle',
+			'ProductPrice',
 			'ProductSummary',
 			'ProductStockIndicator',
 			'ProductButton',


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
Adds Global Styles support for Product Price element block.

- ⚠️ **comes sat a cost of losing control over regular vs sale price**
- adds font style and weight controls
- enables new ui controls via `supports`
- includes refactor of attribute from align to textAlign as align
   is a reserved supports feature attribute and textAlign is
   used across the Gutenberg project when text-align css is used
- includes removal of attributes that are controlled by supports 
   
I’ve noticed that we are using align attribute in couple of places in a wrong way. Since introduction of supports: { align } Gutenberg uses context based align attributes for anything that is not align. IE. css text-align should be `textAlign` and so on. Apart of that it seemed like it might be causing conflicts when using these “reserved” attributes in other contexts (ie. product title align which doesn't use the supports property stopped working on front-end and works just fine if changed to another name). 
   
<!-- Reference any related issues or PRs here -->
Fixes #5672

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader

### Screenshots

|before|after|
|-|-|
|  ![Screenshot 2022-02-25 at 15 56 16](https://user-images.githubusercontent.com/112270/155736820-98e0ebf3-bf1d-4115-a1fb-0f16c4188802.jpg) |  ![Screenshot 2022-02-25 at 15 43 09](https://user-images.githubusercontent.com/112270/155735251-acc22e2f-6fda-4983-af92-36b2e3c4f89b.jpg) |

### Manual Testing

How to test the changes in this Pull Request:


1. Edit Global Styles for the Product Price block (color, font-size).
2. Add Single Product and All Products components to a page.
3. The Price component should reflect global styles.
4. Add another set of Single Product and All Products components.
5. For these override Global Styles with local styles.
6. Ensure both sets work as expected on the Front-End of your store.

<!-- If you can, add the appropriate labels -->


### Changelog

> Add Global Styles support to the Product Price block.
