### PR TITLE
Improve goToSiteEditor E2E utils

### DIFF
--- a/tests/e2e/specs/backend/site-editing-templates.test.js
+++ b/tests/e2e/specs/backend/site-editing-templates.test.js
@@ -15,7 +15,8 @@ import {
 	DEFAULT_TIMEOUT,
 	filterCurrentBlocks,
 	getAllTemplates,
-	goToSiteEditor,
+	goToTemplateEditor,
+	goToTemplatesList,
 	saveTemplate,
 	useTheme,
 } from '../../utils';
@@ -24,7 +25,7 @@ async function visitTemplateAndAddCustomParagraph(
 	templateSlug,
 	customText = CUSTOMIZED_STRING
 ) {
-	await goToSiteEditor( {
+	await goToTemplateEditor( {
 		postId: `woocommerce/woocommerce//${ templateSlug }`,
 	} );
 
@@ -118,7 +119,7 @@ describe( 'Store Editing Templates', () => {
 		it( 'default template from WooCommerce Blocks is available on an FSE theme', async () => {
 			const EXPECTED_TEMPLATE = defaultTemplateProps( 'Single Product' );
 
-			await goToSiteEditor();
+			await goToTemplatesList();
 
 			const templates = await getAllTemplates();
 
@@ -136,7 +137,7 @@ describe( 'Store Editing Templates', () => {
 		} );
 
 		it( 'should contain the "WooCommerce Single Product Block" classic template', async () => {
-			await goToSiteEditor( {
+			await goToTemplateEditor( {
 				postId: 'woocommerce/woocommerce//single-product',
 			} );
 
@@ -161,7 +162,7 @@ describe( 'Store Editing Templates', () => {
 
 			await visitTemplateAndAddCustomParagraph( 'single-product' );
 
-			await goToSiteEditor( { waitForActions: true } );
+			await goToTemplatesList( { waitFor: 'actions' } );
 
 			const templates = await getAllTemplates();
 
@@ -179,7 +180,7 @@ describe( 'Store Editing Templates', () => {
 		} );
 
 		it( 'should preserve and correctly show the user customization on the back-end', async () => {
-			await goToSiteEditor( {
+			await goToTemplateEditor( {
 				postId: 'woocommerce/woocommerce//single-product',
 			} );
 
@@ -211,7 +212,7 @@ describe( 'Store Editing Templates', () => {
 		it( 'default template from WooCommerce Blocks is available on an FSE theme', async () => {
 			const EXPECTED_TEMPLATE = defaultTemplateProps( 'Product Catalog' );
 
-			await goToSiteEditor();
+			await goToTemplatesList();
 
 			const templates = await getAllTemplates();
 
@@ -229,7 +230,7 @@ describe( 'Store Editing Templates', () => {
 		} );
 
 		it( 'should contain the "WooCommerce Product Grid Block" classic template', async () => {
-			await goToSiteEditor( {
+			await goToTemplateEditor( {
 				postId: 'woocommerce/woocommerce//archive-product',
 			} );
 
@@ -251,7 +252,7 @@ describe( 'Store Editing Templates', () => {
 
 			await visitTemplateAndAddCustomParagraph( 'archive-product' );
 
-			await goToSiteEditor( { waitForActions: true } );
+			await goToTemplatesList( { waitFor: 'actions' } );
 
 			const templates = await getAllTemplates();
 
@@ -269,7 +270,7 @@ describe( 'Store Editing Templates', () => {
 		} );
 
 		it( 'should preserve and correctly show the user customization on the back-end', async () => {
-			await goToSiteEditor( {
+			await goToTemplateEditor( {
 				postId: 'woocommerce/woocommerce//archive-product',
 			} );
 
@@ -304,7 +305,7 @@ describe( 'Store Editing Templates', () => {
 				'Products by Category'
 			);
 
-			await goToSiteEditor();
+			await goToTemplatesList();
 
 			const templates = await getAllTemplates();
 
@@ -322,7 +323,7 @@ describe( 'Store Editing Templates', () => {
 		} );
 
 		it( 'should contain the "WooCommerce Product Taxonomy Block" classic template', async () => {
-			await goToSiteEditor( {
+			await goToTemplateEditor( {
 				postId: 'woocommerce/woocommerce//taxonomy-product_cat',
 			} );
 
@@ -345,7 +346,7 @@ describe( 'Store Editing Templates', () => {
 
 			await visitTemplateAndAddCustomParagraph( 'taxonomy-product_cat' );
 
-			await goToSiteEditor( { waitForActions: true } );
+			await goToTemplatesList( { waitFor: 'actions' } );
 
 			const templates = await getAllTemplates();
 
@@ -363,7 +364,7 @@ describe( 'Store Editing Templates', () => {
 		} );
 
 		it( 'should preserve and correctly show the user customization on the back-end', async () => {
-			await goToSiteEditor( {
+			await goToTemplateEditor( {
 				postId: 'woocommerce/woocommerce//taxonomy-product_cat',
 			} );
 
@@ -392,7 +393,7 @@ describe( 'Store Editing Templates', () => {
 		it( 'default template from WooCommerce Blocks is available on an FSE theme', async () => {
 			const EXPECTED_TEMPLATE = defaultTemplateProps( 'Products by Tag' );
 
-			await goToSiteEditor();
+			await goToTemplatesList();
 
 			const templates = await getAllTemplates();
 
@@ -410,7 +411,7 @@ describe( 'Store Editing Templates', () => {
 		} );
 
 		it( 'should contain the "WooCommerce Product Taxonomy Block" classic template', async () => {
-			await goToSiteEditor( {
+			await goToTemplateEditor( {
 				postId: 'woocommerce/woocommerce//taxonomy-product_tag',
 			} );
 
@@ -433,7 +434,7 @@ describe( 'Store Editing Templates', () => {
 
 			await visitTemplateAndAddCustomParagraph( 'taxonomy-product_tag' );
 
-			await goToSiteEditor( { waitForActions: true } );
+			await goToTemplatesList( { waitFor: 'actions' } );
 
 			const templates = await getAllTemplates();
 
@@ -451,7 +452,7 @@ describe( 'Store Editing Templates', () => {
 		} );
 
 		it( 'should preserve and correctly show the user customization on the back-end', async () => {
-			await goToSiteEditor( {
+			await goToTemplateEditor( {
 				postId: 'woocommerce/woocommerce//taxonomy-product_tag',
 			} );
 

--- a/tests/e2e/specs/backend/site-editing-templates.test.js
+++ b/tests/e2e/specs/backend/site-editing-templates.test.js
@@ -6,7 +6,6 @@ import {
 	getCurrentSiteEditorContent,
 	insertBlock,
 } from '@wordpress/e2e-test-utils';
-import { addQueryArgs } from '@wordpress/url';
 import {
 	getNormalPagePermalink,
 	visitPostOfType,
@@ -19,20 +18,16 @@ import {
 	goToSiteEditor,
 	saveTemplate,
 	useTheme,
-	waitForCanvas,
 } from '../../utils';
 
 async function visitTemplateAndAddCustomParagraph(
 	templateSlug,
 	customText = CUSTOMIZED_STRING
 ) {
-	const templateQuery = addQueryArgs( '', {
+	await goToSiteEditor( {
 		postId: `woocommerce/woocommerce//${ templateSlug }`,
-		postType: 'wp_template',
 	} );
 
-	await goToSiteEditor( templateQuery );
-	await waitForCanvas();
 	await insertBlock( 'Paragraph' );
 	await page.keyboard.type( customText );
 	await saveTemplate();
@@ -123,7 +118,8 @@ describe( 'Store Editing Templates', () => {
 		it( 'default template from WooCommerce Blocks is available on an FSE theme', async () => {
 			const EXPECTED_TEMPLATE = defaultTemplateProps( 'Single Product' );
 
-			await goToSiteEditor( '?postType=wp_template' );
+			await goToSiteEditor();
+
 			const templates = await getAllTemplates();
 
 			try {
@@ -140,13 +136,9 @@ describe( 'Store Editing Templates', () => {
 		} );
 
 		it( 'should contain the "WooCommerce Single Product Block" classic template', async () => {
-			const templateQuery = addQueryArgs( '', {
+			await goToSiteEditor( {
 				postId: 'woocommerce/woocommerce//single-product',
-				postType: 'wp_template',
 			} );
-
-			await goToSiteEditor( templateQuery );
-			await waitForCanvas();
 
 			const [ classicBlock ] = await filterCurrentBlocks(
 				( block ) => block.name === BLOCK_DATA[ 'single-product' ].name
@@ -169,9 +161,8 @@ describe( 'Store Editing Templates', () => {
 
 			await visitTemplateAndAddCustomParagraph( 'single-product' );
 
-			await goToSiteEditor( '?postType=wp_template' );
-			// we need to wait for the selector to show up, sometimes the loading is delayed and test becomes flaky
-			await page.waitForSelector( SELECTORS.templates.templateActions );
+			await goToSiteEditor( { waitForActions: true } );
+
 			const templates = await getAllTemplates();
 
 			try {
@@ -188,13 +179,9 @@ describe( 'Store Editing Templates', () => {
 		} );
 
 		it( 'should preserve and correctly show the user customization on the back-end', async () => {
-			const templateQuery = addQueryArgs( '', {
+			await goToSiteEditor( {
 				postId: 'woocommerce/woocommerce//single-product',
-				postType: 'wp_template',
 			} );
-
-			await goToSiteEditor( templateQuery );
-			await waitForCanvas();
 
 			await expect( canvas() ).toMatchElement(
 				SELECTORS.blocks.paragraph,
@@ -224,7 +211,8 @@ describe( 'Store Editing Templates', () => {
 		it( 'default template from WooCommerce Blocks is available on an FSE theme', async () => {
 			const EXPECTED_TEMPLATE = defaultTemplateProps( 'Product Catalog' );
 
-			await goToSiteEditor( '?postType=wp_template' );
+			await goToSiteEditor();
+
 			const templates = await getAllTemplates();
 
 			try {
@@ -241,13 +229,9 @@ describe( 'Store Editing Templates', () => {
 		} );
 
 		it( 'should contain the "WooCommerce Product Grid Block" classic template', async () => {
-			const templateQuery = addQueryArgs( '', {
+			await goToSiteEditor( {
 				postId: 'woocommerce/woocommerce//archive-product',
-				postType: 'wp_template',
 			} );
-
-			await goToSiteEditor( templateQuery );
-			await waitForCanvas();
 
 			const [ classicBlock ] = await filterCurrentBlocks(
 				( block ) => block.name === BLOCK_DATA[ 'archive-product' ].name
@@ -267,8 +251,8 @@ describe( 'Store Editing Templates', () => {
 
 			await visitTemplateAndAddCustomParagraph( 'archive-product' );
 
-			await goToSiteEditor( '?postType=wp_template' );
-			await page.waitForSelector( SELECTORS.templates.templateActions );
+			await goToSiteEditor( { waitForActions: true } );
+
 			const templates = await getAllTemplates();
 
 			try {
@@ -285,13 +269,9 @@ describe( 'Store Editing Templates', () => {
 		} );
 
 		it( 'should preserve and correctly show the user customization on the back-end', async () => {
-			const templateQuery = addQueryArgs( '', {
+			await goToSiteEditor( {
 				postId: 'woocommerce/woocommerce//archive-product',
-				postType: 'wp_template',
 			} );
-
-			await goToSiteEditor( templateQuery );
-			await waitForCanvas();
 
 			await expect( canvas() ).toMatchElement(
 				SELECTORS.blocks.paragraph,
@@ -324,7 +304,8 @@ describe( 'Store Editing Templates', () => {
 				'Products by Category'
 			);
 
-			await goToSiteEditor( '?postType=wp_template' );
+			await goToSiteEditor();
+
 			const templates = await getAllTemplates();
 
 			try {
@@ -341,13 +322,9 @@ describe( 'Store Editing Templates', () => {
 		} );
 
 		it( 'should contain the "WooCommerce Product Taxonomy Block" classic template', async () => {
-			const templateQuery = addQueryArgs( '', {
+			await goToSiteEditor( {
 				postId: 'woocommerce/woocommerce//taxonomy-product_cat',
-				postType: 'wp_template',
 			} );
-
-			await goToSiteEditor( templateQuery );
-			await waitForCanvas();
 
 			const [ classicBlock ] = await filterCurrentBlocks(
 				( block ) =>
@@ -368,8 +345,8 @@ describe( 'Store Editing Templates', () => {
 
 			await visitTemplateAndAddCustomParagraph( 'taxonomy-product_cat' );
 
-			await goToSiteEditor( '?postType=wp_template' );
-			await page.waitForSelector( SELECTORS.templates.templateActions );
+			await goToSiteEditor( { waitForActions: true } );
+
 			const templates = await getAllTemplates();
 
 			try {
@@ -386,13 +363,9 @@ describe( 'Store Editing Templates', () => {
 		} );
 
 		it( 'should preserve and correctly show the user customization on the back-end', async () => {
-			const templateQuery = addQueryArgs( '', {
+			await goToSiteEditor( {
 				postId: 'woocommerce/woocommerce//taxonomy-product_cat',
-				postType: 'wp_template',
 			} );
-
-			await goToSiteEditor( templateQuery );
-			await waitForCanvas();
 
 			await expect( canvas() ).toMatchElement(
 				SELECTORS.blocks.paragraph,
@@ -419,7 +392,8 @@ describe( 'Store Editing Templates', () => {
 		it( 'default template from WooCommerce Blocks is available on an FSE theme', async () => {
 			const EXPECTED_TEMPLATE = defaultTemplateProps( 'Products by Tag' );
 
-			await goToSiteEditor( '?postType=wp_template' );
+			await goToSiteEditor();
+
 			const templates = await getAllTemplates();
 
 			try {
@@ -436,13 +410,9 @@ describe( 'Store Editing Templates', () => {
 		} );
 
 		it( 'should contain the "WooCommerce Product Taxonomy Block" classic template', async () => {
-			const templateQuery = addQueryArgs( '', {
+			await goToSiteEditor( {
 				postId: 'woocommerce/woocommerce//taxonomy-product_tag',
-				postType: 'wp_template',
 			} );
-
-			await goToSiteEditor( templateQuery );
-			await waitForCanvas();
 
 			const [ classicBlock ] = await filterCurrentBlocks(
 				( block ) =>
@@ -463,8 +433,8 @@ describe( 'Store Editing Templates', () => {
 
 			await visitTemplateAndAddCustomParagraph( 'taxonomy-product_tag' );
 
-			await goToSiteEditor( '?postType=wp_template' );
-			await page.waitForSelector( SELECTORS.templates.templateActions );
+			await goToSiteEditor( { waitForActions: true } );
+
 			const templates = await getAllTemplates();
 
 			try {
@@ -481,13 +451,9 @@ describe( 'Store Editing Templates', () => {
 		} );
 
 		it( 'should preserve and correctly show the user customization on the back-end', async () => {
-			const templateQuery = addQueryArgs( '', {
+			await goToSiteEditor( {
 				postId: 'woocommerce/woocommerce//taxonomy-product_tag',
-				postType: 'wp_template',
 			} );
-
-			await goToSiteEditor( templateQuery );
-			await waitForCanvas();
 
 			await expect( canvas() ).toMatchElement(
 				SELECTORS.blocks.paragraph,

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -213,11 +213,13 @@ export async function saveTemplate() {
 
 	await page.click( saveButton );
 	await page.waitForSelector( savePrompt );
-	await page.click( confirmSave );
-	await page.waitForResponse( ( res ) => {
-		// Will match both templates and template_parts endpoints.
-		return res.url().includes( '/wp/v2/template' );
-	} );
+	await Promise.all( [
+		await page.waitForResponse( ( res ) => {
+			// Will match both templates and template_parts endpoints.
+			return res.url().includes( '/wp/v2/template' );
+		} ),
+		await page.click( confirmSave ),
+	] );
 }
 
 /**

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -156,9 +156,9 @@ export const isBlockInsertedInWidgetsArea = async ( blockName ) => {
  */
 export async function goToSiteEditor( {
 	postId,
-	waitForActions = false,
 	postType = 'wp_template',
 	editorContext = GUTENBERG_EDITOR_CONTEXT,
+	waitForActions = false,
 } = {} ) {
 	// There is a bug in Gutenberg/WPCore now that makes it impossible to rely on site-editor.php on setups
 	// with locally installed Gutenberg. Details in https://github.com/WordPress/gutenberg/issues/39639.

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -161,9 +161,9 @@ async function goToSiteEditor( editorContext = 'core', params ) {
 
 	if ( editorContext === 'gutenberg' ) {
 		editorPath = 'themes.php';
+		queryParams.page = 'gutenberg-edit-site';
 	} else {
 		editorPath = 'site-editor.php';
-		queryParams.page = 'gutenberg-edit-site';
 	}
 
 	return await visitAdminPage( editorPath, addQueryArgs( '', queryParams ) );

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -213,13 +213,12 @@ export async function saveTemplate() {
 
 	await page.click( saveButton );
 	await page.waitForSelector( savePrompt );
-	await Promise.all( [
-		await page.waitForResponse( ( res ) => {
-			// Will match both templates and template_parts endpoints.
-			return res.url().includes( '/wp/v2/template' );
-		} ),
-		await page.click( confirmSave ),
-	] );
+	await page.click( confirmSave );
+	await page.waitForSelector( `${ saveButton }[aria-disabled="true"]` );
+	await page.waitForResponse( ( res ) => {
+		// Will match both templates and template_parts endpoints.
+		return res.url().includes( '/wp/v2/template' );
+	} );
 }
 
 /**

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -209,8 +209,7 @@ export async function saveTemplate() {
 export async function getAllTemplates() {
 	const { templatesListTable } = SELECTORS;
 
-	await page.waitForSelector( templatesListTable.root );
-	const table = await page.$( templatesListTable.root );
+	const table = await page.waitForSelector( templatesListTable.root );
 
 	if ( ! table ) throw new Error( 'Templates table not found' );
 


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This is a follow up to #6080 as discussed [here](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/6080#discussion_r833195402). 

The change cleans up `tests/e2e/specs/backend/site-editing-templates.test.js` E2E tests by hiding UX details of waiting for navigation to different contexts of Site Editor inside the goToSiteEditor E2E. 

It will: 
- wait for table being rendered when accessing template or template parts list - via `postType` param (defaults to `wp_template`)
- or waiting for Actions controls on template or template parts list when we want to ensure latest templates state is fetched and Actions are available on modified templates - via `waitForActions` param.
- wait for canvas when going to editing a template or template_part view - via `postId` param

By default the method if no params are provided will take us to the templates list view.

<!-- Reference any related issues or PRs here -->
Fixes #6080 

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. E2E CI should pass