### PR TITLE
Implement `Fixed image` and `Repeated image` media controls for the `Featured Product`

### DIFF
--- a/assets/js/blocks/featured-category/block.js
+++ b/assets/js/blocks/featured-category/block.js
@@ -52,9 +52,9 @@ import {
 	dimRatioToClass,
 	getCategoryImageId,
 	getCategoryImageSrc,
+	calculateBackgroundImagePosition,
 } from './utils';
 import { withCategory } from '../../hocs';
-import { calculateBackgroundImagePosition } from '../featured-product/utils';
 import { ConstrainedResizable } from '../featured-product/block';
 
 const DEFAULT_EDITOR_SIZE = {

--- a/assets/js/blocks/featured-category/utils.js
+++ b/assets/js/blocks/featured-category/utils.js
@@ -60,3 +60,14 @@ export {
 	getBackgroundImageStyles,
 	dimRatioToClass,
 };
+
+export function calculateBackgroundImagePosition( coords ) {
+	if ( ! coords ) return {};
+
+	const x = Math.round( coords.x * 100 );
+	const y = Math.round( coords.y * 100 );
+
+	return {
+		objectPosition: `${ x }% ${ y }%`,
+	};
+}

--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -330,9 +330,6 @@ const FeaturedProduct = ( {
 										onChange={ () => {
 											setAttributes( {
 												hasParallax: ! hasParallax,
-												...( ! hasParallax
-													? { focalPoint: undefined }
-													: {} ),
 											} );
 										} }
 									/>

--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -521,9 +521,6 @@ const FeaturedProduct = ( {
 			borderRadius: style?.border?.radius,
 		};
 
-		const backgroundImageSrc =
-			mediaSrc || getImageSrcFromProduct( product );
-
 		const backgroundImageStyle = {
 			objectPosition: calculateImagePosition( focalPoint ),
 			objectFit: imageFit,

--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -265,7 +265,11 @@ const FeaturedProduct = ( {
 
 	const getInspectorControls = () => {
 		const url = attributes.mediaSrc || getImageSrcFromProduct( product );
-		const { focalPoint = { x: 0.5, y: 0.5 } } = attributes;
+		const {
+			focalPoint = { x: 0.5, y: 0.5 },
+			hasParallax,
+			isRepeated,
+		} = attributes;
 		// FocalPointPicker was introduced in Gutenberg 5.0 (WordPress 5.2),
 		// so we need to check if it exists before using it.
 		const focalPointPickerExists = typeof FocalPointPicker === 'function';
@@ -313,6 +317,33 @@ const FeaturedProduct = ( {
 										'woo-gutenberg-products-block'
 									) }
 								>
+									<ToggleControl
+										label={ __(
+											'Fixed background',
+											'woo-gutenberg-products-block'
+										) }
+										checked={ hasParallax }
+										onChange={ () => {
+											setAttributes( {
+												hasParallax: ! hasParallax,
+												...( ! hasParallax
+													? { focalPoint: undefined }
+													: {} ),
+											} );
+										} }
+									/>
+									<ToggleControl
+										label={ __(
+											'Repeated background',
+											'woo-gutenberg-products-block'
+										) }
+										checked={ isRepeated }
+										onChange={ () => {
+											setAttributes( {
+												isRepeated: ! isRepeated,
+											} );
+										} }
+									/>
 									<ToggleGroupControl
 										help={
 											<>

--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -493,6 +493,7 @@ const FeaturedProduct = ( {
 			contentAlign,
 			dimRatio,
 			focalPoint,
+			hasParallax,
 			isRepeated,
 			imageFit,
 			minHeight,
@@ -528,7 +529,7 @@ const FeaturedProduct = ( {
 			objectFit: imageFit,
 		};
 
-		const isImgElement = ! isRepeated;
+		const isImgElement = ! isRepeated && ! hasParallax;
 
 		const wrapperStyle = {
 			...( ! isImgElement
@@ -541,6 +542,10 @@ const FeaturedProduct = ( {
 				: undefined ),
 			...getSpacingClassesAndStyles( attributes ).style,
 			minHeight,
+			...( ! isRepeated && {
+				backgroundRepeat: 'no-repeat',
+				backgroundSize: imageFit === 'cover' ? imageFit : 'auto',
+			} ),
 		};
 
 		const overlayStyle = {
@@ -558,7 +563,10 @@ const FeaturedProduct = ( {
 				/>
 				<div className={ classes } style={ containerStyle }>
 					<div
-						className="wc-block-featured-product__wrapper"
+						className={ classnames(
+							'wc-block-featured-product__wrapper',
+							{ 'has-parallax': hasParallax }
+						) }
 						style={ wrapperStyle }
 					>
 						<div

--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -407,30 +407,32 @@ const FeaturedProduct = ( {
 											} )
 										}
 									/>
-									<TextareaControl
-										label={ __(
-											'Alt text (alternative text)',
-											'woo-gutenberg-products-block'
-										) }
-										value={ attributes.alt }
-										onChange={ ( alt ) => {
-											setAttributes( { alt } );
-										} }
-										help={
-											<>
-												<ExternalLink href="https://www.w3.org/WAI/tutorials/images/decision-tree">
+									{ ! isRepeated && (
+										<TextareaControl
+											label={ __(
+												'Alt text (alternative text)',
+												'woo-gutenberg-products-block'
+											) }
+											value={ attributes.alt }
+											onChange={ ( alt ) => {
+												setAttributes( { alt } );
+											} }
+											help={
+												<>
+													<ExternalLink href="https://www.w3.org/WAI/tutorials/images/decision-tree">
+														{ __(
+															'Describe the purpose of the image',
+															'woo-gutenberg-products-block'
+														) }
+													</ExternalLink>
 													{ __(
-														'Describe the purpose of the image',
+														'Leaving it empty will use the product name.',
 														'woo-gutenberg-products-block'
 													) }
-												</ExternalLink>
-												{ __(
-													'Leaving it empty will use the product name.',
-													'woo-gutenberg-products-block'
-												) }
-											</>
-										}
-									/>
+												</>
+											}
+										/>
+									) }
 								</PanelBody>
 							) }
 							<PanelColorGradientSettings

--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -526,6 +526,11 @@ const FeaturedProduct = ( {
 		const isImgElement = ! isRepeated && ! hasParallax;
 
 		const wrapperStyle = {
+			...getSpacingClassesAndStyles( attributes ).style,
+			minHeight,
+		};
+
+		const backgroundDivStyle = {
 			...( ! isImgElement
 				? {
 						...backgroundImageStyles( backgroundImageSrc ),
@@ -534,8 +539,6 @@ const FeaturedProduct = ( {
 						),
 				  }
 				: undefined ),
-			...getSpacingClassesAndStyles( attributes ).style,
-			minHeight,
 			...( ! isRepeated && {
 				backgroundRepeat: 'no-repeat',
 				backgroundSize: imageFit === 'cover' ? imageFit : 'auto',
@@ -558,8 +561,7 @@ const FeaturedProduct = ( {
 				<div className={ classes } style={ containerStyle }>
 					<div
 						className={ classnames(
-							'wc-block-featured-product__wrapper',
-							{ 'has-parallax': hasParallax }
+							'wc-block-featured-product__wrapper'
 						) }
 						style={ wrapperStyle }
 					>
@@ -579,6 +581,17 @@ const FeaturedProduct = ( {
 										width: e.target?.naturalWidth,
 									} );
 								} }
+							/>
+						) }
+						{ ! isImgElement && (
+							<div
+								className={ classnames(
+									'wc-block-featured-product__background-image',
+									{
+										'has-parallax': hasParallax,
+									}
+								) }
+								style={ backgroundDivStyle }
 							/>
 						) }
 						<h2

--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -278,6 +278,8 @@ const FeaturedProduct = ( {
 		// so we need to check if it exists before using it.
 		const focalPointPickerExists = typeof FocalPointPicker === 'function';
 
+		const isImgElement = ! isRepeated && ! hasParallax;
+
 		return (
 			<>
 				<InspectorControls key="inspector">
@@ -404,7 +406,7 @@ const FeaturedProduct = ( {
 											} )
 										}
 									/>
-									{ ! isRepeated && (
+									{ isImgElement && (
 										<TextareaControl
 											label={ __(
 												'Alt text (alternative text)',
@@ -807,6 +809,7 @@ export default compose( [
 			state = {
 				doUrlUpdate: false,
 			};
+
 			componentDidUpdate() {
 				const {
 					attributes,
@@ -828,9 +831,11 @@ export default compose( [
 					this.setState( { doUrlUpdate: false } );
 				}
 			}
+
 			triggerUrlUpdate = () => {
 				this.setState( { doUrlUpdate: true } );
 			};
+
 			render() {
 				return (
 					<ProductComponent
@@ -840,6 +845,7 @@ export default compose( [
 				);
 			}
 		}
+
 		return WrappedComponent;
 	}, 'withUpdateButtonAttributes' ),
 ] )( FeaturedProduct );

--- a/assets/js/blocks/featured-product/block.json
+++ b/assets/js/blocks/featured-product/block.json
@@ -56,6 +56,14 @@
             "type": "string",
             "default": "none"
         },
+        "hasParallax": {
+            "type": "boolean",
+            "default": false
+        },
+        "isRepeated": {
+            "type": "boolean",
+            "default": false
+        },
         "mediaId": {
             "type": "number",
             "default": 0

--- a/assets/js/blocks/featured-product/example.js
+++ b/assets/js/blocks/featured-product/example.js
@@ -10,6 +10,8 @@ export const example = {
 		contentAlign: 'center',
 		dimRatio: 50,
 		editMode: false,
+		hasParallax: false,
+		isRepeated: false,
 		height: getSetting( 'default_height', 500 ),
 		mediaSrc: '',
 		overlayColor: '#000000',

--- a/assets/js/blocks/featured-product/style.scss
+++ b/assets/js/blocks/featured-product/style.scss
@@ -58,6 +58,7 @@
 		display: flex;
 		flex-wrap: wrap;
 		height: 100%;
+		width: 100%;
 		justify-content: center;
 		overflow: hidden;
 	}

--- a/assets/js/blocks/featured-product/style.scss
+++ b/assets/js/blocks/featured-product/style.scss
@@ -61,6 +61,22 @@
 		width: 100%;
 		justify-content: center;
 		overflow: hidden;
+
+		&.has-parallax {
+			background-attachment: fixed;
+
+			// Mobile Safari does not support fixed background attachment properly.
+			// See also https://stackoverflow.com/questions/24154666/background-size-cover-not-working-on-ios
+			// Chrome on Android does not appear to support the attachment at all: https://issuetracker.google.com/issues/36908439
+			@supports (-webkit-overflow-scrolling: touch) {
+				background-attachment: scroll;
+			}
+
+			// Remove the appearance of scrolling based on OS-level animation preferences.
+			@media (prefers-reduced-motion: reduce) {
+				background-attachment: scroll;
+			}
+		}
 	}
 
 	&.has-left-content {

--- a/assets/js/blocks/featured-product/style.scss
+++ b/assets/js/blocks/featured-product/style.scss
@@ -17,6 +17,11 @@
 		}
 	}
 
+	&.is-repeated {
+		background-repeat: repeat;
+		background-size: auto;
+	}
+
 	// Applying image edits
 	.is-applying {
 		.components-spinner {

--- a/assets/js/blocks/featured-product/style.scss
+++ b/assets/js/blocks/featured-product/style.scss
@@ -61,22 +61,6 @@
 		width: 100%;
 		justify-content: center;
 		overflow: hidden;
-
-		&.has-parallax {
-			background-attachment: fixed;
-
-			// Mobile Safari does not support fixed background attachment properly.
-			// See also https://stackoverflow.com/questions/24154666/background-size-cover-not-working-on-ios
-			// Chrome on Android does not appear to support the attachment at all: https://issuetracker.google.com/issues/36908439
-			@supports (-webkit-overflow-scrolling: touch) {
-				background-attachment: scroll;
-			}
-
-			// Remove the appearance of scrolling based on OS-level animation preferences.
-			@media (prefers-reduced-motion: reduce) {
-				background-attachment: scroll;
-			}
-		}
 	}
 
 	&.has-left-content {
@@ -155,6 +139,22 @@
 	.wc-block-featured-product__background-image {
 		@include absolute-stretch();
 		object-fit: none;
+
+		&.has-parallax {
+			background-attachment: fixed;
+
+			// Mobile Safari does not support fixed background attachment properly.
+			// See also https://stackoverflow.com/questions/24154666/background-size-cover-not-working-on-ios
+			// Chrome on Android does not appear to support the attachment at all: https://issuetracker.google.com/issues/36908439
+			@supports (-webkit-overflow-scrolling: touch) {
+				background-attachment: scroll;
+			}
+
+			// Remove the appearance of scrolling based on OS-level animation preferences.
+			@media (prefers-reduced-motion: reduce) {
+				background-attachment: scroll;
+			}
+		}
 	}
 
 	.wp-block-button.aligncenter {

--- a/assets/js/blocks/featured-product/utils.js
+++ b/assets/js/blocks/featured-product/utils.js
@@ -1,12 +1,10 @@
-export function calculateBackgroundImagePosition( coords ) {
+export function calculateImagePosition( coords ) {
 	if ( ! coords ) return {};
 
 	const x = Math.round( coords.x * 100 );
 	const y = Math.round( coords.y * 100 );
 
-	return {
-		objectPosition: `${ x }% ${ y }%`,
-	};
+	return `${ x }% ${ y }%`;
 }
 
 /**
@@ -19,4 +17,8 @@ export function dimRatioToClass( ratio ) {
 	return ratio === 0 || ratio === 50
 		? null
 		: `has-background-dim-${ 10 * Math.round( ratio / 10 ) }`;
+}
+
+export function backgroundImageStyles( url ) {
+	return { backgroundImage: `url(${ url })` };
 }

--- a/src/BlockTypes/FeaturedProduct.php
+++ b/src/BlockTypes/FeaturedProduct.php
@@ -114,6 +114,27 @@ class FeaturedProduct extends AbstractDynamicBlock {
 	}
 
 	/**
+	 * Returns the url of a product image
+	 *
+	 * @param array       $attributes Block attributes. Default empty array.
+	 * @param \WC_Product $product Product object.
+	 *
+	 * @return string
+	 */
+	private function get_image_url( $attributes, $product ) {
+		$image_size = 'large';
+		if ( 'none' !== $attributes['align'] || $attributes['height'] > 800 ) {
+			$image_size = 'full';
+		}
+
+		if ( $attributes['mediaId'] ) {
+			return wp_get_attachment_image_url( $attributes['mediaId'], $image_size );
+		}
+
+		return $this->get_image( $product, $image_size );
+	}
+
+	/**
 	 * Renders the featured image
 	 *
 	 * @param array       $attributes Block attributes. Default empty array.
@@ -122,19 +143,9 @@ class FeaturedProduct extends AbstractDynamicBlock {
 	 * @return string
 	 */
 	private function render_image( $attributes, $product ) {
-		$style      = '';
-		$image_size = 'large';
-		if ( 'none' !== $attributes['align'] || $attributes['height'] > 800 ) {
-			$image_size = 'full';
-		}
+		$style = sprintf( 'object-fit: %s;', $attributes['imageFit'] );
 
-		$style .= sprintf( 'object-fit: %s;', $attributes['imageFit'] );
-
-		if ( $attributes['mediaId'] ) {
-			$image = wp_get_attachment_image_url( $attributes['mediaId'], $image_size );
-		} else {
-			$image = $this->get_image( $product, $image_size );
-		}
+		$image = $this->get_image_url( $attributes, $product );
 
 		if ( is_array( $attributes['focalPoint'] ) && 2 === count( $attributes['focalPoint'] ) ) {
 			$style .= sprintf(

--- a/src/BlockTypes/FeaturedProduct.php
+++ b/src/BlockTypes/FeaturedProduct.php
@@ -199,7 +199,7 @@ class FeaturedProduct extends AbstractDynamicBlock {
 	 * Get the styles for the wrapper element (background image, color).
 	 *
 	 * @param array  $attributes Block attributes. Default empty array.
-	 * @param string $image_url Url of the product image.
+	 * @param string $image_url Product image url.
 	 *
 	 * @return string
 	 */
@@ -285,30 +285,6 @@ class FeaturedProduct extends AbstractDynamicBlock {
 		}
 
 		return $image;
-	}
-
-	/**
-	 * Get the styles for the feature product wrapper.
-	 *
-	 * @param array  $attributes Block attributes. Default empty array.
-	 * @param string $image_url Product image url.
-	 * @param string $min_height Block min-height.
-	 *
-	 * @return string
-	 */
-	public function get_wrapper_styles( $attributes, $image_url, $min_height ) {
-		$wrapper_styles = sprintf( 'min-height:%dpx;', intval( $min_height ) );
-
-		if ( $attributes['isRepeated'] ) {
-			$wrapper_styles .= "background-image: url($image_url);";
-			$wrapper_styles .= sprintf(
-				'background-position: %s%% %s%%;',
-				$attributes['focalPoint']['x'] * 100,
-				$attributes['focalPoint']['y'] * 100
-			);
-		}
-
-		return $wrapper_styles;
 	}
 
 	/**

--- a/src/BlockTypes/FeaturedProduct.php
+++ b/src/BlockTypes/FeaturedProduct.php
@@ -94,16 +94,13 @@ class FeaturedProduct extends AbstractDynamicBlock {
 			wp_kses_post( $product->get_price_html() )
 		);
 
-		$styles  = $this->get_styles( $attributes );
-		$classes = $this->get_classes( $attributes );
-
-		$output = sprintf( '<div class="%1$s wp-block-woocommerce-featured-product" style="%2$s">', esc_attr( trim( $classes ) ), esc_attr( $styles ) );
-
 		$image_url = esc_url( $this->get_image_url( $attributes, $product ) );
 
-		$wrapper_styles = $this->get_wrapper_styles( $attributes, $image_url, $min_height );
+		$styles  = $this->get_styles( $attributes, $image_url );
+		$classes = $this->get_classes( $attributes );
 
-		$output .= sprintf( '<div class="wc-block-featured-product__wrapper" style="%s">', esc_attr( $wrapper_styles ) );
+		$output  = sprintf( '<div class="%1$s wp-block-woocommerce-featured-product">', esc_attr( trim( $classes ) ) );
+		$output .= sprintf( '<div class="wc-block-featured-product__wrapper" style="%s">', esc_attr( $styles ) );
 		$output .= $this->render_overlay( $attributes );
 
 		if ( ! $attributes['isRepeated'] ) {
@@ -201,14 +198,24 @@ class FeaturedProduct extends AbstractDynamicBlock {
 	/**
 	 * Get the styles for the wrapper element (background image, color).
 	 *
-	 * @param array $attributes Block attributes. Default empty array.
+	 * @param array  $attributes Block attributes. Default empty array.
+	 * @param string $image_url Url of the product image.
 	 *
 	 * @return string
 	 */
-	public function get_styles( $attributes ) {
+	public function get_styles( $attributes, $image_url ) {
 		$style = '';
 
-		$min_height = isset( $attributes['minHeight'] ) ? $attributes['minHeight'] : wc_get_theme_support( 'featured_block::default_height', 500 );
+		if ( $attributes['isRepeated'] ) {
+			$style .= "background-image: url($image_url);";
+			$style .= sprintf(
+				'background-position: %s%% %s%%;',
+				$attributes['focalPoint']['x'] * 100,
+				$attributes['focalPoint']['y'] * 100
+			);
+		}
+
+		$min_height = $attributes['minHeight'] ?? wc_get_theme_support( 'featured_block::default_height', 500 );
 
 		if ( isset( $attributes['minHeight'] ) ) {
 			$style .= sprintf( 'min-height:%dpx;', intval( $min_height ) );

--- a/src/BlockTypes/FeaturedProduct.php
+++ b/src/BlockTypes/FeaturedProduct.php
@@ -212,7 +212,7 @@ class FeaturedProduct extends AbstractDynamicBlock {
 		}
 
 		if ( ! $attributes['isRepeated'] ) {
-			$style .= "background-repeat: 'no-repeat';";
+			$style .= 'background-repeat: no-repeat;';
 			$style .= 'background-size: ' . ( 'cover' === $attributes['imageFit'] ? $attributes['imageFit'] : 'auto' ) . ';';
 		}
 

--- a/src/BlockTypes/FeaturedProduct.php
+++ b/src/BlockTypes/FeaturedProduct.php
@@ -165,7 +165,7 @@ class FeaturedProduct extends AbstractDynamicBlock {
 		if ( ! empty( $image_url ) ) {
 			return sprintf(
 				'<img alt="%1$s" class="wc-block-featured-product__background-image" src="%2$s" style="%3$s" />',
-				wp_kses_post( $product->get_short_description() ),
+				wp_kses_post( $attributes['alt'] ?: $product->get_name() ),
 				$image_url,
 				$style
 			);

--- a/src/BlockTypes/FeaturedProduct.php
+++ b/src/BlockTypes/FeaturedProduct.php
@@ -96,16 +96,16 @@ class FeaturedProduct extends AbstractDynamicBlock {
 
 		$image_url = esc_url( $this->get_image_url( $attributes, $product ) );
 
-		$styles          = $this->get_styles( $attributes, $image_url );
-		$classes         = $this->get_classes( $attributes );
-		$wrapper_classes = $this->get_wrapper_classes( $attributes );
+		$classes = $this->get_classes( $attributes );
 
 		$output  = sprintf( '<div class="%1$s wp-block-woocommerce-featured-product">', esc_attr( trim( $classes ) ) );
-		$output .= sprintf( '<div class="%s" style="%s">', esc_attr( $wrapper_classes ), esc_attr( $styles ) );
+		$output .= $this->render_wrapper( $attributes );
 		$output .= $this->render_overlay( $attributes );
 
 		if ( ! $attributes['isRepeated'] && ! $attributes['hasParallax'] ) {
 			$output .= $this->render_image( $attributes, $product, $image_url );
+		} else {
+			$output .= $this->render_bg_image( $attributes, $image_url );
 		}
 
 		$output .= $title;
@@ -176,6 +176,43 @@ class FeaturedProduct extends AbstractDynamicBlock {
 	}
 
 	/**
+	 * Renders the featured image as a div background.
+	 *
+	 * @param array  $attributes Block attributes. Default empty array.
+	 * @param string $image_url Product image url.
+	 *
+	 * @return string
+	 */
+	private function render_bg_image( $attributes, $image_url ) {
+		$styles = $this->get_bg_styles( $attributes, $image_url );
+
+		$classes = [ 'wc-block-featured-product__background-image' ];
+
+		if ( $attributes['hasParallax'] ) {
+			$classes[] = ' has-parallax';
+		}
+
+		return sprintf( '<div class="%1$s" style="%2$s" /></div>', implode( ' ', $classes ), $styles );
+	}
+
+	/**
+	 * Renders the image wrapper.
+	 *
+	 * @param array $attributes Block attributes. Default empty array.
+	 *
+	 * @return string
+	 */
+	private function render_wrapper( $attributes ) {
+		$min_height = $attributes['minHeight'] ?? wc_get_theme_support( 'featured_block::default_height', 500 );
+
+		if ( isset( $attributes['minHeight'] ) ) {
+			$style = sprintf( 'min-height:%dpx;', intval( $min_height ) );
+		}
+
+		return sprintf( '<div class="wc-block-featured-product__wrapper" style="%s">', esc_attr( $style ) );
+	}
+
+	/**
 	 * Renders the block overlay
 	 *
 	 * @param array $attributes Block attributes. Default empty array.
@@ -204,7 +241,7 @@ class FeaturedProduct extends AbstractDynamicBlock {
 	 *
 	 * @return string
 	 */
-	public function get_styles( $attributes, $image_url ) {
+	public function get_bg_styles( $attributes, $image_url ) {
 		$style = '';
 
 		if ( $attributes['isRepeated'] || $attributes['hasParallax'] ) {
@@ -224,32 +261,10 @@ class FeaturedProduct extends AbstractDynamicBlock {
 			);
 		}
 
-		$min_height = $attributes['minHeight'] ?? wc_get_theme_support( 'featured_block::default_height', 500 );
-
-		if ( isset( $attributes['minHeight'] ) ) {
-			$style .= sprintf( 'min-height:%dpx;', intval( $min_height ) );
-		}
-
 		$global_style_style = StyleAttributesUtils::get_styles_by_attributes( $attributes, $this->global_style_wrapper );
 		$style             .= $global_style_style;
 
 		return $style;
-	}
-
-	/**
-	 * Get class names for the block wrapper.
-	 *
-	 * @param array $attributes Block attributes. Default empty array.
-	 * @return string
-	 */
-	private function get_wrapper_classes( $attributes ) {
-		$classes[] = 'wc-block-featured-product__wrapper';
-
-		if ( $attributes['hasParallax'] ) {
-			$classes[] = ' has-parallax';
-		}
-
-		return implode( ' ', $classes );
 	}
 
 	/**


### PR DESCRIPTION
This PR adds the `Fixed image` and `Repeated image` media controls for the `Featured Product` block.

Fixes part of https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/6235

### Testing

How to test the changes in this Pull Request:

1. Create a new page and add a `Featured Product`.
2. On the block settings go to `Media Settings` and toggle `Fixed image` and `Repeated image` and save.
3. Check the rendered product on the frontend is correct and matches the one on the edit page.
4. Edit the block again, repeat the steps above with different combinations on `Fixed image`, `Repeated image` and any other configuration.

### Changelog

> Add the `Fixed image` and `Repeated image` media controls to the Featured Product block
