### PR TITLE
Refactor: improve goToBlockPage performance

### DIFF
--- a/tests/utils/index.js
+++ b/tests/utils/index.js
@@ -1,6 +1,10 @@
 export { scrollTo } from './scroll-to.ts';
 export { findLabelWithText } from './find-label-with-text';
-export { visitBlockPage, visitPostOfType } from './visit-block-page';
+export {
+	getBlockPageEditLink,
+	visitBlockPage,
+	visitPostOfType,
+} from './visit-block-page';
 export { getBlockPagePermalink } from './get-block-page-permalink';
 export { getNormalPagePermalink } from './get-normal-page-permalink';
 export { saveOrPublish } from './save-or-publish';

--- a/tests/utils/shopper.js
+++ b/tests/utils/shopper.js
@@ -6,7 +6,7 @@ import { shopper as wcShopper } from '@woocommerce/e2e-utils';
 /**
  * Internal dependencies
  */
-import { getBlockPagePermalink } from './get-block-page-permalink';
+import { getBlockPageEditLink } from './visit-block-page';
 import { SHOP_CART_BLOCK_PAGE, SHOP_CHECKOUT_BLOCK_PAGE } from './constants';
 
 export const shopper = {
@@ -49,11 +49,28 @@ export const shopper = {
 		);
 	},
 
+	/**
+	 * Find a page with the given title then navigate to it.
+	 *
+	 * @param {string} title Page title
+	 */
 	goToBlockPage: async ( title ) => {
-		await page.goto( await getBlockPagePermalink( title ), {
-			waitUntil: 'networkidle0',
-		} );
+		const editLink = await getBlockPageEditLink( title );
 
-		await expect( page ).toMatchElement( 'h1', { text: title } );
+		if ( editLink ) {
+			const url = new URL( editLink );
+
+			await page.goto(
+				`${ url.origin }/?p=${ url.searchParams.get( 'post' ) }`,
+				{
+					waitUntil: 'networkidle0',
+				}
+			);
+
+			// eslint-disable-next-line jest/no-standalone-expect
+			await expect( page ).toMatchElement( 'h1', { text: title } );
+		} else {
+			throw new Error( `Could not find block page: ${ title }` );
+		}
 	},
 };

--- a/tests/utils/visit-block-page.js
+++ b/tests/utils/visit-block-page.js
@@ -33,16 +33,7 @@ async function visitPage( link ) {
 	}
 }
 
-/**
- *
- * @param {string} title the page title, written as `BLOCK_NAME block`
- *
- * This function will attempt to search for a page with the `title`
- * if that block is found, it will open it, if it's not found, it will open
- * a new page, insert the block, save the page content and title as a fixture file.
- * In both cases, this page will end up with a page open with the block inserted.
- */
-export async function visitBlockPage( title ) {
+export async function getBlockPageEditLink( title ) {
 	let link = '';
 	// Visit Import Products page.
 	await visitAdminPage( 'edit.php', 'post_type=page' );
@@ -61,6 +52,22 @@ export async function visitBlockPage( title ) {
 			);
 		}
 	}
+
+	return link;
+}
+
+/**
+ *
+ * @param {string} title the page title, written as `BLOCK_NAME block`
+ *
+ * This function will attempt to search for a page with the `title`
+ * if that block is found, it will open it, if it's not found, it will open
+ * a new page, insert the block, save the page content and title as a fixture file.
+ * In both cases, this page will end up with a page open with the block inserted.
+ */
+export async function visitBlockPage( title ) {
+	const link = await getBlockPageEditLink( title );
+
 	if ( link ) {
 		await visitPage( link );
 	} else {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Relates #5949 

This PR speeds up the `shopper.goToBlockPage()`.

Currently, `shopper.goToBlockPage()` uses `getBlockPagePermalink()`, which is very slow because of how `getBlockPagePermalink()` works:

1. Search for the block page in the page list table.
2. Go to the edit page of the page.
3. Open the sidebar if needed.
4. Toggle the Permalink panel.
5. Get the link to the page on the front end.
6. Navigate to the page using `page.goto()`.

This PR refactors `shopper.goToBlockPage()` so it takes fewer steps to navigate to a block page:
1. Search for the block page in the page list table.
2. Get the edit link and build the page permalink using the page id (which is extracted from the edit link): `http://localhost:8889/?p=1234`.
3. Navigate to the block page permalink.

Notes: 
- Initially, I want to refactor the `getBlockPagePermalink()`, however, that utility doesn't only get the permalink of an existing page but also create the page if the page with the given title doesn't exist.
- Go to the admin page won't slow us down because by default, before every test, we go to Admin Dashboard > Products.