### PR TITLE
Shopper → Mini Cart → Can proceed to checkout

### DIFF
--- a/tests/e2e/specs/shopper/mini-cart.test.js
+++ b/tests/e2e/specs/shopper/mini-cart.test.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { setDefaultOptions, getDefaultOptions } from 'expect-puppeteer';
+import { SHOP_CHECKOUT_PAGE } from '@woocommerce/e2e-utils';
 
 /**
  * Internal dependencies
@@ -216,6 +217,41 @@ describe( 'Shopper → Mini Cart', () => {
 					text: 'Go to checkout',
 				}
 			);
+		} );
+	} );
+
+	describe( 'Checkout page', () => {
+		beforeAll( async () => {
+			await shopper.emptyCart();
+		} );
+
+		it( 'Can go to checkout page from the Mini Cart Footer', async () => {
+			const productTitle = await page.$eval(
+				'.wc-block-grid__product:first-child .wc-block-components-product-name',
+				( el ) => el.textContent
+			);
+
+			await page.click(
+				'.wc-block-grid__product:first-child .add_to_cart_button'
+			);
+
+			await expect( page ).toMatchElement(
+				'.wc-block-mini-cart__products-table',
+				{
+					text: productTitle,
+				}
+			);
+
+			const checkoutUrl = await page.$eval(
+				'.wc-block-mini-cart__footer-checkout',
+				( el ) => el.href
+			);
+
+			expect( checkoutUrl ).toMatch( SHOP_CHECKOUT_PAGE );
+
+			await page.goto( checkoutUrl, { waitUntil: 'networkidle0' } );
+
+			await expect( page ).toMatch( productTitle );
 		} );
 	} );
 } );

--- a/tests/e2e/specs/shopper/mini-cart.test.js
+++ b/tests/e2e/specs/shopper/mini-cart.test.js
@@ -251,6 +251,8 @@ describe( 'Shopper → Mini Cart', () => {
 
 			await page.goto( checkoutUrl, { waitUntil: 'networkidle0' } );
 
+			await expect( page ).toMatchElement( 'h1', { text: 'Checkout' } );
+
 			await expect( page ).toMatch( productTitle );
 		} );
 	} );


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #5837

### Notes

This PR adds e2e tests to verify that a shopper can go to the Checkout page from the Mini Cart drawer.

### Testing

#### Automated Tests
* [x] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests

### Manual Testing

1. Check out this PR.
2. Start Docker Desktop.
3. Run `npm run wp-env destroy && npm run wp-env start` to start a fresh e2e environment.
4. Run `npm run test:e2e -- tests/e2e/specs/shopper/mini-cart.test.js -t "Checkout page"` to run only this test case.
5. Run `npm run test:e2e` to run the whole test suite.