### PR TITLE
Fix E2E Tests on trunk

### DIFF
--- a/tests/e2e/specs/shopper/cart-checkout-translations.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout-translations.test.js
@@ -49,7 +49,7 @@ describe( 'Shopper → Cart → Can view translated cart & checkout blocks', () 
 		const productHeader = await page.$(
 			'.wc-block-cart-items .wc-block-cart-items__header span'
 		);
-		await expect( productHeader ).toMatch( 'Produit' );
+		await expect( productHeader ).toMatch( 'Produit', { timeout: 2000 } );
 
 		const removeLink = await page.$( '.wc-block-cart-item__remove-link' );
 		await expect( removeLink ).toMatch( 'Retirer l’élément' );
@@ -72,7 +72,9 @@ describe( 'Shopper → Cart → Can view translated cart & checkout blocks', () 
 		const contactHeading = await page.$(
 			'#contact-fields .wc-block-components-checkout-step__title'
 		);
-		await expect( contactHeading ).toMatch( 'Coordonnées' );
+		await expect( contactHeading ).toMatch( 'Coordonnées', {
+			timeout: 2000,
+		} );
 
 		const shippingHeading = await page.$(
 			'#shipping-fields .wc-block-components-checkout-step__title'

--- a/tests/e2e/specs/shopper/cart-empty.test.js
+++ b/tests/e2e/specs/shopper/cart-empty.test.js
@@ -3,9 +3,10 @@
  */
 import { shopper } from '../../../utils';
 
-if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 )
+if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 ) {
 	// eslint-disable-next-line jest/no-focused-tests
 	test.only( `skipping ${ block.name } tests`, () => {} );
+}
 
 describe( 'Shopper → Cart → Can view empty cart message', () => {
 	beforeAll( async () => {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
Fixing E2E tests in CI. We merged a [PR](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/6101) that has some failing e2e tests, this is to rectify that

If all is green, all is good :)