### PR TITLE
Fix: Shop page: Filter Products by Price block only works with Number of decimals set to 2

### DIFF
--- a/assets/js/blocks/price-filter/block.js
+++ b/assets/js/blocks/price-filter/block.js
@@ -36,18 +36,17 @@ function findGetParameter( paramName ) {
 /**
  * Formats filter values into a string for the URL parameters needed for filtering PHP templates.
  *
- * @param {string} url       Current page URL.
- * @param {Object} params    Parameters and their constraints.
- * @param {number} precision Number of decimal places to round to.
+ * @param {string} url    Current page URL.
+ * @param {Object} params Parameters and their constraints.
  *
  * @return {string} New URL with query parameters in it.
  */
-function formatParams( url, params, precision ) {
+function formatParams( url, params ) {
 	const paramObject = {};
 
 	for ( const [ key, value ] of Object.entries( params ) ) {
 		if ( value ) {
-			paramObject[ key ] = ( value / 10 ** precision ).toString();
+			paramObject[ key ] = value.toString();
 		} else {
 			delete paramObject[ key ];
 		}
@@ -123,14 +122,10 @@ const PriceFilterBlock = ( { attributes, isEditor = false } ) => {
 
 			// For block templates that render the PHP Classic Template block we need to add the filters as params and reload the page.
 			if ( filteringForPhpTemplate && window ) {
-				const newUrl = formatParams(
-					window.location.href,
-					{
-						min_price: finalMinPrice,
-						max_price: finalMaxPrice,
-					},
-					currency.minorUnit
-				);
+				const newUrl = formatParams( window.location.href, {
+					min_price: finalMinPrice / 10 ** currency.minorUnit,
+					max_price: finalMaxPrice / 10 ** currency.minorUnit,
+				} );
 
 				// If the params have changed, lets reload the page.
 				if ( window.location.href !== newUrl ) {

--- a/assets/js/blocks/price-filter/block.js
+++ b/assets/js/blocks/price-filter/block.js
@@ -36,17 +36,18 @@ function findGetParameter( paramName ) {
 /**
  * Formats filter values into a string for the URL parameters needed for filtering PHP templates.
  *
- * @param {string} url    Current page URL.
- * @param {Object} params Parameters and their constraints.
+ * @param {string} url       Current page URL.
+ * @param {Object} params    Parameters and their constraints.
+ * @param {number} precision Number of decimal places to round to.
  *
  * @return {string} New URL with query parameters in it.
  */
-function formatParams( url, params ) {
+function formatParams( url, params, precision ) {
 	const paramObject = {};
 
 	for ( const [ key, value ] of Object.entries( params ) ) {
 		if ( value ) {
-			paramObject[ key ] = ( value / 100 ).toString();
+			paramObject[ key ] = ( value / 10 ** precision ).toString();
 		} else {
 			delete paramObject[ key ];
 		}
@@ -121,10 +122,14 @@ const PriceFilterBlock = ( { attributes, isEditor = false } ) => {
 
 			// For block templates that render the PHP Classic Template block we need to add the filters as params and reload the page.
 			if ( filteringForPhpTemplate && window ) {
-				const newUrl = formatParams( window.location.href, {
-					min_price: finalMinPrice,
-					max_price: finalMaxPrice,
-				} );
+				const newUrl = formatParams(
+					window.location.href,
+					{
+						min_price: finalMinPrice,
+						max_price: finalMaxPrice,
+					},
+					currency.minorUnit
+				);
 
 				// If the params have changed, lets reload the page.
 				if ( window.location.href !== newUrl ) {
@@ -141,6 +146,7 @@ const PriceFilterBlock = ( { attributes, isEditor = false } ) => {
 			setMinPriceQuery,
 			setMaxPriceQuery,
 			filteringForPhpTemplate,
+			currency,
 		]
 	);
 

--- a/assets/js/blocks/price-filter/block.js
+++ b/assets/js/blocks/price-filter/block.js
@@ -72,31 +72,32 @@ const PriceFilterBlock = ( { attributes, isEditor = false } ) => {
 		''
 	);
 
-	const minPriceParam = findGetParameter( 'min_price' );
-	const maxPriceParam = findGetParameter( 'max_price' );
-
-	const [ minPriceQuery, setMinPriceQuery ] = useQueryStateByKey(
-		'min_price',
-		Number( minPriceParam ) * 100 || null
-	);
-	const [ maxPriceQuery, setMaxPriceQuery ] = useQueryStateByKey(
-		'max_price',
-		Number( maxPriceParam ) * 100 || null
-	);
 	const [ queryState ] = useQueryStateByContext();
 	const { results, isLoading } = useCollectionData( {
 		queryPrices: true,
 		queryState,
 	} );
 
-	const [ minPrice, setMinPrice ] = useState(
-		Number( minPriceParam ) * 100 || null
+	const currency = getCurrencyFromPriceResponse( results.price_range );
+
+	const minPriceParam = findGetParameter( 'min_price' );
+	const maxPriceParam = findGetParameter( 'max_price' );
+
+	const [ minPriceQuery, setMinPriceQuery ] = useQueryStateByKey(
+		'min_price',
+		Number( minPriceParam ) * 10 ** currency.minorUnit || null
 	);
-	const [ maxPrice, setMaxPrice ] = useState(
-		Number( maxPriceParam ) * 100 || null
+	const [ maxPriceQuery, setMaxPriceQuery ] = useQueryStateByKey(
+		'max_price',
+		Number( maxPriceParam ) * 10 ** currency.minorUnit || null
 	);
 
-	const currency = getCurrencyFromPriceResponse( results.price_range );
+	const [ minPrice, setMinPrice ] = useState(
+		Number( minPriceParam ) * 10 ** currency.minorUnit || null
+	);
+	const [ maxPrice, setMaxPrice ] = useState(
+		Number( maxPriceParam ) * 10 ** currency.minorUnit || null
+	);
 
 	const { minConstraint, maxConstraint } = usePriceConstraints( {
 		minPrice: results.price_range


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #6226 

This PR read the price precision from the price query results to return the correct min and max price used in the filter URL.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### Screenshots

<img width="1261" alt="image" src="https://user-images.githubusercontent.com/5423135/162934260-1663d341-36de-417b-a35c-fe18df7cdbd8.png">

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Set ` Number of decimals` set to 1.
2. With a block theme, go to Appearance > Editor > Template > Product Catalog.
3. Add the Filter Products by Price block above the product grid.
4. Change the values of the price slider on the Shop page.
5. See the page reloads with the price in URL and Slider are correct.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
* [ ] See steps below.

### Changelog

> Fix the issue that Filter Products by Price only works with `Number of decimals` set to 2.