### PR TITLE
Classic Template: set the default alignment to wide

### DIFF
--- a/assets/js/blocks/classic-template/README.md
+++ b/assets/js/blocks/classic-template/README.md
@@ -14,6 +14,7 @@ This block does not have any customizable options available, so any style or cus
 
 * `attributes`
   * `template`: `single-product` | `archive-product` | `taxonomy-product_cat` | `taxonomy-product_tag`
+  * `align`: `wide` | `full`
 
 ```html
 <!-- wp:woocommerce/legacy-template {"template":"single-product"} /-->

--- a/assets/js/blocks/classic-template/editor.scss
+++ b/assets/js/blocks/classic-template/editor.scss
@@ -1,3 +1,9 @@
+:where(.wp-block-woocommerce-legacy-template) {
+	margin-left: auto;
+	margin-right: auto;
+	max-width: 1000px;
+}
+
 .wp-block-woocommerce-classic-template__placeholder-copy {
 	max-width: 900px;
 	margin-bottom: 30px;

--- a/assets/js/blocks/classic-template/index.tsx
+++ b/assets/js/blocks/classic-template/index.tsx
@@ -12,6 +12,7 @@ import { box, Icon } from '@wordpress/icons';
  * Internal dependencies
  */
 import './editor.scss';
+import './style.scss';
 import { TEMPLATES } from './constants';
 
 interface Props {

--- a/assets/js/blocks/classic-template/index.tsx
+++ b/assets/js/blocks/classic-template/index.tsx
@@ -17,6 +17,7 @@ import { TEMPLATES } from './constants';
 interface Props {
 	attributes: {
 		template: string;
+		align: string;
 	};
 }
 
@@ -108,6 +109,10 @@ registerBlockType( 'woocommerce/legacy-template', {
 		template: {
 			type: 'string',
 			default: 'any',
+		},
+		align: {
+			type: 'string',
+			default: 'wide',
 		},
 	},
 	edit: Edit,

--- a/assets/js/blocks/classic-template/style.scss
+++ b/assets/js/blocks/classic-template/style.scss
@@ -1,0 +1,5 @@
+:where(div[data-block-name="woocommerce/legacy-template"]) {
+	margin-left: auto;
+	margin-right: auto;
+	max-width: 1000px;
+}

--- a/src/BlockTypes/ClassicTemplate.php
+++ b/src/BlockTypes/ClassicTemplate.php
@@ -235,7 +235,13 @@ class ClassicTemplate extends AbstractDynamicBlock {
 			return $content;
 		}
 
-		$attributes            = (array) $block['attrs'];
+		$attributes = (array) $block['attrs'];
+
+		// Set the default alignment to wide.
+		if ( ! isset( $attributes['align'] ) ) {
+			$attributes['align'] = 'wide';
+		}
+
 		$align_class_and_style = StyleAttributesUtils::get_align_class_and_style( $attributes );
 
 		if ( ! isset( $align_class_and_style['class'] ) ) {
@@ -304,6 +310,5 @@ class ClassicTemplate extends AbstractDynamicBlock {
 		$vars[] = self::FILTER_PRODUCTS_BY_STOCK_QUERY_PARAM;
 		return $vars;
 	}
-
 
 }


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #5863, depends on https://github.com/woocommerce/woocommerce/pull/32840

This PR changes the default alignment of the Classic Template block to `wide` and adds a fallback (1000px width) when the active theme doesn't set contents and wide width. This PR use `:where` for the fallback style to lower its specificity, making it easier to override the style.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Apply this PR to the WooCommerce plugin.
2. With Twenty Twenty-Two activated, clear all customization for a WC template. I use Product Category.
3. Save and reload the Site Editor, see the alignment of the Classic Template set to `wide`.
4. Open a new tab, go to the category page on the front end, and see the wide width applied as expected.
5. Back to the Site Editor tab, change the width to None or Full. Save and see it apply on the front-end accordingly.
6. Open `wp-content/themes/twentytwentytwo/theme.json`, and remove `contentSize` and `wideSize` from the `layout` section.
7. Reload the Site Editor, see the width of the Classic Template block is set to 1000px.
8. On the front-end, reload the category page, and see the width of the Classic Template block is set to 1000px.

* [x] Do not include in the Testing Notes

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Update the default width of Classic Template to Wide width.
