### PR TITLE
Mini Cart block - fix translations handling #6153

### DIFF
--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -260,11 +260,10 @@ class MiniCart extends AbstractBlock {
 			return;
 		}
 		$this->scripts_to_lazy_load[ $script->handle ] = array(
-			'src'          => $script->src,
-			'version'      => $script->ver,
-			'before'       => $wp_scripts->print_inline_script( $script->handle, 'before', false ),
-			'after'        => $wp_scripts->print_inline_script( $script->handle, 'after', false ),
-			'translations' => $wp_scripts->print_translations( $script->handle, false ),
+			'src'     => $script->src,
+			'version' => $script->ver,
+			'before'  => $wp_scripts->print_inline_script( $script->handle, 'before', false ),
+			'after'   => $wp_scripts->print_inline_script( $script->handle, 'after', false ),
 		);
 	}
 
@@ -441,5 +440,27 @@ class MiniCart extends AbstractBlock {
 	 */
 	protected function get_cart_payload() {
 		return WC()->api->get_endpoint_data( '/wc/store/cart' );
+	}
+
+	/**
+	 * Register script and style assets for the block type before it is registered.
+	 *
+	 * This registers the scripts; it does not enqueue them.
+	 * The children blocks are register here because this block handles the loading of the frontend scripts.
+	 */
+	protected function register_block_type_assets() {
+		parent::register_block_type_assets();
+		$blocks = [
+			'mini-cart-contents-block/filled-cart',
+			'mini-cart-contents-block/empty-cart',
+			'mini-cart-contents-block/title',
+			'mini-cart-contents-block/items',
+			'mini-cart-contents-block/products-table',
+			'mini-cart-contents-block/footer',
+			'mini-cart-contents-block/shopping-button',
+		];
+		$chunks = preg_filter( '/$/', '-frontend', $blocks );
+
+		$this->register_chunk_translations( $chunks );
 	}
 }

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -447,6 +447,15 @@ class MiniCart extends AbstractBlock {
 	 * Prepare translations for inner blocks and dependencies.
 	 */
 	protected function get_dependencies_translations() {
+		/**
+		 * Temporary remove the this filter so $wp_scripts->print_translations
+		 * calls won't accident print the translations scripts for the block.
+		 *
+		 * $wp_scripts->print_translations() calls load_script_textdomain()
+		 * which calls load_script_translations() containing the below filter.
+		 */
+		remove_filter( 'pre_load_script_translations', 'woocommerce_blocks_get_i18n_data_json', 10, 4 );
+
 		$wp_scripts   = wp_scripts();
 		$translations = array();
 
@@ -468,7 +477,14 @@ class MiniCart extends AbstractBlock {
 			wp_deregister_script( $handle );
 		}
 
+		foreach ( array_keys( $this->scripts_to_lazy_load ) as $script ) {
+			$translations[] = $wp_scripts->print_translations( $script, false );
+		}
+
 		$translations = array_filter( $translations );
+
+		// Re-add the filter.
+		add_filter( 'pre_load_script_translations', 'woocommerce_blocks_get_i18n_data_json', 10, 4 );
 
 		return implode( '', $translations );
 	}


### PR DESCRIPTION
This PR fixes how the Mini Cart block loads the translations.


<!-- Reference any related issues or PRs here -->
Fixes #6153 


### Technical details

I guess that the current method of how the Mini Cart block loads [the translations is not correct](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/src/BlockTypes/MiniCart.php#L267). It seems that all the blocks using the method `register_chunk_translations`.


@dinhtungdu noticed that the function `append_script_and_deps_src` is used to lazy load the dependencies of Mini Cart and payment method scripts. Are we sure that the line about the translation is necessary?

Another doubt that I have: what are the advantages to split the handling of the translations compared to the other scripts with the suffix `before`? ([here the code](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/ab91245382ef23705d4802f23809e22b482a8d22/assets/js/base/utils/lazy-load-script.ts#L99-L110))


### Testing

### Manual Testing

How to test the changes in this Pull Request:

Check out this branch

1. Go to **Settings -> General** and change the language of the site to any language other than English (my suggestion is to use Dutch because all the translations are available).
2. Enable a classic theme (for example Storefront)
3. Now go to **Appearance -> Widgets** and add `Mini Cart` widget to any Widget Area.
4. Go to any page containing that Widget Area and check that any error related to `wp.i18n`.
5. Check that the `Mini Cart` is translated (check with an empty cart and with a filled cart). Please, be sure that you are using a language that has translations for the Mini Cart Block. My suggestion is to use the Dutch language.
6. Enable a block theme (for example TT2).
7. Now go to **Appearance -> Editor** and add the `Mini Cart` block in the header. Save.
8. Check that the `Mini Cart` is translated (check with an empty cart and with a filled cart). Please, be sure that you are using a language that has translations for the Mini Cart Block. My suggestion is to use the Dutch language.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above

### Changelog

> Mini Cart block: Fix translations loading
