### PR TITLE
Attribute Filter: Fix ESLint errors and warnings

### DIFF
--- a/assets/js/blocks/attribute-filter/block.js
+++ b/assets/js/blocks/attribute-filter/block.js
@@ -46,10 +46,10 @@ import {
 /**
  * Formats filter values into a string for the URL parameters needed for filtering PHP templates.
  *
- * @param {string} url Current page URL.
- * @param {Array} params Parameters and their constraints.
+ * @param  {string} url    Current page URL.
+ * @param  {Array}  params Parameters and their constraints.
  *
- * @return {string} New URL with query parameters in it.
+ * @return {string}        New URL with query parameters in it.
  */
 
 /**
@@ -226,7 +226,7 @@ const AttributeFilterBlock = ( {
 	/**
 	 * Appends query params to the current pages URL and redirects them to the new URL for PHP rendered templates.
 	 *
-	 * @param {Object} query The object containing the active filter query.
+	 * @param {Object}  query             The object containing the active filter query.
 	 * @param {boolean} allFiltersRemoved If there are active filters or not.
 	 */
 	const redirectPageForPhpTemplate = useCallback(
@@ -471,7 +471,8 @@ const AttributeFilterBlock = ( {
 	useEffect( () => {
 		if ( filteringForPhpTemplate ) {
 			const activeFilters = getActiveFilters(
-				filteringForPhpTemplate, attributeObject
+				filteringForPhpTemplate,
+				attributeObject
 			);
 			if (
 				activeFilters.length > 0 &&


### PR DESCRIPTION
Fixing some ESLint errors and warnings in the Attribute Filter block.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

### Manual Testing

How to test the changes in this Pull Request:

Optional regression testing of the block as no logic has been changed:

1. Add Attribute Filter block to a WooCommerce Product Catalog template via the Site Editor using a Block Theme.
2. Check that checking the filters reloads the page and filters the products accordingly.
3. Check that adding the Attribute Filter block to a page using the All Products block does the same without reloading the page.
