### PR TITLE
Fix: Mini Cart Contents: only show the active view

### DIFF
--- a/assets/js/blocks/cart-checkout/mini-cart-contents/editor.scss
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/editor.scss
@@ -4,6 +4,11 @@
 	the mini cart contents on the front end. */
 	margin: 0 auto !important;
 
+	.wp-block-woocommerce-empty-mini-cart-contents-block[hidden],
+	.wp-block-woocommerce-filled-mini-cart-contents-block[hidden] {
+		display: none;
+	}
+
 	.wp-block-woocommerce-filled-mini-cart-contents-block > .block-editor-inner-blocks > .block-editor-block-list__layout {
 		display: flex;
 		flex-direction: column;


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #6028 

This PR adds style for hidden Mini Cart Contents view to fix the issue that both Empty and Filled Mini Cart Contents views are visible in the editor.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

#### Other Checks

- [ ] I've updated [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) for any feature flags or experimental interfaces implemented in this pull request.
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<img width="1372" alt="Screen Shot 2022-03-15 at 15 13 44" src="https://user-images.githubusercontent.com/5423135/158334574-3c294da6-4557-4e3f-8ce1-bf86d89b4960.png">

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Edit Mini Cart template part.
2. Don't see the scroll bar for the Mini Cart Contents block.
3. Can't scroll to see the empty view.
4. Try using view switcher, only one view is visible at a time.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
* [ ] See steps below.
