### PR TITLE
Mini Cart: Add font size and font family controls

### DIFF
--- a/assets/js/blocks/mini-cart/index.tsx
+++ b/assets/js/blocks/mini-cart/index.tsx
@@ -33,6 +33,10 @@ const settings: BlockConfiguration = {
 		html: false,
 		multiple: false,
 		color: true,
+		typography: {
+			fontSize: true,
+			__experimentalFontFamily: true,
+		},
 	},
 	example: {
 		attributes: {

--- a/assets/js/blocks/mini-cart/index.tsx
+++ b/assets/js/blocks/mini-cart/index.tsx
@@ -6,6 +6,7 @@ import { cart } from '@woocommerce/icons';
 import { Icon } from '@wordpress/icons';
 import { registerBlockType } from '@wordpress/blocks';
 import type { BlockConfiguration } from '@wordpress/blocks';
+import { isFeaturePluginBuild } from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies
@@ -35,7 +36,9 @@ const settings: BlockConfiguration = {
 		color: true,
 		typography: {
 			fontSize: true,
-			__experimentalFontFamily: true,
+			...( isFeaturePluginBuild() && {
+				__experimentalFontFamily: true,
+			} ),
 		},
 	},
 	example: {

--- a/assets/js/blocks/mini-cart/style.scss
+++ b/assets/js/blocks/mini-cart/style.scss
@@ -8,6 +8,8 @@
 	border: none;
 	color: inherit;
 	display: flex;
+	font-size: inherit;
+	font-family: inherit;
 	font-weight: 400;
 	padding: em($gap-small) em($gap-smaller);
 

--- a/assets/js/hooks/style-attributes.ts
+++ b/assets/js/hooks/style-attributes.ts
@@ -65,7 +65,7 @@ export const useTypographyProps = ( attributes: unknown ): WithStyle => {
 			lineHeight: typography.lineHeight,
 			fontWeight: typography.fontWeight,
 			textTransform: typography.textTransform,
-			fontFamily: attributesObject.fontFamily,
+			fontFamily: attributesObject.attributes.fontFamily,
 		},
 	};
 };

--- a/assets/js/hooks/style-attributes.ts
+++ b/assets/js/hooks/style-attributes.ts
@@ -65,7 +65,7 @@ export const useTypographyProps = ( attributes: unknown ): WithStyle => {
 			lineHeight: typography.lineHeight,
 			fontWeight: typography.fontWeight,
 			textTransform: typography.textTransform,
-			fontFamily: attributesObject.attributes.fontFamily,
+			fontFamily: attributesObject.fontFamily,
 		},
 	};
 };

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -349,7 +349,7 @@ class MiniCart extends AbstractBlock {
 			$cart_contents_total += $cart->get_subtotal_tax();
 		}
 
-		$classes_styles  = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, array( 'text_color', 'background_color' ) );
+		$classes_styles  = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, array( 'text_color', 'background_color', 'font_size', 'font_family' ) );
 		$wrapper_classes = sprintf( 'wc-block-mini-cart wp-block-woocommerce-mini-cart %s', $classes_styles['classes'] );
 		$wrapper_styles  = $classes_styles['styles'];
 

--- a/src/Utils/StyleAttributesUtils.php
+++ b/src/Utils/StyleAttributesUtils.php
@@ -38,6 +38,26 @@ class StyleAttributesUtils {
 	}
 
 	/**
+	 * Get class and style for font-family from attributes.
+	 *
+	 * @param array $attributes Block attributes.
+	 *
+	 * @return (array | null)
+	 */
+	public static function get_font_family_class_and_style( $attributes ) {
+
+		$font_family = $attributes['fontFamily'] ?? '';
+
+		if ( $font_family ) {
+			return array(
+				'class' => sprintf( 'has-%s-font-family', $font_family ),
+				'style' => null,
+			);
+		}
+		return null;
+	}
+
+	/**
 	 * Get class and style for text-color from attributes.
 	 *
 	 * @param array $attributes Block attributes.
@@ -319,6 +339,7 @@ class StyleAttributesUtils {
 			'line_height'      => self::get_line_height_class_and_style( $attributes ),
 			'text_color'       => self::get_text_color_class_and_style( $attributes ),
 			'font_size'        => self::get_font_size_class_and_style( $attributes ),
+			'font_family'      => self::get_font_family_class_and_style( $attributes ),
 			'link_color'       => self::get_link_color_class_and_style( $attributes ),
 			'background_color' => self::get_background_color_class_and_style( $attributes ),
 			'border_color'     => self::get_border_color_class_and_style( $attributes ),


### PR DESCRIPTION
This PR adds support for Typography options: `Font size` and `Font family` for the `Mini Cart` block.

<!-- Reference any related issues or PRs here -->

Fixes #6254 

### Screenshots
|Before|After|
|-|-|
|![before_now](https://user-images.githubusercontent.com/905781/167665373-ca4d9de0-77e9-4e98-bafb-b168c2e62638.jpg)|![after_now](https://user-images.githubusercontent.com/905781/167665212-fbe1c92b-22cb-494a-b007-76c1bf9fa6b4.jpg)|

### Testing
How to test the changes in this Pull Request:

1. Activate a **block** theme, like Twenty Twenty Two
2. Create a new page, and add the Mini Cart block
3. Check if the `Typography` option is available for the block
4. Check if the `Font size` and `Font family` options work correctly both in the editor and on the frontend

2b. After testing the above, try the same with the Mini Cart block added via the FSE editor (for example in the header)

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
  
### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [ ] Same as above

### Changelog

> Add support for `Font size` and `Font family` for the `Mini Cart` block.
