### PR TITLE
GridContentControl: Add product image control

### DIFF
--- a/assets/js/blocks/handpicked-products/index.js
+++ b/assets/js/blocks/handpicked-products/index.js
@@ -70,6 +70,7 @@ registerBlockType( 'woocommerce/handpicked-products', {
 		contentVisibility: {
 			type: 'object',
 			default: {
+				image: true,
 				title: true,
 				price: true,
 				rating: true,

--- a/assets/js/blocks/product-tag/index.js
+++ b/assets/js/blocks/product-tag/index.js
@@ -71,6 +71,7 @@ registerBlockType( 'woocommerce/product-tag', {
 		contentVisibility: {
 			type: 'object',
 			default: {
+				image: true,
 				title: true,
 				price: true,
 				rating: true,

--- a/assets/js/blocks/products-by-attribute/index.js
+++ b/assets/js/blocks/products-by-attribute/index.js
@@ -78,6 +78,7 @@ registerBlockType( blockTypeName, {
 		contentVisibility: {
 			type: 'object',
 			default: {
+				image: true,
 				title: true,
 				price: true,
 				rating: true,

--- a/assets/js/editor-components/grid-content-control/index.js
+++ b/assets/js/editor-components/grid-content-control/index.js
@@ -13,9 +13,25 @@ import { ToggleControl } from '@wordpress/components';
  * @param {Object}            props.settings
  */
 const GridContentControl = ( { onChange, settings } ) => {
-	const { button, price, rating, title } = settings;
+	const { image, button, price, rating, title } = settings;
 	return (
 		<>
+			<ToggleControl
+				label={ __( 'Product image', 'woo-gutenberg-products-block' ) }
+				help={
+					image
+						? __(
+								'Product image is visible.',
+								'woo-gutenberg-products-block'
+						  )
+						: __(
+								'Product image is hidden.',
+								'woo-gutenberg-products-block'
+						  )
+				}
+				checked={ image }
+				onChange={ () => onChange( { ...settings, image: ! image } ) }
+			/>
 			<ToggleControl
 				label={ __( 'Product title', 'woo-gutenberg-products-block' ) }
 				help={
@@ -92,6 +108,7 @@ GridContentControl.propTypes = {
 	 * The current title visibility.
 	 */
 	settings: PropTypes.shape( {
+		image: PropTypes.bool.isRequired,
 		button: PropTypes.bool.isRequired,
 		price: PropTypes.bool.isRequired,
 		rating: PropTypes.bool.isRequired,

--- a/assets/js/utils/shared-attributes.js
+++ b/assets/js/utils/shared-attributes.js
@@ -58,6 +58,7 @@ export default {
 	contentVisibility: {
 		type: 'object',
 		default: {
+			image: true,
 			title: true,
 			price: true,
 			rating: true,

--- a/src/BlockTypes/AbstractProductGrid.php
+++ b/src/BlockTypes/AbstractProductGrid.php
@@ -131,6 +131,7 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 		return array(
 			'type'       => 'object',
 			'properties' => array(
+				'image'  => $this->get_schema_boolean( true ),
 				'title'  => $this->get_schema_boolean( true ),
 				'price'  => $this->get_schema_boolean( true ),
 				'rating' => $this->get_schema_boolean( true ),
@@ -167,6 +168,7 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 			'categories'        => array(),
 			'catOperator'       => 'any',
 			'contentVisibility' => array(
+				'image'  => true,
 				'title'  => true,
 				'price'  => true,
 				'rating' => true,
@@ -517,6 +519,9 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 	 * @return string
 	 */
 	protected function get_image_html( $product ) {
+		if ( empty( $this->attributes['contentVisibility']['image'] ) ) {
+			return '';
+		}
 
 		$attr = array(
 			'alt' => '',


### PR DESCRIPTION
This PR adds the **Product image** control to all blocks utilizing `GridContentControl`, and those specifically are:
- Hand-picked Products
- Products by Tag
- Products by Attribute
- Products by Category
- Best Selling Products
- Newest Products
- On Sale Products
- Top Rated Products

Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/6064

### Screenshots
|Before|After|
|-|-|
|![Edit_Page_“Hand-picked_products”_‹_kirigami_—_WordPress-2](https://user-images.githubusercontent.com/905781/164820578-3faa7f80-a23a-4a6c-aed1-edff4f4eedeb.jpg)|![Edit_Page_“Hand-picked_products”_‹_kirigami_—_WordPress](https://user-images.githubusercontent.com/905781/164822527-5228978d-943d-4805-8c06-6700daab5545.jpg)|

### Manual Testing

How to test the changes in this Pull Request:

1. Activate a **block** theme, like Twenty Twenty Two
2. Create a new page, and add all the aforementioned, affected blocks (Handpicked Products etc.)
3. Check if the **Product image** toggle is present under **Content**
4. Verify that the toggle shows/hides product Images both in the editor and the frontend

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [ ] Same as above
