### PR TITLE
Convert `Products by Attribute` to TS

### DIFF
--- a/assets/js/blocks/products-by-attribute/block.json
+++ b/assets/js/blocks/products-by-attribute/block.json
@@ -26,10 +26,6 @@
             "type": "number",
             "default": 3
         },
-        "editMode": {
-            "type": "boolean",
-            "default": true
-        },
         "contentVisibility": {
             "type": "object",
             "default": {

--- a/assets/js/blocks/products-by-attribute/block.json
+++ b/assets/js/blocks/products-by-attribute/block.json
@@ -20,6 +20,7 @@
         },
         "attrOperator": {
             "type": "string",
+            "enum": [ "all", "any" ],
             "default": "any"
         },
         "columns": {
@@ -60,6 +61,15 @@
         },
         "orderby": {
             "type": "string",
+            "enum": [
+                "date",
+                "popularity",
+                "price_asc",
+                "price_desc",
+                "rating",
+                "title",
+                "menu_order"
+            ],
             "default": "date"
         },
         "rows": {

--- a/assets/js/blocks/products-by-attribute/block.tsx
+++ b/assets/js/blocks/products-by-attribute/block.tsx
@@ -12,9 +12,7 @@ import {
 	ToolbarGroup,
 	withSpokenMessages,
 } from '@wordpress/components';
-import { Component } from '@wordpress/element';
 import { Icon, category } from '@wordpress/icons';
-import PropTypes from 'prop-types';
 import GridContentControl from '@woocommerce/editor-components/grid-content-control';
 import GridLayoutControl from '@woocommerce/editor-components/grid-layout-control';
 import ProductAttributeTermControl from '@woocommerce/editor-components/product-attribute-term-control';
@@ -26,9 +24,9 @@ import { getSetting } from '@woocommerce/settings';
 /**
  * Component to handle edit mode of "Products by Attribute".
  */
-class ProductsByAttributeBlock extends Component {
-	getInspectorControls() {
-		const { setAttributes } = this.props;
+const ProductsByAttributeBlock = ( props: Props ): JSX.Element => {
+	const getInspectorControls = () => {
+		const { setAttributes } = props;
 		const {
 			attributes,
 			attrOperator,
@@ -38,7 +36,7 @@ class ProductsByAttributeBlock extends Component {
 			rows,
 			alignButtons,
 			stockStatus,
-		} = this.props.attributes;
+		} = props.attributes;
 
 		return (
 			<InspectorControls key="inspector">
@@ -116,11 +114,11 @@ class ProductsByAttributeBlock extends Component {
 				</PanelBody>
 			</InspectorControls>
 		);
-	}
+	};
 
-	renderEditMode() {
-		const { debouncedSpeak, setAttributes } = this.props;
-		const blockAttributes = this.props.attributes;
+	const renderEditMode = () => {
+		const { debouncedSpeak, setAttributes } = props;
+		const blockAttributes = props.attributes;
 		const onDone = () => {
 			setAttributes( { editMode: false } );
 			debouncedSpeak(
@@ -167,10 +165,10 @@ class ProductsByAttributeBlock extends Component {
 				</div>
 			</Placeholder>
 		);
-	}
+	};
 
-	render() {
-		const { attributes, name, setAttributes } = this.props;
+	const render = () => {
+		const { attributes, name, setAttributes } = props;
 		const { editMode } = attributes;
 
 		if ( attributes.isPreview ) {
@@ -195,9 +193,9 @@ class ProductsByAttributeBlock extends Component {
 						] }
 					/>
 				</BlockControls>
-				{ this.getInspectorControls() }
+				{ getInspectorControls() }
 				{ editMode ? (
-					this.renderEditMode()
+					renderEditMode()
 				) : (
 					<Disabled>
 						<ServerSideRender
@@ -208,24 +206,46 @@ class ProductsByAttributeBlock extends Component {
 				) }
 			</>
 		);
-	}
+	};
+
+	return render();
+};
+
+interface Attributes {
+	align?: string;
+	attributes: Array< string >;
+	attrOperator: string;
+	columns: number;
+	editMode: boolean;
+	contentVisibility: {
+		image: boolean;
+		title: boolean;
+		price: boolean;
+		rating: boolean;
+		button: boolean;
+	};
+	orderby: string;
+	rows: number;
+	alignButtons: boolean;
+	isPreview: boolean;
+	stockStatus: Array< string >;
 }
 
-ProductsByAttributeBlock.propTypes = {
+interface Props {
 	/**
 	 * The attributes for this block
 	 */
-	attributes: PropTypes.object.isRequired,
+	attributes: Attributes;
 	/**
 	 * The register block name.
 	 */
-	name: PropTypes.string.isRequired,
+	name: string;
 	/**
 	 * A callback to update attributes
 	 */
-	setAttributes: PropTypes.func.isRequired,
+	setAttributes: ( attributes: Record< string, unknown > ) => void;
 	// from withSpokenMessages
-	debouncedSpeak: PropTypes.func.isRequired,
-};
+	debouncedSpeak: ( message: string ) => void;
+}
 
 export default withSpokenMessages( ProductsByAttributeBlock );

--- a/assets/js/blocks/products-by-attribute/block.tsx
+++ b/assets/js/blocks/products-by-attribute/block.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import ServerSideRender from '@wordpress/server-side-render';
-import { withSpokenMessages } from '@wordpress/components';
 import { gridBlockPreview } from '@woocommerce/resource-previews';
 
 /**
@@ -10,7 +9,7 @@ import { gridBlockPreview } from '@woocommerce/resource-previews';
  */
 import { Props } from './types';
 
-const Block = ( props: Props ): JSX.Element => {
+export const ProductsByAttributeBlock = ( props: Props ): JSX.Element => {
 	const { attributes, name } = props;
 
 	if ( attributes.isPreview ) {
@@ -19,5 +18,3 @@ const Block = ( props: Props ): JSX.Element => {
 
 	return <ServerSideRender block={ name } attributes={ attributes } />;
 };
-
-export const ProductsByAttributeBlock = withSpokenMessages( Block );

--- a/assets/js/blocks/products-by-attribute/block.tsx
+++ b/assets/js/blocks/products-by-attribute/block.tsx
@@ -2,209 +2,26 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { BlockControls, InspectorControls } from '@wordpress/block-editor';
+import { BlockControls } from '@wordpress/block-editor';
 import ServerSideRender from '@wordpress/server-side-render';
 import {
-	Button,
 	Disabled,
-	PanelBody,
-	Placeholder,
 	ToolbarGroup,
 	withSpokenMessages,
 } from '@wordpress/components';
-import { Icon, category } from '@wordpress/icons';
-import GridContentControl from '@woocommerce/editor-components/grid-content-control';
-import GridLayoutControl from '@woocommerce/editor-components/grid-layout-control';
-import ProductAttributeTermControl from '@woocommerce/editor-components/product-attribute-term-control';
-import ProductOrderbyControl from '@woocommerce/editor-components/product-orderby-control';
-import ProductStockControl from '@woocommerce/editor-components/product-stock-control';
 import { gridBlockPreview } from '@woocommerce/resource-previews';
-import { getSetting } from '@woocommerce/settings';
-import { BlockAlignment } from '@wordpress/blocks';
 
-interface Attributes {
-	align?: BlockAlignment;
-	attributes: Array< string >;
-	attrOperator: string;
-	columns: number;
-	editMode: boolean;
-	contentVisibility: {
-		image: boolean;
-		title: boolean;
-		price: boolean;
-		rating: boolean;
-		button: boolean;
-	};
-	orderby: string;
-	rows: number;
-	alignButtons: boolean;
-	isPreview: boolean;
-	stockStatus: Array< string >;
-}
-
-interface Props {
-	/**
-	 * The attributes for this block
-	 */
-	attributes: Attributes;
-	/**
-	 * The register block name.
-	 */
-	name: string;
-	/**
-	 * A callback to update attributes
-	 */
-	setAttributes: ( attributes: Partial< Attributes > ) => void;
-	// from withSpokenMessages
-	debouncedSpeak: ( message: string ) => void;
-}
+/**
+ * Internal dependencies
+ */
+import { Props } from './types';
+import { ProductsByAttributeInspectorControls } from './inspector-controls';
+import { ProductsByAttributeEditMode } from './edit-mode';
 
 /**
  * Component to handle edit mode of "Products by Attribute".
  */
 const ProductsByAttributeBlock = ( props: Props ): JSX.Element => {
-	const getInspectorControls = () => {
-		const { setAttributes } = props;
-		const {
-			attributes,
-			attrOperator,
-			columns,
-			contentVisibility,
-			orderby,
-			rows,
-			alignButtons,
-			stockStatus,
-		} = props.attributes;
-
-		return (
-			<InspectorControls key="inspector">
-				<PanelBody
-					title={ __( 'Layout', 'woo-gutenberg-products-block' ) }
-					initialOpen
-				>
-					<GridLayoutControl
-						columns={ columns }
-						rows={ rows }
-						alignButtons={ alignButtons }
-						setAttributes={ setAttributes }
-						minColumns={ getSetting( 'min_columns', 1 ) }
-						maxColumns={ getSetting( 'max_columns', 6 ) }
-						minRows={ getSetting( 'min_rows', 1 ) }
-						maxRows={ getSetting( 'max_rows', 6 ) }
-					/>
-				</PanelBody>
-				<PanelBody
-					title={ __( 'Content', 'woo-gutenberg-products-block' ) }
-					initialOpen
-				>
-					<GridContentControl
-						settings={ contentVisibility }
-						onChange={ ( value ) =>
-							setAttributes( { contentVisibility: value } )
-						}
-					/>
-				</PanelBody>
-				<PanelBody
-					title={ __(
-						'Filter by Product Attribute',
-						'woo-gutenberg-products-block'
-					) }
-					initialOpen={ false }
-				>
-					<ProductAttributeTermControl
-						selected={ attributes }
-						onChange={ ( value = [] ) => {
-							const result = value.map(
-								( { id, attr_slug: attributeSlug } ) => ( {
-									id,
-									attr_slug: attributeSlug,
-								} )
-							);
-							setAttributes( { attributes: result } );
-						} }
-						operator={ attrOperator }
-						onOperatorChange={ ( value = 'any' ) =>
-							setAttributes( { attrOperator: value } )
-						}
-						isCompact={ true }
-					/>
-				</PanelBody>
-				<PanelBody
-					title={ __( 'Order By', 'woo-gutenberg-products-block' ) }
-					initialOpen={ false }
-				>
-					<ProductOrderbyControl
-						setAttributes={ setAttributes }
-						value={ orderby }
-					/>
-				</PanelBody>
-				<PanelBody
-					title={ __(
-						'Filter by stock status',
-						'woo-gutenberg-products-block'
-					) }
-					initialOpen={ false }
-				>
-					<ProductStockControl
-						setAttributes={ setAttributes }
-						value={ stockStatus }
-					/>
-				</PanelBody>
-			</InspectorControls>
-		);
-	};
-
-	const renderEditMode = () => {
-		const { debouncedSpeak, setAttributes } = props;
-		const blockAttributes = props.attributes;
-		const onDone = () => {
-			setAttributes( { editMode: false } );
-			debouncedSpeak(
-				__(
-					'Showing Products by Attribute block preview.',
-					'woo-gutenberg-products-block'
-				)
-			);
-		};
-
-		return (
-			<Placeholder
-				icon={ <Icon icon={ category } /> }
-				label={ __(
-					'Products by Attribute',
-					'woo-gutenberg-products-block'
-				) }
-				className="wc-block-products-grid wc-block-products-by-attribute"
-			>
-				{ __(
-					'Display a grid of products from your selected attributes.',
-					'woo-gutenberg-products-block'
-				) }
-				<div className="wc-block-products-by-attribute__selection">
-					<ProductAttributeTermControl
-						selected={ blockAttributes.attributes }
-						onChange={ ( value = [] ) => {
-							const result = value.map(
-								( { id, attr_slug: attributeSlug } ) => ( {
-									id,
-									attr_slug: attributeSlug,
-								} )
-							);
-							setAttributes( { attributes: result } );
-						} }
-						operator={ blockAttributes.attrOperator }
-						onOperatorChange={ ( value = 'any' ) =>
-							setAttributes( { attrOperator: value } )
-						}
-					/>
-					<Button isPrimary onClick={ onDone }>
-						{ __( 'Done', 'woo-gutenberg-products-block' ) }
-					</Button>
-				</div>
-			</Placeholder>
-		);
-	};
-
 	const { attributes, name, setAttributes } = props;
 	const { editMode } = attributes;
 
@@ -230,9 +47,9 @@ const ProductsByAttributeBlock = ( props: Props ): JSX.Element => {
 					] }
 				/>
 			</BlockControls>
-			{ getInspectorControls() }
+			<ProductsByAttributeInspectorControls { ...props } />
 			{ editMode ? (
-				renderEditMode()
+				<ProductsByAttributeEditMode { ...props } />
 			) : (
 				<Disabled>
 					<ServerSideRender

--- a/assets/js/blocks/products-by-attribute/block.tsx
+++ b/assets/js/blocks/products-by-attribute/block.tsx
@@ -1,65 +1,23 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { BlockControls } from '@wordpress/block-editor';
 import ServerSideRender from '@wordpress/server-side-render';
-import {
-	Disabled,
-	ToolbarGroup,
-	withSpokenMessages,
-} from '@wordpress/components';
+import { withSpokenMessages } from '@wordpress/components';
 import { gridBlockPreview } from '@woocommerce/resource-previews';
 
 /**
  * Internal dependencies
  */
 import { Props } from './types';
-import { ProductsByAttributeInspectorControls } from './inspector-controls';
-import { ProductsByAttributeEditMode } from './edit-mode';
 
-/**
- * Component to handle edit mode of "Products by Attribute".
- */
-const ProductsByAttributeBlock = ( props: Props ): JSX.Element => {
-	const { attributes, name, setAttributes } = props;
-	const { editMode } = attributes;
+const Block = ( props: Props ): JSX.Element => {
+	const { attributes, name } = props;
 
 	if ( attributes.isPreview ) {
 		return gridBlockPreview;
 	}
 
-	return (
-		<>
-			<BlockControls>
-				<ToolbarGroup
-					controls={ [
-						{
-							icon: 'edit',
-							title: __(
-								'Edit selected attribute',
-								'woo-gutenberg-products-block'
-							),
-							onClick: () =>
-								setAttributes( { editMode: ! editMode } ),
-							isActive: editMode,
-						},
-					] }
-				/>
-			</BlockControls>
-			<ProductsByAttributeInspectorControls { ...props } />
-			{ editMode ? (
-				<ProductsByAttributeEditMode { ...props } />
-			) : (
-				<Disabled>
-					<ServerSideRender
-						block={ name }
-						attributes={ attributes }
-					/>
-				</Disabled>
-			) }
-		</>
-	);
+	return <ServerSideRender block={ name } attributes={ attributes } />;
 };
 
-export default withSpokenMessages( ProductsByAttributeBlock );
+export const ProductsByAttributeBlock = withSpokenMessages( Block );

--- a/assets/js/blocks/products-by-attribute/block.tsx
+++ b/assets/js/blocks/products-by-attribute/block.tsx
@@ -20,6 +20,44 @@ import ProductOrderbyControl from '@woocommerce/editor-components/product-orderb
 import ProductStockControl from '@woocommerce/editor-components/product-stock-control';
 import { gridBlockPreview } from '@woocommerce/resource-previews';
 import { getSetting } from '@woocommerce/settings';
+import { BlockAlignment } from '@wordpress/blocks';
+
+interface Attributes {
+	align?: BlockAlignment;
+	attributes: Array< string >;
+	attrOperator: string;
+	columns: number;
+	editMode: boolean;
+	contentVisibility: {
+		image: boolean;
+		title: boolean;
+		price: boolean;
+		rating: boolean;
+		button: boolean;
+	};
+	orderby: string;
+	rows: number;
+	alignButtons: boolean;
+	isPreview: boolean;
+	stockStatus: Array< string >;
+}
+
+interface Props {
+	/**
+	 * The attributes for this block
+	 */
+	attributes: Attributes;
+	/**
+	 * The register block name.
+	 */
+	name: string;
+	/**
+	 * A callback to update attributes
+	 */
+	setAttributes: ( attributes: Partial< Attributes > ) => void;
+	// from withSpokenMessages
+	debouncedSpeak: ( message: string ) => void;
+}
 
 /**
  * Component to handle edit mode of "Products by Attribute".
@@ -167,85 +205,44 @@ const ProductsByAttributeBlock = ( props: Props ): JSX.Element => {
 		);
 	};
 
-	const render = () => {
-		const { attributes, name, setAttributes } = props;
-		const { editMode } = attributes;
+	const { attributes, name, setAttributes } = props;
+	const { editMode } = attributes;
 
-		if ( attributes.isPreview ) {
-			return gridBlockPreview;
-		}
+	if ( attributes.isPreview ) {
+		return gridBlockPreview;
+	}
 
-		return (
-			<>
-				<BlockControls>
-					<ToolbarGroup
-						controls={ [
-							{
-								icon: 'edit',
-								title: __(
-									'Edit selected attribute',
-									'woo-gutenberg-products-block'
-								),
-								onClick: () =>
-									setAttributes( { editMode: ! editMode } ),
-								isActive: editMode,
-							},
-						] }
+	return (
+		<>
+			<BlockControls>
+				<ToolbarGroup
+					controls={ [
+						{
+							icon: 'edit',
+							title: __(
+								'Edit selected attribute',
+								'woo-gutenberg-products-block'
+							),
+							onClick: () =>
+								setAttributes( { editMode: ! editMode } ),
+							isActive: editMode,
+						},
+					] }
+				/>
+			</BlockControls>
+			{ getInspectorControls() }
+			{ editMode ? (
+				renderEditMode()
+			) : (
+				<Disabled>
+					<ServerSideRender
+						block={ name }
+						attributes={ attributes }
 					/>
-				</BlockControls>
-				{ getInspectorControls() }
-				{ editMode ? (
-					renderEditMode()
-				) : (
-					<Disabled>
-						<ServerSideRender
-							block={ name }
-							attributes={ attributes }
-						/>
-					</Disabled>
-				) }
-			</>
-		);
-	};
-
-	return render();
+				</Disabled>
+			) }
+		</>
+	);
 };
-
-interface Attributes {
-	align?: string;
-	attributes: Array< string >;
-	attrOperator: string;
-	columns: number;
-	editMode: boolean;
-	contentVisibility: {
-		image: boolean;
-		title: boolean;
-		price: boolean;
-		rating: boolean;
-		button: boolean;
-	};
-	orderby: string;
-	rows: number;
-	alignButtons: boolean;
-	isPreview: boolean;
-	stockStatus: Array< string >;
-}
-
-interface Props {
-	/**
-	 * The attributes for this block
-	 */
-	attributes: Attributes;
-	/**
-	 * The register block name.
-	 */
-	name: string;
-	/**
-	 * A callback to update attributes
-	 */
-	setAttributes: ( attributes: Record< string, unknown > ) => void;
-	// from withSpokenMessages
-	debouncedSpeak: ( message: string ) => void;
-}
 
 export default withSpokenMessages( ProductsByAttributeBlock );

--- a/assets/js/blocks/products-by-attribute/edit-mode.tsx
+++ b/assets/js/blocks/products-by-attribute/edit-mode.tsx
@@ -9,13 +9,28 @@ import ProductAttributeTermControl from '@woocommerce/editor-components/product-
 /**
  * Internal dependencies
  */
-import { Props } from './types';
+import { Attributes } from './types';
+
+export interface Props {
+	attributes: Attributes;
+	setAttributes: ( attributes: Partial< Attributes > ) => void;
+	isEditing: boolean;
+	setIsEditing: ( isEditing: boolean ) => void;
+	// from withSpokenMessages
+	debouncedSpeak: ( message: string ) => void;
+}
 
 export const ProductsByAttributeEditMode = ( props: Props ): JSX.Element => {
-	const { debouncedSpeak, setAttributes } = props;
-	const blockAttributes = props.attributes;
+	const {
+		attributes: blockAttributes,
+		setAttributes,
+		setIsEditing,
+		isEditing,
+		debouncedSpeak,
+	} = props;
+
 	const onDone = () => {
-		setAttributes( { editMode: false } );
+		setIsEditing( ! isEditing );
 		debouncedSpeak(
 			__(
 				'Showing Products by Attribute block preview.',

--- a/assets/js/blocks/products-by-attribute/edit-mode.tsx
+++ b/assets/js/blocks/products-by-attribute/edit-mode.tsx
@@ -1,0 +1,63 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Button, Placeholder } from '@wordpress/components';
+import { category, Icon } from '@wordpress/icons';
+import ProductAttributeTermControl from '@woocommerce/editor-components/product-attribute-term-control';
+
+/**
+ * Internal dependencies
+ */
+import { Props } from './types';
+
+export const ProductsByAttributeEditMode = ( props: Props ): JSX.Element => {
+	const { debouncedSpeak, setAttributes } = props;
+	const blockAttributes = props.attributes;
+	const onDone = () => {
+		setAttributes( { editMode: false } );
+		debouncedSpeak(
+			__(
+				'Showing Products by Attribute block preview.',
+				'woo-gutenberg-products-block'
+			)
+		);
+	};
+
+	return (
+		<Placeholder
+			icon={ <Icon icon={ category } /> }
+			label={ __(
+				'Products by Attribute',
+				'woo-gutenberg-products-block'
+			) }
+			className="wc-block-products-grid wc-block-products-by-attribute"
+		>
+			{ __(
+				'Display a grid of products from your selected attributes.',
+				'woo-gutenberg-products-block'
+			) }
+			<div className="wc-block-products-by-attribute__selection">
+				<ProductAttributeTermControl
+					selected={ blockAttributes.attributes }
+					onChange={ ( value = [] ) => {
+						const result = value.map(
+							( { id, attr_slug: attributeSlug } ) => ( {
+								id,
+								attr_slug: attributeSlug,
+							} )
+						);
+						setAttributes( { attributes: result } );
+					} }
+					operator={ blockAttributes.attrOperator }
+					onOperatorChange={ ( value = 'any' ) =>
+						setAttributes( { attrOperator: value } )
+					}
+				/>
+				<Button isPrimary onClick={ onDone }>
+					{ __( 'Done', 'woo-gutenberg-products-block' ) }
+				</Button>
+			</div>
+		</Placeholder>
+	);
+};

--- a/assets/js/blocks/products-by-attribute/edit-mode.tsx
+++ b/assets/js/blocks/products-by-attribute/edit-mode.tsx
@@ -9,18 +9,16 @@ import ProductAttributeTermControl from '@woocommerce/editor-components/product-
 /**
  * Internal dependencies
  */
-import { Attributes } from './types';
+import { Props } from './types';
 
-export interface Props {
-	attributes: Attributes;
-	setAttributes: ( attributes: Partial< Attributes > ) => void;
+export interface EditModeProps extends Props {
 	isEditing: boolean;
 	setIsEditing: ( isEditing: boolean ) => void;
-	// from withSpokenMessages
-	debouncedSpeak: ( message: string ) => void;
 }
 
-export const ProductsByAttributeEditMode = ( props: Props ): JSX.Element => {
+export const ProductsByAttributeEditMode = (
+	props: EditModeProps
+): JSX.Element => {
 	const {
 		attributes: blockAttributes,
 		setAttributes,

--- a/assets/js/blocks/products-by-attribute/edit.tsx
+++ b/assets/js/blocks/products-by-attribute/edit.tsx
@@ -2,7 +2,11 @@
  * External dependencies
  */
 import { BlockControls, useBlockProps } from '@wordpress/block-editor';
-import { Disabled, ToolbarGroup } from '@wordpress/components';
+import {
+	Disabled,
+	ToolbarGroup,
+	withSpokenMessages,
+} from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
@@ -15,7 +19,7 @@ import { ProductsByAttributeInspectorControls } from './inspector-controls';
 import { ProductsByAttributeEditMode } from './edit-mode';
 import { ProductsByAttributeBlock } from './block';
 
-export const Edit = ( props: Props ): JSX.Element => {
+export const EditBlock = ( props: Props ): JSX.Element => {
 	const blockProps = useBlockProps();
 
 	const {
@@ -56,3 +60,5 @@ export const Edit = ( props: Props ): JSX.Element => {
 		</div>
 	);
 };
+
+export const Edit = withSpokenMessages( EditBlock );

--- a/assets/js/blocks/products-by-attribute/edit.tsx
+++ b/assets/js/blocks/products-by-attribute/edit.tsx
@@ -3,6 +3,7 @@
  */
 import { BlockControls, useBlockProps } from '@wordpress/block-editor';
 import { Disabled, ToolbarGroup } from '@wordpress/components';
+import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -17,8 +18,7 @@ import { ProductsByAttributeBlock } from './block';
 export const Edit = ( props: Props ): JSX.Element => {
 	const blockProps = useBlockProps();
 
-	const { attributes, setAttributes } = props;
-	const { editMode } = attributes;
+	const [ isEditing, setIsEditing ] = useState( false );
 
 	return (
 		<div { ...blockProps }>
@@ -31,16 +31,19 @@ export const Edit = ( props: Props ): JSX.Element => {
 								'Edit selected attribute',
 								'woo-gutenberg-products-block'
 							),
-							onClick: () =>
-								setAttributes( { editMode: ! editMode } ),
-							isActive: editMode,
+							onClick: () => setIsEditing( ! isEditing ),
+							isActive: isEditing,
 						},
 					] }
 				/>
 			</BlockControls>
 			<ProductsByAttributeInspectorControls { ...props } />
-			{ editMode ? (
-				<ProductsByAttributeEditMode { ...props } />
+			{ isEditing ? (
+				<ProductsByAttributeEditMode
+					isEditing={ isEditing }
+					setIsEditing={ setIsEditing }
+					{ ...props }
+				/>
 			) : (
 				<Disabled>
 					<ProductsByAttributeBlock { ...props } />

--- a/assets/js/blocks/products-by-attribute/edit.tsx
+++ b/assets/js/blocks/products-by-attribute/edit.tsx
@@ -1,20 +1,51 @@
 /**
  * External dependencies
  */
-import { useBlockProps } from '@wordpress/block-editor';
+import { BlockControls, useBlockProps } from '@wordpress/block-editor';
+import { Disabled, ToolbarGroup } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import Block from './block';
 import './editor.scss';
+import { Props } from './types';
+import { ProductsByAttributeInspectorControls } from './inspector-controls';
+import { ProductsByAttributeEditMode } from './edit-mode';
+import { ProductsByAttributeBlock } from './block';
 
-export const Edit = ( props: unknown ): JSX.Element => {
+export const Edit = ( props: Props ): JSX.Element => {
 	const blockProps = useBlockProps();
+
+	const { attributes, setAttributes } = props;
+	const { editMode } = attributes;
 
 	return (
 		<div { ...blockProps }>
-			<Block { ...props } />
+			<BlockControls>
+				<ToolbarGroup
+					controls={ [
+						{
+							icon: 'edit',
+							title: __(
+								'Edit selected attribute',
+								'woo-gutenberg-products-block'
+							),
+							onClick: () =>
+								setAttributes( { editMode: ! editMode } ),
+							isActive: editMode,
+						},
+					] }
+				/>
+			</BlockControls>
+			<ProductsByAttributeInspectorControls { ...props } />
+			{ editMode ? (
+				<ProductsByAttributeEditMode { ...props } />
+			) : (
+				<Disabled>
+					<ProductsByAttributeBlock { ...props } />
+				</Disabled>
+			) }
 		</div>
 	);
 };

--- a/assets/js/blocks/products-by-attribute/edit.tsx
+++ b/assets/js/blocks/products-by-attribute/edit.tsx
@@ -18,7 +18,11 @@ import { ProductsByAttributeBlock } from './block';
 export const Edit = ( props: Props ): JSX.Element => {
 	const blockProps = useBlockProps();
 
-	const [ isEditing, setIsEditing ] = useState( false );
+	const {
+		attributes: { attributes },
+	} = props;
+
+	const [ isEditing, setIsEditing ] = useState( ! attributes.length );
 
 	return (
 		<div { ...blockProps }>

--- a/assets/js/blocks/products-by-attribute/inspector-controls.tsx
+++ b/assets/js/blocks/products-by-attribute/inspector-controls.tsx
@@ -1,0 +1,110 @@
+/**
+ * External dependencies
+ */
+import { PanelBody } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import GridLayoutControl from '@woocommerce/editor-components/grid-layout-control';
+import { getSetting } from '@woocommerce/settings';
+import GridContentControl from '@woocommerce/editor-components/grid-content-control';
+import ProductAttributeTermControl from '@woocommerce/editor-components/product-attribute-term-control';
+import ProductOrderbyControl from '@woocommerce/editor-components/product-orderby-control';
+import ProductStockControl from '@woocommerce/editor-components/product-stock-control';
+import { InspectorControls } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { Props } from './types';
+
+export const ProductsByAttributeInspectorControls = (
+	props: Props
+): JSX.Element => {
+	const { setAttributes } = props;
+	const {
+		attributes,
+		attrOperator,
+		columns,
+		contentVisibility,
+		orderby,
+		rows,
+		alignButtons,
+		stockStatus,
+	} = props.attributes;
+
+	return (
+		<InspectorControls key="inspector">
+			<PanelBody
+				title={ __( 'Layout', 'woo-gutenberg-products-block' ) }
+				initialOpen
+			>
+				<GridLayoutControl
+					columns={ columns }
+					rows={ rows }
+					alignButtons={ alignButtons }
+					setAttributes={ setAttributes }
+					minColumns={ getSetting( 'min_columns', 1 ) }
+					maxColumns={ getSetting( 'max_columns', 6 ) }
+					minRows={ getSetting( 'min_rows', 1 ) }
+					maxRows={ getSetting( 'max_rows', 6 ) }
+				/>
+			</PanelBody>
+			<PanelBody
+				title={ __( 'Content', 'woo-gutenberg-products-block' ) }
+				initialOpen
+			>
+				<GridContentControl
+					settings={ contentVisibility }
+					onChange={ ( value ) =>
+						setAttributes( { contentVisibility: value } )
+					}
+				/>
+			</PanelBody>
+			<PanelBody
+				title={ __(
+					'Filter by Product Attribute',
+					'woo-gutenberg-products-block'
+				) }
+				initialOpen={ false }
+			>
+				<ProductAttributeTermControl
+					selected={ attributes }
+					onChange={ ( value = [] ) => {
+						const result = value.map(
+							( { id, attr_slug: attributeSlug } ) => ( {
+								id,
+								attr_slug: attributeSlug,
+							} )
+						);
+						setAttributes( { attributes: result } );
+					} }
+					operator={ attrOperator }
+					onOperatorChange={ ( value = 'any' ) =>
+						setAttributes( { attrOperator: value } )
+					}
+					isCompact={ true }
+				/>
+			</PanelBody>
+			<PanelBody
+				title={ __( 'Order By', 'woo-gutenberg-products-block' ) }
+				initialOpen={ false }
+			>
+				<ProductOrderbyControl
+					setAttributes={ setAttributes }
+					value={ orderby }
+				/>
+			</PanelBody>
+			<PanelBody
+				title={ __(
+					'Filter by stock status',
+					'woo-gutenberg-products-block'
+				) }
+				initialOpen={ false }
+			>
+				<ProductStockControl
+					setAttributes={ setAttributes }
+					value={ stockStatus }
+				/>
+			</PanelBody>
+		</InspectorControls>
+	);
+};

--- a/assets/js/blocks/products-by-attribute/types.ts
+++ b/assets/js/blocks/products-by-attribute/types.ts
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import { BlockAlignment } from '@wordpress/blocks';
+
+export interface Attributes {
+	align?: BlockAlignment;
+	attributes: Array< string >;
+	attrOperator: string;
+	columns: number;
+	editMode: boolean;
+	contentVisibility: {
+		image: boolean;
+		title: boolean;
+		price: boolean;
+		rating: boolean;
+		button: boolean;
+	};
+	orderby: string;
+	rows: number;
+	alignButtons: boolean;
+	isPreview: boolean;
+	stockStatus: Array< string >;
+}
+
+export interface Props {
+	/**
+	 * The attributes for this block
+	 */
+	attributes: Attributes;
+	/**
+	 * The register block name.
+	 */
+	name: string;
+	/**
+	 * A callback to update attributes
+	 */
+	setAttributes: ( attributes: Partial< Attributes > ) => void;
+	// from withSpokenMessages
+	debouncedSpeak: ( message: string ) => void;
+}

--- a/assets/js/blocks/products-by-attribute/types.ts
+++ b/assets/js/blocks/products-by-attribute/types.ts
@@ -6,7 +6,7 @@ import { BlockAlignment } from '@wordpress/blocks';
 export interface Attributes {
 	align?: BlockAlignment;
 	attributes: Array< string >;
-	attrOperator: string;
+	attrOperator: 'all' | 'any';
 	columns: number;
 	contentVisibility: {
 		image: boolean;
@@ -15,7 +15,14 @@ export interface Attributes {
 		rating: boolean;
 		button: boolean;
 	};
-	orderby: string;
+	orderby:
+		| 'date'
+		| 'popularity'
+		| 'price_asc'
+		| 'price_desc'
+		| 'rating'
+		| 'title'
+		| 'menu_order';
 	rows: number;
 	alignButtons: boolean;
 	isPreview: boolean;

--- a/assets/js/blocks/products-by-attribute/types.ts
+++ b/assets/js/blocks/products-by-attribute/types.ts
@@ -8,7 +8,6 @@ export interface Attributes {
 	attributes: Array< string >;
 	attrOperator: string;
 	columns: number;
-	editMode: boolean;
 	contentVisibility: {
 		image: boolean;
 		title: boolean;

--- a/src/BlockTypes/ProductsByAttribute.php
+++ b/src/BlockTypes/ProductsByAttribute.php
@@ -63,7 +63,6 @@ class ProductsByAttribute extends AbstractProductGrid {
 			'className'         => $this->get_schema_string(),
 			'columns'           => $this->get_schema_number( wc_get_theme_support( 'product_blocks::default_columns', 3 ) ),
 			'contentVisibility' => $this->get_schema_content_visibility(),
-			'editMode'          => $this->get_schema_boolean( true ),
 			'orderby'           => $this->get_schema_orderby(),
 			'rows'              => $this->get_schema_number( wc_get_theme_support( 'product_blocks::default_rows', 3 ) ),
 			'isPreview'         => $this->get_schema_boolean( false ),


### PR DESCRIPTION
Converts the `Products by Attribute` block.js file to TS.

### Testing

#### Automated Tests
* [x] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests

### Manual Testing

1. Create a page and add a `Products by Attribute` block.
2. Save the page and check it renders correctly the default config in the frontend.
3. Edit the page again and make some changes to the block (hiding some content, changing columns number, ordering, etc.).
4. Save the page and check it renders properly with the new config.