### PR TITLE
Correctly load JS translations from WC core (II)

### DIFF
--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -204,13 +204,22 @@ function woocommerce_blocks_get_i18n_data_json( $translations, $file, $handle, $
 	} )( "{$domain}", {$json_translations} );
 JS;
 
-	// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.NoExplicitVersion
-	wp_register_script( $handle_filename, '', array( 'wp-i18n' ), false, true );
-	wp_enqueue_script( $handle_filename );
-	wp_add_inline_script(
-		$handle_filename,
-		$output
-	);
+	if ( count( $wp_scripts->done ) === 0 ) {
+		// If we hadn't printed any script into the page, let's enqueue the translations.
+		// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.NoExplicitVersion
+		wp_register_script( $handle_filename, '', array( 'wp-i18n' ), false, true );
+		wp_enqueue_script( $handle_filename );
+		wp_add_inline_script(
+			$handle_filename,
+			$output
+		);
+	} else {
+		// If we have already printed scripts into the page, there is the change that
+		// scripts have finished being printed. That means that if we enqueued them here,
+		// they would never be printed. Instead of enqueuing, then, let's print directly
+		// the script tag.
+		printf( "<script type='text/javascript'>\n%s\n</script>\n", $output ); // phpcs:ignore
+	}
 
 	// Finally, short circuit the pre_load_script_translations hook by returning
 	// the translation JSON from the feature plugin, if it exists so this hook

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -214,7 +214,7 @@ JS;
 			$output
 		);
 	} else {
-		// If we have already printed scripts into the page, there is the change that
+		// If we have already printed scripts into the page, there is a chance that
 		// scripts have finished being printed. That means that if we enqueued them here,
 		// they would never be printed. Instead of enqueuing, then, let's print directly
 		// the script tag.

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -204,7 +204,7 @@ function woocommerce_blocks_get_i18n_data_json( $translations, $file, $handle, $
 	} )( "{$domain}", {$json_translations} );
 JS;
 
-	if ( count( $wp_scripts->done ) === 0 ) {
+	if ( empty( $wp_scripts->done ) ) {
 		// If we hadn't printed any script into the page, let's enqueue the translations.
 		// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.NoExplicitVersion
 		wp_register_script( $handle_filename, '', array( 'wp-i18n' ), false, true );


### PR DESCRIPTION
Might be related to #6031, but I'm not 100% sure because I wasn't able to reproduce that one.

The reason of the issue is that in #5910 we changed how translation scripts are loaded. Instead of directly printing them to the page, we now enqueue them. That works well for most of them, except the ones that are being rendered in the footer. At that point, enqueuing a new script won't work because after scripts are printed in the footer, they aren't printed again, that means they will miss the last opportunity to be printed.

What this PR does is that it checks if scripts have already been printed into the page or not. If they haven't, it enqueues the script, if they have, if directly prints the script.

### Manual Testing

1. Go to Settings > General > Language (`/wp-admin/options-general.php`) and select a language which has WC core translation at 100% but WC Blocks' at 0%. (I tested with `Català`).
2. Go to the updates screen (`/wp-admin/update-core.php`), scroll down and update the language translations.
3. Visit the Cart or Checkout block in the frontend and verify **all texts** are translated.

Before #6031| `trunk` | With this fix
--- | --- | ---
![imatge](https://user-images.githubusercontent.com/3616980/157656628-e487b279-706c-485f-a18e-b73cc514dfbf.png) | ![imatge](https://user-images.githubusercontent.com/3616980/157655482-20720748-61ab-4920-a8e7-47405729b051.png) | ![imatge](https://user-images.githubusercontent.com/3616980/157655424-d679f8f5-3b3d-49e9-8a00-9153fac9252a.png)

_(notice some input fields aren't translated in `trunk`)_

There are other blocks affected, like Filter Products by Attribute.

@mikejolley given that this can be considered a regression introduced in WC Blocks 7.1.0, should we include it in 7.2.0?

### Changelog

> Fix loading more WC core translations in locales where WC Blocks is not localized for some strings.
