### PR TITLE
Fix Featured Product block frontend mismatch

### DIFF
--- a/src/BlockTypes/FeaturedProduct.php
+++ b/src/BlockTypes/FeaturedProduct.php
@@ -25,9 +25,10 @@ class FeaturedProduct extends AbstractDynamicBlock {
 		'dimRatio'     => 50,
 		'focalPoint'   => false,
 		'imageFit'     => 'none',
-		'minHeight'    => false,
+		'minHeight'    => 500,
 		'mediaId'      => 0,
 		'mediaSrc'     => '',
+		'overlayColor' => '#000000',
 		'showDesc'     => true,
 		'showPrice'    => true,
 	);
@@ -185,8 +186,10 @@ class FeaturedProduct extends AbstractDynamicBlock {
 	public function get_styles( $attributes ) {
 		$style = '';
 
+		$min_height = isset( $attributes['minHeight'] ) ? $attributes['minHeight'] : wc_get_theme_support( 'featured_block::default_height', 500 );
+
 		if ( isset( $attributes['minHeight'] ) ) {
-			$style .= sprintf( 'min-height:%dpx;', intval( $attributes['minHeight'] ) );
+			$style .= sprintf( 'min-height:%dpx;', intval( $min_height ) );
 		}
 
 		$global_style_style = StyleAttributesUtils::get_styles_by_attributes( $attributes, $this->global_style_wrapper );


### PR DESCRIPTION
If the Featured Product block was added but not modified at all, the block would not match the editor on the front end.

This was due to the fact that, on the frontend, the block is SSR and was missing some defaults styles which were present in JS.

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #6255 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

### Manual Testing

How to test the changes in this Pull Request:

1. Switch to a block-enabled theme (such as Twenty-twentytwo).
2. Add the Featured Product block to a page.
3. Confirm that it has a default, semi-transparent, black overlay and that a default height of 500 px or whatever the theme supports through the `featured_block::default_height` setting.
4. Publish the page.
5. Preview the page and confirm that the block looks like the one in the editor (specifically for height and overlay).
6. Play around with the styles of the block on the editor (change the overlay color, the padding, the opacity, the image fit etc.).
7. Confirm they get correctly applied on the frontend.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above

Skipping changelog here as #6181 (which introduced the bug) was never published.