### PR TITLE
Unify copy on Featured Category with Featured Product block

### DIFF
--- a/assets/js/blocks/featured-category/block.js
+++ b/assets/js/blocks/featured-category/block.js
@@ -110,7 +110,7 @@ const FeaturedCategory = ( {
 								setAttributes( { mediaId: 0, mediaSrc: '' } )
 							}
 						>
-							{ __( 'Remove', 'woo-gutenberg-products-block' ) }
+							{ __( 'Reset', 'woo-gutenberg-products-block' ) }
 						</TextToolbarButton>
 					) : null }
 				</ToolbarGroup>


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
Updates media remove label to read "Reset". 

This is to reflect how we agreed it would be best 
when working on Featured Product block

<!-- Reference any related issues or PRs here -->
Related to #5886

