### PR TITLE
Prepare the Mini Cart block for Feature Plugin

### DIFF
--- a/assets/js/blocks/cart-checkout/mini-cart-contents/index.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart-contents/index.tsx
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { cart } from '@woocommerce/icons';
 import { Icon } from '@wordpress/icons';
-import { registerExperimentalBlockType } from '@woocommerce/block-settings';
+import { registerFeaturePluginBlockType } from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies
@@ -63,4 +63,4 @@ const settings = {
 	save,
 };
 
-registerExperimentalBlockType( blockName, settings );
+registerFeaturePluginBlockType( blockName, settings );

--- a/assets/js/blocks/cart-checkout/mini-cart/index.tsx
+++ b/assets/js/blocks/cart-checkout/mini-cart/index.tsx
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { cart } from '@woocommerce/icons';
 import { Icon } from '@wordpress/icons';
-import { registerExperimentalBlockType } from '@woocommerce/block-settings';
+import { registerFeaturePluginBlockType } from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies
@@ -57,4 +57,4 @@ const settings = {
 	},
 };
 
-registerExperimentalBlockType( 'woocommerce/mini-cart', settings );
+registerFeaturePluginBlockType( 'woocommerce/mini-cart', settings );

--- a/readme.txt
+++ b/readme.txt
@@ -40,6 +40,7 @@ Use this plugin if you want access to the bleeding edge of available blocks for 
 - **Active Product Filters**
 - **Cart**
 - **Checkout**
+- **Mini Cart**
 
 == Getting Started ==
 

--- a/src/BlockTypesController.php
+++ b/src/BlockTypesController.php
@@ -189,10 +189,6 @@ final class BlockTypesController {
 		if ( Package::feature()->is_feature_plugin_build() ) {
 			$block_types[] = 'Checkout';
 			$block_types[] = 'Cart';
-		}
-
-		if ( Package::feature()->is_experimental_build() ) {
-			$block_types[] = 'SingleProduct';
 
 			/**
 			 * Mini Cart blocks should be available in Site Editor, Widgets and frontend (is_admin function checks this) only.
@@ -205,6 +201,10 @@ final class BlockTypesController {
 				$block_types[] = 'MiniCart';
 				$block_types[] = 'MiniCartContents';
 			}
+		}
+
+		if ( Package::feature()->is_experimental_build() ) {
+			$block_types[] = 'SingleProduct';
 		}
 
 		/**


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #6124.

This PR prepares the Mini Cart block to release in the WooCommerce Blocks Feature Plugin.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Run `npm run package-plugin`.
2. On a fresh installation, install, activate and configure WooCommerce.
3. Install and activate the generated plugin.
4. With Storefront:
    1. Go to Appearance > Widgets.
    2. Add a new block to the Sidebar.
    3. See the Mini Cart block available inside the inserter.
    4. Add the Mini Cart block to the sidebar. Save changes.
    5. See the block load and works properly on the front end.
5. With Twenty Twenty-Two
    1. Edit the Header template part.
    2. Can add the block to the header.
    3. Save changes.
    4. See it load and work properly on the front end.
    5. Edit the Mini Cart template part.
    6. See the template part containing the Mini Cart Contents block.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [ ] Same as above, or
* [ ] See steps below.

### Changelog

> Add Mini Cart block.
