### PR TITLE
Add media controls to the Featured Product block

### DIFF
--- a/assets/js/blocks/featured-product/block.js
+++ b/assets/js/blocks/featured-product/block.js
@@ -55,6 +55,11 @@ import {
 } from '../../utils/products';
 import { useThrottle } from '../../utils/useThrottle';
 
+const DEFAULT_EDITOR_SIZE = {
+	height: 500,
+	width: 500,
+};
+
 export const ConstrainedResizable = ( {
 	className = '',
 	onResize,
@@ -116,6 +121,7 @@ const FeaturedProduct = ( {
 	const { mediaId, mediaSrc } = attributes;
 
 	const [ isEditingImage, setIsEditingImage ] = useState( false );
+	const [ backgroundImageSize, setBackgroundImageSize ] = useState( {} );
 	const { setGradient } = useGradient( {
 		gradientAttribute: 'overlayGradient',
 		customGradientAttribute: 'overlayGradient',
@@ -484,6 +490,12 @@ const FeaturedProduct = ( {
 							className="wc-block-featured-product__background-image"
 							src={ backgroundImageSrc }
 							style={ backgroundImageStyle }
+							onLoad={ ( e ) => {
+								setBackgroundImageSize( {
+									height: e.target?.naturalHeight,
+									width: e.target?.naturalWidth,
+								} );
+							} }
 						/>
 						<h2
 							className="wc-block-featured-product__title"
@@ -589,17 +601,6 @@ const FeaturedProduct = ( {
 		</Placeholder>
 	);
 
-	const renderImageEditor = () => (
-		<ImageEditor
-			url={ backgroundImageSrc }
-			width={ 500 }
-			height={ 500 }
-			clientWidth={ 500 }
-			naturalHeight={ 500 }
-			naturalWidth={ 500 }
-		/>
-	);
-
 	const { editMode } = attributes;
 
 	if ( error ) {
@@ -616,16 +617,29 @@ const FeaturedProduct = ( {
 				<ImageEditingProvider
 					id={ backgroundImageId }
 					url={ backgroundImageSrc }
-					naturalWidth={ 500 }
-					naturalHeight={ 500 }
-					clientWidth={ 500 }
+					naturalHeight={
+						backgroundImageSize.height || DEFAULT_EDITOR_SIZE.height
+					}
+					naturalWidth={
+						backgroundImageSize.width || DEFAULT_EDITOR_SIZE.width
+					}
 					onSaveImage={ ( { id, url } ) => {
 						setAttributes( { mediaId: id, mediaSrc: url } );
 					} }
 					isEditing={ isEditingImage }
 					onFinishEditing={ () => setIsEditingImage( false ) }
 				>
-					{ renderImageEditor() }
+					<ImageEditor
+						url={ backgroundImageSrc }
+						height={
+							backgroundImageSize.height ||
+							DEFAULT_EDITOR_SIZE.height
+						}
+						width={
+							backgroundImageSize.width ||
+							DEFAULT_EDITOR_SIZE.width
+						}
+					/>
 				</ImageEditingProvider>
 			</>
 		);

--- a/assets/js/blocks/featured-product/style.scss
+++ b/assets/js/blocks/featured-product/style.scss
@@ -16,6 +16,21 @@
 			height: auto !important;
 		}
 	}
+
+	// Applying image edits
+	.is-applying {
+		.components-spinner {
+			position: absolute;
+			top: 50%;
+			left: 50%;
+			margin-top: -9px;
+			margin-left: -9px;
+		}
+
+		img {
+			opacity: 0.3;
+		}
+	}
 }
 
 .wc-block-featured-product {


### PR DESCRIPTION
This PR adds image editing controls to the Featured Product block. In particular, user can now:

* Rotate the image
* Crop the image
* Change the aspect ratio of the image
* Zoom the image

Each edit gets saved in the database as a new image.

Closes #6235

### Screenshots

![Screen Shot 2022-04-29 at 22 56 48](https://user-images.githubusercontent.com/1847066/166071907-8df1bbdf-4cad-49f8-9f5e-5de02e4d2f22.png)

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. Add the Featured Product block
2. Choose a product with an image or select an image for the block through the toolbar
3. Click on the “Crop” icon on the toolbar
4. Ensure the toolbar controls are now changed and show: `Zoom, Aspect ratio, Rotate | Apply, Cancel` controls
5. Ensure only the image is now visible instead of the whole block inside the image editor
6. Try executing edits and applying them
7. Ensure the image turns semi-transparent and a loading spinner shows in the image
8. Ensure the block now shows your edited image
9. Click on the “Crop” icon again
10. Click away from the block
11. Ensure the block exits “Edit mode”

#### ⚠️ Warning

The image editor UX might not be immediately intuitive, but it will make sense after a while when you'll familiarize. In the meantime, if you have never used that, you might be taken aback from the following things:

1. Cropping doesn't work like many image editors, in which you can draw a box around the image. Instead, you zoom using the scrollwheel and reposition the image inside the given constraints.
2. Depending on the original size of your image, switching from the block to the editor might startle you, as the editor's size depends on the actual size of the image.
3. If you zoom in the image and apply the edit, remember that you are actually (as per step 1) making the image smaller in reality. For this reason, the result might not be what you were expecting from the editor. However, you can get that effect (as shown, for instance, in the screenshot above) by turning on the “Cover” option in the block toolbar.

* [ ] Do not include in the Testing Notes

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Added media controls allowing the user to edit images within the editor on a Featured Product block
