### PR TITLE
Critical flows: Shopper → Cart → Can view empty cart message

### DIFF
--- a/tests/e2e/specs/shopper/cart-empty.test.js
+++ b/tests/e2e/specs/shopper/cart-empty.test.js
@@ -1,0 +1,23 @@
+/**
+ * Internal dependencies
+ */
+import { shopper } from '../../../utils';
+
+if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 )
+	// eslint-disable-next-line jest/no-focused-tests
+	test.only( `skipping ${ block.name } tests`, () => {} );
+
+describe( 'Shopper → Cart → Can remove product', () => {
+	beforeAll( async () => {
+		await shopper.block.emptyCart();
+	} );
+
+	it( 'Can remove product from cart', async () => {
+		await shopper.block.goToCart();
+
+		// Verify cart is empty'
+		await expect( page ).toMatchElement( 'h2', {
+			text: 'Your cart is currently empty!',
+		} );
+	} );
+} );

--- a/tests/e2e/specs/shopper/cart-empty.test.js
+++ b/tests/e2e/specs/shopper/cart-empty.test.js
@@ -7,12 +7,12 @@ if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 )
 	// eslint-disable-next-line jest/no-focused-tests
 	test.only( `skipping ${ block.name } tests`, () => {} );
 
-describe( 'Shopper → Cart → Can remove product', () => {
+describe( 'Shopper → Cart → Can view empty cart message', () => {
 	beforeAll( async () => {
 		await shopper.block.emptyCart();
 	} );
 
-	it( 'Can remove product from cart', async () => {
+	it( 'Shopper Can view empty cart message', async () => {
 		await shopper.block.goToCart();
 
 		// Verify cart is empty'


### PR DESCRIPTION
<!-- Reference any related issues or PRs here -->
Fixes #5753

This PR adds e2e tests to verify that a shopper can view empty cart message.


### Testing

#### Automated Tests
* [x] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Check out this PR.
2. Start Docker Desktop.
3. Run `npm run wp-env destroy && npm run wp-env start` to start a fresh e2e environment.
4. Run `npm run test:e2e-dev -- tests/e2e/specs/shopper/cart-empty.test.js` to run only this test case.
5. Make sure all tests pass. 

