### PR TITLE
Fix/e2e tests timeout issue

### DIFF
--- a/tests/e2e/specs/shopper/cart-checkout-payments.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout-payments.test.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { shopper } from '../../../utils';
-import { SIMPLE_PRODUCT_NAME } from '../../../utils/constants';
+import { SIMPLE_VIRTUAL_PRODUCT_NAME } from '../../../utils/constants';
 
 if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 ) {
 	// eslint-disable-next-line jest/no-focused-tests
@@ -12,7 +12,7 @@ if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 ) {
 describe( 'Shopper → Cart/Checkout → Can use express checkout', () => {
 	it( 'Express Payment button is available on both Cart & Checkout pages', async () => {
 		await shopper.goToShop();
-		await shopper.addToCartFromShopPage( SIMPLE_PRODUCT_NAME );
+		await shopper.addToCartFromShopPage( SIMPLE_VIRTUAL_PRODUCT_NAME );
 		await shopper.block.goToCart();
 		await shopper.block.mockExpressPaymentMethod();
 		// We need to re-render the cart for the express payments block to be updated,

--- a/tests/e2e/specs/shopper/cart-checkout-translations.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout-translations.test.js
@@ -47,9 +47,7 @@ describe( 'Shopper → Cart → Can view translated cart & checkout blocks', () 
 		await shopper.addToCartFromShopPage( '128GB USB Stick' );
 		await shopper.block.goToCart();
 
-		await page.waitForSelector( '.wp-block-woocommerce-cart-items-block' );
-
-		const productHeader = await page.$(
+		const productHeader = await page.waitForSelector(
 			'.wc-block-cart-items .wc-block-cart-items__header span'
 		);
 		await expect( productHeader ).toMatch( 'Produit', { timeout: 30000 } );

--- a/tests/e2e/specs/shopper/cart-checkout-translations.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout-translations.test.js
@@ -64,7 +64,7 @@ describe( 'Shopper → Cart → Can view translated cart & checkout blocks', () 
 		);
 		await expect( submitButton ).toMatch( 'Procéder au paiement' );
 
-		const orderSummary = await page.waitForSelector(
+		const orderSummary = await page.$(
 			'.wp-block-woocommerce-cart-order-summary-block'
 		);
 

--- a/tests/e2e/specs/shopper/cart-checkout-translations.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout-translations.test.js
@@ -47,29 +47,35 @@ describe( 'Shopper → Cart → Can view translated cart & checkout blocks', () 
 		await shopper.addToCartFromShopPage( '128GB USB Stick' );
 		await shopper.block.goToCart();
 
-		const productHeader = await page.$(
+		// await page.waitForNetworkIdle();
+
+		const productHeader = await page.waitForSelector(
 			'.wc-block-cart-items .wc-block-cart-items__header span'
 		);
 		await expect( productHeader ).toMatch( 'Produit', { timeout: 30000 } );
 
-		const removeLink = await page.$( '.wc-block-cart-item__remove-link' );
+		const removeLink = await page.waitForSelector(
+			'.wc-block-cart-item__remove-link'
+		);
 		await expect( removeLink ).toMatch( 'Retirer l’élément' );
 
-		const submitButton = await page.$( '.wc-block-cart__submit-button' );
+		const submitButton = await page.waitForSelector(
+			'.wc-block-cart__submit-button'
+		);
 		await expect( submitButton ).toMatch( 'Procéder au paiement' );
 
-		const orderSummary = await page.$(
+		const orderSummary = await page.waitForSelector(
 			'.wp-block-woocommerce-cart-order-summary-block'
 		);
 
-		const orderHeading = await page.$(
-			'.wp-block-woocommerce-cart-order-summary-heading-block'
+		const orderHeading = await page.waitForSelector(
+			'.wc-block-components-title'
 		);
-		const orderSummarySubtotal = await page.$(
-			'.wp-block-woocommerce-cart-order-summary-subtotal-block'
+		const orderSummarySubtotal = await page.waitForSelector(
+			'.wc-block-components-totals-item__label'
 		);
-		const orderSummaryCoupon = await page.$(
-			'.wp-block-woocommerce-cart-order-summary-coupon-form-block'
+		const orderSummaryCoupon = await page.waitForSelector(
+			'.wc-block-components-totals-coupon'
 		);
 
 		await expect( orderHeading ).toMatch( 'Total panier' );

--- a/tests/e2e/specs/shopper/cart-checkout-translations.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout-translations.test.js
@@ -49,7 +49,7 @@ describe( 'Shopper → Cart → Can view translated cart & checkout blocks', () 
 		const productHeader = await page.$(
 			'.wc-block-cart-items .wc-block-cart-items__header span'
 		);
-		await expect( productHeader ).toMatch( 'Produit' );
+		await expect( productHeader ).toMatch( 'Produit', { timeout: 30000 } );
 
 		const removeLink = await page.$( '.wc-block-cart-item__remove-link' );
 		await expect( removeLink ).toMatch( 'Retirer l’élément' );
@@ -72,7 +72,9 @@ describe( 'Shopper → Cart → Can view translated cart & checkout blocks', () 
 		const contactHeading = await page.$(
 			'#contact-fields .wc-block-components-checkout-step__title'
 		);
-		await expect( contactHeading ).toMatch( 'Coordonnées' );
+		await expect( contactHeading ).toMatch( 'Coordonnées', {
+			timeout: 30000,
+		} );
 
 		const shippingHeading = await page.$(
 			'#shipping-fields .wc-block-components-checkout-step__title'

--- a/tests/e2e/specs/shopper/cart-checkout-translations.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout-translations.test.js
@@ -49,7 +49,7 @@ describe( 'Shopper → Cart → Can view translated cart & checkout blocks', () 
 		const productHeader = await page.$(
 			'.wc-block-cart-items .wc-block-cart-items__header span'
 		);
-		await expect( productHeader ).toMatch( 'Produit', { timeout: 2000 } );
+		await expect( productHeader ).toMatch( 'Produit', { timeout: 30000 } );
 
 		const removeLink = await page.$( '.wc-block-cart-item__remove-link' );
 		await expect( removeLink ).toMatch( 'Retirer l’élément' );
@@ -73,7 +73,7 @@ describe( 'Shopper → Cart → Can view translated cart & checkout blocks', () 
 			'#contact-fields .wc-block-components-checkout-step__title'
 		);
 		await expect( contactHeading ).toMatch( 'Coordonnées', {
-			timeout: 2000,
+			timeout: 30000,
 		} );
 
 		const shippingHeading = await page.$(

--- a/tests/e2e/specs/shopper/cart-checkout-translations.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout-translations.test.js
@@ -47,7 +47,7 @@ describe( 'Shopper → Cart → Can view translated cart & checkout blocks', () 
 		await shopper.addToCartFromShopPage( '128GB USB Stick' );
 		await shopper.block.goToCart();
 
-		// await page.waitForNetworkIdle();
+		await page.waitForNetworkIdle();
 
 		const productHeader = await page.waitForSelector(
 			'.wc-block-cart-items .wc-block-cart-items__header span'

--- a/tests/e2e/specs/shopper/cart-checkout-translations.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout-translations.test.js
@@ -68,19 +68,9 @@ describe( 'Shopper → Cart → Can view translated cart & checkout blocks', () 
 			'.wp-block-woocommerce-cart-order-summary-block'
 		);
 
-		const orderHeading = await page.waitForSelector(
-			'.wc-block-components-title'
-		);
-		const orderSummarySubtotal = await page.waitForSelector(
-			'.wc-block-components-totals-item__label'
-		);
-		const orderSummaryCoupon = await page.waitForSelector(
-			'.wc-block-components-totals-coupon'
-		);
-
-		await expect( orderHeading ).toMatch( 'Total panier' );
-		await expect( orderSummarySubtotal ).toMatch( 'Sous-total' );
-		await expect( orderSummaryCoupon ).toMatch( 'Coupon code' );
+		await expect( orderSummary ).toMatch( 'Total panier' );
+		await expect( orderSummary ).toMatch( 'Sous-total' );
+		await expect( orderSummary ).toMatch( 'Coupon code' );
 	} );
 
 	it( 'should be able to view translated Checkout block', async () => {
@@ -100,8 +90,7 @@ describe( 'Shopper → Cart → Can view translated cart & checkout blocks', () 
 			'#shipping-option .wc-block-components-checkout-step__title'
 		);
 		await expect( shippingOptionsHeading ).toMatch(
-			'Options de livraison',
-			{ timeout: 60000 }
+			'Options de livraison'
 		);
 
 		const paymentMethodHeading = await page.$(

--- a/tests/e2e/specs/shopper/cart-checkout-translations.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout-translations.test.js
@@ -49,7 +49,7 @@ describe( 'Shopper → Cart → Can view translated cart & checkout blocks', () 
 		const productHeader = await page.$(
 			'.wc-block-cart-items .wc-block-cart-items__header span'
 		);
-		await expect( productHeader ).toMatch( 'Produit', { timeout: 30000 } );
+		await expect( productHeader ).toMatch( 'Produit' );
 
 		const removeLink = await page.$( '.wc-block-cart-item__remove-link' );
 		await expect( removeLink ).toMatch( 'Retirer l’élément' );
@@ -72,9 +72,7 @@ describe( 'Shopper → Cart → Can view translated cart & checkout blocks', () 
 		const contactHeading = await page.$(
 			'#contact-fields .wc-block-components-checkout-step__title'
 		);
-		await expect( contactHeading ).toMatch( 'Coordonnées', {
-			timeout: 30000,
-		} );
+		await expect( contactHeading ).toMatch( 'Coordonnées' );
 
 		const shippingHeading = await page.$(
 			'#shipping-fields .wc-block-components-checkout-step__title'

--- a/tests/e2e/specs/shopper/cart-checkout-translations.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout-translations.test.js
@@ -47,38 +47,40 @@ describe( 'Shopper → Cart → Can view translated cart & checkout blocks', () 
 		await shopper.addToCartFromShopPage( '128GB USB Stick' );
 		await shopper.block.goToCart();
 
+		await page.waitForSelector( '.wp-block-woocommerce-filled-cart-block' );
+
 		const productHeader = await page.waitForSelector(
 			'.wc-block-cart-items .wc-block-cart-items__header span'
 		);
-		await expect( productHeader ).toMatch( 'Produit', { timeout: 60000 } );
+		await expect( productHeader ).toMatch( 'Produit' );
 
 		const removeLink = await page.waitForSelector(
 			'.wc-block-cart-item__remove-link'
 		);
-		await expect( removeLink ).toMatch( 'Retirer l’élément', {
-			timeout: 60000,
-		} );
+		await expect( removeLink ).toMatch( 'Retirer l’élément' );
 
 		const submitButton = await page.waitForSelector(
 			'.wc-block-cart__submit-button'
 		);
-		await expect( submitButton ).toMatch( 'Procéder au paiement', {
-			timeout: 60000,
-		} );
+		await expect( submitButton ).toMatch( 'Procéder au paiement' );
 
 		const orderSummary = await page.waitForSelector(
 			'.wp-block-woocommerce-cart-order-summary-block'
 		);
 
-		await expect( orderSummary ).toMatch( 'Total panier', {
-			timeout: 60000,
-		} );
-		await expect( orderSummary ).toMatch( 'Sous-total', {
-			timeout: 60000,
-		} );
-		await expect( orderSummary ).toMatch( 'Coupon code', {
-			timeout: 60000,
-		} );
+		const orderHeading = await page.waitForSelector(
+			'.wc-block-components-title'
+		);
+		const orderSummarySubtotal = await page.waitForSelector(
+			'.wc-block-components-totals-item__label'
+		);
+		const orderSummaryCoupon = await page.waitForSelector(
+			'.wc-block-components-totals-coupon'
+		);
+
+		await expect( orderHeading ).toMatch( 'Total panier' );
+		await expect( orderSummarySubtotal ).toMatch( 'Sous-total' );
+		await expect( orderSummaryCoupon ).toMatch( 'Coupon code' );
 	} );
 
 	it( 'should be able to view translated Checkout block', async () => {
@@ -87,16 +89,12 @@ describe( 'Shopper → Cart → Can view translated cart & checkout blocks', () 
 		const contactHeading = await page.$(
 			'#contact-fields .wc-block-components-checkout-step__title'
 		);
-		await expect( contactHeading ).toMatch( 'Coordonnées', {
-			timeout: 60000,
-		} );
+		await expect( contactHeading ).toMatch( 'Coordonnées' );
 
 		const shippingHeading = await page.$(
 			'#shipping-fields .wc-block-components-checkout-step__title'
 		);
-		await expect( shippingHeading ).toMatch( 'Adresse de livraison', {
-			timeout: 60000,
-		} );
+		await expect( shippingHeading ).toMatch( 'Adresse de livraison' );
 
 		const shippingOptionsHeading = await page.$(
 			'#shipping-option .wc-block-components-checkout-step__title'
@@ -109,36 +107,24 @@ describe( 'Shopper → Cart → Can view translated cart & checkout blocks', () 
 		const paymentMethodHeading = await page.$(
 			'#payment-method .wc-block-components-checkout-step__title'
 		);
-		await expect( paymentMethodHeading ).toMatch( 'Options de paiement', {
-			timeout: 60000,
-		} );
+		await expect( paymentMethodHeading ).toMatch( 'Options de paiement' );
 
 		const returnToCart = await page.$(
 			'.wc-block-components-checkout-return-to-cart-button'
 		);
-		await expect( returnToCart ).toMatch( 'Retour au panier', {
-			timeout: 60000,
-		} );
+		await expect( returnToCart ).toMatch( 'Retour au panier' );
 
 		const submitButton = await page.$(
 			'.wc-block-components-checkout-place-order-button'
 		);
-		await expect( submitButton ).toMatch( 'Passer la commande', {
-			timeout: 60000,
-		} );
+		await expect( submitButton ).toMatch( 'Passer la commande' );
 
 		const orderSummary = await page.$(
 			'.wp-block-woocommerce-checkout-order-summary-block'
 		);
-		await expect( orderSummary ).toMatch( 'Récapitulatif de commande', {
-			timeout: 60000,
-		} );
-		await expect( orderSummary ).toMatch( 'Sous-total', {
-			timeout: 60000,
-		} );
-		await expect( orderSummary ).toMatch( 'Coupon code', {
-			timeout: 60000,
-		} );
-		await expect( orderSummary ).toMatch( 'Livraison', { timeout: 60000 } );
+		await expect( orderSummary ).toMatch( 'Récapitulatif de commande' );
+		await expect( orderSummary ).toMatch( 'Sous-total' );
+		await expect( orderSummary ).toMatch( 'Coupon code' );
+		await expect( orderSummary ).toMatch( 'Livraison' );
 	} );
 } );

--- a/tests/e2e/specs/shopper/cart-checkout-translations.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout-translations.test.js
@@ -47,7 +47,7 @@ describe( 'Shopper → Cart → Can view translated cart & checkout blocks', () 
 		await shopper.addToCartFromShopPage( '128GB USB Stick' );
 		await shopper.block.goToCart();
 
-		await page.waitForNetworkIdle();
+		await page.waitForSelector( '.wp-block-woocommerce-filled-cart-block' );
 
 		const productHeader = await page.waitForSelector(
 			'.wc-block-cart-items .wc-block-cart-items__header span'

--- a/tests/e2e/specs/shopper/cart-checkout-translations.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout-translations.test.js
@@ -47,8 +47,6 @@ describe( 'Shopper → Cart → Can view translated cart & checkout blocks', () 
 		await shopper.addToCartFromShopPage( '128GB USB Stick' );
 		await shopper.block.goToCart();
 
-		await page.waitForNetworkIdle( { idleTime: 1000 } );
-
 		const productHeader = await page.$(
 			'.wc-block-cart-items .wc-block-cart-items__header span'
 		);
@@ -63,10 +61,20 @@ describe( 'Shopper → Cart → Can view translated cart & checkout blocks', () 
 		const orderSummary = await page.$(
 			'.wp-block-woocommerce-cart-order-summary-block'
 		);
-		await expect( orderSummary ).toMatch( 'Total panier' );
-		await expect( orderSummary ).toMatch( 'Sous-total' );
-		await expect( orderSummary ).toMatch( 'Coupon code' );
-		await expect( orderSummary ).toMatch( 'Appliquer un code promo' );
+
+		const orderHeading = await page.$(
+			'.wp-block-woocommerce-cart-order-summary-heading-block'
+		);
+		const orderSummarySubtotal = await page.$(
+			'.wp-block-woocommerce-cart-order-summary-subtotal-block'
+		);
+		const orderSummaryCoupon = await page.$(
+			'.wp-block-woocommerce-cart-order-summary-coupon-form-block'
+		);
+
+		await expect( orderHeading ).toMatch( 'Total panier' );
+		await expect( orderSummarySubtotal ).toMatch( 'Sous-total' );
+		await expect( orderSummaryCoupon ).toMatch( 'Coupon code' );
 	} );
 
 	it( 'should be able to view translated Checkout block', async () => {

--- a/tests/e2e/specs/shopper/cart-checkout-translations.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout-translations.test.js
@@ -47,8 +47,6 @@ describe( 'Shopper → Cart → Can view translated cart & checkout blocks', () 
 		await shopper.addToCartFromShopPage( '128GB USB Stick' );
 		await shopper.block.goToCart();
 
-		await page.waitForSelector( '.wp-block-woocommerce-filled-cart-block' );
-
 		const productHeader = await page.waitForSelector(
 			'.wc-block-cart-items .wc-block-cart-items__header span'
 		);
@@ -72,23 +70,13 @@ describe( 'Shopper → Cart → Can view translated cart & checkout blocks', () 
 			'.wp-block-woocommerce-cart-order-summary-block'
 		);
 
-		const orderHeading = await page.waitForSelector(
-			'.wc-block-components-title'
-		);
-		const orderSummarySubtotal = await page.waitForSelector(
-			'.wc-block-components-totals-item__label'
-		);
-		const orderSummaryCoupon = await page.waitForSelector(
-			'.wc-block-components-totals-coupon'
-		);
-
-		await expect( orderHeading ).toMatch( 'Total panier', {
+		await expect( orderSummary ).toMatch( 'Total panier', {
 			timeout: 60000,
 		} );
-		await expect( orderSummarySubtotal ).toMatch( 'Sous-total', {
+		await expect( orderSummary ).toMatch( 'Sous-total', {
 			timeout: 60000,
 		} );
-		await expect( orderSummaryCoupon ).toMatch( 'Coupon code', {
+		await expect( orderSummary ).toMatch( 'Coupon code', {
 			timeout: 60000,
 		} );
 	} );

--- a/tests/e2e/specs/shopper/cart-checkout-translations.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout-translations.test.js
@@ -52,17 +52,21 @@ describe( 'Shopper → Cart → Can view translated cart & checkout blocks', () 
 		const productHeader = await page.waitForSelector(
 			'.wc-block-cart-items .wc-block-cart-items__header span'
 		);
-		await expect( productHeader ).toMatch( 'Produit', { timeout: 30000 } );
+		await expect( productHeader ).toMatch( 'Produit', { timeout: 60000 } );
 
 		const removeLink = await page.waitForSelector(
 			'.wc-block-cart-item__remove-link'
 		);
-		await expect( removeLink ).toMatch( 'Retirer l’élément' );
+		await expect( removeLink ).toMatch( 'Retirer l’élément', {
+			timeout: 60000,
+		} );
 
 		const submitButton = await page.waitForSelector(
 			'.wc-block-cart__submit-button'
 		);
-		await expect( submitButton ).toMatch( 'Procéder au paiement' );
+		await expect( submitButton ).toMatch( 'Procéder au paiement', {
+			timeout: 60000,
+		} );
 
 		const orderSummary = await page.waitForSelector(
 			'.wp-block-woocommerce-cart-order-summary-block'
@@ -78,9 +82,15 @@ describe( 'Shopper → Cart → Can view translated cart & checkout blocks', () 
 			'.wc-block-components-totals-coupon'
 		);
 
-		await expect( orderHeading ).toMatch( 'Total panier' );
-		await expect( orderSummarySubtotal ).toMatch( 'Sous-total' );
-		await expect( orderSummaryCoupon ).toMatch( 'Coupon code' );
+		await expect( orderHeading ).toMatch( 'Total panier', {
+			timeout: 60000,
+		} );
+		await expect( orderSummarySubtotal ).toMatch( 'Sous-total', {
+			timeout: 60000,
+		} );
+		await expect( orderSummaryCoupon ).toMatch( 'Coupon code', {
+			timeout: 60000,
+		} );
 	} );
 
 	it( 'should be able to view translated Checkout block', async () => {
@@ -90,42 +100,57 @@ describe( 'Shopper → Cart → Can view translated cart & checkout blocks', () 
 			'#contact-fields .wc-block-components-checkout-step__title'
 		);
 		await expect( contactHeading ).toMatch( 'Coordonnées', {
-			timeout: 30000,
+			timeout: 60000,
 		} );
 
 		const shippingHeading = await page.$(
 			'#shipping-fields .wc-block-components-checkout-step__title'
 		);
-		await expect( shippingHeading ).toMatch( 'Adresse de livraison' );
+		await expect( shippingHeading ).toMatch( 'Adresse de livraison', {
+			timeout: 60000,
+		} );
 
 		const shippingOptionsHeading = await page.$(
 			'#shipping-option .wc-block-components-checkout-step__title'
 		);
 		await expect( shippingOptionsHeading ).toMatch(
-			'Options de livraison'
+			'Options de livraison',
+			{ timeout: 60000 }
 		);
 
 		const paymentMethodHeading = await page.$(
 			'#payment-method .wc-block-components-checkout-step__title'
 		);
-		await expect( paymentMethodHeading ).toMatch( 'Options de paiement' );
+		await expect( paymentMethodHeading ).toMatch( 'Options de paiement', {
+			timeout: 60000,
+		} );
 
 		const returnToCart = await page.$(
 			'.wc-block-components-checkout-return-to-cart-button'
 		);
-		await expect( returnToCart ).toMatch( 'Retour au panier' );
+		await expect( returnToCart ).toMatch( 'Retour au panier', {
+			timeout: 60000,
+		} );
 
 		const submitButton = await page.$(
 			'.wc-block-components-checkout-place-order-button'
 		);
-		await expect( submitButton ).toMatch( 'Passer la commande' );
+		await expect( submitButton ).toMatch( 'Passer la commande', {
+			timeout: 60000,
+		} );
 
 		const orderSummary = await page.$(
 			'.wp-block-woocommerce-checkout-order-summary-block'
 		);
-		await expect( orderSummary ).toMatch( 'Récapitulatif de commande' );
-		await expect( orderSummary ).toMatch( 'Sous-total' );
-		await expect( orderSummary ).toMatch( 'Coupon code' );
-		await expect( orderSummary ).toMatch( 'Livraison' );
+		await expect( orderSummary ).toMatch( 'Récapitulatif de commande', {
+			timeout: 60000,
+		} );
+		await expect( orderSummary ).toMatch( 'Sous-total', {
+			timeout: 60000,
+		} );
+		await expect( orderSummary ).toMatch( 'Coupon code', {
+			timeout: 60000,
+		} );
+		await expect( orderSummary ).toMatch( 'Livraison', { timeout: 60000 } );
 	} );
 } );

--- a/tests/e2e/specs/shopper/cart-checkout-translations.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout-translations.test.js
@@ -46,6 +46,9 @@ describe( 'Shopper → Cart → Can view translated cart & checkout blocks', () 
 		await shopper.goToShop();
 		await shopper.addToCartFromShopPage( '128GB USB Stick' );
 		await shopper.block.goToCart();
+
+		await page.waitForSelector( '.wp-block-woocommerce-cart-items-block' );
+
 		const productHeader = await page.$(
 			'.wc-block-cart-items .wc-block-cart-items__header span'
 		);

--- a/tests/e2e/specs/shopper/cart-checkout-translations.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout-translations.test.js
@@ -47,7 +47,9 @@ describe( 'Shopper → Cart → Can view translated cart & checkout blocks', () 
 		await shopper.addToCartFromShopPage( '128GB USB Stick' );
 		await shopper.block.goToCart();
 
-		const productHeader = await page.waitForSelector(
+		await page.waitForNetworkIdle( { idleTime: 1000 } );
+
+		const productHeader = await page.$(
 			'.wc-block-cart-items .wc-block-cart-items__header span'
 		);
 		await expect( productHeader ).toMatch( 'Produit', { timeout: 30000 } );

--- a/tests/e2e/specs/shopper/checkout-different-addresses.test.js
+++ b/tests/e2e/specs/shopper/checkout-different-addresses.test.js
@@ -23,8 +23,11 @@ import {
 	reactivateCompatibilityNotice,
 } from '../../../utils';
 
-import { BILLING_DETAILS, SHIPPING_DETAILS } from '../../../utils/constants';
-const SIMPLE_PRODUCT_NAME = '128GB USB Stick';
+import {
+	BILLING_DETAILS,
+	SHIPPING_DETAILS,
+	SIMPLE_PHYSICAL_PRODUCT_NAME,
+} from '../../../utils/constants';
 
 if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 )
 	// eslint-disable-next-line jest/no-focused-tests
@@ -71,7 +74,7 @@ describe( 'Shopper → Checkout → Can have different shipping and billing addr
 
 	it( 'allows customer to have different shipping and billing addresses', async () => {
 		await shopper.goToShop();
-		await shopper.addToCartFromShopPage( SIMPLE_PRODUCT_NAME );
+		await shopper.addToCartFromShopPage( SIMPLE_PHYSICAL_PRODUCT_NAME );
 		await shopper.block.goToCheckout();
 		await unsetCheckbox( '#checkbox-control-0' );
 		await shopper.block.fillShippingDetails( SHIPPING_DETAILS );

--- a/tests/e2e/specs/shopper/checkout-form-warnings.test.js
+++ b/tests/e2e/specs/shopper/checkout-form-warnings.test.js
@@ -3,7 +3,7 @@
  */
 import { shopper } from '../../../utils';
 import {
-	SIMPLE_PRODUCT_NAME,
+	SIMPLE_VIRTUAL_PRODUCT_NAME,
 	CUSTOMER_USERNAME,
 	CUSTOMER_PASSWORD,
 } from '../../../utils/constants';
@@ -48,7 +48,7 @@ describe( 'Shopper → Checkout → Can see warnings when form is incomplete', (
 
 	it( 'Shows warnings when form is incomplete', async () => {
 		await shopper.goToShop();
-		await shopper.addToCartFromShopPage( SIMPLE_PRODUCT_NAME );
+		await shopper.addToCartFromShopPage( SIMPLE_VIRTUAL_PRODUCT_NAME );
 		await shopper.block.goToCheckout();
 
 		// Click on "Place Order" button

--- a/tests/e2e/specs/shopper/checkout-single-use-coupon.test.js
+++ b/tests/e2e/specs/shopper/checkout-single-use-coupon.test.js
@@ -8,7 +8,7 @@ import { withRestApi } from '@woocommerce/e2e-utils';
  */
 import { shopper } from '../../../utils';
 import { createCoupon } from '../../utils';
-import { SIMPLE_PRODUCT_NAME } from '../../../utils/constants';
+import { SIMPLE_VIRTUAL_PRODUCT_NAME } from '../../../utils/constants';
 
 if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 )
 	// eslint-disable-next-line jest/no-focused-tests
@@ -29,7 +29,7 @@ afterAll( async () => {
 describe( 'Shopper → Checkout → Can apply single-use coupon once', () => {
 	it( 'allows checkout to apply single-use coupon once', async () => {
 		await shopper.goToShop();
-		await shopper.addToCartFromShopPage( SIMPLE_PRODUCT_NAME );
+		await shopper.addToCartFromShopPage( SIMPLE_VIRTUAL_PRODUCT_NAME );
 		await shopper.block.goToCheckout();
 		await shopper.block.applyCouponFromCheckout( coupon.code );
 
@@ -63,7 +63,7 @@ describe( 'Shopper → Checkout → Can apply single-use coupon once', () => {
 
 	it( 'Prevents checkout applying single-use coupon twice', async () => {
 		await shopper.goToShop();
-		await shopper.addToCartFromShopPage( SIMPLE_PRODUCT_NAME );
+		await shopper.addToCartFromShopPage( SIMPLE_VIRTUAL_PRODUCT_NAME );
 		await shopper.block.goToCheckout();
 		await shopper.block.applyCouponFromCheckout( coupon.code );
 		await expect( page ).toMatch( 'Coupon usage limit has been reached.' );

--- a/tests/utils/shopper.js
+++ b/tests/utils/shopper.js
@@ -42,12 +42,10 @@ export const shopper = {
 
 		goToCart: async () => {
 			await shopper.block.goToBlockPage( 'Cart' );
-			await page.waitForNetworkIdle();
 		},
 
 		goToCheckout: async () => {
 			await shopper.block.goToBlockPage( 'Checkout' );
-			await page.waitForNetworkIdle();
 		},
 
 		productIsInCheckout: async ( productTitle, quantity, total ) => {

--- a/tests/utils/shopper.js
+++ b/tests/utils/shopper.js
@@ -42,10 +42,12 @@ export const shopper = {
 
 		goToCart: async () => {
 			await shopper.block.goToBlockPage( 'Cart' );
+			await page.waitForNetworkIdle();
 		},
 
 		goToCheckout: async () => {
 			await shopper.block.goToBlockPage( 'Checkout' );
+			await page.waitForNetworkIdle();
 		},
 
 		productIsInCheckout: async ( productTitle, quantity, total ) => {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
Some of the tests were failing due to importing the wrong constant (`SIMPLE_PRODUCT_NAME` instead of `SIMPLE_VIRTUAL_PRODUCT_NAME`). 

Translation tests were failing randomly because the block hadn't finished loading when the assertions were being made. @gigitux added an extra `waitForSelector` [here](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/6165/files#diff-54d86d13d8fb11ba1eedf513463e83ef15c33f3041f0a25b8b964f9b5bef58d4R50) to wait for the cart to load.

I also realised that the translation tests are failing for legitimate reasons, which are being addressed in this [PR](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/6195)

### Testing

1. Make sure these are the only failing e2e tests:

```
Shopper → Cart → Can view translated cart & checkout blocks › should be able to view translated Cart block 

    TimeoutError: Text not found "Total panier"

      waiting for function failed: timeout 500ms exceeded

Shopper → Cart → Can view translated cart & checkout blocks › should be able to view translated Checkout block

    TimeoutError: Text not found "Coupon code"

      waiting for function failed: timeout 500ms exceeded
```