### PR TITLE
Shopper → Checkout → Can see warnings when form is incomplete

### DIFF
--- a/tests/e2e/specs/shopper/checkout-form-warnings.test.js
+++ b/tests/e2e/specs/shopper/checkout-form-warnings.test.js
@@ -1,0 +1,91 @@
+/**
+ * External dependencies
+ */
+import { MY_ACCOUNT_ACCOUNT_DETAILS } from '@woocommerce/e2e-utils';
+
+/**
+ * Internal dependencies
+ */
+import { shopper } from '../../../utils';
+import { SIMPLE_PRODUCT_NAME } from '../../../utils/constants';
+
+const block = {
+	name: 'Checkout',
+};
+
+if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 )
+	// eslint-disable-next-line jest/no-focused-tests
+	test.only( `skipping ${ block.name } tests`, () => {} );
+
+describe( 'Shopper → Checkout → Can see warnings when form is incomplete', () => {
+	beforeAll( async () => {
+		const isShopperLoggedIn = await shopper.block.isLoggedIn();
+
+		// @todo Find a better way to reset the checkout form instead of login then logout
+		if ( isShopperLoggedIn ) await shopper.logout();
+		else {
+			await shopper.login();
+			await shopper.logout();
+		}
+	} );
+
+	beforeEach( async () => {
+		await shopper.block.emptyCart();
+	} );
+
+	afterAll( async () => {
+		await shopper.block.emptyCart();
+	} );
+
+	it( 'Shows warnings when form is incomplete', async () => {
+		await shopper.goToShop();
+		await shopper.addToCartFromShopPage( SIMPLE_PRODUCT_NAME );
+		await shopper.block.goToCheckout();
+
+		// Click on "Place Order" button
+		await expect( page ).toClick(
+			'.wc-block-components-checkout-place-order-button',
+			{
+				text: 'Place Order',
+			}
+		);
+
+		// Verify that all required fields show the correct warning.
+		await expect( page ).toMatchElement(
+			'#email ~ .wc-block-components-validation-error p',
+			{
+				text: 'Please fill out this field.',
+			}
+		);
+		await expect( page ).toMatchElement(
+			'#billing-first_name ~ .wc-block-components-validation-error p',
+			{
+				text: 'Please fill out this field.',
+			}
+		);
+		await expect( page ).toMatchElement(
+			'#billing-last_name ~ .wc-block-components-validation-error p',
+			{
+				text: 'Please fill out this field.',
+			}
+		);
+		await expect( page ).toMatchElement(
+			'#billing-address_1 ~ .wc-block-components-validation-error p',
+			{
+				text: 'Please fill out this field.',
+			}
+		);
+		await expect( page ).toMatchElement(
+			'#billing-city ~ .wc-block-components-validation-error p',
+			{
+				text: 'Please fill out this field.',
+			}
+		);
+		await expect( page ).toMatchElement(
+			'#billing-postcode ~ .wc-block-components-validation-error p',
+			{
+				text: 'Please fill out this field.',
+			}
+		);
+	} );
+} );

--- a/tests/e2e/specs/shopper/checkout-form-warnings.test.js
+++ b/tests/e2e/specs/shopper/checkout-form-warnings.test.js
@@ -1,13 +1,12 @@
 /**
- * External dependencies
- */
-import { MY_ACCOUNT_ACCOUNT_DETAILS } from '@woocommerce/e2e-utils';
-
-/**
  * Internal dependencies
  */
 import { shopper } from '../../../utils';
-import { SIMPLE_PRODUCT_NAME } from '../../../utils/constants';
+import {
+	SIMPLE_PRODUCT_NAME,
+	CUSTOMER_USERNAME,
+	CUSTOMER_PASSWORD,
+} from '../../../utils/constants';
 
 const block = {
 	name: 'Checkout',
@@ -19,13 +18,23 @@ if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 )
 
 describe( 'Shopper → Checkout → Can see warnings when form is incomplete', () => {
 	beforeAll( async () => {
-		const isShopperLoggedIn = await shopper.block.isLoggedIn();
+		const isShopperLoggedIn = await shopper.isLoggedIn();
 
 		// @todo Find a better way to reset the checkout form instead of login then logout
-		if ( isShopperLoggedIn ) await shopper.logout();
-		else {
-			await shopper.login();
-			await shopper.logout();
+		if ( isShopperLoggedIn ) {
+			// Click on the "Log out" link in "My account" page
+			await await page.click(
+				'.woocommerce-MyAccount-navigation-link--customer-logout a'
+			);
+		} else {
+			await shopper.loginFromMyAccountPage(
+				CUSTOMER_USERNAME,
+				CUSTOMER_PASSWORD
+			);
+
+			await await page.click(
+				'.woocommerce-MyAccount-navigation-link--customer-logout a'
+			);
 		}
 	} );
 

--- a/tests/utils/constants.js
+++ b/tests/utils/constants.js
@@ -10,3 +10,5 @@ const config = require( 'config' );
  */
 export const SIMPLE_PRODUCT_NAME = 'Woo Single #1';
 export const BILLING_DETAILS = config.get( 'addresses.customer.billing' );
+export const CUSTOMER_USERNAME = config.get( 'users.customer.username' );
+export const CUSTOMER_PASSWORD = config.get( 'users.customer.password' );

--- a/tests/utils/shopper.js
+++ b/tests/utils/shopper.js
@@ -354,5 +354,11 @@ export const shopper = {
 
 			await expect( page.$x( cartItemXPath ) ).resolves.toHaveLength( 1 );
 		},
+
+		isLoggedIn: async () => {
+			const adminBar = await page.$( '#wpadminbar' );
+
+			return !! adminBar;
+		},
 	},
 };

--- a/tests/utils/shopper.js
+++ b/tests/utils/shopper.js
@@ -354,11 +354,24 @@ export const shopper = {
 
 			await expect( page.$x( cartItemXPath ) ).resolves.toHaveLength( 1 );
 		},
+	},
 
-		isLoggedIn: async () => {
-			const adminBar = await page.$( '#wpadminbar' );
+	isLoggedIn: async () => {
+		await shopper.gotoMyAccount();
 
-			return !! adminBar;
-		},
+		await expect( page.title() ).resolves.toMatch( 'My account' );
+		const loginForm = await page.$( 'form.woocommerce-form-login' );
+
+		return ! loginForm;
+	},
+
+	loginFromMyAccountPage: async ( username, password ) => {
+		await page.type( '#username', username );
+		await page.type( '#password', password );
+
+		await Promise.all( [
+			page.waitForNavigation( { waitUntil: 'networkidle0' } ),
+			page.click( 'button[name="login"]' ),
+		] );
 	},
 };


### PR DESCRIPTION
Fixes #5771

### Notes

This PR adds an e2e test to verify that shoppers can see warnings when the checkout form is incomplete.

### Testing

#### Automated Tests
* [x] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests

### Manual Testing

If E2E tests run by GitHub actions pass in this PR then it's all good.

As an extra, if you want to test it locally as well:

1. Check out this PR.
2. Start Docker Desktop.
3. Run `npm run wp-env destroy && npm run wp-env start` to start a fresh e2e environment.
4. Run `npm run test:e2e -- tests/e2e/specs/shopper/checkout-form-warnings.test.js` to run only this test case.
5. Run `npm run test:e2e` to run the whole test suite.

### Changelog

> Show warnings when form is incomplete on Checkout