### PR TITLE
Remove button alignment from Featured Product and Featured Category blocks

### DIFF
--- a/assets/js/blocks/featured-category/block.js
+++ b/assets/js/blocks/featured-category/block.js
@@ -271,7 +271,9 @@ const FeaturedCategory = ( {
 				template={ [
 					[
 						'core/buttons',
-						{},
+						{
+							layout: { type: 'flex', justifyContent: 'center' },
+						},
 						[
 							[
 								'core/button',
@@ -281,7 +283,6 @@ const FeaturedCategory = ( {
 										'woo-gutenberg-products-block'
 									),
 									url: category.permalink,
-									align: 'center',
 								},
 							],
 						],

--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -368,7 +368,9 @@ const FeaturedProduct = ( {
 				template={ [
 					[
 						'core/buttons',
-						{},
+						{
+							layout: { type: 'flex', justifyContent: 'center' },
+						},
 						[
 							[
 								'core/button',
@@ -378,7 +380,6 @@ const FeaturedProduct = ( {
 										'woo-gutenberg-products-block'
 									),
 									url: product.permalink,
-									align: 'center',
 								},
 							],
 						],


### PR DESCRIPTION
Fixes #5887.

For some time, alignment of buttons has been controlled by the _Buttons_ block instead of the _Button_ block. This PR updates the Featured Product and Featured Category inner blocks accordingly.

### Manual Testing

1. Activate a block theme (ie: Twenty Twenty-Two).
2. Add Featured Product and/or Featured Category blocks to a post or page.
3. Verify the button is centered by default.
4. Verify you can change the alignment of the button using the _Justify items_ dropdown inherited from the _Buttons_ block.
![imatge](https://user-images.githubusercontent.com/3616980/160625173-f9ad42ed-b769-42e3-9ad8-3f3abe60b61c.png)
5. Test again with a classic theme (ie: Storefront).

### Changelog

> Fix Featured Product and Featured Category buttons misalignment in Twenty Twenty Two theme.
