### PR TITLE
Add clarification about 'Do not include in the Testing Notes' checkbox in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -45,7 +45,7 @@ Fixes #
 2.
 3.
 
-* [ ] Do not include in the Testing Notes
+* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->
 
 ### WooCommerce Visibility
 


### PR DESCRIPTION
This PR adds some clarification to when _Do not include in the Testing Notes_ checkbox should be selected.

See pdToLP-2d-p2#comment-24.

### Testing

* [x] Do not include in the Testing Notes

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Add suggested changelog entry here.
