### PR TITLE
Updates to release checklist and PR template to improve processes

### DIFF
--- a/.github/patch-initial-checklist.md
+++ b/.github/patch-initial-checklist.md
@@ -40,7 +40,7 @@ Additionally, make sure to differentiate between things in the testing notes tha
   * If all PRs are testing as expected, continue with the release.
   * If one or more PRs are not testing as expected: ping the PR authors and the porter of the relevant team and ask them if the change is a release blocker or not (you can also ping the team lead if any of them is not available). In general, if it's not a regression or there is no product/marketing reason why that PR is a blocker, all other PRs should default to not being blockers.
     * If there are blockers: stop the release and ask the PR author and team porter to fix them.
-    * If some PRs are not testing as expected but they are not blockers: remove the from testing steps and changelog, open an issue (or reopen the original one) and proceed with the release.
+    * If some PRs are not testing as expected but they are not blockers: revert the relevant commits, remove the changes from testing steps and changelog, open an issue (or reopen the original one) and proceed with the release.
 * [ ] Execute `npm run deploy`
   * Note: the script automatically updates version numbers (commits on your behalf).
   * **ALERT**: This script will ask you if this release will be deployed to WordPress.org. You should only answer yes for this release **if it's the latest release and you want to deploy to WordPress.org**. Otherwise, answer no. If you answer yes, you will get asked additional verification by the `npm run deploy` script about deploying a patch release to WordPress.org.

--- a/.github/patch-initial-checklist.md
+++ b/.github/patch-initial-checklist.md
@@ -35,6 +35,7 @@ Each porter is responsible for testing the PRs that fall under the focus of thei
   * If one or more PRs are not testing as expected: ping the PR authors and the porter of the relevant team and ask them if the change is a release blocker or not (you can also ping the team lead if any of them is not available). In general, if it's not a regression or there is no product/marketing reason why that PR is a blocker, all other PRs should default to not being blockers.
     * If there are blockers: stop the release and ask the PR author to fix them. If the PR author is AFK, ping the porter of their team.
     * If some PRs are not testing as expected but they are not blockers: revert the relevant commits, remove the changes from testing steps and changelog, open an issue (or reopen the original one) and proceed with the release.
+    * If minor issues are discovered during the testing, each team is responsible for logging them in Github
 
 ## Update Pull Request description and get approvals
 

--- a/.github/patch-initial-checklist.md
+++ b/.github/patch-initial-checklist.md
@@ -21,7 +21,6 @@ The release pull request has been created! This checklist is a guide to follow f
 * [ ] Copy a link to the release zip you created earlier into the testing notes. To generate the link you can upload the zip as an attachment in a GitHub comment and then just copy the path (without publishing the comment).
 * [ ] Commit and push the testing docs to the release branch.
 * [ ] Smoke test built release zip using the testing instructions you created:
-  * At least one other person should test the built zip - ping the current Rubik porter to be this person.
   * Test in a clean environment, e.g. Jurassic.Ninja site.
   * Test existing WooCommerce Blocks content works correctly after update (no block validation errors).
   * Test to confirm blocks are available and work correctly in oldest supported WordPress version (e.g. 5.3).
@@ -29,15 +28,15 @@ The release pull request has been created! This checklist is a guide to follow f
   * Test to confirm new features/fixes are working correctly.
   * Test any UI changes in mobile and desktop views.
   * Smoke test – test a cross section of core functionality.
-
-## Update Pull Request description and get approvals
-
-* [ ] Go through the description of the release pull request and edit it to update all the sections and checklist instructions there.
-* [ ] Ask the porter of Rubik and Kirigami to review the changes in the release pull request and to approve the PR if everything looks good. Each porter is responsible for testing the PRs that fall under the focus of their own team. Shared functionality should be tested by both porters. This means that the Rubik porter will mostly test Cart & Checkout changes while Kirigami porter will test the other blocks.
+* [ ] Ask the porter of Rubik and Kirigami to review the changes as well and to approve the PR if everything looks good. Each porter is responsible for testing the PRs that fall under the focus of their own team. Shared functionality should be tested by both porters. This means that the Rubik porter will mostly test Cart & Checkout changes while Kirigami porter will test the other blocks.
   * If all PRs are testing as expected, continue with the release.
   * If one or more PRs are not testing as expected: ping the PR authors and the porter of the relevant team and ask them if the change is a release blocker or not (you can also ping the team lead if any of them is not available). In general, if it's not a regression or there is no product/marketing reason why that PR is a blocker, all other PRs should default to not being blockers.
     * If there are blockers: stop the release and ask the PR author and team porter to fix them.
     * If some PRs are not testing as expected but they are not blockers: revert the relevant commits, remove the changes from testing steps and changelog, open an issue (or reopen the original one) and proceed with the release.
+
+## Update Pull Request description and get approvals
+
+* [ ] Go through the description of the release pull request and edit it to update all the sections and checklist instructions there.
 * [ ] Execute `npm run deploy`
   * Note: the script automatically updates version numbers (commits on your behalf).
   * **ALERT**: This script will ask you if this release will be deployed to WordPress.org. You should only answer yes for this release **if it's the latest release and you want to deploy to WordPress.org**. Otherwise, answer no. If you answer yes, you will get asked additional verification by the `npm run deploy` script about deploying a patch release to WordPress.org.

--- a/.github/patch-initial-checklist.md
+++ b/.github/patch-initial-checklist.md
@@ -35,7 +35,7 @@ Each porter is responsible for testing the PRs that fall under the focus of thei
   * If one or more PRs are not testing as expected: ping the PR authors and the porter of the relevant team and ask them if the change is a release blocker or not (you can also ping the team lead if any of them is not available). In general, if it's not a regression or there is no product/marketing reason why that PR is a blocker, all other PRs should default to not being blockers.
     * If there are blockers: stop the release and ask the PR author to fix them. If the PR author is AFK, ping the porter of their team.
     * If some PRs are not testing as expected but they are not blockers: revert the relevant commits, remove the changes from testing steps and changelog, open an issue (or reopen the original one) and proceed with the release.
-    * If minor issues are discovered during the testing, each team is responsible for logging them in Github
+    * If minor issues are discovered during the testing, each team is responsible for logging them in Github.
 
 ## Update Pull Request description and get approvals
 

--- a/.github/patch-initial-checklist.md
+++ b/.github/patch-initial-checklist.md
@@ -4,6 +4,7 @@ The release pull request has been created! This checklist is a guide to follow f
 
 ## Initial Preparation
 
+* [ ] Close the milestone of the release you are going to ship. That will prevent newly approved PRs to be automatically assigned to that milestone.
 * [ ] Add the changelog to `readme.txt`
   * [ ] Add the version and date to the changelog section within `readme.txt`, e.g. `= {{version}} - YYYY-MM-DD =`
   * [ ] Copy the changelog from the pull request description above into this new section
@@ -63,9 +64,7 @@ Each porter is responsible for testing the PRs that fall under the focus of thei
   * If the base branch is the release branch this patch release is for, then merge branch into release branch and then merge the release branch back to `trunk` if the patch release is the latest released version. Otherwise just merge back into the release branch.
 * [ ] If you merged the branch to `trunk`, then update version on the `trunk` branch to be for the next version of the plugin and include the `dev` suffix (e.g. something like [`2.6-dev`](https://github.com/woocommerce/woocommerce-gutenberg-products-block/commit/e27f053e7be0bf7c1d376f5bdb9d9999190ce158)) for the next version.
 * [ ] Update the schedules p2 with the shipped date for the release (Pca54o-1N-p2).
-* [ ] Clean up the release milestone.
-  * [ ] Edit the GitHub milestone and add the current date as the due date (this is used to track ship date as well).
-  * [ ] Close the milestone.
+* [ ] Edit the GitHub milestone of the release you just shipped and add the current date as the due date (this is used to track ship date as well).
 
 ## Pull request in WooCommerce Core for Package update
 

--- a/.github/patch-initial-checklist.md
+++ b/.github/patch-initial-checklist.md
@@ -28,7 +28,9 @@ The release pull request has been created! This checklist is a guide to follow f
   * Test to confirm new features/fixes are working correctly.
   * Test any UI changes in mobile and desktop views.
   * Smoke test – test a cross section of core functionality.
-* [ ] Ask the porter of Rubik and Kirigami to review the changes as well and to approve the PR if everything looks good. Each porter is responsible for testing the PRs that fall under the focus of their own team. Shared functionality should be tested by both porters. This means that the Rubik porter will mostly test Cart & Checkout changes while Kirigami porter will test the other blocks.
+* [ ] Ask the porters of Rubik and Kirigami to smoke test the built release zip as well and to approve the PR if everything looks good. 
+
+Each porter is responsible for testing the PRs that fall under the focus of their own team. Shared functionality should be tested by both porters. This means that the Rubik porter will mostly test Cart & Checkout changes while Kirigami porter will test the other blocks.
   * If all PRs are testing as expected, continue with the release.
   * If one or more PRs are not testing as expected: ping the PR authors and the porter of the relevant team and ask them if the change is a release blocker or not (you can also ping the team lead if any of them is not available). In general, if it's not a regression or there is no product/marketing reason why that PR is a blocker, all other PRs should default to not being blockers.
     * If there are blockers: stop the release and ask the PR author to fix them. If the PR author is AFK, ping the porter of their team.

--- a/.github/patch-initial-checklist.md
+++ b/.github/patch-initial-checklist.md
@@ -30,7 +30,7 @@ The release pull request has been created! This checklist is a guide to follow f
   * Smoke test – test a cross section of core functionality.
 * [ ] Ask the porters of Rubik and Kirigami to smoke test the built release zip as well and to approve the PR if everything looks good. 
 
-Each porter is responsible for testing the PRs that fall under the focus of their own team. Shared functionality should be tested by both porters. This means that the Rubik porter will mostly test Cart & Checkout changes while Kirigami porter will test the other blocks.
+Each porter is responsible for testing the PRs that fall under the focus of their own team. Shared functionality should be tested by both porters. This means that the Rubik porter will mostly test checkout blocks and Store API endpoints, while the Kirigami porter will test the product related blocks and Store API endpoints.
   * If all PRs are testing as expected, continue with the release.
   * If one or more PRs are not testing as expected: ping the PR authors and the porter of the relevant team and ask them if the change is a release blocker or not (you can also ping the team lead if any of them is not available). In general, if it's not a regression or there is no product/marketing reason why that PR is a blocker, all other PRs should default to not being blockers.
     * If there are blockers: stop the release and ask the PR author to fix them. If the PR author is AFK, ping the porter of their team.

--- a/.github/patch-initial-checklist.md
+++ b/.github/patch-initial-checklist.md
@@ -36,7 +36,11 @@ Additionally, make sure to differentiate between things in the testing notes tha
 ## Update Pull Request description and get approvals
 
 * [ ] Go through the description of the release pull request and edit it to update all the sections and checklist instructions there.
-* [ ] Ask a team member to review the changes in the release pull request and for anyone who has done testing that they approve the pull request.
+* [ ] Ask the porter of Rubik and Kirigami to review the changes in the release pull request and to approve the PR if everything looks good. The porter of each team is responsible for testing the PRs created by members of their own team. That means Rubik porter will mostly test Cart & Checkout changes while Kirigami porter will test other blocks.
+  * If all PRs are testing as expected, continue with the release.
+  * If one or more PRs are not testing as expected: ping the PR authors and the porter of the relevant team and ask them if the change is a release blocker or not (you can also ping the team lead if any of them is not available). In general, if it's not a regression or there is no product/marketing reason why that PR is a blocker, all other PRs should default to not being blockers.
+    * If there are blockers: stop the release and ask the PR author and team porter to fix them.
+    * If some PRs are not testing as expected but they are not blockers: remove the from testing steps and changelog, open an issue (or reopen the original one) and proceed with the release.
 * [ ] Execute `npm run deploy`
   * Note: the script automatically updates version numbers (commits on your behalf).
   * **ALERT**: This script will ask you if this release will be deployed to WordPress.org. You should only answer yes for this release **if it's the latest release and you want to deploy to WordPress.org**. Otherwise, answer no. If you answer yes, you will get asked additional verification by the `npm run deploy` script about deploying a patch release to WordPress.org.
@@ -64,19 +68,6 @@ Additionally, make sure to differentiate between things in the testing notes tha
   * [ ] Edit the GitHub milestone and add the current date as the due date (this is used to track ship date as well).
   * [ ] Close the milestone.
 
-## Publish Posts
-
-You only need to post public release announcements and update relevant public facing docs if this patch release is deployed to WP.org. Otherwise, you can skip this section.
-
-* [ ] Post release announcement on [WooCommerce Developer Blog](https://developer.woocommerce.com/category/release-post/woocommerce-blocks-release-notes/). Use previous posts for inspiration. If the release contains new features, or API changes, explain what's new so Woo devs/builders/merchants can get excited about it. This post can take time to get right - get feedback from the team, and don't rush it :)
-  - Ensure the release notes are included in the post verbatim.
-  - Don't forget to use category `WooCommerce Blocks Release Notes` for the post.
-* [ ] Announce the release internally (`#woo-announcements` slack).
-* [ ] Update user-facing documentation as needed. When the plugin is released, ensure user-facing documentation is kept up to date with new blocks and compatibility information.
-  - Update minimum supported versions (WordPress, WooCommerce Core) and other requirements where necessary, including:
-    - [WCCOM product page](https://woocommerce.com/products/woocommerce-gutenberg-products-block/)
-    - [WooCommerce blocks main documentation page](https://docs.woocommerce.com/document/woocommerce-blocks/)
-
 ## Pull request in WooCommerce Core for Package update
 
 This only needs done if the patch release needs to be included in WooCommerce Core.
@@ -90,3 +81,17 @@ This only needs done if the patch release needs to be included in WooCommerce Co
   - Verify and make any additional edits to the pull request description for things like: Changelog to be included with WooCommerce core, additional communication that might be needed elsewhere, additional marketing communication notes that may be needed etc.
   - After the checklist is complete and the testing is done, it will be up to the WooCommerce core team to approve and merge the pull request.
 * [ ] Make sure you join the `#woo-core-releases` Slack channel to represent Woo Blocks for the release of WooCommerce core this version is included in.
+
+## Publish Posts
+
+You only need to post public release announcements and update relevant public facing docs if this patch release is deployed to WP.org. Otherwise, you can skip this section.
+
+* [ ] Post release announcement on [WooCommerce Developer Blog](https://developer.woocommerce.com/category/release-post/woocommerce-blocks-release-notes/).
+  - Ping porters from each team to know which changelog entries need to be highlighted. Ask them to write a short text and optionally provide a screenshot. They can use previous posts for inspiration, we usually try to highlight new features or API changes.
+  - Ensure the release notes are included in the post verbatim.
+  - Don't forget to use category `WooCommerce Blocks Release Notes` for the post.
+* [ ] Announce the release internally (`#woo-announcements` slack).
+* [ ] Update user-facing documentation as needed. When the plugin is released, ensure user-facing documentation is kept up to date with new blocks and compatibility information.
+  - Update minimum supported versions (WordPress, WooCommerce Core) and other requirements where necessary, including:
+    - [WCCOM product page](https://woocommerce.com/products/woocommerce-gutenberg-products-block/)
+    - [WooCommerce blocks main documentation page](https://docs.woocommerce.com/document/woocommerce-blocks/)

--- a/.github/patch-initial-checklist.md
+++ b/.github/patch-initial-checklist.md
@@ -10,15 +10,12 @@ The release pull request has been created! This checklist is a guide to follow f
 * [ ] Update compatibility sections (if applicable). __Note:__ Do not change the stable tag or plugin version; this is automated.
 * [ ] Push above changes to the release branch.
 
-## Write Testing Notes
-
-When creating testing notes, please write them from the perspective of a "user" (merchant) familiar with WooCommerce. So you don't have to spell out exact steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful.
-
-Additionally, make sure to differentiate between things in the testing notes that only apply to the feature plugin and things that apply when included in WooCommerce core as there may be variations there.
+## Create the Testing Notes
 
 * [ ] Run `npm ci`
 * [ ] Run `npm run package-plugin:deploy`. This will create a zip of the current branch build locally.
-* [ ] Create testing notes for the release. You can usually go through the pull requests linked in the changelog and grab testing notes from each pull.
+* [ ] Create the testing notes for the release. 
+  * [ ] For each pull request linked in the changelog grab the `User Facing Testing` notes from the PR's description. 
   * [ ] Add the notes to `docs/testing/releases`
   * [ ] Update the `docs/testing/releases/README.md` file index.
 * [ ] Copy a link to the release zip you created earlier into the testing notes. To generate the link you can upload the zip as an attachment in a GitHub comment and then just copy the path (without publishing the comment).
@@ -36,7 +33,7 @@ Additionally, make sure to differentiate between things in the testing notes tha
 ## Update Pull Request description and get approvals
 
 * [ ] Go through the description of the release pull request and edit it to update all the sections and checklist instructions there.
-* [ ] Ask the porter of Rubik and Kirigami to review the changes in the release pull request and to approve the PR if everything looks good. The porter of each team is responsible for testing the PRs created by members of their own team. That means Rubik porter will mostly test Cart & Checkout changes while Kirigami porter will test other blocks.
+* [ ] Ask the porter of Rubik and Kirigami to review the changes in the release pull request and to approve the PR if everything looks good. Each porter is responsible for testing the PRs that fall under the focus of their own team. Shared functionality should be tested by both porters. This means that the Rubik porter will mostly test Cart & Checkout changes while Kirigami porter will test the other blocks.
   * If all PRs are testing as expected, continue with the release.
   * If one or more PRs are not testing as expected: ping the PR authors and the porter of the relevant team and ask them if the change is a release blocker or not (you can also ping the team lead if any of them is not available). In general, if it's not a regression or there is no product/marketing reason why that PR is a blocker, all other PRs should default to not being blockers.
     * If there are blockers: stop the release and ask the PR author and team porter to fix them.
@@ -75,7 +72,7 @@ This only needs done if the patch release needs to be included in WooCommerce Co
 * [ ] Create a pull request for updating the package in WooCommerce core (based off of the WooCommerce core release branch this is deployed for).
   - Create the pull request in the [WooCommerce Core Repository](https://github.com/woocommerce/woocommerce/) that [bumps the package version](https://github.com/woocommerce/woocommerce/blob/master/composer.json) for the blocks package to the version being pulled in.
   - The content for the pull release can follow [this example](https://github.com/woocommerce/woocommerce/pull/27676). Essentially you link to all the important things that have already been prepared. Note, you need to make sure you link to all the related documents for the feature plugin releases since the last package version bump in Woo Core.
-      - Please add a changelog to the content which is aggregated from all the releases included in the package bump. The changelog should only list things surfaced to users of the package in WooCommerce core (i.e. excluding things only available in the feature plugin or development builds). This changelog will be used in the release notes for the WooCommerce release. **Note: This currently is not shown in the linked example.**
+      - The PR's changelog should be aggregated from all the releases included in the package bump. This changelog will be used in the release notes for the WooCommerce release. That's why it should only list the PRs that have WooCoomerce Core in the WooCommerce Visibility section of their description. Don't include changes available in the feature plugin or development builds.
   - Run through the testing checklist to ensure everything works in that branch for that package bump. **Note:** Testing should include ensuring any features/new blocks that are supposed to be behind feature gating for the core merge of this package update are working as expected.
   - Testing should include completing the [Smoke testing checklist](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/testing/smoke-testing.md). It's up to you to verify that those tests have been done.
   - Verify and make any additional edits to the pull request description for things like: Changelog to be included with WooCommerce core, additional communication that might be needed elsewhere, additional marketing communication notes that may be needed etc.

--- a/.github/patch-initial-checklist.md
+++ b/.github/patch-initial-checklist.md
@@ -31,7 +31,7 @@ The release pull request has been created! This checklist is a guide to follow f
 * [ ] Ask the porter of Rubik and Kirigami to review the changes as well and to approve the PR if everything looks good. Each porter is responsible for testing the PRs that fall under the focus of their own team. Shared functionality should be tested by both porters. This means that the Rubik porter will mostly test Cart & Checkout changes while Kirigami porter will test the other blocks.
   * If all PRs are testing as expected, continue with the release.
   * If one or more PRs are not testing as expected: ping the PR authors and the porter of the relevant team and ask them if the change is a release blocker or not (you can also ping the team lead if any of them is not available). In general, if it's not a regression or there is no product/marketing reason why that PR is a blocker, all other PRs should default to not being blockers.
-    * If there are blockers: stop the release and ask the PR author and team porter to fix them.
+    * If there are blockers: stop the release and ask the PR author to fix them. If the PR author is AFK, ping the porter of their team.
     * If some PRs are not testing as expected but they are not blockers: revert the relevant commits, remove the changes from testing steps and changelog, open an issue (or reopen the original one) and proceed with the release.
 
 ## Update Pull Request description and get approvals

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,11 @@
 <!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
 
 <!-- Reference any related issues or PRs here -->
+
 Fixes #
 
 <!-- Don't forget to update the title with something descriptive. -->
-<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->
+<!-- If you can, add the appropriate labels -->
 
 #### Accessibility
 
@@ -17,12 +18,17 @@ Fixes #
 
 #### Other Checks
 
-- [ ] I've updated [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) for any feature flags or experimental interfaces implemented in this pull request.
+- [ ] This PR adds/removes a feature flag & I've updated [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) .
+- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md)
 - [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.
 
 ### Screenshots
 
 <!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->
+
+| Before | After |
+| ------ | ----- |
+|        |       |
 
 ### Testing
 
@@ -37,8 +43,11 @@ How to test the changes in this Pull Request:
 1.
 2.
 3.
+
 ### User Facing Testing
-These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
+
+<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->
+
 * [ ] Same as above, or
 * [ ] See steps below.
 
@@ -46,7 +55,15 @@ These are steps for user testing (where "user" is someone interacting with this 
 2.
 3.
 
-<!-- If you can, add the appropriate labels -->
+* [ ] Do not include in the Testing Notes
+
+### WooCommerce Visibility
+
+<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->
+
+* [ ] WooCommerce Core
+* [ ] Feature plugin
+* [ ] Experimental
 
 ### Performance Impact
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -36,20 +36,10 @@ Fixes #
 * [ ] Changes in this PR are covered by Automated Tests.
   * [ ] Unit tests
   * [ ] E2E tests
-### Manual Testing
 
-How to test the changes in this Pull Request:
-
-1.
-2.
-3.
-
-### User Facing Testing
+#### User Facing Testing
 
 <!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->
-
-* [ ] Same as above, or
-* [ ] See steps below.
 
 1.
 2.

--- a/.github/release-initial-checklist.md
+++ b/.github/release-initial-checklist.md
@@ -25,7 +25,6 @@ The release pull request has been created! This checklist is a guide to follow f
 * [ ] Copy a link to the release zip you created earlier into the testing notes. To generate the link you can upload the zip as an attachment in a GitHub comment and then just copy the path (without publishing the comment).
 * [ ] Commit and push the testing docs to the release branch.
 * [ ] Smoke test built release zip using the testing instructions you created:
-  * At least one other person should test the built zip - ping the current Rubik porter to be this person.
   * Test in a clean environment, e.g. Jurassic.Ninja site.
   * Test existing WooCommerce Blocks content works correctly after update (no block validation errors).
   * Test to confirm blocks are available and work correctly in oldest supported WordPress version (e.g. 5.3).
@@ -33,15 +32,15 @@ The release pull request has been created! This checklist is a guide to follow f
   * Test to confirm new features/fixes are working correctly.
   * Test any UI changes in mobile and desktop views.
   * Smoke test – test a cross section of core functionality.
-
-## Update Pull Request description and get approvals
-
-* [ ] Go through the description of the release pull request and edit it to update all the sections and checklist instructions there.
-* [ ] Ask the porter of Rubik and Kirigami to review the changes in the release pull request and to approve the PR if everything looks good. Each porter is responsible for testing the PRs that fall under the focus of their own team. Shared functionality should be tested by both porters. This means that the Rubik porter will mostly test Cart & Checkout changes while Kirigami porter will test the other blocks.
+* [ ] Ask the porter of Rubik and Kirigami to review the changes as well and to approve the PR if everything looks good. Each porter is responsible for testing the PRs that fall under the focus of their own team. Shared functionality should be tested by both porters. This means that the Rubik porter will mostly test Cart & Checkout changes while Kirigami porter will test the other blocks.
   * If all PRs are testing as expected, continue with the release.
   * If one or more PRs are not testing as expected: ping the PR authors and the porter of the relevant team and ask them if the change is a release blocker or not (you can also ping the team lead if any of them is not available). In general, if it's not a regression or there is no product/marketing reason why that PR is a blocker, all other PRs should default to not being blockers.
     * If there are blockers: stop the release and ask the PR author and team porter to fix them.
     * If some PRs are not testing as expected but they are not blockers: revert the relevant commits, remove the changes from testing steps and changelog, open an issue (or reopen the original one) and proceed with the release.
+
+## Update Pull Request description and get approvals
+
+* [ ] Go through the description of the release pull request and edit it to update all the sections and checklist instructions there.
 
 ## Ensure hub is set up and you're authenticated
 * [ ] Make sure you've got `hub` installed (`brew install hub`)

--- a/.github/release-initial-checklist.md
+++ b/.github/release-initial-checklist.md
@@ -35,7 +35,7 @@ The release pull request has been created! This checklist is a guide to follow f
 * [ ] Ask the porter of Rubik and Kirigami to review the changes as well and to approve the PR if everything looks good. Each porter is responsible for testing the PRs that fall under the focus of their own team. Shared functionality should be tested by both porters. This means that the Rubik porter will mostly test Cart & Checkout changes while Kirigami porter will test the other blocks.
   * If all PRs are testing as expected, continue with the release.
   * If one or more PRs are not testing as expected: ping the PR authors and the porter of the relevant team and ask them if the change is a release blocker or not (you can also ping the team lead if any of them is not available). In general, if it's not a regression or there is no product/marketing reason why that PR is a blocker, all other PRs should default to not being blockers.
-    * If there are blockers: stop the release and ask the PR author and team porter to fix them.
+    * If there are blockers: stop the release and ask the PR author to fix them. If the PR author is AFK, ping the porter of their team.
     * If some PRs are not testing as expected but they are not blockers: revert the relevant commits, remove the changes from testing steps and changelog, open an issue (or reopen the original one) and proceed with the release.
 
 ## Update Pull Request description and get approvals

--- a/.github/release-initial-checklist.md
+++ b/.github/release-initial-checklist.md
@@ -5,6 +5,7 @@ The release pull request has been created! This checklist is a guide to follow f
 ## Initial Preparation
 
 * [ ] Close the milestone of the release you are going to ship. That will prevent newly approved PRs to be automatically assigned to that milestone.
+* [ ] Create a milestone for the next version.
 * [ ] Add the changelog to `readme.txt`
   * [ ] Add the version and date to the changelog section within `readme.txt`, e.g. `= {{version}} - YYYY-MM-DD =`
   * [ ] Copy the changelog from the pull request description above into this new section

--- a/.github/release-initial-checklist.md
+++ b/.github/release-initial-checklist.md
@@ -44,7 +44,7 @@ Additionally, make sure to differentiate between things in the testing notes tha
   * If all PRs are testing as expected, continue with the release.
   * If one or more PRs are not testing as expected: ping the PR authors and the porter of the relevant team and ask them if the change is a release blocker or not (you can also ping the team lead if any of them is not available). In general, if it's not a regression or there is no product/marketing reason why that PR is a blocker, all other PRs should default to not being blockers.
     * If there are blockers: stop the release and ask the PR author and team porter to fix them.
-    * If some PRs are not testing as expected but they are not blockers: remove the from testing steps and changelog, open an issue (or reopen the original one) and proceed with the release.
+    * If some PRs are not testing as expected but they are not blockers: revert the relevant commits, remove the changes from testing steps and changelog, open an issue (or reopen the original one) and proceed with the release.
 
 ## Ensure hub is set up and you're authenticated
 * [ ] Make sure you've got `hub` installed (`brew install hub`)

--- a/.github/release-initial-checklist.md
+++ b/.github/release-initial-checklist.md
@@ -39,7 +39,7 @@ Each porter is responsible for testing the PRs that fall under the focus of thei
   * If one or more PRs are not testing as expected: ping the PR authors and the porter of the relevant team and ask them if the change is a release blocker or not (you can also ping the team lead if any of them is not available). In general, if it's not a regression or there is no product/marketing reason why that PR is a blocker, all other PRs should default to not being blockers.
     * If there are blockers: stop the release and ask the PR author to fix them. If the PR author is AFK, ping the porter of their team.
     * If some PRs are not testing as expected but they are not blockers: revert the relevant commits, remove the changes from testing steps and changelog, open an issue (or reopen the original one) and proceed with the release.
-    * If minor issues are discovered during the testing, each team is responsible for logging them in Github
+    * If minor issues are discovered during the testing, each team is responsible for logging them in Github.
 
 ## Update Pull Request description and get approvals
 

--- a/.github/release-initial-checklist.md
+++ b/.github/release-initial-checklist.md
@@ -39,6 +39,7 @@ Each porter is responsible for testing the PRs that fall under the focus of thei
   * If one or more PRs are not testing as expected: ping the PR authors and the porter of the relevant team and ask them if the change is a release blocker or not (you can also ping the team lead if any of them is not available). In general, if it's not a regression or there is no product/marketing reason why that PR is a blocker, all other PRs should default to not being blockers.
     * If there are blockers: stop the release and ask the PR author to fix them. If the PR author is AFK, ping the porter of their team.
     * If some PRs are not testing as expected but they are not blockers: revert the relevant commits, remove the changes from testing steps and changelog, open an issue (or reopen the original one) and proceed with the release.
+    * If minor issues are discovered during the testing, each team is responsible for logging them in Github
 
 ## Update Pull Request description and get approvals
 

--- a/.github/release-initial-checklist.md
+++ b/.github/release-initial-checklist.md
@@ -40,7 +40,11 @@ Additionally, make sure to differentiate between things in the testing notes tha
 ## Update Pull Request description and get approvals
 
 * [ ] Go through the description of the release pull request and edit it to update all the sections and checklist instructions there.
-* [ ] Ask a team member to review the changes in the release pull request and for anyone who has done testing that they approve the pull request.
+* [ ] Ask the porter of Rubik and Kirigami to review the changes in the release pull request and to approve the PR if everything looks good. The porter of each team is responsible for testing the PRs created by members of their own team. That means Rubik porter will mostly test Cart & Checkout changes while Kirigami porter will test other blocks.
+  * If all PRs are testing as expected, continue with the release.
+  * If one or more PRs are not testing as expected: ping the PR authors and the porter of the relevant team and ask them if the change is a release blocker or not (you can also ping the team lead if any of them is not available). In general, if it's not a regression or there is no product/marketing reason why that PR is a blocker, all other PRs should default to not being blockers.
+    * If there are blockers: stop the release and ask the PR author and team porter to fix them.
+    * If some PRs are not testing as expected but they are not blockers: remove the from testing steps and changelog, open an issue (or reopen the original one) and proceed with the release.
 
 ## Ensure hub is set up and you're authenticated
 * [ ] Make sure you've got `hub` installed (`brew install hub`)
@@ -85,19 +89,6 @@ Additionally, make sure to differentiate between things in the testing notes tha
   * [ ] Close the milestone.
   * [ ] Remove any unfinished issues from the Zenhub epics completed by this release and then close the epics.
 
-## Publish posts
-
-* [ ] Post release announcement on [WooCommerce Developer Blog](https://developer.woocommerce.com/category/release-post/woocommerce-blocks-release-notes/). Use previous posts for inspiration. If the release contains new features, or API changes, explain what's new so Woo devs/builders/merchants can get excited about it. This post can take time to get right - get feedback from the team, and don't rush it :)
-  - Ensure the release notes are included in the post verbatim.
-  - Don't forget to use category `WooCommerce Blocks Release Notes` for the post.
-* [ ] Announce the release internally (`#woo-announcements` slack).
-* [ ] Update user-facing documentation as needed. When the plugin is released, ensure user-facing documentation is kept up to date with new blocks and compatibility information. The dev team should update documents in collaboration with support team and WooCommerce docs guild. In particular, please review and update as needed:
-  - Are there any new blocks in this release? Ensure they have adequate user documentation.
-  - Ensure any major improvements or changes are documented.
-  - Update minimum supported versions (WordPress, WooCommerce Core) and other requirements where necessary, including:
-    - [WCCOM product page](https://woocommerce.com/products/woocommerce-gutenberg-products-block/)
-    - [WooCommerce blocks main documentation page](https://docs.woocommerce.com/document/woocommerce-blocks/)
-
 ## Pull request in WooCommerce Core for Package update
 
 This only needs to be done if this release is the last release of the feature plugin before code freeze in the WooCommerce core cycle. If this condition doesn't exist you can skip this section.
@@ -123,4 +114,16 @@ This only needs to be done if this release is the last release of the feature pl
   * After the checklist is complete and the testing is done, it will be up to the WooCommerce core team to approve and merge the pull request.
 * [ ] Make sure you join the `#woo-core-releases` Slack channel to represent Woo Blocks for the release of WooCommerce core this version is included in.
 
+## Publish posts
 
+* [ ] Post release announcement on [WooCommerce Developer Blog](https://developer.woocommerce.com/category/release-post/woocommerce-blocks-release-notes/).
+  - Ping porters from each team to know which changelog entries need to be highlighted. Ask them to write a short text and optionally provide a screenshot. They can use previous posts for inspiration, we usually try to highlight new features or API changes.
+  - Ensure the release notes are included in the post verbatim.
+  - Don't forget to use category `WooCommerce Blocks Release Notes` for the post.
+* [ ] Announce the release internally (`#woo-announcements` slack).
+* [ ] Update user-facing documentation as needed. When the plugin is released, ensure user-facing documentation is kept up to date with new blocks and compatibility information. The dev team should update documents in collaboration with support team and WooCommerce docs guild. In particular, please review and update as needed:
+  - Are there any new blocks in this release? Ensure they have adequate user documentation.
+  - Ensure any major improvements or changes are documented.
+  - Update minimum supported versions (WordPress, WooCommerce Core) and other requirements where necessary, including:
+    - [WCCOM product page](https://woocommerce.com/products/woocommerce-gutenberg-products-block/)
+    - [WooCommerce blocks main documentation page](https://docs.woocommerce.com/document/woocommerce-blocks/)

--- a/.github/release-initial-checklist.md
+++ b/.github/release-initial-checklist.md
@@ -34,7 +34,7 @@ The release pull request has been created! This checklist is a guide to follow f
   * Smoke test – test a cross section of core functionality.
 * [ ] Ask the porters of Rubik and Kirigami to test the built zip as well and to approve the PR if everything looks good.
 
-Each porter is responsible for testing the PRs that fall under the focus of their own team. Shared functionality should be tested by both porters. This means that the Rubik porter will mostly test Cart & Checkout changes while Kirigami porter will test the other blocks.
+Each porter is responsible for testing the PRs that fall under the focus of their own team. Shared functionality should be tested by both porters. This means that the Rubik porter will mostly test checkout blocks and Store API endpoints, while the Kirigami porter will test the product related blocks and Store API endpoints.
   * If all PRs are testing as expected, continue with the release.
   * If one or more PRs are not testing as expected: ping the PR authors and the porter of the relevant team and ask them if the change is a release blocker or not (you can also ping the team lead if any of them is not available). In general, if it's not a regression or there is no product/marketing reason why that PR is a blocker, all other PRs should default to not being blockers.
     * If there are blockers: stop the release and ask the PR author to fix them. If the PR author is AFK, ping the porter of their team.

--- a/.github/release-initial-checklist.md
+++ b/.github/release-initial-checklist.md
@@ -13,16 +13,13 @@ The release pull request has been created! This checklist is a guide to follow f
   * [ ] If necessary, update the `phpcs.xml` file to reference the minimum WP version supported by **WooCommerce Core**. It would be this line: `<config name="minimum_supported_wp_version" value="5.6" />`.
 * [ ] Push above changes to the release branch.
 
-## Write Testing Notes
-
-When creating testing notes, please write them from the perspective of a "user" (merchant) familiar with WooCommerce. So you don't have to spell out exact steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful.
-
-Additionally, make sure to differentiate between things in the testing notes that only apply to the feature plugin and things that apply when included in WooCommerce core as there may be variations there.
+## Create the Testing Notes
 
 * [ ] Run `npm ci`
 * [ ] Run `npm run package-plugin:deploy`. This will create a zip of the current branch build locally.
   *  Note: The zip file is functionally equivalent to what gets released except the version bump.
-* [ ] Create testing notes for the release. You can usually go through the pull requests linked in the changelog and grab testing notes from each pull.
+* [ ] Create the testing notes for the release. 
+  * [ ] For each pull request linked in the changelog grab the `User Facing Testing` notes from the PR's description. 
   * [ ] Add the notes to `docs/testing/releases`
   * [ ] Update the `docs/testing/releases/README.md` file index.
 * [ ] Copy a link to the release zip you created earlier into the testing notes. To generate the link you can upload the zip as an attachment in a GitHub comment and then just copy the path (without publishing the comment).
@@ -40,7 +37,7 @@ Additionally, make sure to differentiate between things in the testing notes tha
 ## Update Pull Request description and get approvals
 
 * [ ] Go through the description of the release pull request and edit it to update all the sections and checklist instructions there.
-* [ ] Ask the porter of Rubik and Kirigami to review the changes in the release pull request and to approve the PR if everything looks good. The porter of each team is responsible for testing the PRs created by members of their own team. That means Rubik porter will mostly test Cart & Checkout changes while Kirigami porter will test other blocks.
+* [ ] Ask the porter of Rubik and Kirigami to review the changes in the release pull request and to approve the PR if everything looks good. Each porter is responsible for testing the PRs that fall under the focus of their own team. Shared functionality should be tested by both porters. This means that the Rubik porter will mostly test Cart & Checkout changes while Kirigami porter will test the other blocks.
   * If all PRs are testing as expected, continue with the release.
   * If one or more PRs are not testing as expected: ping the PR authors and the porter of the relevant team and ask them if the change is a release blocker or not (you can also ping the team lead if any of them is not available). In general, if it's not a regression or there is no product/marketing reason why that PR is a blocker, all other PRs should default to not being blockers.
     * If there are blockers: stop the release and ask the PR author and team porter to fix them.
@@ -97,7 +94,7 @@ This only needs to be done if this release is the last release of the feature pl
 * [ ] Create a pull request for updating the package in the [WooCommerce Core Repository](https://github.com/woocommerce/woocommerce/) that [bumps the package version](https://github.com/woocommerce/woocommerce/blob/747cb6b7184ba9fdc875ab104da5839cfda8b4be/plugins/woocommerce/composer.json) for the Woo Blocks package to the version being pulled in.
   * The content for the pull release can follow [this example](https://github.com/woocommerce/woocommerce/pull/32627). 
      * In the PR description you will link to all the important things that have already been prepared since the version you replaced. Note, you need to make sure you link to all the related documents for the plugin releases since the last package version bump in Woo Core.
-     * Please add a changelog to the content which is aggregated from all the releases included in the package bump. The changelog should only list things surfaced to users of the package in WooCommerce core (i.e. excluding things only available in the feature plugin or development builds). This changelog will be used in the release notes for the WooCommerce release.  
+     * The PR's changelog should be aggregated from all the releases included in the package bump. This changelog will be used in the release notes for the WooCommerce release. That's why it should only list the PRs that have WooCoomerce Core in the WooCommerce Visibility section of their description. Don't include changes available in the feature plugin or development builds.
       * Update the `plugins/woocommerce/composer.json` file and then run `composer update`. 
 
       * Since WooCommerce Blocks 7.4.0, the changelog entry for WooCommerce core must include the fields `Significance` and `Type`. In our case, we're using the following definition as seen on [plugins/woocommerce/changelog/update-woocommerce-blocks-7.4.0](https://github.com/woocommerce/woocommerce/pull/32627/commits/99bf4afd262280ad4e45386ce4ad00ce3425af93) file:

--- a/.github/release-initial-checklist.md
+++ b/.github/release-initial-checklist.md
@@ -3,6 +3,8 @@ The release pull request has been created! This checklist is a guide to follow f
 * [ ] Checkout the release branch locally.
 
 ## Initial Preparation
+
+* [ ] Close the milestone of the release you are going to ship. That will prevent newly approved PRs to be automatically assigned to that milestone.
 * [ ] Add the changelog to `readme.txt`
   * [ ] Add the version and date to the changelog section within `readme.txt`, e.g. `= {{version}} - YYYY-MM-DD =`
   * [ ] Copy the changelog from the pull request description above into this new section
@@ -83,10 +85,7 @@ Each porter is responsible for testing the PRs that fall under the focus of thei
     * [ ] `src/Package.php`
     * [ ] `woocommerce-gutenberg-products-block.php`.
 * [ ] Update the schedules p2 with the shipped date for the release (Pca54o-1N-p2).
-* [ ] Clean up the release milestone and Zenhub.
-  * [ ] Edit the [GitHub milestone](https://github.com/woocommerce/woocommerce-gutenberg-products-block/milestones) and add the current date as the due date (this is used to track ship date as well).
-  * [ ] Close the milestone.
-  * [ ] Remove any unfinished issues from the Zenhub epics completed by this release and then close the epics.
+* [ ] Edit the GitHub milestone of the release you just shipped and add the current date as the due date (this is used to track ship date as well).
 
 ## Pull request in WooCommerce Core for Package update
 

--- a/.github/release-initial-checklist.md
+++ b/.github/release-initial-checklist.md
@@ -32,7 +32,9 @@ The release pull request has been created! This checklist is a guide to follow f
   * Test to confirm new features/fixes are working correctly.
   * Test any UI changes in mobile and desktop views.
   * Smoke test – test a cross section of core functionality.
-* [ ] Ask the porter of Rubik and Kirigami to review the changes as well and to approve the PR if everything looks good. Each porter is responsible for testing the PRs that fall under the focus of their own team. Shared functionality should be tested by both porters. This means that the Rubik porter will mostly test Cart & Checkout changes while Kirigami porter will test the other blocks.
+* [ ] Ask the porters of Rubik and Kirigami to test the built zip as well and to approve the PR if everything looks good.
+
+Each porter is responsible for testing the PRs that fall under the focus of their own team. Shared functionality should be tested by both porters. This means that the Rubik porter will mostly test Cart & Checkout changes while Kirigami porter will test the other blocks.
   * If all PRs are testing as expected, continue with the release.
   * If one or more PRs are not testing as expected: ping the PR authors and the porter of the relevant team and ask them if the change is a release blocker or not (you can also ping the team lead if any of them is not available). In general, if it's not a regression or there is no product/marketing reason why that PR is a blocker, all other PRs should default to not being blockers.
     * If there are blockers: stop the release and ask the PR author to fix them. If the PR author is AFK, ping the porter of their team.


### PR DESCRIPTION
This PR introduces several changes to the release checklist:

* States that release leads should ask porters from both teams to test the release.
* Gives some steps to proceed when PRs are not working as expected.
* _Publish Posts_ section has been moved to the bottom of the process. So it's more clear that this step doesn't block creating the PR in WC core.
* Mentions that porters are responsible of providing the release lead with the highlights of the changes their team has introduced in that release.

In general, this PR reduces the amount of work the release lead needs to do with the con of introducing some more work for porters. The rationale is that porters from each team are more aware of what their team is working on, so for them it's easier to test and provide release post insights than it is for the release leads.