### PR TITLE
Fix: Empty Mini Cart Contents view in editor is not vertically centered on WP 6.0

### DIFF
--- a/assets/js/blocks/mini-cart/mini-cart-contents/editor.scss
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/editor.scss
@@ -59,15 +59,19 @@
 		padding: 0;
 
 		> .block-editor-inner-blocks {
-			max-height: 100vh;
-			overflow-y: auto;
 			box-sizing: border-box;
+			display: flex;
+			flex-direction: column;
+			height: 100vh;
+			justify-content: center;
+			overflow-y: auto;
 			padding: $gap-largest $gap $gap;
 		}
 
 		// Temporary fix after the appender button was positioned absolute
 		// See https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5742#issuecomment-1032804168
 		.block-list-appender {
+			margin-top: $gap;
 			position: relative;
 		}
 

--- a/assets/js/blocks/mini-cart/mini-cart-contents/editor.scss
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/editor.scss
@@ -60,10 +60,7 @@
 
 		> .block-editor-inner-blocks {
 			box-sizing: border-box;
-			display: flex;
-			flex-direction: column;
-			height: 100vh;
-			justify-content: center;
+			max-height: 100vh;
 			overflow-y: auto;
 			padding: $gap-largest $gap $gap;
 		}

--- a/assets/js/blocks/mini-cart/mini-cart-contents/editor.scss
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/editor.scss
@@ -63,6 +63,10 @@
 			max-height: 100vh;
 			overflow-y: auto;
 			padding: $gap-largest $gap $gap;
+
+			> .block-editor-block-list__layout {
+				min-height: 100vh;
+			}
 		}
 
 		// Temporary fix after the appender button was positioned absolute

--- a/assets/js/blocks/mini-cart/mini-cart-contents/editor.scss
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/editor.scss
@@ -55,6 +55,7 @@
 	}
 
 	.wp-block-woocommerce-empty-mini-cart-contents-block {
+		min-height: 100vh;
 		overflow-y: unset;
 		padding: 0;
 
@@ -63,10 +64,6 @@
 			max-height: 100vh;
 			overflow-y: auto;
 			padding: $gap-largest $gap $gap;
-
-			> .block-editor-block-list__layout {
-				min-height: 100vh;
-			}
 		}
 
 		// Temporary fix after the appender button was positioned absolute

--- a/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/empty-mini-cart-contents-block/frontend.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/empty-mini-cart-contents-block/frontend.tsx
@@ -33,7 +33,9 @@ const EmptyMiniCartContentsBlock = ( {
 
 	return (
 		<div tabIndex={ -1 } ref={ elementRef } className={ className }>
-			{ children }
+			<div className="wc-block-mini-cart__empty-cart-wrapper">
+				{ children }
+			</div>
 		</div>
 	);
 };

--- a/assets/js/blocks/mini-cart/style.scss
+++ b/assets/js/blocks/mini-cart/style.scss
@@ -84,7 +84,7 @@
 	justify-content: space-between;
 }
 
-.wp-block-woocommerce-empty-mini-cart-contents-block {
+.wp-block-woocommerce-empty-mini-cart-contents-block .wc-block-mini-cart__empty-cart-wrapper {
 	overflow-y: auto;
 	padding: $gap-largest $gap $gap;
 }


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #6375

This PR updates the editor style of the Mini Cart Contents block to handle editor updates in WP 6.0 which breaks the styling of the Mini Cart Contents empty view.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|    <img width="1508" alt="Screen Shot 2022-05-05 at 14 01 49" src="https://user-images.githubusercontent.com/5423135/166896457-a225b68b-dc5e-4278-8d4a-3c5778aadd7a.png">    |    <img width="1616" alt="image" src="https://user-images.githubusercontent.com/5423135/166896557-4ca3d237-f5d8-447f-a60b-fa6c8440991a.png">   |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

0. Upgrade to WP 6.0 beta version or activate the latest version of Gutenberg.
1. With a block theme like 2022, Go to Edit Site > Template Parts > Mini Cart.
2. Switch to the Empty Mini Cart Contents view.
3. See the content is aligned center as expected.
5. Roll back to WP 5.9.3 or deactivate the Gutenberg plugin.
6. Go to Edit Site > Template Parts > Mini Cart.
7. Switch to the Empty Mini Cart Contents view.
8. See no regression introduced by this PR:
  - Add the All Products block to the empty view.
  - Resize the browser to make the content of the empty view overflow.
  - See the empty view is scrollable both in the editor and on the front end.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Fix: Align Empty Mini Cart Contents block center in the Site Editor.
