### PR TITLE
Check asset_data_registry keys do not exist before adding them for PHP templates

### DIFF
--- a/src/BlockTypes/AllProducts.php
+++ b/src/BlockTypes/AllProducts.php
@@ -22,9 +22,7 @@ class AllProducts extends AbstractBlock {
 	protected function enqueue_data( array $attributes = [] ) {
 		parent::enqueue_data( $attributes );
 		// Set this so filter blocks being used as widgets know when to render.
-		if ( ! $this->asset_data_registry->exists( 'has_filterable_products' ) ) {
-			$this->asset_data_registry->add( 'has_filterable_products', true, null );
-		}
+		$this->asset_data_registry->add( 'has_filterable_products', true, true );
 
 		$this->asset_data_registry->add( 'min_columns', wc_get_theme_support( 'product_blocks::min_columns', 1 ), true );
 		$this->asset_data_registry->add( 'max_columns', wc_get_theme_support( 'product_blocks::max_columns', 6 ), true );

--- a/src/BlockTypes/AllProducts.php
+++ b/src/BlockTypes/AllProducts.php
@@ -22,7 +22,9 @@ class AllProducts extends AbstractBlock {
 	protected function enqueue_data( array $attributes = [] ) {
 		parent::enqueue_data( $attributes );
 		// Set this so filter blocks being used as widgets know when to render.
-		$this->asset_data_registry->add( 'has_filterable_products', true, null );
+		if ( ! $this->asset_data_registry->exists( 'has_filterable_products' ) ) {
+			$this->asset_data_registry->add( 'has_filterable_products', true, null );
+		}
 
 		$this->asset_data_registry->add( 'min_columns', wc_get_theme_support( 'product_blocks::min_columns', 1 ), true );
 		$this->asset_data_registry->add( 'max_columns', wc_get_theme_support( 'product_blocks::max_columns', 6 ), true );

--- a/src/BlockTypes/ClassicTemplate.php
+++ b/src/BlockTypes/ClassicTemplate.php
@@ -67,14 +67,10 @@ class ClassicTemplate extends AbstractDynamicBlock {
 			return $this->render_single_product();
 		} elseif ( in_array( $attributes['template'], $archive_templates, true ) ) {
 			// Set this so that our product filters can detect if it's a PHP template.
-			if ( ! $this->asset_data_registry->exists( 'is_rendering_php_template' ) ) {
-				$this->asset_data_registry->add( 'is_rendering_php_template', true, null );
-			}
+			$this->asset_data_registry->add( 'is_rendering_php_template', true, true );
 
 			// Set this so filter blocks being used as widgets know when to render.
-			if ( ! $this->asset_data_registry->exists( 'has_filterable_products' ) ) {
-				$this->asset_data_registry->add( 'has_filterable_products', true, null );
-			}
+			$this->asset_data_registry->add( 'has_filterable_products', true, true );
 
 			$this->asset_data_registry->add(
 				'page_url',

--- a/src/BlockTypes/ClassicTemplate.php
+++ b/src/BlockTypes/ClassicTemplate.php
@@ -67,10 +67,14 @@ class ClassicTemplate extends AbstractDynamicBlock {
 			return $this->render_single_product();
 		} elseif ( in_array( $attributes['template'], $archive_templates, true ) ) {
 			// Set this so that our product filters can detect if it's a PHP template.
-			$this->asset_data_registry->add( 'is_rendering_php_template', true, null );
+			if ( ! $this->asset_data_registry->exists( 'is_rendering_php_template' ) ) {
+				$this->asset_data_registry->add( 'is_rendering_php_template', true, null );
+			}
 
 			// Set this so filter blocks being used as widgets know when to render.
-			$this->asset_data_registry->add( 'has_filterable_products', true, null );
+			if ( ! $this->asset_data_registry->exists( 'has_filterable_products' ) ) {
+				$this->asset_data_registry->add( 'has_filterable_products', true, null );
+			}
 
 			$this->asset_data_registry->add(
 				'page_url',

--- a/src/Templates/ClassicTemplatesCompatibility.php
+++ b/src/Templates/ClassicTemplatesCompatibility.php
@@ -60,9 +60,7 @@ class ClassicTemplatesCompatibility {
 		global $pagenow;
 
 		if ( is_shop() || is_product_taxonomy() || 'widgets.php' === $pagenow ) {
-			if ( ! $this->asset_data_registry->exists( 'has_filterable_products' ) ) {
-				$this->asset_data_registry->add( 'has_filterable_products', true, null );
-			}
+			$this->asset_data_registry->add( 'has_filterable_products', true, true );
 		}
 	}
 
@@ -77,9 +75,7 @@ class ClassicTemplatesCompatibility {
 	 */
 	public function set_php_template_data() {
 		if ( is_shop() || is_product_taxonomy() ) {
-			if ( ! $this->asset_data_registry->exists( 'is_rendering_php_template' ) ) {
-				$this->asset_data_registry->add( 'is_rendering_php_template', true, null );
-			}
+			$this->asset_data_registry->add( 'is_rendering_php_template', true, true );
 		}
 	}
 }

--- a/src/Templates/ClassicTemplatesCompatibility.php
+++ b/src/Templates/ClassicTemplatesCompatibility.php
@@ -60,7 +60,9 @@ class ClassicTemplatesCompatibility {
 		global $pagenow;
 
 		if ( is_shop() || is_product_taxonomy() || 'widgets.php' === $pagenow ) {
-			$this->asset_data_registry->add( 'has_filterable_products', true, null );
+			if ( ! $this->asset_data_registry->exists( 'has_filterable_products' ) ) {
+				$this->asset_data_registry->add( 'has_filterable_products', true, null );
+			}
 		}
 	}
 
@@ -75,7 +77,9 @@ class ClassicTemplatesCompatibility {
 	 */
 	public function set_php_template_data() {
 		if ( is_shop() || is_product_taxonomy() ) {
-			$this->asset_data_registry->add( 'is_rendering_php_template', true, null );
+			if ( ! $this->asset_data_registry->exists( 'is_rendering_php_template' ) ) {
+				$this->asset_data_registry->add( 'is_rendering_php_template', true, null );
+			}
 		}
 	}
 }


### PR DESCRIPTION
Using `asset_data_registry` can cause fatal errors when overriding keys that have already been registered. So we need to check if they already exist before adding them.

Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/6383

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

**Testing existing fatal error does not exist:**

1. Activate Twenty Twenty-Two.
2. Edit the Mini Cart template part.
3. Add the All Products block to the empty view.
4. Add the Mini Cart block to the header if haven't.
5. Go to the Shop page.
6. This is where a fatal error occurred, check it no longer does.

**Testing regressions:**

1. Add a page with the All Products block and some product filters.
2. Test that activating the filters does not trigger a page refresh
3. Now add the filters to the Product Catalog template via the Appearance > Site Editor using a Block Theme
4. Test that activating the filters triggers a page refresh
5. Activate Storefront now and add the filter blocks to the sidebar
6. Go to the Shop page and see that the filters render on the frontend where they should
7. Now go to a non-Woocommerce page such as Sample Page and check that the filters do not render on the frontend

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Check `has_filterable_products` and `is_rendering_php_template` keys do not exist before adding them for PHP templates