### PR TITLE
Mini Cart Block and related blocks: now the additional classes are visible on frontend page

### DIFF
--- a/assets/js/base/components/drawer/style.scss
+++ b/assets/js/base/components/drawer/style.scss
@@ -69,7 +69,6 @@ $drawer-width-mobile: 100vw;
 	display: block;
 	height: 100%;
 	left: 100%;
-	overflow: auto;
 	position: fixed;
 	right: 0;
 	top: 0;

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/empty-mini-cart-contents-block/frontend.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/empty-mini-cart-contents-block/frontend.tsx
@@ -10,10 +10,12 @@ import { useEffect, useRef } from 'react';
 
 type EmptyMiniCartContentsBlockProps = {
 	children: JSX.Element | JSX.Element[];
+	className: string;
 };
 
 const EmptyMiniCartContentsBlock = ( {
 	children,
+	className,
 }: EmptyMiniCartContentsBlockProps ): JSX.Element | null => {
 	const { cartItems, cartIsLoading } = useStoreCart();
 
@@ -30,11 +32,7 @@ const EmptyMiniCartContentsBlock = ( {
 	}
 
 	return (
-		<div
-			tabIndex={ -1 }
-			ref={ elementRef }
-			className="wp-block-woocommerce-empty-mini-cart-contents-block"
-		>
+		<div tabIndex={ -1 } ref={ elementRef } className={ className }>
 			{ children }
 		</div>
 	);

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/filled-mini-cart-contents-block/frontend.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/filled-mini-cart-contents-block/frontend.tsx
@@ -3,18 +3,22 @@
  */
 import { useStoreCart } from '@woocommerce/base-context/hooks';
 
+type FilledMiniCartContentsBlockProps = {
+	children: JSX.Element;
+	className: string;
+};
+
 const FilledMiniCartContentsBlock = ( {
 	children,
-}: {
-	children: JSX.Element | JSX.Element[];
-} ): JSX.Element | null => {
+	className,
+}: FilledMiniCartContentsBlockProps ): JSX.Element | null => {
 	const { cartItems } = useStoreCart();
 
 	if ( cartItems.length === 0 ) {
 		return null;
 	}
 
-	return <>{ children }</>;
+	return <div className={ className }>{ children }</div>;
 };
 
 export default FilledMiniCartContentsBlock;

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-footer-block/block.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-footer-block/block.tsx
@@ -14,6 +14,7 @@ import { getSetting } from '@woocommerce/settings';
 import { CART_URL, CHECKOUT_URL } from '@woocommerce/block-settings';
 import Button from '@woocommerce/base-components/button';
 import { PaymentMethodDataProvider } from '@woocommerce/base-context';
+import classNames from 'classnames';
 
 const PaymentMethodIconsElement = (): JSX.Element => {
 	const { paymentMethods } = usePaymentMethods();
@@ -27,16 +28,19 @@ const PaymentMethodIconsElement = (): JSX.Element => {
 interface Props {
 	color?: string;
 	backgroundColor?: string;
+	className: string;
 }
 
-const Block = ( { color, backgroundColor }: Props ): JSX.Element => {
+const Block = ( { color, backgroundColor, className }: Props ): JSX.Element => {
 	const { cartTotals } = useStoreCart();
 	const subTotal = getSetting( 'displayCartPricesIncludingTax', false )
 		? parseInt( cartTotals.total_items, 10 ) +
 		  parseInt( cartTotals.total_items_tax, 10 )
 		: parseInt( cartTotals.total_items, 10 );
 	return (
-		<div className="wc-block-mini-cart__footer">
+		<div
+			className={ classNames( className, 'wc-block-mini-cart__footer' ) }
+		>
 			<TotalsItem
 				className="wc-block-mini-cart__footer-subtotal"
 				currency={ getCurrencyFromPriceResponse( cartTotals ) }

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-items-block/frontend.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-items-block/frontend.tsx
@@ -1,5 +1,22 @@
-const Block = ( { children }: { children: JSX.Element } ): JSX.Element => {
-	return <div className="wc-block-mini-cart__items">{ children }</div>;
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+
+type MiniCartItemsBlockProps = {
+	children: JSX.Element;
+	className: string;
+};
+
+const Block = ( {
+	children,
+	className,
+}: MiniCartItemsBlockProps ): JSX.Element => {
+	return (
+		<div className={ classNames( className, 'wc-block-mini-cart__items' ) }>
+			{ children }
+		</div>
+	);
 };
 
 export default Block;

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-products-table-block/block.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-products-table-block/block.tsx
@@ -2,16 +2,26 @@
  * External dependencies
  */
 import { useStoreCart } from '@woocommerce/base-context/hooks';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
 import CartLineItemsTable from '../../../cart/cart-line-items-table';
 
-const Block = (): JSX.Element => {
+type MiniCartContentsBlockProps = {
+	className: string;
+};
+
+const Block = ( { className }: MiniCartContentsBlockProps ): JSX.Element => {
 	const { cartItems, cartIsLoading } = useStoreCart();
 	return (
-		<div className="wc-block-mini-cart__products-table">
+		<div
+			className={ classNames(
+				className,
+				'wc-block-mini-cart__products-table'
+			) }
+		>
 			<CartLineItemsTable
 				lineItems={ cartItems }
 				isLoading={ cartIsLoading }

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-shopping-button-block/block.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-shopping-button-block/block.tsx
@@ -3,18 +3,30 @@
  */
 import { __ } from '@wordpress/i18n';
 import { SHOP_URL } from '@woocommerce/block-settings';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
 
-const Block = (): JSX.Element | null => {
+type MiniCartShoppingButtonBlockProps = {
+	className: string;
+};
+
+const Block = ( {
+	className,
+}: MiniCartShoppingButtonBlockProps ): JSX.Element | null => {
 	if ( ! SHOP_URL ) {
 		return null;
 	}
 
 	return (
-		<div className="wc-block-mini-cart__shopping-button">
+		<div
+			className={ classNames(
+				className,
+				'wc-block-mini-cart__shopping-button'
+			) }
+		>
 			<a href={ SHOP_URL }>
 				{ __( 'Start shopping', 'woo-gutenberg-products-block' ) }
 			</a>

--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-title-block/block.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/mini-cart-title-block/block.tsx
@@ -3,15 +3,20 @@
  */
 import { sprintf, _n, __ } from '@wordpress/i18n';
 import { useStoreCart } from '@woocommerce/base-context/hooks';
+import classNames from 'classnames';
 
 /**
  * Internal dependencies
  */
 
-const Block = (): JSX.Element => {
+type MiniCartTitleBlockProps = {
+	className: string;
+};
+
+const Block = ( { className }: MiniCartTitleBlockProps ): JSX.Element => {
 	const { cartItemsCount, cartIsLoading } = useStoreCart();
 	return (
-		<h2 className="wc-block-mini-cart__title">
+		<h2 className={ classNames( className, 'wc-block-mini-cart__title' ) }>
 			{ cartIsLoading
 				? __( 'Your cart', 'woo-gutenberg-products-block' )
 				: sprintf(

--- a/assets/js/blocks/cart-checkout/mini-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/mini-cart/style.scss
@@ -77,11 +77,24 @@
 .wp-block-woocommerce-mini-cart-contents {
 	background: #fff;
 	box-sizing: border-box;
-	display: flex;
-	flex-direction: column;
 	height: 100vh;
 	padding: 0;
 	justify-content: center;
+}
+
+.wp-block-woocommerce-empty-mini-cart-contents-block,
+.wp-block-woocommerce-filled-mini-cart-contents-block {
+	height: 100%;
+	display: flex;
+	flex-direction: column;
+}
+
+.wp-block-woocommerce-empty-mini-cart-contents-block {
+	justify-content: center;
+}
+
+.wp-block-woocommerce-filled-mini-cart-contents-block {
+	justify-content: space-between;
 }
 
 .wp-block-woocommerce-empty-mini-cart-contents-block {

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -326,6 +326,10 @@ class MiniCart extends AbstractBlock {
 			$wrapper_classes .= ' align-' . $attributes['align'];
 		}
 
+		if ( ! empty( $attributes['className'] ) ) {
+			$wrapper_classes .= ' ' . $attributes['className'];
+		}
+
 		if ( ! isset( $attributes['transparentButton'] ) || $attributes['transparentButton'] ) {
 			$wrapper_classes .= ' is-transparent';
 		}


### PR DESCRIPTION
With this PR, the additional classes added on the editor side are now rendered on the frontend side.
This PR fixes the scrollbar issue when there are too many products.

<!-- Reference any related issues or PRs here -->
Fixes #5881 


### Testing
### Manual Testing

How to test the changes in this Pull Request:
Check out this branch:


#### Classname problem

1. Open the FSE editor.
2. Add the Mini Cart block.
3. Get focused on it.
4. On the right sidebar, on the block settings -> advanced section, add custom classes.
5. Save.
6. On the frontend page, inspect the Mini Cart Block element.
7. Check that the custom classes are added.
8. Open the FSE editor.
9. Open Mini Cart template editor.
10. Repeat 3-7 steps for each block in the template ( `Mini Cart Contents`, `Filled Mini Cart Contents`, `Mini Cart Title`, `Mini Cart Items`, `Mini Cart Products Table`, `Mini Cart Footer`,  `Empty Mini Cart Contents`, `Mini Cart Shopping Button`)


#### Scrollbar issue
1. Open the FSE editor.
2. Add the Mini Cart block.
3. Save.
4. On the frontend side, add a lot of products to the cart.
5. Open the Mini Cart Block and check that the scroll works well (check the attached gif to see the potential issue).



![Screen Capture on 2022-03-03 at 12-08-40](https://user-images.githubusercontent.com/4463174/156599480-298df2af-92e8-452e-8394-f7ed232ec5bd.gif)

