### PR TITLE
Cart & Checkout translations test use nl_NL

### DIFF
--- a/bin/wp-env-config.sh
+++ b/bin/wp-env-config.sh
@@ -24,7 +24,7 @@ wp wc customer update 1 --user=1 --billing='{"first_name":"John","last_name":"Do
 wp language core install nl_NL
 wp language plugin install woocommerce nl_NL
 wp language plugin install woo-gutenberg-products-block nl_NL
-# We need to run update after installing the langauge to update it to the latest version. Otherwise, new strings won't be available.
+# We need to run update after installing the language to update it to the latest version. Otherwise, new strings won't be available.
 wp language plugin update woo-gutenberg-products-block nl_NL
 
 exit $EXIT_CODE

--- a/bin/wp-env-config.sh
+++ b/bin/wp-env-config.sh
@@ -22,6 +22,7 @@ wp wc customer update 1 --user=1 --billing='{"first_name":"John","last_name":"Do
 
 ## Prepare translation for the test suite
 wp language core install nl_NL
+wp language plugin install woocommerce nl_NL
 wp language plugin install woo-gutenberg-products-block nl_NL
 # We need to run update after installing the langauge to update it to the latest version. Otherwise, new strings won't be available.
 wp language plugin update woo-gutenberg-products-block nl_NL

--- a/tests/e2e/specs/shopper/cart-checkout/checkout.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/checkout.test.js
@@ -196,7 +196,7 @@ describe( 'Shopper → Checkout', () => {
 		} );
 	} );
 
-	describe.only( `Shipping`, () => {
+	describe( `Shipping`, () => {
 		const FREE_SHIPPING_NAME = 'Free Shipping';
 		const FREE_SHIPPING_PRICE = '$0.00';
 		const NORMAL_SHIPPING_NAME = 'Normal Shipping';

--- a/tests/e2e/specs/shopper/cart-checkout/checkout.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/checkout.test.js
@@ -196,7 +196,7 @@ describe( 'Shopper → Checkout', () => {
 		} );
 	} );
 
-	describe( `Shipping`, () => {
+	describe.only( `Shipping`, () => {
 		const FREE_SHIPPING_NAME = 'Free Shipping';
 		const FREE_SHIPPING_PRICE = '$0.00';
 		const NORMAL_SHIPPING_NAME = 'Normal Shipping';
@@ -219,7 +219,7 @@ describe( 'Shopper → Checkout', () => {
 				FREE_SHIPPING_PRICE
 			);
 			await shopper.block.placeOrder();
-			await page.waitForTimeout( 2000 );
+			await page.waitForSelector( '.woocommerce-order' );
 			await expect( page ).toMatch( 'Order received' );
 			await expect( page ).toMatch( FREE_SHIPPING_NAME );
 		} );
@@ -233,7 +233,7 @@ describe( 'Shopper → Checkout', () => {
 				NORMAL_SHIPPING_PRICE
 			);
 			await shopper.block.placeOrder();
-			await page.waitForTimeout( 2000 );
+			await page.waitForSelector( '.woocommerce-order' );
 			await expect( page ).toMatch( 'Order received' );
 			await expect( page ).toMatch( NORMAL_SHIPPING_NAME );
 		} );

--- a/tests/e2e/specs/shopper/cart-checkout/translations.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/translations.test.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { cli, merchant, shopper } from '../../../../utils';
+import { merchant, shopper } from '../../../../utils';
 
 if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 ) {
 	// eslint-disable-next-line jest/no-focused-tests
@@ -9,18 +9,12 @@ if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 ) {
 }
 
 describe( 'Shopper → Cart & Checkout → Translations', () => {
-	// We need to install the language files for the blocks plugin.
-	// We also need to install the plugin from w.org via the cli. This is because
-	// on w.org, the slug is `woo-gutenberg-products-block` where as here it's
-	// `woocommerce-gutenberg-products-block`. If we try to install the language files
-	// directly, it won't find them because of the slug mismatch.
 	beforeAll( async () => {
 		await merchant.changeLanguage( 'nl_NL' );
 	} );
 
-	// We need to clean up here by changing the language back to English
-	// and uninstalling the w.org version of Woo Blocks plugin and the language files
 	afterAll( async () => {
+		// default value empty in the select menu for English (United States)
 		await merchant.changeLanguage( 'en_EN' );
 	} );
 

--- a/tests/e2e/specs/shopper/cart-checkout/translations.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/translations.test.js
@@ -15,29 +15,13 @@ describe( 'Shopper → Cart & Checkout → Translations', () => {
 	// `woocommerce-gutenberg-products-block`. If we try to install the language files
 	// directly, it won't find them because of the slug mismatch.
 	beforeAll( async () => {
-		const resultInstallBlocks = await cli(
-			'npm run wp-env run tests-cli "wp plugin install woo-gutenberg-products-block"'
-		);
-		const resultInstallLanguages = await cli(
-			'npm run wp-env run tests-cli "wp language plugin install woo-gutenberg-products-block fr_FR"'
-		);
-		expect( resultInstallBlocks.code ).toEqual( 0 );
-		expect( resultInstallLanguages.code ).toEqual( 0 );
-		await merchant.changeLanguage( 'fr_FR' );
+		await merchant.changeLanguage( 'nl_NL' );
 	} );
 
 	// We need to clean up here by changing the language back to English
 	// and uninstalling the w.org version of Woo Blocks plugin and the language files
 	afterAll( async () => {
 		await merchant.changeLanguage( 'en_EN' );
-		const resultUninstallBlocks = await cli(
-			'npm run wp-env run tests-cli "wp plugin uninstall woo-gutenberg-products-block"'
-		);
-		const resultUninstallLanguages = await cli(
-			'npm run wp-env run tests-cli "wp language plugin uninstall woo-gutenberg-products-block fr_FR"'
-		);
-		expect( resultUninstallBlocks.code ).toEqual( 0 );
-		expect( resultUninstallLanguages.code ).toEqual( 0 );
 	} );
 
 	it( 'User can view translated Cart block ', async () => {
@@ -50,25 +34,25 @@ describe( 'Shopper → Cart & Checkout → Translations', () => {
 		const productHeader = await page.waitForSelector(
 			'.wc-block-cart-items .wc-block-cart-items__header span'
 		);
-		await expect( productHeader ).toMatch( 'Produit' );
+		await expect( productHeader ).toMatch( 'Product' );
 
 		const removeLink = await page.waitForSelector(
 			'.wc-block-cart-item__remove-link'
 		);
-		await expect( removeLink ).toMatch( 'Retirer l’élément' );
+		await expect( removeLink ).toMatch( 'Artikel verwijderen' );
 
 		const submitButton = await page.waitForSelector(
 			'.wc-block-cart__submit-button'
 		);
-		await expect( submitButton ).toMatch( 'Procéder au paiement' );
+		await expect( submitButton ).toMatch( 'Doorgaan naar afrekenen' );
 
 		const orderSummary = await page.$(
 			'.wp-block-woocommerce-cart-order-summary-block'
 		);
 
-		await expect( orderSummary ).toMatch( 'Total panier' );
-		await expect( orderSummary ).toMatch( 'Sous-total' );
-		await expect( orderSummary ).toMatch( 'Coupon code' );
+		await expect( orderSummary ).toMatch( 'Subtotaal' );
+		await expect( orderSummary ).toMatch( 'Waardebon code' );
+		await expect( orderSummary ).toMatch( 'Totaal' );
 	} );
 
 	it( 'USer can view translated Checkout block', async () => {
@@ -77,41 +61,40 @@ describe( 'Shopper → Cart & Checkout → Translations', () => {
 		const contactHeading = await page.$(
 			'#contact-fields .wc-block-components-checkout-step__title'
 		);
-		await expect( contactHeading ).toMatch( 'Coordonnées' );
+		await expect( contactHeading ).toMatch( 'Contactgegevens' );
 
 		const shippingHeading = await page.$(
 			'#shipping-fields .wc-block-components-checkout-step__title'
 		);
-		await expect( shippingHeading ).toMatch( 'Adresse de livraison' );
+		await expect( shippingHeading ).toMatch( 'Verzendadres' );
 
 		const shippingOptionsHeading = await page.$(
 			'#shipping-option .wc-block-components-checkout-step__title'
 		);
-		await expect( shippingOptionsHeading ).toMatch(
-			'Options de livraison'
-		);
+		await expect( shippingOptionsHeading ).toMatch( 'Verzendopties' );
 
 		const paymentMethodHeading = await page.$(
 			'#payment-method .wc-block-components-checkout-step__title'
 		);
-		await expect( paymentMethodHeading ).toMatch( 'Options de paiement' );
+		await expect( paymentMethodHeading ).toMatch( 'Betaalopties' );
 
 		const returnToCart = await page.$(
 			'.wc-block-components-checkout-return-to-cart-button'
 		);
-		await expect( returnToCart ).toMatch( 'Retour au panier' );
+		await expect( returnToCart ).toMatch( 'Ga terug naar winkelwagen' );
 
 		const submitButton = await page.$(
 			'.wc-block-components-checkout-place-order-button'
 		);
-		await expect( submitButton ).toMatch( 'Passer la commande' );
+		await expect( submitButton ).toMatch( 'Plaats bestelling' );
 
 		const orderSummary = await page.$(
 			'.wp-block-woocommerce-checkout-order-summary-block'
 		);
-		await expect( orderSummary ).toMatch( 'Récapitulatif de commande' );
-		await expect( orderSummary ).toMatch( 'Sous-total' );
-		await expect( orderSummary ).toMatch( 'Coupon code' );
-		await expect( orderSummary ).toMatch( 'Livraison' );
+		await expect( orderSummary ).toMatch( 'Besteloverzicht' );
+		await expect( orderSummary ).toMatch( 'Subtotaal' );
+		await expect( orderSummary ).toMatch( 'Waardebon code' );
+		await expect( orderSummary ).toMatch( 'Verzendmethoden' );
+		await expect( orderSummary ).toMatch( 'Totaal' );
 	} );
 } );

--- a/tests/utils/shopper.js
+++ b/tests/utils/shopper.js
@@ -422,7 +422,7 @@ export const shopper = {
 			await expect( page ).toClick( couponExpandButtonSelector );
 			await expect( page ).toFill( couponInputSelector, couponCode );
 			await expect( page ).toClick( couponApplyButtonSelector );
-			await page.waitForNetworkIdle();
+			await page.waitForNetworkIdle( { idleTime: 2000 } );
 		},
 	},
 

--- a/tests/utils/shopper.js
+++ b/tests/utils/shopper.js
@@ -244,59 +244,51 @@ export const shopper = {
 
 		// prettier-ignore
 		verifyBillingDetails: async ( customerBillingDetails ) => {
-			const opts = { timeout: 2000 };
+			await page.waitForSelector( '#billing-first_name' );
 			await Promise.all( [
 				expect( page ).toMatch(
-					customerBillingDetails.firstname,
-					opts
+					customerBillingDetails.firstname
 				),
-				expect( page ).toMatch( customerBillingDetails.lastname, opts ),
-				expect( page ).toMatch( customerBillingDetails.company, opts ),
+				expect( page ).toMatch( customerBillingDetails.lastname),
+				expect( page ).toMatch( customerBillingDetails.company),
 				expect( page ).toMatch(
-					customerBillingDetails.addressfirstline,
-					opts
+					customerBillingDetails.addressfirstline
 				),
 				expect( page ).toMatch(
-					customerBillingDetails.addresssecondline,
-					opts
+					customerBillingDetails.addresssecondline
 				),
 				// expect( page ).toMatch( customerBillingDetails.country ),
-				expect( page ).toMatch( customerBillingDetails.city, opts ),
-				expect( page ).toMatch( customerBillingDetails.state, opts ),
-				expect( page ).toMatch( customerBillingDetails.postcode, opts ),
-				expect( page ).toMatch( customerBillingDetails.phone, opts ),
+				expect( page ).toMatch( customerBillingDetails.city),
+				expect( page ).toMatch( customerBillingDetails.state),
+				expect( page ).toMatch( customerBillingDetails.postcode),
+				expect( page ).toMatch( customerBillingDetails.phone),
 			] );
 		},
 
 		// prettier-ignore
 		verifyShippingDetails: async ( customerShippingDetails ) => {
-			const opts = { timeout: 2000 };
+			await page.waitForSelector( '#shipping-first_name' );
 			await Promise.all( [
 				expect( page ).toMatch(
-					customerShippingDetails.firstname,
-					opts
+					customerShippingDetails.firstname
 				),
 				expect( page ).toMatch(
-					customerShippingDetails.lastname,
-					opts
+					customerShippingDetails.lastname
 				),
-				expect( page ).toMatch( customerShippingDetails.company, opts ),
+				expect( page ).toMatch( customerShippingDetails.company),
 				expect( page ).toMatch(
-					customerShippingDetails.addressfirstline,
-					opts
+					customerShippingDetails.addressfirstline
 				),
 				expect( page ).toMatch(
-					customerShippingDetails.addresssecondline,
-					opts
+					customerShippingDetails.addresssecondline
 				),
 				// expect( page ).toMatch( customerShippingDetails.country ),
-				expect( page ).toMatch( customerShippingDetails.city, opts ),
-				expect( page ).toMatch( customerShippingDetails.state, opts ),
+				expect( page ).toMatch( customerShippingDetails.city),
+				expect( page ).toMatch( customerShippingDetails.state),
 				expect( page ).toMatch(
-					customerShippingDetails.postcode,
-					opts
+					customerShippingDetails.postcode
 				),
-				expect( page ).toMatch( customerShippingDetails.phone, opts ),
+				expect( page ).toMatch( customerShippingDetails.phone),
 			] );
 		},
 

--- a/tests/utils/shopper.js
+++ b/tests/utils/shopper.js
@@ -244,7 +244,7 @@ export const shopper = {
 
 		// prettier-ignore
 		verifyBillingDetails: async ( customerBillingDetails ) => {
-			await page.waitForSelector( '#billing-first_name' );
+			await page.waitForSelector( '.woocommerce-column--billing-address' );
 			await Promise.all( [
 				expect( page ).toMatch(
 					customerBillingDetails.firstname
@@ -267,7 +267,9 @@ export const shopper = {
 
 		// prettier-ignore
 		verifyShippingDetails: async ( customerShippingDetails ) => {
-			await page.waitForSelector( '#shipping-first_name' );
+			await page.waitForSelector(
+				'.woocommerce-column--shipping-address'
+			);
 			await Promise.all( [
 				expect( page ).toMatch(
 					customerShippingDetails.firstname

--- a/tests/utils/shopper.js
+++ b/tests/utils/shopper.js
@@ -244,33 +244,59 @@ export const shopper = {
 
 		// prettier-ignore
 		verifyBillingDetails: async ( customerBillingDetails ) => {
+			const opts = { timeout: 2000 };
 			await Promise.all( [
-				expect( page ).toMatch( customerBillingDetails.firstname ),
-				expect( page ).toMatch( customerBillingDetails.lastname ),
-				expect( page ).toMatch( customerBillingDetails.company ),
-				expect( page ).toMatch( customerBillingDetails.addressfirstline ),
-				expect( page ).toMatch( customerBillingDetails.addresssecondline ),
+				expect( page ).toMatch(
+					customerBillingDetails.firstname,
+					opts
+				),
+				expect( page ).toMatch( customerBillingDetails.lastname, opts ),
+				expect( page ).toMatch( customerBillingDetails.company, opts ),
+				expect( page ).toMatch(
+					customerBillingDetails.addressfirstline,
+					opts
+				),
+				expect( page ).toMatch(
+					customerBillingDetails.addresssecondline,
+					opts
+				),
 				// expect( page ).toMatch( customerBillingDetails.country ),
-				expect( page ).toMatch( customerBillingDetails.city ),
-				expect( page ).toMatch( customerBillingDetails.state ),
-				expect( page ).toMatch( customerBillingDetails.postcode ),
-				expect( page ).toMatch( customerBillingDetails.phone ),
+				expect( page ).toMatch( customerBillingDetails.city, opts ),
+				expect( page ).toMatch( customerBillingDetails.state, opts ),
+				expect( page ).toMatch( customerBillingDetails.postcode, opts ),
+				expect( page ).toMatch( customerBillingDetails.phone, opts ),
 			] );
 		},
 
 		// prettier-ignore
 		verifyShippingDetails: async ( customerShippingDetails ) => {
+			const opts = { timeout: 2000 };
 			await Promise.all( [
-				expect( page ).toMatch( customerShippingDetails.firstname ),
-				expect( page ).toMatch( customerShippingDetails.lastname ),
-				expect( page ).toMatch( customerShippingDetails.company ),
-				expect( page ).toMatch( customerShippingDetails.addressfirstline ),
-				expect( page ).toMatch( customerShippingDetails.addresssecondline ),
+				expect( page ).toMatch(
+					customerShippingDetails.firstname,
+					opts
+				),
+				expect( page ).toMatch(
+					customerShippingDetails.lastname,
+					opts
+				),
+				expect( page ).toMatch( customerShippingDetails.company, opts ),
+				expect( page ).toMatch(
+					customerShippingDetails.addressfirstline,
+					opts
+				),
+				expect( page ).toMatch(
+					customerShippingDetails.addresssecondline,
+					opts
+				),
 				// expect( page ).toMatch( customerShippingDetails.country ),
-				expect( page ).toMatch( customerShippingDetails.city ),
-				expect( page ).toMatch( customerShippingDetails.state ),
-				expect( page ).toMatch( customerShippingDetails.postcode ),
-				expect( page ).toMatch( customerShippingDetails.phone ),
+				expect( page ).toMatch( customerShippingDetails.city, opts ),
+				expect( page ).toMatch( customerShippingDetails.state, opts ),
+				expect( page ).toMatch(
+					customerShippingDetails.postcode,
+					opts
+				),
+				expect( page ).toMatch( customerShippingDetails.phone, opts ),
 			] );
 		},
 

--- a/tests/utils/shopper.js
+++ b/tests/utils/shopper.js
@@ -317,11 +317,12 @@ export const shopper = {
 					text: shippingName,
 				}
 			);
-			await page.waitForTimeout( 1000 );
+
 			await expect( page ).toMatchElement(
 				'.wc-block-components-totals-shipping .wc-block-formatted-money-amount',
 				{
 					text: shippingPrice,
+					timeout: 5000,
 				}
 			);
 		},


### PR DESCRIPTION
This PR solves the failing translations e2e test which attempts to re-install a different language via the CLI within the test itself. Instead, we now use the already installed `nl_NL` from `wp-env-config.sh`. **All future translation tests should use this from now on**

I've also added a `waitForSelector` in `verifyShippingDetails` and `verifyBillingDetails` checks as these failed randomly in CI and I've seen them fail before.

### Testing

#### Automated Tests
* [x] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests

### Manual Testing

How to test the changes in this Pull Request:

1. Run `npm run test:e2e -- translations` and it should pass
2. E2E tests pass in CI
