### PR TITLE
Fix: Prevent page reloads twice when the shopper sets a price filter and attribute filter using blocks in a PHP template

### DIFF
--- a/assets/js/blocks/price-filter/block.js
+++ b/assets/js/blocks/price-filter/block.js
@@ -186,7 +186,7 @@ const PriceFilterBlock = ( { attributes, isEditor = false } ) => {
 			setMinPriceQuery,
 			setMaxPriceQuery,
 			filteringForPhpTemplate,
-			currency,
+			currency.minorUnit,
 		]
 	);
 
@@ -202,13 +202,30 @@ const PriceFilterBlock = ( { attributes, isEditor = false } ) => {
 			if ( prices[ 1 ] !== maxPrice ) {
 				setMaxPrice( prices[ 1 ] );
 			}
+
+			if (
+				filteringForPhpTemplate &&
+				hasSetPhpFilterDefaults &&
+				! attributes.showFilterButton
+			) {
+				onSubmit( prices[ 0 ], prices[ 1 ] );
+			}
 		},
-		[ minPrice, maxPrice, setMinPrice, setMaxPrice ]
+		[
+			minPrice,
+			maxPrice,
+			setMinPrice,
+			setMaxPrice,
+			filteringForPhpTemplate,
+			hasSetPhpFilterDefaults,
+			onSubmit,
+			attributes.showFilterButton,
+		]
 	);
 
 	// Track price STATE changes - if state changes, update the query.
 	useEffect( () => {
-		if ( ! attributes.showFilterButton ) {
+		if ( ! attributes.showFilterButton && ! filteringForPhpTemplate ) {
 			debouncedUpdateQuery( minPrice, maxPrice );
 		}
 	}, [
@@ -216,6 +233,7 @@ const PriceFilterBlock = ( { attributes, isEditor = false } ) => {
 		maxPrice,
 		attributes.showFilterButton,
 		debouncedUpdateQuery,
+		filteringForPhpTemplate,
 	] );
 
 	// Track price query/price constraint changes so the slider reflects current filters.

--- a/assets/js/blocks/price-filter/block.js
+++ b/assets/js/blocks/price-filter/block.js
@@ -208,7 +208,7 @@ const PriceFilterBlock = ( { attributes, isEditor = false } ) => {
 				hasSetPhpFilterDefaults &&
 				! attributes.showFilterButton
 			) {
-				onSubmit( prices[ 0 ], prices[ 1 ] );
+				debouncedUpdateQuery( prices[ 0 ], prices[ 1 ] );
 			}
 		},
 		[
@@ -218,7 +218,7 @@ const PriceFilterBlock = ( { attributes, isEditor = false } ) => {
 			setMaxPrice,
 			filteringForPhpTemplate,
 			hasSetPhpFilterDefaults,
-			onSubmit,
+			debouncedUpdateQuery,
 			attributes.showFilterButton,
 		]
 	);


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #6330 

This PR fixes the issue when the page reloads twice after setting a price filter and attribute filter using blocks in a PHP template. The root of the issue is that we're tracking the change in the state and updating the price filter block when the state changes. This works for blocks but doesn't work well for PHP templates where the state is shared between page loads through the URL causing the additional page reload (thanks @tjcafferkey for [the investigation](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/6330#issuecomment-1111992728)).

One more thing I noticed that we may want to fix: When using with products grid block like All Products, when the shopper set a price filter then an attribute filter, the product grid flashes because of the same reason pointed out above. The product grid first loads the result, then flashes, and then shows the same result, please check [this screencast](https://user-images.githubusercontent.com/5423135/166095061-5d1ad527-e931-4af0-af3f-58f2e7ea0185.mov) for more info.

### Screencasts

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

<table>
<tr>
	<td> Before
	<td> After
<tr>
	<td> <video src="https://user-images.githubusercontent.com/3616980/165425137-34a877d9-f74f-436e-9a2a-7a8131817727.mp4">
	<td> <video src="https://user-images.githubusercontent.com/5423135/166094595-b5a3cac1-2e59-44bb-be3a-3f069739f91d.mov">
</table>

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. With a block theme, go to Appearance > Site Editor.
2. Go to Templates and edit the Product Catalog template.
3. Above the WooCommerce Classic Template block, add the Filter Products by Price and Filter Products by Attribute blocks.
4. In the frontend, filter by price and let the page reload.
5. Now, filter also by attribute.
6. Notice the page **not** reloads twice.

* [ ] Do not include in the Testing Notes

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental