### PR TITLE
Add feature gate for enabling the global styles for Product Sale Badge block only for the feature plugin

### DIFF
--- a/assets/js/atomic/blocks/product-elements/button/supports.ts
+++ b/assets/js/atomic/blocks/product-elements/button/supports.ts
@@ -3,6 +3,11 @@
  */
 import { isFeaturePluginBuild } from '@woocommerce/block-settings';
 
+/**
+ * Internal dependencies
+ */
+import { hasSpacingStyleSupport } from '../../../../utils/global-style';
+
 export const supports = {
 	...( isFeaturePluginBuild() && {
 		color: {
@@ -15,10 +20,12 @@ export const supports = {
 			radius: true,
 			__experimentalSkipSerialization: true,
 		},
-		spacing: {
-			padding: true,
-			__experimentalSkipSerialization: true,
-		},
+		...( hasSpacingStyleSupport() && {
+			spacing: {
+				padding: true,
+				__experimentalSkipSerialization: true,
+			},
+		} ),
 		typography: {
 			fontSize: true,
 			__experimentalFontWeight: true,

--- a/assets/js/atomic/blocks/product-elements/image/supports.ts
+++ b/assets/js/atomic/blocks/product-elements/image/supports.ts
@@ -3,6 +3,11 @@
  */
 import { isFeaturePluginBuild } from '@woocommerce/block-settings';
 
+/**
+ * Internal dependencies
+ */
+import { hasSpacingStyleSupport } from '../../../../utils/global-style';
+
 export const supports = {
 	...( isFeaturePluginBuild() && {
 		__experimentalBorder: {
@@ -13,10 +18,12 @@ export const supports = {
 			fontSize: true,
 			__experimentalSkipSerialization: true,
 		},
-		spacing: {
-			margin: true,
-			__experimentalSkipSerialization: true,
-		},
+		...( hasSpacingStyleSupport() && {
+			spacing: {
+				margin: true,
+				__experimentalSkipSerialization: true,
+			},
+		} ),
 		__experimentalSelector: '.wc-block-components-product-image',
 	} ),
 };

--- a/assets/js/atomic/blocks/product-elements/sale-badge/index.js
+++ b/assets/js/atomic/blocks/product-elements/sale-badge/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
+import { isFeaturePluginBuild } from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies
@@ -23,27 +24,29 @@ const blockConfig = {
 	apiVersion: 2,
 	supports: {
 		html: false,
-		color: {
-			gradients: true,
-			background: true,
-			link: false,
-			__experimentalSkipSerialization: true,
-		},
-		typography: {
-			fontSize: true,
-			__experimentalSkipSerialization: true,
-		},
-		__experimentalBorder: {
-			color: true,
-			radius: true,
-			width: true,
-			__experimentalSkipSerialization: true,
-		},
-		spacing: {
-			padding: true,
-			__experimentalSkipSerialization: true,
-		},
-		__experimentalSelector: '.wc-block-components-product-sale-badge',
+		...( isFeaturePluginBuild() && {
+			color: {
+				gradients: true,
+				background: true,
+				link: false,
+				__experimentalSkipSerialization: true,
+			},
+			typography: {
+				fontSize: true,
+				__experimentalSkipSerialization: true,
+			},
+			__experimentalBorder: {
+				color: true,
+				radius: true,
+				width: true,
+				__experimentalSkipSerialization: true,
+			},
+			spacing: {
+				padding: true,
+				__experimentalSkipSerialization: true,
+			},
+			__experimentalSelector: '.wc-block-components-product-sale-badge',
+		} ),
 	},
 	attributes,
 	edit,

--- a/assets/js/atomic/blocks/product-elements/sale-badge/index.js
+++ b/assets/js/atomic/blocks/product-elements/sale-badge/index.js
@@ -16,6 +16,7 @@ import {
 	BLOCK_DESCRIPTION as description,
 } from './constants';
 import { Save } from './save';
+import { hasSpacingStyleSupport } from '../../../../utils/global-style';
 
 const blockConfig = {
 	title,
@@ -41,11 +42,14 @@ const blockConfig = {
 				width: true,
 				__experimentalSkipSerialization: true,
 			},
-			spacing: {
-				padding: true,
-				__experimentalSkipSerialization: true,
-			},
-			__experimentalSelector: '.wc-block-components-product-sale-badge',
+			...( hasSpacingStyleSupport() && {
+				spacing: {
+					padding: true,
+					__experimentalSkipSerialization: true,
+				},
+				__experimentalSelector:
+					'.wc-block-components-product-sale-badge',
+			} ),
 		} ),
 	},
 	attributes,


### PR DESCRIPTION
This PR adds the feature gate for enabling the global styles support for the Product Sale Badge block only for the feature plugin. We don't introduce any breaks because Product Sale Badge Global Styles support is introduced in the 7.0.0 version that is not integrated into WooCommerce Core.

It also adds additional controls to add spacing support to several blocks:  Button, Image, and Sale Badge.

<!-- Reference any related issues or PRs here -->
Fixes #6007 

