### PR TITLE
Fix: Exclude Button block from the Empty Mini Cart Contents block insterter

### DIFF
--- a/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/allowed-blocks.ts
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/inner-blocks/allowed-blocks.ts
@@ -19,6 +19,7 @@ const EXCLUDED_BLOCKS: readonly string[] = [
 	'core/post-comments-count',
 	'core/comments-pagination',
 	'core/post-navigation-link',
+	'core/button',
 ];
 
 export const getMiniCartAllowedBlocks = (): string[] =>


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #6030

This PR excludes the `<Button>` block from the allowed inner blocks for Empty and Filled Mini Cart Contents blocks. By doing so, users won't accidentally insert the `<Button>` to Mini Cart Contents.

### Screenshots
<img width="1372" alt="image" src="https://user-images.githubusercontent.com/5423135/157654858-ad260da7-61f6-401f-973c-297022e7e2e4.png">

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Edit Mini Cart Contents template part.
2. Switch to Empty Mini Cart Contents.
3. Try adding a new block.
4. Don't see the Button block.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
* [ ] See steps below.