### PR TITLE
Remove `internal` comments from Store API file comments

### DIFF
--- a/src/StoreApi/Exceptions/InvalidStockLevelsInCartException.php
+++ b/src/StoreApi/Exceptions/InvalidStockLevelsInCartException.php
@@ -6,8 +6,7 @@ use WP_Error;
 /**
  * InvalidStockLevelsInCartException class.
  *
- * @internal This API is used internally by Blocks, this exception is thrown if any items are out of stock
- * after each product on a draft order has been stock checked.
+ * This exception is thrown if any items are out of stock after each product on a draft order has been stock checked.
  */
 class InvalidStockLevelsInCartException extends \Exception {
 	/**

--- a/src/StoreApi/Exceptions/NotPurchasableException.php
+++ b/src/StoreApi/Exceptions/NotPurchasableException.php
@@ -4,7 +4,6 @@ namespace Automattic\WooCommerce\StoreApi\Exceptions;
 /**
  * NotPurchasableException class.
  *
- * This exception is thrown when an item in the cart is not able to be
- * purchased.
+ * This exception is thrown when an item in the cart is not able to be purchased.
  */
 class NotPurchasableException extends StockAvailabilityException {}

--- a/src/StoreApi/Exceptions/NotPurchasableException.php
+++ b/src/StoreApi/Exceptions/NotPurchasableException.php
@@ -4,7 +4,7 @@ namespace Automattic\WooCommerce\StoreApi\Exceptions;
 /**
  * NotPurchasableException class.
  *
- * @internal This API is used internally by Blocks, this exception is thrown when an item in the cart is not able to be
+ * This exception is thrown when an item in the cart is not able to be
  * purchased.
  */
 class NotPurchasableException extends StockAvailabilityException {}

--- a/src/StoreApi/Exceptions/OutOfStockException.php
+++ b/src/StoreApi/Exceptions/OutOfStockException.php
@@ -4,7 +4,6 @@ namespace Automattic\WooCommerce\StoreApi\Exceptions;
 /**
  * OutOfStockException class.
  *
- * @internal This API is used internally by Blocks, this exception is thrown when an item in a draft order is out
- * of stock completely.
+ * This exception is thrown when an item in a draft order is out of stock completely.
  */
 class OutOfStockException extends StockAvailabilityException {}

--- a/src/StoreApi/Exceptions/PartialOutOfStockException.php
+++ b/src/StoreApi/Exceptions/PartialOutOfStockException.php
@@ -4,7 +4,6 @@ namespace Automattic\WooCommerce\StoreApi\Exceptions;
 /**
  * PartialOutOfStockException class.
  *
- * @internal This API is used internally by Blocks, this exception is thrown when an item in a draft order has a
- * quantity greater than what is available in stock.
+ * This exception is thrown when an item in a draft order has a quantity greater than what is available in stock.
  */
 class PartialOutOfStockException extends StockAvailabilityException {}

--- a/src/StoreApi/Exceptions/RouteException.php
+++ b/src/StoreApi/Exceptions/RouteException.php
@@ -3,8 +3,6 @@ namespace Automattic\WooCommerce\StoreApi\Exceptions;
 
 /**
  * RouteException class.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class RouteException extends \Exception {
 	/**

--- a/src/StoreApi/Exceptions/StockAvailabilityException.php
+++ b/src/StoreApi/Exceptions/StockAvailabilityException.php
@@ -4,8 +4,7 @@ namespace Automattic\WooCommerce\StoreApi\Exceptions;
 /**
  * StockAvailabilityException class.
  *
- * @internal This API is used internally by Blocks, this exception is thrown when more than one of a product that
- * can only be purchased individually is in a cart.
+ * This exception is thrown when more than one of a product that can only be purchased individually is in a cart.
  */
 class StockAvailabilityException extends \Exception {
 	/**

--- a/src/StoreApi/Exceptions/TooManyInCartException.php
+++ b/src/StoreApi/Exceptions/TooManyInCartException.php
@@ -4,7 +4,6 @@ namespace Automattic\WooCommerce\StoreApi\Exceptions;
 /**
  * TooManyInCartException class.
  *
- * @internal This API is used internally by Blocks, this exception is thrown when more than one of a product that
- * can only be purchased individually is in a cart.
+ * This exception is thrown when more than one of a product that can only be purchased individually is in a cart.
  */
 class TooManyInCartException extends StockAvailabilityException {}

--- a/src/StoreApi/Formatters/CurrencyFormatter.php
+++ b/src/StoreApi/Formatters/CurrencyFormatter.php
@@ -5,8 +5,6 @@ namespace Automattic\WooCommerce\StoreApi\Formatters;
  * Currency Formatter.
  *
  * Formats an array of monetary values by inserting currency data.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class CurrencyFormatter implements FormatterInterface {
 	/**

--- a/src/StoreApi/Formatters/DefaultFormatter.php
+++ b/src/StoreApi/Formatters/DefaultFormatter.php
@@ -3,8 +3,6 @@ namespace Automattic\WooCommerce\StoreApi\Formatters;
 
 /**
  * Default Formatter.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class DefaultFormatter implements FormatterInterface {
 	/**

--- a/src/StoreApi/Formatters/FormatterInterface.php
+++ b/src/StoreApi/Formatters/FormatterInterface.php
@@ -3,8 +3,6 @@ namespace Automattic\WooCommerce\StoreApi\Formatters;
 
 /**
  * FormatterInterface.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 interface FormatterInterface {
 	/**

--- a/src/StoreApi/Formatters/MoneyFormatter.php
+++ b/src/StoreApi/Formatters/MoneyFormatter.php
@@ -5,8 +5,6 @@ namespace Automattic\WooCommerce\StoreApi\Formatters;
  * Money Formatter.
  *
  * Formats monetary values using store settings.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class MoneyFormatter implements FormatterInterface {
 	/**

--- a/src/StoreApi/Routes/RouteInterface.php
+++ b/src/StoreApi/Routes/RouteInterface.php
@@ -3,8 +3,6 @@ namespace Automattic\WooCommerce\StoreApi\Routes;
 
 /**
  * RouteInterface.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 interface RouteInterface {
 	/**

--- a/src/StoreApi/Routes/V1/AbstractCartRoute.php
+++ b/src/StoreApi/Routes/V1/AbstractCartRoute.php
@@ -11,8 +11,6 @@ use Automattic\WooCommerce\StoreApi\Utilities\DraftOrderTrait;
 use Automattic\WooCommerce\StoreApi\Utilities\OrderController;
 /**
  * Abstract Cart Route
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 abstract class AbstractCartRoute extends AbstractRoute {
 	use DraftOrderTrait;

--- a/src/StoreApi/Routes/V1/AbstractRoute.php
+++ b/src/StoreApi/Routes/V1/AbstractRoute.php
@@ -10,8 +10,6 @@ use WP_Error;
 
 /**
  * AbstractRoute class.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 abstract class AbstractRoute implements RouteInterface {
 	/**

--- a/src/StoreApi/Routes/V1/AbstractTermsRoute.php
+++ b/src/StoreApi/Routes/V1/AbstractTermsRoute.php
@@ -6,8 +6,6 @@ use WP_Term_Query;
 
 /**
  * AbstractTermsRoute class.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 abstract class AbstractTermsRoute extends AbstractRoute {
 	/**

--- a/src/StoreApi/Routes/V1/Batch.php
+++ b/src/StoreApi/Routes/V1/Batch.php
@@ -8,8 +8,6 @@ use WP_REST_Response;
 
 /**
  * Batch Route class.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class Batch extends AbstractRoute implements RouteInterface {
 	/**

--- a/src/StoreApi/Routes/V1/Cart.php
+++ b/src/StoreApi/Routes/V1/Cart.php
@@ -1,8 +1,3 @@
-Warning: Class 'Automattic\WooCommerce\StoreApi\Routes\V1\Batch' not found in /Users/mikejolley/Developer/plugins/woocommerce-gutenberg-products-block/src/StoreApi/deprecated.php on line 43
-
-Warning: Class 'Automattic\WooCommerce\StoreApi\Routes\V1\Checkout' not found in /Users/mikejolley/Developer/plugins/woocommerce-gutenberg-products-block/src/StoreApi/deprecated.php on line 57
-
-Warning: Class 'Automattic\WooCommerce\StoreApi\Routes\V1\ProductReviews' not found in /Users/mikejolley/Developer/plugins/woocommerce-gutenberg-products-block/src/StoreApi/deprecated.php on line 64
 <?php
 namespace Automattic\WooCommerce\StoreApi\Routes\V1;
 

--- a/src/StoreApi/Routes/V1/Cart.php
+++ b/src/StoreApi/Routes/V1/Cart.php
@@ -1,10 +1,13 @@
+Warning: Class 'Automattic\WooCommerce\StoreApi\Routes\V1\Batch' not found in /Users/mikejolley/Developer/plugins/woocommerce-gutenberg-products-block/src/StoreApi/deprecated.php on line 43
+
+Warning: Class 'Automattic\WooCommerce\StoreApi\Routes\V1\Checkout' not found in /Users/mikejolley/Developer/plugins/woocommerce-gutenberg-products-block/src/StoreApi/deprecated.php on line 57
+
+Warning: Class 'Automattic\WooCommerce\StoreApi\Routes\V1\ProductReviews' not found in /Users/mikejolley/Developer/plugins/woocommerce-gutenberg-products-block/src/StoreApi/deprecated.php on line 64
 <?php
 namespace Automattic\WooCommerce\StoreApi\Routes\V1;
 
 /**
  * Cart class.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class Cart extends AbstractCartRoute {
 	/**

--- a/src/StoreApi/Routes/V1/CartAddItem.php
+++ b/src/StoreApi/Routes/V1/CartAddItem.php
@@ -5,8 +5,6 @@ use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
 
 /**
  * CartAddItem class.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class CartAddItem extends AbstractCartRoute {
 	/**

--- a/src/StoreApi/Routes/V1/CartApplyCoupon.php
+++ b/src/StoreApi/Routes/V1/CartApplyCoupon.php
@@ -5,8 +5,6 @@ use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
 
 /**
  * CartApplyCoupon class.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class CartApplyCoupon extends AbstractCartRoute {
 	/**

--- a/src/StoreApi/Routes/V1/CartCoupons.php
+++ b/src/StoreApi/Routes/V1/CartCoupons.php
@@ -5,8 +5,6 @@ use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
 
 /**
  * CartCoupons class.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class CartCoupons extends AbstractCartRoute {
 	/**

--- a/src/StoreApi/Routes/V1/CartCouponsByCode.php
+++ b/src/StoreApi/Routes/V1/CartCouponsByCode.php
@@ -5,8 +5,6 @@ use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
 
 /**
  * CartCouponsByCode class.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class CartCouponsByCode extends AbstractCartRoute {
 	/**

--- a/src/StoreApi/Routes/V1/CartExtensions.php
+++ b/src/StoreApi/Routes/V1/CartExtensions.php
@@ -5,8 +5,6 @@ use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
 
 /**
  * CartExtensions class.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class CartExtensions extends AbstractCartRoute {
 	/**

--- a/src/StoreApi/Routes/V1/CartItems.php
+++ b/src/StoreApi/Routes/V1/CartItems.php
@@ -5,8 +5,6 @@ use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
 
 /**
  * CartItems class.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class CartItems extends AbstractCartRoute {
 	/**

--- a/src/StoreApi/Routes/V1/CartItemsByKey.php
+++ b/src/StoreApi/Routes/V1/CartItemsByKey.php
@@ -5,8 +5,6 @@ use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
 
 /**
  * CartItemsByKey class.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class CartItemsByKey extends AbstractCartRoute {
 	/**

--- a/src/StoreApi/Routes/V1/CartRemoveCoupon.php
+++ b/src/StoreApi/Routes/V1/CartRemoveCoupon.php
@@ -5,8 +5,6 @@ use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
 
 /**
  * CartRemoveCoupon class.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class CartRemoveCoupon extends AbstractCartRoute {
 	/**

--- a/src/StoreApi/Routes/V1/CartRemoveItem.php
+++ b/src/StoreApi/Routes/V1/CartRemoveItem.php
@@ -6,8 +6,6 @@ use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
 
 /**
  * CartRemoveItem class.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class CartRemoveItem extends AbstractCartRoute {
 	use DraftOrderTrait;

--- a/src/StoreApi/Routes/V1/CartSelectShippingRate.php
+++ b/src/StoreApi/Routes/V1/CartSelectShippingRate.php
@@ -5,8 +5,6 @@ use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
 
 /**
  * CartSelectShippingRate class.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class CartSelectShippingRate extends AbstractCartRoute {
 	/**

--- a/src/StoreApi/Routes/V1/CartUpdateCustomer.php
+++ b/src/StoreApi/Routes/V1/CartUpdateCustomer.php
@@ -7,8 +7,6 @@ use Automattic\WooCommerce\StoreApi\Utilities\DraftOrderTrait;
  * CartUpdateCustomer class.
  *
  * Updates the customer billing and shipping address and returns an updated cart--things such as taxes may be recalculated.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class CartUpdateCustomer extends AbstractCartRoute {
 	use DraftOrderTrait;

--- a/src/StoreApi/Routes/V1/CartUpdateItem.php
+++ b/src/StoreApi/Routes/V1/CartUpdateItem.php
@@ -3,8 +3,6 @@ namespace Automattic\WooCommerce\StoreApi\Routes\V1;
 
 /**
  * CartUpdateItem class.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class CartUpdateItem extends AbstractCartRoute {
 	/**

--- a/src/StoreApi/Routes/V1/Checkout.php
+++ b/src/StoreApi/Routes/V1/Checkout.php
@@ -11,8 +11,6 @@ use Automattic\WooCommerce\Checkout\Helpers\ReserveStockException;
 
 /**
  * Checkout class.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class Checkout extends AbstractCartRoute {
 	use DraftOrderTrait;

--- a/src/StoreApi/Routes/V1/ProductAttributeTerms.php
+++ b/src/StoreApi/Routes/V1/ProductAttributeTerms.php
@@ -5,8 +5,6 @@ use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
 
 /**
  * ProductAttributeTerms class.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class ProductAttributeTerms extends AbstractTermsRoute {
 	/**

--- a/src/StoreApi/Routes/V1/ProductAttributes.php
+++ b/src/StoreApi/Routes/V1/ProductAttributes.php
@@ -3,8 +3,6 @@ namespace Automattic\WooCommerce\StoreApi\Routes\V1;
 
 /**
  * ProductAttributes class.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class ProductAttributes extends AbstractRoute {
 	/**

--- a/src/StoreApi/Routes/V1/ProductAttributesById.php
+++ b/src/StoreApi/Routes/V1/ProductAttributesById.php
@@ -5,8 +5,6 @@ use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
 
 /**
  * ProductAttributesById class.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class ProductAttributesById extends AbstractRoute {
 	/**

--- a/src/StoreApi/Routes/V1/ProductCategories.php
+++ b/src/StoreApi/Routes/V1/ProductCategories.php
@@ -3,8 +3,6 @@ namespace Automattic\WooCommerce\StoreApi\Routes\V1;
 
 /**
  * ProductCategories class.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class ProductCategories extends AbstractTermsRoute {
 	/**

--- a/src/StoreApi/Routes/V1/ProductCategoriesById.php
+++ b/src/StoreApi/Routes/V1/ProductCategoriesById.php
@@ -5,8 +5,6 @@ use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
 
 /**
  * ProductCategoriesById class.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class ProductCategoriesById extends AbstractRoute {
 	/**

--- a/src/StoreApi/Routes/V1/ProductCollectionData.php
+++ b/src/StoreApi/Routes/V1/ProductCollectionData.php
@@ -8,8 +8,6 @@ use Automattic\WooCommerce\StoreApi\Utilities\ProductQueryFilters;
  * Get aggregate data from a collection of products.
  *
  * Supports the same parameters as /products, but returns a different response.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class ProductCollectionData extends AbstractRoute {
 	/**

--- a/src/StoreApi/Routes/V1/ProductReviews.php
+++ b/src/StoreApi/Routes/V1/ProductReviews.php
@@ -6,8 +6,6 @@ use Automattic\WooCommerce\StoreApi\Utilities\Pagination;
 
 /**
  * ProductReviews class.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class ProductReviews extends AbstractRoute {
 	/**

--- a/src/StoreApi/Routes/V1/ProductTags.php
+++ b/src/StoreApi/Routes/V1/ProductTags.php
@@ -3,8 +3,6 @@ namespace Automattic\WooCommerce\StoreApi\Routes\V1;
 
 /**
  * ProductTags class.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class ProductTags extends AbstractTermsRoute {
 	/**

--- a/src/StoreApi/Routes/V1/Products.php
+++ b/src/StoreApi/Routes/V1/Products.php
@@ -6,8 +6,6 @@ use Automattic\WooCommerce\StoreApi\Utilities\ProductQuery;
 
 /**
  * Products class.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class Products extends AbstractRoute {
 	/**

--- a/src/StoreApi/Routes/V1/ProductsById.php
+++ b/src/StoreApi/Routes/V1/ProductsById.php
@@ -5,8 +5,6 @@ use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
 
 /**
  * ProductsById class.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class ProductsById extends AbstractRoute {
 	/**

--- a/src/StoreApi/RoutesController.php
+++ b/src/StoreApi/RoutesController.php
@@ -7,8 +7,6 @@ use Routes\AbstractRoute;
 
 /**
  * RoutesController class.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class RoutesController {
 	/**

--- a/src/StoreApi/SchemaController.php
+++ b/src/StoreApi/SchemaController.php
@@ -5,8 +5,6 @@ use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
 
 /**
  * SchemaController class.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class SchemaController {
 

--- a/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -5,9 +5,6 @@ namespace Automattic\WooCommerce\StoreApi\Schemas\V1;
  * AddressSchema class.
  *
  * Provides a generic address schema for composition in other schemas.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
- * @since 4.1.0
  */
 abstract class AbstractAddressSchema extends AbstractSchema {
 	/**

--- a/src/StoreApi/Schemas/V1/AbstractSchema.php
+++ b/src/StoreApi/Schemas/V1/AbstractSchema.php
@@ -8,9 +8,6 @@ use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
  * AbstractSchema class.
  *
  * For REST Route Schemas
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
- * @since 2.5.0
  */
 abstract class AbstractSchema {
 	/**

--- a/src/StoreApi/Schemas/V1/BillingAddressSchema.php
+++ b/src/StoreApi/Schemas/V1/BillingAddressSchema.php
@@ -7,8 +7,6 @@ use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
  * BillingAddressSchema class.
  *
  * Provides a generic billing address schema for composition in other schemas.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class BillingAddressSchema extends AbstractAddressSchema {
 	/**

--- a/src/StoreApi/Schemas/V1/CartCouponSchema.php
+++ b/src/StoreApi/Schemas/V1/CartCouponSchema.php
@@ -5,10 +5,6 @@ use Automattic\WooCommerce\StoreApi\Utilities\CartController;
 
 /**
  * CartCouponSchema class.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
- * @since 2.5.0
- * @since 3.9.0 Coupon type (`discount_type`) added.
  */
 class CartCouponSchema extends AbstractSchema {
 	/**

--- a/src/StoreApi/Schemas/V1/CartExtensionsSchema.php
+++ b/src/StoreApi/Schemas/V1/CartExtensionsSchema.php
@@ -5,8 +5,6 @@ use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
 
 /**
  * Class CartExtensionsSchema
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class CartExtensionsSchema extends AbstractSchema {
 	/**

--- a/src/StoreApi/Schemas/V1/CartFeeSchema.php
+++ b/src/StoreApi/Schemas/V1/CartFeeSchema.php
@@ -3,8 +3,6 @@ namespace Automattic\WooCommerce\StoreApi\Schemas\V1;
 
 /**
  * CartFeeSchema class.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class CartFeeSchema extends AbstractSchema {
 	/**

--- a/src/StoreApi/Schemas/V1/CartItemSchema.php
+++ b/src/StoreApi/Schemas/V1/CartItemSchema.php
@@ -3,11 +3,9 @@ namespace Automattic\WooCommerce\StoreApi\Schemas\V1;
 
 use Automattic\WooCommerce\StoreApi\Utilities\DraftOrderTrait;
 use Automattic\WooCommerce\StoreApi\Utilities\QuantityLimits;
+
 /**
  * CartItemSchema class.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
- * @since 2.5.0
  */
 class CartItemSchema extends ProductSchema {
 	use DraftOrderTrait;

--- a/src/StoreApi/Schemas/V1/CartSchema.php
+++ b/src/StoreApi/Schemas/V1/CartSchema.php
@@ -10,9 +10,6 @@ use WP_Error;
 
 /**
  * CartSchema class.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
- * @since 2.5.0
  */
 class CartSchema extends AbstractSchema {
 	/**

--- a/src/StoreApi/Schemas/V1/CartShippingRateSchema.php
+++ b/src/StoreApi/Schemas/V1/CartShippingRateSchema.php
@@ -5,8 +5,6 @@ use WC_Shipping_Rate as ShippingRate;
 
 /**
  * CartShippingRateSchema class.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class CartShippingRateSchema extends AbstractSchema {
 	/**

--- a/src/StoreApi/Schemas/V1/CheckoutSchema.php
+++ b/src/StoreApi/Schemas/V1/CheckoutSchema.php
@@ -8,8 +8,6 @@ use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
 
 /**
  * CheckoutSchema class.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class CheckoutSchema extends AbstractSchema {
 	/**

--- a/src/StoreApi/Schemas/V1/ErrorSchema.php
+++ b/src/StoreApi/Schemas/V1/ErrorSchema.php
@@ -3,9 +3,6 @@ namespace Automattic\WooCommerce\StoreApi\Schemas\V1;
 
 /**
  * ErrorSchema class.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
- * @since 2.5.0
  */
 class ErrorSchema extends AbstractSchema {
 	/**

--- a/src/StoreApi/Schemas/V1/ImageAttachmentSchema.php
+++ b/src/StoreApi/Schemas/V1/ImageAttachmentSchema.php
@@ -3,8 +3,6 @@ namespace Automattic\WooCommerce\StoreApi\Schemas\V1;
 
 /**
  * ImageAttachmentSchema class.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class ImageAttachmentSchema extends AbstractSchema {
 	/**

--- a/src/StoreApi/Schemas/V1/OrderCouponSchema.php
+++ b/src/StoreApi/Schemas/V1/OrderCouponSchema.php
@@ -3,8 +3,6 @@ namespace Automattic\WooCommerce\StoreApi\Schemas\V1;
 
 /**
  * OrderCouponSchema class.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class OrderCouponSchema extends AbstractSchema {
 	/**

--- a/src/StoreApi/Schemas/V1/ProductAttributeSchema.php
+++ b/src/StoreApi/Schemas/V1/ProductAttributeSchema.php
@@ -3,9 +3,6 @@ namespace Automattic\WooCommerce\StoreApi\Schemas\V1;
 
 /**
  * ProductAttributeSchema class.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
- * @since 2.5.0
  */
 class ProductAttributeSchema extends AbstractSchema {
 	/**

--- a/src/StoreApi/Schemas/V1/ProductCategorySchema.php
+++ b/src/StoreApi/Schemas/V1/ProductCategorySchema.php
@@ -7,8 +7,6 @@ use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
 
 /**
  * ProductCategorySchema class.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class ProductCategorySchema extends TermSchema {
 	/**

--- a/src/StoreApi/Schemas/V1/ProductCollectionDataSchema.php
+++ b/src/StoreApi/Schemas/V1/ProductCollectionDataSchema.php
@@ -3,9 +3,6 @@ namespace Automattic\WooCommerce\StoreApi\Schemas\V1;
 
 /**
  * ProductCollectionDataSchema class.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
- * @since 2.5.0
  */
 class ProductCollectionDataSchema extends AbstractSchema {
 	/**

--- a/src/StoreApi/Schemas/V1/ProductReviewSchema.php
+++ b/src/StoreApi/Schemas/V1/ProductReviewSchema.php
@@ -6,8 +6,6 @@ use Automattic\WooCommerce\StoreApi\SchemaController;
 
 /**
  * ProductReviewSchema class.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class ProductReviewSchema extends AbstractSchema {
 	/**

--- a/src/StoreApi/Schemas/V1/ProductSchema.php
+++ b/src/StoreApi/Schemas/V1/ProductSchema.php
@@ -7,9 +7,6 @@ use Automattic\WooCommerce\StoreApi\Utilities\QuantityLimits;
 
 /**
  * ProductSchema class.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
- * @since 2.5.0
  */
 class ProductSchema extends AbstractSchema {
 	/**

--- a/src/StoreApi/Schemas/V1/ShippingAddressSchema.php
+++ b/src/StoreApi/Schemas/V1/ShippingAddressSchema.php
@@ -7,9 +7,6 @@ use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
  * ShippingAddressSchema class.
  *
  * Provides a generic shipping address schema for composition in other schemas.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
- * @since 2.5.0
  */
 class ShippingAddressSchema extends AbstractAddressSchema {
 	/**

--- a/src/StoreApi/Schemas/V1/TermSchema.php
+++ b/src/StoreApi/Schemas/V1/TermSchema.php
@@ -3,9 +3,6 @@ namespace Automattic\WooCommerce\StoreApi\Schemas\V1;
 
 /**
  * TermSchema class.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
- * @since 2.5.0
  */
 class TermSchema extends AbstractSchema {
 	/**

--- a/src/StoreApi/Utilities/CartController.php
+++ b/src/StoreApi/Utilities/CartController.php
@@ -16,10 +16,8 @@ use WP_Error;
 
 /**
  * Woo Cart Controller class.
- * Helper class to bridge the gap between the cart API and Woo core.
  *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
- * @since 2.5.0
+ * Helper class to bridge the gap between the cart API and Woo core.
  */
 class CartController {
 	use DraftOrderTrait;

--- a/src/StoreApi/Utilities/NoticeHandler.php
+++ b/src/StoreApi/Utilities/NoticeHandler.php
@@ -7,8 +7,6 @@ use WP_Error;
 /**
  * NoticeHandler class.
  * Helper class to handle notices.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class NoticeHandler {
 

--- a/src/StoreApi/Utilities/OrderController.php
+++ b/src/StoreApi/Utilities/OrderController.php
@@ -7,8 +7,6 @@ use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
 /**
  * OrderController class.
  * Helper class which creates and syncs orders with the cart.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
  */
 class OrderController {
 

--- a/src/StoreApi/Utilities/Pagination.php
+++ b/src/StoreApi/Utilities/Pagination.php
@@ -3,9 +3,6 @@ namespace Automattic\WooCommerce\StoreApi\Utilities;
 
 /**
  * Pagination class.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
- * @since 2.5.0
  */
 class Pagination {
 

--- a/src/StoreApi/Utilities/ProductQuery.php
+++ b/src/StoreApi/Utilities/ProductQuery.php
@@ -5,10 +5,8 @@ use WC_Tax;
 
 /**
  * Product Query class.
- * Helper class to handle product queries for the API.
  *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
- * @since 2.5.0
+ * Helper class to handle product queries for the API.
  */
 class ProductQuery {
 	/**

--- a/src/StoreApi/Utilities/ProductQueryFilters.php
+++ b/src/StoreApi/Utilities/ProductQueryFilters.php
@@ -5,9 +5,6 @@ use Automattic\WooCommerce\StoreApi\Utilities\ProductQuery;
 
 /**
  * Product Query filters class.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
- * @since 2.5.0
  */
 class ProductQueryFilters {
 	/**

--- a/src/StoreApi/Utilities/QuantityLimits.php
+++ b/src/StoreApi/Utilities/QuantityLimits.php
@@ -8,9 +8,6 @@ use Automattic\WooCommerce\StoreApi\Utilities\DraftOrderTrait;
  * QuantityLimits class.
  *
  * Returns limits for products and cart items when using the StoreAPI and supporting classes.
- *
- * @internal This API is used internally by Blocks--it is still in flux and may be subject to revisions.
- * @since 2.5.0
  */
 final class QuantityLimits {
 	use DraftOrderTrait;


### PR DESCRIPTION
Removes all `internal` notices stating that Store API is a private API so it can be considered stable.

Nothing to test here; only touches docblocks. Check PHP Unit passes in case of syntax error.

Closes #5998