### PR TITLE
Fix: Customizer fatal error for bundled woocommerce-blocks package

### DIFF
--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -150,8 +150,14 @@ class MiniCart extends AbstractBlock {
 		 *
 		 * $wp_scripts->print_translations() calls load_script_textdomain()
 		 * which calls load_script_translations() containing the below filter.
+		 *
+		 * In Customzier, woocommerce_blocks_get_i18n_data_json doesn't exist
+		 * at the time of this filter call. So we need checking for its
+		 * existence to prevent fatal error.
 		 */
-		remove_filter( 'pre_load_script_translations', 'woocommerce_blocks_get_i18n_data_json', 10, 4 );
+		if ( function_exists( 'woocommerce_blocks_get_i18n_data_json' ) ) {
+			remove_filter( 'pre_load_script_translations', 'woocommerce_blocks_get_i18n_data_json', 10, 4 );
+		}
 
 		$script_data = $this->asset_api->get_script_data( 'build/mini-cart-component-frontend.js' );
 
@@ -187,7 +193,9 @@ class MiniCart extends AbstractBlock {
 		);
 
 		// Re-add the filter.
-		add_filter( 'pre_load_script_translations', 'woocommerce_blocks_get_i18n_data_json', 10, 4 );
+		if ( function_exists( 'woocommerce_blocks_get_i18n_data_json' ) ) {
+			add_filter( 'pre_load_script_translations', 'woocommerce_blocks_get_i18n_data_json', 10, 4 );
+		}
 
 		$this->asset_data_registry->add(
 			'mini_cart_block_frontend_dependencies',


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #6314

This PR fixes the fatal error in Customizer when using Woocommerce Blocks bundled in WC Core. This is a hotfix and should be revisited later.

At the time the Customizer is loading, the `wp-content/plugins/woocommerce/packages/woocommerce-blocks/woocommerce-gutenberg-products-block.php` isn't loaded first, which causes the fatal error. This doesn't happen for the WooCommerce Blocks plugin.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Switch to PHP 8.
1. Activate WC 6.5 beta 1 and Storefront.
1. Apply change in this PR to `wp-content/plugins/woocommerce/packages/woocommerce-blocks/src/BlockTypes/MiniCart.php`.
2. Go to Appearance > Customize.
3. See no fatal error, the Customizer is loading and working as expected.
### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
* [ ] See steps below.

### Changelog

> Fix Customizer fatal error on PHP 8.
