### PR TITLE
Remove lodash forEach usage

### DIFF
--- a/assets/js/editor-components/search-list-control/utils.tsx
+++ b/assets/js/editor-components/search-list-control/utils.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { groupBy, keyBy, forEach } from 'lodash';
+import { groupBy, keyBy } from 'lodash';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
 
@@ -77,7 +77,7 @@ export const buildTermsTree = (
 	delete termsByParent[ '0' ];
 
 	// anything left in termsByParent has no visible parent
-	forEach( termsByParent, ( terms ) => {
+	Object.values( termsByParent ).forEach( ( terms ) => {
 		tree.push( ...fillWithChildren( terms || [] ) );
 	} );
 

--- a/assets/js/editor-components/search-list-control/utils.tsx
+++ b/assets/js/editor-components/search-list-control/utils.tsx
@@ -44,6 +44,7 @@ export const buildTermsTree = (
 ): SearchListItemType[] | [  ] => {
 	const termsByParent = groupBy( filteredList, 'parent' );
 	const listById = keyBy( list, 'id' );
+	const builtParents = [ '0' ];
 
 	const getParentsName = ( term = {} as SearchListItemType ): string[] => {
 		if ( ! term.parent ) {
@@ -61,7 +62,7 @@ export const buildTermsTree = (
 	} )[] => {
 		return terms.map( ( term ) => {
 			const children = termsByParent[ term.id ];
-			delete termsByParent[ term.id ];
+			builtParents.push( '' + term.id );
 			return {
 				...term,
 				breadcrumbs: getParentsName( listById[ term.parent ] ),
@@ -74,11 +75,12 @@ export const buildTermsTree = (
 	};
 
 	const tree = fillWithChildren( termsByParent[ '0' ] || [] );
-	delete termsByParent[ '0' ];
 
-	// anything left in termsByParent has no visible parent
-	Object.values( termsByParent ).forEach( ( terms ) => {
-		tree.push( ...fillWithChildren( terms || [] ) );
+	// Handle remaining items in termsByParent that have not been built (orphaned).
+	Object.entries( termsByParent ).forEach( ( [ termId, terms ] ) => {
+		if ( ! builtParents.includes( termId ) ) {
+			tree.push( ...fillWithChildren( terms || [] ) );
+		}
 	} );
 
 	return tree;


### PR DESCRIPTION
Got fed up seeing:

![Screenshot 2022-03-01 at 11 02 54](https://user-images.githubusercontent.com/90977/156158997-05f5c1f0-7d20-4ec4-94c4-59e0a43b85f6.png)

Removed lodash `forEach` to resolve it.

### Testing

How to test the changes in this Pull Request:

1. Insert products by category block
2. Check console for errors once the search list component has rendered
