### PR TITLE
Convert `CheckoutOrderNotes` to TS

### DIFF
--- a/assets/js/base/components/textarea/index.tsx
+++ b/assets/js/base/components/textarea/index.tsx
@@ -9,7 +9,7 @@ import classnames from 'classnames';
 import './style.scss';
 
 interface TextareaProps {
-	className: string;
+	className?: string;
 	disabled: boolean;
 	onTextChange: ( newText: string ) => void;
 	placeholder: string;

--- a/assets/js/blocks/checkout/order-notes/index.tsx
+++ b/assets/js/blocks/checkout/order-notes/index.tsx
@@ -11,7 +11,19 @@ import { Textarea } from '@woocommerce/base-components/textarea';
  */
 import './style.scss';
 
-const CheckoutOrderNotes = ( { disabled, onChange, placeholder, value } ) => {
+interface CheckoutOrderNotesProps {
+	disabled: boolean;
+	onChange: ( newText: string ) => void;
+	placeholder: string;
+	value: string;
+}
+
+const CheckoutOrderNotes = ( {
+	disabled,
+	onChange,
+	placeholder,
+	value,
+}: CheckoutOrderNotesProps ): JSX.Element => {
 	const [ withOrderNotes, setWithOrderNotes ] = useState( false );
 	// Store order notes when the textarea is hidden. This allows us to recover
 	// text entered previously by the user when the checkbox is re-enabled

--- a/assets/js/blocks/checkout/order-notes/index.tsx
+++ b/assets/js/blocks/checkout/order-notes/index.tsx
@@ -13,7 +13,7 @@ import './style.scss';
 
 interface CheckoutOrderNotesProps {
 	disabled: boolean;
-	onChange: ( newText: string ) => void;
+	onChange: ( orderNotes: string ) => void;
 	placeholder: string;
 	value: string;
 }


### PR DESCRIPTION
Converts the `CheckoutOrderNotes` component to TS.

### Testing

#### Automated Tests
* [x] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [x] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Add the "Checkout block" to a page
2. Add a product to the cart and go to the checkout page with the block
3. Check the "Add a note to your order" checkbox
4. Check that the textarea for adding notes is showing and can be used
5. Leave a note and place the order
6. Check the note is shown on the next screen
7. Go to the order on the admin and check the note is also showing there