### PR TITLE
Critical flows: Shopper → Cart → Can remove product

### DIFF
--- a/tests/e2e/specs/shopper/cart-products.test.js
+++ b/tests/e2e/specs/shopper/cart-products.test.js
@@ -1,0 +1,28 @@
+/**
+ * Internal dependencies
+ */
+import { shopper } from "../../../utils";
+import { SIMPLE_PRODUCT_NAME } from "../../../utils/constants";
+
+if (process.env.WOOCOMMERCE_BLOCKS_PHASE < 2)
+  // eslint-disable-next-line jest/no-focused-tests
+  test.only(`skipping ${block.name} tests`, () => {});
+
+describe("Shopper → Cart → Can remove product", () => {
+  beforeAll(async () => {
+    await shopper.block.emptyCart();
+  });
+
+  it("Can remove product from cart", async () => {
+    await shopper.goToShop();
+    await shopper.addToCartFromShopPage(SIMPLE_PRODUCT_NAME);
+    await shopper.block.goToCart();
+    const removeProductLink = await page.$(".wc-block-cart-item__remove-link");
+    await removeProductLink.click();
+
+    // Verify product is removed from the cart'
+    await expect(page).toMatchElement("h2", {
+      text: "Your cart is currently empty!",
+    });
+  });
+});

--- a/tests/e2e/specs/shopper/cart-products.test.js
+++ b/tests/e2e/specs/shopper/cart-products.test.js
@@ -1,28 +1,30 @@
 /**
  * Internal dependencies
  */
-import { shopper } from "../../../utils";
-import { SIMPLE_PRODUCT_NAME } from "../../../utils/constants";
+import { shopper } from '../../../utils';
+import { SIMPLE_PRODUCT_NAME } from '../../../utils/constants';
 
-if (process.env.WOOCOMMERCE_BLOCKS_PHASE < 2)
-  // eslint-disable-next-line jest/no-focused-tests
-  test.only(`skipping ${block.name} tests`, () => {});
+if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 )
+	// eslint-disable-next-line jest/no-focused-tests
+	test.only( `skipping ${ block.name } tests`, () => {} );
 
-describe("Shopper → Cart → Can remove product", () => {
-  beforeAll(async () => {
-    await shopper.block.emptyCart();
-  });
+describe( 'Shopper → Cart → Can remove product', () => {
+	beforeAll( async () => {
+		await shopper.block.emptyCart();
+	} );
 
-  it("Can remove product from cart", async () => {
-    await shopper.goToShop();
-    await shopper.addToCartFromShopPage(SIMPLE_PRODUCT_NAME);
-    await shopper.block.goToCart();
-    const removeProductLink = await page.$(".wc-block-cart-item__remove-link");
-    await removeProductLink.click();
+	it( 'Can remove product from cart', async () => {
+		await shopper.goToShop();
+		await shopper.addToCartFromShopPage( SIMPLE_PRODUCT_NAME );
+		await shopper.block.goToCart();
+		const removeProductLink = await page.$(
+			'.wc-block-cart-item__remove-link'
+		);
+		await removeProductLink.click();
 
-    // Verify product is removed from the cart'
-    await expect(page).toMatchElement("h2", {
-      text: "Your cart is currently empty!",
-    });
-  });
-});
+		// Verify product is removed from the cart'
+		await expect( page ).toMatchElement( 'h2', {
+			text: 'Your cart is currently empty!',
+		} );
+	} );
+} );


### PR DESCRIPTION
<!-- Reference any related issues or PRs here -->
Fixes #5756

This PR adds e2e tests to verify that a shopper can remove products in the Cart block page.


### Testing

#### Automated Tests
* [x] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Check out this PR.
2. Start Docker Desktop.
3. Run `npm run wp-env destroy && npm run wp-env start` to start a fresh e2e environment.
4. Run `npm run test:e2e-dev -- tests/e2e/specs/shopper/cart-products.test.js` to run only this test case.
5. Make sure all tests pass. 

