### PR TITLE
Format Markdown files using wp-scripts

### DIFF
--- a/bin/add-doc-footer.sh
+++ b/bin/add-doc-footer.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 function update_footer {
 	export REPLACEWITH='
+
 ---
 
 [We'\''re hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20'$1')
+
 '
 
 	# Replace everything after <!-- FEEDBACK -->

--- a/bin/hook-docs/data/actions.json
+++ b/bin/hook-docs/data/actions.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://raw.githubusercontent.com/johnbillion/wp-hooks-generator/0.7.0/schema.json",
+    "$schema": "https://raw.githubusercontent.com/johnbillion/wp-hooks-generator/0.7.3/schema.json",
     "hooks": [
         {
             "name": "woocommerce_add_to_cart",

--- a/bin/hook-docs/data/filters.json
+++ b/bin/hook-docs/data/filters.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://raw.githubusercontent.com/johnbillion/wp-hooks-generator/0.7.0/schema.json",
+    "$schema": "https://raw.githubusercontent.com/johnbillion/wp-hooks-generator/0.7.3/schema.json",
     "hooks": [
         {
             "name": "__experimental_woocommerce_blocks_add_data_attributes_to_block",
@@ -880,7 +880,7 @@
                 "tags": [
                     {
                         "name": "param",
-                        "content": "Quantity limit which defaults to 99 unless sold individually.",
+                        "content": "Quantity limit which defaults to 9999 unless sold individually.",
                         "types": [
                             "integer"
                         ],

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,13 +10,15 @@ The WooCommerce Blocks Handbook provides documentation for designers and develop
 | [Store API (REST API)](../src/StoreApi/README.md) | These documents cover the Store API used to get product data on the frontend.                                                                                                                                                                                                   |
 | [Extensibility](extensibility/README.md)          | These documents cover extensibility of WooCommerce Blocks.                                                                                                                                                                                                                      |
 | [Theming](theming/README.md)                      | These documents cover theming for blocks, styles, CSS classnames and other theming best practices.                                                                                                                                                                              |
-| [Templates](templates/README.md)                  | These documents provide a technical overview of WooCommerce block template (parts) functionality.                                                                                                                                                      |
+| [Templates](templates/README.md)                  | These documents provide a technical overview of WooCommerce block template (parts) functionality.                                                                                                                                                                               |
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
-🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/readme.md)
+🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/README.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/block-client-apis/README.md
+++ b/docs/block-client-apis/README.md
@@ -13,10 +13,12 @@ For more details about extensibility points in the blocks, you can reference the
 | [Notices](./notices.md)                                                  | Explains how the notices system works and which methods are available to add an remove them.                |
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/block-client-apis/README.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/block-client-apis/checkout/checkout-api.md
+++ b/docs/block-client-apis/checkout/checkout-api.md
@@ -47,13 +47,13 @@ The customer data context exposes the api interfaces for the following things vi
 
 The shipping method data context exposes the api interfaces for the following things (typedef `ShippingMethodDataContext`) via the `useShippingMethodData` hook:
 
-- `shippingErrorStatus`: The current error status for the context.
-- `dispatchErrorStatus`: A function for dispatching a shipping error status. Used in combination with...
-- `shippingErrorTypes`: An object with the various error statuses that can be dispatched (`NONE`, `INVALID_ADDRESS`, `UNKNOWN`)
-- `onShippingRateSuccess`: This is a function for registering a callback to be invoked when shipping rates are retrieved successfully. Callbacks will receive the new rates as an argument.
-- `onShippingRateFail`: This is a function for registering a callback to be invoked when shipping rates fail to be retrieved. Callbacks will receive the error status as an argument.
-- `onShippingRateSelectSuccess`: This is a function for registering a callback to be invoked when shipping rate selection is successful.
-- `onShippingRateSelectFail`: This is a function for registering a callback to be invoked when shipping rates selection is unsuccessful.
+-   `shippingErrorStatus`: The current error status for the context.
+-   `dispatchErrorStatus`: A function for dispatching a shipping error status. Used in combination with...
+-   `shippingErrorTypes`: An object with the various error statuses that can be dispatched (`NONE`, `INVALID_ADDRESS`, `UNKNOWN`)
+-   `onShippingRateSuccess`: This is a function for registering a callback to be invoked when shipping rates are retrieved successfully. Callbacks will receive the new rates as an argument.
+-   `onShippingRateFail`: This is a function for registering a callback to be invoked when shipping rates fail to be retrieved. Callbacks will receive the error status as an argument.
+-   `onShippingRateSelectSuccess`: This is a function for registering a callback to be invoked when shipping rate selection is successful.
+-   `onShippingRateSelectFail`: This is a function for registering a callback to be invoked when shipping rates selection is unsuccessful.
 
 #### Payment Method Data Context
 
@@ -116,10 +116,12 @@ _Why don't payment methods just implement this hook_?
 The contract is established through props fed to the payment method components via props. This allows us to avoid having to expose the hook publicly and experiment with how the props are retrieved and exposed in the future.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/block-client-apis/checkout/checkout-api.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/block-client-apis/notices.md
+++ b/docs/block-client-apis/notices.md
@@ -185,7 +185,6 @@ Remove all notices from the current context. If a `status` is provided, only the
 | -------- | ------ | ----------------------------------------------------------------------------------------------------- |
 | `status` | string | Status that notices must match to be removed. If not provided, all notices of any status are removed. |
 
-
 ## StoreSnackbarNoticesProvider
 
 The `StoreSnackbarNoticesProvider` allows managing snackbar notices in the frontend. Snackbar notices are displayed in the bottom left corner and disappear after a certain time.
@@ -220,7 +219,6 @@ Whether notices are suppressed. If true, it will hide the notices from the front
 | -------- | ------- | --------------------------- |
 | `val`    | boolean | Id of the notice to remove. |
 
-
 ## Example usage
 
 The following example shows a `CheckoutProcessor` component that displays an error notice when the payment process fails and it removes it every time the payment is started. When the payment is completed correctly, it shows a snackbar notice.
@@ -253,10 +251,12 @@ const CheckoutProcessor = () => {
 ```
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/block-client-apis/notices.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/blocks/README.md
+++ b/docs/blocks/README.md
@@ -8,10 +8,12 @@ This folder contains documentation for specific Blocks and Blocks functionality.
 | [Features Flags and Experimental interfaces](./feature-flags-and-experimental-interfaces.md) | This doc outlines all the current features that are gated behind a feature or experimental flag as well as any interfaces that are experimental |
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/blocks/README.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/blocks/feature-flags-and-experimental-interfaces.md
+++ b/docs/blocks/feature-flags-and-experimental-interfaces.md
@@ -131,10 +131,12 @@ Current list of events:
 -   `experimental__woocommerce_blocks-checkout-set-phone-number` - Fired when a phone number is added during checkout.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/blocks/feature-flags-and-experimental-interfaces.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/blocks/stock-reservation.md
+++ b/docs/blocks/stock-reservation.md
@@ -95,10 +95,12 @@ The point of which stock is reserved differs between the new Block based checkou
 You can see that in both Checkouts, if stock cannot be reserved for all items in the order, either the order is rejected, or the user cannot proceed with checkout.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/blocks/stock-reservation.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/contributors/README.md
+++ b/docs/contributors/README.md
@@ -2,21 +2,23 @@
 
 This folder contains documentation for developers and contributors looking to get started with WooCommerce Block Development.
 
-| Document                                                         | Description                                                                         |
-| ---------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| [Getting Started](getting-started.md)                            | This doc covers tooling and creating builds during development.                     |
-| [Coding Guidelines](coding-guidelines.md)                        | This doc covers development best practices.                                         |
-| [JavaScript Testing](javascript-testing.md)                      | This doc explains how to run automated JavaScript tests.                            |
-| [Developing Components (& Storybook)](components.md)             | This doc outlines where our reusable components live, and how to test them in Storybook. |
-| [Block Script Assets](block-assets.md)                           | This doc explains how Block Script Assets are loaded and used.                      |
-| [JS build system](js-build-system.md)                            | This doc explains how JavaScript files are built.                                   |
-| [CSS build system](css-build-system.md)                          | This doc explains how CSS is built.                                                 |
+| Document                                             | Description                                                                              |
+| ---------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| [Getting Started](getting-started.md)                | This doc covers tooling and creating builds during development.                          |
+| [Coding Guidelines](coding-guidelines.md)            | This doc covers development best practices.                                              |
+| [JavaScript Testing](javascript-testing.md)          | This doc explains how to run automated JavaScript tests.                                 |
+| [Developing Components (& Storybook)](components.md) | This doc outlines where our reusable components live, and how to test them in Storybook. |
+| [Block Script Assets](block-assets.md)               | This doc explains how Block Script Assets are loaded and used.                           |
+| [JS build system](js-build-system.md)                | This doc explains how JavaScript files are built.                                        |
+| [CSS build system](css-build-system.md)              | This doc explains how CSS is built.                                                      |
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/contributors/README.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/contributors/block-assets.md
+++ b/docs/contributors/block-assets.md
@@ -79,10 +79,12 @@ wc.wcSettings.getSetting( 'key' );
 ```
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/contributors/block-assets.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/contributors/coding-guidelines.md
+++ b/docs/contributors/coding-guidelines.md
@@ -162,10 +162,12 @@ As you can see, the styles coming from the themes have higher specificity, so ou
 Notice in the worst case scenario we would have increased selector specificity by 2 classes (0, 2, 0). That shouldn't make it too difficult for other themes to write styles on top of ours.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/contributors/coding-guidelines.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/contributors/components.md
+++ b/docs/contributors/components.md
@@ -7,45 +7,48 @@ The storybook is automatically built and published to [GitHub pages](https://woo
 https://woocommerce.github.io/woocommerce-gutenberg-products-block/
 
 ## Where are our components?
+
 We have components in a few folders, for different contexts.
 
-- [`assets/js/base/components`](https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/trunk/assets/js/base/components)
-- [`assets/js/editor-components`](https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/trunk/assets/js/editor-components)
-- [`assets/js/icons`](https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/trunk/assets/js/icons)
+-   [`assets/js/base/components`](https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/trunk/assets/js/base/components)
+-   [`assets/js/editor-components`](https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/trunk/assets/js/editor-components)
+-   [`assets/js/icons`](https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/trunk/assets/js/icons)
 
-__`assets/js/base/components`__ are used in front-end code, as well as editor & admin.
+**`assets/js/base/components`** are used in front-end code, as well as editor & admin.
 These components help us build consistent interfaces across the front end (shopper) experience and elsewhere.
 Because they can be used in the front end and editor, components in this folder should:
 
--  Perform efficiently - i.e. not adversely affect page performance/experience.
--  Have lean dependencies - i.e. not bloat the payload unnecessarily.
--  Look consistent in common themes; ideally should allow themes to adjust appearance as necessary.
+-   Perform efficiently - i.e. not adversely affect page performance/experience.
+-   Have lean dependencies - i.e. not bloat the payload unnecessarily.
+-   Look consistent in common themes; ideally should allow themes to adjust appearance as necessary.
 
-__`assets/js/editor-components`__ are used in the editor UI for our blocks.
+**`assets/js/editor-components`** are used in the editor UI for our blocks.
 They allow us to build a consistent and powerful UI for merchants for authoring content relating to Woo data - e.g. selecting products or product attributes. Because they are focused on the editor, they can rely on known editor dependencies and optimise styling for the editor only.
 
-__`assets/js/icons`__ is a suite of icons and SVG images that we use in our interfaces.
+**`assets/js/icons`** is a suite of icons and SVG images that we use in our interfaces.
 
 For more info about individual components, refer to [Storybook](https://woocommerce.github.io/woocommerce-gutenberg-products-block/) or individual readme files.
 
 ## How to run Storybook locally and test components
 
-- `npm run storybook`
-- Point your browser at port 6006, e.g. http://localhost:6006
-- Play with components 🎛!
+-   `npm run storybook`
+-   Point your browser at port 6006, e.g. http://localhost:6006
+-   Play with components 🎛!
 
 ## How to add a story for a component
 
-- Add a `stories` folder alongside the component.
-- Add stories in `.js` files in this folder.
+-   Add a `stories` folder alongside the component.
+-   Add stories in `.js` files in this folder.
 
 If you're stuck, copy source of an existing story to get started.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/contributors/components.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/contributors/css-build-system.md
+++ b/docs/contributors/css-build-system.md
@@ -31,10 +31,12 @@ Webpack config is split between several files, some relevant ones for the CSS bu
         -   [`bin/webpack-entries.js`](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/bin/webpack-entries.js): Code for generating [webpack `entry` definitions](https://webpack.js.org/concepts/entry-points/) and mapping source files to entry points. If you're adding a new block or module to the build, start here.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/contributors/css-build-system.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/contributors/documentation-guidelines.md
+++ b/docs/contributors/documentation-guidelines.md
@@ -1,21 +1,22 @@
 # Documentation Guidelines
 
-- [Use active instead of passive voice](#use-active-instead-of-passive-voice)
-- [Use the personal pronoun “you”](#use-the-personal-pronoun-you)
-- [Don’t use gendered pronouns](#dont-use-gendered-pronouns)
-- [Filename must resemble the title](#filename-must-resemble-the-title)
-- [Use correct heading hierarchy](#use-correct-heading-hierarchy)
-- [Use semantically correct markup](#use-semantically-correct-markup)
-- [Use correct spelling](#use-correct-spelling)
-- [Use images not wider than 50% width](#use-images-not-wider-than-50-width)
-- [Use descriptive links](#use-descriptive-links)
-- [Explain arguments](#explain-arguments)
-- [Explicitly define language for code examples](#explicitly-define-language-for-code-examples)
-- [Use table of contents for top-level readme](#use-table-of-contents-for-top-level-readme)
-- [Use internal links](#use-internal-links)
-- [Sort releases descending](#sort-releases-descending)
-- [Structure “How to” instructions](#structure-how-to-instructions)
-- [Link references](#link-references)
+- [Documentation Guidelines](#documentation-guidelines)
+	- [Use active instead of passive voice](#use-active-instead-of-passive-voice)
+	- [Use the personal pronoun “you”](#use-the-personal-pronoun-you)
+	- [Don’t use gendered pronouns](#dont-use-gendered-pronouns)
+	- [Filename must resemble the title](#filename-must-resemble-the-title)
+	- [Use correct heading hierarchy](#use-correct-heading-hierarchy)
+	- [Use semantically correct markup](#use-semantically-correct-markup)
+	- [Use correct spelling](#use-correct-spelling)
+	- [Use images not wider than 50% width](#use-images-not-wider-than-50-width)
+	- [Use descriptive links](#use-descriptive-links)
+	- [Explain arguments](#explain-arguments)
+	- [Explicitly define language for code examples](#explicitly-define-language-for-code-examples)
+	- [Use table of contents for top-level readme](#use-table-of-contents-for-top-level-readme)
+	- [Use internal links](#use-internal-links)
+	- [Sort releases descending](#sort-releases-descending)
+	- [Structure “How to” instructions](#structure-how-to-instructions)
+	- [Link references](#link-references)
 
 ## Use active instead of passive voice
 
@@ -150,10 +151,12 @@ When explaining functionality, the following structure should be used:
 When referencing other documentations, the corresponding document should be linked.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/contributors/documentation-guidelines.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/contributors/folder-structure.md
+++ b/docs/contributors/folder-structure.md
@@ -190,10 +190,12 @@ The following snippet explains how the WooCommerce Blocks repository is structur
     This file is inspired by the great work of @JustinyAhin and @gziolo in https://github.com/WordPress/gutenberg/blob/trunk/docs/contributors/folder-structure.md.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/contributors/folder-structure.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/contributors/getting-started.md
+++ b/docs/contributors/getting-started.md
@@ -129,17 +129,19 @@ This will use the `.prettierrc.js` file in the root folder of the Blocks plugin 
 
 You’ll find a handful of scripts in `package.json` that performs the automated tests and linting. You can run the following commands to execute automated tests in your terminal:
 
-- JS tests: `npm run test`
+-   JS tests: `npm run test`
 
-- Run `npm run wp-env` command to setup the development environment in Docker.
+-   Run `npm run wp-env` command to setup the development environment in Docker.
 
 To find out more about how to run automated JavaScript tests, check out the documentation on [JavaScript Testing](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/contributors/javascript-testing.md).
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/contributors/getting-started.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/contributors/javascript-testing.md
+++ b/docs/contributors/javascript-testing.md
@@ -130,10 +130,12 @@ You also need to check any existing tests that checks the WP version.
 In `./tests/e2e/specs`, verify for conditions like `if ( process.env.WP_VERSION < 5.4 )` and remove them if they're not relevant anymore.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/contributors/javascript-testing.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/contributors/js-build-system.md
+++ b/docs/contributors/js-build-system.md
@@ -51,16 +51,18 @@ There were legacy builds of the `MainConfig`, `FrontendConfig` and `StylingConfi
 
 Webpack config is split between several files:
 
-- [`webpack.config.js`](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/webpack.config.js): Top level webpack config. Includes support for legacy and main build.
-- [`bin/webpack-configs.js`](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/bin/webpack-configs.js): Code for generating each build config. This most closely resembles a classic webpack config - if you're looking for something, start here.
-- [`bin/webpack-entries.js`](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/bin/webpack-entries.js): Code for generating [webpack `entry` definitions](https://webpack.js.org/concepts/entry-points/) and mapping source files to entry points. If you're adding a new block or module to the build, start here.
-- [`bin/webpack-helpers.js`](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/bin/webpack-helpers.js): Includes utils to load external code at run time, e.g. some dependencies from Woo and WordPress core.
+-   [`webpack.config.js`](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/webpack.config.js): Top level webpack config. Includes support for legacy and main build.
+-   [`bin/webpack-configs.js`](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/bin/webpack-configs.js): Code for generating each build config. This most closely resembles a classic webpack config - if you're looking for something, start here.
+-   [`bin/webpack-entries.js`](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/bin/webpack-entries.js): Code for generating [webpack `entry` definitions](https://webpack.js.org/concepts/entry-points/) and mapping source files to entry points. If you're adding a new block or module to the build, start here.
+-   [`bin/webpack-helpers.js`](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/bin/webpack-helpers.js): Includes utils to load external code at run time, e.g. some dependencies from Woo and WordPress core.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/contributors/js-build-system.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/extensibility/README.md
+++ b/docs/extensibility/README.md
@@ -46,10 +46,12 @@ In addition to the reference material below, [please see the `block-checkout` pa
 | [DOM Events](./dom-events.md)                      | A list of DOM Events used by some blocks to communicate between them and with other parts of WooCommerce.         |
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/extensibility/README.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/extensibility/actions.md
+++ b/docs/extensibility/actions.md
@@ -735,10 +735,12 @@ do_action( 'woocommerce_store_api_validate_cart_item', \WC_Product $product, arr
 
 ---
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/extensibility/actions.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/extensibility/available-endpoints-to-extend.md
+++ b/docs/extensibility/available-endpoints-to-extend.md
@@ -44,10 +44,12 @@ The main products endpoint is extensible via ExtendSchema. The data is available
 -   `ProductSchema::IDENTIFIER`
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/extensibility/available-endpoints-to-extend.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/extensibility/available-filters.md
+++ b/docs/extensibility/available-filters.md
@@ -4,13 +4,13 @@ This document lists the filters that are currently available to extensions and o
 
 Information on registering filters can be found on the [Checkout - Filter Registry](../../packages/checkout/filter-registry/README.md) page.
 
-***
+---
 
-- [Cart Line Items](#cart-line-items)
-- [Order Summary Items](#order-summary-items)
-- [Totals footer item](#totals-footer-item-in-cart-and-checkout)
-- [Coupons](#coupons)
-- [Snackbar notices](#snackbar-notices)
+-   [Cart Line Items](#cart-line-items)
+-   [Order Summary Items](#order-summary-items)
+-   [Totals footer item](#totals-footer-item-in-cart-and-checkout)
+-   [Coupons](#coupons)
+-   [Snackbar notices](#snackbar-notices)
 
 ### Cart Line Items
 
@@ -25,7 +25,7 @@ The following filters are available for line items:
 | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
 | `itemName`             | Used to change the name of the item before it is rendered onto the page                                                                | `string`                                                                              |
 | `cartItemPrice`        | This is the price of the item, multiplied by the number of items in the cart.                                                          | `string` and **must** contain the substring `<price/>` where the price should appear. |
-| `cartItemClass`        | This is the className of the item cell.                                                          | `string` |
+| `cartItemClass`        | This is the className of the item cell.                                                                                                | `string`                                                                              |
 | `subtotalPriceFormat`  | This is the price of a single item. Irrespective of the number in the cart, this value will always be the current price of _one_ item. | `string` and **must** contain the substring `<price/>` where the price should appear. |
 | `saleBadgePriceFormat` | This is amount of money saved when buying this item. It is the difference between the item's regular price and its sale price.         | `string` and **must** contain the substring `<price/>` where the price should appear. |
 
@@ -44,7 +44,7 @@ The sale badges are not shown here, so those filters are not applied in the Orde
 | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
 | `itemName`            | Used to change the name of the item before it is rendered onto the page                                                                | `string`                                                                              |
 | `cartItemPrice`       | This is the price of the item, multiplied by the number of items in the cart.                                                          | `string` and **must** contain the substring `<price/>` where the price should appear. |
-| `cartItemClass`        | This is the className of the item cell.                                                          | `string` |
+| `cartItemClass`       | This is the className of the item cell.                                                                                                | `string`                                                                              |
 | `subtotalPriceFormat` | This is the price of a single item. Irrespective of the number in the cart, this value will always be the current price of _one_ item. | `string` and **must** contain the substring `<price/>` where the price should appear. |
 
 Each of these filters has the following additional arguments passed to it: `{ context: 'summary', cartItem: CartItem }` ([CartItem](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/c00da597efe4c16fcf5481c213d8052ec5df3766/assets/js/type-defs/cart.ts#L113))
@@ -254,10 +254,12 @@ working correctly.
 The error will also be shown in your console.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/extensibility/available-filters.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/extensibility/available-slot-fills.md
+++ b/docs/extensibility/available-slot-fills.md
@@ -76,10 +76,12 @@ Checkout:
 -   `context`, equal to the name of the Block in which the fill is rendered: `woocommerce/cart` or `woocommerce/checkout`
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/extensibility/available-slot-fills.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/extensibility/checkout-flow-and-events.md
+++ b/docs/extensibility/checkout-flow-and-events.md
@@ -5,20 +5,20 @@ This document gives an overview of the flow for the checkout in the WooCommerce 
 ## Table of Contents <!-- omit in toc -->
 
 - [General Concepts](#general-concepts)
-  - [Tracking flow through status](#tracking-flow-through-status)
-    - [`CheckoutProvider` Exposed Statuses](#checkoutprovider-exposed-statuses)
-      - [Special States:](#special-states)
-    - [`ShippingProvider` Exposed Statuses](#shippingprovider-exposed-statuses)
-    - [`PaymentMethodDataProvider` Exposed Statuses](#paymentmethoddataprovider-exposed-statuses)
-  - [Emitting Events](#emitting-events)
-    - [`onCheckoutValidationBeforeProcessing`](#oncheckoutvalidationbeforeprocessing)
-    - [`onPaymentProcessing`](#onpaymentprocessing)
-    - [`onCheckoutAfterProcessingWithSuccess`](#oncheckoutafterprocessingwithsuccess)
-    - [`onCheckoutAfterProcessingWithError`](#oncheckoutafterprocessingwitherror)
-    - [`onShippingRateSuccess`](#onshippingratesuccess)
-    - [`onShippingRateFail`](#onshippingratefail)
-    - [`onShippingRateSelectSuccess`](#onshippingrateselectsuccess)
-    - [`onShippingRateSelectFail`](#onshippingrateselectfail)
+	- [Tracking flow through status](#tracking-flow-through-status)
+		- [`CheckoutProvider` Exposed Statuses](#checkoutprovider-exposed-statuses)
+			- [Special States:](#special-states)
+		- [`ShippingProvider` Exposed Statuses](#shippingprovider-exposed-statuses)
+		- [`PaymentMethodDataProvider` Exposed Statuses](#paymentmethoddataprovider-exposed-statuses)
+	- [Emitting Events](#emitting-events)
+		- [`onCheckoutValidationBeforeProcessing`](#oncheckoutvalidationbeforeprocessing)
+		- [`onPaymentProcessing`](#onpaymentprocessing)
+		- [`onCheckoutAfterProcessingWithSuccess`](#oncheckoutafterprocessingwithsuccess)
+		- [`onCheckoutAfterProcessingWithError`](#oncheckoutafterprocessingwitherror)
+		- [`onShippingRateSuccess`](#onshippingratesuccess)
+		- [`onShippingRateFail`](#onshippingratefail)
+		- [`onShippingRateSelectSuccess`](#onshippingrateselectsuccess)
+		- [`onShippingRateSelectFail`](#onshippingrateselectfail)
 
 The architecture of the Checkout Block is derived from the following principles:
 
@@ -474,10 +474,12 @@ This event emitter is fired when a shipping rate selection is not being persiste
 This event emitter doesn't care about any registered observer response and will simply execute all registered observers passing them the current error status in the context.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/extensibility/checkout-flow-and-events.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/extensibility/dom-events.md
+++ b/docs/extensibility/dom-events.md
@@ -23,7 +23,7 @@ _Example usage in WC Blocks:_ Cart and Mini Cart blocks (via the `useStoreCart()
 #### `detail` parameters:
 
 | Parameter          | Type    | Default value | Description                                                                                                                                                                                                                                                                                                                                                                                   |
-|--------------------|---------|---------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| ------------------ | ------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `preserveCartData` | boolean | `false`       | Whether Cart data in the store should be preserved. By default, it's `false` so any `wc-blocks_added_to_cart` event will invalidate cart data and blocks listening to it will refetch cart data again. However, if the code triggering the event already updates the store (ie: All Products block), it can set `preserveCartData: true` to avoid the other blocks refetching the data again. |
 
 ### `wc-blocks_removed_from_cart`
@@ -32,12 +32,13 @@ This event is the equivalent to the jQuery event `removed_from_cart` triggered b
 
 _Example usage in WC Blocks:_ Cart and Mini Cart blocks (via the `useStoreCart()` hook) listen to this event to know if they need to update their contents.
 
-
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/extensibility/dom-events.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/extensibility/extend-rest-api-add-data.md
+++ b/docs/extensibility/extend-rest-api-add-data.md
@@ -324,10 +324,12 @@ You may wish to use our pre-existing Formatters to ensure your data is passed th
 correct format. More information on the Formatters can be found in the [StoreApi Formatters documentation](./extend-rest-api-formatters.md).
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/extensibility/extend-rest-api-add-data.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/extensibility/extend-rest-api-formatters.md
+++ b/docs/extensibility/extend-rest-api-formatters.md
@@ -126,10 +126,12 @@ returns
 `alert('bad script!') This &#8220;coffee&#8221; is <strong>very strong</strong>.`
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/extensibility/extend-rest-api-formatters.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/extensibility/extend-rest-api-new-endpoint.md
+++ b/docs/extensibility/extend-rest-api-new-endpoint.md
@@ -41,10 +41,12 @@ That's it, your endpoint would now contain `extensions` in your endpoint, and yo
 Extending a new endpoint is usually half the work, you will need to receive this data in the frontend and pass it to any other extensibility point (Slot, Filter, Event).
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/extensibility/extend-rest-api-new-endpoint.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/extensibility/extend-rest-api-update-cart.md
+++ b/docs/extensibility/extend-rest-api-update-cart.md
@@ -196,10 +196,12 @@ Now that this is registered, when the button is pressed, the `cart/extensions` e
 will be updated by WooCommerce Blocks.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/extensibility/extend-rest-api-update-cart.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/extensibility/filtering-payment-methods.md
+++ b/docs/extensibility/filtering-payment-methods.md
@@ -180,10 +180,12 @@ with a `Bookable` item in your cart, any method that does not `supports` the `bo
 not display, while yours, the one that _does_ support this requirement _will_ display.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/extensibility/filtering-payment-methods.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/extensibility/filters.md
+++ b/docs/extensibility/filters.md
@@ -760,7 +760,7 @@ apply_filters( 'woocommerce_store_api_product_quantity_limit', integer $quantity
 
 | Argument | Type | Description |
 | -------- | ---- | ----------- |
-| $quantity_limit | integer | Quantity limit which defaults to 99 unless sold individually. |
+| $quantity_limit | integer | Quantity limit which defaults to 9999 unless sold individually. |
 | $product | \WC_Product | Product instance. |
 
 ### Returns
@@ -845,10 +845,12 @@ apply_filters( 'woocommerce_variation_option_name', string $value, null $unused,
 
 ---
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/extensibility/filters.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/extensibility/integration-interface.md
+++ b/docs/extensibility/integration-interface.md
@@ -1,11 +1,13 @@
 # `IntegrationRegistry` and `IntegrationInterface`
 
 ## The problem
+
 You are an extension developer, and to allow users to interact with your extension on the client-side, you have written
 some CSS and JavaScript that you would like to be included on the page. Your JavaScript also relies on some server-side
 data, and you'd like this to be available to your scripts.
 
 ## The solution
+
 You may use the `IntegrationRegistry` to register an `IntegrationInterface` this will be a class that will handle the
 enqueuing of scripts, styles, and data. You may have a different `IntegrationInterface` for each block (Mini Cart, Cart
 and Checkout), or you may use the same one, it is entirely dependent on your use case.
@@ -16,34 +18,41 @@ You should use the hooks: `woocommerce_blocks_mini-cart_block_registration`. `wo
 You may then use the `register` method on this object to register your `IntegrationInterface`.
 
 ## `IntegrationInterface` methods
+
 To begin, we'll need to create our integration class, our `IntegrationInterface`. This will be a class that implements
 WooCommerce Blocks' interface named [`IntegrationInterface`](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/src/Integrations/IntegrationInterface.php).
 
 In this section, we will step through the interface's members and discuss what they are used for.
 
 ### `get_name()`
-This is the `IntegrationInterface`'s way of namespacing your integration. The name chosen here should be unique to your 
+
+This is the `IntegrationInterface`'s way of namespacing your integration. The name chosen here should be unique to your
 extension. This method should return a string.
 
 ### `initialize()`
+
 This is where any setup, or initialization for your integration should be placed. For example, you could register the
 scripts and styles your extension needs here. This method should not return anything.
 
 ### `get_script_handles()`
+
 This is where the handles of any scripts you want to be enqueued on the client-side in the frontend context should be
 placed. This method should return an array of strings.
 
 ### `get_editor_script_handles()`
+
 This is where the handles of any scripts you want to be enqueued on the client-side in the editor context should be
 placed. This method should return an array of strings.
 
 ### `get_script_data()`
+
 This is where you can set values you want to be available to your scripts on the frontend. This method should return an
 associative array, the keys of which will be used to get the data using the JavaScript function `getSetting`.
 
 The keys and values of this array should all be serializable.
 
 ## Usage example
+
 Let's suppose we're the author of an extension: `WooCommerce Example Plugin`. We want to enqueue scripts, styles,
 and data on the frontend when either the Mini Cart, Cart or Checkout blocks are being used.
 
@@ -51,7 +60,7 @@ We also want some data from a server-side function to be available to our front-
 
 You will notice that in the example below, we reference the `/build/index.asset.php` file. This is created by the [`DependencyExtractionWebpackPlugin`](https://www.npmjs.com/package/@wordpress/dependency-extraction-webpack-plugin)
 which creates a PHP file mapping the dependencies of your client-side scripts, so that they can be added in the
-`dependencies` array of `wp_register_script`. 
+`dependencies` array of `wp_register_script`.
 
 Let's create our `IntegrationInterface`.
 
@@ -155,7 +164,7 @@ class WooCommerce_Example_Plugin_Integration implements IntegrationInterface {
 		if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG && file_exists( $file ) ) {
 			return filemtime( $file );
 		}
-		
+
 		// As above, let's assume that WooCommerce_Example_Plugin_Assets::VERSION resolves to some versioning number our
 		// extension uses.
 		return \WooCommerce_Example_Plugin_Assets::VERSION;
@@ -190,6 +199,7 @@ add_action(
 Now, when we load a page containing either block, we should see the scripts we registered in `initialize` being loaded!
 
 ### Getting data added in `get_script_data`
+
 We associated some data with the extension in the `get_script_data` method of our interface, we need to know how to get
 this!
 
@@ -198,13 +208,15 @@ string. The name of the setting containing the data added in `get_script_data` i
 (i.e. the value returned by `get_name`) suffixed with `_data`. In our example it would be: `woocommerce-example-plugin_data`.
 
 The value returned here is a plain old JavaScript object, keyed by the keys of the array returned by `get_script_data`,
-the values will serialized. 
+the values will serialized.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/extensibility/integration-interface.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/extensibility/payment-method-integration.md
+++ b/docs/extensibility/payment-method-integration.md
@@ -240,10 +240,12 @@ function my_extension_woocommerce_blocks_support() {
 As an example, you can see how the Stripe extension adds it's integration in this [pull request](https://github.com/woocommerce/woocommerce-gateway-stripe/pull/1467/files).
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/extensibility/payment-method-integration.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/extensibility/slot-fills.md
+++ b/docs/extensibility/slot-fills.md
@@ -56,10 +56,12 @@ You use `registerPlugin` to feed in your plugin namespace, your component `rende
 For this to work, your script must be enqueued after Cart and Checkout. You can follow the [IntegrationInterface](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/50f9b3e8d012f425d318908cc13d9c601d97bd68/docs/extensibility/integration-interface.md) documentation for enqueueing your script.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/extensibility/slot-fills.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/templates/README.md
+++ b/docs/templates/README.md
@@ -4,27 +4,29 @@ This page includes documentation related to WooCommerce Block Templates.
 
 ## Table of Contents
 
-* [Overview](#overview)
-  * [Requirements](#requirements) 
-* [Technical Overview](#technical-overview)
-  * [The Problem](#the-problem)
-  * [The Solution](#the-solution)
-* [Some things to be aware of](#some-things-to-be-aware-of)
-* [Related Files](#related-files)
+- [WooCommerce Block Templates](#woocommerce-block-templates)
+  - [Table of Contents](#table-of-contents)
+  - [Overview](#overview)
+    - [Requirements](#requirements)
+  - [Technical Overview](#technical-overview)
+    - [The Problem](#the-problem)
+    - [The Solution](#the-solution)
+    - [Some things to be aware of](#some-things-to-be-aware-of)
+  - [Related files](#related-files)
 
 ## Overview
 
-WooCommerce Block Templates are a collection of WooCommerce Core templates for the WordPress Full Site Editing experience introduced in WordPress 5.9. You can customize these templates in the Site Editor. 
+WooCommerce Block Templates are a collection of WooCommerce Core templates for the WordPress Full Site Editing experience introduced in WordPress 5.9. You can customize these templates in the Site Editor.
 
 You can read more about the Full Site Editing (FSE) experience [here](https://developer.wordpress.org/block-editor/getting-started/full-site-editing/).
 
 ### Requirements
 
-| Software        | Minimum Version  |
-|-----------------|------------------|
-| WordPress       | 5.9              |
-| WooCommerce     | 6.0              |
-| Theme | Any [block theme](https://developer.wordpress.org/block-editor/how-to-guides/themes/block-theme-overview/#what-is-a-block-theme)               |
+| Software    | Minimum Version                                                                                                                  |
+| ----------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| WordPress   | 5.9                                                                                                                              |
+| WooCommerce | 6.0                                                                                                                              |
+| Theme       | Any [block theme](https://developer.wordpress.org/block-editor/how-to-guides/themes/block-theme-overview/#what-is-a-block-theme) |
 
 ## Technical Overview
 
@@ -40,26 +42,28 @@ The BlockTemplateController class is primarily responsible for hooking into both
 
 ### Some things to be aware of
 
-* Individual templates are represented by a placeholder block within the Site Editor until we can 'block-ify' these. This is the long-term goal. Until then users will be able to customize templates by adding blocks above and below the placeholder.
-* At the beginning of the project, we unintentionally used the incorrect WooCommerce plugin slug. This has resulted in us maintaining both the incorrect and correct slugs. We reference these via `BlockTemplateUtils::DEPRECATED_PLUGIN_SLUG` and `BlockTemplateUtils::PLUGIN_SLUG`. More information on that [here](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5423).
-* If a theme has a `archive-product.html` template file, but does not have any taxonomy related files. We will automatically duplicate their themes `archive-product.html` file in place of these taxonomy files within `BlockTemplateController->get_block_file_template()`.
-* In `BlockTemplateController->get_block_templates()` we filter out templates in production that are behind a feature flag. These will be available in development, but will be absent in production unless the feature flag is removed.
+-   Individual templates are represented by a placeholder block within the Site Editor until we can 'block-ify' these. This is the long-term goal. Until then users will be able to customize templates by adding blocks above and below the placeholder.
+-   At the beginning of the project, we unintentionally used the incorrect WooCommerce plugin slug. This has resulted in us maintaining both the incorrect and correct slugs. We reference these via `BlockTemplateUtils::DEPRECATED_PLUGIN_SLUG` and `BlockTemplateUtils::PLUGIN_SLUG`. More information on that [here](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5423).
+-   If a theme has a `archive-product.html` template file, but does not have any taxonomy related files. We will automatically duplicate their themes `archive-product.html` file in place of these taxonomy files within `BlockTemplateController->get_block_file_template()`.
+-   In `BlockTemplateController->get_block_templates()` we filter out templates in production that are behind a feature flag. These will be available in development, but will be absent in production unless the feature flag is removed.
 
 ## Related files
 
-| File                        | Description                                                                                                                                                                     | Source                                                                                                                          | Docs                                                      |
-| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
-| templates/templates/\*      | Location in the filesystem where WooCommerce block template HTML files are stored.                                                                                              | [Source files](https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/trunk/templates/templates)              |                                                           |
-| classic-template/\*         | The JavaScript block rendered in the Site Editor. This is a server-side rendered component which is handled by ClassicTemplate.php                                              | [Source file](https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/trunk/assets/js/blocks/classic-template)  | [README](../../assets/js/blocks/classic-template/README.md)|
-| ClassicTemplate.php         | Class used to setup the block on the server-side and render the correct template                                                                                                | [Source file](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/src/BlockTypes/ClassicTemplate.php) | [README](./classic-template.md)                            |
-| BlockTemplateController.php | Class which contains all the business logic which loads the templates into the Site Editor or on the front-end through various hooks available in WordPress & WooCommerce core. | [Source file](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/src/BlockTemplatesController.php)  | [README](./block-template-controller.md)                  |
-| BlockTemplateUtils.php      | Class containing a collection of useful utility methods.                                                                                                                        | [Source file](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/src/Utils/BlockTemplateUtils.php)  |                                                           |
+| File                        | Description                                                                                                                                                                     | Source                                                                                                                           | Docs                                                        |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| templates/templates/\*      | Location in the filesystem where WooCommerce block template HTML files are stored.                                                                                              | [Source files](https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/trunk/templates/templates)               |                                                             |
+| classic-template/\*         | The JavaScript block rendered in the Site Editor. This is a server-side rendered component which is handled by ClassicTemplate.php                                              | [Source file](https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/trunk/assets/js/blocks/classic-template)  | [README](../../assets/js/blocks/classic-template/README.md) |
+| ClassicTemplate.php         | Class used to setup the block on the server-side and render the correct template                                                                                                | [Source file](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/src/BlockTypes/ClassicTemplate.php) | [README](./classic-template.md)                             |
+| BlockTemplateController.php | Class which contains all the business logic which loads the templates into the Site Editor or on the front-end through various hooks available in WordPress & WooCommerce core. | [Source file](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/src/BlockTemplatesController.php)   | [README](./block-template-controller.md)                    |
+| BlockTemplateUtils.php      | Class containing a collection of useful utility methods.                                                                                                                        | [Source file](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/src/Utils/BlockTemplateUtils.php)   |                                                             |
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/templates/README.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/templates/block-template-controller.md
+++ b/docs/templates/block-template-controller.md
@@ -1,48 +1,55 @@
 # BlockTemplateController
+
 [Source file](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/src/BlockTemplatesController.php)
 
-The BlockTemplateController class contains all the business logic which loads the templates into the Site Editor or on the front-end through various hooks available in WordPress & WooCommerce core. Without documenting every method individually, I will look to provide some insight into key functionality. 
+The BlockTemplateController class contains all the business logic which loads the templates into the Site Editor or on the front-end through various hooks available in WordPress & WooCommerce core. Without documenting every method individually, I will look to provide some insight into key functionality.
 
 ## Table of Contents
 
-* [Overview](#overview)
-* [add_block_templates( $query_result, $query, $template_type )](#add_block_templates-query_result-query-template_type-)
-* [get_block_file_template( $template, $id, $template_type )](#get_block_file_template-template-id-template_type-)
-* [render_block_template()](#render_block_template)
+- [BlockTemplateController](#blocktemplatecontroller)
+  - [Table of Contents](#table-of-contents)
+  - [Overview](#overview)
+  - [add_block_templates( $query_result, $query, \$template_type )](#add_block_templates-query_result-query-template_type-)
+    - [Return value](#return-value)
+  - [get_block_file_template( $template, $id, \$template_type )](#get_block_file_template-template-id-template_type-)
+    - [Return value](#return-value-1)
+  - [render_block_template()](#render_block_template)
+    - [Return value](#return-value-2)
 
 ## Overview
 
 In the initialization of the class, we hook into the three hooks listed below. These provide us with all of the extensibility points necessary in order to load our own block templates alongside the themes.
 
-Within each method section, I will explain in what scenarios they are executed. 
+Within each method section, I will explain in what scenarios they are executed.
 
-* filter: `get_block_templates` with `add_block_templates`.
-* filter: `pre_get_block_file_template` with `get_block_file_template`.
-* action: `template_redirect` with `render_block_template`.
+-   filter: `get_block_templates` with `add_block_templates`.
+-   filter: `pre_get_block_file_template` with `get_block_file_template`.
+-   action: `template_redirect` with `render_block_template`.
 
-## add_block_templates( $query_result, $query, $template_type )
+## add_block_templates( $query_result, $query, \$template_type )
 
 This method is applied to the filter `get_block_templates`, which is executed before returning a unified list of template objects based on a query.
 
 **Typically executed when:**
-* Loading the "All Templates" view in the Site Editor
-* Loading one of the templates on the front-end where the query would build a list of relevant templates based on a hierarchy (for example, the product page hierarchy could be an array containing  `single-product-[product-name].html`, `single-product.html`, `single.html`).
-* Loading the "Edit Product" view.
+
+-   Loading the "All Templates" view in the Site Editor
+-   Loading one of the templates on the front-end where the query would build a list of relevant templates based on a hierarchy (for example, the product page hierarchy could be an array containing `single-product-[product-name].html`, `single-product.html`, `single.html`).
+-   Loading the "Edit Product" view.
 
 **This method is responsible for:**
 
-* Giving our templates a user-friendly title (e.g. turning "single-product" into "Product Page").
-* It collects all the WooCommerce templates from both the filesystem and the database (customized templates are stored in the database as posts) and adds them to the returned list.
-* In the event the theme has a `archive-product.html` template file, but not category/tag template files, it is eligible to use the `archive-product.html` file in their place. So we trick Gutenberg in thinking some templates (e.g. category/tag) have a theme file available if it is using the `archive-product.html` template, even though _technically_ the theme does not have a specific file for them.
-* Ensuring we do not add irrelevant WooCommerce templates in the returned list. For example, if  `$query['post_type']` has a value (e.g. `product`) this means the query is requesting templates related to that specific post type, so we filter out any irrelevant ones. This _could_ be used to show/hide templates from the template dropdown on the "Edit Product" screen in WP Admin.
+-   Giving our templates a user-friendly title (e.g. turning "single-product" into "Product Page").
+-   It collects all the WooCommerce templates from both the filesystem and the database (customized templates are stored in the database as posts) and adds them to the returned list.
+-   In the event the theme has a `archive-product.html` template file, but not category/tag template files, it is eligible to use the `archive-product.html` file in their place. So we trick Gutenberg in thinking some templates (e.g. category/tag) have a theme file available if it is using the `archive-product.html` template, even though _technically_ the theme does not have a specific file for them.
+-   Ensuring we do not add irrelevant WooCommerce templates in the returned list. For example, if `$query['post_type']` has a value (e.g. `product`) this means the query is requesting templates related to that specific post type, so we filter out any irrelevant ones. This _could_ be used to show/hide templates from the template dropdown on the "Edit Product" screen in WP Admin.
 
 ### Return value
 
 This method will return an array of `WP_Block_Template` values
 
-## get_block_file_template( $template, $id, $template_type )
+## get_block_file_template( $template, $id, \$template_type )
 
-This method is applied to the filter `pre_get_block_file_template` inside the WordPress core function `get_block_file_template` (not to be confused with this method from the `BlockTemplateController` class, which has the same name). 
+This method is applied to the filter `pre_get_block_file_template` inside the WordPress core function `get_block_file_template` (not to be confused with this method from the `BlockTemplateController` class, which has the same name).
 
 The order of execution is as follows:
 
@@ -52,10 +59,12 @@ The order of execution is as follows:
 During step 2 it's important we hook into the `pre_get_block_file_template`. If we don't, the function will check if the first part of the template ID (e.g. `woocommerce/woocommerce`) is the same as the current themes ID (e.g. `twentytwentytwo`), which will resolve `false` and return `null` instead of the expected `WP_Block_Template` object.
 
 **Typically executed when:**
-* A user clears the customizations of a WooCommerce template.
+
+-   A user clears the customizations of a WooCommerce template.
 
 **This method is responsible for:**
-* Loading the template files from the filesystem, and building a `WP_Block_Template` version of it.
+
+-   Loading the template files from the filesystem, and building a `WP_Block_Template` version of it.
 
 ### Return value
 
@@ -68,19 +77,25 @@ This method is applied to the filter `template_redirect` and executed before Wor
 This allows us to hook into WooCommerce core through the filter `woocommerce_has_block_template` where we can determine if a specific block template exists and should be loaded.
 
 **Typically executed when:**
-* A user loads a page on the front-end.
+
+-   A user loads a page on the front-end.
 
 **This method is responsible for:**
-* Determining if the current page has an appropriate WooCommerce block template available to render.
-* Checking if the currently loaded page is from WooCommerce. It then checks if the theme has an appropriate template to use: if it does not, then it finally checks if WooCommerce has a default block template available. If so, we override the value through `woocommerce_has_block_template` to resolve `true`.
+
+-   Determining if the current page has an appropriate WooCommerce block template available to render.
+-   Checking if the currently loaded page is from WooCommerce. It then checks if the theme has an appropriate template to use: if it does not, then it finally checks if WooCommerce has a default block template available. If so, we override the value through `woocommerce_has_block_template` to resolve `true`.
 
 ### Return value
+
 Void. This method does not return a value but rather sets up hooks to render block templates on the front-end.
+
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/templates/block-template-controller.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/templates/classic-template.md
+++ b/docs/templates/classic-template.md
@@ -11,11 +11,14 @@ From this file, we enqueue the front-end scripts necessary to enable dynamic fun
 From the `render()` method we inspect the `$attributes` object for a `template` property which helps determine which core PHP templating code to execute (e.g. `single-product`) for the front-end views.
 
 ![Classic Block Template Attribute](./assets/classic-template-attributes.png)
+
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/templates/classic-template.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -2,18 +2,20 @@
 
 This folder contains documentation around manual testing of WooCommerce Blocks.
 
-| Document                                                         | Description                                                                         |
-| ---------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| Document                                                           | Description                                                                              |
+| ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- |
 | [When to employ end to end testing](when-to-employ-e2e-testing.md) | This doc explains when End to End tests should be used and when unit tests will suffice. |
-| [Smoke Testing](smoke-testing.md)                                | This doc explains how to smoke test key Blocks functionality.                       |
-| [Cart and Checkout Testing](./cart-checkout/readme.md) | Various testing flows for Cart and Checkout Blocks |
-| [Releases](./releases/README.md) | We document all testing flows for releases in this folder |
+| [Smoke Testing](smoke-testing.md)                                  | This doc explains how to smoke test key Blocks functionality.                            |
+| [Cart and Checkout Testing](./cart-checkout/readme.md)             | Various testing flows for Cart and Checkout Blocks                                       |
+| [Releases](./releases/README.md)                                   | We document all testing flows for releases in this folder                                |
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/README.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/cart-checkout/README.md
+++ b/docs/testing/cart-checkout/README.md
@@ -19,15 +19,16 @@ separate them.
 ### Known limitations
 
 <!-- Debating on where to put this section -->
+
 This is a list of all known limitation for Cart and Checkout blocks, it means
 we're aware of them, and will probably not tackle them in this first release:
 
-- Cart and Checkout blocks do not support third-party plugins that integrate with
-  regular Cart and Checkout shortcode, if you somehow see a third party plugin working
-  well, this is pure coincidence, the only exception is Stripe payment gateway.
+-   Cart and Checkout blocks do not support third-party plugins that integrate with
+    regular Cart and Checkout shortcode, if you somehow see a third party plugin working
+    well, this is pure coincidence, the only exception is Stripe payment gateway.
 
-- The only payment gateway supported are Check and Stripe.
-- Storefront and TwentyTwenty are expected to work fine, no guarantee is presented on other themes, but do report them if you feel like that's something we can fix on our end.
+-   The only payment gateway supported are Check and Stripe.
+-   Storefront and TwentyTwenty are expected to work fine, no guarantee is presented on other themes, but do report them if you feel like that's something we can fix on our end.
 
 <!-- Currently this is unneeded so I'm omitting this section -->.
 <!--
@@ -71,21 +72,22 @@ the Cart and Checkout shortcodes.
 
 ## Testing Checklist
 
-- [General Flow](general-flow.md)
-- [Editor](editor.md)
-- [Shipping](shipping.md)
-- [Payments](payment.md)
-- [Items](items.md)
-- [Taxes](taxes.md)
-- [Coupons](coupons.md)
-- [Cross Browser and platform](cross-browser.md)
-
+-   [General Flow](general-flow.md)
+-   [Editor](editor.md)
+-   [Shipping](shipping.md)
+-   [Payments](payment.md)
+-   [Items](items.md)
+-   [Taxes](taxes.md)
+-   [Coupons](coupons.md)
+-   [Cross Browser and platform](cross-browser.md)
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
-🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/cart-checkout/readme.md)
+🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/cart-checkout/README.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/cart-checkout/coupons.md
+++ b/docs/testing/cart-checkout/coupons.md
@@ -5,38 +5,41 @@
 ## Setup
 
 You will need to setup some types of coupon in order to test this.
-- A general purpose coupon `coupon`.
-- An expired coupon `oldcoupon`.
-- An email limited coupon `a12s` that is limited to `*@automattic.com` emails.
-- A cart condition coupon that is limited to carts above x threshold (e.g $200) `above200`.
-- An individually used coupon `alone`.
-- A free shipping coupon `freeship`.
+
+-   A general purpose coupon `coupon`.
+-   An expired coupon `oldcoupon`.
+-   An email limited coupon `a12s` that is limited to `*@automattic.com` emails.
+-   A cart condition coupon that is limited to carts above x threshold (e.g \$200) `above200`.
+-   An individually used coupon `alone`.
+-   A free shipping coupon `freeship`.
 
 ## What to test
 
 With coupons disabled: <!-- heading -->
 
-- [ ] You should not see the add coupon section in your cart and checkout and in the editor.
+-   [ ] You should not see the add coupon section in your cart and checkout and in the editor.
 
 With coupons enabled: <!-- heading -->
 
-- [ ] You can apply coupons in both Cart and Checkout blocks.
-- [ ] A valid coupon `coupon` should reduce your totals.
-- [ ] An expired coupon `oldcoupon` should return an error.
-- [ ] An invalid coupon should return an error.
-- [ ] An email limited coupon should apply to your cart.
-  - [ ] If the email is correct, you should be able to checkout.
-  - [ ] If the email is incorrect, you should receive an error, and the coupon will be removed from your cart.
-- [ ] A condition coupon should not be added until you meet the condition.
-  - [ ] Adding a condition coupon then removing the condition (reduce cart total or remove related item) should remove the coupon from your cart with an error.
-- [ ] Adding a coupon then adding `alone` coupon should replace the first one.
-- [ ] Adding `alone` then trying to another coupon should result in an error.
-- [ ] Adding `freeship` should show the free shipping method you previously created.
+-   [ ] You can apply coupons in both Cart and Checkout blocks.
+-   [ ] A valid coupon `coupon` should reduce your totals.
+-   [ ] An expired coupon `oldcoupon` should return an error.
+-   [ ] An invalid coupon should return an error.
+-   [ ] An email limited coupon should apply to your cart.
+    -   [ ] If the email is correct, you should be able to checkout.
+    -   [ ] If the email is incorrect, you should receive an error, and the coupon will be removed from your cart.
+-   [ ] A condition coupon should not be added until you meet the condition.
+    -   [ ] Adding a condition coupon then removing the condition (reduce cart total or remove related item) should remove the coupon from your cart with an error.
+-   [ ] Adding a coupon then adding `alone` coupon should replace the first one.
+-   [ ] Adding `alone` then trying to another coupon should result in an error.
+-   [ ] Adding `freeship` should show the free shipping method you previously created.
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/cart-checkout/coupons.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/cart-checkout/cross-browser.md
+++ b/docs/testing/cart-checkout/cross-browser.md
@@ -3,15 +3,18 @@
 The main goal of this is to test in a variety of themes, browsers, platforms, and setups, this is a list of things you can test with, with sane expectations.
 
 The baseline for testing is:
-- WordPress 5.4 and up.
-- WooCommerce 4.2 and up
-- All Browsers supported by [those two versions](https://make.wordpress.org/core/handbook/best-practices/browser-support/) so this includes Internet Explorer 11, and latest two versions of each browser.
-- Storefront, TwentyTwenty, and TwentyNineteen themes, we use storefront as a basis for development and push fixes to it regularly, so make sure you run the latest version.
+
+-   WordPress 5.4 and up.
+-   WooCommerce 4.2 and up
+-   All Browsers supported by [those two versions](https://make.wordpress.org/core/handbook/best-practices/browser-support/) so this includes Internet Explorer 11, and latest two versions of each browser.
+-   Storefront, TwentyTwenty, and TwentyNineteen themes, we use storefront as a basis for development and push fixes to it regularly, so make sure you run the latest version.
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/cart-checkout/cross-browser.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/cart-checkout/editor.md
+++ b/docs/testing/cart-checkout/editor.md
@@ -2,17 +2,19 @@
 
 # Editor experience
 
-- [ ] You should be able to add one and only one Cart or Checkout block to a page.
-- [ ] The preview in the inserter should show a skeleton of how the block structure should look like.
-- [ ] When inserting any of the blocks, it should have some data already in it.
-- [ ] You should not be able to interact directly with the block (except for some sections).
-- [ ] You should be able to see block settings on the sidebar when it is focused.
-- [ ] Proceed to Checkout and Back to cart block settings should present you with a list of your website pages.
+-   [ ] You should be able to add one and only one Cart or Checkout block to a page.
+-   [ ] The preview in the inserter should show a skeleton of how the block structure should look like.
+-   [ ] When inserting any of the blocks, it should have some data already in it.
+-   [ ] You should not be able to interact directly with the block (except for some sections).
+-   [ ] You should be able to see block settings on the sidebar when it is focused.
+-   [ ] Proceed to Checkout and Back to cart block settings should present you with a list of your website pages.
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/cart-checkout/editor.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/cart-checkout/general-flow.md
+++ b/docs/testing/cart-checkout/general-flow.md
@@ -10,20 +10,22 @@ taxes (if you have any), shipping and so on.
 
 ## What to test
 
-- [ ] Create pages with Cart and Checkout blocks.
-- [ ] Set the continue to checkout link your Cart settings to the Checkout page you created.
-- [ ] In Woocommerce -> Settings -> Advanced, set the new pages to your default Cart and Checkout.
-- [ ] Add some products to your cart.
-- [ ] Mix in a limited stock product or a coupon.
-- [ ] Continue to checkout.
-- [ ] You should be able to fix your info, if you have them saved, they will show up.
-- [ ] Depending on what payment method you enabled (Credit Card, Check, Express payment), you can place the order.
-- [ ] You should see an order received page.
+-   [ ] Create pages with Cart and Checkout blocks.
+-   [ ] Set the continue to checkout link your Cart settings to the Checkout page you created.
+-   [ ] In Woocommerce -> Settings -> Advanced, set the new pages to your default Cart and Checkout.
+-   [ ] Add some products to your cart.
+-   [ ] Mix in a limited stock product or a coupon.
+-   [ ] Continue to checkout.
+-   [ ] You should be able to fix your info, if you have them saved, they will show up.
+-   [ ] Depending on what payment method you enabled (Credit Card, Check, Express payment), you can place the order.
+-   [ ] You should see an order received page.
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/cart-checkout/general-flow.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/cart-checkout/items.md
+++ b/docs/testing/cart-checkout/items.md
@@ -4,31 +4,32 @@
 
 ## Setup
 
-- You will need an item that is [sold individually](https://docs.woocommerce.com/wp-content/uploads/2016/06/disable-stock-mgmt.png).
-- You will need a low stock item with a [low threshold quantity](https://docs.woocommerce.com/wp-content/uploads/2016/06/simpleproduct-inventory.png) below the stock quantity.
-- You will need a low stock item with a [low threshold quantity](https://docs.woocommerce.com/wp-content/uploads/2016/06/simpleproduct-inventory.png) above 0 and a stock quantity below the threshold.
+-   You will need an item that is [sold individually](https://docs.woocommerce.com/wp-content/uploads/2016/06/disable-stock-mgmt.png).
+-   You will need a low stock item with a [low threshold quantity](https://docs.woocommerce.com/wp-content/uploads/2016/06/simpleproduct-inventory.png) below the stock quantity.
+-   You will need a low stock item with a [low threshold quantity](https://docs.woocommerce.com/wp-content/uploads/2016/06/simpleproduct-inventory.png) above 0 and a stock quantity below the threshold.
 
 ## What to test
 
-- [ ] You should be able to add items to your cart.
-- [ ] You should be able to change item quantity in your Cart.
-- [ ] You should not be able to change "sold individually" items quantity.
-- [ ] Items that have quantity lower than the threshold should show "x Left in stock".
-	- [ ] You should not be able to increase that item quantity to above that is left in stock.
-- [ ] If you try to increase an item quantity to above its stock quantity, you get an error. **Note:** This is not something that can be tested with a single browser instance. To test you need to do the following:
-  - [ ] Set a stock of 4 on an item.
-  - [ ] Open tabs in two different browsers (so you have two different sessions in play).
-  - [ ] In both browsers add 1 of that item into the cart.
-  - [ ] In both browsers, load the cart (block).
-  - [ ] In one browser, increase the quantity of that item to the maximum you can.
-  - [ ] In the other browser, try increasing the quantity. An error should appear.
-- [ ] You should be able to remove an item.
+-   [ ] You should be able to add items to your cart.
+-   [ ] You should be able to change item quantity in your Cart.
+-   [ ] You should not be able to change "sold individually" items quantity.
+-   [ ] Items that have quantity lower than the threshold should show "x Left in stock". - [ ] You should not be able to increase that item quantity to above that is left in stock.
+-   [ ] If you try to increase an item quantity to above its stock quantity, you get an error. **Note:** This is not something that can be tested with a single browser instance. To test you need to do the following:
+    -   [ ] Set a stock of 4 on an item.
+    -   [ ] Open tabs in two different browsers (so you have two different sessions in play).
+    -   [ ] In both browsers add 1 of that item into the cart.
+    -   [ ] In both browsers, load the cart (block).
+    -   [ ] In one browser, increase the quantity of that item to the maximum you can.
+    -   [ ] In the other browser, try increasing the quantity. An error should appear.
+-   [ ] You should be able to remove an item.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/cart-checkout/items.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/cart-checkout/payment.md
+++ b/docs/testing/cart-checkout/payment.md
@@ -4,24 +4,25 @@
 
 ## Setup
 
-- The Checkout Block supports Three methods of payments:
-  - Check Payment, found in WooCommerce payment section.
-  - Stripe Credit Card payments, provided by [Stripe Gateway](https://woocommerce.com/products/stripe/).
-  - Express Payment methods, provided by [Stripe Gateway](https://woocommerce.com/products/stripe/).
+-   The Checkout Block supports Three methods of payments:
+    -   Check Payment, found in WooCommerce payment section.
+    -   Stripe Credit Card payments, provided by [Stripe Gateway](https://woocommerce.com/products/stripe/).
+    -   Express Payment methods, provided by [Stripe Gateway](https://woocommerce.com/products/stripe/).
 
 To test Stripe and Express payment methods, you will need API keys, you can get them by creating a testing account
 in stripe.
 
 Special Cases:
 To test Express payment methods there are some special requirements like
-- You need to be serving the website over https, try ephemeral websites.
-- You need to be from a supported country.
-- To test Apple Pay you will need to have an iOS or device.
-- To test Google Pay you will need to have Chrome installed and a payment method setup.
-- To test Microsoft Pay you will need to have Edge installed.
-- You will also need to be on a supported country, to better verify your compatibility visit
-  [this page](https://stripe.com/docs/stripe-js/elements/payment-request-button#react-overview)
-  You should see if you're on a supported platform or not.
+
+-   You need to be serving the website over https, try ephemeral websites.
+-   You need to be from a supported country.
+-   To test Apple Pay you will need to have an iOS or device.
+-   To test Google Pay you will need to have Chrome installed and a payment method setup.
+-   To test Microsoft Pay you will need to have Edge installed.
+-   You will also need to be on a supported country, to better verify your compatibility visit
+    [this page](https://stripe.com/docs/stripe-js/elements/payment-request-button#react-overview)
+    You should see if you're on a supported platform or not.
 
 Unsupported:
 ![](https://i.imgur.com/EpkFrat.png).
@@ -30,19 +31,21 @@ Unsupported:
 
 If no payment method is set up: <!-- heading -->
 
-- [ ] An error will show up in the frontend, saying that no payment method is available.
-- [ ] In the editor, you will be prompted to set up a payment method.
+-   [ ] An error will show up in the frontend, saying that no payment method is available.
+-   [ ] In the editor, you will be prompted to set up a payment method.
 
 If you have a payment method available: <!-- heading -->
 
-- [ ] You should be able to perform a successful checkout with Check payments.
-- [ ] You should be able to perform a successful checkout credit card payment using this cart `4242424242424242`
-- [ ] You should be able to perform a failed checkout credit card payment using this cart `4000000000000002`
+-   [ ] You should be able to perform a successful checkout with Check payments.
+-   [ ] You should be able to perform a successful checkout credit card payment using this cart `4242424242424242`
+-   [ ] You should be able to perform a failed checkout credit card payment using this cart `4000000000000002`
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/cart-checkout/payment.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/cart-checkout/shipping.md
+++ b/docs/testing/cart-checkout/shipping.md
@@ -4,42 +4,43 @@
 
 ## Setup
 
-- You will need to setup shipping zones for a couple of countries.
-- You will need to have a free shipping method that is enabled with a coupon or a threshold.
-
+-   You will need to setup shipping zones for a couple of countries.
+-   You will need to have a free shipping method that is enabled with a coupon or a threshold.
 
 ## What to test
 
 With shipping zones available: <!-- heading -->
 
-- [ ] You should be able to see preview rates (that are not your actual rates) in the editor.
-- [ ] You should be able to see your actual rates on the frontend.
-- [ ] Selecting a shipping rate should update the totals.
-- [ ] Changing the address in Cart block should update the rates.
-- [ ] Try entering an address that does not have rates for, you should:
-  - [ ] See an error saying "No options were found".
-  - [ ] See the default shipping option if you have it setup.
-- [ ] The countries in the shipping rates form should reflect the countries you have in WooCommerce -> Settings -> General -> Shipping location(s).
-- [ ] If your cart has only digital products, the Cart and Checkout blocks should act like shipping is disabled.
-- [ ] Your free shipping method should show up when you increase the cart quantity to above that limit.
-  - [ ] Once you decrease it, the shipping rate will disappear, the next rate will be selected.
-- [ ] The rate you select in Cart should still be selected in Checkout.
-- [ ] Updating your shipping address in Checkout should give you live updates about rates in your cart.
+-   [ ] You should be able to see preview rates (that are not your actual rates) in the editor.
+-   [ ] You should be able to see your actual rates on the frontend.
+-   [ ] Selecting a shipping rate should update the totals.
+-   [ ] Changing the address in Cart block should update the rates.
+-   [ ] Try entering an address that does not have rates for, you should:
+    -   [ ] See an error saying "No options were found".
+    -   [ ] See the default shipping option if you have it setup.
+-   [ ] The countries in the shipping rates form should reflect the countries you have in WooCommerce -> Settings -> General -> Shipping location(s).
+-   [ ] If your cart has only digital products, the Cart and Checkout blocks should act like shipping is disabled.
+-   [ ] Your free shipping method should show up when you increase the cart quantity to above that limit.
+    -   [ ] Once you decrease it, the shipping rate will disappear, the next rate will be selected.
+-   [ ] The rate you select in Cart should still be selected in Checkout.
+-   [ ] Updating your shipping address in Checkout should give you live updates about rates in your cart.
 
 If you don't have any shipping zones set up and/or shipping is disabled: <!-- heading -->
 
-- [ ] You should only see the billing form in both editor and frontend for the Checkout Block.
-- [ ] The shipping options step should not be visible.
-- [ ] The shipping cost should not be visible in the sidebar.
+-   [ ] You should only see the billing form in both editor and frontend for the Checkout Block.
+-   [ ] The shipping options step should not be visible.
+-   [ ] The shipping cost should not be visible in the sidebar.
 
 If you don't have any shipping zones set up but **shipping is enabled**: <!-- heading -->
 
-- [ ] In the editor, Checkout Block will show you a placeholder promoting you to set up shipping zones.
+-   [ ] In the editor, Checkout Block will show you a placeholder promoting you to set up shipping zones.
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/cart-checkout/shipping.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/cart-checkout/taxes.md
+++ b/docs/testing/cart-checkout/taxes.md
@@ -4,23 +4,25 @@
 
 ## Setup
 
-- You will need to have taxes setup for a region.
+-   You will need to have taxes setup for a region.
 
 ## What to test
 
 With taxes disabled: <!-- heading -->
 
-- [ ] You should not see "Taxes" line in the cart or checkout.
+-   [ ] You should not see "Taxes" line in the cart or checkout.
 
 With taxes enabled: <!-- heading -->
 
-- [ ] You should see "Taxes" line in the cart or checkout.
-- [ ] If the user address or store settings country doesn't have taxes in it, the value will be 0.
+-   [ ] You should see "Taxes" line in the cart or checkout.
+-   [ ] If the user address or store settings country doesn't have taxes in it, the value will be 0.
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/cart-checkout/taxes.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/260.md
+++ b/docs/testing/releases/260.md
@@ -5,41 +5,40 @@
 **Zip File for testing:**
 [woocommerce-gutenberg-products-block.zip](https://github.com/woocommerce/woocommerce-gutenberg-products-block/archive/v2.6.0.zip)
 
-
 ### Cart and Checkout Blocks
 
 [See testing notes here](https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/trunk/docs/testing/cart-checkout)
 
 ### All Products
 
-- All of these tests should be done in Safari, Chrome, and Firefox (latest version).
-- Also validate the behaviour of the block in mobile views vs desktop.
+-   All of these tests should be done in Safari, Chrome, and Firefox (latest version).
+-   Also validate the behaviour of the block in mobile views vs desktop.
 
-* [ ] Verify the block can be added to a new page.
-* [ ] Verify only one instance of the block can be added to a page/post.
-* [ ] Verify the various settings and configuration for the block in the editor works as expected for the given UI.
-* [ ] Verify the block functions as expected for the given configuration on the frontend of the site.
-* [ ] For an instance of this block setup on a post in an earlier release, verify that upgrading to this release doesn't break the block functionality in the frontend or in the editor.
+*   [ ] Verify the block can be added to a new page.
+*   [ ] Verify only one instance of the block can be added to a page/post.
+*   [ ] Verify the various settings and configuration for the block in the editor works as expected for the given UI.
+*   [ ] Verify the block functions as expected for the given configuration on the frontend of the site.
+*   [ ] For an instance of this block setup on a post in an earlier release, verify that upgrading to this release doesn't break the block functionality in the frontend or in the editor.
 
 #### Specific changes to test for in this release.
 
-* [ ]  When editing the All Products block, verify that when you change the default sorting options in the inspector controls for the block that the corresponding filter dropdown in the block preview updates as expected (see highlighted areas below):
+-   [ ] When editing the All Products block, verify that when you change the default sorting options in the inspector controls for the block that the corresponding filter dropdown in the block preview updates as expected (see highlighted areas below):
 
 ![example affected areas](https://user-images.githubusercontent.com/2207451/71814247-15521400-307c-11ea-92da-8f4073492397.png)
 
-* [ ] Verify that an error notice is shown in the All Products block if you try to add a product to the cart (using the Add to Cart button) if the product is out of stock or is sold individually and there is already an instance of that product in the cart.
+-   [ ] Verify that an error notice is shown in the All Products block if you try to add a product to the cart (using the Add to Cart button) if the product is out of stock or is sold individually and there is already an instance of that product in the cart.
 
 ### Filter blocks
 
 These blocks are used in tandem with the All Products block to provide filtering options on the content rendered by the All Products block. They include:
 
-- Filter Products By Attribute
-- Filter Products By Price
-- Active Product Filters
+-   Filter Products By Attribute
+-   Filter Products By Price
+-   Active Product Filters
 
 These blocks can be tested by adding them to the same page as the All Products block as the selected values in these blocks affects the products displayed by the All Products block.
 
-* [ ] General testing involves setting up the filter blocks and verifying the the various configurations for the blocks work as expected in the editor (for settings) and the frontend (according to how the block was configured). Validate that when various filters are applied the expected results are shown in the All Products block.
+-   [ ] General testing involves setting up the filter blocks and verifying the the various configurations for the blocks work as expected in the editor (for settings) and the frontend (according to how the block was configured). Validate that when various filters are applied the expected results are shown in the All Products block.
 
 #### Specific changes to test for in this release.
 
@@ -48,14 +47,15 @@ These blocks can be tested by adding them to the same page as the All Products b
 One fix in this release for this block is that when the price display setting (including or excluding tax) for WooCommerce differs from the price entered setting (prices input including or excluding tax), the displayed prices for filtered results from the entered Price Filter block might appear to be a mismatch (when it's querying based on the prices _saved to the database_). With this release, this is fixed so that no matter how WooCommerce is configured for displaying or saving prices respective to taxes, the displayed products will have prices matching the expected range set via the price filter block.
 
 To test:
-* [ ] In WooCommerce > Settings > Taxes, **choose to enter prices inclusive of tax, but display prices excluding tax.** Test that filters work as expected for the blocks.
-* [ ] In WooCommerce > Settings > Taxes, **choose to enter prices exclusive of tax, but display prices including tax**. Test that filters work on products.
+
+-   [ ] In WooCommerce > Settings > Taxes, **choose to enter prices inclusive of tax, but display prices excluding tax.** Test that filters work as expected for the blocks.
+-   [ ] In WooCommerce > Settings > Taxes, **choose to enter prices exclusive of tax, but display prices including tax**. Test that filters work on products.
 
 **And/Or labelling in Active Filters block**
 
-* [ ] Setup various filter blocks so that some are set to `any` type filtering and others are set to `all` type filtering.
-* [ ] Add the Active Filters block to the same post/page.
-* [ ] Verify that when you apply filters on the frontend, the Active Filter block updates it's text to match the type of filtering being done.
+-   [ ] Setup various filter blocks so that some are set to `any` type filtering and others are set to `all` type filtering.
+-   [ ] Add the Active Filters block to the same post/page.
+-   [ ] Verify that when you apply filters on the frontend, the Active Filter block updates it's text to match the type of filtering being done.
 
 **Dropdown display style to Attribute Filter block**
 
@@ -65,40 +65,40 @@ This release introduces a dropdown display style for the Filter Products by Attr
 
 To test:
 
-* [ ] Create a post with a Filter Products by Attribute block and select the Dropdown option in _Display style_ settings.
-* [ ] Preview the post and interact with the filter (search terms, add them, remove them, repeat only using the keyboard, using a screen-reader etc).
-* [ ] Verify everything works as expected for the ui/ux behaviour and for the returned results in the All Products block.
-* [ ] This should work for either "and" or "or" filtering.
+-   [ ] Create a post with a Filter Products by Attribute block and select the Dropdown option in _Display style_ settings.
+-   [ ] Preview the post and interact with the filter (search terms, add them, remove them, repeat only using the keyboard, using a screen-reader etc).
+-   [ ] Verify everything works as expected for the ui/ux behaviour and for the returned results in the All Products block.
+-   [ ] This should work for either "and" or "or" filtering.
 
 **Add option to display an "apply filter button" for the Filter Products by Attribute block**
 
-* [ ] Create a post with an Filter Products by Attribute block and All products block
-* [ ] For the Filter Products by Attribute block, enable the _Filter Button_ option.
-* [ ] Preview the post and verify selecting/unselecting options doesn't update the _All Products_ block until you press the _Go_ button.
+-   [ ] Create a post with an Filter Products by Attribute block and All products block
+-   [ ] For the Filter Products by Attribute block, enable the _Filter Button_ option.
+-   [ ] Preview the post and verify selecting/unselecting options doesn't update the _All Products_ block until you press the _Go_ button.
 
 ### All Product Grid based blocks
 
 All of these blocks share a common ancestor for the PHP side registration, so it's good to test them together. These blocks include:
 
-- Top Rated Products
-- Best Selling Products
-- On Sale Products
-- Products By Attribute
-- Hand-picked Products
-- Products by Category
-- Products by Tag
-- Newest Products
+-   Top Rated Products
+-   Best Selling Products
+-   On Sale Products
+-   Products By Attribute
+-   Hand-picked Products
+-   Products by Category
+-   Products by Tag
+-   Newest Products
 
 #### Specific changes to test for in these blocks for this release:
 
-* [ ] Verify that if there are no products on sale, the On Sale Products block shows this placeholder in the editor:
+-   [ ] Verify that if there are no products on sale, the On Sale Products block shows this placeholder in the editor:
 
 ![On Sale Products placeholder](https://user-images.githubusercontent.com/90977/71984453-c2fe2800-3220-11ea-9b6e-fd3c9ca2ece2.png)
 
-* [ ] For any of the product grid blocks, verify that when a fresh instance of the block is added to the editor, it defaults to 3 rows and 3 columns for the grid.
-* [ ] Verify that changing any of the values for the grid "sticks" and persists across saves. Also verify it shows as expected and configured on the frontend.
-* [ ] For any of the product grid blocks, for an instance of the block setup on a post in an earlier release with no changes to it's settings, verify that upgrading to this release doesn't break the block functionality in the frontend or in the editor (However note that the grid will change from the default of 1 in the earlier release to 3 in the recent release automatically).
-* [ ] Same test as above, except in the earlier release, change the grid to something other than 1 row and save. When upgrading to the new release the setting for the grid should have persisted with the block.
+-   [ ] For any of the product grid blocks, verify that when a fresh instance of the block is added to the editor, it defaults to 3 rows and 3 columns for the grid.
+-   [ ] Verify that changing any of the values for the grid "sticks" and persists across saves. Also verify it shows as expected and configured on the frontend.
+-   [ ] For any of the product grid blocks, for an instance of the block setup on a post in an earlier release with no changes to it's settings, verify that upgrading to this release doesn't break the block functionality in the frontend or in the editor (However note that the grid will change from the default of 1 in the earlier release to 3 in the recent release automatically).
+-   [ ] Same test as above, except in the earlier release, change the grid to something other than 1 row and save. When upgrading to the new release the setting for the grid should have persisted with the block.
 
 ### Other blocks
 
@@ -110,24 +110,25 @@ In this fix, when a product is changed for an existing featured product block, t
 
 To test:
 
-* [ ] Verify any existing instance of this block in a previous release does not show any errors in the editor when updating to this release.
-* [ ] Verify that if you edit the block and change the product it uses, the button url will update as well.
+-   [ ] Verify any existing instance of this block in a previous release does not show any errors in the editor when updating to this release.
+-   [ ] Verify that if you edit the block and change the product it uses, the button url will update as well.
 
 #### Product Categories Block
 
 Support was added for showing category images in the Product Categories block. The following expectations:
 
-- For the "List" display style the toggle option for showing category images is available (and is disabled by default).
-- This option is not available for the "Dropdown" display style.
-- When the option is toggled to "Show Category Image", images for categories are shown per category item in the list.
-
-* [ ] Verify the new option works as expected according to the above both in the editor and in the frontend.
+-   For the "List" display style the toggle option for showing category images is available (and is disabled by default).
+-   This option is not available for the "Dropdown" display style.
+-   When the option is toggled to "Show Category Image", images for categories are shown per category item in the list.
+-   [ ] Verify the new option works as expected according to the above both in the editor and in the frontend.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/260.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/261.md
+++ b/docs/testing/releases/261.md
@@ -20,10 +20,12 @@ _Note: assuming you are using a development site where you are okay with losing 
 3. Verify the `wc_reserved_stock` table was re-created.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/261.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/270.md
+++ b/docs/testing/releases/270.md
@@ -6,36 +6,27 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 
 ### Cart and Checkout styles
 
-- Create pages with the Cart and Checkout blocks.
-- Check the styles of both pages and verify:
-	- The Cart and Checkout headings match the styles inherited from the theme (#2597)
-	- In Checkout, step progress indicators match the heading style and they don't have a background circle (#2649).<br>
-![Checkout heading styles](https://user-images.githubusercontent.com/3616980/84032118-1e327300-a997-11ea-8c06-363ac2bd78b3.png)
-	- In Checkout, the item quantity badges are visible with dark backgrounds (with Storefront, you can change the background color in Appearance > Customize > Background) (#2619).<br>
-![Item quantity badges](https://user-images.githubusercontent.com/3616980/84031988-ed523e00-a996-11ea-8545-339111e31f5f.png)
-		- Try adding the code snippet from the [Cart and Checkout theming](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/theming/cart-and-checkout.md#item-quantity-badge) docs (you can do it via a child theme or directly in the browser devtools) and verify the item quantity badge styles update accordingly.
-	- In general, verify there were no regressions introduced after 2.6.0.
-- The Cart block title should be `Your cart (X items)` (#2615).<br>
-![Cart block title](https://user-images.githubusercontent.com/3616980/84032294-66ea2c00-a997-11ea-8d6d-929668cb702b.png)
-- Introduce an invalid credit card number and verify there is enough padding around the validation errors (#2662).<br>
-![Credit card validation errors](https://user-images.githubusercontent.com/3616980/84011799-f0d5cd00-a976-11ea-8cb2-a7e7ef38b0b0.png)
-- In the editor, add the Cart block and verify the headings have the proper font size and there is margin between the `Proceed to Checkout` button and the credit card icons -- to get the icons, you need to install the Stripe payment gateway (#2486).
+-   Create pages with the Cart and Checkout blocks.
+-   Check the styles of both pages and verify: - The Cart and Checkout headings match the styles inherited from the theme (#2597) - In Checkout, step progress indicators match the heading style and they don't have a background circle (#2649).<br>
+    ![Checkout heading styles](https://user-images.githubusercontent.com/3616980/84032118-1e327300-a997-11ea-8c06-363ac2bd78b3.png) - In Checkout, the item quantity badges are visible with dark backgrounds (with Storefront, you can change the background color in Appearance > Customize > Background) (#2619).<br>
+    ![Item quantity badges](https://user-images.githubusercontent.com/3616980/84031988-ed523e00-a996-11ea-8545-339111e31f5f.png) - Try adding the code snippet from the [Cart and Checkout theming](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/theming/cart-and-checkout.md#item-quantity-badge) docs (you can do it via a child theme or directly in the browser devtools) and verify the item quantity badge styles update accordingly. - In general, verify there were no regressions introduced after 2.6.0.
+-   The Cart block title should be `Your cart (X items)` (#2615).<br>
+    ![Cart block title](https://user-images.githubusercontent.com/3616980/84032294-66ea2c00-a997-11ea-8d6d-929668cb702b.png)
+-   Introduce an invalid credit card number and verify there is enough padding around the validation errors (#2662).<br>
+    ![Credit card validation errors](https://user-images.githubusercontent.com/3616980/84011799-f0d5cd00-a976-11ea-8cb2-a7e7ef38b0b0.png)
+-   In the editor, add the Cart block and verify the headings have the proper font size and there is margin between the `Proceed to Checkout` button and the credit card icons -- to get the icons, you need to install the Stripe payment gateway (#2486).
 
 | 2.6.0                                                                                                                           | 2.7.0                                                                                                                           |
 | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | ![Cart in editor in 2.6.0](https://user-images.githubusercontent.com/3616980/81926566-71a4e180-95e2-11ea-8c43-7a5064831e5b.png) | ![Cart in editor in 2.7.0](https://user-images.githubusercontent.com/3616980/81926959-24753f80-95e3-11ea-8cd4-6374ff3870ce.png) |
 
 #### Specific themes
-- [Hello theme](https://elementor.com/hello-theme/):
-	- Verify the text inside the selects is visible on hover (#2647).<br>
-![Select in Hello theme](https://user-images.githubusercontent.com/3616980/84032650-f4c61700-a997-11ea-969d-6427d1e221bb.png)
-- Twenty Twenty:
-	- Add the All Products block and the Hand-picked Products block in a page and verify (#2573):
-		- That with the All Products block you can add the On Sale badge and it's correctly aligned in the editor and the frontend (before, it was always shown on top of the image).<br>
-![All Products in Twenty Twenty](https://user-images.githubusercontent.com/3616980/83013870-fef22800-a01d-11ea-8ea8-21229285d10a.png)
-		- The Hand-picked Products block discounted prices are not underlined.<br>
-![Hand-picked Products in Twenty Twenty](https://user-images.githubusercontent.com/3616980/83013599-8e4b0b80-a01d-11ea-88ab-a1537110c4e2.png)
-	- Go to the Checkout block and verify font sizes look correct (they are inherited from the theme) (#2533).
+
+-   [Hello theme](https://elementor.com/hello-theme/): - Verify the text inside the selects is visible on hover (#2647).<br>
+    ![Select in Hello theme](https://user-images.githubusercontent.com/3616980/84032650-f4c61700-a997-11ea-969d-6427d1e221bb.png)
+-   Twenty Twenty: - Add the All Products block and the Hand-picked Products block in a page and verify (#2573): - That with the All Products block you can add the On Sale badge and it's correctly aligned in the editor and the frontend (before, it was always shown on top of the image).<br>
+    ![All Products in Twenty Twenty](https://user-images.githubusercontent.com/3616980/83013870-fef22800-a01d-11ea-8ea8-21229285d10a.png) - The Hand-picked Products block discounted prices are not underlined.<br>
+    ![Hand-picked Products in Twenty Twenty](https://user-images.githubusercontent.com/3616980/83013599-8e4b0b80-a01d-11ea-88ab-a1537110c4e2.png) - Go to the Checkout block and verify font sizes look correct (they are inherited from the theme) (#2533).
 
 ### Cart and Checkout error flow (#2655)
 
@@ -74,36 +65,39 @@ You'll need to be logged in with a user that has saved payment methods.
 4. Submit the checkout and this should result in the purchase completing successfully for the cheque payment method.
 
 ### No shipping methods placeholder when they are all disabled (#2543)
+
 _(Requires at least WooCommerce 4.3)_
+
 1. Disable all shipping methods from your store.
 2. Edit a page with the _Checkout_ block and verify the 'no shipping methods' placeholder appears.
 
 ### Feature flags (#2591)
-* Verify you can't add the Single Product block.
+
+-   Verify you can't add the Single Product block.
 
 ### Single Product page regression (#2648)
-* Go to a product page.
-* Verify you can see the product images as usual.<br>
-![Single Product page](https://user-images.githubusercontent.com/3616980/84032892-4f5f7300-a998-11ea-9f2d-f2d0e57860c9.png)
+
+-   Go to a product page.
+-   Verify you can see the product images as usual.<br>
+    ![Single Product page](https://user-images.githubusercontent.com/3616980/84032892-4f5f7300-a998-11ea-9f2d-f2d0e57860c9.png)
 
 #### Product grid inconsistencies (#2428)
-- Update a product so it has a very small image (100px or less).
-- Add the All Products block and a PHP-based product grids block (Hand-picked Products, for example) and verify:
-	- Both of them have the same styles for prices.
-	- Both of them scale up the small image.
-_Hand-picked Products on top, All Products below:_<br>
-![Product grid blocks by default](https://user-images.githubusercontent.com/3616980/83166453-3d1b4480-a10f-11ea-813f-2515b26dedac.png)
-- Add the [code snippets](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/theming/product-grid-270.md#product-grid-blocks-style-update-in-270) from the theming docs to undo the changes and verify:
-	- Hand-picked Products block doesn't scale up the image anymore.
-	- All Products block shows discounted prices in two lines.
-_Hand-picked Products on top, All Products below:_<br>
-![Product grid blocks with the code snippets applied](https://user-images.githubusercontent.com/3616980/83164436-828a4280-a10c-11ea-81c1-b9a62cdf52b5.png)
+
+-   Update a product so it has a very small image (100px or less).
+-   Add the All Products block and a PHP-based product grids block (Hand-picked Products, for example) and verify: - Both of them have the same styles for prices. - Both of them scale up the small image.
+    _Hand-picked Products on top, All Products below:_<br>
+    ![Product grid blocks by default](https://user-images.githubusercontent.com/3616980/83166453-3d1b4480-a10f-11ea-813f-2515b26dedac.png)
+-   Add the [code snippets](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/theming/product-grid-270.md#product-grid-blocks-style-update-in-270) from the theming docs to undo the changes and verify: - Hand-picked Products block doesn't scale up the image anymore. - All Products block shows discounted prices in two lines.
+    _Hand-picked Products on top, All Products below:_<br>
+    ![Product grid blocks with the code snippets applied](https://user-images.githubusercontent.com/3616980/83164436-828a4280-a10c-11ea-81c1-b9a62cdf52b5.png)
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/270.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/271.md
+++ b/docs/testing/releases/271.md
@@ -20,10 +20,12 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 -   Go to the PHP logs of your site and verify there isn't any PHP warning in the logs related to the steps described above.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/271.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/272.md
+++ b/docs/testing/releases/272.md
@@ -15,7 +15,7 @@ Variations of tests:
 
 Expected behaviour here is:
 
-* [ ] `woocommerce_cleanup_draft_orders` action should not appear in the scheduled tasks for Action Scheduler (Tools->Scheduled Actions).
+-   [ ] `woocommerce_cleanup_draft_orders` action should not appear in the scheduled tasks for Action Scheduler (Tools->Scheduled Actions).
 
 These actions only appear when the feature flag is on for the install. If you are not testing the package inclusion in WooCommerce core, you can simulate this by adding a `blocks.ini` file to the same directory as where this plugin is activated and include in the file the following code:
 
@@ -29,20 +29,21 @@ woocommerce_blocks_phase = 1
 
 Expected behaviour is:
 
-* [ ] `woocommerce_cleanup_draft_orders` action **should** appear in the scheduled tasks for Action Scheduler (Tools->Scheduled Actions).
-* [ ] Create a draft order (on the frontend load the checkout block with products in the cart and do not complete the order).
-* [ ] Trigger the scheduled action for `woocommerce_cleanup_draft_orders` and verify the just created draft order and none of the other orders on your test site have been deleted.
-* [ ] Modify the draft order date so that it's greater than 24 hours in the past from now (you need to modify the `post_modifed_gmt` field)
-* [ ] Trigger the scheduled action again, this time the draft order you modified (and only that draft order) should be deleted.
+-   [ ] `woocommerce_cleanup_draft_orders` action **should** appear in the scheduled tasks for Action Scheduler (Tools->Scheduled Actions).
+-   [ ] Create a draft order (on the frontend load the checkout block with products in the cart and do not complete the order).
+-   [ ] Trigger the scheduled action for `woocommerce_cleanup_draft_orders` and verify the just created draft order and none of the other orders on your test site have been deleted.
+-   [ ] Modify the draft order date so that it's greater than 24 hours in the past from now (you need to modify the `post_modifed_gmt` field)
+-   [ ] Trigger the scheduled action again, this time the draft order you modified (and only that draft order) should be deleted.
 
 There are phpunit tests covering behaviour as well (including catching errors).
 
-
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/272.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/280.md
+++ b/docs/testing/releases/280.md
@@ -8,85 +8,86 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 
 #### Tax display in shipping methods <!-- heading -->
 
-- [ ] Go to _WooCommerce_ > _Settings_ > _Tax_ > _Tax options_ and set _Display prices during cart and checkout_ to _Including tax_:
-![imatge](https://user-images.githubusercontent.com/3616980/83771631-c5a36300-a682-11ea-9a42-dfa71a1e6641.png)
-- [ ] Set a flat rate shipping method with cost 5:
-![imatge](https://user-images.githubusercontent.com/3616980/83772266-7d387500-a683-11ea-8105-17e47ee68487.png)
-- [ ] Set default tax rates to 10%:
-![imatge](https://user-images.githubusercontent.com/3616980/83772343-90e3db80-a683-11ea-976e-e20b530e8707.png)
-- [ ] Now, as a customer, add a product that needs shipping to your cart and visit the _Cart_ page (with the block).
-- [ ] Go to the Checkout page and verify shipping method prices also appear with taxes [#2748](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2748).
+-   [ ] Go to _WooCommerce_ > _Settings_ > _Tax_ > _Tax options_ and set _Display prices during cart and checkout_ to _Including tax_:
+        ![imatge](https://user-images.githubusercontent.com/3616980/83771631-c5a36300-a682-11ea-9a42-dfa71a1e6641.png)
+-   [ ] Set a flat rate shipping method with cost 5:
+        ![imatge](https://user-images.githubusercontent.com/3616980/83772266-7d387500-a683-11ea-8105-17e47ee68487.png)
+-   [ ] Set default tax rates to 10%:
+        ![imatge](https://user-images.githubusercontent.com/3616980/83772343-90e3db80-a683-11ea-976e-e20b530e8707.png)
+-   [ ] Now, as a customer, add a product that needs shipping to your cart and visit the _Cart_ page (with the block).
+-   [ ] Go to the Checkout page and verify shipping method prices also appear with taxes [#2748](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2748).
 
 #### Accessibility <!-- heading -->
 
-- [ ] With a screen reader navigate the Cart block and verify when the Change address button is focused, it correctly announces whether it's expanded or not [#2603](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2603).
+-   [ ] With a screen reader navigate the Cart block and verify when the Change address button is focused, it correctly announces whether it's expanded or not [#2603](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2603).
 
 #### Styling <!-- heading -->
 
-- [ ] Change to a theme with a background color different from white or in the customizer change Storefront's background color to another one.
-- Visit the Checkout page and verify that  <!-- heading -->
-- [ ] The `Express checkout` title doesn't have a background color different from the rest of the page and has left and right padding (so it doesn't collide with the border).
-- [ ] The `Express checkout` and `Order summary` titles are aligned.
-- [ ] The `Express checkout` box border is 1px wide, like in the [new designs](https://user-images.githubusercontent.com/3616980/83534129-c0161380-a4f0-11ea-985f-851b40d2e92b.png).
+-   [ ] Change to a theme with a background color different from white or in the customizer change Storefront's background color to another one.
+-   Visit the Checkout page and verify that <!-- heading -->
+-   [ ] The `Express checkout` title doesn't have a background color different from the rest of the page and has left and right padding (so it doesn't collide with the border).
+-   [ ] The `Express checkout` and `Order summary` titles are aligned.
+-   [ ] The `Express checkout` box border is 1px wide, like in the [new designs](https://user-images.githubusercontent.com/3616980/83534129-c0161380-a4f0-11ea-985f-851b40d2e92b.png).
 
-- [ ] Disable all shipping methods but one.
-- [ ] Go to the Cart page and verify there is no double-border between the shipping method and the _Coupon Code_ panel (the border should be 1px instead of 2px as it was before).
+-   [ ] Disable all shipping methods but one.
+-   [ ] Go to the Cart page and verify there is no double-border between the shipping method and the _Coupon Code_ panel (the border should be 1px instead of 2px as it was before).
 
 ![imatge](https://user-images.githubusercontent.com/3616980/84389951-25f05280-abf7-11ea-90d5-27d182982e43.png)
 
-- [ ] Create a product with a long name.
-- [ ] Go to the Checkout page and resize the window to trigger different sizes.
-- [ ] Verify there is always spacing between the product name and the price in the _Order summary_ panel.
-![imatge](https://user-images.githubusercontent.com/3616980/84388946-ad3cc680-abf5-11ea-94cf-2f4c30f5e40e.png)
+-   [ ] Create a product with a long name.
+-   [ ] Go to the Checkout page and resize the window to trigger different sizes.
+-   [ ] Verify there is always spacing between the product name and the price in the _Order summary_ panel.
+        ![imatge](https://user-images.githubusercontent.com/3616980/84388946-ad3cc680-abf5-11ea-94cf-2f4c30f5e40e.png)
 
-- [ ] Still in the Checkout page, verify the _Order summary_ panel doesn't have top and bottom borders.
+-   [ ] Still in the Checkout page, verify the _Order summary_ panel doesn't have top and bottom borders.
 
 ![imatge](https://user-images.githubusercontent.com/3616980/84389065-d2313980-abf5-11ea-9215-1356919d29ed.png)
 
-- [ ] Make sure you don't have any express payment method enabled.
-- [ ] Go to the Checkout page.
-- [ ] Verify the step 1 title and the sidebar title are aligned.
+-   [ ] Make sure you don't have any express payment method enabled.
+-   [ ] Go to the Checkout page.
+-   [ ] Verify the step 1 title and the sidebar title are aligned.
 
 ![imatge](https://user-images.githubusercontent.com/3616980/84397770-5dfb9380-abff-11ea-8ca4-12cd393cd8b1.png)
 
-- [ ] Add the Checkout block to a page or post and, in the editor, verify there is no spacing between the product description and the product variations in the _Order summary_.
+-   [ ] Add the Checkout block to a page or post and, in the editor, verify there is no spacing between the product description and the product variations in the _Order summary_.
 
 ![imatge](https://user-images.githubusercontent.com/3616980/84389163-f2f98f00-abf5-11ea-9f77-63032fee21f6.png)
 
-- [ ] Disable all shipping options from your store.
-- [ ] Go to the Cart block.
-- [ ] Verify there is margin below the 'no shipping options' notice.
+-   [ ] Disable all shipping options from your store.
+-   [ ] Go to the Cart block.
+-   [ ] Verify there is margin below the 'no shipping options' notice.
 
 ![imatge](https://user-images.githubusercontent.com/3616980/84391799-be87d200-abf9-11ea-9d50-dd6e8b11cf5b.png)
 
-- [ ] With Storefront, go to Appearance > Customize and change the typography color.
-- [ ] Verify the color is applied to the Cart and Checkout text and borders.
-- [ ] Test other themes to verify there are no regressions.
-
+-   [ ] With Storefront, go to Appearance > Customize and change the typography color.
+-   [ ] Verify the color is applied to the Cart and Checkout text and borders.
+-   [ ] Test other themes to verify there are no regressions.
 
 ### Product Categories List <!-- heading -->
 
 #### Fix Product Categories List breaking when changing align attribute. <!-- heading -->
 
-- [ ] Add a Product Categories List block to a page.
-- [ ] Switch to _Full Width_ align.
-- [ ] Verify the block doesn't show an error.
-- [ ] If you are using Storefront or another theme with sidebar, make sure the page has the _Full Width_ template.
-- [ ] Open the page in the frontend and verify the Product Categories List block is aligned as a full width block.
+-   [ ] Add a Product Categories List block to a page.
+-   [ ] Switch to _Full Width_ align.
+-   [ ] Verify the block doesn't show an error.
+-   [ ] If you are using Storefront or another theme with sidebar, make sure the page has the _Full Width_ template.
+-   [ ] Open the page in the frontend and verify the Product Categories List block is aligned as a full width block.
 
 ### Miscellaneous <!-- heading -->
 
-- [ ] Go to Appearance > Customize > WooCommerce > Product images and change the cropping options.
-- [ ] Test the Cart, Checkout and Review blocks (for Review blocks, you might need to change its attributes so it shows the product image instead of the customer image) and verify they show the cropped image.
-- [ ] Edit an old All Products block and verify the block didn't invalidate.
-- [ ] Edit it and select the Product image inner block. There, toggle the _Image sizing_ attribute.
-- [ ] Verify when _Cropped_ is selected, the cropped image is displayed.
-- [ ] Repeat the process with the Product block.
+-   [ ] Go to Appearance > Customize > WooCommerce > Product images and change the cropping options.
+-   [ ] Test the Cart, Checkout and Review blocks (for Review blocks, you might need to change its attributes so it shows the product image instead of the customer image) and verify they show the cropped image.
+-   [ ] Edit an old All Products block and verify the block didn't invalidate.
+-   [ ] Edit it and select the Product image inner block. There, toggle the _Image sizing_ attribute.
+-   [ ] Verify when _Cropped_ is selected, the cropped image is displayed.
+-   [ ] Repeat the process with the Product block.
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/280.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/290.md
+++ b/docs/testing/releases/290.md
@@ -3,22 +3,25 @@
 Zip file for testing: tbc
 
 ### Testing notes
+
 ## Correctly sort translated state and country drop-down menus in Checkout block. #2779
+
 In some languages, the `State` and `Country` drop-down menus in the checkout block were sorted incorrectly. They should now be alphabetically sorted in all circumstances.
 
-1. Edit the `Checkout` page, remove the `[checkout]`  shortcode, add the `Checkout` block, and save changes.
+1. Edit the `Checkout` page, remove the `[checkout]` shortcode, add the `Checkout` block, and save changes.
 1. Go to `Dashboard > Settings > General`, select `Català` from `Site Language`, click `Save Changes`.
 1. Update language packs: `Dashboard > Updates > Download translation packs`.
 1. View the front end of your site and add a product to the cart. Navigate to checkout page.
 1. In checkout, select `Espanya` (Spain) from `País / Regió` (country) dropdown.
 1. Click `Província` (state) dropdown and confirm that the menu items are alphabetically sorted.
 
-
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/290.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/300.md
+++ b/docs/testing/releases/300.md
@@ -6,12 +6,12 @@ Zip file: [woocommerce-gutenberg-products-block.zip](https://github.com/woocomme
 
 ### Verify Single Product block is not available
 
-- Verify in this build that the Single Product block is not available
+-   Verify in this build that the Single Product block is not available
 
 ### When included as a package in Woo Core
 
-- Verify that the Cart and Checkout blocks are not available.
-- Verify that the Single Product block is not available.
+-   Verify that the Cart and Checkout blocks are not available.
+-   Verify that the Single Product block is not available.
 
 ### Fix Credit Card Input font size in some themes.
 
@@ -26,7 +26,6 @@ _Before:_
 
 _After:_
 ![image](https://user-images.githubusercontent.com/3616980/87527780-e4871300-c68c-11ea-9549-92d59b1a544c.png)
-
 
 1. Go to Stripe settings and check 'Inline Credit Card Form'.
 2. Go back to the Checkout block and notice the card icon is not too small and the label doesn't overlap the card icon.
@@ -58,8 +57,8 @@ Bonus points for doing some testing with other themes, changing the default font
 2. Set up cart & checkout pages with blocks.
 3. Add stuff to cart, proceed to checkout.
 4. Complete purchase with COD and confirm everything's working as expected.
-2. COD has options so merchant can limit it to shippable products and / or specific shipping methods. Experiment with these settings and confirm that COD works correctly, and is only available when appropriate.
-5. Confirm that all other payment gateways still work correctly.
+5. COD has options so merchant can limit it to shippable products and / or specific shipping methods. Experiment with these settings and confirm that COD works correctly, and is only available when appropriate.
+6. Confirm that all other payment gateways still work correctly.
 
 Bonus points - set up more complicated shipping (multiple packages, different carriers) & orders and confirm that the correct payment methods are available dependent on selected shipping rate.
 
@@ -80,9 +79,9 @@ Note: It's not possible to test this flow with the All Products block because of
 ### Show products on backorder
 
 1. Edit a product and under Inventory set:
-  1.1 Manage stock? Checked.
-  1.2 Stock quantity: 0.
-  1.3 Allow backorders? Allow, but notify customer.
+   1.1 Manage stock? Checked.
+   1.2 Stock quantity: 0.
+   1.3 Allow backorders? Allow, but notify customer.
 2. Update the product and go to the frontend of the store.
 3. Add that product to the cart.
 4. Go to the Cart page and verify the Cart block shows the product is on backorder.
@@ -91,32 +90,33 @@ Note: It's not possible to test this flow with the All Products block because of
 
 ### Lazy Loading Atomic Components
 
-- Test the All Products block and verify that editing element blocks (the inner blocks that can be added/re-positioned for the rendered grid) on the backend and the behavior of those blocks on the frontend work as expected. The All Products block should work with existing filter blocks as well.
-- Verify adding the All Products block to a new page works as expected with no errors.
-- Verify loading a pre-existing page with the block from an earlier version of the blocks plugin works as expected.
+-   Test the All Products block and verify that editing element blocks (the inner blocks that can be added/re-positioned for the rendered grid) on the backend and the behavior of those blocks on the frontend work as expected. The All Products block should work with existing filter blocks as well.
+-   Verify adding the All Products block to a new page works as expected with no errors.
+-   Verify loading a pre-existing page with the block from an earlier version of the blocks plugin works as expected.
 
 ### Remove Dashicon classes
 
 Testing means ensuring there are no visual regressions in the affected blocks:
+
 1. Cart: verify coupon chip close icon looks as it did.
-![image](https://user-images.githubusercontent.com/3616980/87140895-816b3a00-c2a2-11ea-95a8-4b2d13ff308e.png)
+   ![image](https://user-images.githubusercontent.com/3616980/87140895-816b3a00-c2a2-11ea-95a8-4b2d13ff308e.png)
 2. Attribute Filter: set Query Type: AND, Display Style: Dropdown. Then, select a value and check that the cross icon still shows up correct.
-![image](https://user-images.githubusercontent.com/3616980/87140925-8cbe6580-c2a2-11ea-84da-24bd67923d0a.png)
+   ![image](https://user-images.githubusercontent.com/3616980/87140925-8cbe6580-c2a2-11ea-84da-24bd67923d0a.png)
 
 ### Unify Chip styles
 
 0. Ideally, set your theme background to something different from white so you can verify inputs are still legible.
 1. Create a page with the All Products block and the Filter Products by Attribute (set the attributes to Query Type: OR, Display Style: Dropdown) and Active Filters (Display Style: Chips).
 2. Filter Products by Attribute:
-  2.1. Try adding new filters.
-  2.2. Verify chips have the correct styles.
-  2.3. Try removing them with the keyboard (backspace or <kbd>Del</kbd>).
-  2.4. Try removing them clicking on the chip name.
+   2.1. Try adding new filters.
+   2.2. Verify chips have the correct styles.
+   2.3. Try removing them with the keyboard (backspace or <kbd>Del</kbd>).
+   2.4. Try removing them clicking on the chip name.
 3. Active Filters:
-  3.1 Verify chips have the correct styles.
+   3.1 Verify chips have the correct styles.
 4. Catching regressions:
-  4.1. Verify there are no regression in the Filter Products by Attribute and the Active Filters blocks with other attribute combinations: verify everything is still working and there are no visual bugs.
-  4.2. Verify there are no regressions with the Chips in the Cart: try adding a coupon in the Cart or Checkout blocks and verify it still looks correct.
+   4.1. Verify there are no regression in the Filter Products by Attribute and the Active Filters blocks with other attribute combinations: verify everything is still working and there are no visual bugs.
+   4.2. Verify there are no regressions with the Chips in the Cart: try adding a coupon in the Cart or Checkout blocks and verify it still looks correct.
 
 ### Support bank transfer (BACS) payment method in checkout block
 
@@ -137,10 +137,12 @@ Confirm that other payment methods still work correctly.
 5. With an WP version between 5.2.0 and 5.3.0 (ie: 5.2.5) and verify legacy scripts are still being enqueued.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/300.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/310.md
+++ b/docs/testing/releases/310.md
@@ -76,10 +76,12 @@ We also made some changes to our API endpoints to make them work correctly with 
 -   [ ] Checkout
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/310.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/320.md
+++ b/docs/testing/releases/320.md
@@ -2,124 +2,124 @@
 
 [![Create Todo list](https://raw.githubusercontent.com/senadir/todo-my-markdown/master/public/github-button.svg?sanitize=true)](https://git-todo.netlify.app/create)
 
-
 Zip file: [woocommerce-gutenberg-products-block.zip](https://github.com/woocommerce/woocommerce-gutenberg-products-block/files/5090607/woocommerce-gutenberg-products-block.zip)
 
-### Cart & Checkout   <!-- heading -->
+### Cart & Checkout <!-- heading -->
 
-#### Order note   <!-- heading -->
+#### Order note <!-- heading -->
 
-- [ ] Go to the Checkout block and check the 'Add a note to your order' checkbox.
-- [ ] Introduce some text in the text area that appeared.
-- [ ] Place the order and go to the admin, WooCommerce > Orders and verify the order has the note under Customer provided note.
+-   [ ] Go to the Checkout block and check the 'Add a note to your order' checkbox.
+-   [ ] Introduce some text in the text area that appeared.
+-   [ ] Place the order and go to the admin, WooCommerce > Orders and verify the order has the note under Customer provided note.
 
-#### Autocapitalize address form fields   <!-- heading -->
+#### Autocapitalize address form fields <!-- heading -->
 
-- [ ] Visit the Checkout page with a handheld device with Chrome for Android or iOS Safari.
-- [ ] Navigate through the input fields in the address form.
-- [ ] Verify when a field is focused, the keyboard shows capital letters by default according to the settings.
+-   [ ] Visit the Checkout page with a handheld device with Chrome for Android or iOS Safari.
+-   [ ] Navigate through the input fields in the address form.
+-   [ ] Verify when a field is focused, the keyboard shows capital letters by default according to the settings.
 
-#### JS-Rendered blocks inside Empty Cart   <!-- heading -->
+#### JS-Rendered blocks inside Empty Cart <!-- heading -->
 
-- [ ] Add the Cart block and switch to the Empty Cart edit mode.
-- [ ] Replace the Newest products block with the All Products block. Feel free to add other JS-rendered blocks like a filter or a Reviews block.
-- [ ] View the page in the frontend.
-- [ ] Verify all blocks render correctly when the cart is empty.
-- [ ] Try adding a product to the cart (so it switches to the Full Cart view) and removing it (so it switches back to the Empty Cart view).
-- [ ] Verify the blocks still render correctly.
+-   [ ] Add the Cart block and switch to the Empty Cart edit mode.
+-   [ ] Replace the Newest products block with the All Products block. Feel free to add other JS-rendered blocks like a filter or a Reviews block.
+-   [ ] View the page in the frontend.
+-   [ ] Verify all blocks render correctly when the cart is empty.
+-   [ ] Try adding a product to the cart (so it switches to the Full Cart view) and removing it (so it switches back to the Empty Cart view).
+-   [ ] Verify the blocks still render correctly.
 
-#### Don't show sale badge if saving are negative   <!-- heading -->
+#### Don't show sale badge if saving are negative <!-- heading -->
 
-You will need Product Add-ons extension to test this.   <!-- heading -->
+You will need Product Add-ons extension to test this. <!-- heading -->
 
-- [ ] Add a product with a priced add on.
-- [ ] Add the product to your cart, with the add on enabled.
-- [ ] See that the price is shown without a negative discount value.
+-   [ ] Add a product with a priced add on.
+-   [ ] Add the product to your cart, with the add on enabled.
+-   [ ] See that the price is shown without a negative discount value.
 
-#### Respect payment gateways order set by merchant   <!-- heading -->
+#### Respect payment gateways order set by merchant <!-- heading -->
 
-- [ ] Set up a few different payment methods.
-- [ ] Reorder your payment methods how you like in WooCommerce > Settings > Payments, then click Save changes to persist.
-- [ ] On front end, add stuff to cart and proceed to checkout.
-- [ ] Payment methods should display using the order you chose.
-- [ ] Complete a few test purchases to confirm that payment methods are still working and there are no regressions in checkout.
-- [ ] Also test payment methods that may be hidden based on checkout state, e.g. make COD only available with specific shipping methods.
+-   [ ] Set up a few different payment methods.
+-   [ ] Reorder your payment methods how you like in WooCommerce > Settings > Payments, then click Save changes to persist.
+-   [ ] On front end, add stuff to cart and proceed to checkout.
+-   [ ] Payment methods should display using the order you chose.
+-   [ ] Complete a few test purchases to confirm that payment methods are still working and there are no regressions in checkout.
+-   [ ] Also test payment methods that may be hidden based on checkout state, e.g. make COD only available with specific shipping methods.
 
-#### Show Checkout block in Editor when 'guest checkout' is disabled   <!-- heading -->
+#### Show Checkout block in Editor when 'guest checkout' is disabled <!-- heading -->
 
-- [ ] Go to WooCommerce > Settings > Accounts & Privacy and uncheck Allow customers to place orders without an account.
-- [ ] Edit a page with the Checkout block.
-- [ ] Verify the whole Checkout block is rendered in the editor, instead of only showing the `You must be logged in to checkout. Click here to log in`. message.
+-   [ ] Go to WooCommerce > Settings > Accounts & Privacy and uncheck Allow customers to place orders without an account.
+-   [ ] Edit a page with the Checkout block.
+-   [ ] Verify the whole Checkout block is rendered in the editor, instead of only showing the `You must be logged in to checkout. Click here to log in`. message.
 
-#### Remove generic payment methods icons   <!-- heading -->
+#### Remove generic payment methods icons <!-- heading -->
 
-- [ ] Set up Stripe CC (Stripe extension) and Cheque (core) payment methods.
-- [ ] Set up a page with checkout block, add stuff to cart.
-- [ ] View checkout and confirm payment method tabs render and function correctly without icons.
+-   [ ] Set up Stripe CC (Stripe extension) and Cheque (core) payment methods.
+-   [ ] Set up a page with checkout block, add stuff to cart.
+-   [ ] View checkout and confirm payment method tabs render and function correctly without icons.
 
-#### Error focus styles for inputs and select   <!-- heading -->
+#### Error focus styles for inputs and select <!-- heading -->
 
-- [ ] Go to the Checkout block and press 'Place order` without filling any form detail.
-- [ ] Tab through the input fields under 'Shipping address' and verify the outline that appears on focus is red in text inputs and selects.
-- [ ] Repeat the steps above at least with Storefront and Twenty Twenty and with Firefox, Chrome and Safari.
+-   [ ] Go to the Checkout block and press 'Place order` without filling any form detail.
+-   [ ] Tab through the input fields under 'Shipping address' and verify the outline that appears on focus is red in text inputs and selects.
+-   [ ] Repeat the steps above at least with Storefront and Twenty Twenty and with Firefox, Chrome and Safari.
 
-#### Hide saved payment methods if their gateway is disabled   <!-- heading -->
+#### Hide saved payment methods if their gateway is disabled <!-- heading -->
 
-- [ ] Set up checkout block, Stripe CC payment method, check Enable Payment via Saved Cards.
-- [ ] Complete a purchase with Stripe test card and check the `Save payment information to my account for future purchases.` checkbox on checkout.
-- [ ] Go to WooCommerce > Settings > Payments and disable Stripe CC payment method.
-- [ ] Add new stuff to cart, proceed to checkout.
-- [ ] Scroll down and verify saved card (e.g. Visa ending in 4242 (expires 02/22)) is not there.
+-   [ ] Set up checkout block, Stripe CC payment method, check Enable Payment via Saved Cards.
+-   [ ] Complete a purchase with Stripe test card and check the `Save payment information to my account for future purchases.` checkbox on checkout.
+-   [ ] Go to WooCommerce > Settings > Payments and disable Stripe CC payment method.
+-   [ ] Add new stuff to cart, proceed to checkout.
+-   [ ] Scroll down and verify saved card (e.g. Visa ending in 4242 (expires 02/22)) is not there.
 
-#### Text overlap with errors and icons   <!-- heading -->
+#### Text overlap with errors and icons <!-- heading -->
 
-- [ ] activate and set up Stripe CC, disable Inline Credit Card Form option.
-- [ ] Add stuff to cart and proceed to checkout.
-- [ ] Select stripe credit card payment, don't enter any card details.
-- [ ] Click Place Order.
-- [ ] Error messages shouldn't overlap with credit card icons.
+-   [ ] activate and set up Stripe CC, disable Inline Credit Card Form option.
+-   [ ] Add stuff to cart and proceed to checkout.
+-   [ ] Select stripe credit card payment, don't enter any card details.
+-   [ ] Click Place Order.
+-   [ ] Error messages shouldn't overlap with credit card icons.
 
-#### Dark mode support for fields and controls   <!-- heading -->
+#### Dark mode support for fields and controls <!-- heading -->
 
-- [ ] Test inputs, select, radio, checkbox, quantity selectors, and textarea of Cart and Checkout, they should have light colors and text should be readable.
-- [ ] Switch the colors of your theme to a dark variation, you can do that in the customizer for storefront or dark mode for TwentyTwenty or TwentySeventeen.
-- [ ] Switch the blocks to use dark colors in the blocks settings.
-- [ ] Test inputs, select, radio, checkbox, quantity selectors, and textarea again, make sure nothing is broken and everything is visible.
+-   [ ] Test inputs, select, radio, checkbox, quantity selectors, and textarea of Cart and Checkout, they should have light colors and text should be readable.
+-   [ ] Switch the colors of your theme to a dark variation, you can do that in the customizer for storefront or dark mode for TwentyTwenty or TwentySeventeen.
+-   [ ] Switch the blocks to use dark colors in the blocks settings.
+-   [ ] Test inputs, select, radio, checkbox, quantity selectors, and textarea again, make sure nothing is broken and everything is visible.
 
-#### Use real previews for Cart and Checkout   <!-- heading -->
+#### Use real previews for Cart and Checkout <!-- heading -->
 
-- [ ] Preview the cart and checkout blocks inside the block inserter.
-- [ ] You should see the actual block, not a white placeholder.
-- [ ] Make sure the block is not very long and overflowing.
-- [ ] Make sure the changes didn't leak to the actual block or the editor block, the block should not be cut.
+-   [ ] Preview the cart and checkout blocks inside the block inserter.
+-   [ ] You should see the actual block, not a white placeholder.
+-   [ ] Make sure the block is not very long and overflowing.
+-   [ ] Make sure the changes didn't leak to the actual block or the editor block, the block should not be cut.
 
-### All Products   <!-- heading -->
+### All Products <!-- heading -->
 
 #### Broken link for "No Products" placeholder
 
-- [ ] In a store with no products (move them to trash).
-- [ ] Create a new page and add the All Products block.
-- [ ] Click on the Add new product link and verify it works.
+-   [ ] In a store with no products (move them to trash).
+-   [ ] Create a new page and add the All Products block.
+-   [ ] Click on the Add new product link and verify it works.
 
 #### PHP Error notices
 
-- [ ] Make sure you have WP_DEBUG set to true.
-- [ ] Load a page that already contains a product data, so single product or All Products, either in the editor or frontend.
-- [ ] Make sure no notices are printed to the page, you can check the source code or at the top of the page.
+-   [ ] Make sure you have WP_DEBUG set to true.
+-   [ ] Load a page that already contains a product data, so single product or All Products, either in the editor or frontend.
+-   [ ] Make sure no notices are printed to the page, you can check the source code or at the top of the page.
 
-### Product Search   <!-- heading -->
+### Product Search <!-- heading -->
 
 #### Updated styling in Editor
 
-- [ ] In the editor, confirm that Product Search input has borders.
-- [ ] the input should be functional.
-
+-   [ ] In the editor, confirm that Product Search input has borders.
+-   [ ] the input should be functional.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/320.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/330.md
+++ b/docs/testing/releases/330.md
@@ -4,77 +4,77 @@
 
 Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.com/woocommerce/woocommerce-gutenberg-products-block/files/5159231/woocommerce-gutenberg-products-block.zip)
 
-### Enhancements   <!-- heading -->
+### Enhancements <!-- heading -->
 
 #### Cart block: Show express payment methods in the Cart block (for example: Apple Pay, Chrome Pay). <!-- heading -->
 
-- [ ] This feature requires the following:
-  - [WooCommerce Stripe extension](https://woocommerce.com/products/stripe) installed and active.
-  - One or more express payment methods supported and enabled on the store and client system (OS, browser). Note that Chrome Pay and Apple Pay are not supported in all regions. Please refer to documentation for Apple Pay and Chrome Pay for more information.
-- [ ] Go to `Dashboard > WooCommerce > Settings > Payments` and activate `Stripe – Credit Card`.
-- [ ] Click `Manage` button for `Stripe – Credit Card`.
-- [ ] Ensure `Payment Request Buttons` checkbox is enabled, and click `Save changes`.
-- [ ] Add the Cart block to a page and publish the page (for example, the main store `cart` page).
-- [ ] In the editor, the Cart block should show a preview of express payment options (for example, Apple Pay button).
-- [ ] View store front end in a browser with an express payment method enabled and configured. For example Chrome or Safari.
-- [ ] Add some products to cart.
-- [ ] View cart. If express payment is supported and available, you should see relevant express payment buttons above the cart `Proceed to checkout` button.
-  - Note: if you don't see any express payment options, confirm that they are working in the Checkout block, product page, or shortcode checkout page. 
-  - The cart block should include the same express payment options as other store pages.
-
+-   [ ] This feature requires the following:
+    -   [WooCommerce Stripe extension](https://woocommerce.com/products/stripe) installed and active.
+    -   One or more express payment methods supported and enabled on the store and client system (OS, browser). Note that Chrome Pay and Apple Pay are not supported in all regions. Please refer to documentation for Apple Pay and Chrome Pay for more information.
+-   [ ] Go to `Dashboard > WooCommerce > Settings > Payments` and activate `Stripe – Credit Card`.
+-   [ ] Click `Manage` button for `Stripe – Credit Card`.
+-   [ ] Ensure `Payment Request Buttons` checkbox is enabled, and click `Save changes`.
+-   [ ] Add the Cart block to a page and publish the page (for example, the main store `cart` page).
+-   [ ] In the editor, the Cart block should show a preview of express payment options (for example, Apple Pay button).
+-   [ ] View store front end in a browser with an express payment method enabled and configured. For example Chrome or Safari.
+-   [ ] Add some products to cart.
+-   [ ] View cart. If express payment is supported and available, you should see relevant express payment buttons above the cart `Proceed to checkout` button.
+    -   Note: if you don't see any express payment options, confirm that they are working in the Checkout block, product page, or shortcode checkout page.
+    -   The cart block should include the same express payment options as other store pages.
 
 ### Enhancements (shipped in 3.1.0) <!-- heading -->
 
 The following enhancements shipped in WooCommerce Blocks 3.1.0 but were missed in the changelog. Including testing instructions here.
 
-#### All Products block: Can now customize text size, color and alignment in Product Title child block.  <!-- heading -->
+#### All Products block: Can now customize text size, color and alignment in Product Title child block. <!-- heading -->
 
-- [ ] Add an all products block. 
-- [ ] Click the `Edit` (pencil icon) button to edit the layout of products within the grid.
-- [ ] Select the product title block, or add it if needed.
-- [ ] In the block toolbar, change the alignment option to center or right.
-- [ ] In the block toolbar, select a different heading level.
-- [ ] In the settings inspector, change the text size and colour options.
-- [ ] Publish the page or update to save changes.
-- [ ] Verify the product title shows as customized in editor and front end.
+-   [ ] Add an all products block.
+-   [ ] Click the `Edit` (pencil icon) button to edit the layout of products within the grid.
+-   [ ] Select the product title block, or add it if needed.
+-   [ ] In the block toolbar, change the alignment option to center or right.
+-   [ ] In the block toolbar, select a different heading level.
+-   [ ] In the settings inspector, change the text size and colour options.
+-   [ ] Publish the page or update to save changes.
+-   [ ] Verify the product title shows as customized in editor and front end.
 
-#### All Products block: Can now customize text size, color and alignment in Product Price child block.  <!-- heading -->
+#### All Products block: Can now customize text size, color and alignment in Product Price child block. <!-- heading -->
 
-- [ ] Add an all products block. 
-- [ ] Click the `Edit` (pencil icon) button to edit the layout of products within the grid.
-- [ ] Select the product price block, or add it if needed.
-- [ ] In the block toolbar, change the alignment option to center or right.
-- [ ] In the settings inspector, change the text size and colour options.
-- [ ] Publish the page or update to save changes.
-- [ ] Verify the product price shows as customized in editor and front end.
+-   [ ] Add an all products block.
+-   [ ] Click the `Edit` (pencil icon) button to edit the layout of products within the grid.
+-   [ ] Select the product price block, or add it if needed.
+-   [ ] In the block toolbar, change the alignment option to center or right.
+-   [ ] In the settings inspector, change the text size and colour options.
+-   [ ] Publish the page or update to save changes.
+-   [ ] Verify the product price shows as customized in editor and front end.
 
-### Bug Fixes   <!-- heading -->
+### Bug Fixes <!-- heading -->
 
-#### Cart block: Fix alignment of discounted prices.  <!-- heading -->
+#### Cart block: Fix alignment of discounted prices. <!-- heading -->
 
-- [ ] Add a product on sale to the Cart and visit the Cart block.
-- [ ] Verify regular and discounted prices are both aligned to the right.
+-   [ ] Add a product on sale to the Cart and visit the Cart block.
+-   [ ] Verify regular and discounted prices are both aligned to the right.
 
-#### Checkout block: Fix an issue with products sold individually (max of 1 per cart); the Checkout block now shows a notice if shopper attempts to add another instance of product via an add-to-cart link.  <!-- heading -->
+#### Checkout block: Fix an issue with products sold individually (max of 1 per cart); the Checkout block now shows a notice if shopper attempts to add another instance of product via an add-to-cart link. <!-- heading -->
 
-- Configure your store so the Checkout block is used on the checkout page.
-- [ ] Set a `Sold individually` option on a product:
-  - Edit a product. Note down the product ID.
-  - Scroll down to `Product data` box, select `Inventory` tab.
-  - Enable `Sold individually` option, and click `Update` to save changes to the product.
-- [ ] As a shopper on front end, add the product to your cart. You should have 1x of the product in your cart. 
-- [ ] Navigate to a url with add-to-cart URL param for the product ID, for example: `https://one.wordpress.test/checkout/?add-to-cart=19`. This will attempt to add a second item to the cart.
-  - Note: Replace `one.wordpress.test` with your test site URL and `19` with the ID of the product you modified.
-  - You can navigate to this URL directly - paste the url. OR you can add a button block linking to the url, simulating a "Buy" button on a landing page for the product.
-- [ ] Proceed to checkout block and verify there is an error notice informing shopper why there is a single item in the cart.
-- [ ] Ensure the checkout block works correctly and shopper can complete purchase.
-
+-   Configure your store so the Checkout block is used on the checkout page.
+-   [ ] Set a `Sold individually` option on a product:
+    -   Edit a product. Note down the product ID.
+    -   Scroll down to `Product data` box, select `Inventory` tab.
+    -   Enable `Sold individually` option, and click `Update` to save changes to the product.
+-   [ ] As a shopper on front end, add the product to your cart. You should have 1x of the product in your cart.
+-   [ ] Navigate to a url with add-to-cart URL param for the product ID, for example: `https://one.wordpress.test/checkout/?add-to-cart=19`. This will attempt to add a second item to the cart.
+    -   Note: Replace `one.wordpress.test` with your test site URL and `19` with the ID of the product you modified.
+    -   You can navigate to this URL directly - paste the url. OR you can add a button block linking to the url, simulating a "Buy" button on a landing page for the product.
+-   [ ] Proceed to checkout block and verify there is an error notice informing shopper why there is a single item in the cart.
+-   [ ] Ensure the checkout block works correctly and shopper can complete purchase.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/330.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/340.md
+++ b/docs/testing/releases/340.md
@@ -6,22 +6,22 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 
 ### Ensure shopper saved card is used as default payment method (default was being overwritten in some circumstances). ([3131](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3131))
 
-- Set up checkout page using block.
-- Enable BACS and Stripe payment methods (only, though may reproduce with other combinations). Note BACS needs to be earlier in the order than Stripe (drag handle in `WooCommerce > Settings > Payments`).
-- Complete a purchase using a new payment method, Stripe CC, check `Save payment information to my account for future purchases`.
-- Add something to cart, proceed to checkout.
-- Leave the default selected payment method - i.e. the first saved payment method. Submit checkout.
+-   Set up checkout page using block.
+-   Enable BACS and Stripe payment methods (only, though may reproduce with other combinations). Note BACS needs to be earlier in the order than Stripe (drag handle in `WooCommerce > Settings > Payments`).
+-   Complete a purchase using a new payment method, Stripe CC, check `Save payment information to my account for future purchases`.
+-   Add something to cart, proceed to checkout.
+-   Leave the default selected payment method - i.e. the first saved payment method. Submit checkout.
 
 Should always complete the purchase with the correct payment method - the one visibly selected when user clicks submit, i.e. the saved card.
 
 Please also test a variety of other payment method scenarios and ordering - with / without saved cards (are there any other gateways that support saved payment methods?), with more/less gateways available, in different orders, and with dynamically-available gateways (COD can depend on shipping option). In all cases confirm the following:
 
-- There is a payment method tab selected by default.
-- Submitting checkout without touching payment section uses the correct payment method (i.e. saved card, payment method tab).
-- Selecting a non-default saved card (from the default) works correctly, uses correct card/token (may need to check network requests to check token).
-- Selecting a non-default payment method uses correct method.
-- Saving a payment method (card) works and is available for use next checkout with that account.
-- Payment tab order should match the configured order.
+-   There is a payment method tab selected by default.
+-   Submitting checkout without touching payment section uses the correct payment method (i.e. saved card, payment method tab).
+-   Selecting a non-default saved card (from the default) works correctly, uses correct card/token (may need to check network requests to check token).
+-   Selecting a non-default payment method uses correct method.
+-   Saving a payment method (card) works and is available for use next checkout with that account.
+-   Payment tab order should match the configured order.
 
 ### Fix Cart & Checkout sidebar layout broken in some themes. ([3111](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3111))
 
@@ -33,7 +33,6 @@ _Before:_
 
 _After:_
 ![image](https://user-images.githubusercontent.com/3616980/92132043-f2dcea00-ee06-11ea-895b-afda511e36f8.png)
-
 
 ### Use wp_login_url instead of hardcoding login path. ([3090](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3090))
 
@@ -56,7 +55,7 @@ _After:_
 7. Delete what was selected to return the field to its initial state.
 8. Visit checkout again, COD is still working.
 
-- Fix JS console error when COD is enabled and no shipping method is available. ([3086](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3086))
+-   Fix JS console error when COD is enabled and no shipping method is available. ([3086](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3086))
 
 1. Enable COD and limit it to a certain shipping method type.
 2. Add that method to a certain address.
@@ -66,17 +65,17 @@ _After:_
 
 Smoke test the Checkout block:
 
-* create a new page and add the Checkout block, change some attributes in the sidebar and verify changes take place
-* verify the Checkout block works in the frontend: try changing your address, picking a different shipping and payment method, etc.
-* verify you can make a purchase.
+-   create a new page and add the Checkout block, change some attributes in the sidebar and verify changes take place
+-   verify the Checkout block works in the frontend: try changing your address, picking a different shipping and payment method, etc.
+-   verify you can make a purchase.
 
 ## The following impacts testing for both feature plugin and when included in WooCommerce Core.
 
 ### Fix product reviews schema date fields to use new (WP 5.5) `date-time` format. ([3109](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3109))
 
-- Add some reviews for products.
-- Add an All Reviews block to post or page content.
-- Verify the frontend rendering of the block shows the expected dates for the reviews.
+-   Add some reviews for products.
+-   Add an All Reviews block to post or page content.
+-   Verify the frontend rendering of the block shows the expected dates for the reviews.
 
 ### Merge ProductPrice atomic block and component. ([3065](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3065))
 
@@ -88,10 +87,12 @@ Testing this change basically means verifying there are no regressions:
 4. Repeat the verifications above using with the [Seedlet theme](https://wordpress.org/themes/seedlet/).
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/340.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/350.md
+++ b/docs/testing/releases/350.md
@@ -2,75 +2,76 @@
 
 Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.com/woocommerce/woocommerce-gutenberg-products-block/files/5298708/woocommerce-gutenberg-products-block.zip)
 
-
 ## The following are changes that only impact Feature Plugin release.
-
 
 ### Use light default background colour for country/state dropdowns in Cart and Checkout blocks
 
-- Test light mode / default
-- [ ] Add checkout block to a page. Disable Dark mode inputs option and publish.
-- [ ] View checkout on front end and expand country or state input.
-- [ ] Background/colours should be consistent - e.g. white background, black text.
+-   Test light mode / default
+-   [ ] Add checkout block to a page. Disable Dark mode inputs option and publish.
+-   [ ] View checkout on front end and expand country or state input.
+-   [ ] Background/colours should be consistent - e.g. white background, black text.
 
-- Test dark mode
-- [ ] Add checkout block to a page. Enable Dark mode inputs option and publish.
-- [ ] View checkout on front end and expand country or state input.
-- [ ] Background/colours should look reasonable; text should be white on black.
+-   Test dark mode
+-   [ ] Add checkout block to a page. Enable Dark mode inputs option and publish.
+-   [ ] View checkout on front end and expand country or state input.
+-   [ ] Background/colours should look reasonable; text should be white on black.
 
 ### Fix broken Express Payment Method use in the Checkout block for logged out or incognito users.
 
-- [ ] Make sure you are either logged out or using an incognito mode browser instance.
-- [ ] Add a product to cart.
-- [ ] Load the page with the checkout block.
-- [ ] Click express payment (Chrome Pay if using Chrome, Apple Pay if using Safari).
-- [ ] Choose account details in the express payment modal and submit. Verify that the checkout processes correctly.
+-   [ ] Make sure you are either logged out or using an incognito mode browser instance.
+-   [ ] Add a product to cart.
+-   [ ] Load the page with the checkout block.
+-   [ ] Click express payment (Chrome Pay if using Chrome, Apple Pay if using Safari).
+-   [ ] Choose account details in the express payment modal and submit. Verify that the checkout processes correctly.
 
 ### Use noticeContexts from useEmitResponse instead of hardcoded values
 
-- [ ] Install & activate WooCommerce Stripe.
-- [ ] Enable Stripe CC payment method - don't add an api key (or delete the option).
-- [ ] Add checkout block to checkout page.
-- [ ] On front end, add something to cart and proceed to checkout with an **admin user**.
-- [ ] Verify an error appears in the express payment methods section and in the payment methods step.
+-   [ ] Install & activate WooCommerce Stripe.
+-   [ ] Enable Stripe CC payment method - don't add an api key (or delete the option).
+-   [ ] Add checkout block to checkout page.
+-   [ ] On front end, add something to cart and proceed to checkout with an **admin user**.
+-   [ ] Verify an error appears in the express payment methods section and in the payment methods step.
 
 ![checkout-errors](https://user-images.githubusercontent.com/3616980/93592030-b803b600-f9b1-11ea-976e-70c7b594f474.png)
 
 ### Fix State label for Spain
 
-- [ ] Go to the Checkout block and change the country to Spain.
-- [ ] Verify the field below the country changes its label to Province instead of State.
+-   [ ] Go to the Checkout block and change the country to Spain.
+-   [ ] Verify the field below the country changes its label to Province instead of State.
 
 ### Don't throw an error when registering a payment method fails
 
 #### Confirm other payment methods are shown if Stripe is not configured.
-- [ ] Install & activate WooCommerce Stripe.
-- [ ] Enable Stripe CC payment method - don't add an api key (or delete the option).
-- [ ] Enable BACS or other payment methods (e.g. cheque).
-- [ ] Add checkout block to checkout page.
-- [ ] On front end, add something to cart and proceed to checkout.
-- [ ] Make sure you have an admin user with saved payment methods<sup>*</sup> and a user without saved payment methods (or a guest).
-- [ ] With those two users, check the Checkout page in the frontend. Also open the Checkout page in the editor.
-- [ ] Verify the statements below are true. 👇
 
-| Scenario | With Stripe API key | Without Stripe API key |
-| --- | --- | --- |
-| Admin with saved payment methods / Editor | <ul><li>Saved payment methods are displayed.</li><li>Credit Card payment method is displayed (under use a new payment method).</li><li>There is no error notice.</li></ul> | <ul><li>Saved payment methods are not displayed.</li><li>There is an error notice about Stripe not being registered correctly.</li><li>Other payment methods are displayed as usual.</li></ul> |
-| Guest user | <ul><li>Saved payment methods are not displayed.</li><li>Credit Card payment method is displayed.</li><li>There is no error notice.</li></ul> | <ul><li>Saved payment methods are not displayed.</li><li>Credit Card payment method is not displayed.</li><li>There is no error notice.</li><li>Other payment methods are displayed as usual.</li></ul> |
+-   [ ] Install & activate WooCommerce Stripe.
+-   [ ] Enable Stripe CC payment method - don't add an api key (or delete the option).
+-   [ ] Enable BACS or other payment methods (e.g. cheque).
+-   [ ] Add checkout block to checkout page.
+-   [ ] On front end, add something to cart and proceed to checkout.
+-   [ ] Make sure you have an admin user with saved payment methods<sup>\*</sup> and a user without saved payment methods (or a guest).
+-   [ ] With those two users, check the Checkout page in the frontend. Also open the Checkout page in the editor.
+-   [ ] Verify the statements below are true. 👇
 
-<sup>*</sup> In order to save a payment method with a user. Enable the WooCommerce Stripe plugin, set the keys and make a purchase with a user selecting the `Save payment information to my account for future purchases.` option. Next time you visit the Checkout with that user, the saved payment method will show up.
+| Scenario                                  | With Stripe API key                                                                                                                                                        | Without Stripe API key                                                                                                                                                                                  |
+| ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Admin with saved payment methods / Editor | <ul><li>Saved payment methods are displayed.</li><li>Credit Card payment method is displayed (under use a new payment method).</li><li>There is no error notice.</li></ul> | <ul><li>Saved payment methods are not displayed.</li><li>There is an error notice about Stripe not being registered correctly.</li><li>Other payment methods are displayed as usual.</li></ul>          |
+| Guest user                                | <ul><li>Saved payment methods are not displayed.</li><li>Credit Card payment method is displayed.</li><li>There is no error notice.</li></ul>                              | <ul><li>Saved payment methods are not displayed.</li><li>Credit Card payment method is not displayed.</li><li>There is no error notice.</li><li>Other payment methods are displayed as usual.</li></ul> |
+
+<sup>\*</sup> In order to save a payment method with a user. Enable the WooCommerce Stripe plugin, set the keys and make a purchase with a user selecting the `Save payment information to my account for future purchases.` option. Next time you visit the Checkout with that user, the saved payment method will show up.
 
 #### Stripe Saved credit cards are not available when the 'Enable Payment via Saved Cards' option is unchecked.
 
-- Assuming you already have a user with saved credit cards in Stripe from the steps above.
-- [ ] Go to Stripe settings and uncheck `Enable Payment via Saved Cards`. Make sure you have added back the API keys that you might have removed in the steps above.
-- [ ] Start a purchase with a user that has saved payment methods and go to the Checkout block.
-- [ ] Verify saved credit cards are not shown in the Payment method options.
+-   Assuming you already have a user with saved credit cards in Stripe from the steps above.
+-   [ ] Go to Stripe settings and uncheck `Enable Payment via Saved Cards`. Make sure you have added back the API keys that you might have removed in the steps above.
+-   [ ] Start a purchase with a user that has saved payment methods and go to the Checkout block.
+-   [ ] Verify saved credit cards are not shown in the Payment method options.
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/350.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/360.md
+++ b/docs/testing/releases/360.md
@@ -59,10 +59,12 @@ _After:_
 ![Screenshot with normal height select](https://user-images.githubusercontent.com/3616980/94667483-29772900-030f-11eb-8b82-1a792c693e2e.png)
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/360.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/370.md
+++ b/docs/testing/releases/370.md
@@ -11,16 +11,16 @@ Merchants can now enable shoppers to sign up for a user account when completing 
 0. Ensure you can see emails from your test site (e.g. new customer account notification email).
 1. Ensure your store is running WooCommerce 4.7 RC or newer.
 1. Install and activate WooCommerce Blocks 3.7 or newer.
-2. Ensure checkout page uses the checkout block – replace the checkout shortcode (if used). Ensure you have a valid payment method set up. 
-3. Log out of your store user account if necessary (or use an incognito window). Add something to cart and proceed to checkout block page.
-3. Enter an email address and complete the form. 
-3. Check the `Create an account` checkbox.
-2. Complete & submit checkout.
+1. Ensure checkout page uses the checkout block – replace the checkout shortcode (if used). Ensure you have a valid payment method set up.
+1. Log out of your store user account if necessary (or use an incognito window). Add something to cart and proceed to checkout block page.
+1. Enter an email address and complete the form.
+1. Check the `Create an account` checkbox.
+1. Complete & submit checkout.
 1. Find the `Your {store} account has been created!` email. Copy the `Click here to set your new password.` url.
     - Link should look something like this: `http://localhost:8333/my-account/lost-password/?action=newaccount&key=6lye4PPX11pbjWPJozSR&login=bob`
-4. In an incognito window, or after logging out, navigate to set password url. 
-6. Should see reset password form (2 password fields) with `Set password` title. 
-7. Reset the account password and confirm the customer account and password are all correct.
+1. In an incognito window, or after logging out, navigate to set password url.
+1. Should see reset password form (2 password fields) with `Set password` title.
+1. Reset the account password and confirm the customer account and password are all correct.
 
 See also [related testing instructions in WooCommerce Core](https://github.com/woocommerce/woocommerce/wiki/Release-Testing-Instructions-WooCommerce-4.7#improvements-to-my-account--lost-password-endpoint).
 
@@ -33,26 +33,30 @@ See also [related testing instructions in WooCommerce Core](https://github.com/w
 5. Verify only one error is displayed, inside the payment methods step.
 6. Without modifying the payment number, click on `Place order` again and verify the authentication modal appears again and you can complete the order.
 
-### Correctly process orders with $0 total (e.g. via coupon) in Checkout block. ([3298](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3298))
+### Correctly process orders with \$0 total (e.g. via coupon) in Checkout block. ([3298](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3298))
 
 1. Add a $0 product to your cart and checkout. Here are two ways to set up a $0 order:
-  - Configure a "100% off" coupon and use it.
-  - Set the price for product(s) to $0 (and only add those products to cart).
+
+-   Configure a "100% off" coupon and use it.
+-   Set the price for product(s) to \$0 (and only add those products to cart).
+
 2. Complete payment and submit the order.
 3. View order in back end.
-3. In the same user/browser session as the first order, repeat another $0 order and submit.
-3. View orders in back end and confirm both orders are present and correct. 
+4. In the same user/browser session as the first order, repeat another \$0 order and submit.
+5. View orders in back end and confirm both orders are present and correct.
 
 ### Respect Enable Taxes setting for checkout block taxes display. ([3291](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3291))
 
 1. Enable taxes and set up a tax rate.
 2. Set these tax options:
-  - `Display prices in the shop: Excluding tax`
-  - `Display prices during cart and checkout: Including tax`
+
+-   `Display prices in the shop: Excluding tax`
+-   `Display prices during cart and checkout: Including tax`
+
 3. Add items to the cart.
 4. View the Checkout block. Tax component should be visible and show tax amount.
 5. Disable taxes: `WooCommerce > Settings > General > Enable taxes: [unchecked]`.
-6. View the Checkout block. Tax component should not be displayed, no taxes should be included in total. Note you may need to refresh the Checkout page if tax values are cached. 
+6. View the Checkout block. Tax component should not be displayed, no taxes should be included in total. Note you may need to refresh the Checkout page if tax values are cached.
 
 ### Improve layout of Cart block line item quantity selector & price on smaller screens. ([3299](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3299))
 
@@ -60,7 +64,6 @@ See also [related testing instructions in WooCommerce Core](https://github.com/w
 1. Go to a page with a Cart block.
 1. Reduce the viewport and check how the price behaves below 320px width.
 1. View Cart block in various screen sizes and devices and ensure that line items look and function correctly.
-
 
 ## The following changes affect feature plugin and WooCommerce package.
 
@@ -76,10 +79,12 @@ Test all blocks in editor/frontend and verify there are no evident issues with i
 4. Confirm your existing attributes are selected by default.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/370.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/371.md
+++ b/docs/testing/releases/371.md
@@ -8,14 +8,15 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 
 All tests require:
 
-- Checkout block published in woo checkout page.
-- Items added to cart.
-- Anon / incognito user session.
+-   Checkout block published in woo checkout page.
+-   Items added to cart.
+-   Anon / incognito user session.
 
 ### Test 1: Store API will only create an account if store options allow it
+
 1. Render checkout block with `Create an account?` checkbox. We're going to use a stale copy of the page to submit a checkout API request with `should_create_account=true`.
-   - Ensure `WooCommerce > Settings > Accounts & Privacy > Allow customers to create an account during checkout` is checked (temporarily enable).
-   - Edit checkout page, ensure `Allow shoppers to sign up for a user account during checkout` is enabled, publish.
+    - Ensure `WooCommerce > Settings > Accounts & Privacy > Allow customers to create an account during checkout` is checked (temporarily enable).
+    - Edit checkout page, ensure `Allow shoppers to sign up for a user account during checkout` is enabled, publish.
 2. In another browser/window, view checkout page (with items in cart, as anon user/logged out). Should see `Create an account` checkbox.
 3. Complete checkout form and check `Create an account`. **Do not submit** (yet).
 4. As admin, disable `WooCommerce > Settings > Accounts & Privacy > Allow customers to create an account during checkout` and save settings.
@@ -25,20 +26,24 @@ All tests require:
 As an alternative to (1), could also hack the JS REST request to always send `should_create_account=true`, or use other approaches to call the API with that value set.
 
 ### Test 2: Checkout block will only offer to create an account if store options allow it
+
 1. As admin, disable `WooCommerce > Settings > Accounts & Privacy > Allow customers to create an account during checkout` and save settings.
 2. View checkout page and ensure there is no `Create an account` checkbox.
 3. Repeat the above test with different block settings and ensure no checkbox is displayed unless store option is enabled. E.g. allow checkout signup in settings, enable block `Allow shoppers to sign up for a user account during checkout` setting, publish, change store setting and refresh page.
 
 ### Other possible tests
-- Repeat similar tests with a custom plugin implementing `woocommerce_checkout_registration_enabled` hook to disable checkout signup.
-- Test various combinations of store settings (e.g. guest checkout `Allow customers to place orders without an account`) and ensure that accounts are created when appropriate.
-- Test with WooCommerce < v4.7 and ensure that checkout block sign-up feature is not available, and there is no way to sign up using checkout block.
+
+-   Repeat similar tests with a custom plugin implementing `woocommerce_checkout_registration_enabled` hook to disable checkout signup.
+-   Test various combinations of store settings (e.g. guest checkout `Allow customers to place orders without an account`) and ensure that accounts are created when appropriate.
+-   Test with WooCommerce < v4.7 and ensure that checkout block sign-up feature is not available, and there is no way to sign up using checkout block.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/371.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/380.md
+++ b/docs/testing/releases/380.md
@@ -21,10 +21,12 @@ Moves the rendering of address fields to a single file so that PhoneNumber (new 
 1. Confirm -- usage in built files.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/380.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/390.md
+++ b/docs/testing/releases/390.md
@@ -23,121 +23,123 @@ Test in Safari to ensure issue is resolved, then test in another browser to ensu
 
 Setup:
 
-* Make sure your testing environment has Stripe setup for both CC and Express payment methods.
+-   Make sure your testing environment has Stripe setup for both CC and Express payment methods.
 
 Testing:
 
-* [ ] When checkout is loaded, make sure the Stripe CC payment method is the active payment method tab.
-* [ ] Click express payment method button (Chrome Pay or Apple Pay) to initiate payment flow.
-* [ ] Submit the express payment and ensure the checkout order is processed (resulting in a successful redirect to the Order complete page)
-* [ ] Try setting up the scenario, and then instead of completing the express payment, try canceling the express payment and completing payment with CC.
-* [ ] Try cancelling the express payment method and then triggering it again (after setting up the scenario again).
-* [ ] Try all scenarios with a logged out and logged in user.
+-   [ ] When checkout is loaded, make sure the Stripe CC payment method is the active payment method tab.
+-   [ ] Click express payment method button (Chrome Pay or Apple Pay) to initiate payment flow.
+-   [ ] Submit the express payment and ensure the checkout order is processed (resulting in a successful redirect to the Order complete page)
+-   [ ] Try setting up the scenario, and then instead of completing the express payment, try canceling the express payment and completing payment with CC.
+-   [ ] Try cancelling the express payment method and then triggering it again (after setting up the scenario again).
+-   [ ] Try all scenarios with a logged out and logged in user.
 
 ### Refresh Express Payment methods after cancelling payment to prevent addresses remaining populated on repeat attempts.
 
-* [ ] Go to the cart page with items in your cart.
-* [ ] Click on Pay Now (stripe Chrome pay). The PaymentRequest window is opened.
-* [ ] In the PaymentRequest window, select a delivery address.
-* [ ] Cancel the payment.
-* [ ] Click the Pay Now button again.
-* [ ] The delivery address area should not have an address selected. This is the fix.
+-   [ ] Go to the cart page with items in your cart.
+-   [ ] Click on Pay Now (stripe Chrome pay). The PaymentRequest window is opened.
+-   [ ] In the PaymentRequest window, select a delivery address.
+-   [ ] Cancel the payment.
+-   [ ] Click the Pay Now button again.
+-   [ ] The delivery address area should not have an address selected. This is the fix.
 
 ### Ensure "Add a note to your order" section is styled correctly when disabled.
 
-* [ ] Add a product to your cart and go to a page with the checkout block
-* [ ] Fill in the required form fields. Leave the "Add a note to your order" unticked.
-* [ ] Submit the form
-* [ ] Ensure the "Add a note to your order" section looks disabled
-* [ ] Restart the checkout process and fill in all required form fields.
-* [ ] Tick the box next to "Add a note to your order" and (optionally) fill in the textarea with something
-* [ ] Submit the form again and ensure the entire "Add a note to your order" section is disabled (while the order is processing), including the textarea.
+-   [ ] Add a product to your cart and go to a page with the checkout block
+-   [ ] Fill in the required form fields. Leave the "Add a note to your order" unticked.
+-   [ ] Submit the form
+-   [ ] Ensure the "Add a note to your order" section looks disabled
+-   [ ] Restart the checkout process and fill in all required form fields.
+-   [ ] Tick the box next to "Add a note to your order" and (optionally) fill in the textarea with something
+-   [ ] Submit the form again and ensure the entire "Add a note to your order" section is disabled (while the order is processing), including the textarea.
 
 ### Prevent checkout step heading text overlapping actual heading on small viewports.
 
-* [ ] Ensure the Allow customers to log into an existing account during checkout option is enabled in **WooCommerce -> Settings -> Accounts & Privacy**.
-* [ ] Log out of the site and add a product to your cart.
-* [ ] Go to a page with the checkout block on and reduce the viewport so far that the "Already have an account? Log in" text is about to overlap.
-* [ ] Ensure the text drops to below the header and does not overlap with the section heading.
+-   [ ] Ensure the Allow customers to log into an existing account during checkout option is enabled in **WooCommerce -> Settings -> Accounts & Privacy**.
+-   [ ] Log out of the site and add a product to your cart.
+-   [ ] Go to a page with the checkout block on and reduce the viewport so far that the "Already have an account? Log in" text is about to overlap.
+-   [ ] Ensure the text drops to below the header and does not overlap with the section heading.
 
 ### Hide Stripe Express payment if transaction in cart is lower than .30
 
-* [ ] Enable Stripe + Chrome Pay
-* [ ] Add an item to the cart costing 0.10
-* [ ] No express payment method is visible
-* [ ] Increase quantity in cart to 3. Express payment method should then be shown.
-* [ ] Reduce the quantity again. The payment method will disappear.
-* [ ] Go to checkout with total in cart less than 0.30 and ensure Stripe express payment method does not show.
+-   [ ] Enable Stripe + Chrome Pay
+-   [ ] Add an item to the cart costing 0.10
+-   [ ] No express payment method is visible
+-   [ ] Increase quantity in cart to 3. Express payment method should then be shown.
+-   [ ] Reduce the quantity again. The payment method will disappear.
+-   [ ] Go to checkout with total in cart less than 0.30 and ensure Stripe express payment method does not show.
 
 ### Stop hidden products from being linked in cart and checkout blocks.
 
-* [ ] Create a page that contains the checkout and cart blocks.
-* [ ] Find a product in the dashboard and set its catalogue visibility to hidden.
-* [ ] Add that product to your cart (Note you will have to visit the url for the product directly in order to add it).
-* [ ] Visit the page with the checkout and cart blocks and ensure the name of the hidden product does not link to the product page in the checkout sidebar and in the line items in the cart.
-* [ ] Repeat steps 2-4 with the catalogue visibility set to "Search results only".
+-   [ ] Create a page that contains the checkout and cart blocks.
+-   [ ] Find a product in the dashboard and set its catalogue visibility to hidden.
+-   [ ] Add that product to your cart (Note you will have to visit the url for the product directly in order to add it).
+-   [ ] Visit the page with the checkout and cart blocks and ensure the name of the hidden product does not link to the product page in the checkout sidebar and in the line items in the cart.
+-   [ ] Repeat steps 2-4 with the catalogue visibility set to "Search results only".
 
 ### Fix orders not being placed when paying with an Express payment method from the Cart block.
 
 In a device compatible with express payment methods and a site with Stripe payment gateway enabled:
 
-* [ ] Verify Apple Pay or Google Pay buttons appear in the Cart block and clicking on them triggers the payment process.
-* [ ] Proceed with the payment and verify you are redirected to the success screen and the order appears in the admin (WooCommerce > Orders).
-* [ ] Verify express payment methods from the Checkout block are not broken.
-* [ ] Verify regular payment methods are not broken either.
+-   [ ] Verify Apple Pay or Google Pay buttons appear in the Cart block and clicking on them triggers the payment process.
+-   [ ] Proceed with the payment and verify you are redirected to the success screen and the order appears in the admin (WooCommerce > Orders).
+-   [ ] Verify express payment methods from the Checkout block are not broken.
+-   [ ] Verify regular payment methods are not broken either.
 
 ### Cart and checkout should respect the global "Hide shipping costs until an address is entered" setting.
 
-* [ ] Before running this PR, in **Settings > Shipping > Shipping Options**, turn on the option to require an address
-* [ ] Setup a single shipping rate
-* [ ] The messaging in cart and checkout states that shipping will be shown after providing an address.
-* [ ] After entering your address, rates are then displayed and the total cost is not 0
-* [ ] The "Hide shipping costs until an address is entered" block level option is no longer displayed when editing the block.
+-   [ ] Before running this PR, in **Settings > Shipping > Shipping Options**, turn on the option to require an address
+-   [ ] Setup a single shipping rate
+-   [ ] The messaging in cart and checkout states that shipping will be shown after providing an address.
+-   [ ] After entering your address, rates are then displayed and the total cost is not 0
+-   [ ] The "Hide shipping costs until an address is entered" block level option is no longer displayed when editing the block.
 
 ### Exclude checkout-draft orders from WC Admin reports and My Account > Orders
 
-* [ ] Make sure your store has at least one completed order and one draft order. You can achieve that adding some products to the cart and navigating to the Cart and Checkout blocks but without completing the order.
-* [ ] Go to Analytics > Settings and verify there isn't a Custom statuses section or, if it exists, make sure none of the statuses is named Draft.
-* [ ] Go to the bottom of the page and click on Delete Previously Imported Data.
-* [ ] Wait until the process finishes and then import all data again.
-* [ ] Go to Analytics > Orders.
-* [ ] Verify the 'draft' order is not counted in the totals.
-* [ ] In the frontend, go to My Account > Orders with the user that made the draft order.
-* [ ] Verify the draft order is not listed there.
+-   [ ] Make sure your store has at least one completed order and one draft order. You can achieve that adding some products to the cart and navigating to the Cart and Checkout blocks but without completing the order.
+-   [ ] Go to Analytics > Settings and verify there isn't a Custom statuses section or, if it exists, make sure none of the statuses is named Draft.
+-   [ ] Go to the bottom of the page and click on Delete Previously Imported Data.
+-   [ ] Wait until the process finishes and then import all data again.
+-   [ ] Go to Analytics > Orders.
+-   [ ] Verify the 'draft' order is not counted in the totals.
+-   [ ] In the frontend, go to My Account > Orders with the user that made the draft order.
+-   [ ] Verify the draft order is not listed there.
 
 ### Sync shipping address with billing address when shipping address fields are disabled.
 
 #### Case 1
 
-* [ ] Create 2 tax rates; one for UK and one for US
-* [ ] Delete all shipping methods and rates so shipping is disabled and no fields are shown during checkout
-* [ ] Go to checkout. Enter a UK address. See the tax rate.
-* [ ] Change country field. See the tax rates update after the API request completes.
-* [ ] Place order. Check the order has the same shipping and billing address saved.
+-   [ ] Create 2 tax rates; one for UK and one for US
+-   [ ] Delete all shipping methods and rates so shipping is disabled and no fields are shown during checkout
+-   [ ] Go to checkout. Enter a UK address. See the tax rate.
+-   [ ] Change country field. See the tax rates update after the API request completes.
+-   [ ] Place order. Check the order has the same shipping and billing address saved.
 
 #### Case 2
 
-* [ ] In general settings, in the option for where you ship to, select 'disable shipping calculations'
-* [ ] Go to checkout. Enter a UK address. See the tax rate.
-* [ ] Change country field. See the tax rates update after the API request completes.
-* [ ] Place order. Check the order has the same shipping and billing address saved.
+-   [ ] In general settings, in the option for where you ship to, select 'disable shipping calculations'
+-   [ ] Go to checkout. Enter a UK address. See the tax rate.
+-   [ ] Change country field. See the tax rates update after the API request completes.
+-   [ ] Place order. Check the order has the same shipping and billing address saved.
 
 #### Case 3
 
-* [ ] In tax settings, choose to base taxes on the billing address.
-* [ ] Go to checkout. Enter a different billing and shipping address.
-* [ ] Toggle the "ship to billing" checkbox and see if the rate changes after doing so reliably.
-* [ ] In all cases you should see a network request to update-customer a short while after entering any billing or shipping data, or toggling the 'use shipping address' checkbox on checkout.
+-   [ ] In tax settings, choose to base taxes on the billing address.
+-   [ ] Go to checkout. Enter a different billing and shipping address.
+-   [ ] Toggle the "ship to billing" checkbox and see if the rate changes after doing so reliably.
+-   [ ] In all cases you should see a network request to update-customer a short while after entering any billing or shipping data, or toggling the 'use shipping address' checkbox on checkout.
 
 ### Move feature flag PHP logic to a service class
 
-* [ ] Verify Product Element blocks (i.e. `Product Price`) are not available in the feature plugin from the block picker (it is expected that some product element blocks are available when editing the template view for the All Products block).
+-   [ ] Verify Product Element blocks (i.e. `Product Price`) are not available in the feature plugin from the block picker (it is expected that some product element blocks are available when editing the template view for the All Products block).
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/390.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/400.md
+++ b/docs/testing/releases/400.md
@@ -8,12 +8,12 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 
 Setup:
 
-* Create a Products Block, Filter by Price Block, and Checkout Block.
+-   Create a Products Block, Filter by Price Block, and Checkout Block.
 
 Testing:
 
-- [ ] With IE11, check that there are no visual regressions in the Filter products by price block.
-- [ ] With IE11, check that there are no visual regressions in the checkboxes of the Checkout block.
+-   [ ] With IE11, check that there are no visual regressions in the Filter products by price block.
+-   [ ] With IE11, check that there are no visual regressions in the checkboxes of the Checkout block.
 
 See screenshots in https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3473.
 
@@ -23,26 +23,26 @@ See screenshots in https://github.com/woocommerce/woocommerce-gutenberg-products
 
 Setup:
 
-* Install and activate Twenty Twenty One.
-* Go to Customize > Colors & Dark mode and check the Dark mode support checkbox.
-* In the frontend, make sure the dark mode is enabled and go to a page with the Checkout block.
+-   Install and activate Twenty Twenty One.
+-   Go to Customize > Colors & Dark mode and check the Dark mode support checkbox.
+-   In the frontend, make sure the dark mode is enabled and go to a page with the Checkout block.
 
 Testing:
 
-* [ ] Try submitting the form leaving one of the required inputs empty so the error notice appears.
-* [ ] Verify the close button is visible.
+-   [ ] Try submitting the form leaving one of the required inputs empty so the error notice appears.
+-   [ ] Verify the close button is visible.
 
 ### Ensure correct alignment of checkout notice's dismiss button
 
 Setup:
 
-* Enable Storefront theme
-* Add an item to the cart and go to the checkout block
+-   Enable Storefront theme
+-   Add an item to the cart and go to the checkout block
 
 Testing:
 
-* [ ] Leave a required field on the checkout form blank and attempt checkout
-* [ ] Ensure the error notice's dismiss button is aligned to the right
+-   [ ] Leave a required field on the checkout form blank and attempt checkout
+-   [ ] Ensure the error notice's dismiss button is aligned to the right
 
 See screenshot in https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3455.
 
@@ -50,41 +50,41 @@ See screenshot in https://github.com/woocommerce/woocommerce-gutenberg-products-
 
 Setup:
 
-* Add the checkout block to a page. 
-* Add an item to your cart, and go to checkout.
+-   Add the checkout block to a page.
+-   Add an item to your cart, and go to checkout.
 
 Testing:
 
-* [ ] Change the value of the Country/Region select.
-* [ ] Verify no errors appear in the browser console.
+-   [ ] Change the value of the Country/Region select.
+-   [ ] Verify no errors appear in the browser console.
 
 ### Checkout block: Fixes around account creation and coupon validation
 
 Setup:
 
-* Create a coupon with a usage requirement of a specific email address.
-* Enable registration during checkout.
-* Add the checkout block to a page. 
-* Add an item to your cart, apply the coupon, and go to checkout.
+-   Create a coupon with a usage requirement of a specific email address.
+-   Enable registration during checkout.
+-   Add the checkout block to a page.
+-   Add an item to your cart, apply the coupon, and go to checkout.
 
 Testing:
 
-* [ ] Fill out the checkout form, and indicate that you would like to create an account. Use an email address different to the coupon restriction. Submit the form.
-* [ ] Confirm a coupon error appears, and the create account signup box is hidden.
-* [ ] Submit the form again. Order should go through without error.
+-   [ ] Fill out the checkout form, and indicate that you would like to create an account. Use an email address different to the coupon restriction. Submit the form.
+-   [ ] Confirm a coupon error appears, and the create account signup box is hidden.
+-   [ ] Submit the form again. Order should go through without error.
 
 ### Remove held stock for a draft order if an item is removed from the cart
 
 Setup:
 
-* Setup a stock managed item with 1 in stock
-* Add that 1 item to the cart
-* Go to checkout
-* Go back to the cart and remove the item from your cart
+-   Setup a stock managed item with 1 in stock
+-   Add that 1 item to the cart
+-   Go to checkout
+-   Go back to the cart and remove the item from your cart
 
 Testing:
 
-* [ ] From another device or in another browser, add the same item to the cart. No stock errors should be shown.
+-   [ ] From another device or in another browser, add the same item to the cart. No stock errors should be shown.
 
 ### Make sure cart is initialized before the CartItems route is used in the Store API
 
@@ -101,15 +101,17 @@ POST `https://yourstore.test/wp-json/wc/store/cart/add-item`
 }
 ```
 
-Testing: 
+Testing:
 
-* [ ] GET the following endpoint: `https://yourstore.test/wp-json/wc/store/cart/items`. There should be a valid response with response code 200.
+-   [ ] GET the following endpoint: `https://yourstore.test/wp-json/wc/store/cart/items`. There should be a valid response with response code 200.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/400.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/410.md
+++ b/docs/testing/releases/410.md
@@ -6,119 +6,123 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 
 ### Update minimum required WP version to 5.4
 
-- [ ] Open the inserter when creating/editing a post or page and verify All Products, Price Filter, Attribute Filter, Active Filters, Checkout and Cart blocks are available.
+-   [ ] Open the inserter when creating/editing a post or page and verify All Products, Price Filter, Attribute Filter, Active Filters, Checkout and Cart blocks are available.
 
 ### Update usage of legacy packages (inc. ServerSideRender)
 
-- [ ] check that SSR blocks still function in the editor and frontend. And example of an SSR block is Products by Tag.
-
+-   [ ] check that SSR blocks still function in the editor and frontend. And example of an SSR block is Products by Tag.
 
 ### add fallback screen reader styles
 
-- [ ] In your theme, remove the `.screen-reader-text` styles.
-- [ ] Add checkout block to a page and stuff to cart.
-- [ ] View checkout on front end - confirm .screen-reader-text is hidden by default and is helpful when using a screen reader.
-- [ ] Revert the style changes to ensure these styles don't conflict or cause issues.
+-   [ ] In your theme, remove the `.screen-reader-text` styles.
+-   [ ] Add checkout block to a page and stuff to cart.
+-   [ ] View checkout on front end - confirm .screen-reader-text is hidden by default and is helpful when using a screen reader.
+-   [ ] Revert the style changes to ensure these styles don't conflict or cause issues.
 
 ### Hide elements that use 'hidden' attribute
 
-- [ ] Install Artisan theme.
-- [ ] Go to the Cart or Checkout blocks and verify you can expand/contract the Coupon Code panel.
-
+-   [ ] Install Artisan theme.
+-   [ ] Go to the Cart or Checkout blocks and verify you can expand/contract the Coupon Code panel.
 
 ## Compatibility with WordPress 5.6 (both feature plugin and what is included with package inclusion in core)
 
 ### Replace IconButton component with Button
 
-- [ ] Add the Featured Product to a post or page.
-- [ ] Choose a product and select the block.
-- [ ] Verify the Edit media button looks good and ensure there isn't any JS message in the console with a deprecation message for the IconButton component.
-image.
+-   [ ] Add the Featured Product to a post or page.
+-   [ ] Choose a product and select the block.
+-   [ ] Verify the Edit media button looks good and ensure there isn't any JS message in the console with a deprecation message for the IconButton component.
+        image.
 
 ![image](https://user-images.githubusercontent.com/3616980/102064675-e7cb2a00-3df7-11eb-82b9-af170671cb43.png)
 
-- [ ] Repeat steps 1-3 with Featured Category block.
-- [ ] Add the All Products block to a page.
-- [ ] Click the edit button (pencil icon) and verify the Reset Layout button looks good and there aren't JS errors in the console.
-- [ ] Add the All Products block to a page (or use the one you just added in the steps above).
-- [ ] Click the edit button (pencil icon) and verify the layout looks like in the screenshot on the right.
+-   [ ] Repeat steps 1-3 with Featured Category block.
+-   [ ] Add the All Products block to a page.
+-   [ ] Click the edit button (pencil icon) and verify the Reset Layout button looks good and there aren't JS errors in the console.
+-   [ ] Add the All Products block to a page (or use the one you just added in the steps above).
+-   [ ] Click the edit button (pencil icon) and verify the layout looks like in the screenshot on the right.
 
-| Before | After |
-| --- | --- |
+| Before                                                                                                         | After                                                                                                           |
+| -------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
 | ![image](https://user-images.githubusercontent.com/3616980/102066515-35489680-3dfa-11eb-972d-420d9eeeb3f0.png) | ![imatge](https://user-images.githubusercontent.com/3616980/102065872-5fe61f80-3df9-11eb-9958-94f16c901932.png) |
-
 
 ### Fix isDefault on Buttons and switch Toolbar with ToolbarGroup
 
 Smoke test the following blocks
-- [ ] any atomic block settings.
-- [ ] attributes filter
-- [ ] featured category
-- [ ] featured product
-- [ ] handpicked products
-- [ ] product category
-- [ ] product tag
-- [ ] products by attribute
-- [ ] all products
-- [ ] all reviews
-- [ ] single product
+
+-   [ ] any atomic block settings.
+-   [ ] attributes filter
+-   [ ] featured category
+-   [ ] featured product
+-   [ ] handpicked products
+-   [ ] product category
+-   [ ] product tag
+-   [ ] products by attribute
+-   [ ] all products
+-   [ ] all reviews
+-   [ ] single product
 
 ### Fix direct call to setAttribute in EditProductSearch body
 
-- [ ] Insert Product Search, there should be no console errors.
-- [ ] Save the page and reload, the block should render fine.
-- [ ] Checkout the page code, the formId attribute should be set.
+-   [ ] Insert Product Search, there should be no console errors.
+-   [ ] Save the page and reload, the block should render fine.
+-   [ ] Checkout the page code, the formId attribute should be set.
 
 ### Fix product list images skewed in Widgets editor
 
-- [ ] Install latest Gutenberg version and go to Apperance > Widgets.
-- [ ] Add a Top Rated Products block into one of the widget areas and verify images have the correct aspect ratio.
+-   [ ] Install latest Gutenberg version and go to Apperance > Widgets.
+-   [ ] Add a Top Rated Products block into one of the widget areas and verify images have the correct aspect ratio.
 
 ### Fix select inputs when dark mode is enabled in Twenty Twenty-One
 
-- [ ] Install and activate Twenty Twenty One.
-- [ ] Go to Customize > Colors & Dark mode and check the Dark mode support checkbox.
-- [ ] Add a checkout block to a page, ensure items are in your basket.
-- [ ] Visit the page, enable dark mode (bottom right of screen), and open the country dropdown.
-- [ ] Ensure text is readable.
-- [ ] Change checkout block settings to enable dark mode inputs.
-- [ ] Check again and ensure the colour of the text has changed to white on black and that it is is still readable.
+-   [ ] Install and activate Twenty Twenty One.
+-   [ ] Go to Customize > Colors & Dark mode and check the Dark mode support checkbox.
+-   [ ] Add a checkout block to a page, ensure items are in your basket.
+-   [ ] Visit the page, enable dark mode (bottom right of screen), and open the country dropdown.
+-   [ ] Ensure text is readable.
+-   [ ] Change checkout block settings to enable dark mode inputs.
+-   [ ] Check again and ensure the colour of the text has changed to white on black and that it is is still readable.
 
 ## Feature plugin only
 
 ### Fix Fees not visible in Cart & Checkout blocks when order doesn't need shipping
 
-- [ ] Add this PHP code snippet to any PHP file (for example, woocommerce-gutenberg-products-block.php):
+-   [ ] Add this PHP code snippet to any PHP file (for example, woocommerce-gutenberg-products-block.php):
+
 ```php
 add_action( 'woocommerce_cart_calculate_fees', 'add_fee', 10 );
 function add_fee( $cart ) {
 	$cart->add_fee( __( 'Fee', 'woo-gutenberg-products-block' ), 100, true );
 }
 ```
-- [ ] Add a product that doesn't need shipping to your cart and go to the Cart and Checkout blocks.
-- [ ] Verify 'Fees' is listed in the sidebar.
+
+-   [ ] Add a product that doesn't need shipping to your cart and go to the Cart and Checkout blocks.
+-   [ ] Verify 'Fees' is listed in the sidebar.
 
 ### Fix Address Validation in the Store API and client
 
 White space:
 For the white space issue, it's easier to test without this PR first to see what happened, and then test it worked.
-- [ ] Add something to the cart.
-- [ ] Go to checkout.
-- [ ] Enter a space character in the postcode field.
-- [ ] See if it validates or not. Before this PR it does not—it allows checkout submission.
+
+-   [ ] Add something to the cart.
+-   [ ] Go to checkout.
+-   [ ] Enter a space character in the postcode field.
+-   [ ] See if it validates or not. Before this PR it does not—it allows checkout submission.
 
 Validation via API
 For validation, best to post to the API.
 
 First add something to the cart via the API:
+
 ```
 POST https://one.wordpress.test/wp-json/wc/store/cart/add-item
 ```
+
 Body:
+
 ```json
 {
 	"id": 32,
-	"quantity":1
+	"quantity": 1
 }
 ```
 
@@ -127,17 +131,18 @@ POST https://one.wordpress.test/wp-json/wc/store/checkout
 ```
 
 Body:
+
 ```json
 {
 	"payment_method": "bacs",
 	"billing_address": {
-	"first_name": "Mike",
+		"first_name": "Mike",
 		"last_name": "Jolley",
 		"address_1": "Test Address",
 		"city": "Test City",
-		"country":"US",
-		"state":"AL",
-		"postcode":"90210",
+		"country": "US",
+		"state": "AL",
+		"postcode": "90210",
 		"email": "test@test.com"
 	},
 	"shipping_address": {
@@ -145,44 +150,46 @@ Body:
 		"last_name": "Jolley",
 		"address_1": "Test Address",
 		"city": "Test City",
-		"country":"US",
-		"state":"AL",
-		"postcode":"90210"
+		"country": "US",
+		"state": "AL",
+		"postcode": "90210"
 	}
 }
 ```
-- [ ] Leave out certain values to see validation errors. e.g. use an invalid email address, remove the state, enter an invalid state, use a non-existing country etc. Each will produce an error 400 and show a message.
+
+-   [ ] Leave out certain values to see validation errors. e.g. use an invalid email address, remove the state, enter an invalid state, use a non-existing country etc. Each will produce an error 400 and show a message.
 
 Validation via Checkout
-- [ ] Also confirm checkout works as usual and this validation does not block. One thing you can do is checkout using a US address and enter a non-numeric zip code, e.g. ABC. You'll see error notices as the address updates and also if you try to place an order.
 
+-   [ ] Also confirm checkout works as usual and this validation does not block. One thing you can do is checkout using a US address and enter a non-numeric zip code, e.g. ABC. You'll see error notices as the address updates and also if you try to place an order.
 
 ### Use em for coupon code button height
 
-- [ ] Set your browser font size to something smaller than 16px.
-- [ ] Open the Cart block and expand the Coupon Code panel.
-- [ ] Verify the button has the same height as the input text on the left.
+-   [ ] Set your browser font size to something smaller than 16px.
+-   [ ] Open the Cart block and expand the Coupon Code panel.
+-   [ ] Verify the button has the same height as the input text on the left.
 
 ### use ReplaceMediaFlow in featured category and feature product
 
-- [ ] Insert Featured Category and Featured Product
-- [ ] Try updating the image via media library or directly uploading.
-- [ ] There should be no console errors or warnings.
-- [ ] Your upload should work fine.
-
+-   [ ] Insert Featured Category and Featured Product
+-   [ ] Try updating the image via media library or directly uploading.
+-   [ ] There should be no console errors or warnings.
+-   [ ] Your upload should work fine.
 
 ### Fix nonce issues when adding product to cart from All Products
 
-- [ ] In a private window, go to All Products, try to add to cart, it should work
-- [ ] Do it several times with several products.
-- [ ] Paginate the block and try to add products again.
-- [ ] If you have filters set up, try using filters and then adding to cart.
+-   [ ] In a private window, go to All Products, try to add to cart, it should work
+-   [ ] Do it several times with several products.
+-   [ ] Paginate the block and try to add products again.
+-   [ ] If you have filters set up, try using filters and then adding to cart.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/410.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/420.md
+++ b/docs/testing/releases/420.md
@@ -21,10 +21,12 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 5. Try to make a purchase and verify it completes successfully and no error is shown.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/420.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/430.md
+++ b/docs/testing/releases/430.md
@@ -10,7 +10,6 @@ No changes.
 
 ### - Update input colors and alignment. ([3597](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3597))
 
-
 1. Open a page with a Checkout Block and observer the checkboxes and radio buttons - they should be clearly visible.
 2. Go to the page Customizer and change page background to a dark color.
 3. Again check the checkboxes and radio buttons at the page with the Checkout Block - they should be clearly visible.
@@ -31,8 +30,8 @@ No changes.
     ```PHP
     add_action( 'woocommerce_cart_calculate_fees', 'add_fees', 10 );
     function add_fees( $cart ) {
-	    $cart->add_fee( __( 'Packaging 1', 'woo-gutenberg-products-block' ), 100, true );
-	    $cart->add_fee( __( 'Packaging 2', 'woo-gutenberg-products-block' ), 50, true );
+        $cart->add_fee( __( 'Packaging 1', 'woo-gutenberg-products-block' ), 100, true );
+        $cart->add_fee( __( 'Packaging 2', 'woo-gutenberg-products-block' ), 50, true );
     }
     ```
 2. Go to the cart page and see fee rows.
@@ -40,7 +39,6 @@ No changes.
 4. Test with and without prices including tax in WC Tax settings.
 
 ### - Extensibility: Show item data in Cart and Checkout blocks and update the variation data styles. ([3665](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3665))
-
 
 Variations:
 
@@ -61,10 +59,12 @@ WC Product Add-Ons:
 3. Verify add-on data is displayed.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/430.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/440.md
+++ b/docs/testing/releases/440.md
@@ -97,10 +97,12 @@ This is a regression test due to the changes made for Subscriptions Integration.
 3. Place an order. Confirm details persist.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/440.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/450.md
+++ b/docs/testing/releases/450.md
@@ -35,21 +35,24 @@ No changes.
 1. Create a coupon with no expiry date, minimum spend restriction, product restrictions, or usage limit.
 2. Add a product to the cart, go to the checkout block, then apply the coupon.
 3. Repeat these steps several times, with different coupons and new baskets each time.
-  - Modify the coupon's expiry date to be in the past.
-  - Modify the allowed products for the coupon, to ensure it is not applicable to the cart you're testing against.
-  - Create a coupon with a single use. Apply it to this test cart. Then use it on another, unrelated cart and complete the checkout.
-  - Add a minimum order value to the coupon, that is above the cart's value.
+
+-   Modify the coupon's expiry date to be in the past.
+-   Modify the allowed products for the coupon, to ensure it is not applicable to the cart you're testing against.
+-   Create a coupon with a single use. Apply it to this test cart. Then use it on another, unrelated cart and complete the checkout.
+-   Add a minimum order value to the coupon, that is above the cart's value.
+
 4. Complete checkout
 
 ### Improve design of cart and checkout sidebars. ([3797](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3797))
 
 Go to the Cart and Checkout block and verify designs look good. Some ideas of things to try:
-* Test in a situation where there are +1 shipping rate options, only 1 or when there are no available options.
-* Test when there is more than one shipping package and when there is only one.
-* Test in several themes.
-* Test with a different browser font size.
-* Verify things look good in the editor as well.
-* Test mobile too.
+
+-   Test in a situation where there are +1 shipping rate options, only 1 or when there are no available options.
+-   Test when there is more than one shipping package and when there is only one.
+-   Test in several themes.
+-   Test with a different browser font size.
+-   Verify things look good in the editor as well.
+-   Test mobile too.
 
 ### Improve error displayed to customers when an item's stock status changes during checkout. ([3703](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3703))
 
@@ -72,15 +75,15 @@ Go to the Cart and Checkout block and verify designs look good. Some ideas of th
 
 1. Add items to cart and go to the Checkout block. You will need to test with various combinations of the following payment methods
 
-- No saved payment methods.
-- One saved payment methods.
-- Multiple saved payment methods.
+-   No saved payment methods.
+-   One saved payment methods.
+-   Multiple saved payment methods.
 
 and
 
-- No payment methods.
-- One payment method.
-- Multiple saved payment methods.
+-   No payment methods.
+-   One payment method.
+-   Multiple saved payment methods.
 
 2. Ensure the payment methods UI and UX (switching, filling in details) works
 3. Ensure you can still check out and pay.
@@ -99,7 +102,9 @@ and
 3. Optionally, test some other themes in addition to Storefront.
 
 ### Ensure special characters are displayed properly in the Cart sidebar. ([3721](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3721))
+
 1. Add this code snippet to any PHP file (ie: `/woocommerce-gutenberg-products-block.php`):
+
 ```PHP
 add_action( 'woocommerce_cart_calculate_fees', 'add_fees', 10 );
 function add_fees( $cart ) {
@@ -107,21 +112,25 @@ function add_fees( $cart ) {
 	$cart->add_fee( __( 'Fee - Number 2', 'woo-gutenberg-products-block' ), 100, true );
 }
 ```
+
 2. Add a product to your cart and visit the Cart or Checkout pages.
 3. Verify the dash is rendered correctly.
 
 ### Show cart item total price including taxes when DISPLAY_CART_PRICES_INCLUDING_TAX is true ([3851](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3851))
+
 In wp-admin:
-1. Go to WooCommerce > Settings and check the option `Enable tax rates and calculations `.
+
+1. Go to WooCommerce > Settings and check the option `Enable tax rates and calculations`.
 2. Go to WooCommerce > Settings > Tax and set `Prices entered with tax` to `No, I will enter prices exclusive of tax` and `Display prices during cart and checkout` to `Including tax`.
 3. Go to WooCommerce > Settings > Tax > Standard Rates and create a tax rate for a specific country.
 
 In the frontend:
+
 1. Add a product to your cart and go to the Cart or Checkout blocks.
 2. Verify the product unitary price and the cart line total show the price including taxes:
 
-| Before | After |
-| --- | --- |
+| Before                                                                                                         | After                                                                                                          |
+| -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
 | ![image](https://user-images.githubusercontent.com/3616980/108037796-5ddb4f80-703a-11eb-9656-cac05a57b8c5.png) | ![image](https://user-images.githubusercontent.com/3616980/108038392-10abad80-703b-11eb-8c96-52e1c0f2341f.png) |
 
 ### Fix product price not displaying properly when product is on sale ([3853](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3853))
@@ -130,10 +139,12 @@ In the frontend:
 2. Go to the cart and checkout blocks and make sure you can see the struckthrough regular price, and the sale price is displayed normally.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/450.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/452.md
+++ b/docs/testing/releases/452.md
@@ -15,18 +15,19 @@ No changes.
 2. Add any product to your cart and go to the Cart and Checkout blocks.
 3. Verify cart line prices are displayed correctly, instead of being `0`.
 
-
 ### Show total sale badge in medium carts & make it display below price [(3879)](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3879)
 
 1. Set your currency settings to display without a decimal place, like this: ![image](https://user-images.githubusercontent.com/3616980/108694932-fae92d00-74ff-11eb-8ab5-d2038527ea98.png)
 1. Add a product that is on sale to your cart, if you've got an up to date WooCommerce Subscriptions repo (on branch: `feature/checkout-block-simple-multiple-subscriptions`) then add a subscription product that's on sale, too.
-2. View the Cart block and ensure the price and sale badge display well.
+1. View the Cart block and ensure the price and sale badge display well.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/452.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/460.md
+++ b/docs/testing/releases/460.md
@@ -8,13 +8,13 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 
 The following are related to various changes impacting some existing flows so just need validated there's nothing broken:
 
-- Test that adding products to the cart via the add to cart button in the All Products block works as expected (product is added to cart and button updated accordingly).
+-   Test that adding products to the cart via the add to cart button in the All Products block works as expected (product is added to cart and button updated accordingly).
 
 ### Fix button styles in Twenty Nineteen Theme (#3862)
 
-* Insert all products block in a page.
-* View a product with a link (external product).
-* Verify the text in the button for the link is white on blue background.
+-   Insert all products block in a page.
+-   View a product with a link (external product).
+-   Verify the text in the button for the link is white on blue background.
 
 #### Screenshots
 
@@ -40,24 +40,24 @@ After:
 
 ### Remove shadows from text buttons and gradient background from selects in some themes (#3846)
 
-* Install and activate the [Bookshop](https://woocommerce.com/products/bookshop/) theme.
-* Go to the cart block output on the frontend and verify the `Delete item` button doesn't have text shadow.
+-   Install and activate the [Bookshop](https://woocommerce.com/products/bookshop/) theme.
+-   Go to the cart block output on the frontend and verify the `Delete item` button doesn't have text shadow.
 
-| Before | After |
-| --- | --- |
+| Before                                                                                                          | After                                                                                                           |
+| --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
 | ![imatge](https://user-images.githubusercontent.com/3616980/107967337-4609ba00-6fad-11eb-9dd9-f4929f699bff.png) | ![imatge](https://user-images.githubusercontent.com/3616980/107967434-633e8880-6fad-11eb-9e7d-6dc21c8f3984.png) |
 
-* Go to the checkout block and verify Country and State selects don't have a gradient in the background.
+-   Go to the checkout block and verify Country and State selects don't have a gradient in the background.
 
-| Before | After |
-| --- | --- |
+| Before                                                                                                          | After                                                                                                           |
+| --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
 | ![imatge](https://user-images.githubusercontent.com/3616980/107967156-1195fe00-6fad-11eb-95ca-d9379e7ff794.png) | ![imatge](https://user-images.githubusercontent.com/3616980/107967052-ef03e500-6fac-11eb-8a76-e2ac0a73ce46.png) |
 
 ### Only use `SHOP_URL` if set (#3845)
 
-* In WC > Settings > Products, unset the shop page and save.
-* Insert a NEW cart block instance into a page.
-* Confirm the empty cart template does not include a link to browse the shop.
+-   In WC > Settings > Products, unset the shop page and save.
+-   Insert a NEW cart block instance into a page.
+-   Confirm the empty cart template does not include a link to browse the shop.
 
 ### Show cart item subtotal instead of total in Cart and Checkout blocks (#3905)
 
@@ -65,21 +65,22 @@ After:
 2. Go to the Cart block and apply a coupon with a fixed cart discount.
 3. Verify the cart item subtotal doesn't change when the coupon discount is applied.
 
-
 ### Smoke Testing
 
 The following are related to various changes impacting some existing flows so just need validated there's nothing broken
 
-- Cart and checkout coupons interaction works as expected.
-- Cart and checkout changing quantities works as expected.
-- Cart and checkout shipping interaction works as expected.
-- Cart and checkout express payment method works as expected.
+-   Cart and checkout coupons interaction works as expected.
+-   Cart and checkout changing quantities works as expected.
+-   Cart and checkout shipping interaction works as expected.
+-   Cart and checkout express payment method works as expected.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/460.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/470.md
+++ b/docs/testing/releases/470.md
@@ -8,10 +8,10 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 
 The following are related to various changes impacting some existing flows so just need validated there's nothing broken:
 
-- Create a post or page and add some WC Blocks.
-- Verify they look correct and styles loaded properly.
-- Publish that post or page.
-- In the frontend, verify blocks also look correct and styles loaded properly.
+-   Create a post or page and add some WC Blocks.
+-   Verify they look correct and styles loaded properly.
+-   Publish that post or page.
+-   In the frontend, verify blocks also look correct and styles loaded properly.
 
 ### Fix FSE not being visible when WC Blocks was enabled (#3898)
 
@@ -27,6 +27,7 @@ The following are related to various changes impacting some existing flows so ju
 3. Check that all the component elements are visible.
 
 #### Screenshots
+
 The cursor for _Filter Products by price_ is cut on top-bottom and is more visible on dark backgrounds
 Before:
 
@@ -36,8 +37,7 @@ after:
 
 ![image](https://user-images.githubusercontent.com/1628454/109490442-24fe9a00-7a80-11eb-9d23-a39e4dd5dd0f.png)
 
-
-The button from _Product search_  and _Product Categories List_ is barely visible
+The button from _Product search_ and _Product Categories List_ is barely visible
 
 Before:
 ![image](https://user-images.githubusercontent.com/1628454/108357873-4e9d0300-71ee-11eb-88f4-708fc74efc75.png)
@@ -45,7 +45,6 @@ Before:
 after:
 ![image](https://user-images.githubusercontent.com/1628454/109490516-3e074b00-7a80-11eb-9177-b280eaadcabd.png)
 ![image](https://user-images.githubusercontent.com/1628454/109490656-7018ad00-7a80-11eb-8ae1-35f776a2763f.png)
-
 
 The remove button from _Active Product filters_ is barely visible.
 
@@ -61,7 +60,6 @@ after:
 2. Confirm prices are displayed
 3. Confirm prices still display in cart/checkout to verify no regressions
 
-
 ## Feature plugin only
 
 ### Ensure sale badges have a uniform height in the Cart block. (#3897)
@@ -70,12 +68,12 @@ after:
 2. Verify the sale badges are the same height.
 
 #### Screenshots
+
 Before:
 ![image](https://user-images.githubusercontent.com/5656702/109493773-e0293200-7a84-11eb-8153-fdc47125835f.png)
 
 after:
 ![image](https://user-images.githubusercontent.com/5656702/109491715-dce07700-7a81-11eb-8dee-8258626b71ae.png)
-
 
 ### Remove extra padding from payment methods with no description #3952
 
@@ -106,6 +104,7 @@ after:
 3. See the preview of the block
 
 #### Screenshots
+
 Before:
 ![image](https://user-images.githubusercontent.com/1628454/110649430-7d851400-81b1-11eb-8eb0-b2a1cea80f63.png)
 
@@ -121,16 +120,18 @@ after:
 
 The following are related to various changes impacting some existing flows so just need validated there's nothing broken
 
-- Cart and checkout coupons interaction works as expected.
-- Cart and checkout changing quantities works as expected.
-- Cart and checkout shipping interaction works as expected.
-- Cart and checkout express payment method works as expected.
+-   Cart and checkout coupons interaction works as expected.
+-   Cart and checkout changing quantities works as expected.
+-   Cart and checkout shipping interaction works as expected.
+-   Cart and checkout express payment method works as expected.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/470.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/480.md
+++ b/docs/testing/releases/480.md
@@ -65,10 +65,12 @@ The following are related to various changes impacting some existing flows so ju
 -   Cart and checkout express payment method works as expected.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/480.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/490.md
+++ b/docs/testing/releases/490.md
@@ -8,14 +8,14 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 
 Smoke test these blocks can be inserted and render correctly:
 
-* Hand-picked Products Block
-* Best Selling Products Block
-* Top Rated Products Block
-* Newest Products Block
-* On Sale Products Block
-* Products by Category Block
-* Products by Tag Block
-* Products by Attribute Block
+-   Hand-picked Products Block
+-   Best Selling Products Block
+-   Top Rated Products Block
+-   Newest Products Block
+-   On Sale Products Block
+-   Products by Category Block
+-   Products by Tag Block
+-   Products by Attribute Block
 
 ### Fix Featured Product and Featured Category button alignment (#4028)
 
@@ -23,17 +23,17 @@ Smoke test these blocks can be inserted and render correctly:
 2. Without making any change on them, preview them in the frontend and verify the button is centered.
 3. Change the alignment of the button to the left, right, back to the center, etc. and verify it works.
 
-| Before | After |
-| --- | --- |
+| Before                                                                                                          | After                                                                                                           |
+| --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
 | ![imatge](https://user-images.githubusercontent.com/3616980/113333925-5985a000-9323-11eb-8c11-25796187bbcc.png) | ![imatge](https://user-images.githubusercontent.com/3616980/113333839-3e1a9500-9323-11eb-9e12-4bd783487638.png) |
 
 ### Enable Google Analytics Integration (#4020)
 
-- Install the [Google Analytics Integration Extension](https://github.com/woocommerce/woocommerce-google-analytics-integration)
-- Setup the extension with a G-X type ID from your Google Analytics account. Google Analytics account is required to test this.
-- Install [Google Analytics Debugger](https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna?hl=en) browser extension. It needs to be installed, but do not click it (debug mode should be off). 
-- Go to the store and trigger some events using the All Products Block and Cart block (feature plugin only). See list of events in https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3953.
-- Google Analytics Debugger should indicate that an event was fired.
+-   Install the [Google Analytics Integration Extension](https://github.com/woocommerce/woocommerce-google-analytics-integration)
+-   Setup the extension with a G-X type ID from your Google Analytics account. Google Analytics account is required to test this.
+-   Install [Google Analytics Debugger](https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna?hl=en) browser extension. It needs to be installed, but do not click it (debug mode should be off).
+-   Go to the store and trigger some events using the All Products Block and Cart block (feature plugin only). See list of events in https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3953.
+-   Google Analytics Debugger should indicate that an event was fired.
 
 To test SSR blocks:
 
@@ -55,24 +55,24 @@ To test the checkout functionality (feature plugin only):
 
 The following are related to various changes impacting some existing flows so just need validated there's nothing broken:
 
-- Cart and Checkout blocks:
-  - Coupons interaction works as expected.
-  - Changing quantities works as expected.
-  - Shipping interaction works as expected.
-- Orders can be placed using regular and express payment methods.
-- Orders can be placed from the Checkout block starting from the Cart block and from the shortcode.
+-   Cart and Checkout blocks:
+    -   Coupons interaction works as expected.
+    -   Changing quantities works as expected.
+    -   Shipping interaction works as expected.
+-   Orders can be placed using regular and express payment methods.
+-   Orders can be placed from the Checkout block starting from the Cart block and from the shortcode.
 
-  *Testing steps of these PRs are included in this section: Fix Circular Dependencies During Builds (#4025), Remove useCheckoutRedirectUrl() (#4032) and  Update @automattic/data-stores and remove mapped-types.ts (#4024)*
+    _Testing steps of these PRs are included in this section: Fix Circular Dependencies During Builds (#4025), Remove useCheckoutRedirectUrl() (#4032) and Update @automattic/data-stores and remove mapped-types.ts (#4024)_
 
 ### Load translation file for JS files that has translatable strings (#4050))
 
-- In WooCommerce > Settings check the option to Enable tax rates and calculations.
-- In the Tax tab, set `Display prices during cart and checkout` to `Excluding tax` and `Display tax totals` to `As a single total`.
-- In the Standard rates tab, make sure you have at least one tax rate created. If not, create it.
-- In Settings > General, change site language to something other than English; Spanish is a good example of a 100% translated language.
-- Go to Dashboard > Updates and scroll down to download the new translations immediately.
-- Visit Cart or Checkout block.
-- Strings like `Taxes` should be translated (in Spanish, it should be `Impuestos`).
+-   In WooCommerce > Settings check the option to Enable tax rates and calculations.
+-   In the Tax tab, set `Display prices during cart and checkout` to `Excluding tax` and `Display tax totals` to `As a single total`.
+-   In the Standard rates tab, make sure you have at least one tax rate created. If not, create it.
+-   In Settings > General, change site language to something other than English; Spanish is a good example of a 100% translated language.
+-   Go to Dashboard > Updates and scroll down to download the new translations immediately.
+-   Visit Cart or Checkout block.
+-   Strings like `Taxes` should be translated (in Spanish, it should be `Impuestos`).
 
 ### Fix Twenty(X) styling issues for cart/checkout form fields (#4046)
 
@@ -93,26 +93,28 @@ The following are related to various changes impacting some existing flows so ju
 3. Apply the changes and go to the Checkout page in the frontend.
 4. Verify the payments methods of the Checkout block have a border with the same color as the text.
 
-| Before | After |
-| --- | --- |
+| Before                                                                                                          | After                                                                                                           |
+| --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
 | ![imatge](https://user-images.githubusercontent.com/3616980/114059318-8b06ea00-9894-11eb-9097-401c8125db5d.png) | ![imatge](https://user-images.githubusercontent.com/3616980/114059261-7e829180-9894-11eb-978d-420cbfc4cf41.png) |
 
 ### Cart: fix headline alignment in the empty state of the cart block (#4044)
 
 1. Prerequisite: ensure you have an empty cart.
 2. Create a new page and add the Cart block.
-2. Check that the empty state looks as expected in the editor (see After state below).
-3. Publish the page and check the empty state in the frontend.
+3. Check that the empty state looks as expected in the editor (see After state below).
+4. Publish the page and check the empty state in the frontend.
 
-|Before|After|
-|-|-|
-|<img width="825" alt="Screenshot 2021-04-07 at 15 19 57" src="https://user-images.githubusercontent.com/1562646/113873096-c631ec00-97b4-11eb-9d04-e96f25dac34a.png">|<img width="821" alt="Screenshot 2021-04-07 at 15 18 52" src="https://user-images.githubusercontent.com/1562646/113873114-c9c57300-97b4-11eb-8857-4399a5786c11.png">|
+| Before                                                                                                                                                               | After                                                                                                                                                                |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <img width="825" alt="Screenshot 2021-04-07 at 15 19 57" src="https://user-images.githubusercontent.com/1562646/113873096-c631ec00-97b4-11eb-9d04-e96f25dac34a.png"> | <img width="821" alt="Screenshot 2021-04-07 at 15 18 52" src="https://user-images.githubusercontent.com/1562646/113873114-c9c57300-97b4-11eb-8857-4399a5786c11.png"> |
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/490.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/491.md
+++ b/docs/testing/releases/491.md
@@ -1,24 +1,26 @@
 ## Testing notes and ZIP for release 4.9.1
 
- Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.com/woocommerce/woocommerce-gutenberg-products-block/files/6304864/woocommerce-gutenberg-products-block.zip)
+Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.com/woocommerce/woocommerce-gutenberg-products-block/files/6304864/woocommerce-gutenberg-products-block.zip)
 
- ## Feature plugin and package inclusion in WooCommerce core
+## Feature plugin and package inclusion in WooCommerce core
 
- ### Breakage with Elementor ([4056](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4056))
+### Breakage with Elementor ([4056](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4056))
 
- - On a website with PHP 8, install Elementor.
- - Enable any payment method.
- - Create a new page, and select "Edit with Elementor", there should be no fatal errors.
+-   On a website with PHP 8, install Elementor.
+-   Enable any payment method.
+-   Create a new page, and select "Edit with Elementor", there should be no fatal errors.
 
- ### Smoke Testing
+### Smoke Testing
 
- - Cart and Checkout block should load fine on frontend.
- - Cart and Checkout should be insertable.
+-   Cart and Checkout block should load fine on frontend.
+-   Cart and Checkout should be insertable.
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/491.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/500.md
+++ b/docs/testing/releases/500.md
@@ -58,10 +58,12 @@ Optionally, because this is difficult to achieve, if you tab to an add to cart b
 5. When placing an order, an account will be created for you.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/500.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/510.md
+++ b/docs/testing/releases/510.md
@@ -8,25 +8,27 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 
 The following are related to various changes impacting existing flows, so smoke testing is needed to verify there are no regressions:
 
-- Place orders via the Checkout block and ensure the following:
-  - All payment methods included with the blocks work as expected for completing the order.
-  - Intentionally triggering payment errors for various payment methods surface the errors as expected and another payment method can be tried.
-  - Express payment methods (via Stripe) work as expected in both the Cart context and Checkout context.
+-   Place orders via the Checkout block and ensure the following:
+    -   All payment methods included with the blocks work as expected for completing the order.
+    -   Intentionally triggering payment errors for various payment methods surface the errors as expected and another payment method can be tried.
+    -   Express payment methods (via Stripe) work as expected in both the Cart context and Checkout context.
 
 ### Fixed bug with clearing email and phone fields when using separate billing address.
 
 Test both guest and logged in scenarios for the following:
 
-- On checkout, fill out email address, shipping fields, and phone number.
-- Uncheck "use shipping for billing" checkbox.
-- Verify email and phone fields still have their values.
-- Submit the order and make sure those values persist on the server with the order.
+-   On checkout, fill out email address, shipping fields, and phone number.
+-   Uncheck "use shipping for billing" checkbox.
+-   Verify email and phone fields still have their values.
+-   Submit the order and make sure those values persist on the server with the order.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/510.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/520.md
+++ b/docs/testing/releases/520.md
@@ -4,11 +4,13 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 
 ## Feature plugin only
 
-#### Added a key prop to each `CartTotalItem` within `usePaymentMethodInterface `. ([4240](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4240))
+#### Added a key prop to each `CartTotalItem` within `usePaymentMethodInterface`. ([4240](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4240))
+
 1. Smoke test cart and checkout. The key prop is added in `prepareTotalItems` but is not visible.
 2. To _really_ test this you may `console.log` the result of `prepareTotalItems` and verify the key is there.
 
 #### Sync customer data during checkout with draft orders. ([4197](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4197))
+
 1. Go to checkout
 2. Fill out billing email
 3. Go to admin, Orders > Drafts. See if the billing email is populated in the draft order.
@@ -16,36 +18,40 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 #### Update the display of the sidebar/order summary in the Cart and Checkout blocks. ([4180](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4180))
 
 ##### Setup steps
+
 1. Ensure some items in your store are taxable, and add a few of them to your cart, for bonus points you can set up additional tax rates and add products from each rate to your cart.
 2. Ensure you have a coupon available to use in your store.
 3. Go to `WooCommerce -> Settings -> Tax` and set `Display tax totals` to `Itemized` and `Display prices during basket and checkout` to `Excluding Tax`.
-2. Using the designs presented in #4093 - Figma link: eaQcoMs7E8Ys0YgxfkOKxR-fi-727%3A1243 do the following:
+4. Using the designs presented in #4093 - Figma link: eaQcoMs7E8Ys0YgxfkOKxR-fi-727%3A1243 do the following:
 
 ##### Editor testing - do these in the block editor
 
 **These instructions are for both the Cart and Checkout block!**
+
 1. Add the block and ensure it matches the designs from the Figma file.
 2. Ensure you have the option to `Show rate after tax name` in the editor sidebar.
-2. Toggle this on and off and verify the rate percentage is shown in the Taxes section of the block preview.
+3. Toggle this on and off and verify the rate percentage is shown in the Taxes section of the block preview.
 4. Go to `WooCommerce -> Settings -> Tax` and set `Display tax totals` to `As a single total` and then ensure the option to `Show rate after tax name` is no longer available in the Cart and Checkout blocks.
 5. Ensure the individual tax lines are not shown in the block preview.
 6. Set it back to `Itemized`.
-6.  Go to `WooCommerce -> Settings -> Tax` and set `Display prices during basket and checkout` to `Including Tax`.
-7. Ensure the Taxes section is not shown, but that the amount of tax is shown under the total.
-8. Set it back to `Excluding Tax`.
-8. While doing the next set of testing instructions, experiment with combinations of these settings ensuring they work correctly.
+7. Go to `WooCommerce -> Settings -> Tax` and set `Display prices during basket and checkout` to `Including Tax`.
+8. Ensure the Taxes section is not shown, but that the amount of tax is shown under the total.
+9. Set it back to `Excluding Tax`.
+10. While doing the next set of testing instructions, experiment with combinations of these settings ensuring they work correctly.
 
 ##### Front-end testing
+
 1. Go to the Cart/Checkout and ensure the rendered cart matches the Figma file. Ensure you have the correct Taxes section based on your configuration.
-4. Go to `WooCommerce -> Settings -> Tax` and set `Display tax totals` to `As a single total` and then ensure the Taxes section of the sidebar does not include a further breakdown of rates.
-5. Set it back to `Itemized` and ensure the rates are broken down correctly.
-6. Toggle the `Show rate after tax name` option in the block and ensure the changes are reflected on the front-end.
-6.  Go to `WooCommerce -> Settings -> Tax` and set `Display prices during basket and checkout` to `Including Tax`.
-7. Ensure the Taxes section is not shown, but that the amount of tax is shown under the total.
-8. Select different shipping methods and ensure the `via X` updates in the Shipping section of the sidebar. Do this in both Cart and Checkout.
-9. Add a coupon and ensure the discounts section shows the reduction amount.
+2. Go to `WooCommerce -> Settings -> Tax` and set `Display tax totals` to `As a single total` and then ensure the Taxes section of the sidebar does not include a further breakdown of rates.
+3. Set it back to `Itemized` and ensure the rates are broken down correctly.
+4. Toggle the `Show rate after tax name` option in the block and ensure the changes are reflected on the front-end.
+5. Go to `WooCommerce -> Settings -> Tax` and set `Display prices during basket and checkout` to `Including Tax`.
+6. Ensure the Taxes section is not shown, but that the amount of tax is shown under the total.
+7. Select different shipping methods and ensure the `via X` updates in the Shipping section of the sidebar. Do this in both Cart and Checkout.
+8. Add a coupon and ensure the discounts section shows the reduction amount.
 
 #### Improved accessibility and styling of the controls of several of ours blocks. ([4100](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4100))
+
 The controls modified in this PR are used in many blocks, so the steps below should be repeated for all of them.
 
 1. Add the block to a page and ensure you can select items in the controls.
@@ -56,41 +62,48 @@ The controls modified in this PR are used in many blocks, so the steps below sho
 5. Test adding several blocks in the same page, verify controls work independently of each other.
 
 Affected blocks:
-* Featured Product Block
-* Featured Category Block
-* Hand-picked Products Block
-* Products by Category Block
-* Products by Tag Block
-* Products by Attribute Block
-* Reviews by Product
-* Reviews by Category
-* Filter Products by Attribute
+
+-   Featured Product Block
+-   Featured Category Block
+-   Hand-picked Products Block
+-   Products by Category Block
+-   Products by Tag Block
+-   Products by Attribute Block
+-   Reviews by Product
+-   Reviews by Category
+-   Filter Products by Attribute
 
 #### Hide tax breakdown if the total amount of tax to be paid is 0. ([4262](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4262))
+
 1. Enable taxes and ensure "Display prices during cart and checkout" is set to "Including taxes"
 2. Add an item to your cart with a zero-rate tax setting.
 3. View the Cart and Checkout block and ensure it does not say "Including £0.00 in taxes".
 
 #### Prevent Coupon code panel from appearing in stores were coupons are disabled. ([4202](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4202))
+
 1. Go to WooCommerce > Settings > General and uncheck Enable the use of coupon codes.
 2. Go to the Cart or Checkout blocks and verify there is no Coupon panel in the sidebar.
 
 #### For payment methods, only use `canMakePayment` in the frontend (not the editor) context. ([4188](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4188))
+
 1. Test this by enabling the Stripe plugin and ensuring the preview (apple pay) appeared correctly in the editor.
 2. Also confirm that canMakePayment still works on the frontend, and that it isn't running in the editor context.
 
 #### Fix duplicate react keys in ProductDetails component. ([4187](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4187))
+
 1. Using WooCommerce Product Add-ons, create a product with checkbox addons.
 2. View the product page, select two of the checkboxes and add the product to the cart.
 3. View the cart block.
 4. Ensure there is no error in the console.
 
 #### Fix sending of confirmation emails for orders when no payment is needed. ([4186](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4186))
-1. Add a VIRTUAL product costing $0 to the cart. The order total should be 0.
+
+1. Add a VIRTUAL product costing \$0 to the cart. The order total should be 0.
 2. Go to Block checkout and place the order.
 3. Check mailhog (if using WP Local) and confirm the new order emails (x2) were received.
 
 #### Stopped a warning being shown when using WooCommerce Force Sells and adding a product with a Synced Force Sell to the cart. ([4182](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4182))
+
 1. Install WooCommerce Force Sells (https://woocommerce.com/products/force-sells/ or https://github.com/woocommerce/woocommerce-force-sells/)
 2. Edit a product to add a "Synced force sell"
    ![image](https://user-images.githubusercontent.com/5656702/117461956-0caa7000-af46-11eb-9638-40671d798570.png)
@@ -99,11 +112,13 @@ Affected blocks:
 5. Do the same for the Checkout block
 
 #### Move Button and Label components to `@woocommerce/blocks-checkout` package. ([4222](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4222))
+
 1. Smoke test of Blocks functionality.
 2. Ensure critical flows work, such as adding items to cart from the All Products Block, continuing to Checkout from the Cart Block and placing an order in the Checkout Block.
 3. Ensure labels are displaying correctly in blocks, compare to trunk and ensure nothing is different or missing.
 
 #### Add couponName filter to allow extensions to modify how coupons are displayed in the Cart and Checkout summary. ([4166](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4166))
+
 1. Check out 422-gh-woocommerce/woocommerce-points-and-rewards
 2. Run npm run build in both repositories.
 3. In the dashboard, go to WooCommerce > Points and rewards > Manage points and add some points to your user account.
@@ -115,6 +130,7 @@ Affected blocks:
 ## Feature plugin and package inclusion in WooCommerce core
 
 #### Hide legacy widgets with a feature-complete block equivalent from the widget area block inserter. ([4237](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4237))
+
 Do the testing steps for the following widgets: Product Search, Product Categories, Products, Products by Rating, and Recent Product Reviews
 
 1. Ensure the Gutenberg feature plugin is enabled. To enable block widgets in the Customizer, go to Gutenberg -> Experiments and check the checkbox next to Widgets. After you’ve saved the experimental settings, navigate to Appearance -> Customize -> Widgets. **Note:** Later versions of Gutenberg will have the block widget interface already enabled (and no longer experimental) - if the option to enable this is not on this page just go to the next step.
@@ -122,15 +138,18 @@ Do the testing steps for the following widgets: Product Search, Product Categori
 3. Insert the "Legacy Widget" block in the Widget editor. You shouldn't be able to see the above-mentioned widgets in the Select widget dropdown.
 
 #### Hide the All Products Block from the Customizer Widget Areas until full support is achieved. ([4225](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4225))
+
 1. Ensure Gutenberg feature plugin is enabled. To enable block widgets in the Customizer, go to Gutenberg -> Experiments and check the checkbox next to Widgets. After you’ve saved the experimental settings, navigate to Appearance -> Customize -> Widgets. **Note:** Later versions of Gutenberg will have the block widget interface already enabled (and no longer experimental) - if the option to enable this is not on this page just go to the next step.
 2. Go to Appearance -> Customize and then click Widgets. Try to insert "All Products", "Price Filter", "Attribute Filter", and "Active Filter" blocks into the Sidebar area. You shouldn't be able to see them in the inspector!
 3. Edit a page and try to insert "All Products", "Price Filter", "Attribute Filter", and "Active Filter" blocks. It should work as expected.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/520.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/530.md
+++ b/docs/testing/releases/530.md
@@ -52,10 +52,12 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 4. Verify you cannot see the spinner on the button and when redirected on the product page, the WooCommerce error message does not show.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/530.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/531.md
+++ b/docs/testing/releases/531.md
@@ -6,28 +6,28 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 
 ### Fix Product Categories List display issues in WP 5.8. ([4335](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4335))
 
-1. In your admin panel, install and activate the [Gutenberg Plugin](https://wordpress.org/plugins/gutenberg/). 
+1. In your admin panel, install and activate the [Gutenberg Plugin](https://wordpress.org/plugins/gutenberg/).
 2. Install the [TT1 Blocks](https://wordpress.org/themes/tt1-blocks/) theme
 3. In the Admin sidebar click on to the Site Editor (beta) menu
 4. Add a Product Categories List block.
 5. Set the `Show category images` attribute to true.
 6. Verify images have the correct size:
 
-| Before | After |
-| --- | --- |
+| Before                                                                                                                                                                | After                                                                                                                                                                                |
+| --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | ![Screenshot of Products Categories List rendering huge images](https://user-images.githubusercontent.com/3616980/121377547-b6fd2500-c942-11eb-8823-1dec7e8f4e72.png) | ![Screenshot of Products Categories List rendering images of the correct size](https://user-images.githubusercontent.com/3616980/121376793-1a3a8780-c942-11eb-914b-911192b07250.png) |
 
 5. With the same theme, add the Product Categories List block to a post or page and verify there is no bottom space between the image and the border.
 
-| Before | After |
-| --- | --- |
+| Before                                                                                                                                                                        | After                                                                                                                                                                            |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | ![Screenshot of Products Categories List images having a border offset](https://user-images.githubusercontent.com/3616980/121377492-ac429000-c942-11eb-86ac-8075341ab1ac.png) | ![Screenshot of Products Categories List images without the border offset](https://user-images.githubusercontent.com/3616980/121376865-2c1c2a80-c942-11eb-9f6e-79c51bfa2a49.png) |
 
 ### Make Product Categories List links unclickable in the editor. ([4339](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4339))
 
 1. Add the Product Categories List block to a post or page.
 2. Try to click on a Category Link.<br>
-![Scheenshot of pointer cursor over a category name](https://user-images.githubusercontent.com/3616980/121380040-d8f7a700-c944-11eb-98e1-24736043dc0a.png)
+   ![Scheenshot of pointer cursor over a category name](https://user-images.githubusercontent.com/3616980/121380040-d8f7a700-c944-11eb-98e1-24736043dc0a.png)
 3. Verify you can't click on it and you aren't redirected to the Category page.
 
 ### Load woocommerce.css in Site editor. ([4345](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4345))
@@ -37,15 +37,17 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 3. Go to the Site Editor.
 4. Add a Reviews block and verify rating stars are rendered correctly.
 
-| Before | After |
-| --- | --- |
+| Before                                                                                                                                                   | After                                                                                                                                                          |
+| -------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | ![Screenshot where rating stars are replaced by S](https://user-images.githubusercontent.com/3616980/121849894-3cd6f280-ccec-11eb-81e4-de37f47ef9d3.png) | ![Schreenshot where rating stars are rendered correctly](https://user-images.githubusercontent.com/3616980/121849806-1fa22400-ccec-11eb-9359-007a4c6dd8a7.png) |
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/531.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/532.md
+++ b/docs/testing/releases/532.md
@@ -15,10 +15,12 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 No changes.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/532.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/540.md
+++ b/docs/testing/releases/540.md
@@ -37,10 +37,12 @@ To test this properly you'll need Stripe setup locally in sandbox mode. You can 
 2. See SKUs shown for products with a SKU
 3. Try searching for a SKU. See results.
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/540.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/550.md
+++ b/docs/testing/releases/550.md
@@ -11,7 +11,7 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 3. Add a product that does need shipping to your cart and go back to the Cart and Checkout blocks. Verify that the Shipping section is present, and again verify that there are no double borders, or empty sections.
 4. Go to WooCommerce -> Settings and disable coupons in the store.
 5. Go back to the Cart/Checkout blocks and verify there are no double borders or empty sections.
-6. In WooCommerce -> Settings -> Tax set the "Calculate tax based on" option to "Customer shipping address". Then ensure you have at least one tax rate set up for a specific country. Also make sure you have no tax rates with a wildcard (*) country name in them.
+6. In WooCommerce -> Settings -> Tax set the "Calculate tax based on" option to "Customer shipping address". Then ensure you have at least one tax rate set up for a specific country. Also make sure you have no tax rates with a wildcard (\*) country name in them.
 7. Go to the Cart and Checkout blocks and change your shipping address to be in the country for which you have a tax rate set up. Verify the taxes section shows in the sidebars, and that no double borders or empty sections are present.
 8. Change your shipping address to be in a country that your store doesn't have a tax rate for. Verify no empty sections or double borders are present.
 
@@ -32,28 +32,32 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 ### Ensure product grids display as intended in the editor. ([4424](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4424))
 
 Test in the block editor:
+
 1. Ensure the Gutenberg feature plugin is enabled and up to date.
 2. Create a new page.
 3. Insert blocks that use the product grid e.g. _Top Rated Products_.
 4. Save the page as a draft.
 5. Navigate to Pages > All Pages and then select `Edit` on the draft you just saved.
-4. Confirm that the number of columns displayed equals the number set in the block settings (Default: 3).
+6. Confirm that the number of columns displayed equals the number set in the block settings (Default: 3).
 
 Test in the widget editor:
+
 1. Ensure the Gutenberg feature plugin is enabled and up to date.
-2. Go to the Widgets editor in Appearance > Widgets. 
+2. Go to the Widgets editor in Appearance > Widgets.
 3. Go to Sidebar widgets and insert blocks that use the product grid e.g. _Top Rated Products_.
 4. Confirm that the number of columns displayed equals the number set in the block settings (Default: 3).
 
-| Before | After |
-| - | - |
+| Before                                                                                                         | After                                                                                                          |
+| -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
 | ![image](https://user-images.githubusercontent.com/1562646/124119268-983a0c00-da72-11eb-8660-5465e3cbbdd8.png) | ![image](https://user-images.githubusercontent.com/1562646/124119281-9bcd9300-da72-11eb-9a33-3a171e6aa72f.png) |
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/550.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/560.md
+++ b/docs/testing/releases/560.md
@@ -14,17 +14,17 @@ Ensure matched results match your query. Try searching for both titles and SKUs.
 
 ### Fix all review memory leak on block transform ([4428](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4428))
 
-- Create an empty page and add the All Reviews block.
-- Select the block and in the toolbar select the transform option
-- Hover on one option and hover out before the preview is loaded
-- Check the console is free of error warnings
+-   Create an empty page and add the All Reviews block.
+-   Select the block and in the toolbar select the transform option
+-   Hover on one option and hover out before the preview is loaded
+-   Check the console is free of error warnings
 
 ### Switch arrow unicode characters ([4364](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4364))
 
 View the pagination rendered on the all products block and confirm the symbol matches the screenshot above.
 
-| Before | After |
-| --- | --- |
+| Before                                                                                                        | After                                                                                                        |
+| ------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
 | ![Before](https://user-images.githubusercontent.com/90977/122258064-8bd97f00-cec8-11eb-8e0a-a82e62a4804a.png) | ![After](https://user-images.githubusercontent.com/90977/122258089-9136c980-cec8-11eb-90a0-543ca30dc482.png) |
 
 ## Feature plugin only
@@ -33,8 +33,8 @@ View the pagination rendered on the all products block and confirm the symbol ma
 
 1. Load the Cart block and verify the margin under the `Your cart` title doesn't change between the rendered block and the loading skeleton.
 
-| Before | After |
-| --- | --- |
+| Before                                                                                                          | After                                                                                                          |
+| --------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
 | ![Before](https://user-images.githubusercontent.com/3616980/126756563-6771d730-1379-4eef-99b5-0d4823ba969f.gif) | ![After](https://user-images.githubusercontent.com/3616980/126756468-3b2f898d-c60f-46a8-bfbb-8c716f6c11a5.gif) |
 
 ### Add styles to stop totals items being padded inside panels ([4435](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4435))
@@ -44,14 +44,14 @@ View the pagination rendered on the all products block and confirm the symbol ma
 3. Expand the "Daily/Weekly/Monthly recurring total" section at the bottom of the sidebar in both blocks.
 4. Ensure there is no extra padding and that the totals for each recurring section are aligned well.
 
-| Before | After |
-|---|---|
+| Before                                                                                                         | After                                                                                                          |
+| -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
 | ![image](https://user-images.githubusercontent.com/5656702/124741599-c8225d00-df13-11eb-8650-2fd3cdabac5f.png) | ![image](https://user-images.githubusercontent.com/5656702/124741331-7d084a00-df13-11eb-9ccf-34a7dd398d1d.png) |
 
 ### Make payment method icons display well even if theme tries to override their height/width ([4427](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4427))
 
-
 1. Add some custom CSS to your theme, do something that will "accidentally" catch all images in the Cart/Checkout blocks, e.g:
+
 ```css
 .wp-block-woocommerce-cart img,
 .wp-block-woocommerce-checkout img {
@@ -59,23 +59,29 @@ View the pagination rendered on the all products block and confirm the symbol ma
 	width: 100% !important;
 }
 ```
+
 2. Go to the Cart and Checkout blocks and ensure that the payment method icons display correctly and are not too large.
 3. Experiment with a few different themes and ensure this works for each one you test.
 
 #### Cart
-| Before | After |
-|---|---|
+
+| Before                                                                                                          | After                                                                                                          |
+| --------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
 | ![Before](https://user-images.githubusercontent.com/5656702/124503622-dbbbaf80-ddbd-11eb-9465-3647810ce35d.png) | ![After](https://user-images.githubusercontent.com/5656702/124503569-c3e42b80-ddbd-11eb-9dd3-c9cd83ee771d.png) |
 
 #### Checkout
-| Before | After |
-|---|---|
+
+| Before                                                                                                         | After                                                                                                          |
+| -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
 | ![image](https://user-images.githubusercontent.com/5656702/124503666-ed04bc00-ddbd-11eb-9da1-f9bf9fe3c274.png) | ![After](https://user-images.githubusercontent.com/5656702/124503503-9eefb880-ddbd-11eb-9bd9-e3d0e7145169.png) |
+
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/560.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/570.md
+++ b/docs/testing/releases/570.md
@@ -95,10 +95,12 @@ Test with the Twenty Twenty-One theme active. You'll need a test product and a t
 | ![#4404-before](https://user-images.githubusercontent.com/3323310/128184619-030aecf6-1496-43c8-b649-c7e513d9a377.png) | ![#4404-after](https://user-images.githubusercontent.com/3323310/128184613-fb17fd6c-c7c4-401c-9628-5337f1b24082.png) |
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/570.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/571.md
+++ b/docs/testing/releases/571.md
@@ -4,7 +4,7 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 
 ## Feature plugin and package inclusion in WooCommerce
 
-###  Disable Cart, Checkout, All Products & filters blocks from the widgets screen ([4646](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4646))
+### Disable Cart, Checkout, All Products & filters blocks from the widgets screen ([4646](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4646))
 
 With Storefront and WP 5.8:
 
@@ -13,10 +13,12 @@ With Storefront and WP 5.8:
 3. Create a new post or page and verify those blocks can be added without problems.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/571.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/572.md
+++ b/docs/testing/releases/572.md
@@ -22,10 +22,12 @@ With Storefront active:
 4. The search block should be shown full width, with a gap between the search input and the button.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/572.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/580.md
+++ b/docs/testing/releases/580.md
@@ -28,16 +28,15 @@ A new block was introduced for filtering products by stock:
 5. For any product that is `out of stock` change it back to `in stock`. All products should now either be `on backorder` or `in stock`.
 6. Reload the page and ensure the option to filter out of stock products is not there.
 7. Set some products back to being `out of stock`.
-8.  Change the `Hide out of stock products from catalogue` to **enabled** in **WooCommerce > Settings > Products > Inventory**
+8. Change the `Hide out of stock products from catalogue` to **enabled** in **WooCommerce > Settings > Products > Inventory**
 9. Reload the page and ensure the option to filter out of stock products is not there.
 10. Add the `Filter Products by Price` and `Filter Products by Attribute` block to the page.
 11. Verify that the filters work together and the correct products are shown in the `All Products` block..
 
-
 ### Fix layout issues with Category List Block ([4587](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4587))
 
-| Before | After |
-|---|---|
+| Before                                                                                                         | After                                                                                                          |
+| -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
 | ![image](https://user-images.githubusercontent.com/5656702/129597106-6162e3f7-d12a-4dd1-8e84-a81a69a05195.png) | ![image](https://user-images.githubusercontent.com/5656702/129597035-eb6b2f63-219e-4a49-9d77-344d369c9115.png) |
 
 1. Add the Product Category List block to a page.
@@ -48,21 +47,25 @@ A new block was introduced for filtering products by stock:
 ### Ensure no impact from changes to SortSelect components ([4580](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4580))
 
 #### Reviews blocks
+
 1. Make sure you have at least a couple of reviews in your store.
 2. Create a post or page with the All Reviews, Reviews by Product and Reviews by Category blocks.
 3. In the editor, make sure you can change the `Order Product Reviews by` value under `List Settings` and blocks are updated accordingly.
 4. In the frontend, make sure you can change the order reviews are displayed in.
 
 #### All Products block
+
 1. Create a post or page with the All Products block.
 2. In the editor, make sure you can change the `Order Products By` value under `Content Settings` and the block is updated accordingly.
 3. In the frontend, make sure you can change the order products are displayed in.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/580.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/590.md
+++ b/docs/testing/releases/590.md
@@ -8,21 +8,26 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 
 1. Make sure Check payments and Cash on delivery payment methods are activated and appear in the Checkout block
 2. Install this extension specifically made for testing: [woocommerce-payment-method-test.zip](https://github.com/woocommerce/woocommerce-gutenberg-products-block/files/7160423/woocommerce-payment-method-test.zip)
-```js
-import { registerPaymentMethodExtensionCallbacks} from '@woocommerce/blocks-registry';
 
-registerPaymentMethodExtensionCallbacks( 'woocommerce-marketplace-extension',
-	{
-		cod: ( arg ) => { return false; },
-		cheque: ( arg ) => { return arg.billingData.city === "Denver";}
-	}
-);
+```js
+import { registerPaymentMethodExtensionCallbacks } from '@woocommerce/blocks-registry';
+
+registerPaymentMethodExtensionCallbacks( 'woocommerce-marketplace-extension', {
+	cod: ( arg ) => {
+		return false;
+	},
+	cheque: ( arg ) => {
+		return arg.billingData.city === 'Denver';
+	},
+} );
 ```
+
 3. Go to the Checkout block
 4. Notice that Cash on delivery is no longer available
 5. Notice that Check payments are available only when the City is set to "Denver"
 
 ### Smoke test the Checkout block
+
 Because of experimental work done during this release, we need to ensure no regressions have been made to the checkout block. Please smoke test the checkout block.
 
 1. Enable a few different payment methods in your store.
@@ -40,15 +45,17 @@ Because of experimental work done during this release, we need to ensure no regr
 1. Add the Product Search block to a page.
 2. Ensure it renders at full width with a gap between the input and the button.
 
-| Before | After |
-|---|---|
+| Before                                                                                                             | After                                                                                                          |
+| ------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------- |
 | <img src="https://user-images.githubusercontent.com/3616980/133223981-f31f54ff-2a4d-4652-a8e8-599c7942b7ce.png" /> | ![image](https://user-images.githubusercontent.com/5656702/133245602-8751a6fd-9bad-40b2-aad0-4d91e09afdd7.png) |
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/590.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/591.md
+++ b/docs/testing/releases/591.md
@@ -13,10 +13,12 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 5. Verify you can remove applied attribute filters either using the cross icon next to each filter, or pressing the "Clear All" link.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/591.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/600.md
+++ b/docs/testing/releases/600.md
@@ -6,52 +6,55 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 
 ### Checkout v1 updates fine to Checkout i2. ([4745](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4745))
 
-- Before installing WooCommerce Blocks 6.0.0, install WooCommerce Blocks 5.9.0.
-- Insert Checkout into a page and save it.
-- Install WooCommerce Blocks 6.0.0.
-- Add an item to your cart.
-- Visit the frontend of the checkout page you saved, it should render fine.
-- Visit the checkout page in the editor, the block should load fine, you should be able to save the page.
-- Save the page, visit the frontend again, the block should work fine.
+-   Before installing WooCommerce Blocks 6.0.0, install WooCommerce Blocks 5.9.0.
+-   Insert Checkout into a page and save it.
+-   Install WooCommerce Blocks 6.0.0.
+-   Add an item to your cart.
+-   Visit the frontend of the checkout page you saved, it should render fine.
+-   Visit the checkout page in the editor, the block should load fine, you should be able to save the page.
+-   Save the page, visit the frontend again, the block should work fine.
 
 ### Terms and Conditions block. ([4745](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4745))
 
-- On the Checkout editor, the terms and conditions block should be preinserted.
-- Assuming you didn't setup a Terms and Conditions page and a Privacy Policy page, you should see a notice telling you to set them up.
-- After setting up those pages, the notice should be gone and links should work fine.
-- You can edit the text, and it would persist on frontend.
-- If you remove or change the links, you will get a warning that you must insert the correct links.
-- If you require checkbox on the block, you should not be able to place an order on the frontend without checking it.
+-   On the Checkout editor, the terms and conditions block should be preinserted.
+-   Assuming you didn't setup a Terms and Conditions page and a Privacy Policy page, you should see a notice telling you to set them up.
+-   After setting up those pages, the notice should be gone and links should work fine.
+-   You can edit the text, and it would persist on frontend.
+-   If you remove or change the links, you will get a warning that you must insert the correct links.
+-   If you require checkbox on the block, you should not be able to place an order on the frontend without checking it.
 
 ### Improve the Checkout Order Summary block accessibility by making more info available to screen readers. ([4810](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4810))
 
-- Add one or more items to your cart.
-- Visit Checkout and click on Order Summary to expand the tab, or navigate to it using TAB key.
-- Navigate using the TAB key.
-- Optionally you could enable the screen reader.
-
+-   Add one or more items to your cart.
+-   Visit Checkout and click on Order Summary to expand the tab, or navigate to it using TAB key.
+-   Navigate using the TAB key.
+-   Optionally you could enable the screen reader.
 
 ### Pass billingData to canMakePayment and debounce its calls ([4776](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4776))
 
-- Add this code somewhere (you can try `assets/js/base/context/providers/cart-checkout/payment-methods/use-payment-method-registration.ts`).
-- If you can't edit files, install `Custom CSS & JS` plugin and insert this code:
+-   Add this code somewhere (you can try `assets/js/base/context/providers/cart-checkout/payment-methods/use-payment-method-registration.ts`).
+-   If you can't edit files, install `Custom CSS & JS` plugin and insert this code:
 
 ```js
-wc.wcBlocksRegistry.registerPaymentMethodExtensionCallbacks( 'woocommerce-marketplace-extension', {
-	cod: ( arg ) => {
-		console.log( 'checking COD' );
-		return arg.billingData.first_name === 'Alexandra';
-	},
-} );
+wc.wcBlocksRegistry.registerPaymentMethodExtensionCallbacks(
+	'woocommerce-marketplace-extension',
+	{
+		cod: ( arg ) => {
+			console.log( 'checking COD' );
+			return arg.billingData.first_name === 'Alexandra';
+		},
+	}
+);
 ```
-- Make the console visible
-- Go to Checkout block and notice that COD payment method is missing and that an initial check was made COD (see console.log())
-- Deselect Use same address for billing and write "Alexandra" for First Name in the Billing Address section. Cash on Delivery option should be available as a payment method.
-- Notice that the check for COD is done only after the user finished typing
+
+-   Make the console visible
+-   Go to Checkout block and notice that COD payment method is missing and that an initial check was made COD (see console.log())
+-   Deselect Use same address for billing and write "Alexandra" for First Name in the Billing Address section. Cash on Delivery option should be available as a payment method.
+-   Notice that the check for COD is done only after the user finished typing
 
 ### Add support for extensions to filter express payment methods. ([4774](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4774))
 
-- As the previous step, paste this code somewhere:
+-   As the previous step, paste this code somewhere:
 
 ```js
 wc.wcBlocksRegistry.registerExpressPaymentMethod( {
@@ -66,33 +69,36 @@ wc.wcBlocksRegistry.registerExpressPaymentMethod( {
 } );
 ```
 
-- Make sure that you see "My express test method" in Checkout.
-- Add this code now:
+-   Make sure that you see "My express test method" in Checkout.
+-   Add this code now:
 
 ```js
-wc.wcBlocksRegistry.registerPaymentMethodExtensionCallbacks( 'woocommerce-marketplace-extension', {
-	expressMethod: ( arg ) => {
-		console.log( 'canMakePayment expressMethod' );
-		return false;
-	},
-} );
+wc.wcBlocksRegistry.registerPaymentMethodExtensionCallbacks(
+	'woocommerce-marketplace-extension',
+	{
+		expressMethod: ( arg ) => {
+			console.log( 'canMakePayment expressMethod' );
+			return false;
+		},
+	}
+);
 ```
-- You shouldn't be able to see that express method now.
-- Remove the code.
 
+-   You shouldn't be able to see that express method now.
+-   Remove the code.
 
 ### Checkout: Throw an exception if there is a shipping method required and one isn't selected at the time of placing an order. ([4784](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4784))
 
-- Set a shipping zone in a country of your choice
-- Add a physical product to your cart and enter a country that isn't covered by the shipping zone
-- Clicking "Place Order" should throw an exception which should be displayed in the checkout, whilst preventing you from placing an order.
+-   Set a shipping zone in a country of your choice
+-   Add a physical product to your cart and enter a country that isn't covered by the shipping zone
+-   Clicking "Place Order" should throw an exception which should be displayed in the checkout, whilst preventing you from placing an order.
 
 ### Show placeholder message in the shipping section when there are no rates. ([4765](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4765))
 
-- In WooCommerce Shipping Settings, enable "Hide shipping until an address is entered"
-- Open checkout in a new incognito window as a guest
-- Add an item to the cart and go to the checkout
-- Confirm the shipping section shows a message: "Shipping options will be displayed here after entering your full shipping address."
+-   In WooCommerce Shipping Settings, enable "Hide shipping until an address is entered"
+-   Open checkout in a new incognito window as a guest
+-   Add an item to the cart and go to the checkout
+-   Confirm the shipping section shows a message: "Shipping options will be displayed here after entering your full shipping address."
 
 #### Screenshots
 
@@ -104,10 +110,9 @@ After:
 
 ### Fix state validation if base location has a state, and the address has an optional state. ([4761](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4761))
 
-- Setup base location to have a state (US Address)
-- Setup a global shipping rate.
-- On Checkout, Select New Zeland, do not select a state during checkout. Ensure you can place the order.
-
+-   Setup base location to have a state (US Address)
+-   Setup a global shipping rate.
+-   On Checkout, Select New Zeland, do not select a state during checkout. Ensure you can place the order.
 
 ### Fix validation message styling so they never overlap other elements. ([4734](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4734))
 
@@ -122,31 +127,30 @@ After:
 ### Added global styles to All Reviews, Reviews by Category and Reviews by Product blocks. ([4323](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4323))
 
 In a classic theme (Storefront):
-- Add the All Reviews block to a post or page.
-- Verify you can change the text color and font size.
-- Repeat the process for the Reviews by Category and Reviews by Product blocks.
+
+-   Add the All Reviews block to a post or page.
+-   Verify you can change the text color and font size.
+-   Repeat the process for the Reviews by Category and Reviews by Product blocks.
 
 #### Screenshots
 
-| Default display (before) | Default display (after) |
-| --- | --- |
+| Default display (before)                                                                                        | Default display (after)                                                                                         |
+| --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
 | ![imatge](https://user-images.githubusercontent.com/3616980/121198934-cdd44680-c872-11eb-8d30-ab51b2c436f8.png) | ![imatge](https://user-images.githubusercontent.com/3616980/121198534-7c2bbc00-c872-11eb-9e99-53a65ca3864a.png) |
 
 Tweaking some colors and font size in Storefront:
 ![imatge](https://user-images.githubusercontent.com/3616980/132874660-10faa689-5d59-4ba6-ad34-332449bdbb47.png)
 
-
 In a block-based theme (ie: TT1 Blocks) with Gutenberg enabled:
-- Go to Appearance > Site editor, click on the Global styles icon and verify the All Reviews block is shown and you can tweak its styles.
-- Add the All Reviews block to a post or page.
-- Verify it honors the styles you set in the Site editor.
-- Change the styles in the post/page editor and verify they have priority over the styles from the Site editor.
-- Repeat the process for the Reviews by Category and Reviews by Product blocks.
-![imatge](https://user-images.githubusercontent.com/3616980/121201895-2a386580-c875-11eb-928b-34ca0a1be531.png).
 
+-   Go to Appearance > Site editor, click on the Global styles icon and verify the All Reviews block is shown and you can tweak its styles.
+-   Add the All Reviews block to a post or page.
+-   Verify it honors the styles you set in the Site editor.
+-   Change the styles in the post/page editor and verify they have priority over the styles from the Site editor.
+-   Repeat the process for the Reviews by Category and Reviews by Product blocks.
+    ![imatge](https://user-images.githubusercontent.com/3616980/121201895-2a386580-c875-11eb-928b-34ca0a1be531.png).
 
 ### Update All Reviews block so it honors 'ratings enabled' and 'show avatars' preferences. ([4764](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4764))
-
 
 1. In wp-admin, go to _Settings_ > _Discussion_ > _Avatars_ and uncheck _Show Avatars_.
 2. Add an All Reviews block and verify avatars are not shown and instead there is a warning in the sidebar:
@@ -156,47 +160,46 @@ In a block-based theme (ie: TT1 Blocks) with Gutenberg enabled:
 3. In wp-admin, go to _WooCommerce_ > _Settings_ > _Products_ and uncheck _Enable star rating on reviews_.
 4. In the All Reviews block, verify ratings and the _Sort by_ select aren't displayed.
 
-
 ### Fix infinite recursion when removing an attribute filter from the Active filters block. ([4816](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4816))
 
-- Insert All Products, Filter Products by Attribute and Active filter blocks into a page.
-- Publish the page.
-- Go to Frontend on same page which created in above step.
-- Apply filter for any attribute.
-- Verify you can remove attribute filters either using the cross icon next to it or pressing Clear All.
-
+-   Insert All Products, Filter Products by Attribute and Active filter blocks into a page.
+-   Publish the page.
+-   Go to Frontend on same page which created in above step.
+-   Apply filter for any attribute.
+-   Verify you can remove attribute filters either using the cross icon next to it or pressing Clear All.
 
 ### Products by Category: Moved renderEmptyResponsePlaceholder to separate method to prevent unnecessary rerender. ([4751](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4751))
 
-- Go to a new or existing page and add the "Products by Category" block
-- Select a category with products in it.
-- Select and unselect the block.
-- The block should no longer go into loading state and rerender products again.
-
+-   Go to a new or existing page and add the "Products by Category" block
+-   Select a category with products in it.
+-   Select and unselect the block.
+-   The block should no longer go into loading state and rerender products again.
 
 ### Fix calculation of number of reviews in the Reviews by Category block. ([4729](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4729))
 
-- Add some reviews to some of your products.
-- Create a page and add the Reviews by Category block.
-- Verify the counter shows the correct number of reviews. Take special attention to categories with more than one review and categories with subcategories.
+-   Add some reviews to some of your products.
+-   Create a page and add the Reviews by Category block.
+-   Verify the counter shows the correct number of reviews. Take special attention to categories with more than one review and categories with subcategories.
 
 #### Screenshots
 
-| Before | After |
-| --- | --- |
+| Before                                                                                                                     | After                                                                                                                     |
+| -------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
 | ![Before screenshot](https://user-images.githubusercontent.com/3616980/132999205-923856f1-47f7-4a34-b3e4-c823ec9c5623.png) | ![After screenshot](https://user-images.githubusercontent.com/3616980/132999179-691761f0-1396-459d-a3f8-f79261bcd9b4.png) |
 
 ### Removed `wp-blocks` dependency from several frontend scripts. ([4767](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4767))
 
-- Open a page with the Cart block.
-- In the browser devtools, open the Network tab.
-- Search for a JS script with this part in the name `blocks/index.min.js`.
-- Verify it isn't there meaning it was loaded.
+-   Open a page with the Cart block.
+-   In the browser devtools, open the Network tab.
+-   Search for a JS script with this part in the name `blocks/index.min.js`.
+-   Verify it isn't there meaning it was loaded.
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/600.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/610.md
+++ b/docs/testing/releases/610.md
@@ -3,17 +3,22 @@
 Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.com/woocommerce/woocommerce-gutenberg-products-block/files/7329441/woocommerce-gutenberg-products-block.zip)
 
 ## Feature Plugin
+
 ### Remove IntersectionObserver shim in favor of dropping IE11 support. ([4808](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4808))
+
 1. Smoke test the Cart block and ensure no errors appear in the console
 
 ## Feature plugin and package inclusion in WooCommerce
 
 ### Product categories list block hierarchy display fix ([4920](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4920))
+
 1. Create 4 WooCommerce product categories, each one nested under the previous one created, like follows:
-- Level 1
-  - Level 2
-    - Level 3
-      - Level 4
+
+-   Level 1
+    -   Level 2
+        -   Level 3
+            -   Level 4
+
 2. Add a product to the last category
 3. To a page, add the block Product Categories List
 4. Under the block settings > List settings > Display style, pick "Dropdown"
@@ -21,28 +26,34 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 6. Save and view page
 
 ### Fixed string translations within the All Products Block. ([4897](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4897))
+
 1. Switch to Brazilian Portuguese translation.
-2. View the all products block. Confirm sale badges are translated to "Oferta".  
+2. View the all products block. Confirm sale badges are translated to "Oferta".
 
 ### Filter By Price: Update aria values to be more representative of the actual values presented. ([4839](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4839))
+
 1. Add the Filter By Price block to your All Products page
 2. Turn Voice Over on your Mac (click the power button 3 times to do this)
 3. Move the slider back and forth, the voice should say "Ninety" instead of "Nine thousand" for example.
 
 ### Fixed: Filter button from Filter Products by Attribute block is not aligned with the input field. ([4814](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4814))
+
 1. Add the Filter Products by Attribute block and select 'Display Style: Dropdown' and check 'Filter button'.
 2. See the filter button aligned correctly on both editor and front end.
 
 ### Prefix the search input id with wc- instead of wp- ([4882](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4882))
+
 1. Add a WordPress search block to a page.
 2. Add a Product search block to the same page.
 3. Go to frontend and open the browser tools console, ensure no errors about elements with non-unique IDs appear (relating to the search box ID).
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/610.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/620.md
+++ b/docs/testing/releases/620.md
@@ -5,42 +5,50 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 ## Feature Plugin
 
 ### Cart v2: The cart block, like checkout block, now supports inner blocks that allow for greater customizability. ([4973](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4973))
+
 1. Insert the Cart block into a new page and smoke test the following functionality:
-- Confirm you can select inner blocks in the Cart.
-- Change some settings of inner blocks. Preview your changes and make sure they persist on the frontend of your store.
-- Using the Cart block's toolbar switch from the Filled Cart to the Empty Cart. Confirm you can switch back and forth between boths states.
-- Change the content of the empty cart. Preview your changes and make sure they persist on the frontend of your store.
-- Add custom classnames. They should persist on all blocks.
-- Change the alignment options. Again, changes should persist.
-- On frontend of your store, you should see a loading indicator before seeing your cart.
-- On frontend of your store, add an item to your cart. Now when you empty your cart, the cart should change to the empty cart state.
+
+-   Confirm you can select inner blocks in the Cart.
+-   Change some settings of inner blocks. Preview your changes and make sure they persist on the frontend of your store.
+-   Using the Cart block's toolbar switch from the Filled Cart to the Empty Cart. Confirm you can switch back and forth between boths states.
+-   Change the content of the empty cart. Preview your changes and make sure they persist on the frontend of your store.
+-   Add custom classnames. They should persist on all blocks.
+-   Change the alignment options. Again, changes should persist.
+-   On frontend of your store, you should see a loading indicator before seeing your cart.
+-   On frontend of your store, add an item to your cart. Now when you empty your cart, the cart should change to the empty cart state.
 
 ### Fix custom classname support for inner checkout blocks. ([4978](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4978))
+
 1. Smoke test the Checkout block.
 2. Confirm you can add classnames to the Checkout block's inner blocks and that they persist on the frontend of your store.
-- Select an inner block e.g. the shipping address.
-- In the block's sidebar settings, open the Advanced section.
-- Add additional CSS class(es).
-- Preview the changes on the frontend of your store.
-- Inspect the inner block using your browser's developer tools and confirm the class(es) are present.
+
+-   Select an inner block e.g. the shipping address.
+-   In the block's sidebar settings, open the Advanced section.
+-   Add additional CSS class(es).
+-   Preview the changes on the frontend of your store.
+-   Inspect the inner block using your browser's developer tools and confirm the class(es) are present.
 
 ### Fix a bug in free orders and trial subscription products. ([4955](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4955))
-1. Create a free ($0) virtual product. Add only this product to the cart.
-3. View the Checkout block on the frontend of your store. The Payment and Express Payment steps shouldn't show.
-4. Place the order. You should not see an error.
+
+1. Create a free (\$0) virtual product. Add only this product to the cart.
+2. View the Checkout block on the frontend of your store. The Payment and Express Payment steps shouldn't show.
+3. Place the order. You should not see an error.
 
 ## Feature plugin and package inclusion in WooCommerce
 
 ### Improve accessibility for the editor view of the Product search block. ([4905](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4905))
+
 1. Create a new post and add the Product Search block.
 2. Start a Screen reader e.g. toggle VoiceOver on macOS by pressing Command+F5.
 3. Select the Search label block and confirm that it's announced as Search label.
 
 ### Remove duplicate attributes in saved block HTML. ([4941](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4941))
+
 1. Smoke test that all WooCommerce Blocks render on the frontend of your store.
 2. Add the Checkout block to a page and save. Smoke test that it works as expected both in the editor and on the frontend of your store.
 
 ### Fix render error of Filter by Attribute block when no attribute is selected. ([4847](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4847))
+
 1. Ensure your store has no product attributes set up. You can delete them on the Products > Attributes page.
 2. Create a new product attribute with no products assigned to it.
 3. Create a new page and add the Filter by Attribute block.
@@ -48,13 +56,15 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 5. Confirm a related warning message appears.
 6. Edit the block using the pencil icon in the block toolbar.
 7. Select the previously created attribute that isn't assigned to any product.
-7. Confirm a different warning message appears.
+8. Confirm a different warning message appears.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/620.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/630.md
+++ b/docs/testing/releases/630.md
@@ -112,10 +112,12 @@ Example of button text for the Hand-picked Products block:
 3. Verify that the sale badge is aligned on the right.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/630.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/631.md
+++ b/docs/testing/releases/631.md
@@ -15,10 +15,12 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 7. Finalize the order and verify that the new shipping address is visible on the order details.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/631.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/632.md
+++ b/docs/testing/releases/632.md
@@ -14,10 +14,12 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 6. Confirm that the block gets deleted in the editor.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/632.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/633.md
+++ b/docs/testing/releases/633.md
@@ -4,7 +4,7 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 
 ## Feature plugin and package inclusion in WooCommerce
 
-###  Check that functions gutenberg_supports_block_templates and gutenberg_get_block_template exist before usages. ([5183](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5183))
+### Check that functions gutenberg_supports_block_templates and gutenberg_get_block_template exist before usages. ([5183](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5183))
 
 1. Make sure Gutenberg is NOT active on your site
 2. Install the [WordPress Beta Tester plugin](https://wordpress.org/plugins/wordpress-beta-tester/).
@@ -12,11 +12,14 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 4. Go to Dashboard > Updates and click "Update to latest 5.9 nightly".
 5. After updating to e.g. WP 5.9-alpha-52211 navigate to `/shop`.
 6. Verify there is no fatal error in `/shop`.
+
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/633.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/640.md
+++ b/docs/testing/releases/640.md
@@ -7,23 +7,28 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 ### Switch variables round in the error message of `mustContain` validation function. ([5155](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5155))
 
 1. Install the [Simple Custom CSS and JS](https://wordpress.org/plugins/custom-css-js/) plugin and, inside its settings, add this JS code to the footer:
+
 ```js
 wc.blocksCheckout.__experimentalRegisterCheckoutFilters( 'my-test-extension', {
-		subtotalPriceFormat: ( value ) => 'test',
-	} );
+	subtotalPriceFormat: ( value ) => 'test',
+} );
 ```
+
 2. Visit the Cart or Checkout block and ensure the error message reads `Error: Returned value must include "<price/>", you passed "test"`
 3. Change the code to
+
 ```js
 wc.blocksCheckout.__experimentalRegisterCheckoutFilters( 'my-test-extension', {
-		subtotalPriceFormat: ( value ) => '<price/>test',
-	} );
+	subtotalPriceFormat: ( value ) => '<price/>test',
+} );
 ```
+
 4. Reload the page and verify the Cart and Checkout block loads correctly.
 
 <img src="https://user-images.githubusercontent.com/5656702/141991343-fd10d3c3-a04f-4486-ac2b-505f8cba3ac0.png" alt="" width="642" />
 
 ### Lazy load missing translation files. ([5112](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5112))
+
 1. Switch the site language to Spanish.
 2. Update the translations via `WP Admin → Dashboard → Translations → Update Translations`.
 3. Create a test page, add the Checkout block and save it.
@@ -36,6 +41,7 @@ wc.blocksCheckout.__experimentalRegisterCheckoutFilters( 'my-test-extension', {
 ![#5005-German-after](https://user-images.githubusercontent.com/3323310/140933183-0887538e-5c3a-4161-aef8-bd53ac8463dc.png)
 
 ### Checkout Terms Block: Fix Terms and Conditions checkbox position in editor. ([5191](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5191))
+
 1. Go to the post editor.
 2. Add Checkout block.
 3. Select **Terms and Conditions** child block.
@@ -45,25 +51,29 @@ wc.blocksCheckout.__experimentalRegisterCheckoutFilters( 'my-test-extension', {
 ![Screen Shot 2021-11-18 at 23 34 05](https://user-images.githubusercontent.com/1847066/142507675-5cd34956-8bdf-41b2-9f3d-eff00928f548.png)
 
 ### Fix manual entry within Quantity Inputs. ([5197](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5197))
-- Add a product to your cart.
-- Go to a page with the Cart block.
-- Try typing a quantity into the line item.
-- Totals should update.
-- Try typing a letter. Input should be ignored and reset to `1`.
+
+-   Add a product to your cart.
+-   Go to a page with the Cart block.
+-   Try typing a quantity into the line item.
+-   Totals should update.
+-   Try typing a letter. Input should be ignored and reset to `1`.
 
 ## Feature plugin and package inclusion in WooCommerce
 
 ### Feature gate WC Block Templates to WC v6.0.0. ([5210](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5210))
+
 1. Install and activate version 11.9.1 of [the Gutenberg plugin](https://wordpress.org/plugins/gutenberg/).
 2. Install and activate a FSE enabled theme, such as [the TT1 Blocks theme](https://wordpress.org/themes/tt1-blocks/).
 3. In WC 5.9, check that block templates are not loading. You can verify that going to a single product page (ie: Cap) and verify that contents don't appear twice.
 4. Also check the templates are not loading in the Site Editor (Appearance > Editor > Templates > General templates -- if this last folder doesn't exist, that means this is testing well).
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/640.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/650.md
+++ b/docs/testing/releases/650.md
@@ -33,10 +33,12 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 4. Should see relevant search results based on search
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/650.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/660.md
+++ b/docs/testing/releases/660.md
@@ -36,7 +36,7 @@ Add the following block markup to the following templates so you know which one 
 
 Template:
 
-```
+```html
 <!-- wp:paragraph -->
 <p>Woo Blocks: [template-filename].html</p>
 <!-- /wp:paragraph -->
@@ -148,10 +148,12 @@ This requires Stripe and a saved payment method.
 4. Verify the template name is not editable.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/660.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/670.md
+++ b/docs/testing/releases/670.md
@@ -87,10 +87,12 @@ On an store with no products add the Query Monitor extension, then:
 4. Verify that the options within the Filter Products by Attribute and Filter Products by Stock blocks are not underlined.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/670.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/671.md
+++ b/docs/testing/releases/671.md
@@ -15,10 +15,12 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 7. Notice that you can successfully place the order and no `payment_data[0][value] is not of type string.boolean` error is showed.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/671.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/672.md
+++ b/docs/testing/releases/672.md
@@ -16,10 +16,12 @@ Note: This is mostly regression testing.
 -   Check that we're now not receiving 404 network requests for WooCommerce templates on the Site Editor templates list page as described here: https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5327
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/672.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/673.md
+++ b/docs/testing/releases/673.md
@@ -11,10 +11,12 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 3. Check that `Mini Cart` template is NOT visible.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/673.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/680.md
+++ b/docs/testing/releases/680.md
@@ -180,10 +180,12 @@ Install the [Stripe Payment Method Extension](https://github.com/woocommerce/woo
 16. Check if these styles have priority over the styles from the Site Editor.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/680.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/690.md
+++ b/docs/testing/releases/690.md
@@ -64,11 +64,14 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 3. Open settings sidebar.
 4. Activate Account Options » Allow shoppers to sign up for a user account during checkout.
 5. Verify that the Create an account? section has [sufficient top margin](https://user-images.githubusercontent.com/3323310/150910947-7e54c5cc-6f65-4eb9-8a9b-16328d0af2c1.png) as opposed to [being crammed](https://user-images.githubusercontent.com/3323310/150910955-97d4fb04-a619-40ce-8758-32ba4aa90bb0.png).
+
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/690.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/700.md
+++ b/docs/testing/releases/700.md
@@ -122,10 +122,12 @@ The following components have been converted to TypeScript, hence they benefit f
 6. Confirm `View cart` action is centred under the `Add to cart` button and not broken into two lines
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/700.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/710.md
+++ b/docs/testing/releases/710.md
@@ -23,7 +23,7 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 4. Click the Edit icon in the block toolbar. Select the `Add To Cart Button`.
 5. On the right sidebar, personalize the styles of the block. Click Done & save.
 6. View the post on the Frontend and confirm your changes changes.
-7. Reset to default using the `Reset` button from the different sections. 
+7. Reset to default using the `Reset` button from the different sections.
 8. Go to Dashboard and select Appearance > Editor (beta). At the top of the screen, select Home > Browse all templates > Single Post. When the page is loaded, add the `All Products` block to the page.
 9. On the Editor page click on the `Styles` icon in the top-right corner.
 10. Verify that the `Add To Cart Button` is shown under the `Blocks` section. Personalize the block again.
@@ -46,14 +46,14 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 2. Install and enable the `Twenty Twenty-Two` theme.
 3. Select Appearance > Editor (beta).
 4. Select the dropdown next to Home and click the "Browse all templates" button.
-4. Confirm that the WooCommerce block template names appear on the list according to the following table:
+5. Confirm that the WooCommerce block template names appear on the list according to the following table:
 
-Old Title | New Title
--- | --
-Product Archive | Product Catalog
-Product Tag | Products by Tag
-Product Category | Products by Category
-Single Product | _no change_
+| Old Title        | New Title            |
+| ---------------- | -------------------- |
+| Product Archive  | Product Catalog      |
+| Product Tag      | Products by Tag      |
+| Product Category | Products by Category |
+| Single Product   | _no change_          |
 
 ### Featured Product block: Add the ability to reset to a previously set custom background image. ([5886](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5886))
 
@@ -72,10 +72,12 @@ Single Product | _no change_
 3. Visit the Cart or Checkout block in the frontend and verify the texts are translated.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/710.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/720.md
+++ b/docs/testing/releases/720.md
@@ -44,11 +44,14 @@ These instructions use WooCommerce Subscriptions as this is known to use several
 6. Fill out billing address
 7. Place order. It should succeed.
 8. Check order details. Shipping should match billing address.
+
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/720.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/releases/721.md
+++ b/docs/testing/releases/721.md
@@ -11,3 +11,14 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 3. Go to WP Admin. No notices are visible.
 4. Check the error log. See the notices there.
 5. Edit the code in this PR and remove the 7.4 from the function calls. Repeat steps 2-4 and confirm logs are used.
+
+<!-- FEEDBACK -->
+
+---
+
+[We're hiring!](https://woocommerce.com/careers/) Come work with us!
+
+🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/721.md)
+
+<!-- /FEEDBACK -->
+

--- a/docs/testing/releases/722.md
+++ b/docs/testing/releases/722.md
@@ -8,5 +8,16 @@
 
 1. Go to an atomic website (or locally with symlinked WooCommrece).
 2. Install WC Subscriptions.
-Try to open wp-admin > WooCommerce > Home (/wp-admin/admin.php?page=wc-admin).
-3. Page should load normally.
+3. Try to open wp-admin > WooCommerce > Home (/wp-admin/admin.php?page=wc-admin).
+4. Page should load normally.
+
+<!-- FEEDBACK -->
+
+---
+
+[We're hiring!](https://woocommerce.com/careers/) Come work with us!
+
+🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/722.md)
+
+<!-- /FEEDBACK -->
+

--- a/docs/testing/releases/730.md
+++ b/docs/testing/releases/730.md
@@ -25,8 +25,7 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 1. With a block theme active open the site editor.
 2. Go to Appearance > Site Editor and select one of the WooCommerce templates (for example Single Product Page).
 3. Open the List view and check that `WooCommerce Legacy Template` is now `WooCommerce Classic Template`.
-4. Click on it and check that in the right sidebar it also appears as Classic template: `WooCommerce Classic Template
-   Renders classic WooCommerce PHP templates.`
+4. Click on it and check that in the right sidebar it also appears as Classic template: `WooCommerce Classic Template Renders classic WooCommerce PHP templates.`
 
 ### Product Ratings: Add Global Styles font size and spacing support [#5927](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5927)
 
@@ -66,3 +65,14 @@ With Twenty Twenty-Two:
 2. Add this coupon to your order in the Cart block, ensure a snackbar notice appears when adding and removing the coupon.
 3. Do this multiple times and ensure the snackbar notice appears each time it changes.
 4. Repeat step 2 and 3 in the Checkout block.
+
+<!-- FEEDBACK -->
+
+---
+
+[We're hiring!](https://woocommerce.com/careers/) Come work with us!
+
+🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/730.md)
+
+<!-- /FEEDBACK -->
+

--- a/docs/testing/releases/740.md
+++ b/docs/testing/releases/740.md
@@ -30,23 +30,23 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 2. Add Featured Product and/or Featured Category blocks to a post or page.
 3. Verify the button is centered by default.
 4. Verify you can change the alignment of the button using the _Justify items_ dropdown inherited from the _Buttons_ block.
-![imatge](https://user-images.githubusercontent.com/3616980/160625173-f9ad42ed-b769-42e3-9ad8-3f3abe60b61c.png)
+   ![imatge](https://user-images.githubusercontent.com/3616980/160625173-f9ad42ed-b769-42e3-9ad8-3f3abe60b61c.png)
 5. Test again with a classic theme (ie: Storefront).
 
 ### Remove the ToggleButtonControl in favor of ToggleGroupControl. ([5967](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5967))
 
 1. Activate a **block theme**, like Twenty Twenty Two
 2. Create a new page, and add the following blocks:
-   - Active Filters
-   - Attribute Filter
-   - Price Filter
-   - Product Categories
-   - Reviews
+    - Active Filters
+    - Attribute Filter
+    - Price Filter
+    - Product Categories
+    - Reviews
 3. Open each block settings and ensure that options are using the new component's design (toggle button) and are working correctly:
 
-|Before|After|
-|-|-|
-|![OLD](https://user-images.githubusercontent.com/905781/156161666-57c4baed-9d17-4c65-8fc8-4a8d2316dfde.jpg)|![new](https://user-images.githubusercontent.com/905781/156161720-b962056e-be7f-40ca-9173-52a72443b01a.jpg)|
+| Before                                                                                                      | After                                                                                                       |
+| ----------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| ![OLD](https://user-images.githubusercontent.com/905781/156161666-57c4baed-9d17-4c65-8fc8-4a8d2316dfde.jpg) | ![new](https://user-images.githubusercontent.com/905781/156161720-b962056e-be7f-40ca-9173-52a72443b01a.jpg) |
 
 ## Feature Plugin
 
@@ -55,14 +55,16 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 1. Go to a page and add the Checkout block.
 2. Go to a page and add the Cart block
 3. In the editor, inside each block, select the Order summary and notice that you can select the following inner blocks:
-    | Cart | Checkout |
-    | --------------- | --------------- |
-    |  Heading, Subtotal, Cart Items, Fees, Coupon Form, Shipping, Taxes | Subtotal, Cart Items, Fees, Coupon Form, Shipping, Taxes |
+
+    | Cart                                                              | Checkout                                                 |
+    | ----------------------------------------------------------------- | -------------------------------------------------------- |
+    | Heading, Subtotal, Cart Items, Fees, Coupon Form, Shipping, Taxes | Subtotal, Cart Items, Fees, Coupon Form, Shipping, Taxes |
+
 4. Try to move some of the inner blocks and save. Confirm that in the Cart block only Order Summary Heading and the Coupon form inner blocks can be removed, and for the Checkout block only the Coupon form.
 5. Check on the website that your changes are reflected. Note that Taxes, Fees and Coupons will appear on the website only if the shop supports them.
 6. For the Cart > Shipping inner block make sure you can enable disable the shipping calculator and that the change is visibile in the website
-7. Enable Taxes on your website (`/wp-admin/admin.php?page=wc-settings`) by clicking  `Enable tax rates and calculations`
-8. Go to the C & C blocks and select the Taxes inner block. 
+7. Enable Taxes on your website (`/wp-admin/admin.php?page=wc-settings`) by clicking `Enable tax rates and calculations`
+8. Go to the C & C blocks and select the Taxes inner block.
 9. In the inner block's setting toggle on / of `Show rate after tax name` and make sure that is reflected in the website
 10. Try to place an order and make sure it's successful.
 
@@ -70,3 +72,14 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 
 1. Go to the shop page and add any product to the cart
 2. Go to the Cart block page and increase product quantity to 9999
+
+<!-- FEEDBACK -->
+
+---
+
+[We're hiring!](https://woocommerce.com/careers/) Come work with us!
+
+🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/740.md)
+
+<!-- /FEEDBACK -->
+

--- a/docs/testing/releases/741.md
+++ b/docs/testing/releases/741.md
@@ -8,5 +8,16 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 
 1. Go to an atomic website (or locally with symlinked WooCommrece).
 2. Install WC Subscriptions.
-Try to open wp-admin > WooCommerce > Home (/wp-admin/admin.php?page=wc-admin).
+   Try to open wp-admin > WooCommerce > Home (/wp-admin/admin.php?page=wc-admin).
 3. Page should load normally.
+
+<!-- FEEDBACK -->
+
+---
+
+[We're hiring!](https://woocommerce.com/careers/) Come work with us!
+
+🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/741.md)
+
+<!-- /FEEDBACK -->
+

--- a/docs/testing/releases/742.md
+++ b/docs/testing/releases/742.md
@@ -2,19 +2,31 @@
 
 [woocommerce-gutenberg-products-block.zip](https://github.com/woocommerce/woocommerce-gutenberg-products-block/files/8496130/woocommerce-gutenberg-products-block.zip)
 
-
 ## Feature plugin and package inclusion in WooCommerce
 
 ### Fix bug with server errors not showing in Cart/Checkout. ([6268](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/6268))
 
 #### Checkout
+
 1. Create a Simple Product that is in stock.
 2. Add it to the cart.
 3. Navigate to the checkout block.
 4. Change the stock status to "Out of stock" and place the order. Ensure an error notice appears at the top of the Checkout block.
 
 #### Cart
+
 1. Create a Simple Product that is in stock.
 2. Add it to the cart.
 3. Change the stock status to "Out of stock" and refresh the page.
 4. Ensure a notice informing the customer that there is an out of stock product in the cart appears at the top of the block.
+
+<!-- FEEDBACK -->
+
+---
+
+[We're hiring!](https://woocommerce.com/careers/) Come work with us!
+
+🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/742.md)
+
+<!-- /FEEDBACK -->
+

--- a/docs/testing/releases/750.md
+++ b/docs/testing/releases/750.md
@@ -5,13 +5,15 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 ## Feature plugin and package inclusion in WooCommerce
 
 ### Add PHP templates support to the Active Product Filters block. ([6295](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/6295))
+
 1. With a block theme, go to Edit Site > Product Catalog.
 2. Add `Active Product Filters`, `Filter Products by Stock`, `Filter Products by Attribute`, `Filter Products by Price` blocks to the template.
 3. Go to the shop page on the front end.
 4. Select some filters, see the page reload and the selected filters appear in the Active Products Filters block.
 5. Remove an arbitrary filter, see the page reload and the removed filter doesn't appear in the Active Product Filters block. See the filtered product results updates accordingly.
 
-### Enhanced the *Featured Category block* ([6276](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/6276)):
+### Enhanced the _Featured Category block_ ([6276](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/6276)):
+
 1. Use a block theme (such as Twenty Twenty Two)
 2. Add the ”Featured Category” block to a page and select a product.
 3. Make sure that the resizable handle is a shown fully (it should be a full circle), and that is shown only when the block is selected.
@@ -23,14 +25,17 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 9. Increase the `padding-top` of the block and notice that the content can't get pushed out of the container, but instead the container resizes.
 10. When that's the case, try resizing the block through the handle to a lower height: the handle should move but the container should not resize. When the mouse is lifted, the handle should return to its original position.
 11. For the steps 4–9 above, save the page and check that the styles are applied correctly on the front-end (as the block is rendered statically via PHP).
-###  Allow adding the Filter Products by Stock block to Product Catalog templates to filter products. ([6261](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/6261))
+
+### Allow adding the Filter Products by Stock block to Product Catalog templates to filter products. ([6261](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/6261))
+
 1. With a block theme, go to Appearance > Editor > Template > Product Catalog.
 2. Add the Filter Products by Stock block above the product grid.
 3. Be sure that you have some out stock products. Check "out of stock" on the frontend.
 4. Notice the page reloads and the list of products updates accordingly.
 5. Add a test page to your site with the `All Products` block, and the `Filter Product by Stock` block and ensure no regressions have been introduced here.
 
-###  Enhanced the *Featured Product block* ([6181](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/6181)):
+### Enhanced the _Featured Product block_ ([6181](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/6181)):
+
 1. Use a block theme (such as Twenty Twenty Two)
 2. Add the ”Featured Product” block to a page and select a product.
 3. Make sure that the resizable handle is a shown fully (it should be a full circle), and that is shown only when the block is selected.
@@ -42,23 +47,29 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 9. Increase the `padding-top` of the block and notice that the content can't get pushed out of the container, but instead the container resizes.
 10. When that's the case, try resizing the block through the handle to a lower height: the handle should move but the container should not resize. When the mouse is lifted, the handle should return to its original position.
 11. For the steps 4–9 above, save the page and check that the styles are applied correctly on the front-end (as the block is rendered statically via PHP).
-###  Allow saved payment methods labels other than card/eCheck to display brand & last 4 digits if present. ([6177](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/6177))
+
+### Allow saved payment methods labels other than card/eCheck to display brand & last 4 digits if present. ([6177](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/6177))
+
 1. Install latest dev/release version of WooCommerce Payments & setup an account in [dev mode](https://woocommerce.com/document/payments/testing/dev-mode/).
-2. Under WooCommerce Payments -> Settings, Enable the new WooCommerce Payments checkout experience and add new payment methods. 
+2. Under WooCommerce Payments -> Settings, Enable the new WooCommerce Payments checkout experience and add new payment methods.
     - This _should_ have enabled Euros in Multi-Currency automatically, but if not, go to WooCommerce > Settings > Multi-Currency and enable Euros as an additional currency.
 3. Save SEPA account to your customer account in one of two ways:
 
     - Add item to your cart and go to the classic checkout page, select SEPA, enter the account, and choose Save payment information to my account for future purchases., then check out.
     - Go to My Account > Payment Methods, and add the SEPA method there.
     - SEPA account to useAT611904300234573201 or other test numbers available here: https://stripe.com/docs/testing#sepa-direct-debit
+
 4. Once the SEPA method is saved, add an item to your cart and go to the page with the checkout block.
 5. Confirm that under Payment options you will see SEPA IBAN ending in 3201.
 
 ### Store API: Allow Store API to filter products by custom taxonomies. ([6152](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/6152))
+
 1. Add an All Products Block to a page, add the Filter Products by Attribute Block, and Filter by Price Block too.
 2. Go to the page and use the filters, ensure they update the All Products Block correctly.
+
 ### Filter Products by Attribute: Fix the page reload which happens when clicking the filter button on Woo templates using the Classic Template block. ([6287](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/6287))
-1. On a block theme, go to Edit Site >  Product Catalog template.
+
+1. On a block theme, go to Edit Site > Product Catalog template.
 2. Add Active Filters and Filter Products by Attribute block to the template.
 3. Choose an attribute to filter, and make sure the filter button is toggled.
 4. Go to the shop page.
@@ -66,42 +77,53 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 6. Once the filter has been applied. Uncheck it, a reload should not happen until you click the filter button.
 7. Try this again with the filter button untoggled, although these reloads should now happen as soon as you check the attribute you're filtering by
 8. Check there are no regressions on All Products block.
+
 ### Store API: Show visible attributes in simple products, and hidden attributes in variable products. ([6274](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/6274))
+
 1. Create a simple product with attributes and set them as visible.
 2. Using a REST client, fetch `wc/store/v1/products/:id` and check the attributes field for the product where `:id` is the product id, in both cases, you should see the attributes you added.
 3. Uncheck visible attributes, fetch your product again, no attributes should be returned.
 4. Turn the product into a variable product, keep attributes hidden but check "used for variations".
 5. Fetch your product again, you should see your attributes.
 6. Make them visible, you should still see the attributes.
+
 ### Add RTL support for the Mini Cart icon. ([6264](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/6264))
+
 1. Add Mini Cart to the site (Header for block themes, Sidebar for classic theme).
 2. Set the language to an RTL language (ie: Arabic).
 3. See the Mini Cart looks good on the front end.
 
 ### Fix page load problem due to incorrect URL to certain assets. ([6260](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/6260))
+
 1. Install WC 6.4 but move and symlink its folder.
+
 ```
 mv wp-content/plugins/woocommerce ~/Desktop/woocommerce
 ln -s ~/Desktop/woocommerce wp-content/plugins/woocommerce
 ```
 
 2. Install WooCommerce Subscriptions.
-
 3. Try to open wp-admin > WooCommerce > Home (/wp-admin/admin.php?page=wc-admin). With base branch, expect a blank page. With this PR branch, expect page loads normally.
+
 ### Make Filters Products by Price work with Active Filters block for the PHP rendered Classic Template. ([6245](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/6245))
+
 1. Add the `Filter Products by Price` block & `Active Filters` block to the **Shop** Page
 2. Open the **Shop** page
 3. Use the `Filter Products by Price` block, the page should reload with the filter params now being in the URL too.
 4. Check the `Active Filters` block shows the active price filter.
+
 ### Fix attribute filter dropdown list z-index level. ([6294](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/6294))
+
 1. Create new page with Filter Products by Attribute and All Products block right under
 2. Configure Filter block to use Dropdown display style and show Colour attribute (if using sample products)
 3. Have products on sale in first row
 4. Visit page and focus on field to see dropdown
 
-- All Products block Placeholder elements should be under the dropdown
-- Sale badge shouldn't bleed through the dropdown
+-   All Products block Placeholder elements should be under the dropdown
+-   Sale badge shouldn't bleed through the dropdown
+
 ### Fix Featured Product block frontend mismatch. ([6263](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/6263))
+
 1. Switch to a block-enabled theme (such as Twenty-twentytwo).
 2. Add the Featured Product block to a page.
 3. Confirm that it has a default, semi-transparent, black overlay and that a default height of 500 px or whatever the theme supports through the `featured_block::default_height` setting.
@@ -111,6 +133,7 @@ ln -s ~/Desktop/woocommerce wp-content/plugins/woocommerce
 7. Confirm they get correctly applied on the frontend.
 
 ### Fix Customizer fatal error on PHP 8. ([6317](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/6317))
+
 1. Switch to PHP 8.
 2. Activate WC 6.5 beta 1 and Storefront.
 3. Apply change in this PR to `wp-content/plugins/woocommerce/packages/woocommerce-blocks/src/BlockTypes/MiniCart.php`.
@@ -118,8 +141,19 @@ ln -s ~/Desktop/woocommerce wp-content/plugins/woocommerce
 5. See no fatal error, the Customizer is loading and working as expected.
 
 ### Fix page refresh when using filters with the All Products block on non-product archive templates for WooCommerce. ([6324](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/6324))
+
 1. Activate Storefront
 2. Add the All Products block to a newly created page, along with a filter block such as Filter by Attribute
 3. Visit this page on the frontend and select some attributes to filter by.
 4. Observe the filters being applied without a page refresh.
+
+<!-- FEEDBACK -->
+
+---
+
+[We're hiring!](https://woocommerce.com/careers/) Come work with us!
+
+🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/750.md)
+
+<!-- /FEEDBACK -->
 

--- a/docs/testing/releases/760.md
+++ b/docs/testing/releases/760.md
@@ -7,14 +7,16 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 ### Featured Category: Add background color option. ([6368](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/6368))
 
 Prerequisites:
-- Use the latest WordPress version (we want to use the site editor / Global Styles in testing).
-- Install & use a block theme e.g.[ Twenty Twenty-Two](https://pcm.wordpress.org/themes/twentytwentytwo/).
-- **Deactivate** the Gutenberg plugin for testing as we're currently observing [this issue](https://github.com/WordPress/gutenberg/issues/40808).
+
+-   Use the latest WordPress version (we want to use the site editor / Global Styles in testing).
+-   Install & use a block theme e.g.[ Twenty Twenty-Two](https://pcm.wordpress.org/themes/twentytwentytwo/).
+-   **Deactivate** the Gutenberg plugin for testing as we're currently observing [this issue](https://github.com/WordPress/gutenberg/issues/40808).
+
 1. Create a new post/page.
 2. In the editor, add two `Featured Category` blocks.
 3. For each block select the same category, it should have a product picture.
 4. Select each block and use the Replace button in the block toolbar to add a product image smaller than the Featured Category block (for an example see screenshots above).
-5. Now select the first `Featured Category` block. In the editor sidebar's `Color` section of the block select a `Background` color. The background color should be visible in the parts not covered by the product image. 
+5. Now select the first `Featured Category` block. In the editor sidebar's `Color` section of the block select a `Background` color. The background color should be visible in the parts not covered by the product image.
 6. Save your post/page.
 7. In the admin dashboard navigate to `Appearance` > `Editor` (`/wp-admin/site-editor.php`).
 8. Open the Styles sidebar by clicking the round Styles icon in the top right of the editor.
@@ -27,14 +29,16 @@ Prerequisites:
 ### Featured Product: Add background color option. ([6367](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/6367))
 
 Prerequisites:
-- Use the latest WordPress version (we want to use the site editor / Global Styles in testing).
-- Install & use a block theme e.g.[ Twenty Twenty-Two](https://pcm.wordpress.org/themes/twentytwentytwo/).
-- **Deactivate** the Gutenberg plugin for testing as we're currently observing [this issue](https://github.com/WordPress/gutenberg/issues/40808).
+
+-   Use the latest WordPress version (we want to use the site editor / Global Styles in testing).
+-   Install & use a block theme e.g.[ Twenty Twenty-Two](https://pcm.wordpress.org/themes/twentytwentytwo/).
+-   **Deactivate** the Gutenberg plugin for testing as we're currently observing [this issue](https://github.com/WordPress/gutenberg/issues/40808).
+
 1. Create a new post/page.
 2. In the editor, add two `Featured Product` blocks.
 3. For each block select the same product, it should have a product picture.
 4. Select each block and use the Crop tool in the block toolbar to crop the product image smaller than the Featured product block e.g. by setting the aspect ratio to 2:3.
-5. Now select the first `Featured Product` block. In the editor sidebar's `Color` section of the block select a `Background` color. The background color should be visible in the parts not covered by the product image. 
+5. Now select the first `Featured Product` block. In the editor sidebar's `Color` section of the block select a `Background` color. The background color should be visible in the parts not covered by the product image.
 6. Save your post/page.
 7. In the admin dashboard navigate to `Appearance` > `Editor` (`/wp-admin/site-editor.php`).
 8. Open the Styles sidebar by clicking the round Styles icon in the top right of the editor.
@@ -97,14 +101,16 @@ Prerequisites:
 
 1. Activate a **block** theme, like Twenty Twenty Two
 2. Create a new page, and add all the aforementioned, affected blocks (Handpicked Products etc.)
- - Hand-picked Products
- - Products by Tag
- - Products by Attribute
- - Products by Category
- - Best Selling Products
- - Newest Products
- - On Sale Products
- - Top Rated Products
+
+-   Hand-picked Products
+-   Products by Tag
+-   Products by Attribute
+-   Products by Category
+-   Best Selling Products
+-   Newest Products
+-   On Sale Products
+-   Top Rated Products
+
 3. Check if the **Product image** toggle is present under **Content**
 4. Verify that the toggle shows/hides product Images both in the editor and the frontend
 
@@ -113,7 +119,7 @@ Prerequisites:
 1. Active Twenty Twenty-Two.
 2. Make sure WooCommerce is setup (WC pages are installed).
 3. Edit the Shop Page, don't see the Template panel.
-5. Edit other pages, see the Template panel as normal.
+4. Edit other pages, see the Template panel as normal.
 
 ### Parse categories coming from the back-end as a json array. ([6358](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/6358))
 
@@ -134,7 +140,7 @@ Prerequisites:
 1. With Twenty Twenty-Two, add the Mini Cart block to the header template part.
 2. Edit a page using Block Editor.
 3. From the Page sidebar, edit the template.
-<img src="https://user-images.githubusercontent.com/3616980/165728750-2d1863e7-b268-4074-9d4d-fdd7b97d4e88.png" width="288" alt=""/>
+   <img src="https://user-images.githubusercontent.com/3616980/165728750-2d1863e7-b268-4074-9d4d-fdd7b97d4e88.png" width="288" alt=""/>
 4. Notice the Mini Cart block works as expected.
 
 ### Fix Filter Products by Attribute block not working on PHP templates when Filter button was enabled. ([6332](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/6332))
@@ -144,3 +150,14 @@ Prerequisites:
 3. Above the WooCommerce Classic Template block, add the Filter Products by Attribute block (making sure you only have one Filter Products by Attribute block) and set its _Filter button_ attribute to true.
 4. In the frontend, filter by attribute.
 5. Verify the page reloads and the filter is applied.
+
+<!-- FEEDBACK -->
+
+---
+
+[We're hiring!](https://woocommerce.com/careers/) Come work with us!
+
+🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/760.md)
+
+<!-- /FEEDBACK -->
+

--- a/docs/testing/releases/README.md
+++ b/docs/testing/releases/README.md
@@ -73,10 +73,12 @@ Every release includes specific testing instructions for new features and bug fi
 -   [7.6.0](./760.md)
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/releases/README.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/smoke-testing.md
+++ b/docs/testing/smoke-testing.md
@@ -18,13 +18,25 @@ To make future testing more efficient, we recommend setting up some Blocks in ad
 ```html
 <!-- wp:woocommerce/featured-product {"editMode":false,"productId":15} -->
 <!-- wp:button {"align":"center"} -->
-<div class="wp-block-button aligncenter"><a class="wp-block-button__link" href="https://ephemeral-aljullu-20200929.atomicsites.blog/product/beanie/">Shop now</a></div>
+<div class="wp-block-button aligncenter">
+	<a
+		class="wp-block-button__link"
+		href="https://ephemeral-aljullu-20200929.atomicsites.blog/product/beanie/"
+		>Shop now</a
+	>
+</div>
 <!-- /wp:button -->
 <!-- /wp:woocommerce/featured-product -->
 
 <!-- wp:woocommerce/featured-category {"editMode":false,"categoryId":16} -->
 <!-- wp:button {"align":"center"} -->
-<div class="wp-block-button aligncenter"><a class="wp-block-button__link" href="https://ephemeral-aljullu-20200929.atomicsites.blog/product-category/clothing/">Shop now</a></div>
+<div class="wp-block-button aligncenter">
+	<a
+		class="wp-block-button__link"
+		href="https://ephemeral-aljullu-20200929.atomicsites.blog/product-category/clothing/"
+		>Shop now</a
+	>
+</div>
 <!-- /wp:button -->
 <!-- /wp:woocommerce/featured-category -->
 
@@ -49,25 +61,95 @@ To make future testing more efficient, we recommend setting up some Blocks in ad
 <!-- wp:woocommerce/product-categories {"isDropdown":true} /-->
 
 <!-- wp:woocommerce/reviews-by-product {"editMode":false,"productId":15} -->
-<div class="wp-block-woocommerce-reviews-by-product wc-block-reviews-by-product has-image has-name has-date has-rating has-content" data-image-type="reviewer" data-orderby="most-recent" data-reviews-on-page-load="10" data-reviews-on-load-more="10" data-show-load-more="true" data-show-orderby="true" data-product-id="15"></div>
+<div
+	class="wp-block-woocommerce-reviews-by-product wc-block-reviews-by-product has-image has-name has-date has-rating has-content"
+	data-image-type="reviewer"
+	data-orderby="most-recent"
+	data-reviews-on-page-load="10"
+	data-reviews-on-load-more="10"
+	data-show-load-more="true"
+	data-show-orderby="true"
+	data-product-id="15"
+></div>
 <!-- /wp:woocommerce/reviews-by-product -->
 
 <!-- wp:woocommerce/reviews-by-category {"editMode":false,"categoryIds":[16]} -->
-<div class="wp-block-woocommerce-reviews-by-category wc-block-reviews-by-category has-image has-name has-date has-rating has-content has-product-name" data-image-type="reviewer" data-orderby="most-recent" data-reviews-on-page-load="10" data-reviews-on-load-more="10" data-show-load-more="true" data-show-orderby="true" data-category-ids="16"></div>
+<div
+	class="wp-block-woocommerce-reviews-by-category wc-block-reviews-by-category has-image has-name has-date has-rating has-content has-product-name"
+	data-image-type="reviewer"
+	data-orderby="most-recent"
+	data-reviews-on-page-load="10"
+	data-reviews-on-load-more="10"
+	data-show-load-more="true"
+	data-show-orderby="true"
+	data-category-ids="16"
+></div>
 <!-- /wp:woocommerce/reviews-by-category -->
 
 <!-- wp:woocommerce/all-reviews -->
-<div class="wp-block-woocommerce-all-reviews wc-block-all-reviews has-image has-name has-date has-rating has-content has-product-name" data-image-type="reviewer" data-orderby="most-recent" data-reviews-on-page-load="10" data-reviews-on-load-more="10" data-show-load-more="true" data-show-orderby="true"></div>
+<div
+	class="wp-block-woocommerce-all-reviews wc-block-all-reviews has-image has-name has-date has-rating has-content has-product-name"
+	data-image-type="reviewer"
+	data-orderby="most-recent"
+	data-reviews-on-page-load="10"
+	data-reviews-on-load-more="10"
+	data-show-load-more="true"
+	data-show-orderby="true"
+></div>
 <!-- /wp:woocommerce/all-reviews -->
 
 <!-- wp:woocommerce/product-search {"formId":"wc-block-product-search-0"} -->
-<div class="wp-block-woocommerce-product-search"><div class="wc-block-product-search"><form role="search" method="get" action="https://ephemeral-aljullu-20200929.atomicsites.blog/"><label for="wc-block-product-search-0" class="wc-block-product-search__label">Search</label><div class="wc-block-product-search__fields"><input type="search" id="wc-block-product-search-0" class="wc-block-product-search__field" placeholder="Search products…" name="s"/><input type="hidden" name="post_type" value="product"/><button type="submit" class="wc-block-product-search__button" label="Search"><svg aria-hidden="true" role="img" focusable="false" class="dashicon dashicons-arrow-right-alt2" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewbox="0 0 20 20"><path d="M6 15l5-5-5-5 1-2 7 7-7 7z"></path></svg></button></div></form></div></div>
+<div class="wp-block-woocommerce-product-search">
+	<div class="wc-block-product-search">
+		<form
+			role="search"
+			method="get"
+			action="https://ephemeral-aljullu-20200929.atomicsites.blog/"
+		>
+			<label
+				for="wc-block-product-search-0"
+				class="wc-block-product-search__label"
+				>Search</label
+			>
+			<div class="wc-block-product-search__fields">
+				<input
+					type="search"
+					id="wc-block-product-search-0"
+					class="wc-block-product-search__field"
+					placeholder="Search products…"
+					name="s"
+				/><input
+					type="hidden"
+					name="post_type"
+					value="product"
+				/><button
+					type="submit"
+					class="wc-block-product-search__button"
+					label="Search"
+				>
+					<svg
+						aria-hidden="true"
+						role="img"
+						focusable="false"
+						class="dashicon dashicons-arrow-right-alt2"
+						xmlns="http://www.w3.org/2000/svg"
+						width="20"
+						height="20"
+						viewbox="0 0 20 20"
+					>
+						<path d="M6 15l5-5-5-5 1-2 7 7-7 7z"></path>
+					</svg>
+				</button>
+			</div>
+		</form>
+	</div>
+</div>
 <!-- /wp:woocommerce/product-search -->
 ```
+
 </details>
 
-In the `wp:woocommerce/product-search` substitute the URL used for the `action` attribute to your site URL or the block will not embedd correctly. 
-
+In the `wp:woocommerce/product-search` substitute the URL used for the `action` attribute to your site URL or the block will not embedd correctly.
 
 ### 2. Create a page with the All Products Block, and some Filter Blocks, setup to test that functionality in isolation. Using the columns block here too is a good idea to keep things organized.
 
@@ -76,70 +158,126 @@ In the `wp:woocommerce/product-search` substitute the URL used for the `action` 
 
 ```html
 <!-- wp:columns -->
-<div class="wp-block-columns"><!-- wp:column {"width":33.33} -->
-<div class="wp-block-column" style="flex-basis:33.33%"><!-- wp:woocommerce/price-filter -->
-<div class="wp-block-woocommerce-price-filter is-loading" data-showinputfields="true" data-showfilterbutton="false" data-heading="Filter by price" data-heading-level="3"><span aria-hidden="true" class="wc-block-product-categories__placeholder"></span></div>
-<!-- /wp:woocommerce/price-filter -->
+<div class="wp-block-columns">
+	<!-- wp:column {"width":33.33} -->
+	<div class="wp-block-column" style="flex-basis:33.33%">
+		<!-- wp:woocommerce/price-filter -->
+		<div
+			class="wp-block-woocommerce-price-filter is-loading"
+			data-showinputfields="true"
+			data-showfilterbutton="false"
+			data-heading="Filter by price"
+			data-heading-level="3"
+		>
+			<span
+				aria-hidden="true"
+				class="wc-block-product-categories__placeholder"
+			></span>
+		</div>
+		<!-- /wp:woocommerce/price-filter -->
 
-<!-- wp:woocommerce/attribute-filter {"attributeId":1,"heading":"Filter by Color","displayStyle":"dropdown"} -->
-<div class="wp-block-woocommerce-attribute-filter is-loading" data-attribute-id="1" data-show-counts="true" data-query-type="or" data-heading="Filter by Color" data-heading-level="3" data-display-style="dropdown"><span aria-hidden="true" class="wc-block-product-attribute-filter__placeholder"></span></div>
-<!-- /wp:woocommerce/attribute-filter -->
+		<!-- wp:woocommerce/attribute-filter {"attributeId":1,"heading":"Filter by Color","displayStyle":"dropdown"} -->
+		<div
+			class="wp-block-woocommerce-attribute-filter is-loading"
+			data-attribute-id="1"
+			data-show-counts="true"
+			data-query-type="or"
+			data-heading="Filter by Color"
+			data-heading-level="3"
+			data-display-style="dropdown"
+		>
+			<span
+				aria-hidden="true"
+				class="wc-block-product-attribute-filter__placeholder"
+			></span>
+		</div>
+		<!-- /wp:woocommerce/attribute-filter -->
 
-<!-- wp:woocommerce/attribute-filter {"attributeId":2,"heading":"Filter by Size"} -->
-<div class="wp-block-woocommerce-attribute-filter is-loading" data-attribute-id="2" data-show-counts="true" data-query-type="or" data-heading="Filter by Size" data-heading-level="3"><span aria-hidden="true" class="wc-block-product-attribute-filter__placeholder"></span></div>
-<!-- /wp:woocommerce/attribute-filter -->
+		<!-- wp:woocommerce/attribute-filter {"attributeId":2,"heading":"Filter by Size"} -->
+		<div
+			class="wp-block-woocommerce-attribute-filter is-loading"
+			data-attribute-id="2"
+			data-show-counts="true"
+			data-query-type="or"
+			data-heading="Filter by Size"
+			data-heading-level="3"
+		>
+			<span
+				aria-hidden="true"
+				class="wc-block-product-attribute-filter__placeholder"
+			></span>
+		</div>
+		<!-- /wp:woocommerce/attribute-filter -->
 
-<!-- wp:woocommerce/active-filters -->
-<div class="wp-block-woocommerce-active-filters is-loading" data-display-style="list" data-heading="Active filters" data-heading-level="3"><span aria-hidden="true" class="wc-block-active-product-filters__placeholder"></span></div>
-<!-- /wp:woocommerce/active-filters --></div>
-<!-- /wp:column -->
+		<!-- wp:woocommerce/active-filters -->
+		<div
+			class="wp-block-woocommerce-active-filters is-loading"
+			data-display-style="list"
+			data-heading="Active filters"
+			data-heading-level="3"
+		>
+			<span
+				aria-hidden="true"
+				class="wc-block-active-product-filters__placeholder"
+			></span>
+		</div>
+		<!-- /wp:woocommerce/active-filters -->
+	</div>
+	<!-- /wp:column -->
 
-<!-- wp:column {"width":66.66} -->
-<div class="wp-block-column" style="flex-basis:66.66%"><!-- wp:woocommerce/all-products {"columns":3,"rows":3,"alignButtons":false,"contentVisibility":{"orderBy":true},"orderby":"date","layoutConfig":[["woocommerce/product-image"],["woocommerce/product-title"],["woocommerce/product-price"],["woocommerce/product-rating"],["woocommerce/product-button"]]} -->
-<div class="wp-block-woocommerce-all-products wc-block-all-products" data-attributes="{&quot;alignButtons&quot;:false,&quot;columns&quot;:3,&quot;contentVisibility&quot;:{&quot;orderBy&quot;:true},&quot;isPreview&quot;:false,&quot;layoutConfig&quot;:[[&quot;woocommerce/product-image&quot;],[&quot;woocommerce/product-title&quot;],[&quot;woocommerce/product-price&quot;],[&quot;woocommerce/product-rating&quot;],[&quot;woocommerce/product-button&quot;]],&quot;orderby&quot;:&quot;date&quot;,&quot;rows&quot;:3}"></div>
-<!-- /wp:woocommerce/all-products --></div>
-<!-- /wp:column --></div>
+	<!-- wp:column {"width":66.66} -->
+	<div class="wp-block-column" style="flex-basis:66.66%">
+		<!-- wp:woocommerce/all-products {"columns":3,"rows":3,"alignButtons":false,"contentVisibility":{"orderBy":true},"orderby":"date","layoutConfig":[["woocommerce/product-image"],["woocommerce/product-title"],["woocommerce/product-price"],["woocommerce/product-rating"],["woocommerce/product-button"]]} -->
+		<div
+			class="wp-block-woocommerce-all-products wc-block-all-products"
+			data-attributes='{"alignButtons":false,"columns":3,"contentVisibility":{"orderBy":true},"isPreview":false,"layoutConfig":[["woocommerce/product-image"],["woocommerce/product-title"],["woocommerce/product-price"],["woocommerce/product-rating"],["woocommerce/product-button"]],"orderby":"date","rows":3}'
+		></div>
+		<!-- /wp:woocommerce/all-products -->
+	</div>
+	<!-- /wp:column -->
+</div>
 <!-- /wp:columns -->
 ```
 
 </details>
 
-
 ### 3. Add the Cart and Checkout block to the relevant WooCommerce pages.
 
 ## Editor Tests
 
-* [ ] Ensure all WooCommerce Blocks are shown in the Block Inserter.
-* [ ] Check behaviour of Blocks added to a previous saved page from earlier plugin version
-    * [ ] Do they look correct?
-    * [ ] Ensure there are no block invalidation errors for blocks added to a page in a prior version.
-    * [ ] Can you change options/attributes in the Block inspector?
-    * [ ] Are changes persisted on save?
-    * [ ] Is the Browser error console free from errors/notices/warnings?
-* [ ] Test inserting various blocks into the editor
-    * [ ] This can be verified by copying and pasting the code examples above. However, please do also test manually inserting the next three blocks as representative examples for related blocks.
-    * [ ] All Products Blocks (this is powered by the Store API)
-    * [ ] Featured Product (this is powered by the REST API)
-    * [ ] On Sale Products (this is SSR)
-    * [ ] Is the Browser error console free from errors/notices/warnings after inserting them?
-    * [ ] Do they persist and continue to display correctly after save/refresh?
+-   [ ] Ensure all WooCommerce Blocks are shown in the Block Inserter.
+-   [ ] Check behaviour of Blocks added to a previous saved page from earlier plugin version
+    -   [ ] Do they look correct?
+    -   [ ] Ensure there are no block invalidation errors for blocks added to a page in a prior version.
+    -   [ ] Can you change options/attributes in the Block inspector?
+    -   [ ] Are changes persisted on save?
+    -   [ ] Is the Browser error console free from errors/notices/warnings?
+-   [ ] Test inserting various blocks into the editor
+    -   [ ] This can be verified by copying and pasting the code examples above. However, please do also test manually inserting the next three blocks as representative examples for related blocks.
+    -   [ ] All Products Blocks (this is powered by the Store API)
+    -   [ ] Featured Product (this is powered by the REST API)
+    -   [ ] On Sale Products (this is SSR)
+    -   [ ] Is the Browser error console free from errors/notices/warnings after inserting them?
+    -   [ ] Do they persist and continue to display correctly after save/refresh?
 
 ## Frontend Tests
 
-* [ ] Do the blocks on your pre-made pages render correctly?
-* [ ] Are the blocks with user facing interactions working as expected without errors in the browser console or user facing errors (such as All Products block and filter blocks).
-* [ ] Do critical flows for the Cart and Checkout blocks work?
-  * [ ] Address and shipping calculations
-  * [ ] Payment with core payment methods
-  * [ ] Payment with Stripe (extension) and saved payment methods
-  * [ ] Payment with Express payment methods (Chrome Pay or Apple Pay)
-  * [ ] Make sure you test with logged in user and in browser incognito mode.
+-   [ ] Do the blocks on your pre-made pages render correctly?
+-   [ ] Are the blocks with user facing interactions working as expected without errors in the browser console or user facing errors (such as All Products block and filter blocks).
+-   [ ] Do critical flows for the Cart and Checkout blocks work?
+    -   [ ] Address and shipping calculations
+    -   [ ] Payment with core payment methods
+    -   [ ] Payment with Stripe (extension) and saved payment methods
+    -   [ ] Payment with Express payment methods (Chrome Pay or Apple Pay)
+    -   [ ] Make sure you test with logged in user and in browser incognito mode.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/smoke-testing.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/testing/when-to-employ-e2e-testing.md
+++ b/docs/testing/when-to-employ-e2e-testing.md
@@ -21,17 +21,19 @@ test using [React Testing Library](https://testing-library.com/docs/react-testin
 
 An example of things that _should_ be tested with E2E tests:
 
-1.   Blocks cannot be added to the block editor more than once. Reason: **We cannot really mock the Gutenberg functionality
+1.  Blocks cannot be added to the block editor more than once. Reason: **We cannot really mock the Gutenberg functionality
     to test that this happens without some serious effort.**
-2.   Fresh cart data is fetched when using the browser's back buttons. Reason: **We need to emulate the behaviour of a
+2.  Fresh cart data is fetched when using the browser's back buttons. Reason: **We need to emulate the behaviour of a
     browser when the back button is pressed and this can't be done in unit tests.**
-3.   The compatability notice is shown when first adding the checkout block. Reason: **same as 1**
+3.  The compatability notice is shown when first adding the checkout block. Reason: **same as 1**
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/testing/when-to-employ-e2e-testing.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/theming/README.md
+++ b/docs/theming/README.md
@@ -38,7 +38,7 @@ Some of our components have responsive classes depending on the container width.
 Those classes are:
 
 | Container width | Class name  |
-|-----------------|-------------|
+| --------------- | ----------- |
 | >700px          | `is-large`  |
 | 521px-700px     | `is-medium` |
 | 401px-520px     | `is-small`  |
@@ -81,10 +81,12 @@ WooCommerce Blocks avoids using legacy unprefixed classes as much as possible. H
 -   [Class names update in 4.6.0](./class-names-update-460.md)
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/theming/README.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/theming/all-products-and-filters.md
+++ b/docs/theming/all-products-and-filters.md
@@ -29,10 +29,12 @@ Notice the code snippet above uses a CSS custom property, so the default color m
 ```
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/theming/all-products-and-filters.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/theming/cart-and-checkout.md
+++ b/docs/theming/cart-and-checkout.md
@@ -73,10 +73,12 @@ By default, it uses a combination of black and white borders and shadows so it h
 <img src="https://user-images.githubusercontent.com/3616980/83863109-2e421c80-a723-11ea-9bf7-2033a96cf5b2.png" alt="Order summary screenshot with custom styles for the item quantity badge" width="231" />
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/theming/cart-and-checkout.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/theming/class-names-update-280.md
+++ b/docs/theming/class-names-update-280.md
@@ -84,10 +84,12 @@ Some classes that were introduced in previous versions or that have shipped in W
     -   ...
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/theming/class-names-update-280.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/theming/class-names-update-330.md
+++ b/docs/theming/class-names-update-330.md
@@ -48,10 +48,12 @@ WC Blocks 3.3.0, introduced express payment methods in the Cart block. In order 
 </table>
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/theming/class-names-update-330.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/theming/class-names-update-340.md
+++ b/docs/theming/class-names-update-340.md
@@ -14,10 +14,12 @@
 </table>
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/theming/class-names-update-340.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/theming/class-names-update-460.md
+++ b/docs/theming/class-names-update-460.md
@@ -5,17 +5,19 @@ In WC Blocks 4.6.0, some class names were updated in order to follow the same gu
 ## Replaced classes
 
 | Removed                                   | New class name                           |
-|-------------------------------------------|------------------------------------------|
+| ----------------------------------------- | ---------------------------------------- |
 | `wc-blocks-components-panel`              | `wc-block-components-panel`              |
 | `wc-blocks-components-panel__button`      | `wc-block-components-panel__button`      |
 | `wc-blocks-components-panel__button-icon` | `wc-block-components-panel__button-icon` |
 | `wc-blocks-components-panel__content`     | `wc-block-components-panel__content`     |
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/theming/class-names-update-460.md)
+
 <!-- /FEEDBACK -->
 

--- a/docs/theming/product-grid-270.md
+++ b/docs/theming/product-grid-270.md
@@ -39,10 +39,12 @@ _All Products_ block was updated so prices follow the same layout as the other p
 ```
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/theming/product-grid-270.md)
+
 <!-- /FEEDBACK -->
 

--- a/packages/checkout/README.md
+++ b/packages/checkout/README.md
@@ -54,10 +54,12 @@ This package contains the following directories. Navigate to a directory for mor
 | [`utils/`](./utils)                                  | Miscellaneous utility functions for dealing with checkout functionality.                                                                                                                                                                                                                                               |
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./packages/checkout/README.md)
+
 <!-- /FEEDBACK -->
 

--- a/packages/checkout/blocks-registry/README.md
+++ b/packages/checkout/blocks-registry/README.md
@@ -204,10 +204,12 @@ const isValid = hasInnerBlocks( 'woocommerce/checkout-totals-block' ); // true
 ```
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./packages/checkout/blocks-registry/README.md)
+
 <!-- /FEEDBACK -->
 

--- a/packages/checkout/components/README.md
+++ b/packages/checkout/components/README.md
@@ -25,10 +25,12 @@ export default function MyButton() {
 These components are here so they can be consumed by extensions.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./packages/checkout/components/README.md)
+
 <!-- /FEEDBACK -->
 

--- a/packages/checkout/filter-registry/README.md
+++ b/packages/checkout/filter-registry/README.md
@@ -131,10 +131,12 @@ A function that needs to return true when the filtered value is passed in order 
 Filters are implemented throughout the Mini Cart, Cart and Checkout Blocks, as well as some components. For a list of filters, [see this document](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/extensibility/available-filters.md). You can also search for [usage of `__experimentalApplyCheckoutFilter` within the source code](https://github.com/woocommerce/woocommerce-gutenberg-products-block/search?q=__experimentalApplyCheckoutFilter).
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./packages/checkout/filter-registry/README.md)
+
 <!-- /FEEDBACK -->
 

--- a/packages/checkout/slot/README.md
+++ b/packages/checkout/slot/README.md
@@ -184,10 +184,12 @@ registerPlugin( 'my-plugin', { render } );
 Slot Fills are implemented throughout the Cart and Checkout Blocks, as well as some components. For a list of available Slot Fills, [see this document](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/extensibility/available-slot-fills.md).
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./packages/checkout/slot/README.md)
+
 <!-- /FEEDBACK -->
 

--- a/packages/checkout/utils/README.md
+++ b/packages/checkout/utils/README.md
@@ -73,10 +73,12 @@ Value being checked. Must be a string.
 What value must contain. If this is not found within `value`, and error will be thrown.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./packages/checkout/utils/README.md)
+
 <!-- /FEEDBACK -->
 

--- a/src/StoreApi/README.md
+++ b/src/StoreApi/README.md
@@ -158,10 +158,12 @@ If any of the following statements are true, choose to _extend_ the Store API ra
 If the data is sensitive (for example, a core setting that should be private), or not related to the current user (for example, looking up an order by order ID), [choose to use the authenticated WC REST API](https://woocommerce.github.io/woocommerce-rest-api-docs/#introduction).
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./src/StoreApi/README.md)
+
 <!-- /FEEDBACK -->
 

--- a/src/StoreApi/docs/cart-coupons.md
+++ b/src/StoreApi/docs/cart-coupons.md
@@ -161,10 +161,12 @@ curl --request DELETE https://example-store.com/wp-json/wc/store/v1/cart/coupons
 ```
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./src/StoreApi/docs/cart-coupons.md)
+
 <!-- /FEEDBACK -->
 

--- a/src/StoreApi/docs/cart-items.md
+++ b/src/StoreApi/docs/cart-items.md
@@ -356,10 +356,12 @@ curl --request DELETE https://example-store.com/wp-json/wc/store/v1/cart/items
 ```
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./src/StoreApi/docs/cart-items.md)
+
 <!-- /FEEDBACK -->
 

--- a/src/StoreApi/docs/cart.md
+++ b/src/StoreApi/docs/cart.md
@@ -468,10 +468,12 @@ curl --header "Nonce: 12345" --request POST /cart/select-shipping-rate?package_i
 Returns the full [Cart Response](#cart-response) on success, or an [Error Response](#error-response) on failure.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./src/StoreApi/docs/cart.md)
+
 <!-- /FEEDBACK -->
 

--- a/src/StoreApi/docs/checkout.md
+++ b/src/StoreApi/docs/checkout.md
@@ -131,10 +131,12 @@ curl --header "Nonce: 12345" --request POST https://example-store.com/wp-json/wc
 ```
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./src/StoreApi/docs/checkout.md)
+
 <!-- /FEEDBACK -->
 

--- a/src/StoreApi/docs/guiding-principles.md
+++ b/src/StoreApi/docs/guiding-principles.md
@@ -131,10 +131,12 @@ Non-breaking changes are always permitted without the need to increase the API v
 The version will not increase for bug fixes unless the scope of the bug causes a backwards-incompatible change. Fixes would not be rolled back to past API versions with the exception of security issues that require backporting.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./src/StoreApi/docs/guiding-principles.md)
+
 <!-- /FEEDBACK -->
 

--- a/src/StoreApi/docs/nonce-tokens.md
+++ b/src/StoreApi/docs/nonce-tokens.md
@@ -46,10 +46,12 @@ Nonce checks will be bypassed if `woocommerce_store_api_disable_nonce_check` eva
 NOTE: This should only be done on development sites where security is not important. Do not enable this in production.
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./src/StoreApi/docs/nonce-tokens.md)
+
 <!-- /FEEDBACK -->
 

--- a/src/StoreApi/docs/product-attribute-terms.md
+++ b/src/StoreApi/docs/product-attribute-terms.md
@@ -35,10 +35,12 @@ curl "https://example-store.com/wp-json/wc/store/v1/products/attributes/1/terms"
 ```
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./src/StoreApi/docs/product-attribute-terms.md)
+
 <!-- /FEEDBACK -->
 

--- a/src/StoreApi/docs/product-attributes.md
+++ b/src/StoreApi/docs/product-attributes.md
@@ -68,10 +68,12 @@ curl "https://example-store.com/wp-json/wc/store/v1/products/attributes/1"
 ```
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./src/StoreApi/docs/product-attributes.md)
+
 <!-- /FEEDBACK -->
 

--- a/src/StoreApi/docs/product-collection-data.md
+++ b/src/StoreApi/docs/product-collection-data.md
@@ -58,10 +58,12 @@ curl "https://example-store.com/wp-json/wc/store/v1/products/collection-data?cal
 ```
 
 <!-- FEEDBACK -->
+
 ---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./src/StoreApi/docs/product-collection-data.md)
+
 <!-- /FEEDBACK -->
 

--- a/src/StoreApi/docs/products.md
+++ b/src/StoreApi/docs/products.md
@@ -190,10 +190,13 @@ curl "https://example-store.com/wp-json/wc/store/v1/products/34"
 }
 ```
 
-## <!-- FEEDBACK -->
+<!-- FEEDBACK -->
+
+---
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./src/StoreApi/docs/products.md)
 
 <!-- /FEEDBACK -->
+


### PR DESCRIPTION
While working on #6095, I noticed that some of our *.md files are using different formats. Since version 1.8, Prettier supports formatting of Markdown files. This PR aims to format all Markdown files using Prettier.

### Testing

#### User Facing Testing

1. Look up the formatting of the changes files.

* [x] Do not include in the Testing Notes