### PR TITLE
Fix attribute filter dropdown list z-index level

### DIFF
--- a/assets/js/base/components/dropdown-selector/style.scss
+++ b/assets/js/base/components/dropdown-selector/style.scss
@@ -147,7 +147,7 @@ $dropdown-selector-line-height: math.div(18, 14);
 	top: 100%;
 	max-height: 300px;
 	overflow-y: auto;
-	z-index: 1;
+	z-index: 10;
 
 	&:not(:empty) {
 		border: 1px solid #9f9f9f;


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
Updated z-index on the `.wc-block-components-dropdown-selector__list` to `10` so that it doesns't conflict with basic elements of other blocks like: 
- sale badge
- all products placeholder items

<!-- Reference any related issues or PRs here -->
Fixes #5731

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)


<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### Manual Testing

How to test the changes in this Pull Request:

1. Create new page with Filter Products by Attribute and All Products block right under
2. Configure Filter block to use Dropdown display style and show Colour attribute (if using sample products)
3. Have products on sale in first row
4. Visit page and focus on field to see dropdown

- All Products block Placeholder elements should be under the dropdown
- Sale badge shouldn't bleed through the dropdown

(see the issue)
