### PR TITLE
Fix relative include paths

### DIFF
--- a/tests/php/Helpers/TestValidateSchema.php
+++ b/tests/php/Helpers/TestValidateSchema.php
@@ -5,7 +5,7 @@
 
 namespace Automattic\WooCommerce\Blocks\Tests\Helpers;
 
-require_once 'ValidateSchema.php';
+require_once __DIR__ . '/ValidateSchema.php';
 
 /**
  * Test Validate schema.


### PR DESCRIPTION
This is removing a relative include path which is a problem for WPCOM linter and can also lead to trouble where using certain code caching.