### PR TITLE
Cart: Accepted Payment Methods block: Use utility instead of the local function

### DIFF
--- a/assets/js/base/utils/get-icons-from-payment-methods.ts
+++ b/assets/js/base/utils/get-icons-from-payment-methods.ts
@@ -9,8 +9,6 @@ import type {
 /**
  * Get the provider icons from payment methods data.
  *
- * @todo Refactor the Cart blocks to use getIconsFromPaymentMethods utility instead of the local copy.
- *
  * @param {PaymentMethods} paymentMethods Payment Method data
  * @return {PaymentMethodIconsType} Payment Method icons data.
  */

--- a/assets/js/blocks/cart-checkout/cart/inner-blocks/cart-accepted-payment-methods-block/block.tsx
+++ b/assets/js/blocks/cart-checkout/cart/inner-blocks/cart-accepted-payment-methods-block/block.tsx
@@ -3,21 +3,7 @@
  */
 import { PaymentMethodIcons } from '@woocommerce/base-components/cart-checkout';
 import { usePaymentMethods } from '@woocommerce/base-context/hooks';
-import type {
-	PaymentMethods,
-	PaymentMethodIcons as PaymentMethodIconsType,
-} from '@woocommerce/type-defs/payments';
-
-const getIconsFromPaymentMethods = (
-	paymentMethods: PaymentMethods
-): PaymentMethodIconsType => {
-	return Object.values( paymentMethods ).reduce( ( acc, paymentMethod ) => {
-		if ( paymentMethod.icons !== null ) {
-			acc = acc.concat( paymentMethod.icons );
-		}
-		return acc;
-	}, [] as PaymentMethodIconsType );
-};
+import { getIconsFromPaymentMethods } from '@woocommerce/base-utils';
 
 const Block = ( { className }: { className: string } ): JSX.Element => {
 	const { paymentMethods } = usePaymentMethods();


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #5036

This PR removes the local `getIconsFromPaymentMethods` in `woocommerce/cart-accepted-payment-methods-block` and import it from the `@woocommerce/base-utils` instead. The two methods are identical.

<!-- Don't forget to update the title with something descriptive. -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Set up a payment method.
2. Go to the cart page which uses the Cart block.
3. See the payment method icons as before, in the other words, no functional and visual changes.