### PR TITLE
Add E2E tests for the Filter Products By Attribute Block

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -84,7 +84,7 @@
 				"@wordpress/data-controls": "2.2.7",
 				"@wordpress/dependency-extraction-webpack-plugin": "3.2.1",
 				"@wordpress/dom": "3.2.7",
-				"@wordpress/e2e-test-utils": "6.0.2",
+				"@wordpress/e2e-test-utils": "7.4.0",
 				"@wordpress/e2e-tests": "3.1.1",
 				"@wordpress/element": "4.0.4",
 				"@wordpress/env": "4.5.0",
@@ -12885,15 +12885,15 @@
 			}
 		},
 		"node_modules/@wordpress/e2e-test-utils": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils/-/e2e-test-utils-6.0.2.tgz",
-			"integrity": "sha512-0Vz/DcneaVreuVhtZ0ecfv/tKg/q0FflnQ3MnnRlqmf4tZNnkKPuBj6l/XbzRsH61NzQbhYnHV7gYV4o+UIVLQ==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils/-/e2e-test-utils-7.4.0.tgz",
+			"integrity": "sha512-soT2WS4Ys/NTsVUz4KCXzYjIxWjYP8vpNboU51KD/cQcJnbwHvn7IBjacJyqAfjuPv8s5ZP/INcpaWL2vM1hdQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/api-fetch": "^6.0.1",
-				"@wordpress/keycodes": "^3.3.1",
-				"@wordpress/url": "^3.4.1",
+				"@wordpress/api-fetch": "^6.5.0",
+				"@wordpress/keycodes": "^3.8.0",
+				"@wordpress/url": "^3.9.0",
 				"form-data": "^4.0.0",
 				"lodash": "^4.17.21",
 				"node-fetch": "^2.6.0"
@@ -12907,27 +12907,27 @@
 			}
 		},
 		"node_modules/@wordpress/e2e-test-utils/node_modules/@wordpress/api-fetch": {
-			"version": "6.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.4.0.tgz",
-			"integrity": "sha512-JdxMcVNDZjxcfWzzdMIaEIOezaMYgaG7hhJIdX7+VHKTwHRhLuo6CLMfJL/viVWpVt6xohpPEkfQzKiWgMn/4g==",
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.5.0.tgz",
+			"integrity": "sha512-ri3Ha/mgo4lHH5akTSAetd0LLNcuqR/lOBC0hb7tgFUpUXJLWCyZnPNRVFruSgcnXzv5DmeoEnY+F3hPWCZBmA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/i18n": "^4.7.0",
-				"@wordpress/url": "^3.8.0"
+				"@wordpress/i18n": "^4.8.0",
+				"@wordpress/url": "^3.9.0"
 			},
 			"engines": {
 				"node": ">=12"
 			}
 		},
 		"node_modules/@wordpress/e2e-test-utils/node_modules/@wordpress/i18n": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.7.0.tgz",
-			"integrity": "sha512-+v/Xf+zhftUrmX+vaIpQTP5LY8GFKPY5hkmhPGEuFfIjytY7LfT6xNU7LCaoBj+m94RNoPlK/PTtCHYDAQhqzg==",
+			"version": "4.8.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.8.0.tgz",
+			"integrity": "sha512-xo6OHRqBQVTnjOVqXr3gkoKzLbadhUVLxHzyNv2x49Sm1RADMRlOZW7yQCtCu+nkPJZXUwAcik25gzBZHZrYEg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/hooks": "^3.7.0",
+				"@wordpress/hooks": "^3.8.0",
 				"gettext-parser": "^1.3.1",
 				"lodash": "^4.17.21",
 				"memize": "^1.1.0",
@@ -12983,82 +12983,11 @@
 				"puppeteer-core": ">=11"
 			}
 		},
-		"node_modules/@wordpress/e2e-tests/node_modules/@wordpress/api-fetch": {
-			"version": "6.4.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.4.0.tgz",
-			"integrity": "sha512-JdxMcVNDZjxcfWzzdMIaEIOezaMYgaG7hhJIdX7+VHKTwHRhLuo6CLMfJL/viVWpVt6xohpPEkfQzKiWgMn/4g==",
-			"dev": true,
-			"dependencies": {
-				"@babel/runtime": "^7.16.0",
-				"@wordpress/i18n": "^4.7.0",
-				"@wordpress/url": "^3.8.0"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
-		"node_modules/@wordpress/e2e-tests/node_modules/@wordpress/e2e-test-utils": {
-			"version": "7.3.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils/-/e2e-test-utils-7.3.0.tgz",
-			"integrity": "sha512-p3SqoX+HgDSddpeSxj2X+Z03N+RgrHzMcVzx8k20LpQybRHCOu6uTfezBQ0eI8xqghr1DgR8NdCUPgBlXRnCQQ==",
-			"dev": true,
-			"dependencies": {
-				"@babel/runtime": "^7.16.0",
-				"@wordpress/api-fetch": "^6.4.0",
-				"@wordpress/keycodes": "^3.7.0",
-				"@wordpress/url": "^3.8.0",
-				"form-data": "^4.0.0",
-				"lodash": "^4.17.21",
-				"node-fetch": "^2.6.0"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"peerDependencies": {
-				"jest": ">=27",
-				"puppeteer-core": ">=11"
-			}
-		},
-		"node_modules/@wordpress/e2e-tests/node_modules/@wordpress/i18n": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.7.0.tgz",
-			"integrity": "sha512-+v/Xf+zhftUrmX+vaIpQTP5LY8GFKPY5hkmhPGEuFfIjytY7LfT6xNU7LCaoBj+m94RNoPlK/PTtCHYDAQhqzg==",
-			"dev": true,
-			"dependencies": {
-				"@babel/runtime": "^7.16.0",
-				"@wordpress/hooks": "^3.7.0",
-				"gettext-parser": "^1.3.1",
-				"lodash": "^4.17.21",
-				"memize": "^1.1.0",
-				"sprintf-js": "^1.1.1",
-				"tannin": "^1.2.0"
-			},
-			"bin": {
-				"pot-to-php": "tools/pot-to-php.js"
-			},
-			"engines": {
-				"node": ">=12"
-			}
-		},
 		"node_modules/@wordpress/e2e-tests/node_modules/expect-puppeteer": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/expect-puppeteer/-/expect-puppeteer-4.4.0.tgz",
 			"integrity": "sha512-6Ey4Xy2xvmuQu7z7YQtMsaMV0EHJRpVxIDOd5GRrm04/I3nkTKIutELfECsLp6le+b3SSa3cXhPiw6PgqzxYWA==",
 			"dev": true
-		},
-		"node_modules/@wordpress/e2e-tests/node_modules/form-data": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-			"integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-			"dev": true,
-			"dependencies": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.8",
-				"mime-types": "^2.1.12"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
 		},
 		"node_modules/@wordpress/element": {
 			"version": "4.0.4",
@@ -13254,9 +13183,9 @@
 			}
 		},
 		"node_modules/@wordpress/hooks": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.7.0.tgz",
-			"integrity": "sha512-lBTfLEmQVdnuDJZqaHqjU2pEfy2IyBIVlJsvBuvUFVbDIW+tqP2Hbs/3nHWNNNo9A3RFhAG3cW/eNH0alBSAvQ==",
+			"version": "3.8.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.8.0.tgz",
+			"integrity": "sha512-PSBFYs7pH6BFcIuUUX6TQThSVSWtFpcYTfyIRVz26FsptRbCOXUzxHVKc5ofawTmcrOPyvAeDpEiVGJ1UOm8Lw==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0"
 			},
@@ -13419,12 +13348,12 @@
 			}
 		},
 		"node_modules/@wordpress/keycodes": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.7.0.tgz",
-			"integrity": "sha512-bisC53W0wHChvDG4gUYtjPznw2xj+ERs8DDg3iYBGJu7oHNnJI+vDmy/Pmuw/vjz3SfkiefnU/1Y51csy8AdEQ==",
+			"version": "3.8.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.8.0.tgz",
+			"integrity": "sha512-WqYY/NDMQbt9rEAzX+kQRTXBiw0ct4YjPSe4pTVpPW7AHoKpkhyC2xKlYAfIQ6IlbHqRQ0XFLbGBMoi0n9ENAA==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/i18n": "^4.7.0",
+				"@wordpress/i18n": "^4.8.0",
 				"lodash": "^4.17.21"
 			},
 			"engines": {
@@ -13432,12 +13361,12 @@
 			}
 		},
 		"node_modules/@wordpress/keycodes/node_modules/@wordpress/i18n": {
-			"version": "4.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.7.0.tgz",
-			"integrity": "sha512-+v/Xf+zhftUrmX+vaIpQTP5LY8GFKPY5hkmhPGEuFfIjytY7LfT6xNU7LCaoBj+m94RNoPlK/PTtCHYDAQhqzg==",
+			"version": "4.8.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.8.0.tgz",
+			"integrity": "sha512-xo6OHRqBQVTnjOVqXr3gkoKzLbadhUVLxHzyNv2x49Sm1RADMRlOZW7yQCtCu+nkPJZXUwAcik25gzBZHZrYEg==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/hooks": "^3.7.0",
+				"@wordpress/hooks": "^3.8.0",
 				"gettext-parser": "^1.3.1",
 				"lodash": "^4.17.21",
 				"memize": "^1.1.0",
@@ -16280,9 +16209,9 @@
 			}
 		},
 		"node_modules/@wordpress/url": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.8.0.tgz",
-			"integrity": "sha512-gmmij9MEIzpCg88fLG6tGY0pI9vg6uImQIgZTNArkYeYMEGXXYbRxOAHM8fQ8usPrTFjlgxl+OaZcKcsx0/MSw==",
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.9.0.tgz",
+			"integrity": "sha512-fiPvb9xB8g/xwSprq+mEI1MyH/H9xCfpqKcnG10JdAWRFahQky6QU0cAOPTYNuU96l0++Ha/SkHSylVyftzFAw==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
 				"lodash": "^4.17.21"
@@ -60450,39 +60379,39 @@
 			}
 		},
 		"@wordpress/e2e-test-utils": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils/-/e2e-test-utils-6.0.2.tgz",
-			"integrity": "sha512-0Vz/DcneaVreuVhtZ0ecfv/tKg/q0FflnQ3MnnRlqmf4tZNnkKPuBj6l/XbzRsH61NzQbhYnHV7gYV4o+UIVLQ==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils/-/e2e-test-utils-7.4.0.tgz",
+			"integrity": "sha512-soT2WS4Ys/NTsVUz4KCXzYjIxWjYP8vpNboU51KD/cQcJnbwHvn7IBjacJyqAfjuPv8s5ZP/INcpaWL2vM1hdQ==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/api-fetch": "^6.0.1",
-				"@wordpress/keycodes": "^3.3.1",
-				"@wordpress/url": "^3.4.1",
+				"@wordpress/api-fetch": "^6.5.0",
+				"@wordpress/keycodes": "^3.8.0",
+				"@wordpress/url": "^3.9.0",
 				"form-data": "^4.0.0",
 				"lodash": "^4.17.21",
 				"node-fetch": "^2.6.0"
 			},
 			"dependencies": {
 				"@wordpress/api-fetch": {
-					"version": "6.4.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.4.0.tgz",
-					"integrity": "sha512-JdxMcVNDZjxcfWzzdMIaEIOezaMYgaG7hhJIdX7+VHKTwHRhLuo6CLMfJL/viVWpVt6xohpPEkfQzKiWgMn/4g==",
+					"version": "6.5.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.5.0.tgz",
+					"integrity": "sha512-ri3Ha/mgo4lHH5akTSAetd0LLNcuqR/lOBC0hb7tgFUpUXJLWCyZnPNRVFruSgcnXzv5DmeoEnY+F3hPWCZBmA==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.16.0",
-						"@wordpress/i18n": "^4.7.0",
-						"@wordpress/url": "^3.8.0"
+						"@wordpress/i18n": "^4.8.0",
+						"@wordpress/url": "^3.9.0"
 					}
 				},
 				"@wordpress/i18n": {
-					"version": "4.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.7.0.tgz",
-					"integrity": "sha512-+v/Xf+zhftUrmX+vaIpQTP5LY8GFKPY5hkmhPGEuFfIjytY7LfT6xNU7LCaoBj+m94RNoPlK/PTtCHYDAQhqzg==",
+					"version": "4.8.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.8.0.tgz",
+					"integrity": "sha512-xo6OHRqBQVTnjOVqXr3gkoKzLbadhUVLxHzyNv2x49Sm1RADMRlOZW7yQCtCu+nkPJZXUwAcik25gzBZHZrYEg==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.16.0",
-						"@wordpress/hooks": "^3.7.0",
+						"@wordpress/hooks": "^3.8.0",
 						"gettext-parser": "^1.3.1",
 						"lodash": "^4.17.21",
 						"memize": "^1.1.0",
@@ -60524,63 +60453,11 @@
 				"uuid": "^8.3.0"
 			},
 			"dependencies": {
-				"@wordpress/api-fetch": {
-					"version": "6.4.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.4.0.tgz",
-					"integrity": "sha512-JdxMcVNDZjxcfWzzdMIaEIOezaMYgaG7hhJIdX7+VHKTwHRhLuo6CLMfJL/viVWpVt6xohpPEkfQzKiWgMn/4g==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.16.0",
-						"@wordpress/i18n": "^4.7.0",
-						"@wordpress/url": "^3.8.0"
-					}
-				},
-				"@wordpress/e2e-test-utils": {
-					"version": "7.3.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils/-/e2e-test-utils-7.3.0.tgz",
-					"integrity": "sha512-p3SqoX+HgDSddpeSxj2X+Z03N+RgrHzMcVzx8k20LpQybRHCOu6uTfezBQ0eI8xqghr1DgR8NdCUPgBlXRnCQQ==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.16.0",
-						"@wordpress/api-fetch": "^6.4.0",
-						"@wordpress/keycodes": "^3.7.0",
-						"@wordpress/url": "^3.8.0",
-						"form-data": "^4.0.0",
-						"lodash": "^4.17.21",
-						"node-fetch": "^2.6.0"
-					}
-				},
-				"@wordpress/i18n": {
-					"version": "4.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.7.0.tgz",
-					"integrity": "sha512-+v/Xf+zhftUrmX+vaIpQTP5LY8GFKPY5hkmhPGEuFfIjytY7LfT6xNU7LCaoBj+m94RNoPlK/PTtCHYDAQhqzg==",
-					"dev": true,
-					"requires": {
-						"@babel/runtime": "^7.16.0",
-						"@wordpress/hooks": "^3.7.0",
-						"gettext-parser": "^1.3.1",
-						"lodash": "^4.17.21",
-						"memize": "^1.1.0",
-						"sprintf-js": "^1.1.1",
-						"tannin": "^1.2.0"
-					}
-				},
 				"expect-puppeteer": {
 					"version": "4.4.0",
 					"resolved": "https://registry.npmjs.org/expect-puppeteer/-/expect-puppeteer-4.4.0.tgz",
 					"integrity": "sha512-6Ey4Xy2xvmuQu7z7YQtMsaMV0EHJRpVxIDOd5GRrm04/I3nkTKIutELfECsLp6le+b3SSa3cXhPiw6PgqzxYWA==",
 					"dev": true
-				},
-				"form-data": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-					"integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-					"dev": true,
-					"requires": {
-						"asynckit": "^0.4.0",
-						"combined-stream": "^1.0.8",
-						"mime-types": "^2.1.12"
-					}
 				}
 			}
 		},
@@ -60735,9 +60612,9 @@
 			}
 		},
 		"@wordpress/hooks": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.7.0.tgz",
-			"integrity": "sha512-lBTfLEmQVdnuDJZqaHqjU2pEfy2IyBIVlJsvBuvUFVbDIW+tqP2Hbs/3nHWNNNo9A3RFhAG3cW/eNH0alBSAvQ==",
+			"version": "3.8.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.8.0.tgz",
+			"integrity": "sha512-PSBFYs7pH6BFcIuUUX6TQThSVSWtFpcYTfyIRVz26FsptRbCOXUzxHVKc5ofawTmcrOPyvAeDpEiVGJ1UOm8Lw==",
 			"requires": {
 				"@babel/runtime": "^7.16.0"
 			}
@@ -60848,22 +60725,22 @@
 			}
 		},
 		"@wordpress/keycodes": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.7.0.tgz",
-			"integrity": "sha512-bisC53W0wHChvDG4gUYtjPznw2xj+ERs8DDg3iYBGJu7oHNnJI+vDmy/Pmuw/vjz3SfkiefnU/1Y51csy8AdEQ==",
+			"version": "3.8.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.8.0.tgz",
+			"integrity": "sha512-WqYY/NDMQbt9rEAzX+kQRTXBiw0ct4YjPSe4pTVpPW7AHoKpkhyC2xKlYAfIQ6IlbHqRQ0XFLbGBMoi0n9ENAA==",
 			"requires": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/i18n": "^4.7.0",
+				"@wordpress/i18n": "^4.8.0",
 				"lodash": "^4.17.21"
 			},
 			"dependencies": {
 				"@wordpress/i18n": {
-					"version": "4.7.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.7.0.tgz",
-					"integrity": "sha512-+v/Xf+zhftUrmX+vaIpQTP5LY8GFKPY5hkmhPGEuFfIjytY7LfT6xNU7LCaoBj+m94RNoPlK/PTtCHYDAQhqzg==",
+					"version": "4.8.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.8.0.tgz",
+					"integrity": "sha512-xo6OHRqBQVTnjOVqXr3gkoKzLbadhUVLxHzyNv2x49Sm1RADMRlOZW7yQCtCu+nkPJZXUwAcik25gzBZHZrYEg==",
 					"requires": {
 						"@babel/runtime": "^7.16.0",
-						"@wordpress/hooks": "^3.7.0",
+						"@wordpress/hooks": "^3.8.0",
 						"gettext-parser": "^1.3.1",
 						"lodash": "^4.17.21",
 						"memize": "^1.1.0",
@@ -62923,9 +62800,9 @@
 			}
 		},
 		"@wordpress/url": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.8.0.tgz",
-			"integrity": "sha512-gmmij9MEIzpCg88fLG6tGY0pI9vg6uImQIgZTNArkYeYMEGXXYbRxOAHM8fQ8usPrTFjlgxl+OaZcKcsx0/MSw==",
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.9.0.tgz",
+			"integrity": "sha512-fiPvb9xB8g/xwSprq+mEI1MyH/H9xCfpqKcnG10JdAWRFahQky6QU0cAOPTYNuU96l0++Ha/SkHSylVyftzFAw==",
 			"requires": {
 				"@babel/runtime": "^7.16.0",
 				"lodash": "^4.17.21"

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,6 +59,7 @@
 				"@types/dinero.js": "1.9.0",
 				"@types/gtag.js": "0.0.10",
 				"@types/jest": "27.4.1",
+				"@types/jest-environment-puppeteer": "5.0.2",
 				"@types/jquery": "3.5.14",
 				"@types/lodash": "4.14.182",
 				"@types/puppeteer": "5.4.6",
@@ -10435,6 +10436,17 @@
 			"dependencies": {
 				"jest-matcher-utils": "^27.0.0",
 				"pretty-format": "^27.0.0"
+			}
+		},
+		"node_modules/@types/jest-environment-puppeteer": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/@types/jest-environment-puppeteer/-/jest-environment-puppeteer-5.0.2.tgz",
+			"integrity": "sha512-YCdegQnDou6aIK8wqygDDctHgJZtlXd03fI9Bgbqkdu66EFKnImmt7auiR9OkxkSSiqS9smn0joX2pGpVs7ErA==",
+			"dev": true,
+			"dependencies": {
+				"@jest/types": ">=24 <=27",
+				"@types/puppeteer": "*",
+				"jest-environment-node": ">=24 <=27"
 			}
 		},
 		"node_modules/@types/jquery": {
@@ -58312,6 +58324,17 @@
 			"requires": {
 				"jest-matcher-utils": "^27.0.0",
 				"pretty-format": "^27.0.0"
+			}
+		},
+		"@types/jest-environment-puppeteer": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/@types/jest-environment-puppeteer/-/jest-environment-puppeteer-5.0.2.tgz",
+			"integrity": "sha512-YCdegQnDou6aIK8wqygDDctHgJZtlXd03fI9Bgbqkdu66EFKnImmt7auiR9OkxkSSiqS9smn0joX2pGpVs7ErA==",
+			"dev": true,
+			"requires": {
+				"@jest/types": ">=24 <=27",
+				"@types/puppeteer": "*",
+				"jest-environment-node": ">=24 <=27"
 			}
 		},
 		"@types/jquery": {

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
 		"@wordpress/data-controls": "2.2.7",
 		"@wordpress/dependency-extraction-webpack-plugin": "3.2.1",
 		"@wordpress/dom": "3.2.7",
-		"@wordpress/e2e-test-utils": "6.0.2",
+		"@wordpress/e2e-test-utils": "7.4.0",
 		"@wordpress/e2e-tests": "3.1.1",
 		"@wordpress/element": "4.0.4",
 		"@wordpress/env": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
 		"@testing-library/react": "12.1.5",
 		"@testing-library/react-hooks": "7.0.2",
 		"@testing-library/user-event": "13.5.0",
+		"@types/jest-environment-puppeteer": "5.0.2",
 		"@types/classnames": "2.3.0",
 		"@types/dinero.js": "1.9.0",
 		"@types/gtag.js": "0.0.10",

--- a/tests/e2e/config/setup.js
+++ b/tests/e2e/config/setup.js
@@ -20,6 +20,7 @@ import {
 	createBlockPages,
 	enablePaymentGateways,
 	createProductAttributes,
+	disableAttributeLookup,
 } from '../fixtures/fixture-loaders';
 import { PERFORMANCE_REPORT_FILENAME } from '../../utils/constants';
 
@@ -65,6 +66,9 @@ module.exports = async ( globalConfig ) => {
 		products.forEach( async ( productId ) => {
 			await createReviews( productId );
 		} );
+
+		// This is necessary for avoid this bug https://github.com/woocommerce/woocommerce/issues/32065
+		await disableAttributeLookup();
 
 		// Wipe the performance e2e file at the start of every run
 		if ( existsSync( PERFORMANCE_REPORT_FILENAME ) ) {

--- a/tests/e2e/fixtures/fixture-loaders.js
+++ b/tests/e2e/fixtures/fixture-loaders.js
@@ -477,6 +477,11 @@ const deleteProductAttributes = ( ids ) => {
 	return WooCommerce.post( 'products/attributes/batch', { delete: ids } );
 };
 
+const disableAttributeLookup = () =>
+	WooCommerce.put( 'settings/products/woocommerce_attribute_lookup_enabled', {
+		value: 'no',
+	} );
+
 module.exports = {
 	createProductAttributes,
 	deleteProductAttributes,
@@ -498,4 +503,5 @@ module.exports = {
 	deleteShippingZones,
 	createBlockPages,
 	deleteBlockPages,
+	disableAttributeLookup,
 };

--- a/tests/e2e/globals.d.ts
+++ b/tests/e2e/globals.d.ts
@@ -1,0 +1,5 @@
+import { Page } from 'puppeteer';
+
+declare global {
+	const page: Page;
+}

--- a/tests/e2e/globals.d.ts
+++ b/tests/e2e/globals.d.ts
@@ -1,5 +1,0 @@
-import { Page } from 'puppeteer';
-
-declare global {
-	const page: Page;
-}

--- a/tests/e2e/specs/shopper/filter-products-by-attribute.test.ts
+++ b/tests/e2e/specs/shopper/filter-products-by-attribute.test.ts
@@ -1,0 +1,205 @@
+import {
+	canvas,
+	createNewPost,
+	deleteAllTemplates,
+	insertBlock,
+	switchUserToAdmin,
+	publishPost,
+} from '@wordpress/e2e-test-utils';
+import { Frame } from 'puppeteer';
+import { selectBlockByName } from '@woocommerce/blocks-test-utils';
+
+import {
+	BASE_URL,
+	goToTemplateEditor,
+	openBlockEditorSettings,
+	saveTemplate,
+	useTheme,
+} from '../../utils';
+
+const block = {
+	name: 'Filter Products by Attribute',
+	slug: 'woocommerce/attribute-filter',
+	class: '.wc-block-attribute-filter',
+	selectors: {
+		editor: {
+			firstAttributeInTheList:
+				'.woocommerce-search-list__list > li > label > input.woocommerce-search-list__item-input',
+			filterButtonToggle: "//label[text()='Filter button']",
+			doneButton: '.wc-block-attribute-filter__selection > button',
+		},
+		frontend: {
+			firstAttributeInTheList:
+				'.wc-block-attribute-filter-list > li:not([class^="is-loading"])',
+			productsList: '.wc-block-grid__products > li',
+			classicProductsList: '.products.columns-3 > li',
+			filter: "input[id='128gb']",
+			submitButton: '.wc-block-components-filter-submit-button',
+		},
+	},
+	urlSearchParamWhenFilterIsApplied:
+		'?filter_capacity=128gb&query_type_capacity=or',
+};
+
+const waitForAllProductsBlockLoaded = () =>
+	page.waitForSelector( selectors.frontend.productsList + '.is-loading', {
+		hidden: true,
+	} );
+
+const goToShopPage = () =>
+	page.goto( BASE_URL + '/shop', {
+		waitUntil: 'networkidle0',
+	} );
+
+const { selectors } = block;
+
+describe( `${ block.name } Block`, () => {
+	describe( 'with All Products Block', () => {
+		beforeAll( async () => {
+			await switchUserToAdmin();
+			await createNewPost( {
+				postType: 'post',
+				title: block.name,
+			} );
+
+			await insertBlock( block.name );
+			await page.click( selectors.editor.firstAttributeInTheList );
+			await page.click( selectors.editor.doneButton );
+			await insertBlock( 'All Products' );
+			await publishPost();
+
+			const link = await page.evaluate( () =>
+				wp.data.select( 'core/editor' ).getPermalink()
+			);
+
+			await page.goto( link );
+		} );
+
+		it( 'should render', async () => {
+			await waitForAllProductsBlockLoaded();
+			const products = await page.$$( selectors.frontend.productsList );
+
+			expect( products ).toHaveLength( 4 );
+		} );
+
+		it( 'should show only products that match the filter', async () => {
+			const isRefreshed = jest.fn( () => void 0 );
+			page.on( 'load', isRefreshed );
+			await page.click( selectors.frontend.filter );
+			await waitForAllProductsBlockLoaded();
+			const products = await page.$$( selectors.frontend.productsList );
+
+			expect( isRefreshed ).not.toBeCalled();
+			expect( products ).toHaveLength( 1 );
+		} );
+	} );
+
+	describe( 'with PHP classic template ', () => {
+		const productCatalogTemplateId =
+			'woocommerce/woocommerce//archive-product';
+
+		useTheme( 'emptytheme' );
+		beforeAll( async () => {
+			await deleteAllTemplates( 'wp_template' );
+			await deleteAllTemplates( 'wp_template_part' );
+
+			await goToTemplateEditor( {
+				postId: productCatalogTemplateId,
+			} );
+			await insertBlock( block.name );
+			const canvasEl: Frame = canvas();
+
+			// It seems that .click doesn't work well with radio input element.
+			await canvasEl.$eval(
+				block.selectors.editor.firstAttributeInTheList,
+				( el ) => ( el as HTMLInputElement ).click()
+			);
+			await canvasEl.click( selectors.editor.doneButton );
+			await saveTemplate();
+			await goToShopPage();
+		} );
+
+		afterAll( async () => {
+			await deleteAllTemplates( 'wp_template' );
+			await deleteAllTemplates( 'wp_template_part' );
+		} );
+
+		it( 'should render', async () => {
+			const products = await page.$$(
+				selectors.frontend.classicProductsList
+			);
+
+			expect( products ).toHaveLength( 4 );
+		} );
+
+		it( 'should show only products that match the filter', async () => {
+			const isRefreshed = jest.fn( () => void 0 );
+			page.on( 'load', isRefreshed );
+
+			await page.waitForSelector( block.class + '.is-loading', {
+				hidden: true,
+			} );
+
+			await Promise.all( [
+				page.waitForNavigation( {
+					waitUntil: 'networkidle0',
+				} ),
+				page.click( selectors.frontend.filter ),
+			] );
+
+			const products = await page.$$(
+				selectors.frontend.classicProductsList
+			);
+
+			const pageURL = page.url();
+			const parsedURL = new URL( pageURL );
+
+			expect( isRefreshed ).toBeCalledTimes( 1 );
+			expect( products ).toHaveLength( 1 );
+			expect( parsedURL.search ).toEqual(
+				block.urlSearchParamWhenFilterIsApplied
+			);
+		} );
+
+		it( 'should refresh the page only if the user click on button', async () => {
+			await goToTemplateEditor( {
+				postId: productCatalogTemplateId,
+			} );
+
+			await selectBlockByName( block.slug );
+			await openBlockEditorSettings();
+			const [ filterButtonToggle ] = await page.$x(
+				block.selectors.editor.filterButtonToggle
+			);
+			await filterButtonToggle.click();
+			await saveTemplate();
+			await goToShopPage();
+
+			const isRefreshed = jest.fn( () => void 0 );
+			page.on( 'load', isRefreshed );
+			await page.waitForSelector( block.class + '.is-loading', {
+				hidden: true,
+			} );
+			await page.waitForSelector( selectors.frontend.filter );
+			await page.click( selectors.frontend.filter );
+			await Promise.all( [
+				page.waitForNavigation( {
+					waitUntil: 'networkidle0',
+				} ),
+				page.click( selectors.frontend.submitButton ),
+			] );
+
+			const products = await page.$$(
+				selectors.frontend.classicProductsList
+			);
+			const pageURL = page.url();
+			const parsedURL = new URL( pageURL );
+
+			expect( isRefreshed ).toBeCalledTimes( 1 );
+			expect( products ).toHaveLength( 1 );
+			expect( parsedURL.search ).toEqual(
+				block.urlSearchParamWhenFilterIsApplied
+			);
+		} );
+	} );
+} );

--- a/tests/e2e/specs/shopper/filter-products-by-attribute.test.ts
+++ b/tests/e2e/specs/shopper/filter-products-by-attribute.test.ts
@@ -39,6 +39,7 @@ const block = {
 	},
 	urlSearchParamWhenFilterIsApplied:
 		'?filter_capacity=128gb&query_type_capacity=or',
+	foundProduct: '128GB USB Stick',
 };
 
 const waitForAllProductsBlockLoaded = () =>
@@ -91,6 +92,7 @@ describe( `${ block.name } Block`, () => {
 
 			expect( isRefreshed ).not.toBeCalled();
 			expect( products ).toHaveLength( 1 );
+			await expect( page ).toMatch( block.foundProduct );
 		} );
 	} );
 
@@ -140,6 +142,8 @@ describe( `${ block.name } Block`, () => {
 				hidden: true,
 			} );
 
+			expect( isRefreshed ).not.toBeCalled();
+
 			await Promise.all( [
 				page.waitForNavigation( {
 					waitUntil: 'networkidle0',
@@ -156,6 +160,7 @@ describe( `${ block.name } Block`, () => {
 
 			expect( isRefreshed ).toBeCalledTimes( 1 );
 			expect( products ).toHaveLength( 1 );
+			await expect( page ).toMatch( block.foundProduct );
 			expect( parsedURL.search ).toEqual(
 				block.urlSearchParamWhenFilterIsApplied
 			);
@@ -182,6 +187,9 @@ describe( `${ block.name } Block`, () => {
 			} );
 			await page.waitForSelector( selectors.frontend.filter );
 			await page.click( selectors.frontend.filter );
+
+			expect( isRefreshed ).not.toBeCalled();
+
 			await Promise.all( [
 				page.waitForNavigation( {
 					waitUntil: 'networkidle0',
@@ -197,6 +205,7 @@ describe( `${ block.name } Block`, () => {
 
 			expect( isRefreshed ).toBeCalledTimes( 1 );
 			expect( products ).toHaveLength( 1 );
+			await expect( page ).toMatch( block.foundProduct );
 			expect( parsedURL.search ).toEqual(
 				block.urlSearchParamWhenFilterIsApplied
 			);

--- a/tests/e2e/tsconfig.json
+++ b/tests/e2e/tsconfig.json
@@ -1,0 +1,3 @@
+{
+	"extends": "../../tsconfig.base.json"
+}

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -431,3 +431,19 @@ export const createCoupon = async ( coupon ) => {
 
 	return createdCoupon;
 };
+
+/**
+ * Open the block editor settings menu.
+ */
+export const openBlockEditorSettings = async () => {
+	const buttonSelector =
+		'.edit-site-header__actions button[aria-label="Settings"]';
+
+	const isButtonPressed = await page.$eval( buttonSelector, ( el ) =>
+		el.getAttribute( 'aria-pressed' )
+	);
+
+	if ( isButtonPressed === 'false' ) {
+		await page.click( buttonSelector );
+	}
+};

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -439,11 +439,11 @@ export const openBlockEditorSettings = async () => {
 	const buttonSelector =
 		'.edit-site-header__actions button[aria-label="Settings"]';
 
-	const isButtonPressed = await page.$eval( buttonSelector, ( el ) =>
-		el.getAttribute( 'aria-pressed' )
+	const isSideBarAlreadyOpened = await page.$(
+		'.interface-interface-skeleton__sidebar'
 	);
 
-	if ( isButtonPressed === 'false' ) {
+	if ( isSideBarAlreadyOpened === null ) {
 		await page.click( buttonSelector );
 	}
 };


### PR DESCRIPTION
This PR adds E2E tests for the Filter Products By Attribute Block. These tests check that:
- when the filter is applied only the products that match that filter are rendered.
- only on the classic PHP template the refresh is triggered.
- after the page refreshes, the URL is what we expect.
- when the filter button is enabled the page refresh is only triggered once the user clicks on it.
<!-- Reference any related issues or PRs here -->
This PR adds the `Page` TS type to the global variable `page`.

Fixes #6322

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

Check out this branch

1. Run `npm run test:e2e tests/e2e/specs/shopper/filter-products-by-attribute.test.ts`.
2. Be sure that tests don't fail.

* [x] Do not include in the Testing Notes

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental


