### PR TITLE
Parse categories coming from the back-end as a json array

### DIFF
--- a/assets/js/base/hocs/with-reviews.js
+++ b/assets/js/base/hocs/with-reviews.js
@@ -106,10 +106,14 @@ const withReviews = ( OriginalComponent ) => {
 				offset: reviewsToSkip,
 			};
 
-			if ( categoryIds && categoryIds.length ) {
-				args.category_id = Array.isArray( categoryIds )
-					? categoryIds.join( ',' )
-					: categoryIds;
+			const categories = Array.isArray( categoryIds )
+				? categoryIds
+				: JSON.parse( categoryIds );
+
+			if ( categories && categories.length ) {
+				args.category_id = Array.isArray( categories )
+					? categories.join( ',' )
+					: categories;
 			}
 
 			if ( productId ) {

--- a/assets/js/base/hocs/with-reviews.js
+++ b/assets/js/base/hocs/with-reviews.js
@@ -106,11 +106,11 @@ const withReviews = ( OriginalComponent ) => {
 				offset: reviewsToSkip,
 			};
 
-			const categories = Array.isArray( categoryIds )
-				? categoryIds
-				: JSON.parse( categoryIds );
+			if ( categoryIds ) {
+				const categories = Array.isArray( categoryIds )
+					? categoryIds
+					: JSON.parse( categoryIds );
 
-			if ( categories && categories.length ) {
 				args.category_id = Array.isArray( categories )
 					? categories.join( ',' )
 					: categories;


### PR DESCRIPTION
The goal of this PR is to address a problem occurring when rendering the `Reviews by Category` block in the frontend.
The category ids that come from PHP are in `JSON` array format (e.g. '[40,41]'), so it's necessary to parse them and convert them into a js array before processing them. Otherwise, the API request will fail because the `categoryIds` query param will be `categoryIds=[40,41]` instead of the expected `categoryIds=40,41`.

Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/6347

### Testing

#### Manual tests
1. Create two products assigned to two different categories and add one review to each of them.
2. Create a new page and add a `Reviews by Category` block.
3. Select only one category on the block (corresponding to one of the previous products/reviews) and save it.
4. Check that it renders the expected reviews only on the edit mode.
5. Publish the page, go to the frontend and check it renders the same expected reviews.
----
6. Edit the block and select multiple categories.
7. Check that it renders the expected reviews only on the edit mode.
8. Update the page, go to the frontend and check it renders the same expected reviews.
----
9. Edit again the block and deselect all the categories.
10. Check that it renders **all** the reviews only on the edit mode.
11. Update the page, go to the frontend and check it renders also **all** the reviews.

### Changelog
> Fix Reviews by Category: show only reviews belonging to the selected categories
