### PR TITLE
Critical flows: Shopper → Checkout → Can login to existing account and can create an account

### DIFF
--- a/tests/e2e/specs/shopper/cart-checkout/account.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/account.test.js
@@ -31,12 +31,6 @@ describe( 'Shopper → Checkout → Account', () => {
 		await setCheckbox( '#woocommerce_enable_guest_checkout' );
 		await page.click( 'button[name="save"]' );
 		await page.waitForNavigation( { waitUntil: 'networkidle0' } );
-		// await page.evaluate( () => {
-		// 	localStorage.setItem(
-		// 		'wc-blocks_dismissed_compatibility_notices',
-		// 		'["checkout"]'
-		// 	);
-		// } );
 		await visitBlockPage( `${ block.name } Block` );
 		await openDocumentSettingsSidebar();
 		await selectBlockByName( block.slug );

--- a/tests/e2e/specs/shopper/cart-checkout/account.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/account.test.js
@@ -1,33 +1,46 @@
+/**
+ * Internal dependencies
+ */
 import { shopper } from '../../../../utils';
 import { SIMPLE_PHYSICAL_PRODUCT_NAME } from '.../../../../utils/constants';
+
+/**
+ * External dependencies
+ */
 import {
 	visitBlockPage,
 	selectBlockByName,
 	saveOrPublish,
 } from '@woocommerce/blocks-test-utils';
-
 import {
 	merchant,
 	setCheckbox,
-	unsetCheckbox,
 	openDocumentSettingsSidebar,
 } from '@woocommerce/e2e-utils';
 import { switchUserToAdmin, visitAdminPage } from '@wordpress/e2e-test-utils';
+
+// Defining block details
 const block = {
 	name: 'Checkout',
 	slug: 'woocommerce/checkout',
 	class: '.wp-block-woocommerce-checkout',
 };
+
 if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 ) {
+	// eslint-disable-next-line jest/no-focused-tests
 	test.only( 'Skipping Cart & Checkout tests', () => {} );
 }
+
 describe( 'Shopper → Checkout → Account', () => {
 	beforeAll( async () => {
 		await merchant.openSettings( 'account' );
+		//Enable create an account at checkout option
 		await setCheckbox( '#woocommerce_enable_checkout_login_reminder' );
+		//Enable login at checkout option
 		await setCheckbox(
 			'#woocommerce_enable_signup_and_login_from_checkout'
 		);
+		//Enable guest checkout option
 		await setCheckbox( '#woocommerce_enable_guest_checkout' );
 		await page.click( 'button[name="save"]' );
 		await page.waitForNavigation( { waitUntil: 'networkidle0' } );
@@ -37,6 +50,7 @@ describe( 'Shopper → Checkout → Account', () => {
 		await selectBlockByName(
 			'woocommerce/checkout-contact-information-block'
 		);
+		//Enable shoppers to sign up at checkout option
 		await expect( page ).toClick( 'label', {
 			text:
 				'Allow shoppers to sign up for a user account during checkout',
@@ -47,28 +61,33 @@ describe( 'Shopper → Checkout → Account', () => {
 		await shopper.addToCartFromShopPage( SIMPLE_PHYSICAL_PRODUCT_NAME );
 		await shopper.block.goToCheckout();
 	} );
+
 	it( 'user can login to existing account', async () => {
+		//Get the login link from checkout page
 		const loginLink = await page.$eval(
 			'span.wc-block-components-checkout-step__heading-content a',
 			( el ) => el.href
 		);
-
+		//Confirm login link is correct
 		await expect( loginLink ).toContain(
 			`${ process.env.WORDPRESS_BASE_URL }/my-account/?redirect_to`
 		);
 		await expect( loginLink ).toContain( `checkout` );
 	} );
+
 	it( 'user can can create an account', async () => {
 		await expect( page ).toClick( 'span', {
 			text: 'Create an account?',
 		} );
-		const TEST_EMAIL = 'test' + Math.random() * 10 + '@example.com';
-		await expect( page ).toFill( `#email`, TEST_EMAIL );
+		//Create random email to place an order
+		let testEmail = `test${ Math.random() * 10 }@example.com`;
+		await expect( page ).toFill( `#email`, testEmail );
 		await shopper.block.fillInCheckoutWithTestData();
 		await shopper.block.placeOrder();
 		await expect( page ).toMatch( 'Order received' );
 		await switchUserToAdmin();
 		await visitAdminPage( 'users.php' );
-		await expect( page ).toMatch( TEST_EMAIL );
+		//Confirm account is being created with the email
+		await expect( page ).toMatch( testEmail );
 	} );
 } );

--- a/tests/e2e/specs/shopper/cart-checkout/account.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/account.test.js
@@ -1,10 +1,4 @@
 /**
- * Internal dependencies
- */
-import { shopper } from '../../../../utils';
-import { SIMPLE_PHYSICAL_PRODUCT_NAME } from '.../../../../utils/constants';
-
-/**
  * External dependencies
  */
 import {
@@ -19,7 +13,12 @@ import {
 } from '@woocommerce/e2e-utils';
 import { switchUserToAdmin, visitAdminPage } from '@wordpress/e2e-test-utils';
 
-// Defining block details
+/**
+ * Internal dependencies
+ */
+import { shopper } from '../../../../utils';
+import { SIMPLE_PHYSICAL_PRODUCT_NAME } from '.../../../../utils/constants';
+
 const block = {
 	name: 'Checkout',
 	slug: 'woocommerce/checkout',
@@ -27,20 +26,20 @@ const block = {
 };
 
 if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 ) {
-	// eslint-disable-next-line jest/no-focused-tests
+	// Skips all the tests if it's a WooCommerce Core process environment.
 	test.only( 'Skipping Cart & Checkout tests', () => {} );
 }
 
 describe( 'Shopper → Checkout → Account', () => {
 	beforeAll( async () => {
 		await merchant.openSettings( 'account' );
-		//Enable create an account at checkout option
+		//Enable create an account at checkout option.
 		await setCheckbox( '#woocommerce_enable_checkout_login_reminder' );
-		//Enable login at checkout option
+		//Enable login at checkout option.
 		await setCheckbox(
 			'#woocommerce_enable_signup_and_login_from_checkout'
 		);
-		//Enable guest checkout option
+		//Enable guest checkout option.
 		await setCheckbox( '#woocommerce_enable_guest_checkout' );
 		await page.click( 'button[name="save"]' );
 		await page.waitForNavigation( { waitUntil: 'networkidle0' } );
@@ -50,7 +49,7 @@ describe( 'Shopper → Checkout → Account', () => {
 		await selectBlockByName(
 			'woocommerce/checkout-contact-information-block'
 		);
-		//Enable shoppers to sign up at checkout option
+		//Enable shoppers to sign up at checkout option.
 		await expect( page ).toClick( 'label', {
 			text:
 				'Allow shoppers to sign up for a user account during checkout',
@@ -63,12 +62,12 @@ describe( 'Shopper → Checkout → Account', () => {
 	} );
 
 	it( 'user can login to existing account', async () => {
-		//Get the login link from checkout page
+		//Get the login link from checkout page.
 		const loginLink = await page.$eval(
 			'span.wc-block-components-checkout-step__heading-content a',
 			( el ) => el.href
 		);
-		//Confirm login link is correct
+		//Confirm login link is correct.
 		await expect( loginLink ).toContain(
 			`${ process.env.WORDPRESS_BASE_URL }/my-account/?redirect_to`
 		);
@@ -79,7 +78,7 @@ describe( 'Shopper → Checkout → Account', () => {
 		await expect( page ).toClick( 'span', {
 			text: 'Create an account?',
 		} );
-		//Create random email to place an order
+		//Create random email to place an order.
 		let testEmail = `test${ Math.random() * 10 }@example.com`;
 		await expect( page ).toFill( `#email`, testEmail );
 		await shopper.block.fillInCheckoutWithTestData();
@@ -87,7 +86,7 @@ describe( 'Shopper → Checkout → Account', () => {
 		await expect( page ).toMatch( 'Order received' );
 		await switchUserToAdmin();
 		await visitAdminPage( 'users.php' );
-		//Confirm account is being created with the email
+		//Confirm account is being created with the email.
 		await expect( page ).toMatch( testEmail );
 	} );
 } );

--- a/tests/e2e/specs/shopper/cart-checkout/account.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/account.test.js
@@ -1,0 +1,80 @@
+import { shopper } from '../../../../utils';
+import { SIMPLE_PHYSICAL_PRODUCT_NAME } from '.../../../../utils/constants';
+import {
+	visitBlockPage,
+	selectBlockByName,
+	saveOrPublish,
+} from '@woocommerce/blocks-test-utils';
+
+import {
+	merchant,
+	setCheckbox,
+	unsetCheckbox,
+	openDocumentSettingsSidebar,
+} from '@woocommerce/e2e-utils';
+import { switchUserToAdmin, visitAdminPage } from '@wordpress/e2e-test-utils';
+const block = {
+	name: 'Checkout',
+	slug: 'woocommerce/checkout',
+	class: '.wp-block-woocommerce-checkout',
+};
+if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 ) {
+	test.only( 'Skipping Cart & Checkout tests', () => {} );
+}
+describe( 'Shopper → Checkout → Account', () => {
+	beforeAll( async () => {
+		await merchant.openSettings( 'account' );
+		await setCheckbox( '#woocommerce_enable_checkout_login_reminder' );
+		await setCheckbox(
+			'#woocommerce_enable_signup_and_login_from_checkout'
+		);
+		await setCheckbox( '#woocommerce_enable_guest_checkout' );
+		await page.click( 'button[name="save"]' );
+		await page.waitForNavigation( { waitUntil: 'networkidle0' } );
+		// await page.evaluate( () => {
+		// 	localStorage.setItem(
+		// 		'wc-blocks_dismissed_compatibility_notices',
+		// 		'["checkout"]'
+		// 	);
+		// } );
+		await visitBlockPage( `${ block.name } Block` );
+		await openDocumentSettingsSidebar();
+		await selectBlockByName( block.slug );
+		await selectBlockByName(
+			'woocommerce/checkout-contact-information-block'
+		);
+		await expect( page ).toClick( 'label', {
+			text:
+				'Allow shoppers to sign up for a user account during checkout',
+		} );
+		await saveOrPublish();
+		await shopper.logout();
+		await shopper.goToShop();
+		await shopper.addToCartFromShopPage( SIMPLE_PHYSICAL_PRODUCT_NAME );
+		await shopper.block.goToCheckout();
+	} );
+	it( 'user can login to existing account', async () => {
+		const loginLink = await page.$eval(
+			'span.wc-block-components-checkout-step__heading-content a',
+			( el ) => el.href
+		);
+
+		await expect( loginLink ).toContain(
+			`${ process.env.WORDPRESS_BASE_URL }/my-account/?redirect_to`
+		);
+		await expect( loginLink ).toContain( `checkout` );
+	} );
+	it( 'user can can create an account', async () => {
+		await expect( page ).toClick( 'span', {
+			text: 'Create an account?',
+		} );
+		const TEST_EMAIL = 'test' + Math.random() * 10 + '@example.com';
+		await expect( page ).toFill( `#email`, TEST_EMAIL );
+		await shopper.block.fillInCheckoutWithTestData();
+		await shopper.block.placeOrder();
+		await expect( page ).toMatch( 'Order received' );
+		await switchUserToAdmin();
+		await visitAdminPage( 'users.php' );
+		await expect( page ).toMatch( TEST_EMAIL );
+	} );
+} );


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #5780
Fixes #5779

This PR adds e2e tests to ensure that shopper can login to their accounts and create a new account from the Checkout block page. 

### Testing

#### Automated Tests

* [x] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests
 
### Manual Testing

How to test the changes in this Pull Request:

1. Check out this PR.
2. Start Docker Desktop.
3. Run `npm run wp-env destroy && npm run wp-env start` to start a fresh e2e environment.
4. Run `npm run test:e2e-dev -- tests/e2e/specs/shopper/cart-checkout/account.test.js` to run only this test case.
5. Make sure all tests pass. 
