### PR TITLE
E2E test improvements and consolidatng

### DIFF
--- a/tests/e2e/specs/frontend/checkout.test.js
+++ b/tests/e2e/specs/frontend/checkout.test.js
@@ -119,7 +119,7 @@ describe( `${ block.name } Block (frontend)`, () => {
 	} );
 
 	it( 'should display an empty cart message when cart is empty', async () => {
-		await shopper.goToCheckoutBlock();
+		await shopper.block.goToCheckout();
 		const html = await page.content();
 
 		await expect( page ).toMatchElement( 'h1', { text: 'Checkout Block' } );
@@ -131,17 +131,17 @@ describe( `${ block.name } Block (frontend)`, () => {
 	it( 'allows customer to choose available payment methods', async () => {
 		await page.goto( productPermalink );
 		await shopper.addToCart();
-		await shopper.goToCheckoutBlock();
+		await shopper.block.goToCheckout();
 
-		await shopper.productIsInCheckoutBlock(
+		await shopper.block.productIsInCheckout(
 			simpleProductName,
 			`1`,
 			singleProductPrice
 		);
 		await page.goBack( { waitUntil: 'networkidle2' } );
 		await shopper.addToCart();
-		await shopper.goToCheckoutBlock();
-		await shopper.productIsInCheckoutBlock(
+		await shopper.block.goToCheckout();
+		await shopper.block.productIsInCheckout(
 			simpleProductName,
 			`2`,
 			twoProductPrice

--- a/tests/e2e/specs/frontend/legacy-template-blocks.test.js
+++ b/tests/e2e/specs/frontend/legacy-template-blocks.test.js
@@ -1,8 +1,5 @@
 import { URL } from 'url';
-import { activateTheme } from '@wordpress/e2e-test-utils';
-
-import { BASE_URL } from '../../utils';
-
+import { BASE_URL, useTheme } from '../../utils';
 const SELECTORS = {
 	productArchivePage: {
 		paginationUI: '.woocommerce-pagination',
@@ -38,13 +35,7 @@ function extractPaginationData() {
 }
 
 describe( 'Legacy Template blocks', () => {
-	beforeAll( async () => {
-		await activateTheme( 'emptytheme' );
-	} );
-
-	afterAll( async () => {
-		await activateTheme( 'storefront' );
-	} );
+	useTheme( 'emptytheme' );
 
 	describe( 'Product Archive block', () => {
 		it( 'renders a list of products with their count and pagination', async () => {

--- a/tests/e2e/specs/shopper/cart-proceed-to-checkout.test.js
+++ b/tests/e2e/specs/shopper/cart-proceed-to-checkout.test.js
@@ -13,7 +13,7 @@ if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 )
 	test.only( `skipping ${ block.name } tests`, () => {} );
 
 describe( 'Shopper → Cart → Can proceed to checkout', () => {
-	beforeAll( async () => {
+	beforeEach( async () => {
 		await shopper.block.emptyCart();
 	} );
 

--- a/tests/e2e/specs/shopper/cart-proceed-to-checkout.test.js
+++ b/tests/e2e/specs/shopper/cart-proceed-to-checkout.test.js
@@ -27,12 +27,7 @@ describe( 'Shopper → Cart → Can proceed to checkout', () => {
 		await shopper.block.goToCart();
 
 		// Click on "Proceed to Checkout" button
-		await Promise.all( [
-			expect( page ).toClick( 'a.wc-block-cart__submit-button', {
-				text: 'Proceed to Checkout',
-			} ),
-			page.waitForNavigation( { waitUntil: 'networkidle0' } ),
-		] );
+		await shopper.block.proceedToCheckout();
 
 		// Verify that you see the Checkout Block page
 		await expect( page ).toMatchElement( 'h1', { text: 'Checkout' } );

--- a/tests/e2e/specs/shopper/checkout-place-order-as-guest.test.js
+++ b/tests/e2e/specs/shopper/checkout-place-order-as-guest.test.js
@@ -18,7 +18,7 @@ if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 )
 	test.only( `skipping ${ block.name } tests`, () => {} );
 
 describe( 'Shopper → Checkout → Can place an order as guest', () => {
-	beforeAll( async () => {
+	beforeEach( async () => {
 		await shopper.block.emptyCart();
 	} );
 

--- a/tests/e2e/specs/shopper/mini-cart.test.js
+++ b/tests/e2e/specs/shopper/mini-cart.test.js
@@ -15,7 +15,7 @@ import { shopper } from '../../../utils';
 import { getTextContent } from '../../page-utils';
 
 const block = {
-	name: 'Mini Cart Block',
+	name: 'Mini Cart',
 };
 
 const options = getDefaultOptions();
@@ -50,7 +50,7 @@ describe( 'Shopper → Mini Cart', () => {
 	} );
 
 	beforeEach( async () => {
-		await shopper.goToBlockPage( block.name );
+		await shopper.block.goToBlockPage( block.name );
 	} );
 
 	describe( 'Icon', () => {

--- a/tests/e2e/specs/shopper/tax.test.js
+++ b/tests/e2e/specs/shopper/tax.test.js
@@ -15,6 +15,10 @@ const productWooSingle1 = Products().find(
 	( prod ) => prod.name === 'Woo Single #1'
 );
 
+if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 )
+	// eslint-disable-next-line jest/no-focused-tests
+	test.only( `skipping ${ block.name } tests`, () => {} );
+
 describe( 'Shopper -> Tax', () => {
 	beforeEach( async () => {
 		await shopper.block.emptyCart();

--- a/tests/utils/constants.js
+++ b/tests/utils/constants.js
@@ -2,14 +2,11 @@
  * External dependencies
  */
 const config = require( 'config' );
-const baseUrl = config.get( 'url' );
 
 /**
- * Shop pages.
+ * Constants used for E2E tests.
  *
  * @type {string}
  */
-export const SHOP_CART_BLOCK_PAGE = baseUrl + 'cart-block';
-export const SHOP_CHECKOUT_BLOCK_PAGE = baseUrl + 'checkout-block';
 export const SIMPLE_PRODUCT_NAME = 'Woo Single #1';
 export const BILLING_DETAILS = config.get( 'addresses.customer.billing' );

--- a/tests/utils/shopper.js
+++ b/tests/utils/shopper.js
@@ -7,71 +7,60 @@ import {
 	SHOP_CART_PAGE,
 } from '@woocommerce/e2e-utils';
 
-/**
- * Internal dependencies
- */
-import { getBlockPagePermalink } from './get-block-page-permalink';
-import { SHOP_CART_BLOCK_PAGE, SHOP_CHECKOUT_BLOCK_PAGE } from './constants';
-
 export const shopper = {
 	...wcShopper,
 
-	goToCheckoutBlock: async () => {
-		await page.goto( SHOP_CHECKOUT_BLOCK_PAGE, {
-			waitUntil: 'networkidle0',
-		} );
-	},
-
-	goToCartBlock: async () => {
-		await page.goto( SHOP_CART_BLOCK_PAGE, {
-			waitUntil: 'networkidle0',
-		} );
-	},
-
-	productIsInCheckoutBlock: async ( productTitle, quantity, total ) => {
-		// Make sure Order summary is expanded
-		const [ button ] = await page.$x(
-			`//button[contains(@aria-expanded, 'false')]//span[contains(text(), 'Order summary')]`
-		);
-		if ( button ) {
-			await button.click();
-		}
-		await expect( page ).toMatchElement( 'span', {
-			text: productTitle,
-		} );
-		await expect(
-			page
-		).toMatchElement(
-			'div.wc-block-components-order-summary-item__quantity',
-			{ text: quantity }
-		);
-		await expect( page ).toMatchElement(
-			'span.wc-block-components-product-price__value',
-			{
-				text: total,
-			}
-		);
-	},
-
-	goToBlockPage: async ( title ) => {
-		await page.goto( await getBlockPagePermalink( title ), {
-			waitUntil: 'networkidle0',
-		} );
-
-		await expect( page ).toMatchElement( 'h1', { text: title } );
-	},
-
+	// We use the .block property to avoid overriding any wcShopper functionality
+	// This is important as we might one day merge this into core WC.
 	block: {
-		goToCart: async () => {
-			await page.goto( SHOP_CART_BLOCK_PAGE, {
+		// All block pages have a title composed of the block name followed by "Block".
+		// E.g. "Checkout Block or Mini Cart Block". The permalinks are generated from
+		// the page title so we can derive them directly
+		goToBlockPage: async ( blockName ) => {
+			const config = require( 'config' );
+			const baseUrl = config.get( 'url' );
+			const pageTitle = `${ blockName } Block`;
+			const url = baseUrl + pageTitle.toLowerCase().replace( / /g, '-' );
+			await page.goto( url, {
 				waitUntil: 'networkidle0',
+			} );
+
+			await expect( page ).toMatchElement( 'h1', {
+				text: blockName,
 			} );
 		},
 
+		goToCart: async () => {
+			await shopper.block.goToBlockPage( 'Cart' );
+		},
+
 		goToCheckout: async () => {
-			await page.goto( SHOP_CHECKOUT_BLOCK_PAGE, {
-				waitUntil: 'networkidle0',
+			await shopper.block.goToBlockPage( 'Checkout' );
+		},
+
+		productIsInCheckout: async ( productTitle, quantity, total ) => {
+			// Make sure Order summary is expanded
+			const [ button ] = await page.$x(
+				`//button[contains(@aria-expanded, 'false')]//span[contains(text(), 'Order summary')]`
+			);
+			if ( button ) {
+				await button.click();
+			}
+			await expect( page ).toMatchElement( 'span', {
+				text: productTitle,
 			} );
+			await expect(
+				page
+			).toMatchElement(
+				'div.wc-block-components-order-summary-item__quantity',
+				{ text: quantity }
+			);
+			await expect( page ).toMatchElement(
+				'span.wc-block-components-product-price__value',
+				{
+					text: total,
+				}
+			);
 		},
 
 		/**
@@ -148,7 +137,7 @@ export const shopper = {
 		addCoupon: async ( couponCode ) => {
 			const title = await page.title();
 			if ( ! title.includes( 'Cart Block' ) ) {
-				await shopper.goToCartBlock();
+				await shopper.block.goToCart();
 			}
 			// Make sure the coupon panel is open
 			const applyButton = await page.$(

--- a/tests/utils/shopper.js
+++ b/tests/utils/shopper.js
@@ -7,6 +7,11 @@ import {
 	SHOP_CART_PAGE,
 } from '@woocommerce/e2e-utils';
 
+/**
+ * Internal dependencies
+ */
+import { BASE_URL } from '../e2e/utils';
+
 export const shopper = {
 	...wcShopper,
 
@@ -17,10 +22,8 @@ export const shopper = {
 		// E.g. "Checkout Block or Mini Cart Block". The permalinks are generated from
 		// the page title so we can derive them directly
 		goToBlockPage: async ( blockName ) => {
-			const config = require( 'config' );
-			const baseUrl = config.get( 'url' );
 			const pageTitle = `${ blockName } Block`;
-			const url = baseUrl + pageTitle.toLowerCase().replace( / /g, '-' );
+			const url = BASE_URL + pageTitle.toLowerCase().replace( / /g, '-' );
 			await page.goto( url, {
 				waitUntil: 'networkidle0',
 			} );

--- a/tests/utils/shopper.js
+++ b/tests/utils/shopper.js
@@ -258,5 +258,18 @@ export const shopper = {
 				customerBillingDetails.email
 			);
 		},
+
+		/**
+		 * Instead of using the permalink to go to checkout (e.g. "shopper.block.goToCheckout"),
+		 * with this method we actually click on the "Proceed to Checkout" button
+		 */
+		proceedToCheckout: async () => {
+			await Promise.all( [
+				expect( page ).toClick( 'a.wc-block-cart__submit-button', {
+					text: 'Proceed to Checkout',
+				} ),
+				page.waitForNavigation( { waitUntil: 'networkidle0' } ),
+			] );
+		},
 	},
 };


### PR DESCRIPTION
There's been a few PRs on E2E tests and as such there's been a bit of cross over. This PR aims to simplify things a bit. Specifically:

- Use `useTheme()` helper to make sure we are remembering and switching back to the original theme after activating a new theme within a test
- Move all block related functions under the `shopper.block` object for clarity
- Simplify the `goToBlockPage()` function to derive the block page permalink directly, rather than visiting wp-admin
- Remove now unnecessary constants

### Testing

#### Automated Tests
* [x] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests

### Manual Testing

How to test the changes in this Pull Request:

1. Make sure all E2E tests pass

<!-- If you can, add the appropriate labels -->
