### PR TITLE
Add static keyword to function remove_theme_templates_with_custom_alternative

### DIFF
--- a/src/Utils/BlockTemplateUtils.php
+++ b/src/Utils/BlockTemplateUtils.php
@@ -486,7 +486,7 @@ class BlockTemplateUtils {
 	 *
 	 * @return array List of templates with duplicates removed. The customised alternative is preferred over the theme default.
 	 */
-	public function remove_theme_templates_with_custom_alternative( $templates ) {
+	public static function remove_theme_templates_with_custom_alternative( $templates ) {
 
 		// Get the slugs of all templates that have been customised and saved in the database.
 		$customised_template_slugs = array_map(


### PR DESCRIPTION
Adds `static` keyword to method `remove_theme_templates_with_custom_alternative`

<!-- Reference any related issues or PRs here -->
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/6111

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Ensure `WP_DEBUG` is enabled
2. Load the Appearance > Site Editor
3. Ensure there are no warnings/errors related to the modified method.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
* [ ] See steps below.

1.
2.
3.

