### PR TITLE
Increase Cart product quantity limit

### DIFF
--- a/src/StoreApi/Utilities/QuantityLimits.php
+++ b/src/StoreApi/Utilities/QuantityLimits.php
@@ -140,7 +140,7 @@ final class QuantityLimits {
 	 * @return int
 	 */
 	protected function get_product_quantity_limit( \WC_Product $product ) {
-		$limits = [ 99 ];
+		$limits = [ 9999 ];
 
 		if ( $product->is_sold_individually() ) {
 			$limits[] = 1;

--- a/src/StoreApi/Utilities/QuantityLimits.php
+++ b/src/StoreApi/Utilities/QuantityLimits.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Automattic\WooCommerce\StoreApi\Utilities;
 
 use Automattic\WooCommerce\Checkout\Helpers\ReserveStock;
@@ -9,7 +10,8 @@ use Automattic\WooCommerce\StoreApi\Utilities\DraftOrderTrait;
  *
  * Returns limits for products and cart items when using the StoreAPI and supporting classes.
  */
-final class QuantityLimits {
+final class QuantityLimits
+{
 	use DraftOrderTrait;
 
 	/**
@@ -18,10 +20,11 @@ final class QuantityLimits {
 	 * @param array $cart_item A cart item array.
 	 * @return array
 	 */
-	public function get_cart_item_quantity_limits( $cart_item ) {
+	public function get_cart_item_quantity_limits($cart_item)
+	{
 		$product = $cart_item['data'] ?? false;
 
-		if ( ! $product instanceof \WC_Product ) {
+		if (!$product instanceof \WC_Product) {
 			return [
 				'minimum'     => 1,
 				'maximum'     => null,
@@ -30,14 +33,14 @@ final class QuantityLimits {
 			];
 		}
 
-		$multiple_of = (int) $this->filter_value( 1, 'multiple_of', $cart_item );
-		$minimum     = (int) $this->filter_value( 1, 'minimum', $cart_item );
-		$maximum     = (int) $this->filter_value( $this->get_product_quantity_limit( $product ), 'maximum', $cart_item );
-		$editable    = (bool) $this->filter_value( ! $product->is_sold_individually(), 'editable', $cart_item );
+		$multiple_of = (int) $this->filter_value(1, 'multiple_of', $cart_item);
+		$minimum     = (int) $this->filter_value(1, 'minimum', $cart_item);
+		$maximum     = (int) $this->filter_value($this->get_product_quantity_limit($product), 'maximum', $cart_item);
+		$editable    = (bool) $this->filter_value(!$product->is_sold_individually(), 'editable', $cart_item);
 
 		return [
-			'minimum'     => $this->limit_to_multiple( $minimum, $multiple_of, 'ceil' ),
-			'maximum'     => $this->limit_to_multiple( $maximum, $multiple_of, 'floor' ),
+			'minimum'     => $this->limit_to_multiple($minimum, $multiple_of, 'ceil'),
+			'maximum'     => $this->limit_to_multiple($maximum, $multiple_of, 'floor'),
 			'multiple_of' => $multiple_of,
 			'editable'    => $editable,
 		];
@@ -49,14 +52,15 @@ final class QuantityLimits {
 	 * @param \WC_Product $product Product instance.
 	 * @return array
 	 */
-	public function get_add_to_cart_limits( \WC_Product $product ) {
-		$multiple_of = $this->filter_value( 1, 'multiple_of', $product );
-		$minimum     = $this->filter_value( 1, 'minimum', $product );
-		$maximum     = $this->filter_value( $this->get_product_quantity_limit( $product ), 'maximum', $product );
+	public function get_add_to_cart_limits(\WC_Product $product)
+	{
+		$multiple_of = $this->filter_value(1, 'multiple_of', $product);
+		$minimum     = $this->filter_value(1, 'minimum', $product);
+		$maximum     = $this->filter_value($this->get_product_quantity_limit($product), 'maximum', $product);
 
 		return [
-			'minimum'     => $this->limit_to_multiple( $minimum, $multiple_of, 'ceil' ),
-			'maximum'     => $this->limit_to_multiple( $maximum, $multiple_of, 'floor' ),
+			'minimum'     => $this->limit_to_multiple($minimum, $multiple_of, 'ceil'),
+			'maximum'     => $this->limit_to_multiple($maximum, $multiple_of, 'floor'),
 			'multiple_of' => $multiple_of,
 		];
 	}
@@ -69,12 +73,13 @@ final class QuantityLimits {
 	 * @param string $rounding_function ceil, floor, or round.
 	 * @return int
 	 */
-	public function limit_to_multiple( int $number, int $multiple_of, string $rounding_function = 'round' ) {
-		if ( $multiple_of <= 1 ) {
+	public function limit_to_multiple(int $number, int $multiple_of, string $rounding_function = 'round')
+	{
+		if ($multiple_of <= 1) {
 			return $number;
 		}
-		$rounding_function = in_array( $rounding_function, [ 'ceil', 'floor', 'round' ], true ) ? $rounding_function : 'round';
-		return $rounding_function( $number / $multiple_of ) * $multiple_of;
+		$rounding_function = in_array($rounding_function, ['ceil', 'floor', 'round'], true) ? $rounding_function : 'round';
+		return $rounding_function($number / $multiple_of) * $multiple_of;
 	}
 
 	/**
@@ -84,44 +89,45 @@ final class QuantityLimits {
 	 * @param \WC_Product|array $cart_item Cart item.
 	 * @return \WP_Error|true
 	 */
-	public function validate_cart_item_quantity( $quantity, $cart_item ) {
-		$limits = $this->get_cart_item_quantity_limits( $cart_item );
+	public function validate_cart_item_quantity($quantity, $cart_item)
+	{
+		$limits = $this->get_cart_item_quantity_limits($cart_item);
 
-		if ( ! $limits['editable'] ) {
+		if (!$limits['editable']) {
 			return new \WP_Error(
 				'readonly_quantity',
-				__( 'This item is already in the cart and its quantity cannot be edited', 'woo-gutenberg-products-block' )
+				__('This item is already in the cart and its quantity cannot be edited', 'woo-gutenberg-products-block')
 			);
 		}
 
-		if ( $quantity < $limits['minimum'] ) {
+		if ($quantity < $limits['minimum']) {
 			return new \WP_Error(
 				'invalid_quantity',
 				sprintf(
 					// Translators: %s amount.
-					__( 'The minimum quantity that can be added to the cart is %s', 'woo-gutenberg-products-block' ),
+					__('The minimum quantity that can be added to the cart is %s', 'woo-gutenberg-products-block'),
 					$limits['minimum']
 				)
 			);
 		}
 
-		if ( $quantity > $limits['maximum'] ) {
+		if ($quantity > $limits['maximum']) {
 			return new \WP_Error(
 				'invalid_quantity',
 				sprintf(
 					// Translators: %s amount.
-					__( 'The maximum quantity that can be added to the cart is %s', 'woo-gutenberg-products-block' ),
+					__('The maximum quantity that can be added to the cart is %s', 'woo-gutenberg-products-block'),
 					$limits['maximum']
 				)
 			);
 		}
 
-		if ( $quantity % $limits['multiple_of'] ) {
+		if ($quantity % $limits['multiple_of']) {
 			return new \WP_Error(
 				'invalid_quantity',
 				sprintf(
 					// Translators: %s amount.
-					__( 'The quantity added to the cart must be a multiple of %s', 'woo-gutenberg-products-block' ),
+					__('The quantity added to the cart must be a multiple of %s', 'woo-gutenberg-products-block'),
 					$limits['multiple_of']
 				)
 			);
@@ -133,19 +139,20 @@ final class QuantityLimits {
 	/**
 	 * Get the limit for the total number of a product allowed in the cart.
 	 *
-	 * This is based on product properties, including remaining stock, and defaults to a maximum of 99 of any product
+	 * This is based on product properties, including remaining stock, and defaults to a maximum of 9999 of any product
 	 * in the cart at once.
 	 *
 	 * @param \WC_Product $product Product instance.
 	 * @return int
 	 */
-	protected function get_product_quantity_limit( \WC_Product $product ) {
-		$limits = [ 9999 ];
+	protected function get_product_quantity_limit(\WC_Product $product)
+	{
+		$limits = [9999];
 
-		if ( $product->is_sold_individually() ) {
+		if ($product->is_sold_individually()) {
 			$limits[] = 1;
-		} elseif ( ! $product->backorders_allowed() ) {
-			$limits[] = $this->get_remaining_stock( $product );
+		} elseif (!$product->backorders_allowed()) {
+			$limits[] = $this->get_remaining_stock($product);
 		}
 
 		/**
@@ -153,11 +160,11 @@ final class QuantityLimits {
 		 *
 		 * Filters the variation option name for custom option slugs.
 		 *
-		 * @param integer $quantity_limit Quantity limit which defaults to 99 unless sold individually.
+		 * @param integer $quantity_limit Quantity limit which defaults to 9999 unless sold individually.
 		 * @param \WC_Product $product Product instance.
 		 * @return integer
 		 */
-		return apply_filters( 'woocommerce_store_api_product_quantity_limit', max( min( array_filter( $limits ) ), 1 ), $product );
+		return apply_filters('woocommerce_store_api_product_quantity_limit', max(min(array_filter($limits)), 1), $product);
 	}
 
 	/**
@@ -168,13 +175,14 @@ final class QuantityLimits {
 	 * @param \WC_Product $product Product instance.
 	 * @return integer|null
 	 */
-	protected function get_remaining_stock( \WC_Product $product ) {
-		if ( is_null( $product->get_stock_quantity() ) ) {
+	protected function get_remaining_stock(\WC_Product $product)
+	{
+		if (is_null($product->get_stock_quantity())) {
 			return null;
 		}
 
 		$reserve_stock  = new ReserveStock();
-		$reserved_stock = $reserve_stock->get_reserved_stock( $product, $this->get_draft_order_id() );
+		$reserved_stock = $reserve_stock->get_reserved_stock($product, $this->get_draft_order_id());
 
 		return $product->get_stock_quantity() - $reserved_stock;
 	}
@@ -187,7 +195,8 @@ final class QuantityLimits {
 	 * @param \WC_Product|array $cart_item_or_product Either a cart item or a product instance.
 	 * @return mixed
 	 */
-	protected function filter_value( $value, string $value_type, $cart_item_or_product ) {
+	protected function filter_value($value, string $value_type, $cart_item_or_product)
+	{
 		$is_product = $cart_item_or_product instanceof \WC_Product;
 		$product    = $is_product ? $cart_item_or_product : $cart_item_or_product['data'];
 		$cart_item  = $is_product ? null : $cart_item_or_product;
@@ -203,6 +212,6 @@ final class QuantityLimits {
 		 * @param array|null $cart_item The cart item if the product exists in the cart, or null.
 		 * @return mixed
 		 */
-		return apply_filters( "woocommerce_store_api_product_quantity_{$value_type}", $value, $product, $cart_item );
+		return apply_filters("woocommerce_store_api_product_quantity_{$value_type}", $value, $product, $cart_item);
 	}
 }

--- a/src/StoreApi/Utilities/QuantityLimits.php
+++ b/src/StoreApi/Utilities/QuantityLimits.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Automattic\WooCommerce\StoreApi\Utilities;
 
 use Automattic\WooCommerce\Checkout\Helpers\ReserveStock;
@@ -10,8 +9,7 @@ use Automattic\WooCommerce\StoreApi\Utilities\DraftOrderTrait;
  *
  * Returns limits for products and cart items when using the StoreAPI and supporting classes.
  */
-final class QuantityLimits
-{
+final class QuantityLimits {
 	use DraftOrderTrait;
 
 	/**
@@ -20,11 +18,10 @@ final class QuantityLimits
 	 * @param array $cart_item A cart item array.
 	 * @return array
 	 */
-	public function get_cart_item_quantity_limits($cart_item)
-	{
+	public function get_cart_item_quantity_limits( $cart_item ) {
 		$product = $cart_item['data'] ?? false;
 
-		if (!$product instanceof \WC_Product) {
+		if ( ! $product instanceof \WC_Product ) {
 			return [
 				'minimum'     => 1,
 				'maximum'     => null,
@@ -33,14 +30,14 @@ final class QuantityLimits
 			];
 		}
 
-		$multiple_of = (int) $this->filter_value(1, 'multiple_of', $cart_item);
-		$minimum     = (int) $this->filter_value(1, 'minimum', $cart_item);
-		$maximum     = (int) $this->filter_value($this->get_product_quantity_limit($product), 'maximum', $cart_item);
-		$editable    = (bool) $this->filter_value(!$product->is_sold_individually(), 'editable', $cart_item);
+		$multiple_of = (int) $this->filter_value( 1, 'multiple_of', $cart_item );
+		$minimum     = (int) $this->filter_value( 1, 'minimum', $cart_item );
+		$maximum     = (int) $this->filter_value( $this->get_product_quantity_limit( $product ), 'maximum', $cart_item );
+		$editable    = (bool) $this->filter_value( ! $product->is_sold_individually(), 'editable', $cart_item );
 
 		return [
-			'minimum'     => $this->limit_to_multiple($minimum, $multiple_of, 'ceil'),
-			'maximum'     => $this->limit_to_multiple($maximum, $multiple_of, 'floor'),
+			'minimum'     => $this->limit_to_multiple( $minimum, $multiple_of, 'ceil' ),
+			'maximum'     => $this->limit_to_multiple( $maximum, $multiple_of, 'floor' ),
 			'multiple_of' => $multiple_of,
 			'editable'    => $editable,
 		];
@@ -52,15 +49,14 @@ final class QuantityLimits
 	 * @param \WC_Product $product Product instance.
 	 * @return array
 	 */
-	public function get_add_to_cart_limits(\WC_Product $product)
-	{
-		$multiple_of = $this->filter_value(1, 'multiple_of', $product);
-		$minimum     = $this->filter_value(1, 'minimum', $product);
-		$maximum     = $this->filter_value($this->get_product_quantity_limit($product), 'maximum', $product);
+	public function get_add_to_cart_limits( \WC_Product $product ) {
+		$multiple_of = $this->filter_value( 1, 'multiple_of', $product );
+		$minimum     = $this->filter_value( 1, 'minimum', $product );
+		$maximum     = $this->filter_value( $this->get_product_quantity_limit( $product ), 'maximum', $product );
 
 		return [
-			'minimum'     => $this->limit_to_multiple($minimum, $multiple_of, 'ceil'),
-			'maximum'     => $this->limit_to_multiple($maximum, $multiple_of, 'floor'),
+			'minimum'     => $this->limit_to_multiple( $minimum, $multiple_of, 'ceil' ),
+			'maximum'     => $this->limit_to_multiple( $maximum, $multiple_of, 'floor' ),
 			'multiple_of' => $multiple_of,
 		];
 	}
@@ -73,13 +69,12 @@ final class QuantityLimits
 	 * @param string $rounding_function ceil, floor, or round.
 	 * @return int
 	 */
-	public function limit_to_multiple(int $number, int $multiple_of, string $rounding_function = 'round')
-	{
-		if ($multiple_of <= 1) {
+	public function limit_to_multiple( int $number, int $multiple_of, string $rounding_function = 'round' ) {
+		if ( $multiple_of <= 1 ) {
 			return $number;
 		}
-		$rounding_function = in_array($rounding_function, ['ceil', 'floor', 'round'], true) ? $rounding_function : 'round';
-		return $rounding_function($number / $multiple_of) * $multiple_of;
+		$rounding_function = in_array( $rounding_function, [ 'ceil', 'floor', 'round' ], true ) ? $rounding_function : 'round';
+		return $rounding_function( $number / $multiple_of ) * $multiple_of;
 	}
 
 	/**
@@ -89,45 +84,44 @@ final class QuantityLimits
 	 * @param \WC_Product|array $cart_item Cart item.
 	 * @return \WP_Error|true
 	 */
-	public function validate_cart_item_quantity($quantity, $cart_item)
-	{
-		$limits = $this->get_cart_item_quantity_limits($cart_item);
+	public function validate_cart_item_quantity( $quantity, $cart_item ) {
+		$limits = $this->get_cart_item_quantity_limits( $cart_item );
 
-		if (!$limits['editable']) {
+		if ( ! $limits['editable'] ) {
 			return new \WP_Error(
 				'readonly_quantity',
-				__('This item is already in the cart and its quantity cannot be edited', 'woo-gutenberg-products-block')
+				__( 'This item is already in the cart and its quantity cannot be edited', 'woo-gutenberg-products-block' )
 			);
 		}
 
-		if ($quantity < $limits['minimum']) {
+		if ( $quantity < $limits['minimum'] ) {
 			return new \WP_Error(
 				'invalid_quantity',
 				sprintf(
 					// Translators: %s amount.
-					__('The minimum quantity that can be added to the cart is %s', 'woo-gutenberg-products-block'),
+					__( 'The minimum quantity that can be added to the cart is %s', 'woo-gutenberg-products-block' ),
 					$limits['minimum']
 				)
 			);
 		}
 
-		if ($quantity > $limits['maximum']) {
+		if ( $quantity > $limits['maximum'] ) {
 			return new \WP_Error(
 				'invalid_quantity',
 				sprintf(
 					// Translators: %s amount.
-					__('The maximum quantity that can be added to the cart is %s', 'woo-gutenberg-products-block'),
+					__( 'The maximum quantity that can be added to the cart is %s', 'woo-gutenberg-products-block' ),
 					$limits['maximum']
 				)
 			);
 		}
 
-		if ($quantity % $limits['multiple_of']) {
+		if ( $quantity % $limits['multiple_of'] ) {
 			return new \WP_Error(
 				'invalid_quantity',
 				sprintf(
 					// Translators: %s amount.
-					__('The quantity added to the cart must be a multiple of %s', 'woo-gutenberg-products-block'),
+					__( 'The quantity added to the cart must be a multiple of %s', 'woo-gutenberg-products-block' ),
 					$limits['multiple_of']
 				)
 			);
@@ -145,14 +139,13 @@ final class QuantityLimits
 	 * @param \WC_Product $product Product instance.
 	 * @return int
 	 */
-	protected function get_product_quantity_limit(\WC_Product $product)
-	{
-		$limits = [9999];
+	protected function get_product_quantity_limit( \WC_Product $product ) {
+		$limits = [ 9999 ];
 
-		if ($product->is_sold_individually()) {
+		if ( $product->is_sold_individually() ) {
 			$limits[] = 1;
-		} elseif (!$product->backorders_allowed()) {
-			$limits[] = $this->get_remaining_stock($product);
+		} elseif ( ! $product->backorders_allowed() ) {
+			$limits[] = $this->get_remaining_stock( $product );
 		}
 
 		/**
@@ -164,7 +157,7 @@ final class QuantityLimits
 		 * @param \WC_Product $product Product instance.
 		 * @return integer
 		 */
-		return apply_filters('woocommerce_store_api_product_quantity_limit', max(min(array_filter($limits)), 1), $product);
+		return apply_filters( 'woocommerce_store_api_product_quantity_limit', max( min( array_filter( $limits ) ), 1 ), $product );
 	}
 
 	/**
@@ -175,14 +168,13 @@ final class QuantityLimits
 	 * @param \WC_Product $product Product instance.
 	 * @return integer|null
 	 */
-	protected function get_remaining_stock(\WC_Product $product)
-	{
-		if (is_null($product->get_stock_quantity())) {
+	protected function get_remaining_stock( \WC_Product $product ) {
+		if ( is_null( $product->get_stock_quantity() ) ) {
 			return null;
 		}
 
 		$reserve_stock  = new ReserveStock();
-		$reserved_stock = $reserve_stock->get_reserved_stock($product, $this->get_draft_order_id());
+		$reserved_stock = $reserve_stock->get_reserved_stock( $product, $this->get_draft_order_id() );
 
 		return $product->get_stock_quantity() - $reserved_stock;
 	}
@@ -195,8 +187,7 @@ final class QuantityLimits
 	 * @param \WC_Product|array $cart_item_or_product Either a cart item or a product instance.
 	 * @return mixed
 	 */
-	protected function filter_value($value, string $value_type, $cart_item_or_product)
-	{
+	protected function filter_value( $value, string $value_type, $cart_item_or_product ) {
 		$is_product = $cart_item_or_product instanceof \WC_Product;
 		$product    = $is_product ? $cart_item_or_product : $cart_item_or_product['data'];
 		$cart_item  = $is_product ? null : $cart_item_or_product;
@@ -212,6 +203,6 @@ final class QuantityLimits
 		 * @param array|null $cart_item The cart item if the product exists in the cart, or null.
 		 * @return mixed
 		 */
-		return apply_filters("woocommerce_store_api_product_quantity_{$value_type}", $value, $product, $cart_item);
+		return apply_filters( "woocommerce_store_api_product_quantity_{$value_type}", $value, $product, $cart_item );
 	}
 }


### PR DESCRIPTION
### Issue

While the quantities of items in the cart block can be changed, they cannot be set greater than 99.

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

### Solution
With this PR, product quantity in the cart can be increased to 9999. 

<!-- Reference any related issues or PRs here -->
Fixes #6175

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### Screenshots

| Before | After |
|---|---|
| <img width="520" alt="image" src="https://user-images.githubusercontent.com/11503784/161965058-0a3dfd08-c385-49bd-a2f3-4132cebb7908.png"> | <img width="546" alt="image" src="https://user-images.githubusercontent.com/11503784/161964986-5ab8835f-19d1-49ac-b610-04eff742a5c7.png"> |

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Checkout the  `fix/product-quantity-limit ` branch
2. Go to the shop page and add any product to the cart
3. Go to the Cart block page and increase product quantity to 9999
### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or


<!-- If you can, add the appropriate labels -->

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Increase Cart product quantity limit
