### PR TITLE
Fix release schedule link in release and patch initial checklist

### DIFF
--- a/.github/patch-initial-checklist.md
+++ b/.github/patch-initial-checklist.md
@@ -63,7 +63,7 @@ Each porter is responsible for testing the PRs that fall under the focus of thei
   * If the base branch was `trunk`, and this release was deployed to WordPress.org, then merge the branch into `trunk`.
   * If the base branch is the release branch this patch release is for, then merge branch into release branch and then merge the release branch back to `trunk` if the patch release is the latest released version. Otherwise just merge back into the release branch.
 * [ ] If you merged the branch to `trunk`, then update version on the `trunk` branch to be for the next version of the plugin and include the `dev` suffix (e.g. something like [`2.6-dev`](https://github.com/woocommerce/woocommerce-gutenberg-products-block/commit/e27f053e7be0bf7c1d376f5bdb9d9999190ce158)) for the next version.
-* [ ] Update the schedules p2 with the shipped date for the release (Pca54o-1N-p2).
+* [ ] Update the schedules p2 with the shipped date for the release (PdToLP-K-p2).
 * [ ] Edit the GitHub milestone of the release you just shipped and add the current date as the due date (this is used to track ship date as well).
 
 ## Pull request in WooCommerce Core for Package update

--- a/.github/release-initial-checklist.md
+++ b/.github/release-initial-checklist.md
@@ -85,7 +85,7 @@ Each porter is responsible for testing the PRs that fall under the focus of thei
     * [ ] `readme.txt`
     * [ ] `src/Package.php`
     * [ ] `woocommerce-gutenberg-products-block.php`.
-* [ ] Update the schedules p2 with the shipped date for the release (Pca54o-1N-p2).
+* [ ] Update the schedules p2 with the shipped date for the release (PdToLP-K-p2).
 * [ ] Edit the GitHub milestone of the release you just shipped and add the current date as the due date (this is used to track ship date as well).
 
 ## Pull request in WooCommerce Core for Package update


### PR DESCRIPTION
We moved the [release schedule page](PdToLP-K-p2) to [WC Blocks repo](dToLP-p2). This PR updates the release schedule link present in the release and patch initial checklist. 



