### PR TITLE
Prevent `Featured Product` block from breaking when product is out of stock + hidden from catalog 

### DIFF
--- a/assets/js/editor-components/utils/index.js
+++ b/assets/js/editor-components/utils/index.js
@@ -25,6 +25,7 @@ const getProductsRequests = ( {
 	const defaultArgs = {
 		per_page: isLargeCatalog ? 100 : 0,
 		catalog_visibility: 'any',
+		stock_status: [ 'instock', 'outofstock', 'onbackorder' ],
 		search,
 		orderby: 'title',
 		order: 'asc',

--- a/assets/js/hocs/with-product-variations.js
+++ b/assets/js/hocs/with-product-variations.js
@@ -124,7 +124,7 @@ const withProductVariations = createHigherOrderComponent(
 						p.variations &&
 						p.variations.find( ( { id } ) => id === variationId )
 				);
-				return parentProduct.length && parentProduct[ 0 ].id;
+				return parentProduct[ 0 ]?.id;
 			}
 
 			getExpandedProduct() {

--- a/assets/js/hocs/with-product-variations.js
+++ b/assets/js/hocs/with-product-variations.js
@@ -124,7 +124,7 @@ const withProductVariations = createHigherOrderComponent(
 						p.variations &&
 						p.variations.find( ( { id } ) => id === variationId )
 				);
-				return parentProduct[ 0 ].id;
+				return parentProduct.length && parentProduct[ 0 ].id;
 			}
 
 			getExpandedProduct() {
@@ -186,6 +186,7 @@ const withProductVariations = createHigherOrderComponent(
 				showVariations: false,
 			};
 		}
+
 		return WrappedComponent;
 	},
 	'withProductVariations'


### PR DESCRIPTION
When a product is `out of stock` and hidden from the catalog, it is not returned from the `/wc/store/v1/products` endpoint (which is used on the `Featured Product` block to display the list of available products). 
This causes the block to break when editing a `Feature Product` block configured with an `out of stock` product since it tries to find the selected product on the array returned from the endpoint and on the variations, but it's not there.

This PR prevents accessing to the `parentProduct` array when it's empty (which was causing the JS error) and also uses the `stock_status` query param on the `/products` endpoint to explicitly request all products regardless on their statuses.

Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5344

### Testing
### Manual Testing
1. Add a Featured Product block to a page and save
2. Head to the product and set the product to Out of Stock
3. Under WooCommerce > Settings > Products > Inventory, check the box that says "Hide out of stock items from the catalog"
4. Return to the page with your Featured Product block, select it, and select "Edit" to choose a new product to feature
5. Make sure the block can still be edited to choose a new product and the Out of Stock product is also available.

### Changelog

> Fix Featured Product: prevent the block from breaking for out of stock products hidden from catalog 
