### PR TITLE
Allow memoized filters to re-run if `defaultArg` changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Editors
+
 project.xml
 project.properties
 /nbproject/private/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 # Editors
-
 project.xml
 project.properties
 /nbproject/private/


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
In #5143 memoization was added to prevent third party filter functions running unnecessarily. There was no check in place to see if the default value differed between runs. Usually this would be fine because the value is usually static, but in the case of snackbar notices, it is a list that changes based on what notices are in the `core/notices` data store.

This PR will add a check to see if the `defaultValue` has been seen before in previous runs, and if not the filter functions are allowed to run. 

<!-- Reference any related issues or PRs here -->
Fixes #6097

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Create a filter, you can add this code somewhere that will be executed in any JS file.
```
__experimentalRegisterCheckoutFilters('custom-extension', {
  itemName: (name) => {
           console.log('rerunning filter for', name);
	  return `${name} + extra data!`;
  },
});
```
2. Open the browser console and go to the Cart block. Observe the console log added above, ensure it only gets output 1-3 times for each item in the cart. Change the quantity and expect only 1-3 logs for each item again.
3. Create a coupon in your store.
4. Add this coupon to your order in the Cart block, ensure a snackbar notice appears when adding and removing the coupon.
5. Do this multiple times and ensure the snackbar notice appears each time it changes.
6. Repeat step 4 and 5 in the Checkout block.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [ ] Same as above, or
* [x] See steps below.

1. Create a coupon in your store.
2. Add this coupon to your order in the Cart block, ensure a snackbar notice appears when adding and removing the coupon.
3. Do this multiple times and ensure the snackbar notice appears each time it changes.
4. Repeat step 2 and 3 in the Checkout block.

<!-- If you can, add the appropriate labels -->

### Changelog

> Allow memoized checkout filters to re-run if the default value changes between runs.
