### PR TITLE
Ignore storybook dist folder when running eslint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -7,3 +7,4 @@ node_modules
 vendor
 legacy
 tests/e2e/specs
+storybook/dist

--- a/.eslintignore
+++ b/.eslintignore
@@ -6,5 +6,6 @@ languages
 node_modules
 vendor
 legacy
+reports
 tests/e2e/specs
 storybook/dist


### PR DESCRIPTION
Recently we saw that running `npm run lint:js` yielded nothing, after running `npm run lint:js -- --debug` (h/t @tomasztunik ) we found that Storybook dist folder is being included and it's blocking the linter from returning.

I excluded that folder and the command is working fine now.

### Steps to reproduce:

- `npm run storybook:build` to generate the dist folder.
- `npm run lint:js` should work just fine and return.