### PR TITLE
Remove v1 string from Store Keys

### DIFF
--- a/assets/js/base/context/hooks/cart/use-store-cart.ts
+++ b/assets/js/base/context/hooks/cart/use-store-cart.ts
@@ -119,7 +119,7 @@ export const defaultCartData: StoreCart = {
 };
 
 /**
- * This is a custom hook that is wired up to the `wc/store/v1/cart` data
+ * This is a custom hook that is wired up to the `wc/store/cart` data
  * store.
  *
  * @param {Object} options                An object declaring the various

--- a/assets/js/data/cart/constants.ts
+++ b/assets/js/data/cart/constants.ts
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 
-export const STORE_KEY = 'wc/store/v1/cart';
+export const STORE_KEY = 'wc/store/cart';
 export const CART_API_ERROR = {
 	code: 'cart_api_error',
 	message: __(

--- a/assets/js/data/collections/constants.js
+++ b/assets/js/data/collections/constants.js
@@ -1,2 +1,2 @@
-export const STORE_KEY = 'wc/store/v1/collections';
+export const STORE_KEY = 'wc/store/collections';
 export const DEFAULT_EMPTY_ARRAY = [];

--- a/assets/js/data/query-state/constants.js
+++ b/assets/js/data/query-state/constants.js
@@ -1,1 +1,1 @@
-export const STORE_KEY = 'wc/store/v1/query-state';
+export const STORE_KEY = 'wc/store/query-state';

--- a/assets/js/data/schema/constants.js
+++ b/assets/js/data/schema/constants.js
@@ -3,4 +3,4 @@
  *
  * @type {string}
  */
-export const STORE_KEY = 'wc/store/v1/schema';
+export const STORE_KEY = 'wc/store/schema';


### PR DESCRIPTION
With the versioning change in the API (https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5911) `/v1` was appended in bulk to all `wc/store` keys and endpoints. This change was not intended to affect the Store Keys of wp.data stores. This PR reverts that change.

### Testing

How to test the changes in this Pull Request:

1. Smoke test the products block and confirm products are still queried
2. Smoke test cart/checkout
3. Open redux dev tools and confirm the stores are named without a `v1` for example, `wc/store/cart` should be there and have data within.
