### PR TITLE
Fix: Shopping Button default hover and focus style

### DIFF
--- a/assets/js/blocks/cart-checkout/mini-cart/style.scss
+++ b/assets/js/blocks/cart-checkout/mini-cart/style.scss
@@ -171,7 +171,15 @@ h2.wc-block-mini-cart__title {
 	a {
 		border: 2px solid;
 		color: currentColor;
+		font-weight: 600;
 		padding: $gap-small $gap-large;
 		text-decoration: none;
+
+		&:hover,
+		&:focus {
+			background-color: $gray-900;
+			border-color: $gray-900;
+			color: $white;
+		}
 	}
 }


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Follows up #6130

This PR adds the default hover and focus style for the Shopping Button. This fixes the issue that the button disappears on hover/focus when only the background color is set.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### Screenshots

<table>
<tr>
	<td> Before
	<td> <img width="1244" alt="Screen Shot 2022-03-29 at 21 39 27" src="https://user-images.githubusercontent.com/5423135/160637348-67b741ac-1b98-4b1c-b8de-ee24169b1114.png" />
<tr>
	<td> After
	<td> <img width="1247" alt="Screen Shot 2022-03-29 at 21 38 48" src="https://user-images.githubusercontent.com/5423135/160637364-ecae2e7d-3ed6-46ef-b7e8-27a59ad3d474.png" />

</table>

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Edit the Mini Cart Contents block.
2. Set only the background color.
3. On the front end, hover over the Start shopping button.
4. See the button is still visible, with black background and border.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
* [ ] See steps below.