### PR TITLE
Checkout: Missing country error for virtual orders (edge case)

### DIFF
--- a/assets/js/base/context/providers/cart-checkout/checkout-processor.js
+++ b/assets/js/base/context/providers/cart-checkout/checkout-processor.js
@@ -48,7 +48,7 @@ const CheckoutProcessor = () => {
 	const { hasValidationErrors } = useValidationContext();
 	const { shippingErrorStatus } = useShippingDataContext();
 	const { billingData, shippingAddress } = useCustomerDataContext();
-	const { cartNeedsPayment, receiveCart } = useStoreCart();
+	const { cartNeedsPayment, cartNeedsShipping, receiveCart } = useStoreCart();
 	const {
 		activePaymentMethod,
 		isExpressPaymentMethodActive,
@@ -185,14 +185,17 @@ const CheckoutProcessor = () => {
 			billing_address: emptyHiddenAddressFields(
 				currentBillingData.current
 			),
-			shipping_address: emptyHiddenAddressFields(
-				currentShippingAddress.current
-			),
 			customer_note: orderNotes,
 			create_account: shouldCreateAccount,
 			...paymentData,
 			extensions: { ...extensionData },
 		};
+
+		if ( cartNeedsShipping ) {
+			data.shipping_address = emptyHiddenAddressFields(
+				currentShippingAddress.current
+			);
+		}
 
 		triggerFetch( {
 			path: '/wc/store/v1/checkout',
@@ -265,14 +268,15 @@ const CheckoutProcessor = () => {
 	}, [
 		isProcessingOrder,
 		removeNotice,
-		orderNotes,
-		shouldCreateAccount,
 		cartNeedsPayment,
 		paymentMethodId,
 		paymentMethodData,
 		shouldSavePayment,
 		activePaymentMethod,
+		orderNotes,
+		shouldCreateAccount,
 		extensionData,
+		cartNeedsShipping,
 		dispatchActions,
 		addErrorNotice,
 		receiveCart,

--- a/src/StoreApi/Routes/V1/Checkout.php
+++ b/src/StoreApi/Routes/V1/Checkout.php
@@ -393,21 +393,21 @@ class Checkout extends AbstractCartRoute {
 	private function update_customer_from_request( \WP_REST_Request $request ) {
 		$customer = wc()->customer;
 
-		if ( isset( $request['billing_address'] ) ) {
-			foreach ( $request['billing_address'] as $key => $value ) {
-				if ( is_callable( [ $customer, "set_billing_$key" ] ) ) {
-					$customer->{"set_billing_$key"}( $value );
-				}
+		// Billing address is a required field.
+		foreach ( $request['billing_address'] as $key => $value ) {
+			if ( is_callable( [ $customer, "set_billing_$key" ] ) ) {
+				$customer->{"set_billing_$key"}( $value );
 			}
 		}
 
-		if ( isset( $request['shipping_address'] ) ) {
-			foreach ( $request['shipping_address'] as $key => $value ) {
-				if ( is_callable( [ $customer, "set_shipping_$key" ] ) ) {
-					$customer->{"set_shipping_$key"}( $value );
-				} elseif ( 'phone' === $key ) {
-					$customer->update_meta_data( 'shipping_phone', $value );
-				}
+		// If shipping address (optional field) was not provided, set it to the given billing address (required field).
+		$shipping_address_values = $request['shipping_address'] ?? $request['billing_address'];
+
+		foreach ( $shipping_address_values as $key => $value ) {
+			if ( is_callable( [ $customer, "set_shipping_$key" ] ) ) {
+				$customer->{"set_shipping_$key"}( $value );
+			} elseif ( 'phone' === $key ) {
+				$customer->update_meta_data( 'shipping_phone', $value );
 			}
 		}
 

--- a/src/StoreApi/Schemas/V1/CheckoutSchema.php
+++ b/src/StoreApi/Schemas/V1/CheckoutSchema.php
@@ -107,7 +107,6 @@ class CheckoutSchema extends AbstractSchema {
 					'sanitize_callback' => [ $this->shipping_address_schema, 'sanitize_callback' ],
 					'validate_callback' => [ $this->shipping_address_schema, 'validate_callback' ],
 				],
-				'required'    => true,
 			],
 			'payment_method'    => [
 				'description' => __( 'The ID of the payment method being used to process the payment.', 'woo-gutenberg-products-block' ),


### PR DESCRIPTION
Prevents an error when placing a virtual order without a shipping address.

### Testing

Requires the following setup:

- WC settings > General - set default customer location to "no location by default"
- Create a downloadable, virtual product

Testing steps:

1. Go to the store as a logged out guest in incognito mode
2. Add the virtual/downloadable product to your cart
3. Go to checkout
4. Fill out billing address
5. Place order. It should succeed.
6. Check order details. Shipping should match billing address.

### Changelog

> Ensure shipping address is set for virtual orders to prevent missing country errors.
