### PR TITLE
Provide product filter blocks a method to know when to display.

### DIFF
--- a/src/BlockTypes/AllProducts.php
+++ b/src/BlockTypes/AllProducts.php
@@ -21,6 +21,9 @@ class AllProducts extends AbstractBlock {
 	 */
 	protected function enqueue_data( array $attributes = [] ) {
 		parent::enqueue_data( $attributes );
+		// Set this so filter blocks being used as widgets know when to render.
+		$this->asset_data_registry->add( 'has_filterable_products', true, null );
+
 		$this->asset_data_registry->add( 'min_columns', wc_get_theme_support( 'product_blocks::min_columns', 1 ), true );
 		$this->asset_data_registry->add( 'max_columns', wc_get_theme_support( 'product_blocks::max_columns', 6 ), true );
 		$this->asset_data_registry->add( 'default_columns', wc_get_theme_support( 'product_blocks::default_columns', 3 ), true );

--- a/src/BlockTypes/ClassicTemplate.php
+++ b/src/BlockTypes/ClassicTemplate.php
@@ -61,12 +61,11 @@ class ClassicTemplate extends AbstractDynamicBlock {
 		if ( 'single-product' === $attributes['template'] ) {
 			return $this->render_single_product();
 		} elseif ( in_array( $attributes['template'], $archive_templates, true ) ) {
-			// We need to set this so that our product filters can detect if it's a PHP template.
-			$this->asset_data_registry->add(
-				'is_rendering_php_template',
-				true,
-				null
-			);
+			// Set this so that our product filters can detect if it's a PHP template.
+			$this->asset_data_registry->add( 'is_rendering_php_template', true, null );
+
+			// Set this so filter blocks being used as widgets know when to render.
+			$this->asset_data_registry->add( 'has_filterable_products', true, null );
 
 			$this->asset_data_registry->add(
 				'page_url',

--- a/src/Domain/Bootstrap.php
+++ b/src/Domain/Bootstrap.php
@@ -13,6 +13,7 @@ use Automattic\WooCommerce\Blocks\Domain\Services\GoogleAnalytics;
 use Automattic\WooCommerce\Blocks\InboxNotifications;
 use Automattic\WooCommerce\Blocks\Installer;
 use Automattic\WooCommerce\Blocks\Templates\ProductSearchResultsTemplate;
+use Automattic\WooCommerce\Blocks\Templates\ClassicTemplatesCompatibility;
 use Automattic\WooCommerce\Blocks\Payments\Api as PaymentsApi;
 use Automattic\WooCommerce\Blocks\Payments\Integrations\BankTransfer;
 use Automattic\WooCommerce\Blocks\Payments\Integrations\CashOnDelivery;
@@ -97,6 +98,7 @@ class Bootstrap {
 		$this->container->get( BlockTypesController::class );
 		$this->container->get( BlockTemplatesController::class );
 		$this->container->get( ProductSearchResultsTemplate::class );
+		$this->container->get( ClassicTemplatesCompatibility::class );
 		if ( $this->package->feature()->is_feature_plugin_build() ) {
 			$this->container->get( PaymentsApi::class );
 		}
@@ -227,6 +229,13 @@ class Bootstrap {
 			ProductSearchResultsTemplate::class,
 			function () {
 				return new ProductSearchResultsTemplate();
+			}
+		);
+		$this->container->register(
+			ClassicTemplatesCompatibility::class,
+			function ( Container $container ) {
+				$asset_data_registry = $container->get( AssetDataRegistry::class );
+				return new ClassicTemplatesCompatibility( $asset_data_registry );
 			}
 		);
 		$this->container->register(

--- a/src/Templates/ClassicTemplatesCompatibility.php
+++ b/src/Templates/ClassicTemplatesCompatibility.php
@@ -59,7 +59,7 @@ class ClassicTemplatesCompatibility {
 	}
 
 	/**
-	 * This method passes the value `is_rendering_php_template` to the front-end,
+	 * This method passes the value `is_rendering_php_template` to the front-end of Classic themes,
 	 * so that widget product filter blocks are aware of how to filter the products.
 	 *
 	 * @return void

--- a/src/Templates/ClassicTemplatesCompatibility.php
+++ b/src/Templates/ClassicTemplatesCompatibility.php
@@ -33,7 +33,9 @@ class ClassicTemplatesCompatibility {
 	 * Initialization method.
 	 */
 	protected function init() {
-		add_action( 'template_redirect', array( $this, 'set_classic_template_data' ) );
+		if ( ! wc_current_theme_is_fse_theme() ) {
+			add_action( 'template_redirect', array( $this, 'set_classic_template_data' ) );
+		}
 	}
 
 	/**
@@ -65,8 +67,6 @@ class ClassicTemplatesCompatibility {
 	 * @return void
 	 */
 	public function set_php_template_data() {
-		if ( ! wc_current_theme_is_fse_theme() ) {
-			$this->asset_data_registry->add( 'is_rendering_php_template', true, null );
-		}
+		$this->asset_data_registry->add( 'is_rendering_php_template', true, null );
 	}
 }

--- a/src/Templates/ClassicTemplatesCompatibility.php
+++ b/src/Templates/ClassicTemplatesCompatibility.php
@@ -1,0 +1,72 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\Templates;
+
+use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
+
+/**
+ * ClassicTemplatesCompatibility class.
+ *
+ * To bridge the gap on compatibility with widget blocks and classic PHP core templates.
+ *
+ * @internal
+ */
+class ClassicTemplatesCompatibility {
+
+	/**
+	 * Instance of the asset data registry.
+	 *
+	 * @var AssetDataRegistry
+	 */
+	protected $asset_data_registry;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param AssetDataRegistry $asset_data_registry Instance of the asset data registry.
+	 */
+	public function __construct( AssetDataRegistry $asset_data_registry ) {
+		$this->asset_data_registry = $asset_data_registry;
+		$this->init();
+	}
+
+	/**
+	 * Initialization method.
+	 */
+	protected function init() {
+		add_action( 'template_redirect', array( $this, 'set_classic_template_data' ) );
+	}
+
+	/**
+	 * Executes the methods which set the necessary data needed for filter blocks to work correctly as widgets in Classic templates.
+	 *
+	 * @return void
+	 */
+	public function set_classic_template_data() {
+		$this->set_filterable_product_data();
+		$this->set_php_template_data();
+	}
+
+	/**
+	 * This method passes the value `has_filterable_products` to the front-end for product archive pages,
+	 * so that widget product filter blocks are aware of the context they are in and can render accordingly.
+	 *
+	 * @return void
+	 */
+	public function set_filterable_product_data() {
+		if ( is_shop() || is_product_taxonomy() ) {
+			$this->asset_data_registry->add( 'has_filterable_products', true, null );
+		}
+	}
+
+	/**
+	 * This method passes the value `is_rendering_php_template` to the front-end,
+	 * so that widget product filter blocks are aware of how to filter the products.
+	 *
+	 * @return void
+	 */
+	public function set_php_template_data() {
+		if ( ! wc_current_theme_is_fse_theme() ) {
+			$this->asset_data_registry->add( 'is_rendering_php_template', true, null );
+		}
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/6140

This PR introduces a method of passing data to the front-end of pages with filterable products (for context please read the linked issue):

* **Block Themes**: Pages rendering the Classic Template block (specifically the product archive variation of this block)
* **Classic Themes**: Pages rendering the core PHP product archive templates (e.g. shop/product archive/product taxonomy pages)
* **Block Themes & Classic Themes**: Pages rendering the All Products block

This will allow us to deprecate product filter widgets, in favour of product filter blocks.

**Note**: I have not used this PR as an opportunity to replace product filter widgets with product filter blocks. This will be done separately in https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/6144

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

### Manual Testing

How to test the changes in this Pull Request:

1. Activate Storefront
2. Comment out [this line](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/src/BlockTypesController.php#L218) to allow the PriceFilter block to be added as a widget.
3. Add the below snippet of code to the Price Filter block and run `npm run start` to build the component.
4. Add the Price Filter block to the sidebar as a widget under Appearance > Widgets
5. On the frontend, ensure that the price filter block displays and works on pages where there are filterable products (e.g. Store related pages), and does NOT render on non-store related pages (e.g. Sample Page)
6. Add the All Products block to a non-store related page such as your Sample Page, and check that the Price Filter block displays here too now and works correctly.
7. Now activate a block theme such as TwentyTwenty-Two and check steps 1-6 again with your block theme but instead of adding the Price Filter block as a widget described in Step 4, you will need to go into the Site Editor and add it to the appropriate templates.

```js
// assets/js/blocks/price-filter/block.js

const hasFilterableProducts = getSetting( 'has_filterable_products', '' );

if ( ! hasFilterableProducts ) {
    return null;
}
```

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [ ] Same as above, or
* [ ] See steps below.

1.
2.
3.
