### PR TITLE
Fix box-sizing on Global Styles blocks with border width control

### DIFF
--- a/assets/js/atomic/blocks/product-elements/sale-badge/style.scss
+++ b/assets/js/atomic/blocks/product-elements/sale-badge/style.scss
@@ -6,6 +6,7 @@
 	width: auto;
 	border: 1px solid #43454b;
 	border-radius: 3px;
+	box-sizing: border-box;
 	color: #43454b;
 	background: #fff;
 	text-align: center;

--- a/assets/js/blocks/featured-category/style.scss
+++ b/assets/js/blocks/featured-category/style.scss
@@ -3,6 +3,7 @@
 	border-color: transparent;
 	color: #fff;
 	overflow: hidden;
+	box-sizing: border-box;
 }
 
 .wc-block-featured-category {

--- a/assets/js/blocks/featured-product/style.scss
+++ b/assets/js/blocks/featured-product/style.scss
@@ -3,6 +3,7 @@
 	border-color: transparent;
 	color: #fff;
 	overflow: hidden;
+	box-sizing: border-box;
 }
 
 .wc-block-featured-product {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@woocommerce/block-library",
-	"version": "7.2.0-dev",
+	"version": "7.3.0-dev",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@woocommerce/block-library",
-			"version": "7.2.0-dev",
+			"version": "7.3.0-dev",
 			"hasInstallScript": true,
 			"license": "GPL-3.0+",
 			"dependencies": {


### PR DESCRIPTION
Set box-sizing to border-box on affected blocks: Featured product, featured category, sale badge.

This caused blocks with border width set to overflow container blocks (column etc.) horizontally potentially causing horizontal scrollbar to show up or layouts render in unexpected way.

### Screenshots

| before | after |
| - | - |
|  ![Screenshot 2022-03-11 at 11 30 14](https://user-images.githubusercontent.com/112270/157851531-bfa825c1-7356-4592-affe-e53ecbd75b31.jpg) |  ![Screenshot 2022-03-11 at 11 31 50](https://user-images.githubusercontent.com/112270/157851561-0a2848b2-caa2-4a6e-b620-0e9629cd792b.jpg) |

