### PR TITLE
Product Query: allow adding more arguments by applying a filter.

### DIFF
--- a/bin/hook-docs/data/filters.json
+++ b/bin/hook-docs/data/filters.json
@@ -952,6 +952,42 @@
             "args": 3
         },
         {
+            "name": "woocommerce_store_api_product_query_args",
+            "file": "StoreApi/Utilities/ProductQuery.php",
+            "type": "filter",
+            "doc": {
+                "description": "Filters the arguments for the products WP_Query.",
+                "long_description": "",
+                "tags": [
+                    {
+                        "name": "param",
+                        "content": "WP_Query args.",
+                        "types": [
+                            "array"
+                        ],
+                        "variable": "$args"
+                    },
+                    {
+                        "name": "param",
+                        "content": "Request object.",
+                        "types": [
+                            "\\WP_REST_Request"
+                        ],
+                        "variable": "$request"
+                    },
+                    {
+                        "name": "return",
+                        "content": "",
+                        "types": [
+                            "array"
+                        ]
+                    }
+                ],
+                "long_description_html": ""
+            },
+            "args": 2
+        },
+        {
             "name": "woocommerce_variation_option_name",
             "file": "StoreApi/Schemas/V1/CartItemSchema.php",
             "type": "filter",

--- a/docs/extensibility/filters.md
+++ b/docs/extensibility/filters.md
@@ -32,6 +32,7 @@
  - [woocommerce_store_api_disable_nonce_check](#woocommerce_store_api_disable_nonce_check)
  - [woocommerce_store_api_product_quantity_limit](#woocommerce_store_api_product_quantity_limit)
  - [woocommerce_store_api_product_quantity_{$value_type}](#woocommerce_store_api_product_quantity_-value_type)
+ - [woocommerce_store_api_product_query_args](#woocommerce_store_api_product_query_args)
  - [woocommerce_variation_option_name](#woocommerce_variation_option_name)
 
 ---
@@ -805,6 +806,34 @@ apply_filters( 'woocommerce_store_api_product_quantity_{$value_type}', mixed $va
 
 
  - [StoreApi/Utilities/QuantityLimits.php](../src/StoreApi/Utilities/QuantityLimits.php)
+
+---
+
+## woocommerce_store_api_product_query_args
+
+
+Filters the arguments for the products WP_Query.
+
+```php
+apply_filters( 'woocommerce_store_api_product_query_args', array $args, \WP_REST_Request $request )
+```
+
+### Parameters
+
+| Argument | Type | Description |
+| -------- | ---- | ----------- |
+| $args | array | WP_Query args. |
+| $request | \WP_REST_Request | Request object. |
+
+### Returns
+
+
+`array` 
+
+### Source
+
+
+ - [StoreApi/Utilities/ProductQuery.php](../src/StoreApi/Utilities/ProductQuery.php)
 
 ---
 

--- a/src/StoreApi/Utilities/ProductQuery.php
+++ b/src/StoreApi/Utilities/ProductQuery.php
@@ -223,7 +223,14 @@ class ProductQuery {
 			$args['meta_key'] = $ordering_args['meta_key']; // phpcs:ignore
 		}
 
-		return apply_filters( 'store_api_product_query_args', $args, $request );
+		/**
+		 * Filters the arguments for the products WP_Query.
+		 *
+		 * @param array $args WP_Query args.
+		 * @param \WP_REST_Request $request Request object.
+		 * @return array
+		 */
+		return apply_filters( 'woocommerce_store_api_product_query_args', $args, $request );
 	}
 
 	/**

--- a/src/StoreApi/Utilities/ProductQuery.php
+++ b/src/StoreApi/Utilities/ProductQuery.php
@@ -223,7 +223,7 @@ class ProductQuery {
 			$args['meta_key'] = $ordering_args['meta_key']; // phpcs:ignore
 		}
 
-		return $args;
+		return apply_filters( 'store_api_product_query_args', $args, $request );
 	}
 
 	/**


### PR DESCRIPTION
While working on 12894-gh-Automattic/woocommerce.com I have noticed that there aren't any hooks allowing us to extend what arguments can be passed to the `wc/store/products/` API. This PR aims at allowing code outside of this repo to hook into `$query_args` before it gets passed to `WP_Query();`

https://github.com/Automattic/woocommerce.com/blob/476e2a09a2b6e9ff175b9230054ce6ad6dd871a6/plugins/woo-gutenberg-products-block/src/StoreApi/Utilities/ProductQuery.php#L242-L243

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] I've updated [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) for any feature flags or experimental interfaces implemented in this pull request.
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

Perhaps it will be easier testing this 12894-gh-Automattic/woocommerce.com

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [ ] Same as above, or
* [ ] See steps below.

1.
2.
3.

<!-- If you can, add the appropriate labels -->

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Adds `store_api_product_query_args` filter to allow extending the `$query_args` before it gets passed to `WP_Query();`