### PR TITLE
Fix All Products block refreshing on Classic Themes.

### DIFF
--- a/src/Templates/ClassicTemplatesCompatibility.php
+++ b/src/Templates/ClassicTemplatesCompatibility.php
@@ -64,9 +64,14 @@ class ClassicTemplatesCompatibility {
 	 * This method passes the value `is_rendering_php_template` to the front-end of Classic themes,
 	 * so that widget product filter blocks are aware of how to filter the products.
 	 *
+	 * This data only matters on WooCommerce product archive pages.
+	 * On non-archive pages the merchant could be using the All Products block which is not a PHP template.
+	 *
 	 * @return void
 	 */
 	public function set_php_template_data() {
-		$this->asset_data_registry->add( 'is_rendering_php_template', true, null );
+		if ( is_shop() || is_product_taxonomy() ) {
+			$this->asset_data_registry->add( 'is_rendering_php_template', true, null );
+		}
 	}
 }


### PR DESCRIPTION
We set `is_rendering_php_template` for the frontend so we can use filter blocks with PHP rendered templates and deprecate the filters widgets in favour of them for Classic Themes such as Storefront

However, filter blocks are also used to filter the All Products block which is not rendered server-side so there is no need for a page refresh here.

This PR only sets `is_rendering_php_template` on WooCommerce product archive pages such as the Shop page and product category pages where the products are rendered server side. This means on non-product archive pages where the All Products block may be used, we will not refresh the page when using filter blocks.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
### Manual Testing

How to test the changes in this Pull Request:

1. Activate Storefront
2. Add the All Products block to a newly created page, along with a filter block such as Filter by Attribute
3. Visit this page on the frontend and select some attributes to filter by.
4. Observe the filters being applied without a page refresh.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above, or
* [ ] See steps below.

1.
2.
3.

### Changelog

> Fixes page refresh when using filters with the All Products block on non-product archive templates for WooCommerce.
