### PR TITLE
Filter Products by Attribute: Fix dropdown search case sensitivity

### DIFF
--- a/assets/js/base/components/dropdown-selector/index.js
+++ b/assets/js/base/components/dropdown-selector/index.js
@@ -31,6 +31,7 @@ import './style.scss';
  * @param {boolean} props.multiple Whether multi-select is allowed.
  * @param {function():any} props.onChange Function to be called when onChange event fires.
  * @param {Array} props.options The option values to show in the select.
+ * @param {boolean} props.isCaseSensitive Whether the dropdown search should be case-sensitive.
  */
 const DropdownSelector = ( {
 	attributeLabel = '',
@@ -43,6 +44,7 @@ const DropdownSelector = ( {
 	multiple = false,
 	onChange = () => {},
 	options = [],
+	isCaseSensitive = false,
 } ) => {
 	const inputRef = useRef( null );
 
@@ -182,13 +184,20 @@ const DropdownSelector = ( {
 							getItemProps={ getItemProps }
 							getMenuProps={ getMenuProps }
 							highlightedIndex={ highlightedIndex }
-							options={ options.filter(
-								( option ) =>
+							options={ options.filter( ( option ) => {
+								if ( isCaseSensitive ) {
+									return (
+										! inputValue ||
+										option.value.includes( inputValue )
+									);
+								}
+								return (
 									! inputValue ||
-									option.value.startsWith(
-										inputValue.toLowerCase()
-									)
-							) }
+									option.value
+										.toLowerCase()
+										.includes( inputValue.toLowerCase() )
+								);
+							} ) }
 						/>
 					) }
 				</div>
@@ -212,6 +221,7 @@ DropdownSelector.propTypes = {
 			value: PropTypes.string.isRequired,
 		} )
 	),
+	isCaseSensitive: PropTypes.bool,
 };
 
 export default DropdownSelector;

--- a/assets/js/base/components/dropdown-selector/index.js
+++ b/assets/js/base/components/dropdown-selector/index.js
@@ -31,7 +31,7 @@ import './style.scss';
  * @param {boolean} props.multiple Whether multi-select is allowed.
  * @param {function():any} props.onChange Function to be called when onChange event fires.
  * @param {Array} props.options The option values to show in the select.
- * @param {boolean} props.isCaseSensitive Whether the dropdown search should be case-sensitive.
+ * @param {boolean} [props.isCaseSensitive=false] Whether the dropdown search should be case-sensitive.
  */
 const DropdownSelector = ( {
 	attributeLabel = '',
@@ -185,17 +185,15 @@ const DropdownSelector = ( {
 							getMenuProps={ getMenuProps }
 							highlightedIndex={ highlightedIndex }
 							options={ options.filter( ( option ) => {
-								if ( isCaseSensitive ) {
-									return (
-										! inputValue ||
-										option.name.includes( inputValue )
-									);
+								let optionName = option.name;
+								let nameQuery = inputValue?.trim();
+								if ( ! isCaseSensitive ) {
+									optionName = optionName.toLowerCase();
+									nameQuery = nameQuery?.toLowerCase();
 								}
 								return (
-									! inputValue ||
-									option.name
-										.toLowerCase()
-										.includes( inputValue.toLowerCase() )
+									! nameQuery ||
+									optionName.includes( nameQuery )
 								);
 							} ) }
 						/>

--- a/assets/js/base/components/dropdown-selector/index.js
+++ b/assets/js/base/components/dropdown-selector/index.js
@@ -188,12 +188,12 @@ const DropdownSelector = ( {
 								if ( isCaseSensitive ) {
 									return (
 										! inputValue ||
-										option.value.includes( inputValue )
+										option.name.includes( inputValue )
 									);
 								}
 								return (
 									! inputValue ||
-									option.value
+									option.name
 										.toLowerCase()
 										.includes( inputValue.toLowerCase() )
 								);

--- a/assets/js/base/components/dropdown-selector/index.js
+++ b/assets/js/base/components/dropdown-selector/index.js
@@ -185,7 +185,9 @@ const DropdownSelector = ( {
 							options={ options.filter(
 								( option ) =>
 									! inputValue ||
-									option.value.startsWith( inputValue )
+									option.value.startsWith(
+										inputValue.toLowerCase()
+									)
 							) }
 						/>
 					) }


### PR DESCRIPTION
Fix dropdown search case-sensitivity handling for the Filter Products by Attribute block.

Fixes #5718 

### Screenshots
|Before|After|
|-|-|
|![before](https://user-images.githubusercontent.com/905781/159692538-c43838cb-9bd7-4ad5-a9d7-1bb3f3a77d77.jpg)|![after](https://user-images.githubusercontent.com/905781/159692560-a13d6259-b85c-4068-b0be-42e676dfabdd.jpg)|

### Manual Testing
How to test the changes in this Pull Request:

1. Check out this branch and compile the changes
2. Activate a **block theme**, like Twenty Twenty Two
3. Create a new page, and add the **Filter Products by Attribute** block
4. Change the **Display Style** to **Dropdown**
5. In the **Filter Products by Attribute** section select the attribute you want to be filtering by (in my case 'Size')
6. Test the page on the front-end by searching for product attributes
7. Make sure that relevant values are being found for both Uppercase and Lowercase input

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).

- [x] Same as above

### Changelog

> Filter Products by Attribute: Make dropdown search case sensitive.