### PR TITLE
Fix: Make Active Filters work with PHP templates

### DIFF
--- a/assets/js/blocks/active-filters/block.js
+++ b/assets/js/blocks/active-filters/block.js
@@ -14,7 +14,11 @@ import Label from '@woocommerce/base-components/label';
  */
 import './style.scss';
 import { getAttributeFromTaxonomy } from '../../utils/attributes';
-import { formatPriceRange, renderRemovableListItem } from './utils';
+import {
+	formatPriceRange,
+	renderRemovableListItem,
+	updateFilterUrl,
+} from './utils';
 import ActiveAttributeFilters from './active-attribute-filters';
 
 /**
@@ -75,6 +79,10 @@ const ActiveFiltersBlock = ( {
 			removeCallback: () => {
 				setMinPrice( undefined );
 				setMaxPrice( undefined );
+				updateFilterUrl( {
+					min_price: undefined,
+					max_price: undefined,
+				} );
 			},
 			displayStyle: blockAttributes.displayStyle,
 		} );

--- a/assets/js/blocks/active-filters/utils.js
+++ b/assets/js/blocks/active-filters/utils.js
@@ -5,6 +5,8 @@ import { __, sprintf } from '@wordpress/i18n';
 import { formatPrice } from '@woocommerce/price-format';
 import { RemovableChip } from '@woocommerce/base-components/chip';
 import Label from '@woocommerce/base-components/label';
+import { getSetting } from '@woocommerce/settings';
+import { getQueryArgs, addQueryArgs, removeQueryArgs } from '@wordpress/url';
 
 /**
  * Format a min/max price range to display.
@@ -137,4 +139,41 @@ export const renderRemovableListItem = ( {
 			) }
 		</li>
 	);
+};
+
+/**
+ * Update the current URL to update or remove provided query arguments.
+ *
+ *
+ * @param {Object} args Query arguments to inject into the URL.
+ */
+export const updateFilterUrl = ( args ) => {
+	const filteringForPhpTemplate = getSetting(
+		'is_rendering_php_template',
+		''
+	);
+
+	if ( ! filteringForPhpTemplate ) {
+		return;
+	}
+
+	if ( ! window ) {
+		return null;
+	}
+
+	const url = window.location.href;
+	const currentQuery = getQueryArgs( url );
+
+	// removeQueryArgs only works if we remove existing arguments.
+	const argsToClean = Object.keys( args ).filter( ( arg ) =>
+		Object.keys( currentQuery ).includes( arg )
+	);
+
+	// We filter out the args with value set to undefined to remove them from the URL.
+	const filteredQuery = Object.fromEntries(
+		Object.entries( args ).filter( ( [ , value ] ) => value !== undefined )
+	);
+
+	const cleanUrl = removeQueryArgs( url, argsToClean );
+	window.location.href = addQueryArgs( cleanUrl, filteredQuery );
 };


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #6138

This PR makes the Active Filters work with PHP templates. The idea is to update the current URL to remove the corresponding argument when users remove it from the Active Filters Block.

I used `updateFilterUrl` instead of `removeArgsFromFilterUrl` because I want to use the same function for all types of filters:
- For the price filter, we can just remove the `min_price` and `max_price` arguments from the URL.
- But for the attribute filter, users can select many attributes, so we can't simply delete the argument when users delete one attribute. 

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1.
2.
3.
### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [ ] Same as above, or
* [ ] See steps below.

1.
2.
3.

<!-- If you can, add the appropriate labels -->

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Add suggested changelog entry here.
