### PR TITLE
Update `Product Title` link settings to match `Post Title`

### DIFF
--- a/assets/js/atomic/blocks/product-elements/image/block.js
+++ b/assets/js/atomic/blocks/product-elements/image/block.js
@@ -84,7 +84,6 @@ export const Block = ( props ) => {
 	);
 	const anchorProps = {
 		href: product.permalink,
-		rel: 'nofollow',
 		...( ! hasProductImages && { 'aria-label': anchorLabel } ),
 		onClick: () => {
 			dispatchStoreEvent( 'product-view-link', {

--- a/assets/js/atomic/blocks/product-elements/title/attributes.ts
+++ b/assets/js/atomic/blocks/product-elements/title/attributes.ts
@@ -17,7 +17,6 @@ let blockAttributes: Record< string, Record< string, unknown > > = {
 	},
 	rel: {
 		type: 'string',
-		default: '',
 	},
 	productId: {
 		type: 'number',

--- a/assets/js/atomic/blocks/product-elements/title/attributes.ts
+++ b/assets/js/atomic/blocks/product-elements/title/attributes.ts
@@ -12,6 +12,14 @@ let blockAttributes: Record< string, Record< string, unknown > > = {
 		type: 'boolean',
 		default: true,
 	},
+	linkTarget: {
+		type: 'string',
+		default: '_self',
+	},
+	rel: {
+		type: 'string',
+		default: '',
+	},
 	productId: {
 		type: 'number',
 		default: 0,

--- a/assets/js/atomic/blocks/product-elements/title/attributes.ts
+++ b/assets/js/atomic/blocks/product-elements/title/attributes.ts
@@ -14,7 +14,6 @@ let blockAttributes: Record< string, Record< string, unknown > > = {
 	},
 	linkTarget: {
 		type: 'string',
-		default: '_self',
 	},
 	rel: {
 		type: 'string',

--- a/assets/js/atomic/blocks/product-elements/title/attributes.ts
+++ b/assets/js/atomic/blocks/product-elements/title/attributes.ts
@@ -15,9 +15,6 @@ let blockAttributes: Record< string, Record< string, unknown > > = {
 	linkTarget: {
 		type: 'string',
 	},
-	rel: {
-		type: 'string',
-	},
 	productId: {
 		type: 'number',
 		default: 0,

--- a/assets/js/atomic/blocks/product-elements/title/block.tsx
+++ b/assets/js/atomic/blocks/product-elements/title/block.tsx
@@ -124,7 +124,7 @@ export const Block = ( props: Props ): JSX.Element => {
 				disabled={ ! showProductLink }
 				name={ product.name }
 				permalink={ product.permalink }
-				rel={ rel }
+				rel={ showProductLink ? 'nofollow ' + rel : '' }
 				target={ linkTarget }
 				onClick={ () => {
 					dispatchStoreEvent( 'product-view-link', {

--- a/assets/js/atomic/blocks/product-elements/title/block.tsx
+++ b/assets/js/atomic/blocks/product-elements/title/block.tsx
@@ -47,7 +47,6 @@ const TagName = ( {
  * @param {number}  [props.headingLevel]    Heading level (h1, h2, etc.)
  * @param {boolean} [props.showProductLink] Whether or not to display a link to the product page.
  * @param {string}  [props.linkTarget]      Specifies where to open the linked URL.
- * @param {string}  [props.rel]             The relationship of the linked URL.
  * @param {string}  [props.align]           Title alignment.
  * will be used if this is not provided.
  * @return {*} The component.
@@ -58,7 +57,6 @@ export const Block = ( props: Props ): JSX.Element => {
 		headingLevel = 2,
 		showProductLink = true,
 		linkTarget,
-		rel,
 		align,
 	} = props;
 
@@ -124,7 +122,6 @@ export const Block = ( props: Props ): JSX.Element => {
 				disabled={ ! showProductLink }
 				name={ product.name }
 				permalink={ product.permalink }
-				rel={ rel }
 				target={ linkTarget }
 				onClick={ () => {
 					dispatchStoreEvent( 'product-view-link', {

--- a/assets/js/atomic/blocks/product-elements/title/block.tsx
+++ b/assets/js/atomic/blocks/product-elements/title/block.tsx
@@ -44,8 +44,10 @@ const TagName = ( {
  *
  * @param {Object}  props                   Incoming props.
  * @param {string}  [props.className]       CSS Class name for the component.
- * @param {number}  [props.headingLevel]    Heading level (h1, h2 etc)
+ * @param {number}  [props.headingLevel]    Heading level (h1, h2, etc.)
  * @param {boolean} [props.showProductLink] Whether or not to display a link to the product page.
+ * @param {string}  [props.linkTarget]      Specifies where to open the linked URL.
+ * @param {string}  [props.rel]             The relationship of the linked URL.
  * @param {string}  [props.align]           Title alignment.
  * will be used if this is not provided.
  * @return {*} The component.
@@ -55,6 +57,8 @@ export const Block = ( props: Props ): JSX.Element => {
 		className,
 		headingLevel = 2,
 		showProductLink = true,
+		linkTarget = '_self',
+		rel = '',
 		align,
 	} = props;
 
@@ -120,7 +124,8 @@ export const Block = ( props: Props ): JSX.Element => {
 				disabled={ ! showProductLink }
 				name={ product.name }
 				permalink={ product.permalink }
-				rel={ showProductLink ? 'nofollow' : '' }
+				rel={ rel }
+				target={ linkTarget }
 				onClick={ () => {
 					dispatchStoreEvent( 'product-view-link', {
 						product,

--- a/assets/js/atomic/blocks/product-elements/title/block.tsx
+++ b/assets/js/atomic/blocks/product-elements/title/block.tsx
@@ -124,7 +124,7 @@ export const Block = ( props: Props ): JSX.Element => {
 				disabled={ ! showProductLink }
 				name={ product.name }
 				permalink={ product.permalink }
-				rel={ 'nofollow' + ' ' + ( rel || '' ) }
+				rel={ 'nofollow' + ( rel && ' ' + rel ) }
 				target={ linkTarget || undefined }
 				onClick={ () => {
 					dispatchStoreEvent( 'product-view-link', {

--- a/assets/js/atomic/blocks/product-elements/title/block.tsx
+++ b/assets/js/atomic/blocks/product-elements/title/block.tsx
@@ -127,7 +127,7 @@ export const Block = ( props: Props ): JSX.Element => {
 				name={ product.name }
 				permalink={ product.permalink }
 				rel={ 'nofollow' + linkRel }
-				target={ linkTarget || undefined }
+				target={ linkTarget }
 				onClick={ () => {
 					dispatchStoreEvent( 'product-view-link', {
 						product,

--- a/assets/js/atomic/blocks/product-elements/title/block.tsx
+++ b/assets/js/atomic/blocks/product-elements/title/block.tsx
@@ -57,8 +57,8 @@ export const Block = ( props: Props ): JSX.Element => {
 		className,
 		headingLevel = 2,
 		showProductLink = true,
-		linkTarget = '_self',
-		rel = '',
+		linkTarget,
+		rel,
 		align,
 	} = props;
 
@@ -124,8 +124,8 @@ export const Block = ( props: Props ): JSX.Element => {
 				disabled={ ! showProductLink }
 				name={ product.name }
 				permalink={ product.permalink }
-				rel={ showProductLink ? 'nofollow ' + rel : '' }
-				target={ linkTarget }
+				rel={ 'nofollow' + ' ' + ( rel || '' ) }
+				target={ linkTarget || undefined }
 				onClick={ () => {
 					dispatchStoreEvent( 'product-view-link', {
 						product,

--- a/assets/js/atomic/blocks/product-elements/title/block.tsx
+++ b/assets/js/atomic/blocks/product-elements/title/block.tsx
@@ -97,8 +97,6 @@ export const Block = ( props: Props ): JSX.Element => {
 		);
 	}
 
-	const linkRel = rel ? ` ${ rel }` : '';
-
 	return (
 		<TagName
 			headingLevel={ headingLevel }
@@ -126,7 +124,7 @@ export const Block = ( props: Props ): JSX.Element => {
 				disabled={ ! showProductLink }
 				name={ product.name }
 				permalink={ product.permalink }
-				rel={ 'nofollow' + linkRel }
+				rel={ rel }
 				target={ linkTarget }
 				onClick={ () => {
 					dispatchStoreEvent( 'product-view-link', {

--- a/assets/js/atomic/blocks/product-elements/title/block.tsx
+++ b/assets/js/atomic/blocks/product-elements/title/block.tsx
@@ -97,6 +97,8 @@ export const Block = ( props: Props ): JSX.Element => {
 		);
 	}
 
+	const linkRel = rel ? ` ${ rel }` : '';
+
 	return (
 		<TagName
 			headingLevel={ headingLevel }
@@ -124,7 +126,7 @@ export const Block = ( props: Props ): JSX.Element => {
 				disabled={ ! showProductLink }
 				name={ product.name }
 				permalink={ product.permalink }
-				rel={ 'nofollow' + ( rel && ' ' + rel ) }
+				rel={ 'nofollow' + linkRel }
 				target={ linkTarget || undefined }
 				onClick={ () => {
 					dispatchStoreEvent( 'product-view-link', {

--- a/assets/js/atomic/blocks/product-elements/title/edit.tsx
+++ b/assets/js/atomic/blocks/product-elements/title/edit.tsx
@@ -63,10 +63,6 @@ const TitleEdit = ( { attributes, setAttributes }: Props ): JSX.Element => {
 							'Make title a link',
 							'woo-gutenberg-products-block'
 						) }
-						help={ __(
-							'Links the image to the single product listing.',
-							'woo-gutenberg-products-block'
-						) }
 						checked={ showProductLink }
 						onChange={ () =>
 							setAttributes( {

--- a/assets/js/atomic/blocks/product-elements/title/edit.tsx
+++ b/assets/js/atomic/blocks/product-elements/title/edit.tsx
@@ -2,7 +2,12 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Disabled, PanelBody, ToggleControl } from '@wordpress/components';
+import {
+	Disabled,
+	PanelBody,
+	TextControl,
+	ToggleControl,
+} from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import {
 	InspectorControls,
@@ -29,7 +34,13 @@ interface Props {
 
 const TitleEdit = ( { attributes, setAttributes }: Props ): JSX.Element => {
 	const blockProps = useBlockProps();
-	const { headingLevel, showProductLink, align } = attributes;
+	const {
+		headingLevel,
+		showProductLink,
+		align,
+		linkTarget,
+		rel,
+	} = attributes;
 	return (
 		<div { ...blockProps }>
 			<BlockControls>
@@ -70,6 +81,32 @@ const TitleEdit = ( { attributes, setAttributes }: Props ): JSX.Element => {
 							} )
 						}
 					/>
+					{ showProductLink && (
+						<>
+							<ToggleControl
+								label={ __(
+									'Open in new tab',
+									'woo-gutenberg-products-block'
+								) }
+								onChange={ ( value ) =>
+									setAttributes( {
+										linkTarget: value ? '_blank' : '_self',
+									} )
+								}
+								checked={ linkTarget === '_blank' }
+							/>
+							<TextControl
+								label={ __(
+									'Link rel',
+									'woo-gutenberg-products-block'
+								) }
+								value={ rel }
+								onChange={ ( newRel ) =>
+									setAttributes( { rel: newRel } )
+								}
+							/>
+						</>
+					) }
 				</PanelBody>
 			</InspectorControls>
 			<Disabled>

--- a/assets/js/atomic/blocks/product-elements/title/edit.tsx
+++ b/assets/js/atomic/blocks/product-elements/title/edit.tsx
@@ -53,7 +53,10 @@ const TitleEdit = ( { attributes, setAttributes }: Props ): JSX.Element => {
 			</BlockControls>
 			<InspectorControls>
 				<PanelBody
-					title={ __( 'Content', 'woo-gutenberg-products-block' ) }
+					title={ __(
+						'Link settings',
+						'woo-gutenberg-products-block'
+					) }
 				>
 					<ToggleControl
 						label={ __(

--- a/assets/js/atomic/blocks/product-elements/title/edit.tsx
+++ b/assets/js/atomic/blocks/product-elements/title/edit.tsx
@@ -60,7 +60,7 @@ const TitleEdit = ( { attributes, setAttributes }: Props ): JSX.Element => {
 				>
 					<ToggleControl
 						label={ __(
-							'Link to Product Page',
+							'Make title a link',
 							'woo-gutenberg-products-block'
 						) }
 						help={ __(

--- a/assets/js/atomic/blocks/product-elements/title/edit.tsx
+++ b/assets/js/atomic/blocks/product-elements/title/edit.tsx
@@ -2,12 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	Disabled,
-	PanelBody,
-	TextControl,
-	ToggleControl,
-} from '@wordpress/components';
+import { Disabled, PanelBody, ToggleControl } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import {
 	InspectorControls,
@@ -34,13 +29,7 @@ interface Props {
 
 const TitleEdit = ( { attributes, setAttributes }: Props ): JSX.Element => {
 	const blockProps = useBlockProps();
-	const {
-		headingLevel,
-		showProductLink,
-		align,
-		linkTarget,
-		rel,
-	} = attributes;
+	const { headingLevel, showProductLink, align, linkTarget } = attributes;
 	return (
 		<div { ...blockProps }>
 			<BlockControls>
@@ -94,16 +83,6 @@ const TitleEdit = ( { attributes, setAttributes }: Props ): JSX.Element => {
 									} )
 								}
 								checked={ linkTarget === '_blank' }
-							/>
-							<TextControl
-								label={ __(
-									'Link rel',
-									'woo-gutenberg-products-block'
-								) }
-								value={ rel }
-								onChange={ ( newRel ) =>
-									setAttributes( { rel: newRel } )
-								}
 							/>
 						</>
 					) }

--- a/assets/js/atomic/blocks/product-elements/title/test/block.test.js
+++ b/assets/js/atomic/blocks/product-elements/title/test/block.test.js
@@ -59,18 +59,5 @@ describe( 'Product Title Block', () => {
 			expect( anchor.getAttribute( 'href' ) ).toBe( product.permalink );
 			expect( anchor.getAttribute( 'target' ) ).toBe( '_blank' );
 		} );
-
-		test( 'should render an anchor with the product title and a rel', () => {
-			const component = render(
-				<ProductDataContextProvider product={ product }>
-					<Block showProductLink={ true } rel="some_rel" />
-				</ProductDataContextProvider>
-			);
-
-			const productName = component.getByText( product.name );
-			const anchor = productName.closest( 'a' );
-
-			expect( anchor.getAttribute( 'href' ) ).toBe( product.permalink );
-		} );
 	} );
 } );

--- a/assets/js/atomic/blocks/product-elements/title/test/block.test.js
+++ b/assets/js/atomic/blocks/product-elements/title/test/block.test.js
@@ -43,8 +43,8 @@ describe( 'Product Title Block', () => {
 			const anchor = productName.closest( 'a' );
 
 			expect( anchor.getAttribute( 'href' ) ).toBe( product.permalink );
-			expect( anchor.getAttribute( 'target' ) ).toBe( null );
-			expect( anchor.getAttribute( 'rel' ) ).toContain( 'nofollow' );
+			expect( anchor.getAttribute( 'target' ) ).toBeNull();
+			expect( anchor.getAttribute( 'rel' ) ).toBeNull();
 		} );
 
 		test( 'should render an anchor with the product title and target blank', () => {
@@ -59,7 +59,7 @@ describe( 'Product Title Block', () => {
 
 			expect( anchor.getAttribute( 'href' ) ).toBe( product.permalink );
 			expect( anchor.getAttribute( 'target' ) ).toBe( '_blank' );
-			expect( anchor.getAttribute( 'rel' ) ).toContain( 'nofollow' );
+			expect( anchor.getAttribute( 'rel' ) ).toBeNull();
 		} );
 
 		test( 'should render an anchor with the product title and a rel', () => {
@@ -73,8 +73,7 @@ describe( 'Product Title Block', () => {
 			const anchor = productName.closest( 'a' );
 
 			expect( anchor.getAttribute( 'href' ) ).toBe( product.permalink );
-			expect( anchor.getAttribute( 'rel' ) ).toContain( 'some_rel' );
-			expect( anchor.getAttribute( 'rel' ) ).toContain( 'nofollow' );
+			expect( anchor.getAttribute( 'rel' ) ).toBe( 'some_rel' );
 		} );
 	} );
 } );

--- a/assets/js/atomic/blocks/product-elements/title/test/block.test.js
+++ b/assets/js/atomic/blocks/product-elements/title/test/block.test.js
@@ -44,7 +44,6 @@ describe( 'Product Title Block', () => {
 
 			expect( anchor.getAttribute( 'href' ) ).toBe( product.permalink );
 			expect( anchor.getAttribute( 'target' ) ).toBeNull();
-			expect( anchor.getAttribute( 'rel' ) ).toBeNull();
 		} );
 
 		test( 'should render an anchor with the product title and target blank', () => {
@@ -59,7 +58,6 @@ describe( 'Product Title Block', () => {
 
 			expect( anchor.getAttribute( 'href' ) ).toBe( product.permalink );
 			expect( anchor.getAttribute( 'target' ) ).toBe( '_blank' );
-			expect( anchor.getAttribute( 'rel' ) ).toBeNull();
 		} );
 
 		test( 'should render an anchor with the product title and a rel', () => {
@@ -73,7 +71,6 @@ describe( 'Product Title Block', () => {
 			const anchor = productName.closest( 'a' );
 
 			expect( anchor.getAttribute( 'href' ) ).toBe( product.permalink );
-			expect( anchor.getAttribute( 'rel' ) ).toBe( 'some_rel' );
 		} );
 	} );
 } );

--- a/assets/js/atomic/blocks/product-elements/title/test/block.test.js
+++ b/assets/js/atomic/blocks/product-elements/title/test/block.test.js
@@ -1,0 +1,80 @@
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+import { ProductDataContextProvider } from '@woocommerce/shared-context';
+
+/**
+ * Internal dependencies
+ */
+import { Block } from '../block';
+
+const product = {
+	id: 1,
+	name: 'Test product',
+	permalink: 'https://test.com/product/test-product/',
+};
+
+describe( 'Product Title Block', () => {
+	describe( 'without product link', () => {
+		test( 'should render the product title without an anchor wrapper', () => {
+			const component = render(
+				<ProductDataContextProvider product={ product }>
+					<Block showProductLink={ false } />
+				</ProductDataContextProvider>
+			);
+
+			const productName = component.getByText( product.name );
+			const anchor = productName.closest( 'a' );
+
+			expect( anchor ).toBe( null );
+		} );
+	} );
+
+	describe( 'with product link', () => {
+		test( 'should render an anchor with the product title', () => {
+			const component = render(
+				<ProductDataContextProvider product={ product }>
+					<Block showProductLink={ true } />
+				</ProductDataContextProvider>
+			);
+
+			const productName = component.getByText( product.name );
+			const anchor = productName.closest( 'a' );
+
+			expect( anchor.getAttribute( 'href' ) ).toBe( product.permalink );
+			expect( anchor.getAttribute( 'target' ) ).toBe( null );
+			expect( anchor.getAttribute( 'rel' ) ).toContain( 'nofollow' );
+		} );
+
+		test( 'should render an anchor with the product title and target blank', () => {
+			const component = render(
+				<ProductDataContextProvider product={ product }>
+					<Block showProductLink={ true } linkTarget="_blank" />
+				</ProductDataContextProvider>
+			);
+
+			const productName = component.getByText( product.name );
+			const anchor = productName.closest( 'a' );
+
+			expect( anchor.getAttribute( 'href' ) ).toBe( product.permalink );
+			expect( anchor.getAttribute( 'target' ) ).toBe( '_blank' );
+			expect( anchor.getAttribute( 'rel' ) ).toContain( 'nofollow' );
+		} );
+
+		test( 'should render an anchor with the product title and a rel', () => {
+			const component = render(
+				<ProductDataContextProvider product={ product }>
+					<Block showProductLink={ true } rel="some_rel" />
+				</ProductDataContextProvider>
+			);
+
+			const productName = component.getByText( product.name );
+			const anchor = productName.closest( 'a' );
+
+			expect( anchor.getAttribute( 'href' ) ).toBe( product.permalink );
+			expect( anchor.getAttribute( 'rel' ) ).toContain( 'some_rel' );
+			expect( anchor.getAttribute( 'rel' ) ).toContain( 'nofollow' );
+		} );
+	} );
+} );

--- a/assets/js/atomic/blocks/product-elements/title/types.ts
+++ b/assets/js/atomic/blocks/product-elements/title/types.ts
@@ -1,8 +1,8 @@
 export interface Attributes {
 	headingLevel: number;
 	showProductLink: boolean;
-	linkTarget: string;
-	rel: string;
+	linkTarget?: string;
+	rel?: string;
 	productId: number;
 	align: string;
 }

--- a/assets/js/atomic/blocks/product-elements/title/types.ts
+++ b/assets/js/atomic/blocks/product-elements/title/types.ts
@@ -2,7 +2,6 @@ export interface Attributes {
 	headingLevel: number;
 	showProductLink: boolean;
 	linkTarget?: string;
-	rel?: string;
 	productId: number;
 	align: string;
 }

--- a/assets/js/atomic/blocks/product-elements/title/types.ts
+++ b/assets/js/atomic/blocks/product-elements/title/types.ts
@@ -1,6 +1,8 @@
 export interface Attributes {
 	headingLevel: number;
 	showProductLink: boolean;
+	linkTarget: string;
+	rel: string;
 	productId: number;
 	align: string;
 }

--- a/assets/js/base/components/product-name/index.tsx
+++ b/assets/js/base/components/product-name/index.tsx
@@ -42,7 +42,7 @@ export const ProductName = ( {
 	disabled = false,
 	name,
 	permalink = '',
-	target = '_self',
+	target,
 	rel,
 	style,
 	onClick,

--- a/assets/js/base/components/product-name/index.tsx
+++ b/assets/js/base/components/product-name/index.tsx
@@ -42,6 +42,7 @@ export const ProductName = ( {
 	disabled = false,
 	name,
 	permalink = '',
+	target = '_self',
 	rel,
 	style,
 	onClick,
@@ -65,6 +66,7 @@ export const ProductName = ( {
 		<a
 			className={ classes }
 			href={ permalink }
+			target={ target }
 			rel={ rel }
 			{ ...props }
 			dangerouslySetInnerHTML={ {

--- a/assets/js/base/components/product-name/index.tsx
+++ b/assets/js/base/components/product-name/index.tsx
@@ -67,7 +67,6 @@ export const ProductName = ( {
 			className={ classes }
 			href={ permalink }
 			target={ target }
-			rel={ rel }
 			{ ...props }
 			dangerouslySetInnerHTML={ {
 				__html: decodeEntities( name ),

--- a/assets/js/base/components/product-name/test/__snapshots__/index.js.snap
+++ b/assets/js/base/components/product-name/test/__snapshots__/index.js.snap
@@ -9,7 +9,6 @@ exports[`ProductName should merge classes and props 1`] = `
     }
   }
   href="/"
-  rel="nofollow"
 />
 `;
 


### PR DESCRIPTION
This PR changes the settings on the `Product Title` block to be aligned with the `Post Title` block ones.
It introduces these changes:
- Rename Panel from `Content` to `Link settings`.
- Rename toggle `Link to Product Page` to `Make title a link`.
- Remove text `Links the image to the single product listing`.
- Add an option to `Open in new tab`.

Fixes #6004

### Screenshots

Before | After
--- | ---
<img width="280" alt="before" src="https://user-images.githubusercontent.com/186112/160404457-edac8b0a-4b10-44af-97f0-535659392bbd.png">|<img width="280" alt="Screenshot 2022-04-01 at 08 48 54" src="https://user-images.githubusercontent.com/186112/161210485-a2aea284-b48c-41a1-aebd-af9e22fd56c6.png">


### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [ ] E2E tests

### Manual Testing

How to test the changes in this Pull Request:

1. Add a `Product title` block to a page
2. Go to the `Link settings` section on the block settings
3. Check it has the `Make title a link`, `Open in new tab` toggles
5. Make changes to those settings, click the Update button, make sure the settings are stored
6. Open the page frontend and check that the selected settings are applied when the product title block is rendered

### Changelog

> Update `Product Title` link settings content and add an option to `Open in new tab`.
