### PR TITLE
Active Filters: Add support for Filters Products by Rating widget 

### DIFF
--- a/assets/js/blocks/active-filters/utils.js
+++ b/assets/js/blocks/active-filters/utils.js
@@ -184,6 +184,7 @@ export const cleanFilterUrl = () => {
 				if (
 					arg.includes( 'min_price' ) ||
 					arg.includes( 'max_price' ) ||
+					arg.includes( 'rating_filter' ) ||
 					arg.includes( 'filter_' ) ||
 					arg.includes( 'query_type_' )
 				) {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Follows #6315 and #6316
This PR adds support for Filters Products by Rating widget to the Clear All button.
<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->
### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Remove [this line](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/baf7be0bb6925d99bffb23210ef3f3e002e466ec/src/BlockTypesController.php#L221) from Block Types Controller.
2. Active Storefront.
3. In Appearance > Widgets, add Active Filters block and Filter Products by Rating widget to the sidebar.
4. Add some ratings to products if needed.
5. On the shop page, select some filters from Filter Products by Rating widget.
6. After the page reloads, see the selected rating filter appear in the Active Filters Block.
7. Click the clear all button, see the rating filter removed

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
* [ ] See steps below.