### PR TITLE
Remove not necessary todo

### DIFF
--- a/src/BlockTypesController.php
+++ b/src/BlockTypesController.php
@@ -150,7 +150,6 @@ final class BlockTypesController {
 	protected function get_block_types() {
 		global $wp_version, $pagenow;
 
-		// @todo Add a comment why some atomic blocks are included in this array.
 		$block_types = [
 			'AllReviews',
 			'FeaturedCategory',


### PR DESCRIPTION
After #5989 we don't have any more `atomic blocks`. This PR removes an older to-do comment.

Fix #5827 