### PR TITLE
Featured Product: add background color option

### DIFF
--- a/assets/js/blocks/featured-product/block.json
+++ b/assets/js/blocks/featured-product/block.json
@@ -12,7 +12,7 @@
         ],
         "html": false,
         "color": {
-            "background": false,
+            "background": true,
             "text": true,
             "__experimentalDuotone": ".wc-block-featured-product__background-image"
         },

--- a/assets/js/blocks/featured-product/index.tsx
+++ b/assets/js/blocks/featured-product/index.tsx
@@ -46,7 +46,7 @@ registerBlockType( metadata, {
 	supports: {
 		...metadata.supports,
 		color: {
-			background: false,
+			background: true,
 			text: true,
 			...( isFeaturePluginBuild() && {
 				__experimentalDuotone:


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

This PR adds a background color option to the Featured Product block.

Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/6340

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|<img width="672" alt="Screenshot 2022-05-04 at 11 05 34" src="https://user-images.githubusercontent.com/1562646/166652376-6551e41f-bb9d-4b98-b5c4-25678bc5c8bb.png">|<img width="680" alt="Screenshot 2022-05-04 at 11 00 07" src="https://user-images.githubusercontent.com/1562646/166651617-a90cd287-2a0e-4cb0-99de-f0433c532554.png">|

### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

Prerequisites:
- Use the latest WordPress version (we want to use the site editor / Global Styles in testing).
- Install & use a block theme e.g.[ Twenty Twenty-Two](https://pcm.wordpress.org/themes/twentytwentytwo/).
- **Deactivate** the Gutenberg plugin for testing as we're currently observing [this issue](https://github.com/WordPress/gutenberg/issues/40808).
1. Create a new post/page.
2. In the editor, add two `Featured Product` blocks.
3. For each block select the same product, it should have a product picture.
4. Select each block and use the Crop tool in the block toolbar to crop the product image smaller than the Featured product block e.g. by setting the aspect ratio to 2:3.
5. Now select the first `Featured Product` block. In the editor sidebar's `Color` section of the block select a `Background` color. The background color should be visible in the parts not covered by the product image. 
6. Save your post/page.
7. In the admin dashboard navigate to `Appearance` > `Editor` (`/wp-admin/site-editor.php`).
8. Open the Styles sidebar by clicking the round Styles icon in the top right of the editor.
9. In the Styles sidebar navigate to `Blocks` > `Featured Product` > `Colors` > `Background`.
10. Change the background color and save your changes.
11. Navigate back to the post/page you previously created.
12. The first block should still show the background color you selected in step 5. The second block should show the Global Styles color you selected in step 10.
13. Click `Preview` > `Preview in new tab` and confirm the colors appear as expected on the Frontend of your site as well.

* [ ] Do not include in the Testing Notes

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

No considerable performance impact.

### Changelog

> Featured Product: add background color option
