### PR TITLE
Add Product endpoint to ExtendSchema

### DIFF
--- a/docs/extensibility/available-endpoints-to-extend.md
+++ b/docs/extensibility/available-endpoints-to-extend.md
@@ -30,6 +30,19 @@ The items endpoint, which is also available on `wc/store/cart` inside the `items
 
 -   `CartItemSchema::IDENTIFIER`
 
+## `wc/store/products`
+
+The main products endpoint is extensible via ExtendSchema. The data is available via the `extensions` key for each `product` in the response array.
+
+### Passed Parameters:
+
+-   `data_callback`: `$product`.
+-   `schema_callback` none.
+
+### Key:
+
+-   `ProductSchema::IDENTIFIER`
+
 <!-- FEEDBACK -->
 ---
 

--- a/src/StoreApi/Schemas/ExtendSchema.php
+++ b/src/StoreApi/Schemas/ExtendSchema.php
@@ -4,6 +4,7 @@ namespace Automattic\WooCommerce\StoreApi\Schemas;
 use Automattic\WooCommerce\StoreApi\Schemas\V1\CartItemSchema;
 use Automattic\WooCommerce\StoreApi\Schemas\V1\CartSchema;
 use Automattic\WooCommerce\StoreApi\Schemas\V1\CheckoutSchema;
+use Automattic\WooCommerce\StoreApi\Schemas\V1\ProductSchema;
 use Automattic\WooCommerce\StoreApi\Formatters;
 
 /**
@@ -26,6 +27,7 @@ final class ExtendSchema {
 		CartItemSchema::IDENTIFIER,
 		CartSchema::IDENTIFIER,
 		CheckoutSchema::IDENTIFIER,
+		ProductSchema::IDENTIFIER,
 	];
 
 	/**

--- a/src/StoreApi/Schemas/V1/ProductSchema.php
+++ b/src/StoreApi/Schemas/V1/ProductSchema.php
@@ -435,6 +435,7 @@ class ProductSchema extends AbstractSchema {
 					],
 				],
 			],
+			self::EXTENDING_KEY   => $this->get_extended_schema( self::IDENTIFIER ),
 		];
 	}
 
@@ -479,6 +480,8 @@ class ProductSchema extends AbstractSchema {
 				],
 				( new QuantityLimits() )->get_add_to_cart_limits( $product )
 			),
+			self::EXTENDING_KEY   => $this->get_extended_data( self::IDENTIFIER, $product ),
+
 		];
 	}
 

--- a/tests/php/StoreApi/Routes/Products.php
+++ b/tests/php/StoreApi/Routes/Products.php
@@ -89,6 +89,7 @@ class Products extends ControllerTestCase {
 		$this->assertArrayHasKey( 'is_purchasable', $data[0] );
 		$this->assertArrayHasKey( 'is_in_stock', $data[0] );
 		$this->assertArrayHasKey( 'add_to_cart', $data[0] );
+		$this->assertArrayHasKey( 'extensions', $data[0] );
 	}
 
 	/**


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

This PR adds the Product endpoint to ExtendSchema

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### Testing

#### Automated Tests
* [x] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [ ] E2E tests
### Manual Testing

1. Make a request to `/wp-json/wc/store/products`. You can do so adding the All Products block into a page and loading it in the frontend.
2. With your browser devtools (<kbd>F12</kbd>), inspect the request.
3. Confirm that the `extensions` field exists in each product and is an empty object.

### Changelog
> Added the product endpoint to ExtendSchema
