### PR TITLE
StoreAPI: Clear all wc notice types in the cart validation context

### DIFF
--- a/src/StoreApi/Utilities/NoticeHandler.php
+++ b/src/StoreApi/Utilities/NoticeHandler.php
@@ -26,6 +26,7 @@ class NoticeHandler {
 	 */
 	public static function convert_notices_to_exceptions( $error_code = 'unknown_server_error' ) {
 		if ( 0 === wc_notice_count( 'error' ) ) {
+			wc_clear_notices();
 			return;
 		}
 
@@ -42,10 +43,10 @@ class NoticeHandler {
 	/**
 	 * Collects queued error notices into a \WP_Error.
 	 *
-	 * For example, Payment methods may add error notices during validate_fields call to prevent checkout.
+	 * For example, cart validation processes may add error notices to prevent checkout.
 	 * Since we're not rendering notices at all, we need to catch them and group them in a single WP_Error instance.
 	 *
-	 * This method will discards notices once complete.
+	 * This method will discard notices once complete.
 	 *
 	 * @param string $error_code Error code for the thrown exceptions.
 	 *
@@ -55,6 +56,7 @@ class NoticeHandler {
 		$errors = new WP_Error();
 
 		if ( 0 === wc_notice_count( 'error' ) ) {
+			wc_clear_notices();
 			return $errors;
 		}
 


### PR DESCRIPTION
Before the `woocommerce_store_api_cart_errors` was introduced in this PR, the system would run the `woocommerce_check_cart_items` at the Checkout route while processing at `get_route_post_response()`. 

This way, we could be sure to grab all legacy error notices coming from the _wc_add_notice_ and stop the checkout process, if necessary; ditch all the others _(notice types: success, notice)_.

After the cart validation refactor, the newly introduced `CartContoller::validate_cart()` is running the `woocommerce_check_cart_items` in order to group into the `cart.errors` JS state, all errors coming from the _wc_add_notice_; this further enchances the 3PD experience as it could create a _plug-n-play_ situation in existing logic.

**Where's the bug?** 

When the cart validator runs the `woocommerce_check_cart_items` and handles the session notices, it [doesn't flush them unless there is at least one `error` type](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/src/StoreApi/Utilities/NoticeHandler.php#L58) in them.

Therefore, when working with operations that change the JS cart state (e.g., modifying cart quantities), a new notice is added in the session every time.

The next page refresh will cause the PHP controller to deliver all stacked notices on the page. This screencast demonstrates this issue: https://d.pr/v/9WDttl

It's funny how it slipped during refactoring the validation system. I always had a `wc_add_notice('error', 'error')` in my code for testing, so the system would delete all notices, thus hiding this issue from me.

Moreover, this issue couldn't be replicated in a similar situation at the payments API, where the code [re-calls](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/src/Payments/Api.php#L162) the `wc_clear_notices` to ensure that no other errors were added while in `process_payment`.

**Steps to replicate:**
- Add the following PHP snippet in your `functions.php`
```php
add_action( 'woocommerce_check_cart_items', 'add_simple_notice' );
function add_simple_notice() {
    wc_add_notice( 'notice','notice' );
}
```
- Add a product to the cart.
- Navigate to the cart.
- **Make sure there aren't any error notices in the cart**.
- Refresh the page.
- Start "toying" with the quantity and wait for each request to finish.
- Refresh again.

**Solution:**
I suggest following the current path to solving this: Drop them all and keep only the errors.

cc @mikejolley 

#### Accessibility

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

### Changelog

None
