### PR TITLE
Filter for responses items in AbstractSchema.php

### DIFF
--- a/src/StoreApi/Schemas/V1/AbstractSchema.php
+++ b/src/StoreApi/Schemas/V1/AbstractSchema.php
@@ -252,7 +252,7 @@ abstract class AbstractSchema {
 	 * @return array Array of values from the callback function.
 	 */
 	protected function get_item_responses_from_schema( AbstractSchema $schema, $items ) {
-		$items = array_filter( $items );
+		$items = apply_filters( 'woocommerce_get_items_from_schema', array_filter( $items ) );
 
 		if ( empty( $items ) ) {
 			return [];


### PR DESCRIPTION
When creating custom product class ( add_filter( 'woocommerce_product_class', ......  ) ) there are places in ProductSchema.php and CartItemSchema.php where items are forced to be \WC_Product $product and that cast cause errors for the custom product class case. 

With this filter we can be able to exclude our custom product class from that Schema responses.

Errors we got now with the latest WooCommerce version 6.4.1
Fatal error: Uncaught TypeError: Argument 1 passed to Automattic\WooCommerce\StoreApi\Schemas\V1\ProductSchema::get_low_stock_remaining() must be an instance of WC_Product, instance of WC_Product_Room given, called in D:\projects\test\wp-content\plugins\woocommerce\packages\woocommerce-blocks\src\StoreApi\Schemas\V1\CartItemSchema.php on line 347 and defined in D:\projects\test\wp-content\plugins\woocommerce\packages\woocommerce-blocks\src\StoreApi\Schemas\V1\ProductSchema.php:516
