### PR TITLE
Mini Cart Contents Block: not show `wc-block-mini-cart__contents` in additional classes section 

### DIFF
--- a/assets/js/blocks/cart-checkout/mini-cart-contents/editor.scss
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/editor.scss
@@ -1,4 +1,4 @@
-.editor-styles-wrapper .wc-block-mini-cart__contents {
+.editor-styles-wrapper .wp-block-woocommerce-mini-cart-contents {
 	max-width: 480px;
 	/* We need to override the margin top here to simulate the layout of
 	the mini cart contents on the front end. */

--- a/assets/js/blocks/cart-checkout/mini-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/mini-cart/style.scss
@@ -74,7 +74,7 @@
 	}
 }
 
-.wc-block-mini-cart__contents {
+.wp-block-woocommerce-mini-cart-contents {
 	background: #fff;
 	box-sizing: border-box;
 	display: flex;

--- a/templates/parts/mini-cart.html
+++ b/templates/parts/mini-cart.html
@@ -1,5 +1,5 @@
-<!-- wp:woocommerce/mini-cart-contents {"className":"wc-block-mini-cart__contents"} -->
-<div class="wp-block-woocommerce-mini-cart-contents wc-block-mini-cart__contents">
+<!-- wp:woocommerce/mini-cart-contents -->
+<div class="wp-block-woocommerce-mini-cart-contents">
 	<!-- wp:woocommerce/filled-mini-cart-contents-block -->
 	<div class="wp-block-woocommerce-filled-mini-cart-contents-block">
 		<!-- wp:woocommerce/mini-cart-title-block -->


### PR DESCRIPTION
This PR reverts commit 1c478e60acb805733be04c5ca4c9f2d2443f7551 (#5800).

Gutenberg shows in the additional classes section any custom class that is added to the template. At this time there isn't the possibility to fix #5800 if we want that the additional classes input is empty.


<!-- Reference any related issues or PRs here -->
Fixes #5917


### Testing

### Manual Testing

How to test the changes in this Pull Request:

Check out this branch:

1. On FSE editor, go on template parts and click on the `Mini Cart`.
2. Get the focus on the `Mini Cart Contents` block.
3. Open the block settings and check the additional classes section.
4. Check that the input is empty.

