### PR TITLE
Add new `alt` attribute to the `Featured Product` media settings

### DIFF
--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -359,7 +359,7 @@ const FeaturedProduct = ( {
 													) }
 												</ExternalLink>
 												{ __(
-													'Leave empty if the image is purely decorative.',
+													'Leaving it empty will use the product name.',
 													'woo-gutenberg-products-block'
 												) }
 											</>

--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -347,8 +347,8 @@ const FeaturedProduct = ( {
 											'woo-gutenberg-products-block'
 										) }
 										value={ attributes.alt }
-										onChange={ ( newAlt ) => {
-											setAttributes( { alt: newAlt } );
+										onChange={ ( alt ) => {
+											setAttributes( { alt } );
 										} }
 										help={
 											<>

--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -19,12 +19,14 @@ import {
 import { withSelect } from '@wordpress/data';
 import {
 	Button,
+	ExternalLink,
 	FocalPointPicker,
 	PanelBody,
 	Placeholder,
 	RangeControl,
 	ResizableBox,
 	Spinner,
+	TextareaControl,
 	ToggleControl,
 	ToolbarGroup,
 	withSpokenMessages,
@@ -337,6 +339,30 @@ const FeaturedProduct = ( {
 											setAttributes( {
 												focalPoint: value,
 											} )
+										}
+									/>
+									<TextareaControl
+										label={ __(
+											'Alt text (alternative text)',
+											'woo-gutenberg-products-block'
+										) }
+										value={ attributes.alt }
+										onChange={ ( newAlt ) => {
+											setAttributes( { alt: newAlt } );
+										} }
+										help={
+											<>
+												<ExternalLink href="https://www.w3.org/WAI/tutorials/images/decision-tree">
+													{ __(
+														'Describe the purpose of the image',
+														'woo-gutenberg-products-block'
+													) }
+												</ExternalLink>
+												{ __(
+													'Leave empty if the image is purely decorative.',
+													'woo-gutenberg-products-block'
+												) }
+											</>
 										}
 									/>
 								</PanelBody>

--- a/assets/js/blocks/featured-product/example.js
+++ b/assets/js/blocks/featured-product/example.js
@@ -6,6 +6,7 @@ import { previewProducts } from '@woocommerce/resource-previews';
 
 export const example = {
 	attributes: {
+		alt: '',
 		contentAlign: 'center',
 		dimRatio: 50,
 		editMode: false,

--- a/assets/js/blocks/featured-product/index.js
+++ b/assets/js/blocks/featured-product/index.js
@@ -66,6 +66,10 @@ registerBlockType( 'woocommerce/featured-product', {
 	},
 	example,
 	attributes: {
+		alt: {
+			type: 'string',
+			default: '',
+		},
 		/**
 		 * Alignment of content inside block.
 		 */

--- a/src/BlockTypes/FeaturedProduct.php
+++ b/src/BlockTypes/FeaturedProduct.php
@@ -147,7 +147,7 @@ class FeaturedProduct extends AbstractDynamicBlock {
 		if ( ! empty( $image ) ) {
 			return sprintf(
 				'<img alt="%1$s" class="wc-block-featured-product__background-image" src="%2$s" style="%3$s" />',
-				wp_kses_post( $attributes['alt'] ?? $product->get_short_description() ),
+				wp_kses_post( $attributes['alt'] ?? $product->get_name() ),
 				esc_url( $image ),
 				$style
 			);

--- a/src/BlockTypes/FeaturedProduct.php
+++ b/src/BlockTypes/FeaturedProduct.php
@@ -147,7 +147,7 @@ class FeaturedProduct extends AbstractDynamicBlock {
 		if ( ! empty( $image ) ) {
 			return sprintf(
 				'<img alt="%1$s" class="wc-block-featured-product__background-image" src="%2$s" style="%3$s" />',
-				wp_kses_post( $product->get_short_description() ),
+				wp_kses_post( $attributes['alt'] ?? $product->get_short_description() ),
 				esc_url( $image ),
 				$style
 			);


### PR DESCRIPTION
This PR allows defining an `alt` text for the `Featured Product` block image.

Fixes part of https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/6235

### Testing

How to test the changes in this Pull Request:

1. Create a new page and add a `Featured Product`.
2. On the block settings go to `Media Settings` and check the `Alt text` textarea appears empty.
3. Add an `alt` text, save the block and check it renders on the frontend with the specified `alt` text.
4. Edit the block again, remove the `alt` text and save it.
5. Check the `alt` rendered on the frontend corresponds to the product name.

### Changelog

> Add the alt text control to the Featured Product block media settings
