### PR TITLE
Improve caching plugin_dir_url() in Package.

### DIFF
--- a/src/Domain/Package.php
+++ b/src/Domain/Package.php
@@ -52,9 +52,6 @@ class Package {
 		$this->version        = $version;
 		$this->path           = $plugin_path;
 		$this->feature_gating = $feature_gating;
-
-		// Append index.php so WP does not return the parent directory.
-		$this->plugin_dir_url = plugin_dir_url( $this->path . '/index.php' );
 	}
 
 	/**
@@ -87,6 +84,11 @@ class Package {
 	 * @return string
 	 */
 	public function get_url( $relative_url = '' ) {
+		if ( ! $this->plugin_dir_url ) {
+			// Append index.php so WP does not return the parent directory.
+			$this->plugin_dir_url = plugin_dir_url( $this->path . '/index.php' );
+		}
+
 		return $this->plugin_dir_url . $relative_url;
 	}
 


### PR DESCRIPTION
A problem [observed](p1649884900466359-slack-C7U3Y3VMY) in Atomic Site with WC 6.4.0 and WooCommerce Subscription installed.
wp-admin > WooCommerce > Home page is blank because `wc-settings.js` URL returns 404.

It should be `/wp-content/plugins/woocommerce/packages/woocommerce-blocks/build/wc-settings.js`, instead, `/wp-content/plugins/wordpress/plugins/woocommerce/6.4.0/packages/woocommerce-blocks/build/wc-settings.js` is loaded.

Missing `wc-settings.js` causes uncaught error.

![image](https://user-images.githubusercontent.com/73803630/163409957-42d500aa-d449-4e4a-8283-09b938a8dbe7.png)

After some [investigation](p1649936245119909/1649884900.466359-slack-C7U3Y3VMY), this problem happens when `wp-content/plugins/woocommerce` is a symlink (like how Pressable, Atomic Site, and wp.com manages WooCommerce for sites they create) and attempt to cache the return value of `plugin_dir_url()` from https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5915 makes all this possible.

[Calling plugin_dir_url() in Package’s constructor](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/src/Domain/Package.php#L57) gives different result vs [calling it from get_url()](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5915/files#diff-deccd9a660832b41efc10cb868f4549a32152b0e3753555c179b84a4733ee7cbL79-R90).
[plugin_dir_url()](https://github.com/WordPress/WordPress/blob/master/wp-includes/plugin.php#L794-L796) eventually calls [plugins_url()](https://github.com/WordPress/WordPress/blob/master/wp-includes/link-template.php#L3529) which eventually calls [plugin_basename()](https://github.com/WordPress/WordPress/blob/44e4439d6811748c119fb1e8b71ed4c044e920f2/wp-includes/plugin.php#L712-L733).
plugin_basename() depends on the value of a global variable [$wp_plugin_paths](https://github.com/WordPress/WordPress/blob/44e4439d6811748c119fb1e8b71ed4c044e920f2/wp-includes/plugin.php#L713).
When called in Package’s constructor, woocommerce’s path isn’t yet part of $wp_plugin_paths, so it doesn’t return the basename correctly.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
* [ ] Unit tests
* [ ] E2E tests

### Manual Testing

How to test the changes in this Pull Request:

1. Install WC 6.4 but move and symlink its folder.
```
mv wp-content/plugins/woocommerce ~/Desktop/woocommerce
ln -s ~/Desktop/woocommerce wp-content/plugins/woocommerce
```

2. Install WooCommerce Subscriptions.

3. Try to open wp-admin > WooCommerce > Home (/wp-admin/admin.php?page=wc-admin). With base branch, expect a blank page. With this PR branch, expect page loads normally.

I didn't try loading blocks as an independent plugin, only when it's within WooCommerce.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above

<!-- If you can, add the appropriate labels -->

### Performance Impact

This change should have the same optimization as https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5915.

### Changelog

> Fix page load problem due to incorrect URL to certain assets.