### PR TITLE
style Mini Cart block as inline to remove the experimental features usage.

### DIFF
--- a/assets/js/blocks/cart-checkout/mini-cart/edit.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart/edit.tsx
@@ -1,19 +1,13 @@
 /**
  * External dependencies
  */
-import {
-	AlignmentControl,
-	BlockControls,
-	InspectorControls,
-	useBlockProps,
-} from '@wordpress/block-editor';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import type { ReactElement } from 'react';
 import { formatPrice } from '@woocommerce/price-format';
 import { CartCheckoutCompatibilityNotice } from '@woocommerce/editor-components/compatibility-notices';
 import { PanelBody, ExternalLink } from '@wordpress/components';
 import { getSetting } from '@woocommerce/settings';
 import { __ } from '@wordpress/i18n';
-import { positionCenter, positionRight, positionLeft } from '@wordpress/icons';
 import Noninteractive from '@woocommerce/base-components/noninteractive';
 
 /**
@@ -23,7 +17,6 @@ import QuantityBadge from './quantity-badge';
 import { useColorProps } from '../../../hooks/style-attributes';
 
 interface Attributes {
-	align: string;
 	isInitiallyOpen?: boolean;
 	backgroundColor?: string;
 	textColor?: string;
@@ -35,13 +28,9 @@ interface Props {
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
 }
 
-const MiniCartBlock = ( {
-	attributes,
-	setAttributes,
-}: Props ): ReactElement => {
-	const { align } = attributes;
+const MiniCartBlock = ( { attributes }: Props ): ReactElement => {
 	const blockProps = useBlockProps( {
-		className: `wc-block-mini-cart align-${ align }`,
+		className: `wc-block-mini-cart`,
 	} );
 	const colorProps = useColorProps( attributes );
 
@@ -55,40 +44,6 @@ const MiniCartBlock = ( {
 
 	return (
 		<div { ...blockProps }>
-			<BlockControls>
-				<AlignmentControl
-					value={ align }
-					alignmentControls={ [
-						{
-							icon: positionLeft,
-							title: __(
-								'Align button left',
-								'woo-gutenberg-products-block'
-							),
-							align: 'left',
-						},
-						{
-							icon: positionCenter,
-							title: __(
-								'Align button center',
-								'woo-gutenberg-products-block'
-							),
-							align: 'center',
-						},
-						{
-							icon: positionRight,
-							title: __(
-								'Align button right',
-								'woo-gutenberg-products-block'
-							),
-							align: 'right',
-						},
-					] }
-					onChange={ ( newAlign: string ) =>
-						setAttributes( { align: newAlign } )
-					}
-				/>
-			</BlockControls>
 			<InspectorControls>
 				{ templatePartEditUri && (
 					<PanelBody

--- a/assets/js/blocks/cart-checkout/mini-cart/edit.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart/edit.tsx
@@ -14,25 +14,11 @@ import Noninteractive from '@woocommerce/base-components/noninteractive';
  * Internal dependencies
  */
 import QuantityBadge from './quantity-badge';
-import { useColorProps } from '../../../hooks/style-attributes';
 
-interface Attributes {
-	isInitiallyOpen?: boolean;
-	backgroundColor?: string;
-	textColor?: string;
-	style?: Record< string, Record< string, string > >;
-}
-
-interface Props {
-	attributes: Attributes;
-	setAttributes: ( attributes: Record< string, unknown > ) => void;
-}
-
-const MiniCartBlock = ( { attributes }: Props ): ReactElement => {
+const MiniCartBlock = (): ReactElement => {
 	const blockProps = useBlockProps( {
 		className: `wc-block-mini-cart`,
 	} );
-	const colorProps = useColorProps( attributes );
 
 	const templatePartEditUri = getSetting(
 		'templatePartEditUri',
@@ -62,10 +48,7 @@ const MiniCartBlock = ( { attributes }: Props ): ReactElement => {
 				) }
 			</InspectorControls>
 			<Noninteractive>
-				<button
-					className="wc-block-mini-cart__button"
-					style={ colorProps.style }
-				>
+				<button className="wc-block-mini-cart__button">
 					<span className="wc-block-mini-cart__amount">
 						{ formatPrice( productTotal ) }
 					</span>

--- a/assets/js/blocks/cart-checkout/mini-cart/index.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart/index.tsx
@@ -31,19 +31,7 @@ const settings = {
 	supports: {
 		html: false,
 		multiple: false,
-		color: {
-			/**
-			 * Because we don't target the wrapper element, we don't need
-			 * to add color classes and style to the wrapper.
-			 */
-			__experimentalSkipSerialization: true,
-		},
-		/**
-		 * We need this experimental flag because we don't want to style the
-		 * wrapper but inner elements.
-		 */
-		__experimentalSelector:
-			'.wc-block-mini-cart__button, .wc-block-mini-cart__badge',
+		color: true,
 	},
 	example: {
 		attributes: {

--- a/assets/js/blocks/cart-checkout/mini-cart/index.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart/index.tsx
@@ -39,10 +39,6 @@ const settings = {
 		},
 	},
 	attributes: {
-		align: {
-			type: 'string',
-			default: 'right',
-		},
 		isPreview: {
 			type: 'boolean',
 			default: false,

--- a/assets/js/blocks/cart-checkout/mini-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/mini-cart/style.scss
@@ -1,15 +1,5 @@
 .wc-block-mini-cart {
-	background-color: transparent !important;
-	display: flex;
-	justify-content: flex-end;
-
-	&.align-center {
-		justify-content: center;
-	}
-
-	&.align-left {
-		justify-content: flex-start;
-	}
+	display: inline-block;
 }
 
 .wc-block-mini-cart__button {

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -438,7 +438,6 @@ class MiniCart extends AbstractBlock {
 		);
 	}
 
-
 	/**
 	 * Get Cart Payload.
 	 *
@@ -446,17 +445,5 @@ class MiniCart extends AbstractBlock {
 	 */
 	protected function get_cart_payload() {
 		return WC()->api->get_endpoint_data( '/wc/store/cart' );
-	}
-
-	/**
-	 * Get the supports array for this block type.
-	 *
-	 * @see $this->register_block_type()
-	 * @return string;
-	 */
-	protected function get_block_type_supports() {
-		return [
-			'__experimentalSelector' => '.wc-block-mini-cart__button',
-		];
 	}
 }

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -317,10 +317,10 @@ class MiniCart extends AbstractBlock {
 			$cart_contents_total += $cart->get_subtotal_tax();
 		}
 
-		$wrapper_classes = 'wc-block-mini-cart  wp-block-woocommerce-mini-cart';
+		$wrapper_classes = 'wc-block-mini-cart wp-block-woocommerce-mini-cart';
 		$classes_styles  = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, array( 'text_color', 'background_color' ) );
-		$classes         = $classes_styles['classes'];
-		$style           = $classes_styles['styles'];
+		$wrapper_classes = sprintf( '%1$s %2$s', $wrapper_classes, $classes_styles['classes'] );
+		$wrapper_styles  = $classes_styles['styles'];
 
 		$aria_label = sprintf(
 		/* translators: %1$d is the number of products in the cart. %2$s is the cart total */
@@ -347,7 +347,7 @@ class MiniCart extends AbstractBlock {
 
 		if ( is_cart() || is_checkout() ) {
 			return '<div class="' . $wrapper_classes . '">
-				<button class="wc-block-mini-cart__button ' . $classes . '" aria-label="' . esc_attr( $aria_label ) . '" style="' . $style . '" disabled>' . $button_html . '</button>
+				<button class="wc-block-mini-cart__button" aria-label="' . esc_attr( $aria_label ) . '" disabled>' . $button_html . '</button>
 			</div>';
 		}
 
@@ -369,8 +369,8 @@ class MiniCart extends AbstractBlock {
 			);
 		}
 
-		return '<div class="' . $wrapper_classes . '">
-			<button class="wc-block-mini-cart__button ' . $classes . '" aria-label="' . esc_attr( $aria_label ) . '" style="' . $style . '">' . $button_html . '</button>
+		return '<div class="' . $wrapper_classes . '" style="' . $wrapper_styles . '">
+			<button class="wc-block-mini-cart__button" aria-label="' . esc_attr( $aria_label ) . '">' . $button_html . '</button>
 			<div class="wc-block-mini-cart__drawer is-loading is-mobile wc-block-components-drawer__screen-overlay wc-block-components-drawer__screen-overlay--is-hidden" aria-hidden="true">
 				<div class="components-modal__frame wc-block-components-drawer">
 					<div class="components-modal__content">

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -322,10 +322,6 @@ class MiniCart extends AbstractBlock {
 		$classes         = $classes_styles['classes'];
 		$style           = $classes_styles['styles'];
 
-		if ( ! empty( $attributes['align'] ) ) {
-			$wrapper_classes .= ' align-' . $attributes['align'];
-		}
-
 		$aria_label = sprintf(
 		/* translators: %1$d is the number of products in the cart. %2$s is the cart total */
 			_n(


### PR DESCRIPTION
As discussed in https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5985#issuecomment-1059039656, https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5985#pullrequestreview-900156457 and https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5985#issuecomment-1059199933, in this PR, I try to remove the usage of the experimental features:

- Styling Mini Cart block as an `inline-block` element.
- Removing the alignment support.
- Removing unnecessary style manipulation required by the former approach.

The pros: simpler codebase, simpler styling.

The cons: Lack of alignments (which can be provided by a `<Group>` or `<Row>` block).

My take: I prefer this approach. The button is an inline element by its nature. The Mini Cart button is also 'likely' to be put inside a row.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Add the Mini Cart block to the header using Site Editor.
2. Don't see the alignment option in the block toolbar.
3. See the Mini Cart button is on the left.
4. Add a Row block and move the Mini Cart block there.
5. Change the alignment of the Row block.
6. See the Mini Cart position updated accordingly.
7. Save changes, see it works on the front end.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
* [ ] See steps below.