### PR TITLE
Active Filters block: Clear All button work with all types of permalink settings.

### DIFF
--- a/assets/js/blocks/active-filters/block.js
+++ b/assets/js/blocks/active-filters/block.js
@@ -19,7 +19,7 @@ import {
 	formatPriceRange,
 	renderRemovableListItem,
 	removeArgsFromFilterUrl,
-	getBaseUrl,
+	cleanFilterUrl,
 } from './utils';
 import ActiveAttributeFilters from './active-attribute-filters';
 
@@ -189,8 +189,7 @@ const ActiveFiltersBlock = ( {
 					className="wc-block-active-filters__clear-all"
 					onClick={ () => {
 						if ( filteringForPhpTemplate ) {
-							window.location.href = getBaseUrl();
-							return;
+							return cleanFilterUrl();
 						}
 						setMinPrice( undefined );
 						setMaxPrice( undefined );

--- a/assets/js/blocks/active-filters/utils.js
+++ b/assets/js/blocks/active-filters/utils.js
@@ -172,17 +172,28 @@ export const removeArgsFromFilterUrl = ( ...args ) => {
 };
 
 /**
- * Get the base URL for the current page.
- *
- * @return {string} The current URL without the query args.
+ * Clean the filter URL.
  */
-export const getBaseUrl = () => {
+export const cleanFilterUrl = () => {
 	const url = window.location.href;
+	const args = getQueryArgs( url );
+	const cleanUrl = removeQueryArgs( url, ...Object.keys( args ) );
+	const remainingArgs = Object.fromEntries(
+		Object.keys( args )
+			.filter( ( arg ) => {
+				if (
+					arg.includes( 'min_price' ) ||
+					arg.includes( 'max_price' ) ||
+					arg.includes( 'filter_' ) ||
+					arg.includes( 'query_type_' )
+				) {
+					return false;
+				}
 
-	const queryStringIndex = url.indexOf( '?' );
-	if ( queryStringIndex === -1 ) {
-		return url;
-	}
+				return true;
+			} )
+			.map( ( key ) => [ key, args[ key ] ] )
+	);
 
-	return url.substring( 0, queryStringIndex );
+	window.location.href = addQueryArgs( cleanUrl, remainingArgs );
 };


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #6306 

This PR updates the Clear All button to not simply redirector to the base URL. Instead, the Clear All button now removes only query args related to product filters. This makes the Clear All button work with plain URLs.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

0. Set the permalink to `Plain`.
1. With a block theme, edit the Product Catalog template.
2. Add Active Filters, Filter Products by Stock, Filter Products by Attribute, and Filter Products by Price blocks to the page.
3. Go to the shop page on the front end, and choose a filter for each filter block. Ensure all type of filter appears in the Active Filters block.
4. Click the Clear All button.
5. See the page redirect to the shop page <= which is the correct behaivor.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
* [ ] See steps below.