### PR TITLE
Move __experimentalSelector outside of hasSpacingStyleSupport check

### DIFF
--- a/assets/js/atomic/blocks/product-elements/sale-badge/index.js
+++ b/assets/js/atomic/blocks/product-elements/sale-badge/index.js
@@ -47,9 +47,8 @@ const blockConfig = {
 					padding: true,
 					__experimentalSkipSerialization: true,
 				},
-				__experimentalSelector:
-					'.wc-block-components-product-sale-badge',
 			} ),
+			__experimentalSelector: '.wc-block-components-product-sale-badge',
 		} ),
 	},
 	attributes,


### PR DESCRIPTION
Minor regression - we've overlooked __experimentalSelector ending up inside of hasSpacingStyleSupport check.

