### PR TITLE
Enable ESLint for the folder `tests/e2e/specs`

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -7,5 +7,7 @@ node_modules
 vendor
 legacy
 reports
-tests/e2e/specs
+tests/e2e/specs/backend/__fixtures__
+tests/e2e/specs/backend/__snapshots__
+
 storybook/dist

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,6 +38,8 @@ module.exports = {
 			'@wordpress/hooks',
 			'@wordpress/keycodes',
 			'@wordpress/url',
+			'@woocommerce/blocks-test-utils',
+			'@woocommerce/e2e-utils',
 			'babel-jest',
 			'dotenv',
 			'jest-environment-puppeteer',

--- a/assets/js/types/type-defs/index.ts
+++ b/assets/js/types/type-defs/index.ts
@@ -8,3 +8,4 @@ export * from './objects';
 export * from './payment-method-interface';
 export * from './blocks';
 export * from './utils';
+export * from './taxes';

--- a/tests/e2e/specs/backend/active-filters.test.js
+++ b/tests/e2e/specs/backend/active-filters.test.js
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import {
-	getEditedPostContent,
 	getAllBlocks,
 	switchUserToAdmin,
 	openDocumentSettingsSidebar,

--- a/tests/e2e/specs/backend/all-products.test.js
+++ b/tests/e2e/specs/backend/all-products.test.js
@@ -5,6 +5,9 @@ import { getAllBlocks, switchUserToAdmin } from '@wordpress/e2e-test-utils';
 import { visitBlockPage } from '@woocommerce/blocks-test-utils';
 import { merchant } from '@woocommerce/e2e-utils';
 
+/**
+ * Internal dependencies
+ */
 import {
 	searchForBlock,
 	insertBlockDontWaitForInsertClose,

--- a/tests/e2e/specs/backend/attribute-filter.test.js
+++ b/tests/e2e/specs/backend/attribute-filter.test.js
@@ -23,6 +23,7 @@ describe( `${ block.name } Block`, () => {
 		await switchUserToAdmin();
 		await visitBlockPage( `${ block.name } Block` );
 
+		// eslint-disable-next-line jest/no-standalone-expect
 		await expect( page ).toClick(
 			'span.woocommerce-search-list__item-name',
 			{ text: 'Capacity' }
@@ -30,6 +31,7 @@ describe( `${ block.name } Block`, () => {
 		//needed for attributes list to load correctly
 		await page.waitForTimeout( 1000 );
 
+		// eslint-disable-next-line jest/no-standalone-expect
 		await expect( page ).toClick( 'button', { text: 'Done' } );
 		await page.waitForNetworkIdle();
 	} );

--- a/tests/e2e/specs/backend/cart.test.js
+++ b/tests/e2e/specs/backend/cart.test.js
@@ -14,6 +14,9 @@ import {
 } from '@woocommerce/blocks-test-utils';
 import { merchant } from '@woocommerce/e2e-utils';
 
+/**
+ * Internal dependencies
+ */
 import {
 	searchForBlock,
 	insertBlockDontWaitForInsertClose,
@@ -41,7 +44,7 @@ const emptyCartBlock = {
 };
 
 if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 ) {
-	// eslint-disable-next-line jest/no-focused-tests
+	// eslint-disable-next-line jest/no-focused-tests, jest/expect-expect
 	test.only( `skipping ${ block.name } tests`, () => {} );
 }
 
@@ -51,6 +54,7 @@ describe( `${ block.name } Block`, () => {
 			beforeAll( async () => {
 				// make sure CartCheckoutCompatibilityNotice will appear
 				await page.evaluate( () => {
+					// eslint-disable-next-line no-undef
 					localStorage.removeItem(
 						'wc-blocks_dismissed_compatibility_notices'
 					);
@@ -69,6 +73,7 @@ describe( `${ block.name } Block`, () => {
 		describe( 'after compatibility notice is dismissed', () => {
 			beforeAll( async () => {
 				await page.evaluate( () => {
+					// eslint-disable-next-line no-undef
 					localStorage.setItem(
 						'wc-blocks_dismissed_compatibility_notices',
 						'["cart"]'
@@ -80,6 +85,7 @@ describe( `${ block.name } Block`, () => {
 
 			afterAll( async () => {
 				await page.evaluate( () => {
+					// eslint-disable-next-line no-undef
 					localStorage.removeItem(
 						'wc-blocks_dismissed_compatibility_notices'
 					);

--- a/tests/e2e/specs/backend/checkout.test.js
+++ b/tests/e2e/specs/backend/checkout.test.js
@@ -13,6 +13,9 @@ import {
 } from '@woocommerce/blocks-test-utils';
 import { merchant } from '@woocommerce/e2e-utils';
 
+/**
+ * Internal dependencies
+ */
 import {
 	searchForBlock,
 	insertBlockDontWaitForInsertClose,
@@ -29,7 +32,7 @@ const block = {
 };
 
 if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 ) {
-	// eslint-disable-next-line jest/no-focused-tests
+	// eslint-disable-next-line jest/no-focused-tests, jest/expect-expect
 	test.only( `skipping ${ block.name } tests`, () => {} );
 }
 
@@ -39,6 +42,7 @@ describe( `${ block.name } Block`, () => {
 			beforeAll( async () => {
 				// make sure CartCheckoutCompatibilityNotice will appear
 				await page.evaluate( () => {
+					// eslint-disable-next-line no-undef
 					localStorage.removeItem(
 						'wc-blocks_dismissed_compatibility_notices'
 					);
@@ -57,6 +61,7 @@ describe( `${ block.name } Block`, () => {
 		describe( 'after compatibility notice is dismissed', () => {
 			beforeAll( async () => {
 				await page.evaluate( () => {
+					// eslint-disable-next-line no-undef
 					localStorage.setItem(
 						'wc-blocks_dismissed_compatibility_notices',
 						'["checkout"]'
@@ -67,6 +72,7 @@ describe( `${ block.name } Block`, () => {
 			} );
 			afterAll( async () => {
 				await page.evaluate( () => {
+					// eslint-disable-next-line no-undef
 					localStorage.removeItem(
 						'wc-blocks_dismissed_compatibility_notices'
 					);

--- a/tests/e2e/specs/backend/featured-category.test.js
+++ b/tests/e2e/specs/backend/featured-category.test.js
@@ -5,6 +5,9 @@ import { getAllBlocks, switchUserToAdmin } from '@wordpress/e2e-test-utils';
 
 import { visitBlockPage } from '@woocommerce/blocks-test-utils';
 
+/**
+ * Internal dependencies
+ */
 import { insertBlockDontWaitForInsertClose } from '../../utils.js';
 
 const block = {

--- a/tests/e2e/specs/backend/featured-product.test.js
+++ b/tests/e2e/specs/backend/featured-product.test.js
@@ -5,6 +5,9 @@ import { getAllBlocks, switchUserToAdmin } from '@wordpress/e2e-test-utils';
 
 import { visitBlockPage } from '@woocommerce/blocks-test-utils';
 
+/**
+ * Internal dependencies
+ */
 import { insertBlockDontWaitForInsertClose } from '../../utils.js';
 
 const block = {

--- a/tests/e2e/specs/backend/filter-products-by-stock.test.js
+++ b/tests/e2e/specs/backend/filter-products-by-stock.test.js
@@ -1,19 +1,18 @@
 /**
- * Internal dependencies
- */
-import { closeInserter, insertBlockDontWaitForInsertClose } from '../../utils';
-import { findLabelWithText } from '../../../utils';
-
-/**
  * External dependencies
  */
 import {
 	switchUserToAdmin,
-	clickButton,
 	getAllBlocks,
 	openDocumentSettingsSidebar,
 } from '@wordpress/e2e-test-utils';
 import { visitBlockPage } from '@woocommerce/blocks-test-utils';
+
+/**
+ * Internal dependencies
+ */
+import { closeInserter, insertBlockDontWaitForInsertClose } from '../../utils';
+import { findLabelWithText } from '../../../utils';
 
 const block = {
 	name: 'Filter Products by Stock',

--- a/tests/e2e/specs/backend/handpicked-products.test.js
+++ b/tests/e2e/specs/backend/handpicked-products.test.js
@@ -5,6 +5,9 @@ import { getAllBlocks, switchUserToAdmin } from '@wordpress/e2e-test-utils';
 
 import { visitBlockPage } from '@woocommerce/blocks-test-utils';
 
+/**
+ * Internal dependencies
+ */
 import { insertBlockDontWaitForInsertClose } from '../../utils.js';
 
 const block = {

--- a/tests/e2e/specs/backend/mini-cart.test.js
+++ b/tests/e2e/specs/backend/mini-cart.test.js
@@ -36,12 +36,13 @@ const block = {
 };
 
 if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 3 ) {
-	// eslint-disable-next-line jest/no-focused-tests
+	// eslint-disable-next-line jest/no-focused-tests, jest/expect-expect
 	test.only( `skipping ${ block.name } tests`, () => {} );
 }
 
 const removeDismissedCompatibilityNoticesFromLocalStorage = async () => {
 	await page.evaluate( () => {
+		// eslint-disable-next-line no-undef
 		localStorage.removeItem( 'wc-blocks_dismissed_compatibility_notices' );
 	} );
 };
@@ -81,6 +82,7 @@ describe( `${ block.name } Block`, () => {
 
 		it( "after the compatibility notice is dismissed, it doesn't appear again", async () => {
 			await page.evaluate( () => {
+				// eslint-disable-next-line no-undef
 				localStorage.setItem(
 					'wc-blocks_dismissed_compatibility_notices',
 					'["mini-cart"]'
@@ -130,6 +132,7 @@ describe( `${ block.name } Block`, () => {
 
 		it( "after the compatibility notice is dismissed, it doesn't appear again", async () => {
 			await page.evaluate( () => {
+				// eslint-disable-next-line no-undef
 				localStorage.setItem(
 					'wc-blocks_dismissed_compatibility_notices',
 					'["mini-cart"]'

--- a/tests/e2e/specs/backend/price-filter.test.js
+++ b/tests/e2e/specs/backend/price-filter.test.js
@@ -5,7 +5,6 @@ import {
 	openDocumentSettingsSidebar,
 	switchUserToAdmin,
 	getAllBlocks,
-	getEditedPostContent,
 } from '@wordpress/e2e-test-utils';
 import {
 	visitBlockPage,

--- a/tests/e2e/specs/backend/product-best-sellers.test.js
+++ b/tests/e2e/specs/backend/product-best-sellers.test.js
@@ -5,6 +5,9 @@ import { getAllBlocks, switchUserToAdmin } from '@wordpress/e2e-test-utils';
 
 import { visitBlockPage } from '@woocommerce/blocks-test-utils';
 
+/**
+ * Internal dependencies
+ */
 import { insertBlockDontWaitForInsertClose } from '../../utils.js';
 
 const block = {

--- a/tests/e2e/specs/backend/product-categories.test.js
+++ b/tests/e2e/specs/backend/product-categories.test.js
@@ -5,6 +5,9 @@ import { getAllBlocks, switchUserToAdmin } from '@wordpress/e2e-test-utils';
 
 import { visitBlockPage } from '@woocommerce/blocks-test-utils';
 
+/**
+ * Internal dependencies
+ */
 import { insertBlockDontWaitForInsertClose } from '../../utils.js';
 
 const block = {

--- a/tests/e2e/specs/backend/product-category.test.js
+++ b/tests/e2e/specs/backend/product-category.test.js
@@ -5,6 +5,9 @@ import { getAllBlocks, switchUserToAdmin } from '@wordpress/e2e-test-utils';
 
 import { visitBlockPage } from '@woocommerce/blocks-test-utils';
 
+/**
+ * Internal dependencies
+ */
 import { insertBlockDontWaitForInsertClose } from '../../utils.js';
 
 const block = {

--- a/tests/e2e/specs/backend/product-new.test.js
+++ b/tests/e2e/specs/backend/product-new.test.js
@@ -5,6 +5,9 @@ import { getAllBlocks, switchUserToAdmin } from '@wordpress/e2e-test-utils';
 
 import { visitBlockPage } from '@woocommerce/blocks-test-utils';
 
+/**
+ * Internal dependencies
+ */
 import { insertBlockDontWaitForInsertClose } from '../../utils.js';
 
 const block = {

--- a/tests/e2e/specs/backend/product-on-sale.test.js
+++ b/tests/e2e/specs/backend/product-on-sale.test.js
@@ -5,6 +5,9 @@ import { getAllBlocks, switchUserToAdmin } from '@wordpress/e2e-test-utils';
 
 import { visitBlockPage } from '@woocommerce/blocks-test-utils';
 
+/**
+ * Internal dependencies
+ */
 import { insertBlockDontWaitForInsertClose } from '../../utils.js';
 
 const block = {

--- a/tests/e2e/specs/backend/product-tag.test.js
+++ b/tests/e2e/specs/backend/product-tag.test.js
@@ -5,6 +5,9 @@ import { getAllBlocks, switchUserToAdmin } from '@wordpress/e2e-test-utils';
 
 import { visitBlockPage } from '@woocommerce/blocks-test-utils';
 
+/**
+ * Internal dependencies
+ */
 import { insertBlockDontWaitForInsertClose } from '../../utils.js';
 
 const block = {

--- a/tests/e2e/specs/backend/product-top-rated.test.js
+++ b/tests/e2e/specs/backend/product-top-rated.test.js
@@ -5,6 +5,9 @@ import { getAllBlocks, switchUserToAdmin } from '@wordpress/e2e-test-utils';
 
 import { visitBlockPage } from '@woocommerce/blocks-test-utils';
 
+/**
+ * Internal dependencies
+ */
 import { insertBlockDontWaitForInsertClose } from '../../utils.js';
 
 const block = {

--- a/tests/e2e/specs/backend/products-by-attribute.test.js
+++ b/tests/e2e/specs/backend/products-by-attribute.test.js
@@ -5,6 +5,9 @@ import { getAllBlocks, switchUserToAdmin } from '@wordpress/e2e-test-utils';
 
 import { visitBlockPage } from '@woocommerce/blocks-test-utils';
 
+/**
+ * Internal dependencies
+ */
 import { insertBlockDontWaitForInsertClose } from '../../utils.js';
 
 const block = {

--- a/tests/e2e/specs/backend/single-product.test.js
+++ b/tests/e2e/specs/backend/single-product.test.js
@@ -2,11 +2,15 @@
  * External dependencies
  */
 import { getAllBlocks, switchUserToAdmin } from '@wordpress/e2e-test-utils';
-import { insertBlockDontWaitForInsertClose } from '../../utils.js';
 import { visitBlockPage } from '@woocommerce/blocks-test-utils';
 
+/**
+ * Internal dependencies
+ */
+import { insertBlockDontWaitForInsertClose } from '../../utils.js';
+
 if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 3 )
-	// eslint-disable-next-line jest/no-focused-tests
+	// eslint-disable-next-line jest/no-focused-tests, jest/expect-expect
 	test.only( 'skipping all other things', () => {} );
 
 const block = {

--- a/tests/e2e/specs/backend/site-editing-templates.test.js
+++ b/tests/e2e/specs/backend/site-editing-templates.test.js
@@ -1,5 +1,8 @@
+/* eslint-disable jest/no-conditional-expect */
+/**
+ * External dependencies
+ */
 import { URL } from 'url';
-
 import {
 	canvas,
 	deleteAllTemplates,
@@ -10,6 +13,10 @@ import {
 	getNormalPagePermalink,
 	visitPostOfType,
 } from '@woocommerce/blocks-test-utils';
+
+/**
+ * Internal dependencies
+ */
 import {
 	BASE_URL,
 	DEFAULT_TIMEOUT,

--- a/tests/e2e/specs/frontend/legacy-template-blocks.test.ts
+++ b/tests/e2e/specs/frontend/legacy-template-blocks.test.ts
@@ -1,4 +1,11 @@
+/**
+ * External dependencies
+ */
 import { URL } from 'url';
+
+/**
+ * Internal dependencies
+ */
 import { BASE_URL, useTheme } from '../../utils';
 const SELECTORS = {
 	productArchivePage: {

--- a/tests/e2e/specs/merchant/checkout-terms.test.js
+++ b/tests/e2e/specs/merchant/checkout-terms.test.js
@@ -28,7 +28,7 @@ import {
 } from '../../../utils/constants';
 
 if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 ) {
-	// eslint-disable-next-line jest/no-focused-tests
+	// eslint-disable-next-line jest/no-focused-tests, jest/expect-expect
 	test.only( `Skipping checkout tests`, () => {} );
 }
 
@@ -36,6 +36,7 @@ describe( 'Merchant → Checkout → Can adjust T&S and Privacy Policy options',
 	beforeAll( async () => {
 		await shopper.goToShop();
 		await page.goto( `${ BASE_URL }/?setup_terms_and_privacy` );
+		// eslint-disable-next-line jest/no-standalone-expect
 		await expect( page ).toMatch( 'Terms & Privacy pages set up.' );
 		await shopper.block.emptyCart();
 	} );
@@ -43,6 +44,7 @@ describe( 'Merchant → Checkout → Can adjust T&S and Privacy Policy options',
 	afterAll( async () => {
 		await shopper.block.emptyCart();
 		await page.goto( `${ BASE_URL }/?teardown_terms_and_privacy` );
+		// eslint-disable-next-line jest/no-standalone-expect
 		await expect( page ).toMatch( 'Terms & Privacy pages teared down.' );
 	} );
 

--- a/tests/e2e/specs/shopper/active-filters.test.ts
+++ b/tests/e2e/specs/shopper/active-filters.test.ts
@@ -21,7 +21,6 @@ import {
 	clickLink,
 } from '../../utils';
 import { shopper } from '../../../utils';
-import { Frame, Page } from 'puppeteer';
 
 const block = {
 	name: 'Active Product Filters',

--- a/tests/e2e/specs/shopper/cart-checkout/account.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/account.test.js
@@ -26,7 +26,7 @@ const block = {
 
 if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 ) {
 	// Skips all the tests if it's a WooCommerce Core process environment.
-	// eslint-disable-next-line jest/no-focused-tests
+	// eslint-disable-next-line jest/no-focused-tests, jest/expect-expect
 	test.only( 'Skipping Cart & Checkout tests', () => {} );
 }
 
@@ -51,6 +51,7 @@ describe( 'Shopper → Checkout → Account', () => {
 			'woocommerce/checkout-contact-information-block'
 		);
 		//Enable shoppers to sign up at checkout option.
+		// eslint-disable-next-line jest/no-standalone-expect
 		await expect( page ).toClick( 'label', {
 			text:
 				'Allow shoppers to sign up for a user account during checkout',
@@ -66,7 +67,7 @@ describe( 'Shopper → Checkout → Account', () => {
 		await shopper.block.goToCheckout();
 	} );
 
-	it.only( 'user can login to existing account', async () => {
+	it( 'user can login to existing account', async () => {
 		//Get the login link from checkout page.
 		const loginLink = await page.$eval(
 			'span.wc-block-components-checkout-step__heading-content a',
@@ -84,7 +85,7 @@ describe( 'Shopper → Checkout → Account', () => {
 			text: 'Create an account?',
 		} );
 		//Create random email to place an order.
-		let testEmail = `test${ Math.random() * 10 }@example.com`;
+		const testEmail = `test${ Math.random() * 10 }@example.com`;
 		await shopper.block.fillInCheckoutWithTestData();
 		await expect( page ).toFill( `#email`, testEmail );
 		await shopper.block.placeOrder();

--- a/tests/e2e/specs/shopper/cart-checkout/cart.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/cart.test.js
@@ -5,7 +5,7 @@ import { shopper, SIMPLE_VIRTUAL_PRODUCT_NAME } from '../../../../utils';
 
 if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 ) {
 	// Skips all the tests if it's a WooCommerce Core process environment.
-	// eslint-disable-next-line jest/no-focused-tests
+	// eslint-disable-next-line jest/no-focused-tests, jest/expect-expect
 	test.only( `Skipping Cart & Checkout tests`, () => {} );
 }
 

--- a/tests/e2e/specs/shopper/cart-checkout/checkout.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/checkout.test.js
@@ -32,7 +32,7 @@ import { createCoupon } from '../../../utils';
 
 if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 ) {
 	// Skips all the tests if it's a WooCommerce Core process environment.
-	// eslint-disable-next-line jest/no-focused-tests
+	// eslint-disable-next-line jest/no-focused-tests, jest/expect-expect
 	test.only( 'Skipping Cart & Checkout tests', () => {} );
 }
 
@@ -112,6 +112,7 @@ describe( 'Shopper → Checkout', () => {
 			await reactivateCompatibilityNotice();
 		} );
 
+		// eslint-disable-next-line jest/expect-expect
 		it( 'User can have different shipping and billing addresses', async () => {
 			await shopper.goToShop();
 			await shopper.addToCartFromShopPage( SIMPLE_PHYSICAL_PRODUCT_NAME );

--- a/tests/e2e/specs/shopper/cart-checkout/tax.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/tax.test.js
@@ -18,7 +18,7 @@ const productWooSingle1 = Products().find(
 
 if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 ) {
 	// Skips all the tests if it's a WooCommerce Core process environment.
-	// eslint-disable-next-line jest/no-focused-tests
+	// eslint-disable-next-line jest/no-focused-tests, jest/expect-expect
 	test.only( `Skipping Cart & Checkout tests`, () => {} );
 }
 

--- a/tests/e2e/specs/shopper/cart-checkout/translations.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/translations.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable jest/expect-expect */
 /**
  * Internal dependencies
  */
@@ -19,7 +20,7 @@ describe( 'Shopper → Cart & Checkout → Translations', () => {
 		await merchant.changeLanguage( 'en_EN' );
 	} );
 
-	it( 'User can view translated Cart block ', async () => {
+	it( 'User can view translated Cart block', async () => {
 		await shopper.goToShop();
 		await shopper.addToCartFromShopPage( '128GB USB Stick' );
 		await shopper.block.goToCart();

--- a/tests/e2e/specs/shopper/filter-products-by-attribute.test.ts
+++ b/tests/e2e/specs/shopper/filter-products-by-attribute.test.ts
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import {
 	canvas,
 	createNewPost,
@@ -6,8 +9,11 @@ import {
 	switchUserToAdmin,
 	publishPost,
 } from '@wordpress/e2e-test-utils';
-import { Frame } from 'puppeteer';
 import { selectBlockByName } from '@woocommerce/blocks-test-utils';
+
+/**
+ * Internal dependencies
+ */
 import {
 	BASE_URL,
 	goToTemplateEditor,
@@ -41,6 +47,8 @@ const block = {
 	foundProduct: '128GB USB Stick',
 };
 
+const { selectors } = block;
+
 const waitForAllProductsBlockLoaded = () =>
 	page.waitForSelector( selectors.frontend.productsList + '.is-loading', {
 		hidden: true,
@@ -50,8 +58,6 @@ const goToShopPage = () =>
 	page.goto( BASE_URL + '/shop', {
 		waitUntil: 'networkidle0',
 	} );
-
-const { selectors } = block;
 
 describe( `${ block.name } Block`, () => {
 	describe( 'with All Products Block', () => {
@@ -108,7 +114,7 @@ describe( `${ block.name } Block`, () => {
 				postId: productCatalogTemplateId,
 			} );
 			await insertBlock( block.name );
-			const canvasEl: Frame = canvas();
+			const canvasEl = canvas();
 
 			// It seems that .click doesn't work well with radio input element.
 			await canvasEl.$eval(

--- a/tests/e2e/specs/shopper/filter-products-by-price.test.ts
+++ b/tests/e2e/specs/shopper/filter-products-by-price.test.ts
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import {
 	createNewPost,
 	deleteAllTemplates,
@@ -6,6 +9,10 @@ import {
 	publishPost,
 } from '@wordpress/e2e-test-utils';
 import { selectBlockByName } from '@woocommerce/blocks-test-utils';
+
+/**
+ * Internal dependencies
+ */
 import {
 	BASE_URL,
 	clickLink,

--- a/tests/e2e/specs/shopper/filter-products-by-stock.test.ts
+++ b/tests/e2e/specs/shopper/filter-products-by-stock.test.ts
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import {
 	createNewPost,
 	deleteAllTemplates,
@@ -6,6 +9,10 @@ import {
 	publishPost,
 } from '@wordpress/e2e-test-utils';
 import { selectBlockByName } from '@woocommerce/blocks-test-utils';
+
+/**
+ * Internal dependencies
+ */
 import {
 	BASE_URL,
 	goToTemplateEditor,

--- a/tests/e2e/specs/shopper/mini-cart.test.js
+++ b/tests/e2e/specs/shopper/mini-cart.test.js
@@ -69,7 +69,7 @@ const WooCommerce = new WooCommerceRestApi( {
 
 if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 ) {
 	// Skips all the tests if it's a WooCommerce Core process environment.
-	// eslint-disable-next-line jest/no-focused-tests
+	// eslint-disable-next-line jest/no-focused-tests, jest/expect-expect
 	test.only( `Skipping ${ block.name } tests`, () => {} );
 }
 


### PR DESCRIPTION
This PR enables ESLint for the folder `tests/e2e/specs` and fixes the current ESLint errors.

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #6410 

### Testing
#### User Facing Testing

Run the following command and be sure that there aren't any errors from the E2E folder.

```
npm run lint:js
```


* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->


