### PR TITLE
Ensure e2e tests work with TS

### DIFF
--- a/tests/e2e/config/jest.config.js
+++ b/tests/e2e/config/jest.config.js
@@ -4,9 +4,6 @@ module.exports = {
 	// Automatically clear mock calls and instances between every test
 	clearMocks: true,
 
-	// An array of file extensions your modules use
-	moduleFileExtensions: [ 'js', 'ts' ],
-
 	moduleNameMapper: {
 		'@woocommerce/blocks-test-utils': '<rootDir>/tests/utils',
 	},

--- a/tests/e2e/specs/frontend/legacy-template-blocks.test.ts
+++ b/tests/e2e/specs/frontend/legacy-template-blocks.test.ts
@@ -41,7 +41,9 @@ describe( 'Classic Template blocks', () => {
 		it( 'renders a list of products with their count and pagination', async () => {
 			const { productArchivePage } = SELECTORS;
 
-			await page.goto( new URL( '/?post_type=product', BASE_URL ) );
+			await page.goto(
+				new URL( '/?post_type=product', BASE_URL ).toString()
+			);
 
 			await page.waitForSelector( productArchivePage.productsList );
 			await page.waitForSelector( productArchivePage.resultsCount );
@@ -74,7 +76,7 @@ describe( 'Classic Template blocks', () => {
 				new URL(
 					`/product-category/${ CATEGORY_NAME.toLowerCase() }`,
 					BASE_URL
-				)
+				).toString()
 			);
 
 			await expect( page ).toMatchElement( productArchivePage.title, {
@@ -109,7 +111,10 @@ describe( 'Classic Template blocks', () => {
 			const { productArchivePage } = SELECTORS;
 
 			await page.goto(
-				new URL( `/product-tag/${ TAG_NAME.toLowerCase() }`, BASE_URL )
+				new URL(
+					`/product-tag/${ TAG_NAME.toLowerCase() }`,
+					BASE_URL
+				).toString()
 			);
 
 			await expect( page ).toMatchElement( productArchivePage.title, {

--- a/tests/js/jest.config.json
+++ b/tests/js/jest.config.json
@@ -50,6 +50,5 @@
 	"transform": {
 		"^.+\\.(js|ts|tsx)$": "<rootDir>/tests/js/jestPreprocess.js"
 	},
-	"verbose": true,
-	"moduleFileExtensions": [ "js", "jsx", "ts", "tsx", "json", "node" ]
+	"verbose": true
 }


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
Convert example E2E test to TypeScript and verify it runs ok.

Bonus: clean up unnecessary default value override in e2e jest config for [moduleFileExtensions](https://jestjs.io/docs/configuration#modulefileextensions-arraystring) to ensure also `tsx` and other valid modules are supported. 

<!-- Reference any related issues or PRs here -->
Fixes #6067 

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests
  
  
 E2E should pass
