### PR TITLE
Fix mini cart failing tests

### DIFF
--- a/tests/e2e/specs/shopper/mini-cart.test.js
+++ b/tests/e2e/specs/shopper/mini-cart.test.js
@@ -223,11 +223,11 @@ describe( 'Shopper → Mini Cart', () => {
 
 	describe( 'Update quantity', () => {
 		beforeAll( async () => {
-			await shopper.emptyCart();
+			await shopper.block.emptyCart();
 		} );
 
 		afterEach( async () => {
-			await shopper.emptyCart();
+			await shopper.block.emptyCart();
 		} );
 
 		it( 'The quantity of a product can be updated using plus and minus button', async () => {
@@ -325,7 +325,7 @@ describe( 'Shopper → Mini Cart', () => {
 
 	describe( 'Cart page', () => {
 		beforeAll( async () => {
-			await shopper.emptyCart();
+			await shopper.block.emptyCart();
 		} );
 
 		it( 'Can go to cart page from the Mini Cart Footer', async () => {
@@ -361,7 +361,7 @@ describe( 'Shopper → Mini Cart', () => {
 
 	describe( 'Checkout page', () => {
 		beforeAll( async () => {
-			await shopper.emptyCart();
+			await shopper.block.emptyCart();
 		} );
 
 		it( 'Can go to checkout page from the Mini Cart Footer', async () => {


### PR DESCRIPTION
Fix mini cart failing tests

### Notes

This PR Fixes an introduced bug by the following PR: #5901. In this PR we wanted to avoid overriding the WC E2E utility functions and create our own under `shopper.block` object. So, in an attempt to implement this idea, we've moved the `emptyCart` method added in #5923, under `shopper.block`. See line [75](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/tests/utils/shopper.js#L75) in `tests/utils/shopper.js`

We've already refactored the `tests/e2e/specs/shopper/mini-cart.test.js` last time, but we failed to double-check again today before merging.

### Testing

#### Automated Tests
* [x] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests

### Manual Testing

1. Check out this PR.
2. Start Docker Desktop.
3. Run `npm run wp-env destroy && npm run wp-env start` to start a fresh e2e environment.
4. Run `npm run test:e2e -- tests/e2e/specs/shopper/mini-cart.test.js` to run only this test case.
5. Run `npm run test:e2e` to run the whole test suite.