### PR TITLE
Store API: Consistent error code and hook naming

### DIFF
--- a/assets/js/blocks/checkout/checkout-order-error/constants.js
+++ b/assets/js/blocks/checkout/checkout-order-error/constants.js
@@ -1,8 +1,8 @@
-export const PRODUCT_OUT_OF_STOCK = 'woocommerce_product_out_of_stock';
+export const PRODUCT_OUT_OF_STOCK = 'woocommerce_rest_product_out_of_stock';
 export const PRODUCT_NOT_PURCHASABLE =
-	'woocommerce_rest_cart_product_is_not_purchasable';
+	'woocommerce_rest_product_not_purchasable';
 export const PRODUCT_NOT_ENOUGH_STOCK =
-	'woocommerce_rest_cart_product_no_stock';
+	'woocommerce_rest_product_partially_out_of_stock';
 export const PRODUCT_SOLD_INDIVIDUALLY =
-	'woocommerce_rest_cart_product_sold_individually';
+	'woocommerce_rest_product_too_many_in_cart';
 export const GENERIC_CART_ITEM_ERROR = 'woocommerce_rest_cart_item_error';

--- a/bin/hook-docs/data/actions.json
+++ b/bin/hook-docs/data/actions.json
@@ -10,6 +10,10 @@
                 "long_description": "This hook fires when an item is added to the cart. This is triggered from the Store API in this context, but WooCommerce core add to cart events trigger the same hook.",
                 "tags": [
                     {
+                        "name": "internal",
+                        "content": "Matches action name in WooCommerce core."
+                    },
+                    {
                         "name": "param",
                         "content": "ID of the item in the cart.",
                         "types": [
@@ -124,6 +128,10 @@
                 "description": "Fires after a coupon has been applied to the cart.",
                 "long_description": "",
                 "tags": [
+                    {
+                        "name": "internal",
+                        "content": "Matches action name in WooCommerce core."
+                    },
                     {
                         "name": "param",
                         "content": "The coupon code that was applied.",
@@ -269,72 +277,6 @@
             "args": 0
         },
         {
-            "name": "woocommerce_blocks_cart_update_customer_from_request",
-            "file": "StoreApi/Routes/V1/CartUpdateCustomer.php",
-            "type": "action",
-            "doc": {
-                "description": "Fires when the Checkout Block/Store API updates a customer from the API request data.",
-                "long_description": "",
-                "tags": [
-                    {
-                        "name": "param",
-                        "content": "Customer object.",
-                        "types": [
-                            "\\WC_Customer"
-                        ],
-                        "variable": "$customer"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Full details about the request.",
-                        "types": [
-                            "\\WP_REST_Request"
-                        ],
-                        "variable": "$request"
-                    }
-                ],
-                "long_description_html": ""
-            },
-            "args": 2
-        },
-        {
-            "name": "woocommerce_blocks_cart_update_order_from_request",
-            "file": "StoreApi/Routes/V1/AbstractCartRoute.php",
-            "type": "action",
-            "doc": {
-                "description": "Fires when the order is synced with cart data from a cart route.",
-                "long_description": "",
-                "tags": [
-                    {
-                        "name": "param",
-                        "content": "Order object.",
-                        "types": [
-                            "\\WC_Order"
-                        ],
-                        "variable": "$draft_order"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Customer object.",
-                        "types": [
-                            "\\WC_Customer"
-                        ],
-                        "variable": "$customer"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Full details about the request.",
-                        "types": [
-                            "\\WP_REST_Request"
-                        ],
-                        "variable": "$request"
-                    }
-                ],
-                "long_description_html": ""
-            },
-            "args": 2
-        },
-        {
             "name": "woocommerce_blocks_checkout_enqueue_data",
             "file": "BlockTypes/Checkout.php",
             "type": "action",
@@ -345,91 +287,6 @@
                 "long_description_html": ""
             },
             "args": 0
-        },
-        {
-            "name": "woocommerce_blocks_checkout_order_processed",
-            "file": "StoreApi/Routes/V1/Checkout.php",
-            "type": "action",
-            "doc": {
-                "description": "Fires before an order is processed by the Checkout Block/Store API.",
-                "long_description": "This hook informs extensions that $order has completed processing and is ready for payment.\n This is similar to existing core hook woocommerce_checkout_order_processed. We're using a new action: - To keep the interface focused (only pass $order, not passing request data). - This also explicitly indicates these orders are from checkout block/StoreAPI.",
-                "tags": [
-                    {
-                        "name": "see",
-                        "content": "",
-                        "refers": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3238"
-                    },
-                    {
-                        "name": "example",
-                        "content": "docs/examples/checkout-order-processed.md"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Order object.",
-                        "types": [
-                            "\\WC_Order"
-                        ],
-                        "variable": "$order"
-                    }
-                ],
-                "long_description_html": "<p>This hook informs extensions that $order has completed processing and is ready for payment.</p> <p>This is similar to existing core hook woocommerce_checkout_order_processed. We're using a new action:</p> <ul> <li>To keep the interface focused (only pass $order, not passing request data).</li> <li>This also explicitly indicates these orders are from checkout block/StoreAPI.</li> </ul>"
-            },
-            "args": 1
-        },
-        {
-            "name": "woocommerce_blocks_checkout_update_order_from_request",
-            "file": "StoreApi/Routes/V1/Checkout.php",
-            "type": "action",
-            "doc": {
-                "description": "Fires when the Checkout Block/Store API updates an order's from the API request data.",
-                "long_description": "This hook gives extensions the chance to update orders based on the data in the request. This can be used in conjunction with the ExtendSchema class to post custom data and then process it.",
-                "tags": [
-                    {
-                        "name": "param",
-                        "content": "Order object.",
-                        "types": [
-                            "\\WC_Order"
-                        ],
-                        "variable": "$order"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Full details about the request.",
-                        "types": [
-                            "\\WP_REST_Request"
-                        ],
-                        "variable": "$request"
-                    }
-                ],
-                "long_description_html": "<p>This hook gives extensions the chance to update orders based on the data in the request. This can be used in conjunction with the ExtendSchema class to post custom data and then process it.</p>"
-            },
-            "args": 2
-        },
-        {
-            "name": "woocommerce_blocks_checkout_update_order_meta",
-            "file": "StoreApi/Routes/V1/Checkout.php",
-            "type": "action",
-            "doc": {
-                "description": "Fires when the Checkout Block/Store API updates an order's meta data.",
-                "long_description": "This hook gives extensions the chance to add or update meta data on the $order. Throwing an exception from a callback attached to this action will make the Checkout Block render in a warning state, effectively preventing checkout.\n This is similar to existing core hook woocommerce_checkout_update_order_meta. We're using a new action: - To keep the interface focused (only pass $order, not passing request data). - This also explicitly indicates these orders are from checkout block/StoreAPI.",
-                "tags": [
-                    {
-                        "name": "see",
-                        "content": "",
-                        "refers": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3686"
-                    },
-                    {
-                        "name": "param",
-                        "content": "Order object.",
-                        "types": [
-                            "\\WC_Order"
-                        ],
-                        "variable": "$order"
-                    }
-                ],
-                "long_description_html": "<p>This hook gives extensions the chance to add or update meta data on the $order. Throwing an exception from a callback attached to this action will make the Checkout Block render in a warning state, effectively preventing checkout.</p> <p>This is similar to existing core hook woocommerce_checkout_update_order_meta. We're using a new action:</p> <ul> <li>To keep the interface focused (only pass $order, not passing request data).</li> <li>This also explicitly indicates these orders are from checkout block/StoreAPI.</li> </ul>"
-            },
-            "args": 1
         },
         {
             "name": "woocommerce_blocks_enqueue_cart_block_scripts_after",
@@ -480,18 +337,6 @@
             "args": 0
         },
         {
-            "name": "woocommerce_blocks_loaded",
-            "file": "Domain/Bootstrap.php",
-            "type": "action",
-            "doc": {
-                "description": "Fires after WooCommerce Blocks plugin has loaded.",
-                "long_description": "This hook is intended to be used as a safe event hook for when the plugin has been loaded, and all dependency requirements have been met.",
-                "tags": [],
-                "long_description_html": "<p>This hook is intended to be used as a safe event hook for when the plugin has been loaded, and all dependency requirements have been met.</p>"
-            },
-            "args": 0
-        },
-        {
             "name": "woocommerce_blocks_{$this->registry_identifier}_registration",
             "file": "Integrations/IntegrationRegistry.php",
             "type": "action",
@@ -523,6 +368,10 @@
                     {
                         "name": "deprecated",
                         "content": ""
+                    },
+                    {
+                        "name": "internal",
+                        "content": "Matches action name in WooCommerce core."
                     }
                 ],
                 "long_description_html": "<p>Allow 3rd parties to validate cart items. This is a legacy hook from Woo core. This filter will be deprecated because it encourages usage of wc_add_notice. For the API we need to capture notices and convert to wp errors instead.</p>"
@@ -537,6 +386,10 @@
                 "description": "Fires after a customer account has been registered.",
                 "long_description": "This hook fires after customer accounts are created and passes the customer data.",
                 "tags": [
+                    {
+                        "name": "internal",
+                        "content": "Matches filter name in WooCommerce core."
+                    },
                     {
                         "name": "param",
                         "content": "New customer (user) ID.",
@@ -592,6 +445,10 @@
                 "description": "Fires before a customer account is registered.",
                 "long_description": "This hook fires before customer accounts are created and passes the form data (username, email) and an array of errors.\n This could be used to add extra validation logic and append errors to the array.",
                 "tags": [
+                    {
+                        "name": "internal",
+                        "content": "Matches filter name in WooCommerce core."
+                    },
                     {
                         "name": "param",
                         "content": "Customer username.",
@@ -705,6 +562,157 @@
                 "long_description_html": "<p>Functions hooking into this should add custom errors using the provided WP_Error instance.</p>"
             },
             "args": 2
+        },
+        {
+            "name": "woocommerce_store_api_cart_update_customer_from_request",
+            "file": "StoreApi/Routes/V1/CartUpdateCustomer.php",
+            "type": "action",
+            "doc": {
+                "description": "Fires when the Checkout Block/Store API updates a customer from the API request data.",
+                "long_description": "",
+                "tags": [
+                    {
+                        "name": "param",
+                        "content": "Customer object.",
+                        "types": [
+                            "\\WC_Customer"
+                        ],
+                        "variable": "$customer"
+                    },
+                    {
+                        "name": "param",
+                        "content": "Full details about the request.",
+                        "types": [
+                            "\\WP_REST_Request"
+                        ],
+                        "variable": "$request"
+                    }
+                ],
+                "long_description_html": ""
+            },
+            "args": 2
+        },
+        {
+            "name": "woocommerce_store_api_cart_update_order_from_request",
+            "file": "StoreApi/Routes/V1/AbstractCartRoute.php",
+            "type": "action",
+            "doc": {
+                "description": "Fires when the order is synced with cart data from a cart route.",
+                "long_description": "",
+                "tags": [
+                    {
+                        "name": "param",
+                        "content": "Order object.",
+                        "types": [
+                            "\\WC_Order"
+                        ],
+                        "variable": "$draft_order"
+                    },
+                    {
+                        "name": "param",
+                        "content": "Customer object.",
+                        "types": [
+                            "\\WC_Customer"
+                        ],
+                        "variable": "$customer"
+                    },
+                    {
+                        "name": "param",
+                        "content": "Full details about the request.",
+                        "types": [
+                            "\\WP_REST_Request"
+                        ],
+                        "variable": "$request"
+                    }
+                ],
+                "long_description_html": ""
+            },
+            "args": 2
+        },
+        {
+            "name": "woocommerce_store_api_checkout_order_processed",
+            "file": "StoreApi/Routes/V1/Checkout.php",
+            "type": "action",
+            "doc": {
+                "description": "Fires before an order is processed by the Checkout Block/Store API.",
+                "long_description": "This hook informs extensions that $order has completed processing and is ready for payment.\n This is similar to existing core hook woocommerce_checkout_order_processed. We're using a new action: - To keep the interface focused (only pass $order, not passing request data). - This also explicitly indicates these orders are from checkout block/StoreAPI.",
+                "tags": [
+                    {
+                        "name": "see",
+                        "content": "",
+                        "refers": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3238"
+                    },
+                    {
+                        "name": "example",
+                        "content": "docs/examples/checkout-order-processed.md"
+                    },
+                    {
+                        "name": "param",
+                        "content": "Order object.",
+                        "types": [
+                            "\\WC_Order"
+                        ],
+                        "variable": "$order"
+                    }
+                ],
+                "long_description_html": "<p>This hook informs extensions that $order has completed processing and is ready for payment.</p> <p>This is similar to existing core hook woocommerce_checkout_order_processed. We're using a new action:</p> <ul> <li>To keep the interface focused (only pass $order, not passing request data).</li> <li>This also explicitly indicates these orders are from checkout block/StoreAPI.</li> </ul>"
+            },
+            "args": 1
+        },
+        {
+            "name": "woocommerce_store_api_checkout_update_order_from_request",
+            "file": "StoreApi/Routes/V1/Checkout.php",
+            "type": "action",
+            "doc": {
+                "description": "Fires when the Checkout Block/Store API updates an order's from the API request data.",
+                "long_description": "This hook gives extensions the chance to update orders based on the data in the request. This can be used in conjunction with the ExtendSchema class to post custom data and then process it.",
+                "tags": [
+                    {
+                        "name": "param",
+                        "content": "Order object.",
+                        "types": [
+                            "\\WC_Order"
+                        ],
+                        "variable": "$order"
+                    },
+                    {
+                        "name": "param",
+                        "content": "Full details about the request.",
+                        "types": [
+                            "\\WP_REST_Request"
+                        ],
+                        "variable": "$request"
+                    }
+                ],
+                "long_description_html": "<p>This hook gives extensions the chance to update orders based on the data in the request. This can be used in conjunction with the ExtendSchema class to post custom data and then process it.</p>"
+            },
+            "args": 2
+        },
+        {
+            "name": "woocommerce_store_api_checkout_update_order_meta",
+            "file": "StoreApi/Routes/V1/Checkout.php",
+            "type": "action",
+            "doc": {
+                "description": "Fires when the Checkout Block/Store API updates an order's meta data.",
+                "long_description": "This hook gives extensions the chance to add or update meta data on the $order. Throwing an exception from a callback attached to this action will make the Checkout Block render in a warning state, effectively preventing checkout.\n This is similar to existing core hook woocommerce_checkout_update_order_meta. We're using a new action: - To keep the interface focused (only pass $order, not passing request data). - This also explicitly indicates these orders are from checkout block/StoreAPI.",
+                "tags": [
+                    {
+                        "name": "see",
+                        "content": "",
+                        "refers": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3686"
+                    },
+                    {
+                        "name": "param",
+                        "content": "Order object.",
+                        "types": [
+                            "\\WC_Order"
+                        ],
+                        "variable": "$order"
+                    }
+                ],
+                "long_description_html": "<p>This hook gives extensions the chance to add or update meta data on the $order. Throwing an exception from a callback attached to this action will make the Checkout Block render in a warning state, effectively preventing checkout.</p> <p>This is similar to existing core hook woocommerce_checkout_update_order_meta. We're using a new action:</p> <ul> <li>To keep the interface focused (only pass $order, not passing request data).</li> <li>This also explicitly indicates these orders are from checkout block/StoreAPI.</li> </ul>"
+            },
+            "args": 1
         },
         {
             "name": "woocommerce_store_api_validate_add_to_cart",

--- a/bin/hook-docs/data/filters.json
+++ b/bin/hook-docs/data/filters.json
@@ -92,6 +92,10 @@
                 "long_description": "",
                 "tags": [
                     {
+                        "name": "internal",
+                        "content": "Matches filter name in WooCommerce core."
+                    },
+                    {
                         "name": "param",
                         "content": "Array of cart item data being added to the cart.",
                         "types": [
@@ -127,6 +131,10 @@
                 "description": "Filter cart item data for add to cart requests.",
                 "long_description": "",
                 "tags": [
+                    {
+                        "name": "internal",
+                        "content": "Matches filter name in WooCommerce core."
+                    },
                     {
                         "name": "param",
                         "content": "Array of other cart item data.",
@@ -179,6 +187,10 @@
                 "description": "Filter sold individually quantity for add to cart requests.",
                 "long_description": "",
                 "tags": [
+                    {
+                        "name": "internal",
+                        "content": "Matches filter name in WooCommerce core."
+                    },
                     {
                         "name": "param",
                         "content": "Defaults to 1.",
@@ -304,6 +316,10 @@
                 "long_description": "The woocommerce_adjust_non_base_location_prices filter can stop base taxes being taken off when dealing with out of base locations. e.g. If a product costs 10 including tax, all users will pay 10 regardless of location and taxes.",
                 "tags": [
                     {
+                        "name": "internal",
+                        "content": "Matches filter name in WooCommerce core."
+                    },
+                    {
                         "name": "param",
                         "content": "True by default.",
                         "types": [
@@ -343,6 +359,10 @@
                 "description": "Filter coupons to remove when applying an individual use coupon.",
                 "long_description": "",
                 "tags": [
+                    {
+                        "name": "internal",
+                        "content": "Matches filter name in WooCommerce core."
+                    },
                     {
                         "name": "param",
                         "content": "Array of coupons to remove from the cart.",
@@ -387,6 +407,10 @@
                 "description": "Filters if a coupon can be applied alongside other individual use coupons.",
                 "long_description": "",
                 "tags": [
+                    {
+                        "name": "internal",
+                        "content": "Matches filter name in WooCommerce core."
+                    },
                     {
                         "name": "param",
                         "content": "Defaults to false.",
@@ -556,6 +580,10 @@
                 "long_description": "",
                 "tags": [
                     {
+                        "name": "internal",
+                        "content": "Matches filter name in WooCommerce core."
+                    },
+                    {
                         "name": "param",
                         "content": "Array of all cart items.",
                         "types": [
@@ -584,6 +612,10 @@
                 "long_description": "",
                 "tags": [
                     {
+                        "name": "internal",
+                        "content": "Matches filter name in GA extension."
+                    },
+                    {
                         "name": "param",
                         "content": "If true, tracking will be disabled.",
                         "types": [
@@ -604,6 +636,10 @@
                 "description": "Filters cart item data.",
                 "long_description": "Filters the variation option name for custom option slugs.",
                 "tags": [
+                    {
+                        "name": "internal",
+                        "content": "Matches filter name in WooCommerce core."
+                    },
                     {
                         "name": "param",
                         "content": "Cart item data. Empty by default.",
@@ -668,6 +704,10 @@
                 "description": "Filters registration errors before a customer account is registered.",
                 "long_description": "This hook filters registration errors. This can be used to manipulate the array of errors before they are displayed.",
                 "tags": [
+                    {
+                        "name": "internal",
+                        "content": "Matches filter name in WooCommerce core."
+                    },
                     {
                         "name": "param",
                         "content": "Error object.",
@@ -744,6 +784,10 @@
                 "description": "Filters the shipping package name.",
                 "long_description": "",
                 "tags": [
+                    {
+                        "name": "internal",
+                        "content": "Matches filter name in WooCommerce core."
+                    },
                     {
                         "name": "param",
                         "content": "Shipping package name.",
@@ -915,6 +959,10 @@
                 "description": "Filters the variation option name.",
                 "long_description": "Filters the variation option name for custom option slugs.",
                 "tags": [
+                    {
+                        "name": "internal",
+                        "content": "Matches filter name in WooCommerce core."
+                    },
                     {
                         "name": "param",
                         "content": "The name to display.",

--- a/docs/extensibility/actions.md
+++ b/docs/extensibility/actions.md
@@ -15,17 +15,11 @@
  - [woocommerce_before_main_content](#woocommerce_before_main_content)
  - [woocommerce_before_shop_loop](#woocommerce_before_shop_loop)
  - [woocommerce_blocks_cart_enqueue_data](#woocommerce_blocks_cart_enqueue_data)
- - [woocommerce_blocks_cart_update_customer_from_request](#woocommerce_blocks_cart_update_customer_from_request)
- - [woocommerce_blocks_cart_update_order_from_request](#woocommerce_blocks_cart_update_order_from_request)
  - [woocommerce_blocks_checkout_enqueue_data](#woocommerce_blocks_checkout_enqueue_data)
- - [woocommerce_blocks_checkout_order_processed](#woocommerce_blocks_checkout_order_processed)
- - [woocommerce_blocks_checkout_update_order_from_request](#woocommerce_blocks_checkout_update_order_from_request)
- - [woocommerce_blocks_checkout_update_order_meta](#woocommerce_blocks_checkout_update_order_meta)
  - [woocommerce_blocks_enqueue_cart_block_scripts_after](#woocommerce_blocks_enqueue_cart_block_scripts_after)
  - [woocommerce_blocks_enqueue_cart_block_scripts_before](#woocommerce_blocks_enqueue_cart_block_scripts_before)
  - [woocommerce_blocks_enqueue_checkout_block_scripts_after](#woocommerce_blocks_enqueue_checkout_block_scripts_after)
  - [woocommerce_blocks_enqueue_checkout_block_scripts_before](#woocommerce_blocks_enqueue_checkout_block_scripts_before)
- - [woocommerce_blocks_loaded](#woocommerce_blocks_loaded)
  - [woocommerce_blocks_{$this->registry_identifier}_registration](#woocommerce_blocks_-this--registry_identifier-_registration)
  - [woocommerce_check_cart_items](#-woocommerce_check_cart_items)
  - [woocommerce_created_customer](#woocommerce_created_customer)
@@ -34,6 +28,11 @@
  - [woocommerce_rest_checkout_process_payment_with_context](#woocommerce_rest_checkout_process_payment_with_context)
  - [woocommerce_shop_loop](#woocommerce_shop_loop)
  - [woocommerce_store_api_cart_errors](#woocommerce_store_api_cart_errors)
+ - [woocommerce_store_api_cart_update_customer_from_request](#woocommerce_store_api_cart_update_customer_from_request)
+ - [woocommerce_store_api_cart_update_order_from_request](#woocommerce_store_api_cart_update_order_from_request)
+ - [woocommerce_store_api_checkout_order_processed](#woocommerce_store_api_checkout_order_processed)
+ - [woocommerce_store_api_checkout_update_order_from_request](#woocommerce_store_api_checkout_update_order_from_request)
+ - [woocommerce_store_api_checkout_update_order_meta](#woocommerce_store_api_checkout_update_order_meta)
  - [woocommerce_store_api_validate_add_to_cart](#woocommerce_store_api_validate_add_to_cart)
  - [woocommerce_store_api_validate_cart_item](#woocommerce_store_api_validate_cart_item)
 
@@ -47,6 +46,9 @@ Fires when an item is added to the cart.
 ```php
 do_action( 'woocommerce_add_to_cart', string $cart_id, integer $product_id, integer $request_quantity, integer $variation_id, array $variation, array $cart_item_data )
 ```
+
+
+**Note: Matches action name in WooCommerce core.**
 
 ### Description
 
@@ -125,6 +127,9 @@ Fires after a coupon has been applied to the cart.
 ```php
 do_action( 'woocommerce_applied_coupon', string $coupon_code )
 ```
+
+
+**Note: Matches action name in WooCommerce core.**
 
 ### Parameters
 
@@ -229,53 +234,6 @@ do_action( 'woocommerce_blocks_cart_enqueue_data' )
 
 ---
 
-## woocommerce_blocks_cart_update_customer_from_request
-
-
-Fires when the Checkout Block/Store API updates a customer from the API request data.
-
-```php
-do_action( 'woocommerce_blocks_cart_update_customer_from_request', \WC_Customer $customer, \WP_REST_Request $request )
-```
-
-### Parameters
-
-| Argument | Type | Description |
-| -------- | ---- | ----------- |
-| $customer | \WC_Customer | Customer object. |
-| $request | \WP_REST_Request | Full details about the request. |
-
-### Source
-
-
- - [StoreApi/Routes/V1/CartUpdateCustomer.php](../src/StoreApi/Routes/V1/CartUpdateCustomer.php)
-
----
-
-## woocommerce_blocks_cart_update_order_from_request
-
-
-Fires when the order is synced with cart data from a cart route.
-
-```php
-do_action( 'woocommerce_blocks_cart_update_order_from_request', \WC_Order $draft_order, \WC_Customer $customer, \WP_REST_Request $request )
-```
-
-### Parameters
-
-| Argument | Type | Description |
-| -------- | ---- | ----------- |
-| $draft_order | \WC_Order | Order object. |
-| $customer | \WC_Customer | Customer object. |
-| $request | \WP_REST_Request | Full details about the request. |
-
-### Source
-
-
- - [StoreApi/Routes/V1/AbstractCartRoute.php](../src/StoreApi/Routes/V1/AbstractCartRoute.php)
-
----
-
 ## woocommerce_blocks_checkout_enqueue_data
 
 
@@ -289,108 +247,6 @@ do_action( 'woocommerce_blocks_checkout_enqueue_data' )
 
 
  - [BlockTypes/Checkout.php](../src/BlockTypes/Checkout.php)
-
----
-
-## woocommerce_blocks_checkout_order_processed
-
-
-Fires before an order is processed by the Checkout Block/Store API.
-
-```php
-do_action( 'woocommerce_blocks_checkout_order_processed', \WC_Order $order )
-```
-
-### Description
-
-<p>This hook informs extensions that $order has completed processing and is ready for payment.</p> <p>This is similar to existing core hook woocommerce_checkout_order_processed. We're using a new action:</p> <ul> <li>To keep the interface focused (only pass $order, not passing request data).</li> <li>This also explicitly indicates these orders are from checkout block/StoreAPI.</li> </ul>
-
-### Parameters
-
-| Argument | Type | Description |
-| -------- | ---- | ----------- |
-| $order | \WC_Order | Order object. |
-
-### Example
-
-```php
-// The action callback function.
-function my_function_callback( $order ) {
-  // Do something with the $order object.
-  $order->save();
-}
-
-add_action( 'woocommerce_blocks_checkout_order_processed', 'my_function_callback', 10 );
-```
-
-
-### See
-
-
- - https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3238
-
-### Source
-
-
- - [StoreApi/Routes/V1/Checkout.php](../src/StoreApi/Routes/V1/Checkout.php)
-
----
-
-## woocommerce_blocks_checkout_update_order_from_request
-
-
-Fires when the Checkout Block/Store API updates an order's from the API request data.
-
-```php
-do_action( 'woocommerce_blocks_checkout_update_order_from_request', \WC_Order $order, \WP_REST_Request $request )
-```
-
-### Description
-
-<p>This hook gives extensions the chance to update orders based on the data in the request. This can be used in conjunction with the ExtendSchema class to post custom data and then process it.</p>
-
-### Parameters
-
-| Argument | Type | Description |
-| -------- | ---- | ----------- |
-| $order | \WC_Order | Order object. |
-| $request | \WP_REST_Request | Full details about the request. |
-
-### Source
-
-
- - [StoreApi/Routes/V1/Checkout.php](../src/StoreApi/Routes/V1/Checkout.php)
-
----
-
-## woocommerce_blocks_checkout_update_order_meta
-
-
-Fires when the Checkout Block/Store API updates an order's meta data.
-
-```php
-do_action( 'woocommerce_blocks_checkout_update_order_meta', \WC_Order $order )
-```
-
-### Description
-
-<p>This hook gives extensions the chance to add or update meta data on the $order. Throwing an exception from a callback attached to this action will make the Checkout Block render in a warning state, effectively preventing checkout.</p> <p>This is similar to existing core hook woocommerce_checkout_update_order_meta. We're using a new action:</p> <ul> <li>To keep the interface focused (only pass $order, not passing request data).</li> <li>This also explicitly indicates these orders are from checkout block/StoreAPI.</li> </ul>
-
-### Parameters
-
-| Argument | Type | Description |
-| -------- | ---- | ----------- |
-| $order | \WC_Order | Order object. |
-
-### See
-
-
- - https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3686
-
-### Source
-
-
- - [StoreApi/Routes/V1/Checkout.php](../src/StoreApi/Routes/V1/Checkout.php)
 
 ---
 
@@ -458,26 +314,6 @@ do_action( 'woocommerce_blocks_enqueue_checkout_block_scripts_before' )
 
 ---
 
-## woocommerce_blocks_loaded
-
-
-Fires after WooCommerce Blocks plugin has loaded.
-
-```php
-do_action( 'woocommerce_blocks_loaded' )
-```
-
-### Description
-
-<p>This hook is intended to be used as a safe event hook for when the plugin has been loaded, and all dependency requirements have been met.</p>
-
-### Source
-
-
- - [Domain/Bootstrap.php](../src/Domain/Bootstrap.php)
-
----
-
 ## woocommerce_blocks_{$this->registry_identifier}_registration
 
 
@@ -516,6 +352,9 @@ do_action( 'woocommerce_check_cart_items' )
 
 **Deprecated: This hook is deprecated and will be removed**
 
+
+**Note: Matches action name in WooCommerce core.**
+
 ### Description
 
 <p>Allow 3rd parties to validate cart items. This is a legacy hook from Woo core. This filter will be deprecated because it encourages usage of wc_add_notice. For the API we need to capture notices and convert to wp errors instead.</p>
@@ -535,6 +374,9 @@ Fires after a customer account has been registered.
 ```php
 do_action( 'woocommerce_created_customer', integer $customer_id, array $new_customer_data, string $password_generated )
 ```
+
+
+**Note: Matches filter name in WooCommerce core.**
 
 ### Description
 
@@ -584,6 +426,9 @@ Fires before a customer account is registered.
 ```php
 do_action( 'woocommerce_register_post', string $username, string $user_email, \WP_Error $errors )
 ```
+
+
+**Note: Matches filter name in WooCommerce core.**
 
 ### Description
 
@@ -688,6 +533,155 @@ add_action( 'woocommerce_store_api_cart_errors', 'my_function_callback', 10 );
 
 
  - [StoreApi/Utilities/CartController.php](../src/StoreApi/Utilities/CartController.php)
+
+---
+
+## woocommerce_store_api_cart_update_customer_from_request
+
+
+Fires when the Checkout Block/Store API updates a customer from the API request data.
+
+```php
+do_action( 'woocommerce_store_api_cart_update_customer_from_request', \WC_Customer $customer, \WP_REST_Request $request )
+```
+
+### Parameters
+
+| Argument | Type | Description |
+| -------- | ---- | ----------- |
+| $customer | \WC_Customer | Customer object. |
+| $request | \WP_REST_Request | Full details about the request. |
+
+### Source
+
+
+ - [StoreApi/Routes/V1/CartUpdateCustomer.php](../src/StoreApi/Routes/V1/CartUpdateCustomer.php)
+
+---
+
+## woocommerce_store_api_cart_update_order_from_request
+
+
+Fires when the order is synced with cart data from a cart route.
+
+```php
+do_action( 'woocommerce_store_api_cart_update_order_from_request', \WC_Order $draft_order, \WC_Customer $customer, \WP_REST_Request $request )
+```
+
+### Parameters
+
+| Argument | Type | Description |
+| -------- | ---- | ----------- |
+| $draft_order | \WC_Order | Order object. |
+| $customer | \WC_Customer | Customer object. |
+| $request | \WP_REST_Request | Full details about the request. |
+
+### Source
+
+
+ - [StoreApi/Routes/V1/AbstractCartRoute.php](../src/StoreApi/Routes/V1/AbstractCartRoute.php)
+
+---
+
+## woocommerce_store_api_checkout_order_processed
+
+
+Fires before an order is processed by the Checkout Block/Store API.
+
+```php
+do_action( 'woocommerce_store_api_checkout_order_processed', \WC_Order $order )
+```
+
+### Description
+
+<p>This hook informs extensions that $order has completed processing and is ready for payment.</p> <p>This is similar to existing core hook woocommerce_checkout_order_processed. We're using a new action:</p> <ul> <li>To keep the interface focused (only pass $order, not passing request data).</li> <li>This also explicitly indicates these orders are from checkout block/StoreAPI.</li> </ul>
+
+### Parameters
+
+| Argument | Type | Description |
+| -------- | ---- | ----------- |
+| $order | \WC_Order | Order object. |
+
+### Example
+
+```php
+// The action callback function.
+function my_function_callback( $order ) {
+  // Do something with the $order object.
+  $order->save();
+}
+
+add_action( 'woocommerce_blocks_checkout_order_processed', 'my_function_callback', 10 );
+```
+
+
+### See
+
+
+ - https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3238
+
+### Source
+
+
+ - [StoreApi/Routes/V1/Checkout.php](../src/StoreApi/Routes/V1/Checkout.php)
+
+---
+
+## woocommerce_store_api_checkout_update_order_from_request
+
+
+Fires when the Checkout Block/Store API updates an order's from the API request data.
+
+```php
+do_action( 'woocommerce_store_api_checkout_update_order_from_request', \WC_Order $order, \WP_REST_Request $request )
+```
+
+### Description
+
+<p>This hook gives extensions the chance to update orders based on the data in the request. This can be used in conjunction with the ExtendSchema class to post custom data and then process it.</p>
+
+### Parameters
+
+| Argument | Type | Description |
+| -------- | ---- | ----------- |
+| $order | \WC_Order | Order object. |
+| $request | \WP_REST_Request | Full details about the request. |
+
+### Source
+
+
+ - [StoreApi/Routes/V1/Checkout.php](../src/StoreApi/Routes/V1/Checkout.php)
+
+---
+
+## woocommerce_store_api_checkout_update_order_meta
+
+
+Fires when the Checkout Block/Store API updates an order's meta data.
+
+```php
+do_action( 'woocommerce_store_api_checkout_update_order_meta', \WC_Order $order )
+```
+
+### Description
+
+<p>This hook gives extensions the chance to add or update meta data on the $order. Throwing an exception from a callback attached to this action will make the Checkout Block render in a warning state, effectively preventing checkout.</p> <p>This is similar to existing core hook woocommerce_checkout_update_order_meta. We're using a new action:</p> <ul> <li>To keep the interface focused (only pass $order, not passing request data).</li> <li>This also explicitly indicates these orders are from checkout block/StoreAPI.</li> </ul>
+
+### Parameters
+
+| Argument | Type | Description |
+| -------- | ---- | ----------- |
+| $order | \WC_Order | Order object. |
+
+### See
+
+
+ - https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3686
+
+### Source
+
+
+ - [StoreApi/Routes/V1/Checkout.php](../src/StoreApi/Routes/V1/Checkout.php)
 
 ---
 

--- a/docs/extensibility/filtering-payment-methods.md
+++ b/docs/extensibility/filtering-payment-methods.md
@@ -180,9 +180,10 @@ with a `Bookable` item in your cart, any method that does not `supports` the `bo
 not display, while yours, the one that _does_ support this requirement _will_ display.
 
 <!-- FEEDBACK -->
+---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/extensibility/filtering-payment-methods.md)
-
 <!-- /FEEDBACK -->
+

--- a/docs/extensibility/filters.md
+++ b/docs/extensibility/filters.md
@@ -141,6 +141,9 @@ Filters the item being added to the cart.
 apply_filters( 'woocommerce_add_cart_item', array $cart_item_data, string $cart_id )
 ```
 
+
+**Note: Matches filter name in WooCommerce core.**
+
 ### Parameters
 
 | Argument | Type | Description |
@@ -168,6 +171,9 @@ Filter cart item data for add to cart requests.
 ```php
 apply_filters( 'woocommerce_add_cart_item_data', array $cart_item_data, integer $product_id, integer $variation_id, integer $quantity )
 ```
+
+
+**Note: Matches filter name in WooCommerce core.**
 
 ### Parameters
 
@@ -198,6 +204,9 @@ Filter sold individually quantity for add to cart requests.
 ```php
 apply_filters( 'woocommerce_add_to_cart_sold_individually_quantity', integer $sold_individually_quantity, integer $quantity, integer $product_id, integer $variation_id, array $cart_item_data )
 ```
+
+
+**Note: Matches filter name in WooCommerce core.**
 
 ### Parameters
 
@@ -268,6 +277,9 @@ Filters if taxes should be removed from locations outside the store base locatio
 apply_filters( 'woocommerce_adjust_non_base_location_prices', boolean $adjust_non_base_location_prices )
 ```
 
+
+**Note: Matches filter name in WooCommerce core.**
+
 ### Description
 
 <p>The woocommerce_adjust_non_base_location_prices filter can stop base taxes being taken off when dealing with out of base locations. e.g. If a product costs 10 including tax, all users will pay 10 regardless of location and taxes.</p>
@@ -315,6 +327,9 @@ Filter coupons to remove when applying an individual use coupon.
 apply_filters( 'woocommerce_apply_individual_use_coupon', array $coupons, \WC_Coupon $coupon, array $applied_coupons )
 ```
 
+
+**Note: Matches filter name in WooCommerce core.**
+
 ### Parameters
 
 | Argument | Type | Description |
@@ -343,6 +358,9 @@ Filters if a coupon can be applied alongside other individual use coupons.
 ```php
 apply_filters( 'woocommerce_apply_with_individual_use_coupon', boolean $apply_with_individual_use_coupon, \WC_Coupon $coupon, \WC_Coupon $individual_use_coupon, array $applied_coupons )
 ```
+
+
+**Note: Matches filter name in WooCommerce core.**
 
 ### Parameters
 
@@ -459,6 +477,9 @@ Filters the entire cart contents when the cart changes.
 apply_filters( 'woocommerce_cart_contents_changed', array $cart_contents )
 ```
 
+
+**Note: Matches filter name in WooCommerce core.**
+
 ### Parameters
 
 | Argument | Type | Description |
@@ -486,6 +507,9 @@ Filter to disable Google Analytics tracking.
 apply_filters( 'woocommerce_ga_disable_tracking', boolean $disable_tracking )
 ```
 
+
+**Note: Matches filter name in GA extension.**
+
 ### Parameters
 
 | Argument | Type | Description |
@@ -507,6 +531,9 @@ Filters cart item data.
 ```php
 apply_filters( 'woocommerce_get_item_data', array $item_data, array $cart_item )
 ```
+
+
+**Note: Matches filter name in WooCommerce core.**
 
 ### Description
 
@@ -570,6 +597,9 @@ Filters registration errors before a customer account is registered.
 ```php
 apply_filters( 'woocommerce_registration_errors', \WP_Error $errors, string $username, string $user_email )
 ```
+
+
+**Note: Matches filter name in WooCommerce core.**
 
 ### Description
 
@@ -637,6 +667,9 @@ Filters the shipping package name.
 ```php
 apply_filters( 'woocommerce_shipping_package_name', string $shipping_package_name, string $package_id, array $package )
 ```
+
+
+**Note: Matches filter name in WooCommerce core.**
 
 ### Parameters
 
@@ -783,6 +816,9 @@ Filters the variation option name.
 ```php
 apply_filters( 'woocommerce_variation_option_name', string $value, null $unused, string $taxonomy, \WC_Product $product )
 ```
+
+
+**Note: Matches filter name in WooCommerce core.**
 
 ### Description
 

--- a/docs/extensibility/payment-method-integration.md
+++ b/docs/extensibility/payment-method-integration.md
@@ -240,9 +240,10 @@ function my_extension_woocommerce_blocks_support() {
 As an example, you can see how the Stripe extension adds it's integration in this [pull request](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/1467/files).
 
 <!-- FEEDBACK -->
+---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/extensibility/payment-method-integration.md)
-
 <!-- /FEEDBACK -->
+

--- a/src/Domain/Services/GoogleAnalytics.php
+++ b/src/Domain/Services/GoogleAnalytics.php
@@ -55,6 +55,8 @@ class GoogleAnalytics {
 		/**
 		 * Filter to disable Google Analytics tracking.
 		 *
+		 * @internal Matches filter name in GA extension.
+		 *
 		 * @param boolean $disable_tracking If true, tracking will be disabled.
 		 */
 		if ( ! stristr( $settings['ga_id'], 'G-' ) || apply_filters( 'woocommerce_ga_disable_tracking', ! wc_string_to_bool( $settings['ga_event_tracking_enabled'] ) ) ) {

--- a/src/StoreApi/Routes/V1/AbstractCartRoute.php
+++ b/src/StoreApi/Routes/V1/AbstractCartRoute.php
@@ -83,7 +83,7 @@ abstract class AbstractCartRoute extends AbstractRoute {
 		} catch ( RouteException $error ) {
 			$response = $this->get_route_error_response( $error->getErrorCode(), $error->getMessage(), $error->getCode(), $error->getAdditionalData() );
 		} catch ( \Exception $error ) {
-			$response = $this->get_route_error_response( 'unknown_server_error', $error->getMessage(), 500 );
+			$response = $this->get_route_error_response( 'woocommerce_rest_unknown_server_error', $error->getMessage(), 500 );
 		}
 
 		if ( is_wp_error( $response ) ) {

--- a/src/StoreApi/Routes/V1/AbstractCartRoute.php
+++ b/src/StoreApi/Routes/V1/AbstractCartRoute.php
@@ -130,6 +130,17 @@ abstract class AbstractCartRoute extends AbstractRoute {
 		if ( $draft_order ) {
 			$this->order_controller->update_order_from_cart( $draft_order );
 
+			wc_do_deprecated_action(
+				'woocommerce_blocks_cart_update_order_from_request',
+				array(
+					$draft_order,
+					$request,
+				),
+				'7.2.0',
+				'woocommerce_store_api_cart_update_order_from_request',
+				'This action was deprecated in WooCommerce Blocks version 7.2.0. Please use woocommerce_store_api_cart_update_order_from_request instead.'
+			);
+
 			/**
 			 * Fires when the order is synced with cart data from a cart route.
 			 *
@@ -137,7 +148,7 @@ abstract class AbstractCartRoute extends AbstractRoute {
 			 * @param \WC_Customer $customer Customer object.
 			 * @param \WP_REST_Request $request Full details about the request.
 			 */
-			do_action( 'woocommerce_blocks_cart_update_order_from_request', $draft_order, $request );
+			do_action( 'woocommerce_store_api_cart_update_order_from_request', $draft_order, $request );
 		}
 	}
 

--- a/src/StoreApi/Routes/V1/AbstractRoute.php
+++ b/src/StoreApi/Routes/V1/AbstractRoute.php
@@ -116,7 +116,7 @@ abstract class AbstractRoute implements RouteInterface {
 		} catch ( InvalidCartException $error ) {
 			$response = $this->get_route_error_response_from_object( $error->getError(), $error->getCode(), $error->getAdditionalData() );
 		} catch ( \Exception $error ) {
-			$response = $this->get_route_error_response( 'unknown_server_error', $error->getMessage(), 500 );
+			$response = $this->get_route_error_response( 'woocommerce_rest_unknown_server_error', $error->getMessage(), 500 );
 		}
 
 		if ( is_wp_error( $response ) ) {

--- a/src/StoreApi/Routes/V1/Batch.php
+++ b/src/StoreApi/Routes/V1/Batch.php
@@ -111,7 +111,7 @@ class Batch extends AbstractRoute implements RouteInterface {
 		} catch ( RouteException $error ) {
 			$response = $this->get_route_error_response( $error->getErrorCode(), $error->getMessage(), $error->getCode(), $error->getAdditionalData() );
 		} catch ( \Exception $error ) {
-			$response = $this->get_route_error_response( 'unknown_server_error', $error->getMessage(), 500 );
+			$response = $this->get_route_error_response( 'woocommerce_rest_unknown_server_error', $error->getMessage(), 500 );
 		}
 
 		if ( is_wp_error( $response ) ) {

--- a/src/StoreApi/Routes/V1/CartUpdateCustomer.php
+++ b/src/StoreApi/Routes/V1/CartUpdateCustomer.php
@@ -107,13 +107,24 @@ class CartUpdateCustomer extends AbstractCartRoute {
 			)
 		);
 
+		wc_do_deprecated_action(
+			'woocommerce_blocks_cart_update_customer_from_request',
+			array(
+				$customer,
+				$request,
+			),
+			'7.2.0',
+			'woocommerce_store_api_cart_update_customer_from_request',
+			'This action was deprecated in WooCommerce Blocks version 7.2.0. Please use woocommerce_store_api_cart_update_customer_from_request instead.'
+		);
+
 		/**
 		 * Fires when the Checkout Block/Store API updates a customer from the API request data.
 		 *
 		 * @param \WC_Customer $customer Customer object.
 		 * @param \WP_REST_Request $request Full details about the request.
 		 */
-		do_action( 'woocommerce_blocks_cart_update_customer_from_request', $customer, $request );
+		do_action( 'woocommerce_store_api_cart_update_customer_from_request', $customer, $request );
 
 		$customer->save();
 

--- a/src/StoreApi/Routes/V1/Checkout.php
+++ b/src/StoreApi/Routes/V1/Checkout.php
@@ -191,30 +191,24 @@ class Checkout extends AbstractCartRoute {
 		 */
 		$this->order_controller->validate_order_before_payment( $this->order );
 
-		/**
-		 * Fires before an order is processed by the Checkout Block/Store API.
-		 *
-		 * This hook informs extensions that $order has completed processing and is ready for payment.
-		 *
-		 * This is similar to existing core hook woocommerce_checkout_order_processed. We're using a new action:
-		 * - To keep the interface focused (only pass $order, not passing request data).
-		 * - This also explicitly indicates these orders are from checkout block/StoreAPI.
-		 *
-		 * @see https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3238
-		 * @example See docs/examples/checkout-order-processed.md
-		 * @internal This Hook is experimental and may change or be removed.
-
-		 * @param \WC_Order $order Order object.
-		 * @deprecated 6.3.0 Use woocommerce_blocks_checkout_order_processed instead.
-		 */
 		wc_do_deprecated_action(
 			'__experimental_woocommerce_blocks_checkout_order_processed',
 			array(
 				$this->order,
 			),
 			'6.3.0',
+			'woocommerce_store_api_checkout_order_processed',
+			'This action was deprecated in WooCommerce Blocks version 6.3.0. Please use woocommerce_store_api_checkout_order_processed instead.'
+		);
+
+		wc_do_deprecated_action(
 			'woocommerce_blocks_checkout_order_processed',
-			'This action was deprecated in WooCommerce Blocks version 6.3.0. Please use woocommerce_blocks_checkout_order_processed instead.'
+			array(
+				$this->order,
+			),
+			'7.2.0',
+			'woocommerce_store_api_checkout_order_processed',
+			'This action was deprecated in WooCommerce Blocks version 7.2.0. Please use woocommerce_store_api_checkout_order_processed instead.'
 		);
 
 		/**
@@ -231,7 +225,7 @@ class Checkout extends AbstractCartRoute {
 
 		 * @param \WC_Order $order Order object.
 		 */
-		do_action( 'woocommerce_blocks_checkout_order_processed', $this->order );
+		do_action( 'woocommerce_store_api_checkout_order_processed', $this->order );
 
 		/**
 		 * Process the payment and return the results.
@@ -323,31 +317,24 @@ class Checkout extends AbstractCartRoute {
 			$this->order_controller->update_order_from_cart( $this->order );
 		}
 
-		/**
-		 * Fires when the Checkout Block/Store API updates an order's meta data.
-		 *
-		 * This hook gives extensions the chance to add or update meta data on the $order.
-		 *
-		 * This is similar to existing core hook woocommerce_checkout_update_order_meta.
-		 * We're using a new action:
-		 * - To keep the interface focused (only pass $order, not passing request data).
-		 * - This also explicitly indicates these orders are from checkout block/StoreAPI.
-		 *
-		 * @see https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3686
-		 * @internal This Hook is experimental and may change or be removed.
-		 *
-		 * @param \WC_Order $order Order object.
-		 *
-		 * @deprecated 6.3.0 Use woocommerce_blocks_checkout_update_order_meta instead.
-		 */
 		wc_do_deprecated_action(
 			'__experimental_woocommerce_blocks_checkout_update_order_meta',
 			array(
 				$this->order,
 			),
 			'6.3.0',
+			'woocommerce_store_api_checkout_update_order_meta',
+			'This action was deprecated in WooCommerce Blocks version 6.3.0. Please use woocommerce_store_api_checkout_update_order_meta instead.'
+		);
+
+		wc_do_deprecated_action(
 			'woocommerce_blocks_checkout_update_order_meta',
-			'This action was deprecated in WooCommerce Blocks version 6.3.0. Please use woocommerce_blocks_checkout_update_order_meta instead.'
+			array(
+				$this->order,
+			),
+			'7.2.0',
+			'woocommerce_store_api_checkout_update_order_meta',
+			'This action was deprecated in WooCommerce Blocks version 7.2.0. Please use woocommerce_store_api_checkout_update_order_meta instead.'
 		);
 
 		/**
@@ -365,7 +352,7 @@ class Checkout extends AbstractCartRoute {
 		 *
 		 * @param \WC_Order $order Order object.
 		 */
-		do_action( 'woocommerce_blocks_checkout_update_order_meta', $this->order );
+		do_action( 'woocommerce_store_api_checkout_update_order_meta', $this->order );
 
 		// Confirm order is valid before proceeding further.
 		if ( ! $this->order instanceof \WC_Order ) {
@@ -438,19 +425,6 @@ class Checkout extends AbstractCartRoute {
 		$this->order->set_customer_note( $request['customer_note'] ?? '' );
 		$this->order->set_payment_method( $this->get_request_payment_method_id( $request ) );
 
-		/**
-		 * Fires when the Checkout Block/Store API updates an order's from the API request data.
-		 *
-		 * This hook gives extensions the chance to update orders based on the data in the request. This can be used in
-		 * conjunction with the ExtendSchema class to post custom data and then process it.
-		 *
-		 * @internal This Hook is experimental and may change or be removed.
-		 *
-		 * @param \WC_Order $order Order object.
-		 * @param \WP_REST_Request $request Full details about the request.
-		 *
-		 * @deprecated 6.3.0 Use woocommerce_blocks_checkout_update_order_from_request instead.
-		 */
 		wc_do_deprecated_action(
 			'__experimental_woocommerce_blocks_checkout_update_order_from_request',
 			array(
@@ -458,8 +432,18 @@ class Checkout extends AbstractCartRoute {
 				$request,
 			),
 			'6.3.0',
+			'woocommerce_store_api_checkout_update_order_from_request',
+			'This action was deprecated in WooCommerce Blocks version 6.3.0. Please use woocommerce_store_api_checkout_update_order_from_request instead.'
+		);
+
+		wc_do_deprecated_action(
 			'woocommerce_blocks_checkout_update_order_from_request',
-			'This action was deprecated in WooCommerce Blocks version 6.3.0. Please use woocommerce_blocks_checkout_update_order_from_request instead.'
+			array(
+				$this->order,
+			),
+			'7.2.0',
+			'woocommerce_store_api_checkout_update_order_from_request',
+			'This action was deprecated in WooCommerce Blocks version 7.2.0. Please use woocommerce_store_api_checkout_update_order_from_request instead.'
 		);
 
 		/**
@@ -471,7 +455,7 @@ class Checkout extends AbstractCartRoute {
 		 * @param \WC_Order $order Order object.
 		 * @param \WP_REST_Request $request Full details about the request.
 		 */
-		do_action( 'woocommerce_blocks_checkout_update_order_from_request', $this->order, $request );
+		do_action( 'woocommerce_store_api_checkout_update_order_from_request', $this->order, $request );
 
 		$this->order->save();
 	}
@@ -719,6 +703,8 @@ class Checkout extends AbstractCartRoute {
 		 * of errors.
 		 *
 		 * This could be used to add extra validation logic and append errors to the array.
+		 * 
+		 * @internal Matches filter name in WooCommerce core.
 		 *
 		 * @param string $username Customer username.
 		 * @param string $user_email Customer email address.
@@ -731,6 +717,8 @@ class Checkout extends AbstractCartRoute {
 		 *
 		 * This hook filters registration errors. This can be used to manipulate the array of errors before
 		 * they are displayed.
+		 * 
+		 * @internal Matches filter name in WooCommerce core.
 		 *
 		 * @param \WP_Error $errors Error object.
 		 * @param string $username Customer username.
@@ -778,6 +766,8 @@ class Checkout extends AbstractCartRoute {
 		 * Fires after a customer account has been registered.
 		 *
 		 * This hook fires after customer accounts are created and passes the customer data.
+		 * 
+		 * @internal Matches filter name in WooCommerce core.
 		 *
 		 * @param integer $customer_id New customer (user) ID.
 		 * @param array $new_customer_data Array of customer (user) data.

--- a/src/StoreApi/Routes/V1/Checkout.php
+++ b/src/StoreApi/Routes/V1/Checkout.php
@@ -703,7 +703,7 @@ class Checkout extends AbstractCartRoute {
 		 * of errors.
 		 *
 		 * This could be used to add extra validation logic and append errors to the array.
-		 * 
+		 *
 		 * @internal Matches filter name in WooCommerce core.
 		 *
 		 * @param string $username Customer username.
@@ -717,7 +717,7 @@ class Checkout extends AbstractCartRoute {
 		 *
 		 * This hook filters registration errors. This can be used to manipulate the array of errors before
 		 * they are displayed.
-		 * 
+		 *
 		 * @internal Matches filter name in WooCommerce core.
 		 *
 		 * @param \WP_Error $errors Error object.
@@ -766,7 +766,7 @@ class Checkout extends AbstractCartRoute {
 		 * Fires after a customer account has been registered.
 		 *
 		 * This hook fires after customer accounts are created and passes the customer data.
-		 * 
+		 *
 		 * @internal Matches filter name in WooCommerce core.
 		 *
 		 * @param integer $customer_id New customer (user) ID.

--- a/src/StoreApi/Schemas/V1/CartItemSchema.php
+++ b/src/StoreApi/Schemas/V1/CartItemSchema.php
@@ -421,6 +421,8 @@ class CartItemSchema extends ProductSchema {
 				 *
 				 * Filters the variation option name for custom option slugs.
 				 *
+				 * @internal Matches filter name in WooCommerce core.
+				 *
 				 * @param string $value The name to display.
 				 * @param null $unused Unused because this is not a variation taxonomy.
 				 * @param string $taxonomy Taxonomy or product attribute name.
@@ -451,6 +453,8 @@ class CartItemSchema extends ProductSchema {
 		 * Filters cart item data.
 		 *
 		 * Filters the variation option name for custom option slugs.
+		 *
+		 * @internal Matches filter name in WooCommerce core.
 		 *
 		 * @param array $item_data Cart item data. Empty by default.
 		 * @param array $cart_item Cart item array.

--- a/src/StoreApi/Utilities/CartController.php
+++ b/src/StoreApi/Utilities/CartController.php
@@ -511,7 +511,7 @@ class CartController {
 			$plural_error   = $this->get_error_message_for_stock_exception_type( 'out_of_stock', 'plural' );
 
 			$error->add(
-				'woocommerce-blocks-product-out-of-stock',
+				'woocommerce_rest_product_out_of_stock',
 				$this->add_product_names_to_message( $singular_error, $plural_error, $out_of_stock_products )
 			);
 		}
@@ -521,7 +521,7 @@ class CartController {
 			$plural_error   = $this->get_error_message_for_stock_exception_type( 'not_purchasable', 'plural' );
 
 			$error->add(
-				'woocommerce-blocks-product-not-purchasable',
+				'woocommerce_rest_product_not_purchasable',
 				$this->add_product_names_to_message( $singular_error, $plural_error, $not_purchasable_products )
 			);
 		}
@@ -531,7 +531,7 @@ class CartController {
 			$plural_error   = $this->get_error_message_for_stock_exception_type( 'too_many_in_cart', 'plural' );
 
 			$error->add(
-				'woocommerce-blocks-too-many-of-product-in-cart',
+				'woocommerce_rest_product_too_many_in_cart',
 				$this->add_product_names_to_message( $singular_error, $plural_error, $too_many_in_cart_products )
 			);
 		}
@@ -541,7 +541,7 @@ class CartController {
 			$plural_error   = $this->get_error_message_for_stock_exception_type( 'partial_out_of_stock', 'plural' );
 
 			$error->add(
-				'woocommerce-blocks-product-partially-out-of-stock',
+				'woocommerce_rest_product_partially_out_of_stock',
 				$this->add_product_names_to_message( $singular_error, $plural_error, $partial_out_of_stock_products )
 			);
 		}

--- a/src/StoreApi/Utilities/CartController.php
+++ b/src/StoreApi/Utilities/CartController.php
@@ -98,6 +98,8 @@ class CartController {
 		/**
 		 * Filters the item being added to the cart.
 		 *
+		 * @internal Matches filter name in WooCommerce core.
+		 *
 		 * @param array $cart_item_data Array of cart item data being added to the cart.
 		 * @param string $cart_id Id of the item in the cart.
 		 * @return array Updated cart item data.
@@ -122,6 +124,8 @@ class CartController {
 		/**
 		 * Filters the entire cart contents when the cart changes.
 		 *
+		 * @internal Matches filter name in WooCommerce core.
+		 *
 		 * @param array $cart_contents Array of all cart items.
 		 * @return array Updated array of all cart items.
 		 */
@@ -132,6 +136,8 @@ class CartController {
 		 *
 		 * This hook fires when an item is added to the cart. This is triggered from the Store API in this context, but
 		 * WooCommerce core add to cart events trigger the same hook.
+		 *
+		 * @internal Matches action name in WooCommerce core.
 		 *
 		 * @param string $cart_id ID of the item in the cart.
 		 * @param integer $product_id ID of the product added to the cart.
@@ -422,6 +428,7 @@ class CartController {
 		 * notices and convert to wp errors instead.
 		 *
 		 * @deprecated
+		 * @internal Matches action name in WooCommerce core.
 		 */
 		do_action( 'woocommerce_check_cart_items' );
 
@@ -812,6 +819,8 @@ class CartController {
 		/**
 		 * Filters the shipping package name.
 		 *
+		 * @internal Matches filter name in WooCommerce core.
+		 *
 		 * @param string $shipping_package_name Shipping package name.
 		 * @param string $package_id Shipping package ID.
 		 * @param array $package Shipping package from WooCommerce.
@@ -907,6 +916,8 @@ class CartController {
 			/**
 			 * Filters if a coupon can be applied alongside other individual use coupons.
 			 *
+			 * @internal Matches filter name in WooCommerce core.
+			 *
 			 * @param boolean $apply_with_individual_use_coupon Defaults to false.
 			 * @param \WC_Coupon $coupon Coupon object applied to the cart.
 			 * @param \WC_Coupon $individual_use_coupon Individual use coupon already applied to the cart.
@@ -930,6 +941,8 @@ class CartController {
 			/**
 			 * Filter coupons to remove when applying an individual use coupon.
 			 *
+			 * @internal Matches filter name in WooCommerce core.
+			 *
 			 * @param array $coupons Array of coupons to remove from the cart.
 			 * @param \WC_Coupon $coupon Coupon object applied to the cart.
 			 * @param array $applied_coupons Array of applied coupons already applied to the cart.
@@ -949,6 +962,8 @@ class CartController {
 
 		/**
 		 * Fires after a coupon has been applied to the cart.
+		 *
+		 * @internal Matches action name in WooCommerce core.
 		 *
 		 * @param string $coupon_code The coupon code that was applied.
 		 */
@@ -1087,6 +1102,8 @@ class CartController {
 		/**
 		 * Filter cart item data for add to cart requests.
 		 *
+		 * @internal Matches filter name in WooCommerce core.
+		 *
 		 * @param array $cart_item_data Array of other cart item data.
 		 * @param integer $product_id ID of the product added to the cart.
 		 * @param integer $variation_id Variation ID of the product added to the cart.
@@ -1104,6 +1121,8 @@ class CartController {
 		if ( $product->is_sold_individually() ) {
 			/**
 			 * Filter sold individually quantity for add to cart requests.
+			 *
+			 * @internal Matches filter name in WooCommerce core.
 			 *
 			 * @param integer $sold_individually_quantity Defaults to 1.
 			 * @param integer $quantity Quantity of the item added to the cart.

--- a/src/StoreApi/Utilities/CartController.php
+++ b/src/StoreApi/Utilities/CartController.php
@@ -206,7 +206,7 @@ class CartController {
 
 		if ( ! $product->is_in_stock() ) {
 			throw new RouteException(
-				'woocommerce_rest_cart_product_no_stock',
+				'woocommerce_rest_product_out_of_stock',
 				sprintf(
 					/* translators: %s: product name */
 					__( 'You cannot add &quot;%s&quot; to the cart because the product is out of stock.', 'woo-gutenberg-products-block' ),
@@ -222,7 +222,7 @@ class CartController {
 
 			if ( $qty_remaining < $qty_in_cart + $request['quantity'] ) {
 				throw new RouteException(
-					'woocommerce_rest_cart_product_no_stock',
+					'woocommerce_rest_product_partially_out_of_stock',
 					sprintf(
 						/* translators: 1: product name 2: quantity in stock */
 						__( 'You cannot add that amount of &quot;%1$s&quot; to the cart because there is not enough stock (%2$s remaining).', 'woo-gutenberg-products-block' ),
@@ -575,21 +575,21 @@ class CartController {
 
 		if ( ! $product->is_purchasable() ) {
 			throw new NotPurchasableException(
-				'woocommerce_rest_cart_product_not_purchasable',
+				'woocommerce_rest_product_not_purchasable',
 				$product->get_name()
 			);
 		}
 
 		if ( $product->is_sold_individually() && $cart_item['quantity'] > 1 ) {
 			throw new TooManyInCartException(
-				'woocommerce_rest_cart_product_sold_individually',
+				'woocommerce_rest_product_too_many_in_cart',
 				$product->get_name()
 			);
 		}
 
 		if ( ! $product->is_in_stock() ) {
 			throw new OutOfStockException(
-				'woocommerce_rest_cart_product_no_stock',
+				'woocommerce_rest_product_out_of_stock',
 				$product->get_name()
 			);
 		}
@@ -600,7 +600,7 @@ class CartController {
 
 			if ( $qty_remaining < $qty_in_cart ) {
 				throw new PartialOutOfStockException(
-					'woocommerce_rest_cart_product_partially_no_stock',
+					'woocommerce_rest_product_partially_out_of_stock',
 					$product->get_name()
 				);
 			}
@@ -1067,13 +1067,13 @@ class CartController {
 	/**
 	 * Default exception thrown when an item cannot be added to the cart.
 	 *
-	 * @throws RouteException Exception with code woocommerce_rest_cart_product_is_not_purchasable.
+	 * @throws RouteException Exception with code woocommerce_rest_product_not_purchasable.
 	 *
 	 * @param \WC_Product $product Product object associated with the cart item.
 	 */
 	protected function throw_default_product_exception( \WC_Product $product ) {
 		throw new RouteException(
-			'woocommerce_rest_cart_product_is_not_purchasable',
+			'woocommerce_rest_product_not_purchasable',
 			sprintf(
 				/* translators: %s: product name */
 				__( '&quot;%s&quot; is not available for purchase.', 'woo-gutenberg-products-block' ),

--- a/src/StoreApi/Utilities/ProductQuery.php
+++ b/src/StoreApi/Utilities/ProductQuery.php
@@ -456,6 +456,8 @@ class ProductQuery {
 			 * with out of base locations. e.g. If a product costs 10 including tax, all users will pay 10
 			 * regardless of location and taxes.
 			 *
+			 * @internal Matches filter name in WooCommerce core.
+			 *
 			 * @param boolean $adjust_non_base_location_prices True by default.
 			 * @return boolean
 			 */

--- a/src/StoreApi/docs/guiding-principles.md
+++ b/src/StoreApi/docs/guiding-principles.md
@@ -2,14 +2,15 @@
 
 The following principles should be considered when extending, creating, or updating endpoints in the Store API.
 
--   [Routes must include a well-defined JSON schema](#routes-must-include-a-well-defined-json-schema)
--   [Routes should be designed around resources with a single type of schema](#routes-should-be-designed-around-resources-with-a-single-type-of-schema)
-    -   [Error Handling](#error-handling)
-    -   [Cart Operations](#cart-operations)
--   [Exposed data must belong to the current user or be non-sensitive](#exposed-data-must-belong-to-the-current-user-or-be-non-sensitive)
--   [Collections of resources should be paginated](#collections-of-resources-should-be-paginated)
--   [API Responses should use standard HTTP status codes](#api-responses-should-use-standard-http-status-codes)
--   [Breaking changes should be avoided where possible](#breaking-changes-should-be-avoided-where-possible)
+- [Routes must include a well-defined JSON schema](#routes-must-include-a-well-defined-json-schema)
+- [Routes should be designed around resources with a single type of schema](#routes-should-be-designed-around-resources-with-a-single-type-of-schema)
+  - [Error Handling](#error-handling)
+  - [Cart Operations](#cart-operations)
+- [Exposed data must belong to the current user or be non-sensitive](#exposed-data-must-belong-to-the-current-user-or-be-non-sensitive)
+- [Collections of resources should be paginated](#collections-of-resources-should-be-paginated)
+- [API Responses should use standard HTTP status codes](#api-responses-should-use-standard-http-status-codes)
+- [Breaking changes should be avoided where possible](#breaking-changes-should-be-avoided-where-possible)
+- [](#)
 
 ## Routes must include a [well-defined JSON schema](https://developer.wordpress.org/rest-api/extending-the-rest-api/schema/)
 
@@ -72,6 +73,8 @@ Errors, including validation errors, should return an error response code (4xx o
 
 Error messages should be localized, but do not need to be written with language aimed at customers (clients should use the given error code to create customer-facing notices as needed).
 
+Error codes should have the prefix `woocommerce_rest_`.
+
 ### Cart Operations
 
 Some endpoints are designed around operations to avoid clients needing to make multiple round trips to the API. This is purely for convenience.
@@ -127,11 +130,10 @@ Non-breaking changes are always permitted without the need to increase the API v
 
 The version will not increase for bug fixes unless the scope of the bug causes a backwards-incompatible change. Fixes would not be rolled back to past API versions with the exception of security issues that require backporting.
 
-<!-- FEEDBACK -->
----
+## <!-- FEEDBACK -->
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./src/StoreApi/docs/guiding-principles.md)
-<!-- /FEEDBACK -->
 
+<!-- /FEEDBACK -->

--- a/src/StoreApi/docs/guiding-principles.md
+++ b/src/StoreApi/docs/guiding-principles.md
@@ -130,10 +130,11 @@ Non-breaking changes are always permitted without the need to increase the API v
 
 The version will not increase for bug fixes unless the scope of the bug causes a backwards-incompatible change. Fixes would not be rolled back to past API versions with the exception of security issues that require backporting.
 
-## <!-- FEEDBACK -->
+<!-- FEEDBACK -->
+---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./src/StoreApi/docs/guiding-principles.md)
-
 <!-- /FEEDBACK -->
+

--- a/tests/php/StoreApi/Routes/Cart.php
+++ b/tests/php/StoreApi/Routes/Cart.php
@@ -204,7 +204,7 @@ class Cart extends ControllerTestCase {
 		$action_callback = \Mockery::mock( 'ActionCallback' );
 		$action_callback->shouldReceive( 'do_customer_callback' )->once();
 
-		add_action( 'woocommerce_blocks_cart_update_customer_from_request', array( $action_callback, 'do_customer_callback' ) );
+		add_action( 'woocommerce_store_api_cart_update_customer_from_request', array( $action_callback, 'do_customer_callback' ) );
 
 		$this->assertAPIResponse(
 			$request,
@@ -225,7 +225,7 @@ class Cart extends ControllerTestCase {
 			)
 		);
 
-		remove_action( 'woocommerce_blocks_cart_update_customer_from_request', array( $action_callback, 'do_customer_callback' ) );
+		remove_action( 'woocommerce_store_api_cart_update_customer_from_request', array( $action_callback, 'do_customer_callback' ) );
 	}
 
 	/**

--- a/tests/php/StoreApi/Routes/Checkout.php
+++ b/tests/php/StoreApi/Routes/Checkout.php
@@ -164,10 +164,10 @@ class Checkout extends MockeryTestCase {
 				),
 			)
 		)->once();
-		add_action( 'woocommerce_blocks_checkout_update_order_from_request', array( $action_callback, 'do_callback' ), 10, 2 );
+		add_action( 'woocommerce_store_api_checkout_update_order_from_request', array( $action_callback, 'do_callback' ), 10, 2 );
 		$response = rest_get_server()->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
-		remove_action( 'woocommerce_blocks_checkout_update_order_from_request', array( $action_callback, 'do_callback' ), 10, 2 );
+		remove_action( 'woocommerce_store_api_checkout_update_order_from_request', array( $action_callback, 'do_callback' ), 10, 2 );
 	}
 
 	/**

--- a/tests/php/StoreApi/Utilities/CartController.php
+++ b/tests/php/StoreApi/Utilities/CartController.php
@@ -11,33 +11,39 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 class CartControllerTests extends TestCase {
 
-	public function test_get_cart_errors()    {
+	public function test_get_cart_errors() {
 		$class    = new CartController();
 		$fixtures = new FixtureData();
 
 		// This product will simply be in/out of stock.
-		$out_of_stock_product = $fixtures->get_simple_product( [
-			'name' => 'Test Product 1',
-			'regular_price' => 10,
-		] );
+		$out_of_stock_product     = $fixtures->get_simple_product(
+			array(
+				'name'          => 'Test Product 1',
+				'regular_price' => 10,
+			)
+		);
 		$out_of_stock_product_key = wc()->cart->add_to_cart( $out_of_stock_product->get_id(), 2 );
-		$out_of_stock_in_cart = wc()->cart->get_cart_item( $out_of_stock_product_key )['data'];
+		$out_of_stock_in_cart     = wc()->cart->get_cart_item( $out_of_stock_product_key )['data'];
 
 		// This product will have exact levels of stock known
-		$partially_out_of_stock_product = $fixtures->get_simple_product( [
-			'name' => 'Test Product 2',
-			'regular_price' => 10,
-		] );
-		$partially_out_of_stock_key = wc()->cart->add_to_cart( $partially_out_of_stock_product->get_id(), 4 );
+		$partially_out_of_stock_product = $fixtures->get_simple_product(
+			array(
+				'name'          => 'Test Product 2',
+				'regular_price' => 10,
+			)
+		);
+		$partially_out_of_stock_key     = wc()->cart->add_to_cart( $partially_out_of_stock_product->get_id(), 4 );
 		$partially_out_of_stock_in_cart = wc()->cart->get_cart_item( $partially_out_of_stock_key )['data'];
 
 		// This product will have exact levels of stock known
-		$too_many_in_cart_product = $fixtures->get_simple_product( [
-			'name' => 'Test Product 3',
-			'regular_price' => 10,
-		] );
+		$too_many_in_cart_product     = $fixtures->get_simple_product(
+			array(
+				'name'          => 'Test Product 3',
+				'regular_price' => 10,
+			)
+		);
 		$too_many_in_cart_product_key = wc()->cart->add_to_cart( $too_many_in_cart_product->get_id(), 4 );
-		$too_many_in_cart_in_cart = wc()->cart->get_cart_item( $too_many_in_cart_product_key )['data'];
+		$too_many_in_cart_in_cart     = wc()->cart->get_cart_item( $too_many_in_cart_product_key )['data'];
 
 		$out_of_stock_in_cart->set_stock_status( 'outofstock' );
 		$partially_out_of_stock_in_cart->set_manage_stock( true );
@@ -45,34 +51,41 @@ class CartControllerTests extends TestCase {
 		$too_many_in_cart_in_cart->set_sold_individually( true );
 
 		// This product will not be purchasable
-		$not_purchasable_product = $fixtures->get_simple_product( [
-			'name' => 'Test Product 4',
-			'regular_price' => 10,
-		] );
+		$not_purchasable_product = $fixtures->get_simple_product(
+			array(
+				'name'          => 'Test Product 4',
+				'regular_price' => 10,
+			)
+		);
 		wc()->cart->add_to_cart( $not_purchasable_product->get_id(), 2 );
 
 		// This function will force the $product->is_purchasable() function to return false for our $not_purchasable_product
-		add_filter( 'woocommerce_is_purchasable', function( $is_purchasable, $product ) use ( $not_purchasable_product ) {
-			if ( $product->get_id() === $not_purchasable_product->get_id() ) {
-				return false;
-			}
-			return true;
-		}, 10, 2 );
+		add_filter(
+			'woocommerce_is_purchasable',
+			function( $is_purchasable, $product ) use ( $not_purchasable_product ) {
+				if ( $product->get_id() === $not_purchasable_product->get_id() ) {
+					return false;
+				}
+				return true;
+			},
+			10,
+			2
+		);
 
-		$errors          = $class->get_cart_errors();
+		$errors = $class->get_cart_errors();
 
 		$this->assertTrue( is_wp_error( $errors ) );
 		$this->assertTrue( $errors->has_errors() );
 
 		$error_codes     = $errors->get_error_codes();
-		$expected_errors = [
-			'woocommerce-blocks-product-partially-out-of-stock',
-			'woocommerce-blocks-product-out-of-stock',
-			'woocommerce-blocks-product-not-purchasable',
-			'woocommerce-blocks-too-many-of-product-in-cart',
-		];
+		$expected_errors = array(
+			'woocommerce_rest_product_partially_out_of_stock',
+			'woocommerce_rest_product_out_of_stock',
+			'woocommerce_rest_product_not_purchasable',
+			'woocommerce_rest_product_too_many_in_cart',
+		);
 
-		foreach( $expected_errors as $expected_error ) {
+		foreach ( $expected_errors as $expected_error ) {
 			$this->assertContains( $expected_error, $error_codes );
 		}
 


### PR DESCRIPTION
This is a PR for hook name and error code consistency across the Store API codebase. I've updated docs + usage, and deprecated the previous names inline.

 - **For error codes:** Codes should have the prefix `woocommerce_rest_`. This is inline with the majority of existing error codes, but there were a few with either no prefix, or `blocks` prefix. Additionally, codes should use underscores rather than hyphens to separate words.
 - **For action and filter hooks:** Hook names from WooCommerce should be marked as such. I've added inline `@internal` documentation to state this. For new Store API hooks, they should have the `woocommerce_store_api_` prefix. Newer hooks are doing this, but we had some older ones using `woocommerce_blocks_`. I've deprecated these.

We also had some instances where we had different codes for the same type of error in the cart controller, so I cleared this up also.

Fixes #5980

### Testing

Nothing should be user facing however, placing an order via Block checkout should be smoke tested, as well as one of the extensions consuming the deprecated hooks such as pre-orders (https://github.com/woocommerce/woocommerce-pre-orders/blob/bd1169c93ed3ccd8c2f33f3a54b244aefe63b0c2/includes/class-wc-pre-orders-checkout.php#L39  or subscriptions (https://github.com/woocommerce/woocommerce-subscriptions/blob/0704f35c00ea6df2821b9c1592b77205a96e2937/includes/early-renewal/class-wcs-cart-early-renewal.php#L34-L38)

### Changelog

> Deprecated `woocommerce_blocks_checkout_order_processed` in favour of `woocommerce_store_api_checkout_order_processed`
> Deprecated `woocommerce_blocks_checkout_update_order_meta` in favour of `woocommerce_store_api_checkout_update_order_meta`
> Deprecated `woocommerce_blocks_checkout_update_order_from_request` in favour of `woocommerce_store_api_checkout_update_order_from_request`
> Normalised Store API error codes