### PR TITLE
Revert "Remove .gitattributes file"

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,32 @@
+# Ignore all hidden files and directories
+/.* export-ignore
+
+# Ignore all markdown files
+/*.md export-ignore
+
+# Ignore following directories and contents
+/node_modules* export-ignore
+/tests export-ignore
+/bin export-ignore
+/docs export-ignore
+/storybook export-ignore
+
+# Ignore following configuration files
+/phpcs.xml export-ignore
+/phpunit.* export-ignore
+/composer.lock export-ignore
+/composer.json export-ignore
+/CODEOWNERS export-ignore
+/renovate.json export-ignore
+/webpack.config.js export-ignore
+/postcss.config.js export-ignore
+/bundlesize.config.json export-ignore
+/package.json export-ignore
+/package-lock.json export-ignore
+/babel.config.js export-ignore
+/docker-compose.yml export-ignore
+/globals.d.ts export-ignore
+/tsconfig.json export-ignore
+/tsconfig.base.json export-ignore
+/tsconfig.base export-ignore
+/webpack.config.js export-ignore


### PR DESCRIPTION
Reverts woocommerce/woocommerce-gutenberg-products-block#5242

While reverting this does "break" the source zip for releases, the larger issue is that this broke the composer packages from https://packagist.org/packages/woocommerce/woocommerce-blocks#v6.9.0, meaning WooCommerce core would bundle `/bin` and other development directories after installing the blocks package.

We need to revert this and decide on a better solution e.g. cleanup on the core side after installing the package.

cc @senadir 