### PR TITLE
Quick attempt to fix E2E tests

### DIFF
--- a/tests/e2e/specs/shopper/cart-checkout/account.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/account.test.js
@@ -87,6 +87,7 @@ describe( 'Shopper → Checkout → Account', () => {
 		await switchUserToAdmin();
 		await visitAdminPage( 'users.php' );
 		//Confirm account is being created with the email.
+		await page.waitForSelector( '.wp-list-table.users' );
 		await expect( page ).toMatch( testEmail );
 	} );
 } );

--- a/tests/e2e/specs/shopper/cart-checkout/cart.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/cart.test.js
@@ -21,6 +21,7 @@ describe( 'Shopper → Cart', () => {
 		await shopper.block.goToCart();
 
 		// Verify cart is empty'
+		await page.waitForSelector( '.wp-block-woocommerce-empty-cart-block' );
 		await expect( page ).toMatchElement( 'h2', {
 			text: 'Your cart is currently empty!',
 		} );

--- a/tests/e2e/specs/shopper/cart-checkout/checkout.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/checkout.test.js
@@ -239,7 +239,7 @@ describe( 'Shopper → Checkout', () => {
 		} );
 	} );
 
-	describe.only( 'Coupons', () => {
+	describe( 'Coupons', () => {
 		beforeAll( async () => {
 			coupon = await createCoupon( { usageLimit: 1 } );
 			await merchant.login();

--- a/tests/e2e/specs/shopper/cart-checkout/checkout.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/checkout.test.js
@@ -239,7 +239,7 @@ describe( 'Shopper → Checkout', () => {
 		} );
 	} );
 
-	describe( 'Coupons', () => {
+	describe.only( 'Coupons', () => {
 		beforeAll( async () => {
 			coupon = await createCoupon( { usageLimit: 1 } );
 			await merchant.login();
@@ -292,6 +292,9 @@ describe( 'Shopper → Checkout', () => {
 			await shopper.addToCartFromShopPage( SIMPLE_VIRTUAL_PRODUCT_NAME );
 			await shopper.block.goToCheckout();
 			await shopper.block.applyCouponFromCheckout( coupon.code );
+			await page.waitForSelector(
+				'.wc-block-components-totals-coupon__content > .wc-block-components-validation-error'
+			);
 			await expect( page ).toMatch(
 				'Coupon usage limit has been reached.'
 			);

--- a/tests/utils/shopper.js
+++ b/tests/utils/shopper.js
@@ -319,11 +319,12 @@ export const shopper = {
 				}
 			);
 
+			await page.waitForNetworkIdle( { idleTime: 2000 } );
 			await expect( page ).toMatchElement(
 				'.wc-block-components-totals-shipping .wc-block-formatted-money-amount',
 				{
 					text: shippingPrice,
-					timeout: 5000,
+					timeout: 30000,
 				}
 			);
 		},

--- a/tests/utils/shopper.js
+++ b/tests/utils/shopper.js
@@ -35,6 +35,7 @@ export const shopper = {
 				waitUntil: 'networkidle0',
 			} );
 
+			await page.waitForSelector( 'h1' );
 			await expect( page ).toMatchElement( 'h1', {
 				text: blockName,
 			} );
@@ -409,7 +410,8 @@ export const shopper = {
 				cartItemArgs
 			);
 
-			await expect( page.$x( cartItemXPath ) ).resolves.toHaveLength( 1 );
+			const $cartItem = await page.$x( cartItemXPath );
+			await expect( $cartItem ).resolves.toHaveLength( 1 );
 		},
 
 		applyCouponFromCheckout: async ( couponCode ) => {

--- a/tests/utils/shopper.js
+++ b/tests/utils/shopper.js
@@ -328,16 +328,6 @@ export const shopper = {
 					hidden: true,
 				}
 			);
-
-			// testing purposes
-			const name = await page.$eval(
-				'.wc-block-components-totals-shipping .wc-block-formatted-money-amount',
-				( el ) => el.innerText
-			);
-			// eslint-disable-next-line no-console
-			console.log( name );
-
-			// eslint-disable-next-line jest/no-standalone-expect
 			await expect( page ).toMatchElement(
 				'.wc-block-components-totals-shipping .wc-block-formatted-money-amount',
 				{

--- a/tests/utils/shopper.js
+++ b/tests/utils/shopper.js
@@ -412,7 +412,7 @@ export const shopper = {
 			);
 
 			const $cartItem = await page.$x( cartItemXPath );
-			await expect( $cartItem ).resolves.toHaveLength( 1 );
+			await expect( $cartItem ).toHaveLength( 1 );
 		},
 
 		applyCouponFromCheckout: async ( couponCode ) => {

--- a/tests/utils/shopper.js
+++ b/tests/utils/shopper.js
@@ -328,6 +328,16 @@ export const shopper = {
 					hidden: true,
 				}
 			);
+
+			// testing purposes
+			const name = await page.$eval(
+				'.wc-block-components-totals-shipping .wc-block-formatted-money-amount',
+				( el ) => el.innerText
+			);
+			// eslint-disable-next-line no-console
+			console.log( name );
+
+			// eslint-disable-next-line jest/no-standalone-expect
 			await expect( page ).toMatchElement(
 				'.wc-block-components-totals-shipping .wc-block-formatted-money-amount',
 				{

--- a/tests/utils/shopper.js
+++ b/tests/utils/shopper.js
@@ -319,7 +319,15 @@ export const shopper = {
 				}
 			);
 
-			await page.waitForNetworkIdle( { idleTime: 2000 } );
+			// We need to wait for the UI to update after the store API call,
+			// so we wait for the "Place Order" to not be disabled again to indicate
+			// the call has finished. Tried `page.waitForNetworkIdle()` here but it's flakey
+			await page.waitForSelector(
+				'button.wc-block-components-checkout-place-order-button[disabled]',
+				{
+					hidden: true,
+				}
+			);
 			await expect( page ).toMatchElement(
 				'.wc-block-components-totals-shipping .wc-block-formatted-money-amount',
 				{


### PR DESCRIPTION
Quick fix attempt for failing e2e tests. I've mainly added some `await page.waitForSelector()` calls to make sure dom nodes are available before asserting on them. I've gone through the scenarios in #6286 and the failing test mentioned in this slack convo (p1650465604341119/1650464530.659929-slack-C02UBB1EPEF), but I'm sure there are others. I've commented on the issue with possible improvements to e2e tests for the cooldown.

**To test**
1. Pray and hope E2E pass in CI!