### PR TITLE
Fix: Make Active Filters work with PHP templates

### DIFF
--- a/assets/js/blocks/active-filters/active-attribute-filters.js
+++ b/assets/js/blocks/active-filters/active-attribute-filters.js
@@ -7,7 +7,8 @@ import {
 } from '@woocommerce/base-context/hooks';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
-import { getSetting } from '@woocommerce/settings';
+import { getSettingWithCoercion } from '@woocommerce/settings';
+import { isBoolean } from '@woocommerce/types';
 
 /**
  * Internal dependencies
@@ -47,9 +48,10 @@ const ActiveAttributeFilters = ( {
 
 	const attributeLabel = attributeObject.label;
 
-	const filteringForPhpTemplate = getSetting(
+	const filteringForPhpTemplate = getSettingWithCoercion(
 		'is_rendering_php_template',
-		false
+		false,
+		isBoolean
 	);
 
 	return (

--- a/assets/js/blocks/active-filters/block.js
+++ b/assets/js/blocks/active-filters/block.js
@@ -14,7 +14,11 @@ import Label from '@woocommerce/base-components/label';
  */
 import './style.scss';
 import { getAttributeFromTaxonomy } from '../../utils/attributes';
-import { formatPriceRange, renderRemovableListItem } from './utils';
+import {
+	formatPriceRange,
+	renderRemovableListItem,
+	removeArgsFromFilterUrl,
+} from './utils';
 import ActiveAttributeFilters from './active-attribute-filters';
 
 /**
@@ -28,6 +32,10 @@ const ActiveFiltersBlock = ( {
 	attributes: blockAttributes,
 	isEditor = false,
 } ) => {
+	const filteringForPhpTemplate = getSetting(
+		'is_rendering_php_template',
+		false
+	);
 	const [ productAttributes, setProductAttributes ] = useQueryStateByKey(
 		'attributes',
 		[]
@@ -47,6 +55,11 @@ const ActiveFiltersBlock = ( {
 					type: __( 'Stock Status', 'woo-gutenberg-products-block' ),
 					name: STOCK_STATUS_OPTIONS[ slug ],
 					removeCallback: () => {
+						if ( filteringForPhpTemplate ) {
+							return removeArgsFromFilterUrl( {
+								filter_stock_status: slug,
+							} );
+						}
 						const newStatuses = productStockStatus.filter(
 							( status ) => {
 								return status !== slug;
@@ -63,6 +76,7 @@ const ActiveFiltersBlock = ( {
 		productStockStatus,
 		setProductStockStatus,
 		blockAttributes.displayStyle,
+		filteringForPhpTemplate,
 	] );
 
 	const activePriceFilters = useMemo( () => {
@@ -73,6 +87,9 @@ const ActiveFiltersBlock = ( {
 			type: __( 'Price', 'woo-gutenberg-products-block' ),
 			name: formatPriceRange( minPrice, maxPrice ),
 			removeCallback: () => {
+				if ( filteringForPhpTemplate ) {
+					return removeArgsFromFilterUrl( 'max_price', 'min_price' );
+				}
 				setMinPrice( undefined );
 				setMaxPrice( undefined );
 			},
@@ -84,6 +101,7 @@ const ActiveFiltersBlock = ( {
 		blockAttributes.displayStyle,
 		setMinPrice,
 		setMaxPrice,
+		filteringForPhpTemplate,
 	] );
 
 	const activeAttributeFilters = useMemo( () => {

--- a/assets/js/blocks/active-filters/block.js
+++ b/assets/js/blocks/active-filters/block.js
@@ -19,6 +19,7 @@ import {
 	formatPriceRange,
 	renderRemovableListItem,
 	removeArgsFromFilterUrl,
+	getBaseUrl,
 } from './utils';
 import ActiveAttributeFilters from './active-attribute-filters';
 
@@ -187,6 +188,10 @@ const ActiveFiltersBlock = ( {
 				<button
 					className="wc-block-active-filters__clear-all"
 					onClick={ () => {
+						if ( filteringForPhpTemplate ) {
+							window.location.href = getBaseUrl();
+							return;
+						}
 						setMinPrice( undefined );
 						setMaxPrice( undefined );
 						setProductAttributes( [] );

--- a/assets/js/blocks/active-filters/block.js
+++ b/assets/js/blocks/active-filters/block.js
@@ -3,11 +3,12 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useQueryStateByKey } from '@woocommerce/base-context/hooks';
-import { getSetting } from '@woocommerce/settings';
+import { getSetting, getSettingWithCoercion } from '@woocommerce/settings';
 import { useMemo } from '@wordpress/element';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import Label from '@woocommerce/base-components/label';
+import { isBoolean } from '@woocommerce/types';
 
 /**
  * Internal dependencies
@@ -32,9 +33,10 @@ const ActiveFiltersBlock = ( {
 	attributes: blockAttributes,
 	isEditor = false,
 } ) => {
-	const filteringForPhpTemplate = getSetting(
+	const filteringForPhpTemplate = getSettingWithCoercion(
 		'is_rendering_php_template',
-		false
+		false,
+		isBoolean
 	);
 	const [ productAttributes, setProductAttributes ] = useQueryStateByKey(
 		'attributes',

--- a/assets/js/blocks/active-filters/utils.js
+++ b/assets/js/blocks/active-filters/utils.js
@@ -147,10 +147,6 @@ export const renderRemovableListItem = ( {
  * @param {Array<string|Record<string, string>>} args Args to remove
  */
 export const removeArgsFromFilterUrl = ( ...args ) => {
-	if ( ! window ) {
-		return null;
-	}
-
 	const url = window.location.href;
 	const currentQuery = getQueryArgs( url );
 	const cleanUrl = removeQueryArgs( url, ...Object.keys( currentQuery ) );
@@ -173,4 +169,20 @@ export const removeArgsFromFilterUrl = ( ...args ) => {
 	);
 
 	window.location.href = addQueryArgs( cleanUrl, filteredQuery );
+};
+
+/**
+ * Get the base URL for the current page.
+ *
+ * @return {string} The current URL without the query args.
+ */
+export const getBaseUrl = () => {
+	const url = window.location.href;
+
+	const queryStringIndex = url.indexOf( '?' );
+	if ( queryStringIndex === -1 ) {
+		return url;
+	}
+
+	return url.substring( 0, queryStringIndex );
 };

--- a/assets/js/blocks/active-filters/utils.js
+++ b/assets/js/blocks/active-filters/utils.js
@@ -5,6 +5,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { formatPrice } from '@woocommerce/price-format';
 import { RemovableChip } from '@woocommerce/base-components/chip';
 import Label from '@woocommerce/base-components/label';
+import { getQueryArgs, addQueryArgs, removeQueryArgs } from '@wordpress/url';
 
 /**
  * Format a min/max price range to display.
@@ -137,4 +138,39 @@ export const renderRemovableListItem = ( {
 			) }
 		</li>
 	);
+};
+
+/**
+ * Update the current URL to update or remove provided query arguments.
+ *
+ *
+ * @param {Array<string|Record<string, string>>} args Args to remove
+ */
+export const removeArgsFromFilterUrl = ( ...args ) => {
+	if ( ! window ) {
+		return null;
+	}
+
+	const url = window.location.href;
+	const currentQuery = getQueryArgs( url );
+	const cleanUrl = removeQueryArgs( url, ...Object.keys( currentQuery ) );
+
+	args.forEach( ( item ) => {
+		if ( typeof item === 'string' ) {
+			return delete currentQuery[ item ];
+		}
+		if ( typeof item === 'object' ) {
+			const key = Object.keys( item )[ 0 ];
+			const currentQueryValue = currentQuery[ key ].split( ',' );
+			currentQuery[ key ] = currentQueryValue
+				.filter( ( value ) => value !== item[ key ] )
+				.join( ',' );
+		}
+	} );
+
+	const filteredQuery = Object.fromEntries(
+		Object.entries( currentQuery ).filter( ( [ , value ] ) => value )
+	);
+
+	window.location.href = addQueryArgs( cleanUrl, filteredQuery );
 };

--- a/assets/js/blocks/attribute-filter/block.js
+++ b/assets/js/blocks/attribute-filter/block.js
@@ -46,8 +46,8 @@ import {
 /**
  * Formats filter values into a string for the URL parameters needed for filtering PHP templates.
  *
- * @param {string} url Current page URL.
- * @param {Array} params Parameters and their constraints.
+ * @param {string} url    Current page URL.
+ * @param {Array}  params Parameters and their constraints.
  *
  * @return {string} New URL with query parameters in it.
  */
@@ -226,7 +226,7 @@ const AttributeFilterBlock = ( {
 	/**
 	 * Appends query params to the current pages URL and redirects them to the new URL for PHP rendered templates.
 	 *
-	 * @param {Object} query The object containing the active filter query.
+	 * @param {Object}  query             The object containing the active filter query.
 	 * @param {boolean} allFiltersRemoved If there are active filters or not.
 	 */
 	const redirectPageForPhpTemplate = useCallback(
@@ -471,7 +471,8 @@ const AttributeFilterBlock = ( {
 	useEffect( () => {
 		if ( filteringForPhpTemplate ) {
 			const activeFilters = getActiveFilters(
-				filteringForPhpTemplate, attributeObject
+				filteringForPhpTemplate,
+				attributeObject
 			);
 			if (
 				activeFilters.length > 0 &&

--- a/assets/js/blocks/stock-filter/block.js
+++ b/assets/js/blocks/stock-filter/block.js
@@ -243,12 +243,8 @@ const StockStatusFilterBlock = ( {
 	useEffect( () => {
 		if ( filteringForPhpTemplate ) {
 			setChecked( checked );
-			// Only automatically redirect if the filter button is not active.
-			if ( ! blockAttributes.showFilterButton ) {
-				redirectPageForPhpTemplate( checked );
-			}
 		}
-	}, [ filteringForPhpTemplate, checked, blockAttributes.showFilterButton ] );
+	}, [ filteringForPhpTemplate, checked ] );
 
 	/**
 	 * Important: For PHP rendered block templates only.


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #6138

This PR makes the Active Filters work with PHP templates. The idea is to update the current URL to remove the corresponding argument when users remove it from the Active Filters Block.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. With a block theme, go to Edit Site > Product Catalog.
2. Add `Active Product Filters`, `Filter Products by Stock`, `Filter Products by Attribute`, `Filter Products by Price` blocks to the template.
3. Go to the shop page on the front end.
4. Select some filters, see the page reload and the selected filters appear in the Active Products Filters block.
5. Remove an arbitrary filter, see the page reload and the removed filter doesn't appear in the Active Product Filters block. See the filtered product results updates accordingly.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
* [ ] See steps below.

### Changelog

> Add PHP templates support to the Active Product Filters block.
