### PR TITLE
Meaningful comment for skipping the e2e tests

### DIFF
--- a/tests/e2e/specs/shopper/cart-checkout/account.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/account.test.js
@@ -27,6 +27,7 @@ const block = {
 
 if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 ) {
 	// Skips all the tests if it's a WooCommerce Core process environment.
+	// eslint-disable-next-line jest/no-focused-tests
 	test.only( 'Skipping Cart & Checkout tests', () => {} );
 }
 

--- a/tests/e2e/specs/shopper/cart-checkout/cart.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/cart.test.js
@@ -5,6 +5,7 @@ import { shopper, SIMPLE_VIRTUAL_PRODUCT_NAME } from '../../../../utils';
 
 if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 ) {
 	// Skips all the tests if it's a WooCommerce Core process environment.
+	// eslint-disable-next-line jest/no-focused-tests
 	test.only( `Skipping Cart & Checkout tests`, () => {} );
 }
 

--- a/tests/e2e/specs/shopper/cart-checkout/cart.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/cart.test.js
@@ -4,7 +4,7 @@
 import { shopper, SIMPLE_VIRTUAL_PRODUCT_NAME } from '../../../../utils';
 
 if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 ) {
-	// eslint-disable-next-line jest/no-focused-tests
+	// Skips all the tests if it's a WooCommerce Core process environment.
 	test.only( `Skipping Cart & Checkout tests`, () => {} );
 }
 

--- a/tests/e2e/specs/shopper/cart-checkout/checkout.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/checkout.test.js
@@ -31,7 +31,7 @@ import {
 import { createCoupon } from '../../../utils';
 
 if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 ) {
-	// eslint-disable-next-line jest/no-focused-tests
+	// Skips all the tests if it's a WooCommerce Core process environment.
 	test.only( 'Skipping Cart & Checkout tests', () => {} );
 }
 

--- a/tests/e2e/specs/shopper/cart-checkout/checkout.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/checkout.test.js
@@ -32,6 +32,7 @@ import { createCoupon } from '../../../utils';
 
 if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 ) {
 	// Skips all the tests if it's a WooCommerce Core process environment.
+	// eslint-disable-next-line jest/no-focused-tests
 	test.only( 'Skipping Cart & Checkout tests', () => {} );
 }
 

--- a/tests/e2e/specs/shopper/cart-checkout/tax.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/tax.test.js
@@ -17,7 +17,7 @@ const productWooSingle1 = Products().find(
 );
 
 if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 ) {
-	// eslint-disable-next-line jest/no-focused-tests
+	// Skips all the tests if it's a WooCommerce Core process environment.
 	test.only( `Skipping Cart & Checkout tests`, () => {} );
 }
 

--- a/tests/e2e/specs/shopper/cart-checkout/tax.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/tax.test.js
@@ -18,6 +18,7 @@ const productWooSingle1 = Products().find(
 
 if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 ) {
 	// Skips all the tests if it's a WooCommerce Core process environment.
+	// eslint-disable-next-line jest/no-focused-tests
 	test.only( `Skipping Cart & Checkout tests`, () => {} );
 }
 

--- a/tests/e2e/specs/shopper/cart-checkout/translations.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/translations.test.js
@@ -4,7 +4,7 @@
 import { merchant, shopper } from '../../../../utils';
 
 if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 ) {
-	// eslint-disable-next-line jest/no-focused-tests
+	// Skips all the tests if it's a WooCommerce Core process environment.
 	test.only( 'Skipping Cart & Checkout tests', () => {} );
 }
 

--- a/tests/e2e/specs/shopper/cart-checkout/translations.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/translations.test.js
@@ -5,6 +5,7 @@ import { merchant, shopper } from '../../../../utils';
 
 if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 ) {
 	// Skips all the tests if it's a WooCommerce Core process environment.
+	// eslint-disable-next-line jest/no-focused-tests
 	test.only( 'Skipping Cart & Checkout tests', () => {} );
 }
 

--- a/tests/e2e/specs/shopper/mini-cart.test.js
+++ b/tests/e2e/specs/shopper/mini-cart.test.js
@@ -54,7 +54,7 @@ const WooCommerce = new WooCommerceRestApi( {
 	},
 } );
 
-if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 3 ) {
+if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 ) {
 	// Skips all the tests if it's a WooCommerce Core process environment.
 	// eslint-disable-next-line jest/no-focused-tests
 	test.only( `Skipping ${ block.name } tests`, () => {} );

--- a/tests/e2e/specs/shopper/mini-cart.test.js
+++ b/tests/e2e/specs/shopper/mini-cart.test.js
@@ -56,6 +56,7 @@ const WooCommerce = new WooCommerceRestApi( {
 
 if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 3 ) {
 	// Skips all the tests if it's a WooCommerce Core process environment.
+	// eslint-disable-next-line jest/no-focused-tests
 	test.only( `Skipping ${ block.name } tests`, () => {} );
 }
 

--- a/tests/e2e/specs/shopper/mini-cart.test.js
+++ b/tests/e2e/specs/shopper/mini-cart.test.js
@@ -55,7 +55,7 @@ const WooCommerce = new WooCommerceRestApi( {
 } );
 
 if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 3 ) {
-	// eslint-disable-next-line jest/no-focused-tests
+	// Skips all the tests if it's a WooCommerce Core process environment.
 	test.only( `Skipping ${ block.name } tests`, () => {} );
 }
 


### PR DESCRIPTION
We have the following comment for skipping the e2e test cases:

```// eslint-disable-next-line jest/no-focused-tests```

It would be difficult for a new developer to understand why we are skipping these tests.

This PR adds the meaningful comment to skip all the tests if it's running in a WooCommerce Core process environment.
	