### PR TITLE
Active Filters block: support Filter Products by Rating widget

### DIFF
--- a/assets/js/blocks/active-filters/block.js
+++ b/assets/js/blocks/active-filters/block.js
@@ -1,14 +1,15 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useQueryStateByKey } from '@woocommerce/base-context/hooks';
 import { getSetting, getSettingWithCoercion } from '@woocommerce/settings';
-import { useMemo } from '@wordpress/element';
+import { useMemo, useEffect } from '@wordpress/element';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import Label from '@woocommerce/base-components/label';
 import { isBoolean } from '@woocommerce/types';
+import { getUrlParameter } from '@woocommerce/utils';
 
 /**
  * Internal dependencies
@@ -124,10 +125,74 @@ const ActiveFiltersBlock = ( {
 		} );
 	}, [ productAttributes, blockAttributes.displayStyle ] );
 
+	const [ productRatings, setProductRatings ] = useQueryStateByKey(
+		'rating'
+	);
+
+	/**
+	 * Parse the filter URL to set the active rating fitlers.
+	 * This code should be moved to Rating Filter block once it's implemented.
+	 */
+	useEffect( () => {
+		if ( ! filteringForPhpTemplate ) {
+			return;
+		}
+
+		if ( productRatings.length && productRatings.length > 0 ) {
+			return;
+		}
+
+		const currentRatings = getUrlParameter( 'rating_filter' )?.toString();
+
+		if ( ! currentRatings ) {
+			return;
+		}
+
+		setProductRatings( currentRatings.split( ',' ) );
+	}, [ filteringForPhpTemplate, productRatings, setProductRatings ] );
+
+	const activeRatingFilters = useMemo( () => {
+		if ( productRatings.length > 0 ) {
+			return productRatings.map( ( slug ) => {
+				return renderRemovableListItem( {
+					type: __( 'Rating', 'woo-gutenberg-products-block' ),
+					name: sprintf(
+						/* translators: %s is referring to the average rating value */
+						__(
+							'Rated %s out of 5',
+							'woo-gutenberg-products-block'
+						),
+						slug
+					),
+					removeCallback: () => {
+						if ( filteringForPhpTemplate ) {
+							return removeArgsFromFilterUrl( {
+								rating_filter: slug,
+							} );
+						}
+						const newRatings = productRatings.filter(
+							( rating ) => {
+								return rating !== slug;
+							}
+						);
+						setProductRatings( newRatings );
+					},
+					displayStyle: blockAttributes.displayStyle,
+				} );
+			} );
+		}
+	}, [
+		productRatings,
+		setProductRatings,
+		blockAttributes.displayStyle,
+		filteringForPhpTemplate,
+	] );
+
 	const hasFilters = () => {
 		return (
 			productAttributes.length > 0 ||
 			productStockStatus.length > 0 ||
+			productRatings.length > 0 ||
 			Number.isFinite( minPrice ) ||
 			Number.isFinite( maxPrice )
 		);
@@ -182,6 +247,7 @@ const ActiveFiltersBlock = ( {
 							{ activePriceFilters }
 							{ activeStockStatusFilters }
 							{ activeAttributeFilters }
+							{ activeRatingFilters }
 						</>
 					) }
 				</ul>

--- a/assets/js/blocks/active-filters/block.js
+++ b/assets/js/blocks/active-filters/block.js
@@ -126,7 +126,7 @@ const ActiveFiltersBlock = ( {
 	}, [ productAttributes, blockAttributes.displayStyle ] );
 
 	const [ productRatings, setProductRatings ] = useQueryStateByKey(
-		'rating'
+		'ratings'
 	);
 
 	/**

--- a/assets/js/blocks/active-filters/utils.js
+++ b/assets/js/blocks/active-filters/utils.js
@@ -44,7 +44,7 @@ export const formatPriceRange = ( minPrice, maxPrice ) => {
  * @param {Object}   listItem                  The removable item to render.
  * @param {string}   listItem.type             Type string.
  * @param {string}   listItem.name             Name string.
- * @param {string}   listItem.prefix           Prefix shown before item name.
+ * @param {string}   [listItem.prefix='']      Prefix shown before item name.
  * @param {Function} listItem.removeCallback   Callback to remove item.
  * @param {string}   listItem.displayStyle     Whether it's a list or chips.
  * @param {boolean}  [listItem.showLabel=true] Should the label be shown for
@@ -53,7 +53,7 @@ export const formatPriceRange = ( minPrice, maxPrice ) => {
 export const renderRemovableListItem = ( {
 	type,
 	name,
-	prefix,
+	prefix = '',
 	removeCallback = () => {},
 	showLabel = true,
 	displayStyle,


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #6310

This PR adds support for Filter Products by Rating widget to the Active Filters block by parsing the URL and setting the query state for ratings. This also prepares the Active Filters block for future Filter Products by Rating block.

### Screenshots
<img width="1261" alt="image" src="https://user-images.githubusercontent.com/5423135/165232828-6bc59989-ff9e-48dd-9754-33fa13bafacf.png">

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Remove [this line](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/baf7be0bb6925d99bffb23210ef3f3e002e466ec/src/BlockTypesController.php#L221) from Block Types Controller.
2. Active Storefront.
3. In Appearance > Widgets, add Active Filters block and Filter Products by Rating widget to the sidebar.
4. Add some ratings to products if needed.
5. On the shop page, select some filters from Filter Products by Rating widget.
6. After page reloads, see the selected rating filter appear in the Active Filters Block.
### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
* [ ] See steps below.

### Changelog

> Add support for Filter Products by Rating widget to Active Filters block.