### PR TITLE
Check for performance file existence before running reporter

### DIFF
--- a/tests/e2e/config/performance-reporter.js
+++ b/tests/e2e/config/performance-reporter.js
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-const { readFileSync, statSync } = require( 'fs' );
+const { readFileSync, existsSync } = require( 'fs' );
 const chalk = require( 'chalk' );
 const { PERFORMANCE_REPORT_FILENAME } = require( '../../utils/constants' );
 
 class PerformanceReporter {
 	onRunComplete() {
-		if ( statSync( PERFORMANCE_REPORT_FILENAME ).size === 0 ) {
+		if ( ! existsSync( PERFORMANCE_REPORT_FILENAME ) ) {
 			return;
 		}
 		const reportFileContents = readFileSync( PERFORMANCE_REPORT_FILENAME )

--- a/tests/e2e/config/setup.js
+++ b/tests/e2e/config/setup.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import { setup as setupPuppeteer } from 'jest-environment-puppeteer';
-import fs from 'fs';
+const { truncateSync, existsSync } = require( 'fs' );
 /**
  * Internal dependencies
  */
@@ -67,7 +67,9 @@ module.exports = async ( globalConfig ) => {
 		} );
 
 		// Wipe the performance e2e file at the start of every run
-		fs.truncateSync( PERFORMANCE_REPORT_FILENAME );
+		if ( existsSync( PERFORMANCE_REPORT_FILENAME ) ) {
+			truncateSync( PERFORMANCE_REPORT_FILENAME );
+		}
 
 		global.fixtureData = {
 			taxes,


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

The performance E2E test tries to `stat` a file that may not exist, this PR checks for its existence instead.
### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Delete `reports/e2e-performance.json` and run `npm run test:e2e`
2. Expect it to complete without erroring (because of the missing file)

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
- [x] Not required
