### PR TITLE
Revert "Prevent `Featured Product` block from breaking when product is out of stock + hidden from catalog (#6166)"

### DIFF
--- a/assets/js/editor-components/utils/index.js
+++ b/assets/js/editor-components/utils/index.js
@@ -25,7 +25,6 @@ const getProductsRequests = ( {
 	const defaultArgs = {
 		per_page: isLargeCatalog ? 100 : 0,
 		catalog_visibility: 'any',
-		stock_status: [ 'instock', 'outofstock', 'onbackorder' ],
 		search,
 		orderby: 'title',
 		order: 'asc',

--- a/assets/js/hocs/with-product-variations.js
+++ b/assets/js/hocs/with-product-variations.js
@@ -124,7 +124,7 @@ const withProductVariations = createHigherOrderComponent(
 						p.variations &&
 						p.variations.find( ( { id } ) => id === variationId )
 				);
-				return parentProduct[ 0 ]?.id;
+				return parentProduct[ 0 ].id;
 			}
 
 			getExpandedProduct() {
@@ -186,7 +186,6 @@ const withProductVariations = createHigherOrderComponent(
 				showVariations: false,
 			};
 		}
-
 		return WrappedComponent;
 	},
 	'withProductVariations'


### PR DESCRIPTION
This reverts #6166

It seems there is an edge case where the PR changes are causing some bugs. See [Slack thread](https://a8c.slack.com/archives/C02UBB1EPEF/p1649846579861269).

We are reverting it since it's a blocker for the [Release: 7.4.0](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/6225).

TL;DR:

> `Featured Product` displays this error `Your store doesn't have any products`. . But, when we test with the 7.3.0 Woo Blocks, it works as expected.

![image](https://user-images.githubusercontent.com/14235870/163363096-261152bd-ada2-40c4-8c8b-a8893ad5c9f1.png)
 