### PR TITLE
Enable more style options for the Featured Product block

### DIFF
--- a/assets/css/abstracts/_mixins.scss
+++ b/assets/css/abstracts/_mixins.scss
@@ -204,6 +204,19 @@ $fontSizes: (
 	}
 }
 
+// Positions an element absolutely and stretches it over the container
+@mixin absolute-stretch() {
+	margin: 0;
+	padding: 0;
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	width: 100%;
+	height: 100%;
+}
+
 // Converts a px unit to em.
 @function em($size, $base: 16px) {
 	@return math.div($size, $base) * 1em;

--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -28,6 +28,8 @@ import {
 	ToggleControl,
 	ToolbarGroup,
 	withSpokenMessages,
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
 import classnames from 'classnames';
 import { Component } from '@wordpress/element';
@@ -35,7 +37,6 @@ import { compose, createHigherOrderComponent } from '@wordpress/compose';
 import { isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import ProductControl from '@woocommerce/editor-components/product-control';
-import ToggleButtonControl from '@woocommerce/editor-components/toggle-button-control';
 import ErrorPlaceholder from '@woocommerce/editor-components/error-placeholder';
 import TextToolbarButton from '@woocommerce/editor-components/text-toolbar-button';
 import { withProduct } from '@woocommerce/block-hocs';
@@ -274,7 +275,7 @@ const FeaturedProduct = ( {
 										'woo-gutenberg-products-block'
 									) }
 								>
-									<ToggleButtonControl
+									<ToggleGroupControl
 										help={
 											<>
 												<p>
@@ -296,29 +297,28 @@ const FeaturedProduct = ( {
 											'woo-gutenberg-products-block'
 										) }
 										value={ attributes.imageFit }
-										options={ [
-											{
-												label: __(
-													'None',
-													'woo-gutenberg-products-block'
-												),
-												value: 'none',
-											},
-											{
-												/* translators: "Cover" is a verb that indicates an image covering the entire container. */
-												label: __(
-													'Cover',
-													'woo-gutenberg-products-block'
-												),
-												value: 'cover',
-											},
-										] }
 										onChange={ ( value ) =>
 											setAttributes( {
 												imageFit: value,
 											} )
 										}
-									/>
+									>
+										<ToggleGroupControlOption
+											label={ __(
+												'None',
+												'woo-gutenberg-products-block'
+											) }
+											value="none"
+										/>
+										<ToggleGroupControlOption
+											/* translators: "Cover" is a verb that indicates an image covering the entire container. */
+											label={ __(
+												'Cover',
+												'woo-gutenberg-products-block'
+											) }
+											value="cover"
+										/>
+									</ToggleGroupControl>
 									<FocalPointPicker
 										label={ __(
 											'Focal Point Picker',

--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -35,6 +35,7 @@ import { compose, createHigherOrderComponent } from '@wordpress/compose';
 import { isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import ProductControl from '@woocommerce/editor-components/product-control';
+import ToggleButtonControl from '@woocommerce/editor-components/toggle-button-control';
 import ErrorPlaceholder from '@woocommerce/editor-components/error-placeholder';
 import TextToolbarButton from '@woocommerce/editor-components/text-toolbar-button';
 import { withProduct } from '@woocommerce/block-hocs';
@@ -273,6 +274,51 @@ const FeaturedProduct = ( {
 										'woo-gutenberg-products-block'
 									) }
 								>
+									<ToggleButtonControl
+										help={
+											<>
+												<p>
+													{ __(
+														'Choose “Cover” if you want the image to scale automatically to always fit its container.',
+														'woo-gutenberg-products-block'
+													) }
+												</p>
+												<p>
+													{ __(
+														'Note: by choosing “Cover” you will lose the ability to freely move the focal point precisely.',
+														'woo-gutenberg-products-block'
+													) }
+												</p>
+											</>
+										}
+										label={ __(
+											'Image fit',
+											'woo-gutenberg-products-block'
+										) }
+										value={ attributes.imageFit }
+										options={ [
+											{
+												label: __(
+													'None',
+													'woo-gutenberg-products-block'
+												),
+												value: 'none',
+											},
+											{
+												/* translators: "Cover" is a verb that indicates an image covering the entire container. */
+												label: __(
+													'Cover',
+													'woo-gutenberg-products-block'
+												),
+												value: 'cover',
+											},
+										] }
+										onChange={ ( value ) =>
+											setAttributes( {
+												imageFit: value,
+											} )
+										}
+									/>
 									<FocalPointPicker
 										label={ __(
 											'Focal Point Picker',
@@ -345,6 +391,7 @@ const FeaturedProduct = ( {
 			contentAlign,
 			dimRatio,
 			focalPoint,
+			imageFit,
 			mediaSrc,
 			minHeight,
 			overlayColor,
@@ -375,6 +422,7 @@ const FeaturedProduct = ( {
 
 		const backgroundImageStyle = {
 			...calculateBackgroundImagePosition( focalPoint ),
+			objectFit: imageFit,
 		};
 
 		const overlayStyle = {

--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -38,7 +38,7 @@ import { Icon, starEmpty } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import { dimRatioToClass, getBackgroundImageStyles } from './utils';
+import { calculateBackgroundImagePosition, dimRatioToClass } from './utils';
 import {
 	getImageSrcFromProduct,
 	getImageIdFromProduct,
@@ -217,6 +217,26 @@ const FeaturedProduct = ( {
 				</PanelBody>
 				{ !! url && (
 					<>
+						{ focalPointPickerExists && (
+							<PanelBody
+								title={ __(
+									'Media settings',
+									'woo-gutenberg-products-block'
+								) }
+							>
+								<FocalPointPicker
+									label={ __(
+										'Focal Point Picker',
+										'woo-gutenberg-products-block'
+									) }
+									url={ url }
+									value={ focalPoint }
+									onChange={ ( value ) =>
+										setAttributes( { focalPoint: value } )
+									}
+								/>
+							</PanelBody>
+						) }
 						<PanelBody
 							title={ __(
 								'Overlay',
@@ -236,19 +256,6 @@ const FeaturedProduct = ( {
 								max={ 100 }
 								step={ 10 }
 							/>
-							{ focalPointPickerExists && (
-								<FocalPointPicker
-									label={ __(
-										'Focal Point Picker',
-										'woo-gutenberg-products-block'
-									) }
-									url={ url }
-									value={ focalPoint }
-									onChange={ ( value ) =>
-										setAttributes( { focalPoint: value } )
-									}
-								/>
-							) }
 						</PanelBody>
 					</>
 				) }
@@ -262,6 +269,7 @@ const FeaturedProduct = ( {
 			dimRatio,
 			focalPoint,
 			height,
+			mediaSrc,
 			showDesc,
 			showPrice,
 		} = attributes;
@@ -277,15 +285,12 @@ const FeaturedProduct = ( {
 			contentAlign !== 'center' && `has-${ contentAlign }-content`
 		);
 
-		const style = getBackgroundImageStyles(
-			attributes.mediaSrc || product
-		);
+		const backgroundImageSrc =
+			mediaSrc || getImageSrcFromProduct( product );
 
-		if ( focalPoint ) {
-			const bgPosX = focalPoint.x * 100;
-			const bgPosY = focalPoint.y * 100;
-			style.backgroundPosition = `${ bgPosX }% ${ bgPosY }%`;
-		}
+		const backgroundImageStyle = {
+			...calculateBackgroundImagePosition( focalPoint ),
+		};
 
 		const onResizeStop = ( event, direction, elt ) => {
 			setAttributes( { height: parseInt( elt.style.height, 10 ) } );
@@ -298,9 +303,14 @@ const FeaturedProduct = ( {
 				minHeight={ getSetting( 'min_height', 500 ) }
 				enable={ { bottom: true } }
 				onResizeStop={ onResizeStop }
-				style={ style }
 			>
 				<div className="wc-block-featured-product__wrapper">
+					<img
+						alt={ product.short_description }
+						className="wc-block-featured-product__background-image"
+						src={ backgroundImageSrc }
+						style={ backgroundImageStyle }
+					/>
 					<h2
 						className="wc-block-featured-product__title"
 						dangerouslySetInnerHTML={ {

--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -104,7 +104,7 @@ const FeaturedProduct = ( {
 	setAttributes,
 	triggerUrlUpdate = () => void null,
 } ) => {
-	const { gradientValue } = useGradient();
+	const { gradientValue, setGradient } = useGradient();
 	const onResize = useCallback(
 		( _event, _direction, elt ) => {
 			setAttributes( { minHeight: parseInt( elt.style.height, 10 ) } );
@@ -302,8 +302,14 @@ const FeaturedProduct = ( {
 										colorValue: attributes.overlayColor,
 										onColorChange: ( overlayColor ) =>
 											setAttributes( { overlayColor } ),
-									onGradientChange: ( overlayGradient ) =>
-										setAttributes( { overlayGradient } ),
+										onGradientChange: (
+											overlayGradient
+										) => {
+											setGradient( overlayGradient );
+											setAttributes( {
+												overlayGradient,
+											} );
+										},
 										label: __(
 											'Color',
 											'woo-gutenberg-products-block'

--- a/assets/js/blocks/featured-product/example.js
+++ b/assets/js/blocks/featured-product/example.js
@@ -11,6 +11,7 @@ export const example = {
 		editMode: false,
 		height: getSetting( 'default_height', 500 ),
 		mediaSrc: '',
+		overlayColor: '#000000',
 		showDesc: true,
 		productId: 'preview',
 		previewProduct: previewProducts[ 0 ],

--- a/assets/js/blocks/featured-product/index.js
+++ b/assets/js/blocks/featured-product/index.js
@@ -120,6 +120,20 @@ registerBlockType( 'woocommerce/featured-product', {
 		},
 
 		/**
+		 * A minimum height for the block.
+		 *
+		 * Note: if padding is increased, this way the inner content will never
+		 * overflow, but instead will resize the container.
+		 *
+		 * It was decided to change this to make this block more in line with
+		 * the “Cover” block.
+		 */
+		minHeight: {
+			type: 'number',
+			default: getSetting( 'default_height', 500 ),
+		},
+
+		/**
 		 * Text for the product link.
 		 */
 		linkText: {

--- a/assets/js/blocks/featured-product/index.js
+++ b/assets/js/blocks/featured-product/index.js
@@ -38,7 +38,15 @@ registerBlockType( 'woocommerce/featured-product', {
 	supports: {
 		align: [ 'wide', 'full' ],
 		html: false,
-		color: true,
+		color: {
+			__experimentalDuotone:
+				'.wc-block-featured-product__background-image',
+			background: true,
+			text: true,
+		},
+		spacing: {
+			padding: true,
+		},
 		...( isFeaturePluginBuild() && {
 			__experimentalBorder: {
 				color: true,

--- a/assets/js/blocks/featured-product/index.js
+++ b/assets/js/blocks/featured-product/index.js
@@ -41,11 +41,12 @@ registerBlockType( 'woocommerce/featured-product', {
 		color: {
 			__experimentalDuotone:
 				'.wc-block-featured-product__background-image',
-			background: true,
+			background: false,
 			text: true,
 		},
 		spacing: {
 			padding: true,
+			__experimentalSkipSerialization: true,
 		},
 		...( isFeaturePluginBuild() && {
 			__experimentalBorder: {
@@ -122,10 +123,33 @@ registerBlockType( 'woocommerce/featured-product', {
 		},
 
 		/**
+		 * Color for the overlay layer on top of the product image.
+		 */
+		overlayColor: {
+			type: 'string',
+			default: '#000000',
+		},
+
+		/**
+		 * Gradient for the overlay layer on top of the product image.
+		 */
+		overlayGradient: {
+			type: 'string',
+		},
+
+		/**
 		 * The product ID to display.
 		 */
 		productId: {
 			type: 'number',
+		},
+
+		/**
+		 * Product preview.
+		 */
+		previewProduct: {
+			type: 'object',
+			default: null,
 		},
 
 		/**
@@ -142,14 +166,6 @@ registerBlockType( 'woocommerce/featured-product', {
 		showPrice: {
 			type: 'boolean',
 			default: true,
-		},
-
-		/**
-		 * Product preview.
-		 */
-		previewProduct: {
-			type: 'object',
-			default: null,
 		},
 	},
 

--- a/assets/js/blocks/featured-product/index.js
+++ b/assets/js/blocks/featured-product/index.js
@@ -96,11 +96,14 @@ registerBlockType( 'woocommerce/featured-product', {
 		},
 
 		/**
-		 * A fixed height for the block.
+		 * Whether the image should fit the container or not be resized
+		 *
+		 * Note: when the image is resized to fit the container, the user loses
+		 * the ability to have full control over the focus.
 		 */
-		height: {
-			type: 'number',
-			default: getSetting( 'default_height', 500 ),
+		imageFit: {
+			type: 'string',
+			default: 'none',
 		},
 
 		/**

--- a/assets/js/blocks/featured-product/index.js
+++ b/assets/js/blocks/featured-product/index.js
@@ -46,7 +46,12 @@ registerBlockType( 'woocommerce/featured-product', {
 		},
 		spacing: {
 			padding: true,
-			__experimentalSkipSerialization: true,
+			...( isFeaturePluginBuild() && {
+				__experimentalDefaultControls: {
+					padding: true,
+				},
+				__experimentalSkipSerialization: true,
+			} ),
 		},
 		...( isFeaturePluginBuild() && {
 			__experimentalBorder: {

--- a/assets/js/blocks/featured-product/style.scss
+++ b/assets/js/blocks/featured-product/style.scss
@@ -1,5 +1,5 @@
 .wp-block-woocommerce-featured-product {
-	background-color: $gray-900;
+	background-color: transparent;
 	border-color: transparent;
 	color: #fff;
 	overflow: hidden;
@@ -110,21 +110,25 @@
 		text-align: center;
 	}
 
-	&.has-background-dim::before {
-		content: "";
-		position: absolute;
-		top: 0;
-		left: 0;
-		bottom: 0;
-		right: 0;
-		background-color: inherit;
-		opacity: 0.5;
-		z-index: 1;
+	&.has-background-dim {
+		.wc-block-featured-product__overlay::before {
+			background: inherit;
+			content: "";
+			position: absolute;
+			top: 0;
+			left: 0;
+			bottom: 0;
+			right: 0;
+			opacity: 0.5;
+			z-index: 1;
+		}
 	}
 
 	@for $i from 1 through 10 {
-		&.has-background-dim.has-background-dim-#{ $i * 10 }::before {
-			opacity: $i * 0.1;
+		&.has-background-dim.has-background-dim-#{ $i * 10 } {
+			.wc-block-featured-product__overlay::before {
+				opacity: $i * 0.1;
+			}
 		}
 	}
 

--- a/assets/js/blocks/featured-product/style.scss
+++ b/assets/js/blocks/featured-product/style.scss
@@ -2,7 +2,6 @@
 	background-color: transparent;
 	border-color: transparent;
 	color: #fff;
-	overflow: hidden;
 	box-sizing: border-box;
 
 	.components-resizable-box__container {

--- a/assets/js/blocks/featured-product/style.scss
+++ b/assets/js/blocks/featured-product/style.scss
@@ -4,6 +4,19 @@
 	color: #fff;
 	overflow: hidden;
 	box-sizing: border-box;
+
+	.components-resizable-box__container {
+		position: absolute !important;
+		top: 0;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		min-height: 50px;
+
+		&:not(.is-resizing) {
+			height: auto !important;
+		}
+	}
 }
 
 .wc-block-featured-product {

--- a/assets/js/blocks/featured-product/style.scss
+++ b/assets/js/blocks/featured-product/style.scss
@@ -101,6 +101,11 @@
 		}
 	}
 
+	.wc-block-featured-product__background-image {
+		@include absolute-stretch();
+		object-fit: none;
+	}
+
 	.wp-block-button.aligncenter {
 		text-align: center;
 	}

--- a/assets/js/blocks/featured-product/utils.js
+++ b/assets/js/blocks/featured-product/utils.js
@@ -1,40 +1,22 @@
-/**
- * External dependencies
- */
-import { isObject } from 'lodash';
+export function calculateBackgroundImagePosition( coords ) {
+	if ( ! coords ) return {};
 
-/**
- * Internal dependencies
- */
-import { getImageSrcFromProduct } from '../../utils/products';
+	const x = Math.round( coords.x * 100 );
+	const y = Math.round( coords.y * 100 );
 
-/**
- * Generate a style object given either a product object or URL to an image.
- *
- * @param {Object|string} url A product object as returned from the API, or an image URL.
- * @return {Object} A style object with a backgroundImage set (if a valid image is provided).
- */
-function getBackgroundImageStyles( url ) {
-	// If `url` is an object, it's actually a product.
-	if ( isObject( url ) ) {
-		url = getImageSrcFromProduct( url );
-	}
-	if ( url ) {
-		return { backgroundImage: `url(${ url })` };
-	}
-	return {};
+	return {
+		objectPosition: `${ x }% ${ y }%`,
+	};
 }
 
 /**
  * Convert the selected ratio to the correct background class.
  *
  * @param {number} ratio Selected opacity from 0 to 100.
- * @return {string} The class name, if applicable (not used for ratio 0 or 50).
+ * @return {string?} The class name, if applicable (not used for ratio 0 or 50).
  */
-function dimRatioToClass( ratio ) {
+export function dimRatioToClass( ratio ) {
 	return ratio === 0 || ratio === 50
 		? null
 		: `has-background-dim-${ 10 * Math.round( ratio / 10 ) }`;
 }
-
-export { getBackgroundImageStyles, dimRatioToClass };

--- a/assets/js/utils/useThrottle.ts
+++ b/assets/js/utils/useThrottle.ts
@@ -20,6 +20,8 @@ export function useThrottle< T extends ( ...args: unknown[] ) => unknown >(
 		cbRef.current = cb;
 	} );
 
+	// Disabling because we can't pass an arrow function in this case
+	// eslint-disable-next-line react-hooks/exhaustive-deps
 	const throttledCb = useCallback(
 		throttle( ( ...args ) => cbRef.current( ...args ), delay, options ),
 		[ delay ]

--- a/assets/js/utils/useThrottle.ts
+++ b/assets/js/utils/useThrottle.ts
@@ -1,0 +1,29 @@
+/* eslint-disable you-dont-need-lodash-underscore/throttle */
+
+/**
+ * External dependencies
+ */
+import { DebouncedFunc, throttle, ThrottleSettings } from 'lodash';
+import { useCallback, useEffect, useRef } from 'react';
+
+/**
+ * Throttles a function inside a React functional component
+ */
+export function useThrottle< T extends ( ...args: unknown[] ) => unknown >(
+	cb: T,
+	delay: number,
+	options?: ThrottleSettings
+): DebouncedFunc< T > {
+	const cbRef = useRef( cb );
+
+	useEffect( () => {
+		cbRef.current = cb;
+	} );
+
+	const throttledCb = useCallback(
+		throttle( ( ...args ) => cbRef.current( ...args ), delay, options ),
+		[ delay ]
+	);
+
+	return throttledCb;
+}

--- a/src/BlockTypes/FeaturedProduct.php
+++ b/src/BlockTypes/FeaturedProduct.php
@@ -24,7 +24,8 @@ class FeaturedProduct extends AbstractDynamicBlock {
 		'contentAlign' => 'center',
 		'dimRatio'     => 50,
 		'focalPoint'   => false,
-		'height'       => false,
+		'imageFit'     => 'none',
+		'minHeight'    => false,
 		'mediaId'      => 0,
 		'mediaSrc'     => '',
 		'showDesc'     => true,
@@ -127,6 +128,8 @@ class FeaturedProduct extends AbstractDynamicBlock {
 			$image_size = 'full';
 		}
 
+		$style .= sprintf( 'object-fit: %s;', $attributes['imageFit'] );
+
 		if ( $attributes['mediaId'] ) {
 			$image = wp_get_attachment_image_url( $attributes['mediaId'], $image_size );
 		} else {
@@ -182,8 +185,8 @@ class FeaturedProduct extends AbstractDynamicBlock {
 	public function get_styles( $attributes ) {
 		$style = '';
 
-		if ( isset( $attributes['height'] ) ) {
-			$style .= sprintf( 'min-height:%dpx;', intval( $attributes['height'] ) );
+		if ( isset( $attributes['minHeight'] ) ) {
+			$style .= sprintf( 'min-height:%dpx;', intval( $attributes['minHeight'] ) );
 		}
 
 		$global_style_style = StyleAttributesUtils::get_styles_by_attributes( $attributes, $this->global_style_wrapper );

--- a/src/BlockTypes/FeaturedProduct.php
+++ b/src/BlockTypes/FeaturedProduct.php
@@ -68,7 +68,7 @@ class FeaturedProduct extends AbstractDynamicBlock {
 		}
 		$attributes = wp_parse_args( $attributes, $this->defaults );
 
-		$attributes['height'] = $attributes['height'] ? $attributes['height'] : wc_get_theme_support( 'featured_block::default_height', 500 );
+		$attributes['height'] = isset( $attributes['height'] ) ? $attributes['height'] : wc_get_theme_support( 'featured_block::default_height', 500 );
 
 		$title = sprintf(
 			'<h2 class="wc-block-featured-product__title">%s</h2>',

--- a/src/Utils/StyleAttributesUtils.php
+++ b/src/Utils/StyleAttributesUtils.php
@@ -287,6 +287,26 @@ class StyleAttributesUtils {
 	}
 
 	/**
+	 * Get class and style for padding from attributes.
+	 *
+	 * @param array $attributes Block attributes.
+	 *
+	 * @return (array | null)
+	 */
+	public static function get_padding_class_and_style( $attributes ) {
+		$padding = isset( $attributes['style']['spacing']['padding'] ) ? $attributes['style']['spacing']['padding'] : null;
+
+		if ( ! $padding ) {
+			return null;
+		}
+
+		return array(
+			'class' => null,
+			'style' => sprintf( 'padding: %s;', implode( ' ', $padding ) ),
+		);
+	}
+
+	/**
 	 * Get classes and styles from attributes.
 	 *
 	 * @param array $attributes Block attributes.
@@ -304,6 +324,7 @@ class StyleAttributesUtils {
 			'border_color'     => self::get_border_color_class_and_style( $attributes ),
 			'border_radius'    => self::get_border_radius_class_and_style( $attributes ),
 			'border_width'     => self::get_border_width_class_and_style( $attributes ),
+			'padding'          => self::get_padding_class_and_style( $attributes ),
 		);
 
 		if ( ! empty( $properties ) ) {


### PR DESCRIPTION
This PR adds several style options to the Featured Product block. The current status of features supported and planned for each block can be seen in [this spreadsheet](https://docs.google.com/spreadsheets/d/1KsKoq3J86s4PRZoHufj_qshGl_tTWjfolJXsrqE2AsU/edit#gid=1253950386).

**This PR fixes the following problems:**

* Previously, the overlay of this block was actually rendered as a background. That meant inconsistent behavior in certain circumstances (like when an external padding was added). The overlay is now a separate DOM element.
* Previously, the overlay color was controlled within the `Color` section of the sidebar, while its opacity was controlled elsewhere. This PR consolidates the controls under the `Overlay` section.
* Previously, the featured product image was rendered as a background. This meant we could not correctly apply things like duotone filters (see #5555). The image is now rendered as a separate DOM element.
* Previously, the featured image was resized constraining it to the block size. This meant that the focal point could only be moved vertically. Now the focal point can be moved correctly (see below: **Image fit options**).
* The resizable container handle was not completely visible (it would only show half a circle). This is fixed.
* The resizable container handle was always visible regardless of the selected status of the block.
* Previously, if the padding was large enough, the content could be pushed out of the container. Now the block behaves more like the Cover block, in the sense that the padding will scale the container up. This also means that the resizable control is subject to this rule, and can't resize the container lower than a certain minimum (determined by content and size). This is the same behavior as the Cover block.

**This PR adds the following features:**

* **Support for Duotone:** users can now set a duotone filter on the featured product image.
* **Support for gradients:** users can now set the overlay color as a gradient.
* **Support for padding:** users can now set custom padding for the block. Which element to add the padding to was a bit unclear in the specs and was pending an answer [here](pdnLyh-Jv-p2#comment-494). While waiting for an answer, I decided to implement it in the way that made most sense to me after some experimentation, following the example of the *Cover* block. This allows the user to have creative solution like the one screenshotted below. Please @vivialice let me know if you are ok with this decision.
* **Image fit options:** The user can now decide how should the image behave on the resizing of the component; it can either scale to always cover the entire container, or remain its original size.

<!-- Reference any related issues or PRs here -->
Closes #6150

### Screenshots

![Screen Shot 2022-04-06 at 00 52 23](https://user-images.githubusercontent.com/1847066/161863882-2933ff8d-0332-4d4d-91c1-598b2165a7e1.png)

Notice how, thanks to the fixed focal point picker and how the padding was implemented, I can set my image on the top right and my text on the bottom left instead of being constricted to everything being centered.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

### Manual Testing

How to test the changes in this Pull Request:

1. Use a block theme (such as Twenty Twenty Two)
2. Add the ”Featured Product” block to a page and select a product.
3. Make sure that the resizable handle is a shown fully (it should be a full circle), and that is shown only when the block is selected.
4. Select the block and apply a Duotone filter.
5. Make sure the overlay color control is under the `Overlay` section and change the overlay color to a gradient.
6. Add a padding to the block and make sure the padding is added on the inside of the wrapper (i.e. no white space is created outside of the block).
7. Move around your image focal point and make sure you can actually move around the entire image and not only constrained on one dimension.
8. Apply “Image fit > Cover” and notice how the image will scale along with the container. As opposed to point 5 above, now the focal point picker is limited to one dimension.
9. Increase the `padding-top` of the block and notice that the content can't get pushed out of the container, but instead the container resizes.
10. When that's the case, try resizing the block through the handle to a lower height: the handle should move but the container should not resize. When the mouse is lifted, the handle should return to its original position.
11. For the steps 4–9 above, save the page and check that the styles are applied correctly on the front-end (as the block is rendered statically via PHP).

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above

---

**❗  Note:** Since this PR includes several changes, [we agreed that it should have a multi-line changelog](p1649199937104809-slack-C02SGH7JBGS). I checked the automation script which creates the changelog, and it seems to be fine with that. There might be some formatting issues with newlines and such, so perhaps, _release lead_, you might have to adjust a few things before publishing.

### Changelog

>  Enhanced the *Featured Product block*:
> 
> * Implemented support for duotone.
> * Implemented support for gradients on the overlay.
> * Implemented support for custom inner padding.
> * Implemented image fit options: users can now decide how should the image behave on the resizing of the component; it can either scale to always cover the entire container, or remain its original size.
> * Fixed an inconsistency where the overlay color was controlled by the background color control. It is now moved to the correct section.
> * Fixed the focal point picker, it now works on both axis as long as the image fit (above) is set to `none`.
> * Fixed an issue with the visibility of the resizing handle.
> * Fixed an issue which would keep the resizing handle always active regardless of block selection status.
> * Changed the behavior of the resizing: the block can't be resized below a minimum height determined by its content plus the padding.