### PR TITLE
Register missing C&C inner blocks and update fallback template for older C& C versions

### DIFF
--- a/assets/js/blocks/cart/inner-blocks/cart-order-summary-heading/attributes.ts
+++ b/assets/js/blocks/cart/inner-blocks/cart-order-summary-heading/attributes.ts
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 export default {
 	content: {
 		type: 'string',
-		default: __( 'Heading', 'woo-gutenberg-products-block' ),
+		default: __( 'Cart totals', 'woo-gutenberg-products-block' ),
 	},
 	lock: {
 		type: 'object',

--- a/assets/js/blocks/cart/inner-blocks/cart-order-summary-heading/block.json
+++ b/assets/js/blocks/cart/inner-blocks/cart-order-summary-heading/block.json
@@ -17,7 +17,7 @@
 		},
 		"content": {
 			"type": "string",
-			"default": "Heading"
+			"default": "Cart totals"
 		},
 		"lock": {
 			"type": "object",

--- a/assets/js/blocks/cart/inner-blocks/register-components.ts
+++ b/assets/js/blocks/cart/inner-blocks/register-components.ts
@@ -105,6 +105,16 @@ registerCheckoutBlock( {
 } );
 
 registerCheckoutBlock( {
+	metadata: metadata.CART_ORDER_SUMMARY_HEADING,
+	component: lazy( () =>
+		import(
+			/* webpackChunkName: "cart-blocks/order-summary-heading" */
+			'./cart-order-summary-heading/frontend'
+		)
+	),
+} );
+
+registerCheckoutBlock( {
 	metadata: metadata.CART_ORDER_SUMMARY_SUBTOTAL,
 	component: lazy( () =>
 		import(
@@ -135,21 +145,21 @@ registerCheckoutBlock( {
 } );
 
 registerCheckoutBlock( {
-	metadata: metadata.CART_ORDER_SUMMARY_SHIPPING,
-	component: lazy( () =>
-		import(
-			/* webpackChunkName: "cart-blocks/order-summary-shipping" */
-			'./cart-order-summary-shipping/frontend'
-		)
-	),
-} );
-
-registerCheckoutBlock( {
 	metadata: metadata.CART_ORDER_SUMMARY_COUPON_FORM,
 	component: lazy( () =>
 		import(
 			/* webpackChunkName: "cart-blocks/order-summary-coupon-form" */
 			'./cart-order-summary-coupon-form/frontend'
+		)
+	),
+} );
+
+registerCheckoutBlock( {
+	metadata: metadata.CART_ORDER_SUMMARY_SHIPPING,
+	component: lazy( () =>
+		import(
+			/* webpackChunkName: "cart-blocks/order-summary-shipping" */
+			'./cart-order-summary-shipping/frontend'
 		)
 	),
 } );

--- a/assets/js/blocks/checkout/inner-blocks/register-components.ts
+++ b/assets/js/blocks/checkout/inner-blocks/register-components.ts
@@ -124,6 +124,16 @@ registerCheckoutBlock( {
 } );
 
 registerCheckoutBlock( {
+	metadata: metadata.CHECKOUT_ORDER_SUMMARY_CART_ITEMS,
+	component: lazy( () =>
+		import(
+			/* webpackChunkName: "checkout-blocks/order-summary-cart-items" */
+			'./checkout-order-summary-cart-items/frontend'
+		)
+	),
+} );
+
+registerCheckoutBlock( {
 	metadata: metadata.CHECKOUT_ORDER_SUMMARY_SUBTOTAL,
 	component: lazy( () =>
 		import(
@@ -154,16 +164,6 @@ registerCheckoutBlock( {
 } );
 
 registerCheckoutBlock( {
-	metadata: metadata.CHECKOUT_ORDER_SUMMARY_SHIPPING,
-	component: lazy( () =>
-		import(
-			/* webpackChunkName: "checkout-blocks/order-summary-shipping" */
-			'./checkout-order-summary-shipping/frontend'
-		)
-	),
-} );
-
-registerCheckoutBlock( {
 	metadata: metadata.CHECKOUT_ORDER_SUMMARY_COUPON_FORM,
 	component: lazy( () =>
 		import(
@@ -174,21 +174,21 @@ registerCheckoutBlock( {
 } );
 
 registerCheckoutBlock( {
-	metadata: metadata.CHECKOUT_ORDER_SUMMARY_TAXES,
+	metadata: metadata.CHECKOUT_ORDER_SUMMARY_SHIPPING,
 	component: lazy( () =>
 		import(
-			/* webpackChunkName: "checkout-blocks/order-summary-taxes" */
-			'./checkout-order-summary-taxes/frontend'
+			/* webpackChunkName: "checkout-blocks/order-summary-shipping" */
+			'./checkout-order-summary-shipping/frontend'
 		)
 	),
 } );
 
 registerCheckoutBlock( {
-	metadata: metadata.CHECKOUT_ORDER_SUMMARY_CART_ITEMS,
+	metadata: metadata.CHECKOUT_ORDER_SUMMARY_TAXES,
 	component: lazy( () =>
 		import(
-			/* webpackChunkName: "checkout-blocks/order-summary-cart-items" */
-			'./checkout-order-summary-cart-items/frontend'
+			/* webpackChunkName: "checkout-blocks/order-summary-taxes" */
+			'./checkout-order-summary-taxes/frontend'
 		)
 	),
 } );

--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -118,14 +118,13 @@ class Cart extends AbstractBlock {
 		 * Cart i3 added inner blocks for Order summary. We need to add them to Cart i2 templates.
 		 * The order needs to match the order in which these blocks were registered.
 		 */
-		$coupons_enabled                 = wc_coupons_enabled();
 		$order_summary_with_inner_blocks = '$0
 			<div data-block-name="woocommerce/cart-order-summary-heading-block" class="wp-block-woocommerce-cart-order-summary-heading-block"></div>
 			<div data-block-name="woocommerce/cart-order-summary-subtotal-block" class="wp-block-woocommerce-cart-order-summary-subtotal-block"></div>
 			<div data-block-name="woocommerce/cart-order-summary-fee-block" class="wp-block-woocommerce-cart-order-summary-fee-block"></div>
-			<div data-block-name="woocommerce/cart-order-summary-discount-block" class="wp-block-woocommerce-cart-order-summary-discount-block"></div>' .
-			( $coupons_enabled ? '<div data-block-name="woocommerce/cart-order-summary-coupon-form-block" class="wp-block-woocommerce-cart-order-summary-coupon-form-block"></div>' : '' ) .
-			'<div data-block-name="woocommerce/cart-order-summary-shipping-form-block" class="wp-block-woocommerce-cart-order-summary-shipping-block"></div>
+			<div data-block-name="woocommerce/cart-order-summary-discount-block" class="wp-block-woocommerce-cart-order-summary-discount-block"></div>
+			<div data-block-name="woocommerce/cart-order-summary-coupon-form-block" class="wp-block-woocommerce-cart-order-summary-coupon-form-block"></div>
+			<div data-block-name="woocommerce/cart-order-summary-shipping-form-block" class="wp-block-woocommerce-cart-order-summary-shipping-block"></div>
 			<div data-block-name="woocommerce/cart-order-summary-taxes-block" class="wp-block-woocommerce-cart-order-summary-taxes-block"></div>
 		';
 		// Order summary subtotal block was added in i3, so we search for it to see if we have a Cart i2 template.

--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -81,8 +81,9 @@ class Cart extends AbstractBlock {
 		wp_dequeue_style( 'select2' );
 
 		/**
-		 * We need to check if $content has any templates from prior iterations of the block, in order to update to the latest iteration
-		 * When testing for inner blocks presence, only test for blocks with the locked:{remove:true} attribute.
+		 * We need to check if $content has any templates from prior iterations of the block, in order to update to the latest iteration.
+		 * We test the iteration version by searching for new blocks brought in by it.
+		 * The blocks used for testing should be always available in the block (not removable by the user).
 		 */
 
 		$regex_for_filled_cart_block = '/<div[\n\r\s\ta-zA-Z0-9_\-=\'"]*data-block-name="woocommerce\/filled-cart-block"[\n\r\s\ta-zA-Z0-9_\-=\'"]*>/mi';

--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -117,13 +117,14 @@ class Cart extends AbstractBlock {
 		 * Cart i3 added inner blocks for Order summary. We need to add them to Cart i2 templates.
 		 * The order needs to match the order in which these blocks were registered.
 		 */
+		$coupons_enabled                 = wc_coupons_enabled();
 		$order_summary_with_inner_blocks = '$0
 			<div data-block-name="woocommerce/cart-order-summary-heading-block" class="wp-block-woocommerce-cart-order-summary-heading-block"></div>
 			<div data-block-name="woocommerce/cart-order-summary-subtotal-block" class="wp-block-woocommerce-cart-order-summary-subtotal-block"></div>
 			<div data-block-name="woocommerce/cart-order-summary-fee-block" class="wp-block-woocommerce-cart-order-summary-fee-block"></div>
-			<div data-block-name="woocommerce/cart-order-summary-discount-block" class="wp-block-woocommerce-cart-order-summary-discount-block"></div>
-			<div data-block-name="woocommerce/cart-order-summary-coupon-form-block" class="wp-block-woocommerce-cart-order-summary-coupon-form-block"></div>
-			<div data-block-name="woocommerce/cart-order-summary-shipping-form-block" class="wp-block-woocommerce-cart-order-summary-shipping-block"></div>
+			<div data-block-name="woocommerce/cart-order-summary-discount-block" class="wp-block-woocommerce-cart-order-summary-discount-block"></div>' .
+			( $coupons_enabled ? '<div data-block-name="woocommerce/cart-order-summary-coupon-form-block" class="wp-block-woocommerce-cart-order-summary-coupon-form-block"></div>' : '' ) .
+			'<div data-block-name="woocommerce/cart-order-summary-shipping-form-block" class="wp-block-woocommerce-cart-order-summary-shipping-block"></div>
 			<div data-block-name="woocommerce/cart-order-summary-taxes-block" class="wp-block-woocommerce-cart-order-summary-taxes-block"></div>
 		';
 		// Order summary subtotal block was added in i3, so we search for it to see if we have a Cart i2 template.

--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -80,20 +80,37 @@ class Cart extends AbstractBlock {
 		wp_dequeue_script( 'selectWoo' );
 		wp_dequeue_style( 'select2' );
 
-		// If the content contains new inner blocks, it means we're in the newer version of Cart.
-		$regex_for_new_block = '/<div[\n\r\s\ta-zA-Z0-9_\-=\'"]*data-block-name="woocommerce\/filled-cart-block"[\n\r\s\ta-zA-Z0-9_\-=\'"]*>/mi';
+		/**
+		 * We need to check if $content has the latest template, searching for one of the newly added blocks from the last iteration
+		 * The new block needs to be always in the template, so only test for blocks with the locked:{remove:true} attribute.
+		 * If it does, we are in the latest version of the block
+		 * If not, we need to add a fallback to assure a successful migration of the block to the new template
+		 * woocommerce/cart-order-summary-subtotal-block was added in C&C i3 and is a locked block, that should always appear
+		 */
+		$regex_for_new_block = '/<div[\n\r\s\ta-zA-Z0-9_\-=\'"]*data-block-name="woocommerce\/cart-order-summary-subtotal-block"[\n\r\s\ta-zA-Z0-9_\-=\'"]*>/mi';
 
-		$is_new = preg_match( $regex_for_new_block, $content );
+		$block_has_older_structure = ! preg_match( $regex_for_new_block, $content );
 
-		if ( ! $is_new ) {
-			// This fallback needs to match the default templates defined in our Blocks.
+		if ( $block_has_older_structure ) {
+			/**
+			 * This fallback needs to match the defaultTemplate variables defined in the block's edit.tsx files,
+			 * starting from the parent block and going down each inner block
+			 */
 			$inner_blocks_html = '$0
 			<div data-block-name="woocommerce/filled-cart-block" class="wp-block-woocommerce-filled-cart-block">
 				<div data-block-name="woocommerce/cart-items-block" class="wp-block-woocommerce-cart-items-block">
 					<div data-block-name="woocommerce/cart-line-items-block" class="wp-block-woocommerce-cart-line-items-block"></div>
 				</div>
 				<div data-block-name="woocommerce/cart-totals-block" class="wp-block-woocommerce-cart-totals-block">
-					<div data-block-name="woocommerce/cart-order-summary-block" class="wp-block-woocommerce-cart-order-summary-block"></div>
+					<div data-block-name="woocommerce/cart-order-summary-block" class="wp-block-woocommerce-cart-order-summary-block">
+						<div data-block-name="woocommerce/cart-order-summary-heading-block" class="wp-block-woocommerce-cart-order-summary-heading-block"></div>
+						<div data-block-name="woocommerce/cart-order-summary-subtotal-block" class="wp-block-woocommerce-cart-order-summary-subtotal-block"></div>
+						<div data-block-name="woocommerce/cart-order-summary-fee-block" class="wp-block-woocommerce-cart-order-summary-fee-block"></div>
+						<div data-block-name="woocommerce/cart-order-summary-discount-block" class="wp-block-woocommerce-cart-order-summary-discount-block"></div>
+						<div data-block-name="woocommerce/cart-order-summary-coupon-form-block" class="wp-block-woocommerce-cart-order-summary-coupon-form-block"></div>
+						<div data-block-name="woocommerce/cart-order-summary-shipping-form-block" class="wp-block-woocommerce-cart-order-summary-shipping-block"></div>
+						<div data-block-name="woocommerce/cart-order-summary-taxes-block" class="wp-block-woocommerce-cart-order-summary-taxes-block"></div>
+					</div>
 					<div data-block-name="woocommerce/cart-express-payment-block" class="wp-block-woocommerce-cart-express-payment-block"></div>
 					<div data-block-name="woocommerce/proceed-to-checkout-block" class="wp-block-woocommerce-proceed-to-checkout-block"></div>
 					<div data-block-name="woocommerce/cart-accepted-payment-methods-block" class="wp-block-woocommerce-cart-accepted-payment-methods-block"></div>

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -123,7 +123,9 @@ class Checkout extends AbstractBlock {
 				</div>
 			';
 
-			$content = str_replace( '</div>', $inner_blocks_html . '</div>', $content );
+			$content = preg_replace( '/<div class="[a-zA-Z0-9_\- ]*wp-block-woocommerce-checkout[a-zA-Z0-9_\- ]*">/mi', $inner_blocks_html, $content );
+			$content = $content . '</div>';
+
 		}
 
 		return $content;

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -83,21 +83,14 @@ class Checkout extends AbstractBlock {
 		wp_dequeue_style( 'select2' );
 
 		/**
-		 * We need to check if the structure from $content has one of the newly added blocks from the last iteration
-		 * The new block needs to be always in the structure, so only test for blocks with the locked:{remove:true} attribute.
-		 * If it does, we are in the latest version of the block
-		 * If not, we need to add a fallback to assure a successful migration of the block to the new structure
-		 * woocommerce/checkout-order-summary-subtotal-block was added in C&C i3 and is a locked block, that should always appear
+		 * We need to check if $content has any templates from prior iterations of the block, in order to update to the latest iteration
+		 * Checkout i1's content was returning an empty div, with no data-block-name attribute
 		 */
-		$regex_for_new_block = '/<div[\n\r\s\ta-zA-Z0-9_\-=\'"]*data-block-name="woocommerce\/checkout-order-summary-subtotal-block"[\n\r\s\ta-zA-Z0-9_\-=\'"]*>/mi';
+		$regex_for_empty_block = '/<div class="[a-zA-Z0-9_\- ]*wp-block-woocommerce-checkout[a-zA-Z0-9_\- ]*"><\/div>/mi';
+		$has_i1_template       = preg_match( $regex_for_empty_block, $content );
 
-		$block_has_older_structure = ! preg_match( $regex_for_new_block, $content );
-
-		if ( $block_has_older_structure ) {
-			/**
-			 * This fallback needs to match the defaultTemplate variables defined in the block's edit.tsx files,
-			 * starting from the parent block and going down each inner block
-			 */
+		if ( $has_i1_template ) {
+			// This fallback needs to match the default templates defined in our Blocks.
 			$inner_blocks_html = '
 				<div data-block-name="woocommerce/checkout-fields-block" class="wp-block-woocommerce-checkout-fields-block">
 					<div data-block-name="woocommerce/checkout-express-payment-block" class="wp-block-woocommerce-checkout-express-payment-block"></div>
@@ -111,21 +104,34 @@ class Checkout extends AbstractBlock {
 					'<div data-block-name="woocommerce/checkout-actions-block" class="wp-block-woocommerce-checkout-actions-block"></div>
 				</div>
 				<div data-block-name="woocommerce/checkout-totals-block" class="wp-block-woocommerce-checkout-totals-block">
-					<div data-block-name="woocommerce/checkout-order-summary-block" class="wp-block-woocommerce-checkout-order-summary-block">
-						<div data-block-name="woocommerce/checkout-order-summary-cart-items-block" class="wp-block-woocommerce-checkout-order-summary-cart-items-block" />
-						<div data-block-name="woocommerce/checkout-order-summary-subtotal-block" class="wp-block-woocommerce-checkout-order-summary-subtotal-block" />
-						<div data-block-name="woocommerce/checkout-order-summary-fee-block" class="wp-block-woocommerce-checkout-order-summary-fee-block" />
-						<div data-block-name="woocommerce/checkout-order-summary-discount-block" class="wp-block-woocommerce-checkout-order-summary-discount-block" />
-						<div data-block-name="woocommerce/checkout-order-summary-coupon-form-block" class="wp-block-woocommerce-checkout-order-summary-coupon-form-block" />
-						<div data-block-name="woocommerce/checkout-order-summary-shipping-block" class="wp-block-woocommerce-checkout-order-summary-shipping-block" />
-						<div data-block-name="woocommerce/checkout-order-summary-taxes-block" class="wp-block-woocommerce-checkout-order-summary-taxes-block" />
-					</div>
+					<div data-block-name="woocommerce/checkout-order-summary-block" class="wp-block-woocommerce-checkout-order-summary-block"></div>
 				</div>
 			';
 
-			$content = preg_replace( '/<div class="[a-zA-Z0-9_\- ]*wp-block-woocommerce-checkout[a-zA-Z0-9_\- ]*">/mi', $inner_blocks_html, $content );
-			$content = $content . '</div>';
+			$content = str_replace( '</div>', $inner_blocks_html . '</div>', $content );
+		}
 
+		/**
+		 * Checkout i3 added inner blocks for Order summary.
+		 * We need to add them to Checkout i2 templates.
+		 * The order needs to match the order in which these blocks were registered.
+		 */
+		$order_summary_with_inner_blocks = '$0
+			<div data-block-name="woocommerce/checkout-order-summary-cart-items-block" class="wp-block-woocommerce-checkout-order-summary-cart-items-block"></div>
+			<div data-block-name="woocommerce/checkout-order-summary-subtotal-block" class="wp-block-woocommerce-checkout-order-summary-subtotal-block"></div>
+			<div data-block-name="woocommerce/checkout-order-summary-fee-block" class="wp-block-woocommerce-checkout-order-summary-fee-block"></div>
+			<div data-block-name="woocommerce/checkout-order-summary-discount-block" class="wp-block-woocommerce-checkout-order-summary-discount-block"></div>
+			<div data-block-name="woocommerce/checkout-order-summary-coupon-form-block" class="wp-block-woocommerce-checkout-order-summary-coupon-form-block"></div>
+			<div data-block-name="woocommerce/checkout-order-summary-shipping-block" class="wp-block-woocommerce-checkout-order-summary-shipping-block"></div>
+			<div data-block-name="woocommerce/checkout-order-summary-taxes-block" class="wp-block-woocommerce-checkout-order-summary-taxes-block"></div>
+		';
+		// Order summary subtotal block was added in i3, so we search for it to see if we have a Checkout i2 template.
+		$regex_for_order_summary_subtotal = '/<div[\n\r\s\ta-zA-Z0-9_\-=\'"]*data-block-name="woocommerce\/checkout-order-summary-subtotal-block"[\n\r\s\ta-zA-Z0-9_\-=\'"]*>/mi';
+		$regex_for_order_summary          = '/<div[\n\r\s\ta-zA-Z0-9_\-=\'"]*data-block-name="woocommerce\/checkout-order-summary-block"[\n\r\s\ta-zA-Z0-9_\-=\'"]*>/mi';
+		$has_i2_template                  = ! preg_match( $regex_for_order_summary_subtotal, $content );
+
+		if ( $has_i2_template ) {
+			$content = preg_replace( $regex_for_order_summary, $order_summary_with_inner_blocks, $content );
 		}
 
 		return $content;

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -118,14 +118,13 @@ class Checkout extends AbstractBlock {
 		 * We need to add them to Checkout i2 templates.
 		 * The order needs to match the order in which these blocks were registered.
 		 */
-		$coupons_enabled                 = wc_coupons_enabled();
 		$order_summary_with_inner_blocks = '$0
 			<div data-block-name="woocommerce/checkout-order-summary-cart-items-block" class="wp-block-woocommerce-checkout-order-summary-cart-items-block"></div>
 			<div data-block-name="woocommerce/checkout-order-summary-subtotal-block" class="wp-block-woocommerce-checkout-order-summary-subtotal-block"></div>
 			<div data-block-name="woocommerce/checkout-order-summary-fee-block" class="wp-block-woocommerce-checkout-order-summary-fee-block"></div>
-			<div data-block-name="woocommerce/checkout-order-summary-discount-block" class="wp-block-woocommerce-checkout-order-summary-discount-block"></div>' .
-			( $coupons_enabled ? '<div data-block-name="woocommerce/checkout-order-summary-coupon-form-block" class="wp-block-woocommerce-checkout-order-summary-coupon-form-block"></div>' : '' ) .
-			'<div data-block-name="woocommerce/checkout-order-summary-shipping-block" class="wp-block-woocommerce-checkout-order-summary-shipping-block"></div>
+			<div data-block-name="woocommerce/checkout-order-summary-discount-block" class="wp-block-woocommerce-checkout-order-summary-discount-block"></div>
+			<div data-block-name="woocommerce/checkout-order-summary-coupon-form-block" class="wp-block-woocommerce-checkout-order-summary-coupon-form-block"></div>
+			<div data-block-name="woocommerce/checkout-order-summary-shipping-block" class="wp-block-woocommerce-checkout-order-summary-shipping-block"></div>
 			<div data-block-name="woocommerce/checkout-order-summary-taxes-block" class="wp-block-woocommerce-checkout-order-summary-taxes-block"></div>
 		';
 		// Order summary subtotal block was added in i3, so we search for it to see if we have a Checkout i2 template.

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -116,13 +116,14 @@ class Checkout extends AbstractBlock {
 		 * We need to add them to Checkout i2 templates.
 		 * The order needs to match the order in which these blocks were registered.
 		 */
+		$coupons_enabled                 = wc_coupons_enabled();
 		$order_summary_with_inner_blocks = '$0
 			<div data-block-name="woocommerce/checkout-order-summary-cart-items-block" class="wp-block-woocommerce-checkout-order-summary-cart-items-block"></div>
 			<div data-block-name="woocommerce/checkout-order-summary-subtotal-block" class="wp-block-woocommerce-checkout-order-summary-subtotal-block"></div>
 			<div data-block-name="woocommerce/checkout-order-summary-fee-block" class="wp-block-woocommerce-checkout-order-summary-fee-block"></div>
-			<div data-block-name="woocommerce/checkout-order-summary-discount-block" class="wp-block-woocommerce-checkout-order-summary-discount-block"></div>
-			<div data-block-name="woocommerce/checkout-order-summary-coupon-form-block" class="wp-block-woocommerce-checkout-order-summary-coupon-form-block"></div>
-			<div data-block-name="woocommerce/checkout-order-summary-shipping-block" class="wp-block-woocommerce-checkout-order-summary-shipping-block"></div>
+			<div data-block-name="woocommerce/checkout-order-summary-discount-block" class="wp-block-woocommerce-checkout-order-summary-discount-block"></div>' .
+			( $coupons_enabled ? '<div data-block-name="woocommerce/checkout-order-summary-coupon-form-block" class="wp-block-woocommerce-checkout-order-summary-coupon-form-block"></div>' : '' ) .
+			'<div data-block-name="woocommerce/checkout-order-summary-shipping-block" class="wp-block-woocommerce-checkout-order-summary-shipping-block"></div>
 			<div data-block-name="woocommerce/checkout-order-summary-taxes-block" class="wp-block-woocommerce-checkout-order-summary-taxes-block"></div>
 		';
 		// Order summary subtotal block was added in i3, so we search for it to see if we have a Checkout i2 template.

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -82,18 +82,12 @@ class Checkout extends AbstractBlock {
 		wp_dequeue_script( 'selectWoo' );
 		wp_dequeue_style( 'select2' );
 
-		/**
-		 * We need to check if the structure from $content has one of the newly added blocks from the last iteration
-		 * The new block needs to be always in the structure, so only test for blocks with the locked:{remove:true} attribute.
-		 * If it does, we are in the latest version of the block
-		 * If not, we need to add a fallback to assure a successful migration of the block to the new structure
-		 * woocommerce/checkout-order-summary-subtotal-block was added in C&C i3 and is a locked block, that should always appear
-		 */
-		$regex_for_new_block = '/<div[\n\r\s\ta-zA-Z0-9_\-=\'"]*data-block-name="woocommerce\/checkout-order-summary-subtotal-block"[\n\r\s\ta-zA-Z0-9_\-=\'"]*>/mi';
+		// If the content is empty, we may still be in the older checkout block. Insert the default list of blocks.
+		$regex_for_empty_block = '/<div class="[a-zA-Z0-9_\- ]*wp-block-woocommerce-checkout[a-zA-Z0-9_\- ]*"><\/div>/mi';
 
-		$block_has_older_structure = ! preg_match( $regex_for_new_block, $content );
+		$is_empty = preg_match( $regex_for_empty_block, $content );
 
-		if ( $block_has_older_structure ) {
+		if ( $is_empty ) {
 			/**
 			 * This fallback needs to match the defaultTemplate variables defined in the block's edit.tsx files,
 			 * starting from the parent block and going down each inner block
@@ -106,9 +100,9 @@ class Checkout extends AbstractBlock {
 					<div data-block-name="woocommerce/checkout-billing-address-block" class="wp-block-woocommerce-checkout-billing-address-block"></div>
 					<div data-block-name="woocommerce/checkout-shipping-methods-block" class="wp-block-woocommerce-checkout-shipping-methods-block"></div>
 					<div data-block-name="woocommerce/checkout-payment-block" class="wp-block-woocommerce-checkout-payment-block"></div>' .
-					( isset( $attributes['showOrderNotes'] ) && false === $attributes['showOrderNotes'] ? '' : '<div data-block-name="woocommerce/checkout-order-note-block" class="wp-block-woocommerce-checkout-order-note-block"></div>' ) .
-					( isset( $attributes['showPolicyLinks'] ) && false === $attributes['showPolicyLinks'] ? '' : '<div data-block-name="woocommerce/checkout-terms-block" class="wp-block-woocommerce-checkout-terms-block"></div>' ) .
-					'<div data-block-name="woocommerce/checkout-actions-block" class="wp-block-woocommerce-checkout-actions-block"></div>
+				( isset( $attributes['showOrderNotes'] ) && false === $attributes['showOrderNotes'] ? '' : '<div data-block-name="woocommerce/checkout-order-note-block" class="wp-block-woocommerce-checkout-order-note-block"></div>' ) .
+				( isset( $attributes['showPolicyLinks'] ) && false === $attributes['showPolicyLinks'] ? '' : '<div data-block-name="woocommerce/checkout-terms-block" class="wp-block-woocommerce-checkout-terms-block"></div>' ) .
+				'<div data-block-name="woocommerce/checkout-actions-block" class="wp-block-woocommerce-checkout-actions-block"></div>
 				</div>
 				<div data-block-name="woocommerce/checkout-totals-block" class="wp-block-woocommerce-checkout-totals-block">
 					<div data-block-name="woocommerce/checkout-order-summary-block" class="wp-block-woocommerce-checkout-order-summary-block">

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -83,7 +83,9 @@ class Checkout extends AbstractBlock {
 		wp_dequeue_style( 'select2' );
 
 		/**
-		 * We need to check if $content has any templates from prior iterations of the block, in order to update to the latest iteration
+		 * We need to check if $content has any templates from prior iterations of the block, in order to update to the latest iteration.
+		 * We test the iteration version by searching for new blocks brought in by it.
+		 * The blocks used for testing should be always available in the block (not removable by the user).
 		 * Checkout i1's content was returning an empty div, with no data-block-name attribute
 		 */
 		$regex_for_empty_block = '/<div class="[a-zA-Z0-9_\- ]*wp-block-woocommerce-checkout[a-zA-Z0-9_\- ]*"><\/div>/mi';

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -82,12 +82,18 @@ class Checkout extends AbstractBlock {
 		wp_dequeue_script( 'selectWoo' );
 		wp_dequeue_style( 'select2' );
 
-		// If the content is empty, we may still be in the older checkout block. Insert the default list of blocks.
-		$regex_for_empty_block = '/<div class="[a-zA-Z0-9_\- ]*wp-block-woocommerce-checkout[a-zA-Z0-9_\- ]*"><\/div>/mi';
+		/**
+		 * We need to check if the structure from $content has one of the newly added blocks from the last iteration
+		 * The new block needs to be always in the structure, so only test for blocks with the locked:{remove:true} attribute.
+		 * If it does, we are in the latest version of the block
+		 * If not, we need to add a fallback to assure a successful migration of the block to the new structure
+		 * woocommerce/checkout-order-summary-subtotal-block was added in C&C i3 and is a locked block, that should always appear
+		 */
+		$regex_for_new_block = '/<div[\n\r\s\ta-zA-Z0-9_\-=\'"]*data-block-name="woocommerce\/checkout-order-summary-subtotal-block"[\n\r\s\ta-zA-Z0-9_\-=\'"]*>/mi';
 
-		$is_empty = preg_match( $regex_for_empty_block, $content );
+		$block_has_older_structure = ! preg_match( $regex_for_new_block, $content );
 
-		if ( $is_empty ) {
+		if ( $block_has_older_structure ) {
 			/**
 			 * This fallback needs to match the defaultTemplate variables defined in the block's edit.tsx files,
 			 * starting from the parent block and going down each inner block
@@ -100,9 +106,9 @@ class Checkout extends AbstractBlock {
 					<div data-block-name="woocommerce/checkout-billing-address-block" class="wp-block-woocommerce-checkout-billing-address-block"></div>
 					<div data-block-name="woocommerce/checkout-shipping-methods-block" class="wp-block-woocommerce-checkout-shipping-methods-block"></div>
 					<div data-block-name="woocommerce/checkout-payment-block" class="wp-block-woocommerce-checkout-payment-block"></div>' .
-				( isset( $attributes['showOrderNotes'] ) && false === $attributes['showOrderNotes'] ? '' : '<div data-block-name="woocommerce/checkout-order-note-block" class="wp-block-woocommerce-checkout-order-note-block"></div>' ) .
-				( isset( $attributes['showPolicyLinks'] ) && false === $attributes['showPolicyLinks'] ? '' : '<div data-block-name="woocommerce/checkout-terms-block" class="wp-block-woocommerce-checkout-terms-block"></div>' ) .
-				'<div data-block-name="woocommerce/checkout-actions-block" class="wp-block-woocommerce-checkout-actions-block"></div>
+					( isset( $attributes['showOrderNotes'] ) && false === $attributes['showOrderNotes'] ? '' : '<div data-block-name="woocommerce/checkout-order-note-block" class="wp-block-woocommerce-checkout-order-note-block"></div>' ) .
+					( isset( $attributes['showPolicyLinks'] ) && false === $attributes['showPolicyLinks'] ? '' : '<div data-block-name="woocommerce/checkout-terms-block" class="wp-block-woocommerce-checkout-terms-block"></div>' ) .
+					'<div data-block-name="woocommerce/checkout-actions-block" class="wp-block-woocommerce-checkout-actions-block"></div>
 				</div>
 				<div data-block-name="woocommerce/checkout-totals-block" class="wp-block-woocommerce-checkout-totals-block">
 					<div data-block-name="woocommerce/checkout-order-summary-block" class="wp-block-woocommerce-checkout-order-summary-block">

--- a/tests/e2e/specs/shopper/cart-checkout/checkout.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/checkout.test.js
@@ -242,13 +242,15 @@ describe( 'Shopper → Checkout', () => {
 	describe( 'Coupons', () => {
 		beforeAll( async () => {
 			coupon = await createCoupon( { usageLimit: 1 } );
+			await merchant.login();
 		} );
 
 		afterAll( async () => {
 			await withRestApi.deleteCoupon( coupon.id );
+			await merchant.logout();
 		} );
 
-		it( 'User can apply single-use coupon once', async () => {
+		it( 'Logged in user can apply single-use coupon and place order', async () => {
 			await shopper.goToShop();
 			await shopper.addToCartFromShopPage( SIMPLE_VIRTUAL_PRODUCT_NAME );
 			await shopper.block.goToCheckout();
@@ -272,7 +274,6 @@ describe( 'Shopper → Checkout', () => {
 					text: coupon.code,
 				}
 			);
-
 			await shopper.block.placeOrder();
 			await expect( page ).toMatch( 'Your order has been received.' );
 
@@ -286,7 +287,7 @@ describe( 'Shopper → Checkout', () => {
 			);
 		} );
 
-		it( 'User cannot apply single-use coupon twice', async () => {
+		it( 'Logged in user cannot apply single-use coupon twice', async () => {
 			await shopper.goToShop();
 			await shopper.addToCartFromShopPage( SIMPLE_VIRTUAL_PRODUCT_NAME );
 			await shopper.block.goToCheckout();


### PR DESCRIPTION
This will fix the issues with missing Order summary inner blocks: Coupons (both in C & C blocks) and the Cart header. 

The issue was happening because, for example, for Cart the coupons were registered on the on frontend, but it just wasn't forced in the attributes. Because it also wasn't added to the PHP fallback layout, the render function didn't include it. For the Checkout block the coupons inner block wasn't registered at all.

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #6185 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->


#### Other Checks

- [ ] I've updated [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) for any feature flags or experimental interfaces implemented in this pull request.
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->
| Before  | After |
| ------------- | ------------- |
|   <img width="853" alt="Screenshot 2022-04-05 at 11 53 18" src="https://user-images.githubusercontent.com/1628454/161783714-30b73604-af66-4708-ab9c-6f3f25878700.png"> |   <img width="815" alt="Screenshot 2022-04-05 at 16 55 41" src="https://user-images.githubusercontent.com/1628454/161783671-a80edb2a-4a27-4add-bdfd-7bdfe1cd529a.png"> |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:
**Test from tag v7.2.0**

1. Run `git checkout tags/v7.2.0` 
2. Insert fresh Cart/Checkout blocks in different pages, save them
3. Notice that there is no inner blocks for Order summary
4. Switch to the PR branch & build
5. Test that Cart/Checkout blocks load fine in the frontend and the editor without crashing and the missing inner blocks are there


### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [ ] Same as above, or
* [ ] See steps below.
* [x] Not included in user facing testing instructions


<!-- If you can, add the appropriate labels -->

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

