### PR TITLE
Filter default inner blocks template for order summary blocks in edit context

### DIFF
--- a/assets/js/blocks/cart/inner-blocks/cart-order-summary-block/edit.tsx
+++ b/assets/js/blocks/cart/inner-blocks/cart-order-summary-block/edit.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
+import { applyFilters } from '@wordpress/hooks';
 import type { TemplateArray } from '@wordpress/blocks';
 import { innerBlockAreas } from '@woocommerce/blocks-checkout';
 import { __ } from '@wordpress/i18n';
@@ -25,7 +26,7 @@ export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 	const allowedBlocks = getAllowedBlocks(
 		innerBlockAreas.CART_ORDER_SUMMARY
 	);
-	const defaultTemplate = [
+	const defaultTemplate = applyFilters( 'woocommerce_blocks_cart_order_summary_default_template', [
 		[
 			'woocommerce/cart-order-summary-heading-block',
 			{
@@ -39,7 +40,7 @@ export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 		[ 'woocommerce/cart-order-summary-coupon-form-block', {}, [] ],
 		[ 'woocommerce/cart-order-summary-shipping-block', {}, [] ],
 		[ 'woocommerce/cart-order-summary-taxes-block', {}, [] ],
-	] as TemplateArray;
+	] ) as TemplateArray;
 
 	useForcedLayout( {
 		clientId,

--- a/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-block/edit.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-block/edit.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
+import { applyFilters } from '@wordpress/hooks';
 import type { TemplateArray } from '@wordpress/blocks';
 import { innerBlockAreas } from '@woocommerce/blocks-checkout';
 import { TotalsFooterItem } from '@woocommerce/base-components/cart-checkout';
@@ -24,7 +25,7 @@ export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 	const allowedBlocks = getAllowedBlocks(
 		innerBlockAreas.CHECKOUT_ORDER_SUMMARY
 	);
-	const defaultTemplate = [
+	const defaultTemplate = applyFilters( 'woocommerce_blocks_checkout_order_summary_default_template', [
 		[ 'woocommerce/checkout-order-summary-cart-items-block', {}, [] ],
 		[ 'woocommerce/checkout-order-summary-subtotal-block', {}, [] ],
 		[ 'woocommerce/checkout-order-summary-fee-block', {}, [] ],
@@ -32,7 +33,7 @@ export const Edit = ( { clientId }: { clientId: string } ): JSX.Element => {
 		[ 'woocommerce/checkout-order-summary-coupon-form-block', {}, [] ],
 		[ 'woocommerce/checkout-order-summary-shipping-block', {}, [] ],
 		[ 'woocommerce/checkout-order-summary-taxes-block', {}, [] ],
-	] as TemplateArray;
+	] ) as TemplateArray;
 
 	useForcedLayout( {
 		clientId,


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
This PR adds two filters in the
- Checkout Order Summary Inner Block (= `woocommerce_blocks_checkout_order_summary_default_template` ); and
- Cart Order Summary Inner Block (= `woocommerce_blocks_cart_order_summary_default_template` ).

These filters will create a more streamlined experience when merchants/shop managers add "custom" inner blocks in these two delicate areas. 

Here's an example usage filter of adding a custom inner block in the checkout order summary **after the coupon form**:
```js
// Specify default position.
addFilter( 'woocommerce_blocks_checkout_order_summary_default_template', 'my-custom-namespace', function( data ) {

	var coupon_index = 0;
	for ( var i = data.length - 1; i >= 0; i-- ) {

		if ( data[i][0] === "woocommerce/checkout-order-summary-coupon-form-block" ) {
			coupon_index = i;
		}
	}

	var newData = data.slice();
	newData.splice( coupon_index + 1, 0, [ 'woocommerce/checkout-order-summary-custom-block', {}, [] ] );
	return newData;

}, 10 );
```

Based on an internal discussion located at pdqkbG-Sw-p2

<!-- Don't forget to update the title with something descriptive. -->
<!-- If your pull request implements a feature flag, make sure you update [this doc](../docs/blocks/features-and-blocks-behind-a-flag.md) -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader
- [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [x] I've updated [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) for any feature flags or experimental interfaces implemented in this pull request.
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.
