### PR TITLE
Expose the payment method icons from Payments Api

### DIFF
--- a/src/Domain/Bootstrap.php
+++ b/src/Domain/Bootstrap.php
@@ -95,9 +95,7 @@ class Bootstrap {
 		$this->container->get( GoogleAnalytics::class );
 		$this->container->get( BlockTypesController::class );
 		$this->container->get( BlockTemplatesController::class );
-		if ( $this->package->feature()->is_feature_plugin_build() ) {
-			$this->container->get( PaymentsApi::class );
-		}
+		$this->container->get( PaymentsApi::class );
 	}
 
 	/**
@@ -244,16 +242,14 @@ class Bootstrap {
 				return new GoogleAnalytics( $asset_api );
 			}
 		);
-		if ( $this->package->feature()->is_feature_plugin_build() ) {
-			$this->container->register(
-				PaymentsApi::class,
-				function ( Container $container ) {
-					$payment_method_registry = $container->get( PaymentMethodRegistry::class );
-					$asset_data_registry     = $container->get( AssetDataRegistry::class );
-					return new PaymentsApi( $payment_method_registry, $asset_data_registry );
-				}
-			);
-		}
+		$this->container->register(
+			PaymentsApi::class,
+			function ( Container $container ) {
+				$payment_method_registry = $container->get( PaymentMethodRegistry::class );
+				$asset_data_registry     = $container->get( AssetDataRegistry::class );
+				return new PaymentsApi( $payment_method_registry, $asset_data_registry );
+			}
+		);
 		$this->container->register(
 			StoreApi::class,
 			function () {

--- a/src/Payments/Api.php
+++ b/src/Payments/Api.php
@@ -48,12 +48,15 @@ class Api {
 	 */
 	protected function init() {
 		add_action( 'init', array( $this->payment_method_registry, 'initialize' ), 5 );
-		add_filter( 'woocommerce_blocks_register_script_dependencies', array( $this, 'add_payment_method_script_dependencies' ), 10, 2 );
-		add_action( 'woocommerce_blocks_checkout_enqueue_data', array( $this, 'add_payment_method_script_data' ) );
 		add_action( 'woocommerce_blocks_cart_enqueue_data', array( $this, 'add_payment_method_script_data' ) );
-		add_action( 'woocommerce_blocks_payment_method_type_registration', array( $this, 'register_payment_method_integrations' ) );
-		add_action( 'woocommerce_rest_checkout_process_payment_with_context', array( $this, 'process_legacy_payment' ), 999, 2 );
-		add_action( 'wp_print_scripts', array( $this, 'verify_payment_methods_dependencies' ), 1 );
+
+		if ( Package::feature()->is_feature_plugin_build() ) {
+			add_action( 'woocommerce_blocks_checkout_enqueue_data', array( $this, 'add_payment_method_script_data' ) );
+			add_filter( 'woocommerce_blocks_register_script_dependencies', array( $this, 'add_payment_method_script_dependencies' ), 10, 2 );
+			add_action( 'woocommerce_blocks_payment_method_type_registration', array( $this, 'register_payment_method_integrations' ) );
+			add_action( 'woocommerce_rest_checkout_process_payment_with_context', array( $this, 'process_legacy_payment' ), 999, 2 );
+			add_action( 'wp_print_scripts', array( $this, 'verify_payment_methods_dependencies' ), 1 );
+		}
 	}
 
 	/**


### PR DESCRIPTION
We need to run the `add_payment_method_script_data` action to expose the payment methods icons, but we don't want to expose anything else from the `PaymentsApi`, so instead of feature gating the whole class, we feature gate all the actions on the `init` method except the one we need.

Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/6217

### Testing

How to test the changes in this Pull Request:

1. Add the mini-cart block and add a product to it
2. Open the mini-cart and see the payment methods icons don't show (you need to have some payment method enabled, like stripe)
3. Set the `woocommerce_blocks_phase = 1` in the `blocks.ini` file
4. Refresh and open the mini-cart, check the payment methods icons are now showing at the bottom
<img width="491" alt="Screenshot 2022-04-12 at 10 41 24" src="https://user-images.githubusercontent.com/186112/162919188-6f3e2094-372a-40e9-a6eb-5ad5af14c3c7.png">
