### PR TITLE
Add new `alt` attribute to the `Featured Category` media settings

### DIFF
--- a/assets/js/blocks/featured-category/block.js
+++ b/assets/js/blocks/featured-category/block.js
@@ -28,6 +28,8 @@ import {
 	withSpokenMessages,
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+	TextareaControl,
+	ExternalLink,
 } from '@wordpress/components';
 import classnames from 'classnames';
 import { Component } from '@wordpress/element';
@@ -238,6 +240,30 @@ const FeaturedCategory = ( {
 										setAttributes( {
 											focalPoint: value,
 										} )
+									}
+								/>
+								<TextareaControl
+									label={ __(
+										'Alt text (alternative text)',
+										'woo-gutenberg-products-block'
+									) }
+									value={ attributes.alt }
+									onChange={ ( alt ) => {
+										setAttributes( { alt } );
+									} }
+									help={
+										<>
+											<ExternalLink href="https://www.w3.org/WAI/tutorials/images/decision-tree">
+												{ __(
+													'Describe the purpose of the image',
+													'woo-gutenberg-products-block'
+												) }
+											</ExternalLink>
+											{ __(
+												'Leaving it empty will use the category name.',
+												'woo-gutenberg-products-block'
+											) }
+										</>
 									}
 								/>
 							</PanelBody>

--- a/assets/js/blocks/featured-category/example.js
+++ b/assets/js/blocks/featured-category/example.js
@@ -6,6 +6,7 @@ import { previewCategories } from '@woocommerce/resource-previews';
 
 export const example = {
 	attributes: {
+		alt: '',
 		contentAlign: 'center',
 		dimRatio: 50,
 		editMode: false,

--- a/assets/js/blocks/featured-category/index.js
+++ b/assets/js/blocks/featured-category/index.js
@@ -68,6 +68,11 @@ registerBlockType( 'woocommerce/featured-category', {
 	},
 	example,
 	attributes: {
+		alt: {
+			type: 'string',
+			default: '',
+		},
+
 		/**
 		 * Alignment of content inside block.
 		 */

--- a/src/BlockTypes/FeaturedCategory.php
+++ b/src/BlockTypes/FeaturedCategory.php
@@ -151,7 +151,7 @@ class FeaturedCategory extends AbstractDynamicBlock {
 		if ( ! empty( $image ) ) {
 			return sprintf(
 				'<img alt="%1$s" class="wc-block-featured-category__background-image" src="%2$s" style="%3$s" />',
-				wp_kses_post( $category->description ),
+				wp_kses_post( $attributes['alt'] ?? $category->name ),
 				esc_url( $image ),
 				$style
 			);


### PR DESCRIPTION
This PR allows defining an `alt` text for the `Featured Category` block image.

Fixes part of https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/6236

### Testing

How to test the changes in this Pull Request:

1. Create a new page and add a `Featured Category`.
2. On the block settings go to `Media Settings` and check the `Alt text` textarea appears empty.
3. Add an `alt` text, save the block and check it renders on the frontend with the specified `alt` text.
4. Edit the block again, remove the `alt` text and save it.
5. Check the `alt` rendered on the frontend corresponds to the category name.

### Changelog

> Add the alt text control to the Featured Category block media settings
