### PR TITLE
E2E: Explain the reason for the addition language update command

### DIFF
--- a/bin/wp-env-config.sh
+++ b/bin/wp-env-config.sh
@@ -24,7 +24,8 @@ wp wc customer update 1 --user=1 --billing='{"first_name":"John","last_name":"Do
 wp language core install nl_NL
 wp language plugin install woocommerce nl_NL
 wp language plugin install woo-gutenberg-products-block nl_NL
-# We need to run update after installing the language to update it to the latest version. Otherwise, new strings won't be available.
+# Because we don't install the WooCommerce Blocks plugin, WP CLI uses the core version to install the language pack.
+# To get the latest translations, we need to run an additional update command.
 wp language plugin update woo-gutenberg-products-block nl_NL
 
 exit $EXIT_CODE


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

This PR explains the real reason for the additional `wp language plugin update` command used in the `wp-env-config.sh` file for setting up the test environment for E2E testing.

> Because we don't install the WooCommerce Blocks plugin, WP CLI uses the core version to install the language pack. To get the latest translations, we need to run an additional update command.

### Alternatives

We install the plugin first then running only the `install` command should be enough to get the latest translation pack. But at the time of writing, the plugin is 13.5 times bigger in size compared to the translation package.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

Manual verification.
