### PR TITLE
Hide Mini Cart Block on Cart and Checkout page 

### DIFF
--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -371,7 +371,10 @@ class MiniCart extends AbstractBlock {
 		</span>';
 
 		if ( is_cart() || is_checkout() ) {
-			return;
+			// It is not necessary to load the Mini Cart Block on Cart and Checkout page.
+				return '<div class="' . $wrapper_classes . '" style="visibility:hidden" aria-hidden="true">
+				<button class="wc-block-mini-cart__button ' . $classes . '" aria-label="' . esc_attr( $aria_label ) . '" style="' . $style . '" disabled>' . $button_html . '</button>
+			</div>';
 		}
 
 		$template_part_contents = '';

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -371,9 +371,7 @@ class MiniCart extends AbstractBlock {
 		</span>';
 
 		if ( is_cart() || is_checkout() ) {
-			return '<div class="' . $wrapper_classes . '">
-				<button class="wc-block-mini-cart__button ' . $classes . '" aria-label="' . esc_attr( $aria_label ) . '" style="' . $style . '" disabled>' . $button_html . '</button>
-			</div>';
+			return;
 		}
 
 		$template_part_contents = '';


### PR DESCRIPTION
This PR hides the Mini Cart Block on Cart and Checkout page because it is not necessary to load this specific block on these two pages.

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #5931 


### Testing

### Manual Testing

How to test the changes in this Pull Request:

Check out this branch

1. Open the FSE editor.
2. Add the Mini Cart Block in the header or footer section.
3. Open the cart page and check that the Mini Cart Block is not visible.
4. Open the checkout page and check that the Mini Cart Block is not visible.
