### PR TITLE
Ensure Filter Products by Attribute block reloads the page when interacting with PHP templates

### DIFF
--- a/assets/js/blocks/attribute-filter/block.js
+++ b/assets/js/blocks/attribute-filter/block.js
@@ -268,29 +268,36 @@ const AttributeFilterBlock = ( {
 		[ pageUrl, attributeObject?.taxonomy ]
 	);
 
+	const onClickSubmit = ( isChecked ) => {
+		const query = updateAttributeFilter(
+			productAttributesQuery,
+			setProductAttributesQuery,
+			attributeObject,
+			getSelectedTerms( isChecked ),
+			blockAttributes.queryType === 'or' ? 'in' : 'and'
+		);
+
+		// This is for PHP rendered template filtering only.
+		if ( filteringForPhpTemplate ) {
+			redirectPageForPhpTemplate( query, isChecked.length === 0 );
+		}
+	};
+
 	const onSubmit = useCallback(
 		( isChecked ) => {
 			if ( isEditor ) {
 				return;
 			}
 
-			const query = updateAttributeFilter(
+			updateAttributeFilter(
 				productAttributesQuery,
 				setProductAttributesQuery,
 				attributeObject,
 				getSelectedTerms( isChecked ),
 				blockAttributes.queryType === 'or' ? 'in' : 'and'
 			);
-
-			// This is for PHP rendered template filtering only.
-			if ( filteringForPhpTemplate && hasSetPhpFilterDefaults ) {
-				redirectPageForPhpTemplate( query, isChecked.length === 0 );
-			}
 		},
 		[
-			hasSetPhpFilterDefaults,
-			filteringForPhpTemplate,
-			redirectPageForPhpTemplate,
 			isEditor,
 			productAttributesQuery,
 			setProductAttributesQuery,
@@ -578,7 +585,7 @@ const AttributeFilterBlock = ( {
 					<FilterSubmitButton
 						className="wc-block-attribute-filter__button"
 						disabled={ isLoading || isDisabled }
-						onClick={ () => onSubmit( checked ) }
+						onClick={ () => onClickSubmit( checked ) }
 					/>
 				) }
 			</div>


### PR DESCRIPTION
Fixes #6331.

Heads-up that there is a follow-up PR which does some code clean-up: #6333.

### Screenshots

https://user-images.githubusercontent.com/3616980/165433571-9a148eb7-ccad-481d-b9db-92a40f885a26.mp4

### Manual Testing

1. With a block theme, go to Appearance > Site Editor.
2. Go to Templates and edit the Product Catalog template.
3. Above the WooCommerce Classic Template block, add the Filter Products by Attribute block (making sure you only have one Filter Products by Attribute block) and set its _Filter button_ attribute to true.
4. In the frontend, filter by attribute.
5. Verify the page reloads and the filter is applied.

### Changelog

> Fix Filter Products by Attribute block not working on PHP templates when Filter button was enabled.
