### PR TITLE
Fix/order summary sidebar css

### DIFF
--- a/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/style.scss
+++ b/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/style.scss
@@ -6,6 +6,7 @@
 .wc-block-cart__submit-button {
 	width: 100%;
 	margin: 0;
+	box-sizing: border-box;
 }
 
 .wc-block-cart {

--- a/assets/js/blocks/cart/test/block.js
+++ b/assets/js/blocks/cart/test/block.js
@@ -25,6 +25,7 @@ import OrderSummaryBlock from '../inner-blocks/cart-order-summary-block/frontend
 import ExpressPaymentBlock from '../inner-blocks/cart-express-payment-block/block';
 import ProceedToCheckoutBlock from '../inner-blocks/proceed-to-checkout-block/block';
 import AcceptedPaymentMethodsIcons from '../inner-blocks/cart-accepted-payment-methods-block/block';
+import OrderSummaryHeadingBlock from '../inner-blocks/cart-order-summary-heading/frontend';
 import OrderSummarySubtotalBlock from '../inner-blocks/cart-order-summary-subtotal/frontend';
 import OrderSummaryShippingBlock from '../inner-blocks/cart-order-summary-shipping/frontend';
 import OrderSummaryTaxesBlock from '../inner-blocks/cart-order-summary-taxes/frontend';
@@ -49,6 +50,7 @@ const CartBlock = ( {
 				</ItemsBlock>
 				<TotalsBlock>
 					<OrderSummaryBlock>
+						<OrderSummaryHeadingBlock />
 						<OrderSummarySubtotalBlock />
 						<OrderSummaryShippingBlock
 							isShippingCalculatorEnabled={
@@ -93,6 +95,7 @@ describe( 'Testing cart', () => {
 	it( 'renders cart if there are items in the cart', async () => {
 		render( <CartBlock /> );
 		await waitFor( () => expect( fetchMock ).toHaveBeenCalled() );
+
 		expect(
 			screen.getByText( /Proceed to Checkout/i )
 		).toBeInTheDocument();
@@ -108,6 +111,20 @@ describe( 'Testing cart', () => {
 
 		await waitFor( () => expect( fetchMock ).toHaveBeenCalled() );
 		expect( screen.getByText( /Tax/i ) ).toBeInTheDocument();
+	} );
+
+	it( 'Contains a Order summary header', async () => {
+		render( <CartBlock /> );
+
+		await waitFor( () => expect( fetchMock ).toHaveBeenCalled() );
+		expect( screen.getByText( /Cart totals/i ) ).toBeInTheDocument();
+	} );
+
+	it( 'Contains a Order summary Subtotal section', async () => {
+		render( <CartBlock /> );
+
+		await waitFor( () => expect( fetchMock ).toHaveBeenCalled() );
+		expect( screen.getByText( /Subtotal/i ) ).toBeInTheDocument();
 	} );
 
 	it( 'Shows individual tax lines if the store is set to do so', async () => {

--- a/packages/checkout/components/totals/item/style.scss
+++ b/packages/checkout/components/totals/item/style.scss
@@ -2,6 +2,7 @@
 	display: flex;
 	flex-wrap: wrap;
 	width: 100%;
+	box-sizing: border-box;
 }
 
 .wc-block-components-totals-item__label {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
This PR fixes the inner block's width CSS issue in Order Summary sidebar with FSE themes

This PR adds a couple of unit tests for the Order Summary cart inner block

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] I've updated [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) for any feature flags or experimental interfaces implemented in this pull request.
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->
| Before | After |
| ------- | ----- |
| <img width="412" alt="image (1)" src="https://user-images.githubusercontent.com/1628454/162977023-04fdd12f-61ce-4e26-942e-e86476190510.png"> | <img width="379" alt="Screenshot 2022-04-12 at 16 25 52" src="https://user-images.githubusercontent.com/1628454/162985359-0ae104f0-1ffd-4ea2-86b8-23cc2ecead01.png"> |


### Testing

### Manual Testing

How to test the changes in this Pull Request:

1. Install Twenty Twenty-Two theme and activate it
2. Enable Gutenberg plugin as well
3. Go to the Cart block
4. See that there the elements of the Cart sidebar are aligned

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [ ] Same as above, or
* [ ] See steps below.
* [x] Do not include in user facing testing instructions



