### PR TITLE
Mini Cart Contents: Use block pattern to make the empty cart message translatable

### DIFF
--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -63,7 +63,7 @@ class MiniCart extends AbstractBlock {
 	 */
 	protected function initialize() {
 		parent::initialize();
-		add_action( 'wp_loaded', array( $this, 'register_block_pattern' ) );
+		add_action( 'wp_loaded', array( $this, 'register_empty_cart_message_block_pattern' ) );
 	}
 
 	/**
@@ -500,7 +500,7 @@ class MiniCart extends AbstractBlock {
 	/**
 	 * Register block pattern for Empty Cart Message to make it translatable.
 	 */
-	public function register_block_pattern() {
+	public function register_empty_cart_message_block_pattern() {
 		register_block_pattern(
 			'woocommerce/mini-cart-empty-cart-message',
 			array(

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -498,7 +498,7 @@ class MiniCart extends AbstractBlock {
 	}
 
 	/**
-	 * Register block patter for Empty Cart Message to make it translatable.
+	 * Register block pattern for Empty Cart Message to make it translatable.
 	 */
 	public function register_block_pattern() {
 		register_block_pattern(

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -53,7 +53,17 @@ class MiniCart extends AbstractBlock {
 	 */
 	public function __construct( AssetApi $asset_api, AssetDataRegistry $asset_data_registry, IntegrationRegistry $integration_registry ) {
 		parent::__construct( $asset_api, $asset_data_registry, $integration_registry, $this->block_name );
+	}
 
+	/**
+	 * Initialize this block type.
+	 *
+	 * - Hook into WP lifecycle.
+	 * - Register the block with WordPress.
+	 */
+	protected function initialize() {
+		parent::initialize();
+		add_action( 'wp_loaded', array( $this, 'register_block_pattern' ) );
 	}
 
 	/**
@@ -485,5 +495,19 @@ class MiniCart extends AbstractBlock {
 		$translations = array_filter( $translations );
 
 		return implode( '', $translations );
+	}
+
+	/**
+	 * Register block patter for Empty Cart Message to make it translatable.
+	 */
+	public function register_block_pattern() {
+		register_block_pattern(
+			'woocommerce/mini-cart-empty-cart-message',
+			array(
+				'title'    => __( 'Mini Cart Empty Cart Message', 'woo-gutenberg-products-block' ),
+				'inserter' => false,
+				'content'  => '<!-- wp:paragraph {"align":"center"} --><p class="has-text-align-center"><strong>' . __( 'Your cart is currently empty!', 'woo-gutenberg-products-block' ) . '</strong></p><!-- /wp:paragraph -->',
+			)
+		);
 	}
 }

--- a/templates/parts/mini-cart.html
+++ b/templates/parts/mini-cart.html
@@ -23,11 +23,7 @@
 
 	<!-- wp:woocommerce/empty-mini-cart-contents-block -->
 	<div class="wp-block-woocommerce-empty-mini-cart-contents-block">
-		<!-- wp:paragraph {"align":"center"} -->
-		<p class="has-text-align-center">
-			<strong>Your cart is currently empty!</strong>
-		</p>
-		<!-- /wp:paragraph -->
+		<!-- wp:pattern {"slug":"woocommerce/mini-cart-empty-cart-message"} /-->
 
 		<!-- wp:woocommerce/mini-cart-shopping-button-block -->
 		<div class="wp-block-woocommerce-mini-cart-shopping-button-block"></div>


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #6213

This PR follows the Twenty Twenty-Two approach using a block pattern to make the empty cart message translatable. Previously, the empty cart message is hard-coded to the `mini-cart.html` template part and isn't translatable.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

On Storefront:
1. No visual change. The empty cart message should be the same as before.

On Twenty Twenty-Two:
1. On front end, no visual change.
2. In the Site Editor, no visual change, the empty message can be edited as it was.

Running `wp i18n make-pot ./ languages/woo-gutenberg-products-block.pot` in the root directory of the plugin, see new string for the empty cart message in the generated pot file:

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [ ] Same as above, or
* [ ] See steps below.