### PR TITLE
Remove X- Prefixes from custom headers

### DIFF
--- a/assets/js/base/context/providers/cart-checkout/utils.ts
+++ b/assets/js/base/context/providers/cart-checkout/utils.ts
@@ -55,9 +55,9 @@ export const processCheckoutResponseHeaders = (
 	}
 
 	// Update user using headers.
-	if ( headers?.get( 'X-WC-Store-API-User' ) ) {
+	if ( headers?.get( 'User-ID' ) ) {
 		dispatchActions.setCustomerId(
-			parseInt( headers.get( 'X-WC-Store-API-User' ) || '0', 10 )
+			parseInt( headers.get( 'User-ID' ) || '0', 10 )
 		);
 	}
 };

--- a/assets/js/middleware/store-api-nonce.js
+++ b/assets/js/middleware/store-api-nonce.js
@@ -39,12 +39,12 @@ const isStoreApiRequest = ( options ) => {
 const setNonce = ( headers ) => {
 	const nonce =
 		typeof headers?.get === 'function'
-			? headers.get( 'X-WC-Store-API-Nonce' )
-			: headers[ 'X-WC-Store-API-Nonce' ];
+			? headers.get( 'Nonce' )
+			: headers.Nonce;
 	const timestamp =
 		typeof headers?.get === 'function'
-			? headers.get( 'X-WC-Store-API-Nonce-Timestamp' )
-			: headers[ 'X-WC-Store-API-Nonce-Timestamp' ];
+			? headers.get( 'Nonce-Timestamp' )
+			: headers[ 'Nonce-Timestamp' ];
 
 	if ( nonce ) {
 		updateNonce( nonce, timestamp );
@@ -85,7 +85,7 @@ const appendNonceHeader = ( request ) => {
 	const headers = request.headers || {};
 	request.headers = {
 		...headers,
-		'X-WC-Store-API-Nonce': currentNonce,
+		Nonce: currentNonce,
 	};
 	return request;
 };

--- a/docs/testing/releases/440.md
+++ b/docs/testing/releases/440.md
@@ -96,7 +96,7 @@ This is a regression test due to the changes made for Subscriptions Integration.
 2. Enter an address that has no rates. Ensure an error notice is shown in the cart shipping package "No shipping options were found.".
 3. Place an order. Confirm details persist.
 
-## <!-- FEEDBACK -->
+<!-- FEEDBACK -->
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 

--- a/docs/testing/releases/440.md
+++ b/docs/testing/releases/440.md
@@ -4,7 +4,7 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 
 ## Feature plugin and package inclusion in WooCommerce core
 
-### Prevent "X-WC-Store-API-Nonce is invalid" error when going back to a page with the products block using the browser back button. #3770
+### Prevent "Nonce is invalid" error when going back to a page with the products block using the browser back button. #3770
 
 1. Open your store in an incognito window.
 2. Add an item to the cart from the products block.
@@ -75,7 +75,7 @@ This test requires a code edit to force an error.
 
 1. Make sure the cart page is setup with the Cart Block.
 2. Add items to your cart, some with sale prices, add multiple items etc.
-3. See that the subtotal for each item is shown below the item's name, and the overall total is shown to the right. (Overall total is item price * quantity).
+3. See that the subtotal for each item is shown below the item's name, and the overall total is shown to the right. (Overall total is item price \* quantity).
 
 ### Hidden cart item meta data will not be rendered in the Cart and Checkout blocks. #3732
 
@@ -91,16 +91,15 @@ This can only be tested with Subscriptions.
 This is a regression test due to the changes made for Subscriptions Integration.
 
 1. On the cart page, use the shipping calculator.
-   - Confirm your address is populated in the shipping calculated fields.
-   - When updating your address, confirm the shipping rates update.
+    - Confirm your address is populated in the shipping calculated fields.
+    - When updating your address, confirm the shipping rates update.
 2. Enter an address that has no rates. Ensure an error notice is shown in the cart shipping package "No shipping options were found.".
 3. Place an order. Confirm details persist.
 
-<!-- FEEDBACK -->
----
+## <!-- FEEDBACK -->
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/440.md)
-<!-- /FEEDBACK -->
 
+<!-- /FEEDBACK -->

--- a/docs/testing/releases/680.md
+++ b/docs/testing/releases/680.md
@@ -179,7 +179,7 @@ Install the [Stripe Payment Method Extension](https://github.com/woocommerce/woo
 15. Save your changes.
 16. Check if these styles have priority over the styles from the Site Editor.
 
-## <!-- FEEDBACK -->
+<!-- FEEDBACK -->
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 

--- a/readme.txt
+++ b/readme.txt
@@ -723,7 +723,7 @@ This release fixes an error that some users experienced when their site automati
 - Hidden cart item meta data will not be rendered in the Cart and Checkout blocks. ([3732](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3732))
 - Fix - Improved accessibility of product image links in the products block by using correct aria tags and hiding empty image placeholders. ([3722](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3722))
 - Add missing aria-label for stars image in the review-list-item component. ([3706](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3706))
-- Prevent "X-WC-Store-API-Nonce is invalid" error when going back to a page with the products block using the browser back button. ([3770](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3770))
+- Prevent "Nonce is invalid" error when going back to a page with the products block using the browser back button. ([3770](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3770))
 
 #### compatibility
 

--- a/src/StoreApi/Routes/V1/AbstractCartRoute.php
+++ b/src/StoreApi/Routes/V1/AbstractCartRoute.php
@@ -177,7 +177,8 @@ abstract class AbstractCartRoute extends AbstractRoute {
 	 */
 	protected function check_nonce( \WP_REST_Request $request ) {
 		if ( $request->get_header( 'X-WC-Store-API-Nonce' ) ) {
-			rest_handle_deprecated_argument( 'X-WC-Store-API-Nonce', 'Use the "Nonce" Header instead', '7.2.0' );
+			// @todo Blocks 7.5.0: Remove handling and sendinf of deprecated X-WC-Store-API-Nonce Header.
+			rest_handle_deprecated_argument( 'X-WC-Store-API-Nonce', 'Use the "Nonce" Header instead. This header will be removed after Blocks release 7.5', '7.2.0' );
 			$nonce = $request->get_header( 'X-WC-Store-API-Nonce' );
 		} else {
 			$nonce = $request->get_header( 'Nonce' );

--- a/src/StoreApi/Routes/V1/AbstractCartRoute.php
+++ b/src/StoreApi/Routes/V1/AbstractCartRoute.php
@@ -177,7 +177,7 @@ abstract class AbstractCartRoute extends AbstractRoute {
 	 */
 	protected function check_nonce( \WP_REST_Request $request ) {
 		if ( $request->get_header( 'X-WC-Store-API-Nonce' ) ) {
-			// @todo Remove handling and sendinf of deprecated X-WC-Store-API-Nonce Header (Blocks 7.5.0)
+			// @todo Remove handling and sending of deprecated X-WC-Store-API-Nonce Header (Blocks 7.5.0)
 			wc_deprecated_argument( 'X-WC-Store-API-Nonce', '7.2.0', 'Use the "Nonce" Header instead. This header will be removed after Blocks release 7.5' );
 			rest_handle_deprecated_argument( 'X-WC-Store-API-Nonce', 'Use the "Nonce" Header instead. This header will be removed after Blocks release 7.5', '7.2.0' );
 			$nonce = $request->get_header( 'X-WC-Store-API-Nonce' );

--- a/src/StoreApi/Routes/V1/AbstractCartRoute.php
+++ b/src/StoreApi/Routes/V1/AbstractCartRoute.php
@@ -176,13 +176,16 @@ abstract class AbstractCartRoute extends AbstractRoute {
 	 * @return \WP_Error|boolean
 	 */
 	protected function check_nonce( \WP_REST_Request $request ) {
-		if ( $request->get_header( 'X-WC-Store-API-Nonce' ) ) {
+		$nonce = null;
+
+		if ( $request->get_header( 'Nonce' ) ) {
+			$nonce = $request->get_header( 'Nonce' );
+		} elseif ( $request->get_header( 'X-WC-Store-API-Nonce' ) ) {
+			$nonce = $request->get_header( 'X-WC-Store-API-Nonce' );
+
 			// @todo Remove handling and sending of deprecated X-WC-Store-API-Nonce Header (Blocks 7.5.0)
 			wc_deprecated_argument( 'X-WC-Store-API-Nonce', '7.2.0', 'Use the "Nonce" Header instead. This header will be removed after Blocks release 7.5' );
 			rest_handle_deprecated_argument( 'X-WC-Store-API-Nonce', 'Use the "Nonce" Header instead. This header will be removed after Blocks release 7.5', '7.2.0' );
-			$nonce = $request->get_header( 'X-WC-Store-API-Nonce' );
-		} else {
-			$nonce = $request->get_header( 'Nonce' );
 		}
 
 		/**

--- a/src/StoreApi/Routes/V1/AbstractCartRoute.php
+++ b/src/StoreApi/Routes/V1/AbstractCartRoute.php
@@ -100,9 +100,15 @@ abstract class AbstractCartRoute extends AbstractRoute {
 	 * @return \WP_REST_Response
 	 */
 	protected function add_nonce_headers( \WP_REST_Response $response ) {
-		$response->header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$nonce = wp_create_nonce( 'wc_store_api' );
+
+		$response->header( 'Nonce', $nonce );
 		$response->header( 'Nonce-Timestamp', time() );
 		$response->header( 'User-ID', get_current_user_id() );
+
+		// The following headers are deprecated and should be removed in a future version.
+		$response->header( 'X-WC-Store-API-Nonce', $nonce );
+
 		return $response;
 	}
 

--- a/src/StoreApi/Routes/V1/AbstractCartRoute.php
+++ b/src/StoreApi/Routes/V1/AbstractCartRoute.php
@@ -177,7 +177,7 @@ abstract class AbstractCartRoute extends AbstractRoute {
 	 */
 	protected function check_nonce( \WP_REST_Request $request ) {
 		if ( $request->get_header( 'X-WC-Store-API-Nonce' ) ) {
-			// @todo Blocks 7.5.0: Remove handling and sendinf of deprecated X-WC-Store-API-Nonce Header.
+			// @todo Remove handling and sendinf of deprecated X-WC-Store-API-Nonce Header (Blocks 7.5.0)
 			wc_deprecated_argument( 'X-WC-Store-API-Nonce', '7.2.0', 'Use the "Nonce" Header instead. This header will be removed after Blocks release 7.5' );
 			rest_handle_deprecated_argument( 'X-WC-Store-API-Nonce', 'Use the "Nonce" Header instead. This header will be removed after Blocks release 7.5', '7.2.0' );
 			$nonce = $request->get_header( 'X-WC-Store-API-Nonce' );

--- a/src/StoreApi/Routes/V1/AbstractCartRoute.php
+++ b/src/StoreApi/Routes/V1/AbstractCartRoute.php
@@ -170,7 +170,12 @@ abstract class AbstractCartRoute extends AbstractRoute {
 	 * @return \WP_Error|boolean
 	 */
 	protected function check_nonce( \WP_REST_Request $request ) {
-		$nonce = $request->get_header( 'Nonce' );
+		if ( $request->get_header( 'X-WC-Store-API-Nonce' ) ) {
+			rest_handle_deprecated_argument( 'X-WC-Store-API-Nonce', 'Use the "Nonce" Header instead', '7.2.0' );
+			$nonce = $request->get_header( 'X-WC-Store-API-Nonce' );
+		} else {
+			$nonce = $request->get_header( 'Nonce' );
+		}
 
 		/**
 		 * Filters the Store API nonce check.

--- a/src/StoreApi/Routes/V1/AbstractCartRoute.php
+++ b/src/StoreApi/Routes/V1/AbstractCartRoute.php
@@ -178,6 +178,7 @@ abstract class AbstractCartRoute extends AbstractRoute {
 	protected function check_nonce( \WP_REST_Request $request ) {
 		if ( $request->get_header( 'X-WC-Store-API-Nonce' ) ) {
 			// @todo Blocks 7.5.0: Remove handling and sendinf of deprecated X-WC-Store-API-Nonce Header.
+			wc_deprecated_argument( 'X-WC-Store-API-Nonce', '7.2.0', 'Use the "Nonce" Header instead. This header will be removed after Blocks release 7.5' );
 			rest_handle_deprecated_argument( 'X-WC-Store-API-Nonce', 'Use the "Nonce" Header instead. This header will be removed after Blocks release 7.5', '7.2.0' );
 			$nonce = $request->get_header( 'X-WC-Store-API-Nonce' );
 		} else {

--- a/src/StoreApi/Routes/V1/AbstractCartRoute.php
+++ b/src/StoreApi/Routes/V1/AbstractCartRoute.php
@@ -100,9 +100,9 @@ abstract class AbstractCartRoute extends AbstractRoute {
 	 * @return \WP_REST_Response
 	 */
 	protected function add_nonce_headers( \WP_REST_Response $response ) {
-		$response->header( 'X-WC-Store-API-Nonce', wp_create_nonce( 'wc_store_api' ) );
-		$response->header( 'X-WC-Store-API-Nonce-Timestamp', time() );
-		$response->header( 'X-WC-Store-API-User', get_current_user_id() );
+		$response->header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$response->header( 'Nonce-Timestamp', time() );
+		$response->header( 'User-ID', get_current_user_id() );
 		return $response;
 	}
 
@@ -170,7 +170,7 @@ abstract class AbstractCartRoute extends AbstractRoute {
 	 * @return \WP_Error|boolean
 	 */
 	protected function check_nonce( \WP_REST_Request $request ) {
-		$nonce = $request->get_header( 'X-WC-Store-API-Nonce' );
+		$nonce = $request->get_header( 'Nonce' );
 
 		/**
 		 * Filters the Store API nonce check.
@@ -185,11 +185,11 @@ abstract class AbstractCartRoute extends AbstractRoute {
 		}
 
 		if ( null === $nonce ) {
-			return $this->get_route_error_response( 'woocommerce_rest_missing_nonce', __( 'Missing the X-WC-Store-API-Nonce header. This endpoint requires a valid nonce.', 'woo-gutenberg-products-block' ), 401 );
+			return $this->get_route_error_response( 'woocommerce_rest_missing_nonce', __( 'Missing the Nonce header. This endpoint requires a valid nonce.', 'woo-gutenberg-products-block' ), 401 );
 		}
 
 		if ( ! wp_verify_nonce( $nonce, 'wc_store_api' ) ) {
-			return $this->get_route_error_response( 'woocommerce_rest_invalid_nonce', __( 'X-WC-Store-API-Nonce is invalid.', 'woo-gutenberg-products-block' ), 403 );
+			return $this->get_route_error_response( 'woocommerce_rest_invalid_nonce', __( 'Nonce is invalid.', 'woo-gutenberg-products-block' ), 403 );
 		}
 
 		return true;

--- a/src/StoreApi/Routes/V1/Batch.php
+++ b/src/StoreApi/Routes/V1/Batch.php
@@ -116,7 +116,10 @@ class Batch extends AbstractRoute implements RouteInterface {
 			$response = $this->error_to_response( $response );
 		}
 
-		$response->header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$nonce = wp_create_nonce( 'wc_store_api' );
+
+		$response->header( 'Nonce', $nonce );
+		$response->header( 'X-WC-Store-API-Nonce', $nonce );
 		$response->header( 'Nonce-Timestamp', time() );
 		$response->header( 'User-ID', get_current_user_id() );
 

--- a/src/StoreApi/Routes/V1/Batch.php
+++ b/src/StoreApi/Routes/V1/Batch.php
@@ -116,9 +116,9 @@ class Batch extends AbstractRoute implements RouteInterface {
 			$response = $this->error_to_response( $response );
 		}
 
-		$response->header( 'X-WC-Store-API-Nonce', wp_create_nonce( 'wc_store_api' ) );
-		$response->header( 'X-WC-Store-API-Nonce-Timestamp', time() );
-		$response->header( 'X-WC-Store-API-User', get_current_user_id() );
+		$response->header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$response->header( 'Nonce-Timestamp', time() );
+		$response->header( 'User-ID', get_current_user_id() );
 
 		return $response;
 	}

--- a/src/StoreApi/docs/cart.md
+++ b/src/StoreApi/docs/cart.md
@@ -325,7 +325,7 @@ POST /cart/add-item
 | `variation` | array   |   Yes    | Chosen attributes (for variations) containing an array of objects with keys `attribute` and `value`. |
 
 ```sh
-curl --header "X-WC-Store-API-Nonce: 12345" --request POST https://example-store.com/wp-json/wc/store/v1/cart/add-item?id=100&quantity=1
+curl --header "Nonce: 12345" --request POST https://example-store.com/wp-json/wc/store/v1/cart/add-item?id=100&quantity=1
 ```
 
 Returns the full [Cart Response](#cart-response) on success, or an [Error Response](#error-response) on failure.
@@ -345,7 +345,7 @@ POST /cart/remove-item
 | `key`     | string |   Yes    | The key of the cart item to edit. |
 
 ```sh
-curl --header "X-WC-Store-API-Nonce: 12345" --request POST https://example-store.com/wp-json/wc/store/v1/cart/remove-item?key=e369853df766fa44e1ed0ff613f563bd
+curl --header "Nonce: 12345" --request POST https://example-store.com/wp-json/wc/store/v1/cart/remove-item?key=e369853df766fa44e1ed0ff613f563bd
 ```
 
 Returns the full [Cart Response](#cart-response) on success, or an [Error Response](#error-response) on failure.
@@ -366,7 +366,7 @@ POST /cart/update-item
 | `quantity` | integer |   Yes    | Quantity of this item in the cart. |
 
 ```sh
-curl --header "X-WC-Store-API-Nonce: 12345" --request POST https://example-store.com/wp-json/wc/store/v1/cart/update-item?key=e369853df766fa44e1ed0ff613f563bd&quantity=10
+curl --header "Nonce: 12345" --request POST https://example-store.com/wp-json/wc/store/v1/cart/update-item?key=e369853df766fa44e1ed0ff613f563bd&quantity=10
 ```
 
 Returns the full [Cart Response](#cart-response) on success, or an [Error Response](#error-response) on failure.
@@ -386,7 +386,7 @@ POST /cart/apply-coupon/
 | `code`    | string |   Yes    | The coupon code you wish to apply to the cart. |
 
 ```sh
-curl --header "X-WC-Store-API-Nonce: 12345" --request POST https://example-store.com/wp-json/wc/store/v1/cart/apply-coupon?code=20off
+curl --header "Nonce: 12345" --request POST https://example-store.com/wp-json/wc/store/v1/cart/apply-coupon?code=20off
 ```
 
 Returns the full [Cart Response](#cart-response) on success, or an [Error Response](#error-response) on failure.
@@ -406,7 +406,7 @@ POST /cart/remove-coupon/
 | `code`    | string |   Yes    | The coupon code you wish to remove from the cart. |
 
 ```sh
-curl --header "X-WC-Store-API-Nonce: 12345" --request POST https://example-store.com/wp-json/wc/store/v1/cart/remove-coupon?code=20off
+curl --header "Nonce: 12345" --request POST https://example-store.com/wp-json/wc/store/v1/cart/remove-coupon?code=20off
 ```
 
 Returns the full [Cart Response](#cart-response) on success, or an [Error Response](#error-response) on failure.
@@ -462,16 +462,15 @@ POST /cart/select-shipping-rate
 | `rate_id`    | string  |   yes    | The chosen rate ID for the package. |
 
 ```sh
-curl --header "X-WC-Store-API-Nonce: 12345" --request POST /cart/select-shipping-rate?package_id=1&rate_id=flat_rate:1
+curl --header "Nonce: 12345" --request POST /cart/select-shipping-rate?package_id=1&rate_id=flat_rate:1
 ```
 
 Returns the full [Cart Response](#cart-response) on success, or an [Error Response](#error-response) on failure.
 
-<!-- FEEDBACK -->
----
+## <!-- FEEDBACK -->
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./src/StoreApi/docs/cart.md)
-<!-- /FEEDBACK -->
 
+<!-- /FEEDBACK -->

--- a/src/StoreApi/docs/cart.md
+++ b/src/StoreApi/docs/cart.md
@@ -467,7 +467,7 @@ curl --header "Nonce: 12345" --request POST /cart/select-shipping-rate?package_i
 
 Returns the full [Cart Response](#cart-response) on success, or an [Error Response](#error-response) on failure.
 
-## <!-- FEEDBACK -->
+<!-- FEEDBACK -->
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 

--- a/src/StoreApi/docs/checkout.md
+++ b/src/StoreApi/docs/checkout.md
@@ -130,7 +130,7 @@ curl --header "Nonce: 12345" --request POST https://example-store.com/wp-json/wc
 }
 ```
 
-## <!-- FEEDBACK -->
+<!-- FEEDBACK -->
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 

--- a/src/StoreApi/docs/checkout.md
+++ b/src/StoreApi/docs/checkout.md
@@ -20,7 +20,7 @@ GET /wc/store/v1/checkout
 There are no parameters required for this endpoint.
 
 ```sh
-curl --header "X-WC-Store-API-Nonce: 12345" --request GET https://example-store.com/wp-json/wc/store/v1/checkout
+curl --header "Nonce: 12345" --request GET https://example-store.com/wp-json/wc/store/v1/checkout
 ```
 
 **Example response:**
@@ -85,7 +85,7 @@ POST /wc/store/v1/checkout
 | `payment_data`     | array   |    No    | Data to pass through to the payment method when processing payment. |
 
 ```sh
-curl --header "X-WC-Store-API-Nonce: 12345" --request POST https://example-store.com/wp-json/wc/store/v1/checkout?payment_method=paypal&payment_data[0][key]=test-key&payment_data[0][value]=test-value
+curl --header "Nonce: 12345" --request POST https://example-store.com/wp-json/wc/store/v1/checkout?payment_method=paypal&payment_data[0][key]=test-key&payment_data[0][value]=test-value
 ```
 
 **Example response:**
@@ -130,11 +130,10 @@ curl --header "X-WC-Store-API-Nonce: 12345" --request POST https://example-store
 }
 ```
 
-<!-- FEEDBACK -->
----
+## <!-- FEEDBACK -->
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./src/StoreApi/docs/checkout.md)
-<!-- /FEEDBACK -->
 
+<!-- /FEEDBACK -->

--- a/src/StoreApi/docs/nonce-tokens.md
+++ b/src/StoreApi/docs/nonce-tokens.md
@@ -45,7 +45,7 @@ Nonce checks will be bypassed if `woocommerce_store_api_disable_nonce_check` eva
 
 NOTE: This should only be done on development sites where security is not important. Do not enable this in production.
 
-## <!-- FEEDBACK -->
+<!-- FEEDBACK -->
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 

--- a/src/StoreApi/docs/nonce-tokens.md
+++ b/src/StoreApi/docs/nonce-tokens.md
@@ -13,15 +13,15 @@ POST requests to the `/cart` endpoints and all requests to the `/checkout` endpo
 
 ## Sending Nonce Tokens with requests
 
-Nonce tokens are included with the request headers. Create a request header named `X-WC-Store-API-Nonce`. This will be validated by the API.
+Nonce tokens are included with the request headers. Create a request header named `Nonce`. This will be validated by the API.
 
 **Example:**
 
 ```sh
-curl --header "X-WC-Store-API-Nonce: 12345" --request GET https://example-store.com/wp-json/wc/store/v1/checkout
+curl --header "Nonce: 12345" --request GET https://example-store.com/wp-json/wc/store/v1/checkout
 ```
 
-After making a successful request, an updated `X-WC-Store-API-Nonce` header will be sent back--this needs to be stored and updated by the client to make subsequent requests.
+After making a successful request, an updated `Nonce` header will be sent back--this needs to be stored and updated by the client to make subsequent requests.
 
 ## Generating security nonces from WordPress
 
@@ -45,11 +45,10 @@ Nonce checks will be bypassed if `woocommerce_store_api_disable_nonce_check` eva
 
 NOTE: This should only be done on development sites where security is not important. Do not enable this in production.
 
-<!-- FEEDBACK -->
----
+## <!-- FEEDBACK -->
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./src/StoreApi/docs/nonce-tokens.md)
-<!-- /FEEDBACK -->
 
+<!-- /FEEDBACK -->

--- a/tests/php/StoreApi/Routes/Batch.php
+++ b/tests/php/StoreApi/Routes/Batch.php
@@ -42,7 +42,7 @@ class Batch extends ControllerTestCase {
 	 */
 	public function test_success_cart_route_batch() {
 		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/batch' );
-		$request->set_header( 'X-WC-Store-API-Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
 		$request->set_body_params(
 			array(
 				'requests' => array(
@@ -54,7 +54,7 @@ class Batch extends ControllerTestCase {
 							'quantity' => 1,
 						),
 						'headers' => array(
-							'X-WC-Store-API-Nonce' => wp_create_nonce( 'wc_store_api' ),
+							'Nonce' => wp_create_nonce( 'wc_store_api' ),
 						),
 					),
 					array(
@@ -65,7 +65,7 @@ class Batch extends ControllerTestCase {
 							'quantity' => 1,
 						),
 						'headers' => array(
-							'X-WC-Store-API-Nonce' => wp_create_nonce( 'wc_store_api' ),
+							'Nonce' => wp_create_nonce( 'wc_store_api' ),
 						),
 					),
 				),
@@ -85,7 +85,7 @@ class Batch extends ControllerTestCase {
 	 */
 	public function test_mix_cart_route_batch() {
 		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/batch' );
-		$request->set_header( 'X-WC-Store-API-Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
 		$request->set_body_params(
 			array(
 				'requests' => array(
@@ -97,7 +97,7 @@ class Batch extends ControllerTestCase {
 							'quantity' => 1,
 						),
 						'headers' => array(
-							'X-WC-Store-API-Nonce' => wp_create_nonce( 'wc_store_api' ),
+							'Nonce' => wp_create_nonce( 'wc_store_api' ),
 						),
 					),
 					array(
@@ -108,7 +108,7 @@ class Batch extends ControllerTestCase {
 							'quantity' => 1,
 						),
 						'headers' => array(
-							'X-WC-Store-API-Nonce' => wp_create_nonce( 'wc_store_api' ),
+							'Nonce' => wp_create_nonce( 'wc_store_api' ),
 						),
 					),
 				),
@@ -127,7 +127,7 @@ class Batch extends ControllerTestCase {
 	 */
 	public function test_get_cart_route_batch() {
 		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/batch' );
-		$request->set_header( 'X-WC-Store-API-Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
 		$request->set_body_params(
 			array(
 				'requests' => array(

--- a/tests/php/StoreApi/Routes/Cart.php
+++ b/tests/php/StoreApi/Routes/Cart.php
@@ -107,7 +107,7 @@ class Cart extends ControllerTestCase {
 	 */
 	public function test_remove_bad_cart_item() {
 		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/remove-item' );
-		$request->set_header( 'X-WC-Store-API-Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
 		$request->set_body_params(
 			array(
 				'key' => 'bad_item_key_123',
@@ -127,7 +127,7 @@ class Cart extends ControllerTestCase {
 	 */
 	public function test_remove_cart_item() {
 		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/remove-item' );
-		$request->set_header( 'X-WC-Store-API-Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
 		$request->set_body_params(
 			array(
 				'key' => $this->keys[0],
@@ -163,7 +163,7 @@ class Cart extends ControllerTestCase {
 	 */
 	public function test_update_item() {
 		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/update-item' );
-		$request->set_header( 'X-WC-Store-API-Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
 		$request->set_body_params(
 			array(
 				'key'      => $this->keys[0],
@@ -192,7 +192,7 @@ class Cart extends ControllerTestCase {
 	 */
 	public function test_update_customer() {
 		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/update-customer' );
-		$request->set_header( 'X-WC-Store-API-Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
 		$request->set_body_params(
 			array(
 				'shipping_address' => (object) array(
@@ -233,7 +233,7 @@ class Cart extends ControllerTestCase {
 	 */
 	public function test_update_customer_address() {
 		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/update-customer' );
-		$request->set_header( 'X-WC-Store-API-Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
 		$request->set_body_params(
 			array(
 				'shipping_address' => (object) array(
@@ -269,7 +269,7 @@ class Cart extends ControllerTestCase {
 
 		// Address with invalid country.
 		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/update-customer' );
-		$request->set_header( 'X-WC-Store-API-Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
 		$request->set_body_params(
 			array(
 				'shipping_address' => (object) array(
@@ -291,7 +291,7 @@ class Cart extends ControllerTestCase {
 
 		// US address with named state.
 		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/update-customer' );
-		$request->set_header( 'X-WC-Store-API-Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
 		$request->set_body_params(
 			array(
 				'shipping_address' => (object) array(
@@ -323,7 +323,7 @@ class Cart extends ControllerTestCase {
 
 		// US address with invalid state.
 		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/update-customer' );
-		$request->set_header( 'X-WC-Store-API-Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
 		$request->set_body_params(
 			array(
 				'shipping_address' => (object) array(
@@ -345,7 +345,7 @@ class Cart extends ControllerTestCase {
 
 		// US address with invalid postcode.
 		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/update-customer' );
-		$request->set_header( 'X-WC-Store-API-Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
 		$request->set_body_params(
 			array(
 				'shipping_address' => (object) array(
@@ -374,7 +374,7 @@ class Cart extends ControllerTestCase {
 		wc()->cart->remove_coupon( $this->coupon->get_code() );
 
 		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/apply-coupon' );
-		$request->set_header( 'X-WC-Store-API-Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
 		$request->set_body_params(
 			array(
 				'code' => $this->coupon->get_code(),
@@ -395,7 +395,7 @@ class Cart extends ControllerTestCase {
 		// Test coupons with different case.
 		$newcoupon = $fixtures->get_coupon( array( 'code' => 'testCoupon' ) );
 		$request   = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/apply-coupon' );
-		$request->set_header( 'X-WC-Store-API-Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
 		$request->set_body_params(
 			array(
 				'code' => 'testCoupon',
@@ -409,7 +409,7 @@ class Cart extends ControllerTestCase {
 		// Test coupons with special chars in the code.
 		$newcoupon = $fixtures->get_coupon( array( 'code' => '$5 off' ) );
 		$request   = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/apply-coupon' );
-		$request->set_header( 'X-WC-Store-API-Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
 		$request->set_body_params(
 			array(
 				'code' => '$5 off',
@@ -427,7 +427,7 @@ class Cart extends ControllerTestCase {
 	public function test_remove_coupon() {
 		// Invalid coupon.
 		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/remove-coupon' );
-		$request->set_header( 'X-WC-Store-API-Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
 		$request->set_body_params(
 			array(
 				'code' => 'doesnotexist',
@@ -440,7 +440,7 @@ class Cart extends ControllerTestCase {
 
 		// Applied coupon.
 		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/remove-coupon' );
-		$request->set_header( 'X-WC-Store-API-Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
 		$request->set_body_params(
 			array(
 				'code' => $this->coupon->get_code(),

--- a/tests/php/StoreApi/Routes/CartCoupons.php
+++ b/tests/php/StoreApi/Routes/CartCoupons.php
@@ -81,7 +81,7 @@ class CartCoupons extends ControllerTestCase {
 		wc()->cart->remove_coupons();
 
 		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/coupons' );
-		$request->set_header( 'X-WC-Store-API-Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
 		$request->set_body_params(
 			array(
 				'code' => $this->coupon->get_code(),
@@ -103,7 +103,7 @@ class CartCoupons extends ControllerTestCase {
 		wc()->cart->remove_coupons();
 
 		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/coupons' );
-		$request->set_header( 'X-WC-Store-API-Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
 		$request->set_body_params(
 			array(
 				'code' => 'IDONOTEXIST',
@@ -120,21 +120,21 @@ class CartCoupons extends ControllerTestCase {
 	 */
 	public function test_delete_item() {
 		$request = new \WP_REST_Request( 'DELETE', '/wc/store/v1/cart/coupons/' . $this->coupon->get_code() );
-		$request->set_header( 'X-WC-Store-API-Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
 		$this->assertAPIResponse(
 			$request,
 			204
 		);
 
 		$request = new \WP_REST_Request( 'DELETE', '/wc/store/v1/cart/coupons/' . $this->coupon->get_code() );
-		$request->set_header( 'X-WC-Store-API-Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
 		$this->assertAPIResponse(
 			$request,
 			404
 		);
 
 		$request = new \WP_REST_Request( 'DELETE', '/wc/store/v1/cart/coupons/i-do-not-exist' );
-		$request->set_header( 'X-WC-Store-API-Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
 		$this->assertAPIResponse(
 			$request,
 			404
@@ -146,7 +146,7 @@ class CartCoupons extends ControllerTestCase {
 	 */
 	public function test_delete_items() {
 		$request = new \WP_REST_Request( 'DELETE', '/wc/store/v1/cart/coupons' );
-		$request->set_header( 'X-WC-Store-API-Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
 		$this->assertAPIResponse(
 			$request,
 			200,

--- a/tests/php/StoreApi/Routes/CartExtensions.php
+++ b/tests/php/StoreApi/Routes/CartExtensions.php
@@ -17,7 +17,7 @@ class CartExtensions extends ControllerTestCase {
 	 */
 	public function test_post() {
 		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/extensions' );
-		$request->set_header( 'X-WC-Store-API-Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
 		$request->set_body_params(
 			array(
 				'namespace' => 'test-plugin',

--- a/tests/php/StoreApi/Routes/CartItems.php
+++ b/tests/php/StoreApi/Routes/CartItems.php
@@ -132,7 +132,7 @@ class CartItems extends ControllerTestCase {
 		wc_empty_cart();
 
 		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/items' );
-		$request->set_header( 'X-WC-Store-API-Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
 		$request->set_body_params(
 			array(
 				'id'       => $this->products[0]->get_id(),
@@ -174,7 +174,7 @@ class CartItems extends ControllerTestCase {
 		);
 
 		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/cart/items' );
-		$request->set_header( 'X-WC-Store-API-Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
 		$request->set_body_params(
 			array(
 				'id'       => $invalid_product->get_id(),
@@ -192,7 +192,7 @@ class CartItems extends ControllerTestCase {
 	 */
 	public function test_update_item() {
 		$request = new \WP_REST_Request( 'PUT', '/wc/store/v1/cart/items/' . $this->keys[0] );
-		$request->set_header( 'X-WC-Store-API-Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
 		$request->set_body_params(
 			array(
 				'quantity' => '10',
@@ -210,7 +210,7 @@ class CartItems extends ControllerTestCase {
 	 */
 	public function test_delete_item() {
 		$request = new \WP_REST_Request( 'DELETE', '/wc/store/v1/cart/items/' . $this->keys[0] );
-		$request->set_header( 'X-WC-Store-API-Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
 		$this->assertAPIResponse(
 			$request,
 			204,
@@ -218,7 +218,7 @@ class CartItems extends ControllerTestCase {
 		);
 
 		$request = new \WP_REST_Request( 'DELETE', '/wc/store/v1/cart/items/' . $this->keys[0] );
-		$request->set_header( 'X-WC-Store-API-Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
 		$this->assertAPIResponse(
 			$request,
 			404
@@ -230,7 +230,7 @@ class CartItems extends ControllerTestCase {
 	 */
 	public function test_delete_items() {
 		$request = new \WP_REST_Request( 'DELETE', '/wc/store/v1/cart/items' );
-		$request->set_header( 'X-WC-Store-API-Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 

--- a/tests/php/StoreApi/Routes/Checkout.php
+++ b/tests/php/StoreApi/Routes/Checkout.php
@@ -117,7 +117,7 @@ class Checkout extends MockeryTestCase {
 	 */
 	public function test_post_extension_data() {
 		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/checkout' );
-		$request->set_header( 'X-WC-Store-API-Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
 		$request->set_body_params(
 			array(
 				'billing_address'  => (object) array(
@@ -175,7 +175,7 @@ class Checkout extends MockeryTestCase {
 	 */
 	public function test_post_invalid_extension_data() {
 		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/checkout' );
-		$request->set_header( 'X-WC-Store-API-Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
 		$request->set_body_params(
 			array(
 				'billing_address'  => (object) array(
@@ -224,7 +224,7 @@ class Checkout extends MockeryTestCase {
 		update_option( 'woocommerce_enable_signup_and_login_from_checkout', 'yes' );
 
 		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/checkout' );
-		$request->set_header( 'X-WC-Store-API-Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
 		$request->set_body_params(
 			array(
 				'billing_address'  => (object) array(
@@ -281,7 +281,7 @@ class Checkout extends MockeryTestCase {
 		update_option( 'woocommerce_enable_signup_and_login_from_checkout', 'yes' );
 
 		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/checkout' );
-		$request->set_header( 'X-WC-Store-API-Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
 		$request->set_body_params(
 			array(
 				'billing_address'  => (object) array(
@@ -335,7 +335,7 @@ class Checkout extends MockeryTestCase {
 		update_option( 'woocommerce_enable_signup_and_login_from_checkout', 'yes' );
 
 		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/checkout' );
-		$request->set_header( 'X-WC-Store-API-Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
 		$request->set_body_params(
 			array(
 				'billing_address'  => (object) array(


### PR DESCRIPTION
I've read in a few places that `X-` prefixed HTTP headers are no longer recommended. Before we officially launch Store API v1, I thought it might be a good time to rename them.

Ref: https://www.keycdn.com/support/custom-http-headers#naming-conventions

Renames:

- `X-WC-Store-Api-Nonce` to `Nonce`
- `X-WC-Store-Api-Nonce-Timestamp` to `Nonce-Timestamp`
- `X-WC-Store-User` to `User-ID`

### Testing

Covered by unit tests.

### Changelog

> Renamed Store API custom headers to remove `X-WC-Store-API` prefixes.

### Dev Note

As part of finalising the Store API, we've removed all `X-` prefixes from headers since this is no longer a recommended practice. The `X-WC-Store-API-Nonce` has been renamed to just `Nonce` going forward. If you've been consuming the experimental Store API, this will need to be renamed in your client. This also includes `X-WC-Store-Api-Nonce-Timestamp` to `Nonce-Timestamp` and `X-WC-Store-User` to `User-ID`.