### PR TITLE
Stop showing the `PricesSlider` skeleton when moving the slider handles

### DIFF
--- a/assets/js/base/components/price-slider/style.scss
+++ b/assets/js/base/components/price-slider/style.scss
@@ -63,8 +63,7 @@
 		}
 	}
 
-	&.is-loading,
-	&.is-disabled {
+	&.is-loading.is-disabled {
 		.wc-block-components-price-slider__range-input-wrapper,
 		.wc-block-components-price-slider__amount,
 		.wc-block-components-price-slider__button {
@@ -267,8 +266,7 @@
 	}
 
 	.wc-block-components-price-slider {
-		&.is-loading,
-		&.is-disabled {
+		&.is-loading.is-disabled {
 			.wc-block-components-price-slider__range-input-wrapper {
 				@include placeholder();
 				box-shadow: none;


### PR DESCRIPTION
The changes on this PR make the `PriceSlider` component only turn into its skeleton form when it is actually loading for the first time (loading & disabled). Before, it was turning into the skeleton also when the user moved and released one of the sliders.

Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5395

![Screen Capture on 2022-03-22 at 15-30-22](https://user-images.githubusercontent.com/186112/159505844-47309e39-1646-49f6-8eb0-88113be9b5c5.gif)

### Testing
How to test the changes in this Pull Request:

1. Create a new page with the "All Products" and the "Filter Products by Price" blocks.
2. Go to the page on the front and check that when the `PriceSlider` loads it shows the skeleton like: <img width="692" alt="Screenshot 2022-03-22 at 15 35 15" src="https://user-images.githubusercontent.com/186112/159506769-f7dab64c-21b0-49a7-bd97-7018086a0ea1.png">
3. After it finishes loading, move the slider handles and check it does not show the skeleton on the slider again.

### Changelog

> Stop showing the price slider skeleton when moving the slider handles.
