### PR TITLE
Try: register i18n manually for atomic blocks

### DIFF
--- a/src/BlockTypes/AbstractBlock.php
+++ b/src/BlockTypes/AbstractBlock.php
@@ -55,6 +55,20 @@ abstract class AbstractBlock {
 	protected $integration_registry;
 
 	/**
+	 * Manually register the i18n dependency for the frontend block script.
+	 *
+	 * @var boolean
+	 */
+	protected $script_has_i18n = false;
+
+	/**
+	 * Manually register the i18n dependency for the editor block script.
+	 *
+	 * @var boolean
+	 */
+	protected $editor_script_has_i18n = false;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param AssetApi            $asset_api Instance of the asset API.
@@ -132,7 +146,7 @@ abstract class AbstractBlock {
 					$this->get_block_type_editor_script( 'dependencies' ),
 					$this->integration_registry->get_all_registered_editor_script_handles()
 				),
-				$has_i18n
+				$has_i18n || $this->editor_script_has_i18n
 			);
 		}
 		if ( null !== $this->get_block_type_script() ) {
@@ -146,7 +160,7 @@ abstract class AbstractBlock {
 					$this->get_block_type_script( 'dependencies' ),
 					$this->integration_registry->get_all_registered_script_handles()
 				),
-				$has_i18n
+				$has_i18n || $this->script_has_i18n
 			);
 		}
 	}

--- a/src/BlockTypes/ProductImage.php
+++ b/src/BlockTypes/ProductImage.php
@@ -21,6 +21,13 @@ class ProductImage extends AbstractBlock {
 	protected $api_version = '2';
 
 	/**
+	 * Manually register the i18n dependency for the frontend block script.
+	 *
+	 * @var boolean
+	 */
+	protected $script_has_i18n = true;
+
+	/**
 	 * Get block supports. Shared with the frontend.
 	 * IMPORTANT: If you change anything here, make sure to update the JS file too.
 	 *
@@ -45,15 +52,5 @@ class ProductImage extends AbstractBlock {
 			),
 			'__experimentalSelector' => '.wc-block-components-product-image',
 		);
-	}
-
-	/**
-	 * Register script and style assets for the block type before it is registered.
-	 *
-	 * This registers the scripts; it does not enqueue them.
-	 */
-	protected function register_block_type_assets() {
-		parent::register_block_type_assets();
-		$this->register_chunk_translations( [ $this->block_name ] );
 	}
 }


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Relates #6210

This PR is an experiment to fix #6210 where atomic blocks don't have `asset.php` file generated by the build process.

I added two new properties: `$script_has_i18n` and `$editor_script_has_i18n` so atomic block can register `i18n` dependency from their class.

Ultimately, I think we should generate `.asset.php` files for automatic blocks to solve this problem instead (And it's the better solution IMO). I'm investigating why they don't get asset files generated.