### PR TITLE
Fix sort-select frontend CSS

### DIFF
--- a/assets/js/base/components/sort-select/style.scss
+++ b/assets/js/base/components/sort-select/style.scss
@@ -11,4 +11,14 @@
 .wc-block-components-sort-select__select {
 	font-size: inherit;
 	width: max-content;
+	border-color: #8c8f94;
+	-webkit-appearance: none;
+	-moz-appearance: none;
+	border-radius: 3px;
+	padding: 0 24px 0 8px;
+	min-height: 30px;
+	max-width: 25rem;
+	font-weight: normal;
+	background: #fff url(data:image/svg+xml;charset=US-ASCII,%3Csvg%20width%3D%2220%22%20height%3D%2220%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M5%206l5%205%205-5%202%201-7%207-7-7%202-1z%22%20fill%3D%22%23555%22%2F%3E%3C%2Fsvg%3E) no-repeat right 5px top 55%;
+	background-size: 16px 16px;
 }


### PR DESCRIPTION

This PR fixes the CSS for the `<select>`  element of the `All Products` block to provide consistent style across the frontend and page editor.

Fixes #2506 



### Screenshots

| Before | After |
|---|---|
| <img width="401" alt="image" src="https://user-images.githubusercontent.com/11503784/156205478-004a78dd-6334-4dbc-beb9-ac71eecac79a.png"> | <img width="432" alt="image" src="https://user-images.githubusercontent.com/11503784/156205592-5bcc9257-f844-449e-8e2a-db68b28cf350.png"> |


### Manual Testing

How to test the changes in this Pull Request:

1. Check out this branch and compile the changes
2. Create a page with the `All Products` block. 
3. Publish the page. 
4. The frontend `<select>` dropdown style should match the page editor's `<select>` dropdown style.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above,


### Changelog

> Fixed sort-select frontend CSS
