### PR TITLE
Refactor webpack splitting to fix missing translation

### DIFF
--- a/bin/webpack-configs.js
+++ b/bin/webpack-configs.js
@@ -122,9 +122,7 @@ woocommerce_blocks_env = ${ NODE_ENV }
 			// Only concatenate modules in production, when not analyzing bundles.
 			concatenateModules:
 				isProduction && ! process.env.WP_BUNDLE_ANALYZER,
-			splitChunks: {
-				automaticNameDelimiter: '--',
-			},
+			splitChunks: false,
 			minimizer: [
 				new TerserPlugin( {
 					cache: true,
@@ -222,7 +220,7 @@ const getMainConfig = ( options = {} ) => {
 			concatenateModules:
 				isProduction && ! process.env.WP_BUNDLE_ANALYZER,
 			splitChunks: {
-				minSize: 0,
+				minSize: 10000, // makes the smallest chunk file 10kbs, this doesn't affect lazy loaded chunks.
 				automaticNameDelimiter: '--',
 				cacheGroups: {
 					commons: {

--- a/bin/webpack-configs.js
+++ b/bin/webpack-configs.js
@@ -377,9 +377,7 @@ const getFrontConfig = ( options = {} ) => {
 		optimization: {
 			concatenateModules:
 				isProduction && ! process.env.WP_BUNDLE_ANALYZER,
-			splitChunks: {
-				automaticNameDelimiter: '--',
-			},
+			splitChunks: false,
 			minimizer: [
 				new TerserPlugin( {
 					cache: true,

--- a/bin/webpack-configs.js
+++ b/bin/webpack-configs.js
@@ -375,7 +375,41 @@ const getFrontConfig = ( options = {} ) => {
 		optimization: {
 			concatenateModules:
 				isProduction && ! process.env.WP_BUNDLE_ANALYZER,
-			splitChunks: false,
+			splitChunks: {
+				cacheGroups: {
+					default: false,
+					vendors: {
+						test: /[\\/]node_modules[\\/]/,
+						name( module ) {
+							const moduleFileName = module
+								.identifier()
+								.split( '/' )
+								.reduceRight( ( item ) => item );
+							return `vendor/${ moduleFileName }`;
+						},
+						automaticNameDelimiter: '--',
+						minSize: 20000,
+						priority: -20,
+					},
+					'cart-checkout-wp-commons': {
+						test: ( module ) => {
+							if (
+								module?.resource?.match(
+									/wordpress-components/
+								)
+							) {
+								return true;
+							}
+						},
+						name: 'cart-checkout/commons.js',
+						automaticNameDelimiter: '--',
+						reuseExistingChunk: true,
+						enforce: true,
+						minSize: 20000,
+						priority: -10,
+					},
+				},
+			},
 			minimizer: [
 				new TerserPlugin( {
 					cache: true,

--- a/bin/webpack-configs.js
+++ b/bin/webpack-configs.js
@@ -278,12 +278,12 @@ const getMainConfig = ( options = {} ) => {
 					},
 					{
 						from: './assets/js/blocks/product-tag/block.json',
-						to: './product-tag/block.json',
+						to: './product-tag.block.json',
 					},
 					{
 						from:
 							'./assets/js/blocks/products-by-attribute/block.json',
-						to: './products-by-attribute/block.json',
+						to: './products-by-attribute.block.json',
 					},
 				],
 			} ),

--- a/bin/webpack-configs.js
+++ b/bin/webpack-configs.js
@@ -261,22 +261,22 @@ const getMainConfig = ( options = {} ) => {
 				patterns: [
 					{
 						from: './assets/js/blocks/checkout/block.json',
-						to: './checkout/block.json',
+						to: './checkout.block.json',
 					},
 					{
 						from:
 							'./assets/js/blocks/featured-items/featured-category/block.json',
-						to: './featured-category/block.json',
+						to: './featured-category.block.json',
 					},
 					{
 						from:
 							'./assets/js/blocks/featured-items/featured-product/block.json',
-						to: './featured-product/block.json',
+						to: './featured-product.block.json',
 					},
 					{
 						from:
 							'./assets/js/blocks/handpicked-products/block.json',
-						to: './handpicked-products/block.json',
+						to: './handpicked-products.block.json',
 					},
 					{
 						from: './assets/js/blocks/product-tag/block.json',

--- a/bin/webpack-configs.js
+++ b/bin/webpack-configs.js
@@ -391,7 +391,7 @@ const getFrontConfig = ( options = {} ) => {
 						minSize: 20000,
 						priority: -20,
 					},
-					'cart-checkout-wp-commons': {
+					'wp-components': {
 						test: ( module ) => {
 							if (
 								module?.resource?.match(
@@ -401,7 +401,7 @@ const getFrontConfig = ( options = {} ) => {
 								return true;
 							}
 						},
-						name: 'cart-checkout/commons.js',
+						name: 'wp/wp-components.js',
 						automaticNameDelimiter: '--',
 						reuseExistingChunk: true,
 						enforce: true,

--- a/bin/wp-env-config.sh
+++ b/bin/wp-env-config.sh
@@ -28,9 +28,12 @@ wp language plugin install woo-gutenberg-products-block nl_NL
 # To get the latest translations, we need to run an additional update command.
 #wp language plugin update woo-gutenberg-products-block nl_NL
 ## downloaded unpurged translation file
-curl https://translate.wordpress.org/projects/wp-plugins/woo-gutenberg-products-block/stable/nl/default/export-translations/ --output ./wp-content/languages/plugins/woo-gutenberg-products-block-nl_NL.po
-## update po file with new locations
-php -d memory_limit=2024M "$(which wp)" i18n make-pot ./wp-content/plugins/$BASENAME/ ./wp-content/languages/plugins/woo-gutenberg-products-block-nl_NL.po --domain=woo-gutenberg-products-block --exclude=node_modules,vendor
-## regenerate json files
-php -d memory_limit=2024M "$(which wp)" i18n make-json ./wp-content/languages/plugins/woo-gutenberg-products-block-nl_NL.po
+if curl --silent -o "./wp-content/languages/plugins/woo-gutenberg-products-block-nl_NL.po" -L "https://translate.wordpress.org/projects/wp-plugins/woo-gutenberg-products-block/stable/nl/default/export-translations/"; then
+    if php -d memory_limit=2024M "$(which wp)" i18n make-pot ./wp-content/plugins/$BASENAME/ ./wp-content/languages/plugins/woo-gutenberg-products-block-nl_NL.po --domain=woo-gutenberg-products-block --exclude=node_modules,vendor; then
+        php -d memory_limit=2024M "$(which wp)" i18n make-json ./wp-content/languages/plugins/woo-gutenberg-products-block-nl_NL.po
+    fi
+else
+    echo "Something went wrong"
+fi
+echo "Done!"
 exit $EXIT_CODE

--- a/bin/wp-env-config.sh
+++ b/bin/wp-env-config.sh
@@ -26,6 +26,11 @@ wp language plugin install woocommerce nl_NL
 wp language plugin install woo-gutenberg-products-block nl_NL
 # Because we don't install the WooCommerce Blocks plugin, WP CLI uses the core version to install the language pack.
 # To get the latest translations, we need to run an additional update command.
-wp language plugin update woo-gutenberg-products-block nl_NL
-
+#wp language plugin update woo-gutenberg-products-block nl_NL
+## downloaded unpurged translation file
+curl https://translate.wordpress.org/projects/wp-plugins/woo-gutenberg-products-block/stable/nl/default/export-translations/ --output ./wp-content/languages/plugins/woo-gutenberg-products-block-nl_NL.po
+## update po file with new locations
+php -d memory_limit=2024M "$(which wp)" i18n make-pot ./wp-content/plugins/$BASENAME/ ./wp-content/languages/plugins/woo-gutenberg-products-block-nl_NL.po --domain=woo-gutenberg-products-block --exclude=node_modules,vendor
+## regenerate json files
+php -d memory_limit=2024M "$(which wp)" i18n make-json ./wp-content/languages/plugins/woo-gutenberg-products-block-nl_NL.po
 exit $EXIT_CODE

--- a/bin/wp-env-config.sh
+++ b/bin/wp-env-config.sh
@@ -28,12 +28,11 @@ wp language plugin install woo-gutenberg-products-block nl_NL
 # To get the latest translations, we need to run an additional update command.
 #wp language plugin update woo-gutenberg-products-block nl_NL
 ## downloaded unpurged translation file
-if curl --silent -o "./wp-content/languages/plugins/woo-gutenberg-products-block-nl_NL.po" -L "https://translate.wordpress.org/projects/wp-plugins/woo-gutenberg-products-block/stable/nl/default/export-translations/"; then
-    if php -d memory_limit=2024M "$(which wp)" i18n make-pot ./wp-content/plugins/$BASENAME/ ./wp-content/languages/plugins/woo-gutenberg-products-block-nl_NL.po --domain=woo-gutenberg-products-block --exclude=node_modules,vendor; then
-        php -d memory_limit=2024M "$(which wp)" i18n make-json ./wp-content/languages/plugins/woo-gutenberg-products-block-nl_NL.po
-    fi
-else
-    echo "Something went wrong"
-fi
-echo "Done!"
+curl https://translate.wordpress.org/projects/wp-plugins/woo-gutenberg-products-block/stable/nl/default/export-translations/ --output ./wp-content/languages/plugins/woo-gutenberg-products-block-nl_NL.po
+sleep 30
+## update po file with new locations
+php -d memory_limit=2024M "$(which wp)" i18n make-pot ./wp-content/plugins/$BASENAME/ ./wp-content/languages/plugins/woo-gutenberg-products-block-nl_NL.po --domain=woo-gutenberg-products-block --exclude=node_modules,vendor
+sleep 30
+## regenerate json files
+php -d memory_limit=2024M "$(which wp)" i18n make-json ./wp-content/languages/plugins/woo-gutenberg-products-block-nl_NL.po
 exit $EXIT_CODE

--- a/bin/wp-env-config.sh
+++ b/bin/wp-env-config.sh
@@ -19,20 +19,19 @@ wp core version --extra
 wp plugin list
 wp theme activate storefront
 wp wc customer update 1 --user=1 --billing='{"first_name":"John","last_name":"Doe","company":"Automattic","country":"US","address_1":"addr 1","address_2":"addr 2","city":"San Francisco","state":"CA","postcode":"94107","phone":"123456789"}' --shipping='{"first_name":"John","last_name":"Doe","company":"Automattic","country":"US","address_1":"addr 1","address_2":"addr 2","city":"San Francisco","state":"CA","postcode":"94107","phone":"123456789"}'
-
 ## Prepare translation for the test suite
 wp language core install nl_NL
 wp language plugin install woocommerce nl_NL
-wp language plugin install woo-gutenberg-products-block nl_NL
-# Because we don't install the WooCommerce Blocks plugin, WP CLI uses the core version to install the language pack.
-# To get the latest translations, we need to run an additional update command.
-#wp language plugin update woo-gutenberg-products-block nl_NL
-## downloaded unpurged translation file
+## We download a full version of .po (that has translation for js files as well).
 curl https://translate.wordpress.org/projects/wp-plugins/woo-gutenberg-products-block/stable/nl/default/export-translations/ --output ./wp-content/languages/plugins/woo-gutenberg-products-block-nl_NL.po
-sleep 30
-## update po file with new locations
-php -d memory_limit=2024M "$(which wp)" i18n make-pot ./wp-content/plugins/$BASENAME/ ./wp-content/languages/plugins/woo-gutenberg-products-block-nl_NL.po --domain=woo-gutenberg-products-block --exclude=node_modules,vendor
-sleep 30
-## regenerate json files
+sleep 5
+## We generate a new po file, based on the one we just downloaded, but with updated file paths.
+## This should account for when a file changes location between versions.
+php -d memory_limit=2024M "$(which wp)" i18n make-pot ./wp-content/plugins/$1/ ./wp-content/languages/plugins/woo-gutenberg-products-block-nl_NL-updated.po --merge=./wp-content/languages/plugins/woo-gutenberg-products-block-nl_NL.po --domain=woo-gutenberg-products-block --exclude=node_modules,vendor --skip-audit
+## We remove the po we downloaded.
+rm ./wp-content/languages/plugins/woo-gutenberg-products-block-nl_NL.po
+## And rename the one we just created to that one.
+mv ./wp-content/languages/plugins/woo-gutenberg-products-block-nl_NL-updated.po ./wp-content/languages/plugins/woo-gutenberg-products-block-nl_NL.po
+## We regenerate json translation from the new po file we created.
 php -d memory_limit=2024M "$(which wp)" i18n make-json ./wp-content/languages/plugins/woo-gutenberg-products-block-nl_NL.po
 exit $EXIT_CODE

--- a/bin/wp-env-config.sh
+++ b/bin/wp-env-config.sh
@@ -25,13 +25,9 @@ wp language plugin install woocommerce nl_NL
 ## We download a full version of .po (that has translation for js files as well).
 curl https://translate.wordpress.org/projects/wp-plugins/woo-gutenberg-products-block/stable/nl/default/export-translations/ --output ./wp-content/languages/plugins/woo-gutenberg-products-block-nl_NL.po
 sleep 5
-## We generate a new po file, based on the one we just downloaded, but with updated file paths.
+## We update our po file with updated file paths.
 ## This should account for when a file changes location between versions.
-php -d memory_limit=2024M "$(which wp)" i18n make-pot ./wp-content/plugins/$1/ ./wp-content/languages/plugins/woo-gutenberg-products-block-nl_NL-updated.po --merge=./wp-content/languages/plugins/woo-gutenberg-products-block-nl_NL.po --domain=woo-gutenberg-products-block --exclude=node_modules,vendor --skip-audit
-## We remove the po we downloaded.
-rm ./wp-content/languages/plugins/woo-gutenberg-products-block-nl_NL.po
-## And rename the one we just created to that one.
-mv ./wp-content/languages/plugins/woo-gutenberg-products-block-nl_NL-updated.po ./wp-content/languages/plugins/woo-gutenberg-products-block-nl_NL.po
+php -d memory_limit=2024M "$(which wp)" i18n make-pot ./wp-content/plugins/$1/ ./wp-content/languages/plugins/woo-gutenberg-products-block-nl_NL.po --merge --domain=woo-gutenberg-products-block --exclude=node_modules,vendor --skip-audit
 ## We regenerate json translation from the new po file we created.
 php -d memory_limit=2024M "$(which wp)" i18n make-json ./wp-content/languages/plugins/woo-gutenberg-products-block-nl_NL.po
 exit $EXIT_CODE

--- a/bin/wp-env-pre-config.sh
+++ b/bin/wp-env-pre-config.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
 BASENAME=$(basename "`pwd`")
-npm run wp-env run tests-cli './wp-content/plugins/'$BASENAME'/bin/wp-env-config.sh'
+# We need to pass the blocks plugin folder name to the script, the name can change depending on your local env and we can't hardcode it.
+npm run wp-env run tests-cli './wp-content/plugins/'$BASENAME'/bin/wp-env-config.sh' $BASENAME

--- a/src/Assets/Api.php
+++ b/src/Assets/Api.php
@@ -68,7 +68,7 @@ class Api {
 	 * @return string|boolean False if metadata file is not found for the block.
 	 */
 	public function get_block_metadata_path( $block_name ) {
-		$path_to_metadata_from_plugin_root = $this->package->get_path( 'build/' . $block_name . '/block.json' );
+		$path_to_metadata_from_plugin_root = $this->package->get_path( 'build/' . $block_name . '.block.json' );
 		if ( ! file_exists( $path_to_metadata_from_plugin_root ) ) {
 			return false;
 		}

--- a/src/BlockTypes/AbstractBlock.php
+++ b/src/BlockTypes/AbstractBlock.php
@@ -172,7 +172,20 @@ abstract class AbstractBlock {
 	}
 
 	/**
+	 * Generate an array of chunks paths for loading translation.
+	 */
+	protected function get_chunks_paths() {
+		foreach ( glob( \Automattic\WooCommerce\Blocks\Package::get_path() . "build/{$this->chunks_folder}/*-frontend.js" ) as $block_name ) {
+			$blocks[] = "{$this->chunks_folder}/" . basename( $block_name );
+		}
+
+		$chunks = preg_filter( '/.js/', '', $blocks );
+		return $chunks;
+	}
+	/**
 	 * Registers the block type with WordPress.
+	 *
+	 * @return string[] Chunks paths.
 	 */
 	protected function register_block_type() {
 		$block_settings = [

--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -236,12 +236,22 @@ class Cart extends AbstractBlock {
 	protected function register_block_type_assets() {
 		parent::register_block_type_assets();
 		$blocks = [
-			'cart-blocks/express-payment--checkout-blocks/express-payment--checkout-blocks/payment',
-			'cart-blocks/line-items',
-			'cart-blocks/order-summary',
-			'cart-blocks/order-summary--checkout-blocks/billing-address--checkout-blocks/shipping-address',
-			'cart-blocks/checkout-button',
-			'cart-blocks/express-payment',
+			'cart-blocks/cart-accepted-payment-methods',
+			'cart-blocks/cart-express-payment',
+			'cart-blocks/cart-items',
+			'cart-blocks/cart-line-items',
+			'cart-blocks/cart-order-summary',
+			'cart-blocks/cart-totals',
+			'cart-blocks/empty-cart',
+			'cart-blocks/filled-cart',
+			'cart-blocks/order-summary-coupon-form',
+			'cart-blocks/order-summary-discount',
+			'cart-blocks/order-summary-fee',
+			'cart-blocks/order-summary-heading',
+			'cart-blocks/order-summary-shipping',
+			'cart-blocks/order-summary-subtotal',
+			'cart-blocks/order-summary-taxes',
+			'cart-blocks/proceed-to-checkout',
 		];
 		$chunks = preg_filter( '/$/', '-frontend', $blocks );
 		$this->register_chunk_translations( $chunks );

--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -19,6 +19,13 @@ class Cart extends AbstractBlock {
 	protected $block_name = 'cart';
 
 	/**
+	 * Chunks build folder.
+	 *
+	 * @var string
+	 */
+	protected $chunks_folder = 'cart-blocks';
+
+	/**
 	 * Get the editor script handle for this block type.
 	 *
 	 * @param string $key Data to get, or default to everything.
@@ -227,7 +234,6 @@ class Cart extends AbstractBlock {
 	protected function hydrate_from_api() {
 		$this->asset_data_registry->hydrate_api_request( '/wc/store/v1/cart' );
 	}
-
 	/**
 	 * Register script and style assets for the block type before it is registered.
 	 *
@@ -235,25 +241,7 @@ class Cart extends AbstractBlock {
 	 */
 	protected function register_block_type_assets() {
 		parent::register_block_type_assets();
-		$blocks = [
-			'cart-blocks/cart-accepted-payment-methods',
-			'cart-blocks/cart-express-payment',
-			'cart-blocks/cart-items',
-			'cart-blocks/cart-line-items',
-			'cart-blocks/cart-order-summary',
-			'cart-blocks/cart-totals',
-			'cart-blocks/empty-cart',
-			'cart-blocks/filled-cart',
-			'cart-blocks/order-summary-coupon-form',
-			'cart-blocks/order-summary-discount',
-			'cart-blocks/order-summary-fee',
-			'cart-blocks/order-summary-heading',
-			'cart-blocks/order-summary-shipping',
-			'cart-blocks/order-summary-subtotal',
-			'cart-blocks/order-summary-taxes',
-			'cart-blocks/proceed-to-checkout',
-		];
-		$chunks = preg_filter( '/$/', '-frontend', $blocks );
+		$chunks = $this->get_chunks_paths();
 		$this->register_chunk_translations( $chunks );
 	}
 }

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -401,17 +401,25 @@ class Checkout extends AbstractBlock {
 	protected function register_block_type_assets() {
 		parent::register_block_type_assets();
 		$blocks = [
-			'checkout-blocks/express-payment',
-			'checkout-blocks/contact-information',
-			'checkout-blocks/shipping-address',
-			'checkout-blocks/billing-address--checkout-blocks/shipping-address',
-			'checkout-blocks/billing-address',
-			'checkout-blocks/shipping-methods',
-			'checkout-blocks/payment',
-			'checkout-blocks/order-note',
 			'checkout-blocks/actions',
-			'checkout-blocks/terms',
+			'checkout-blocks/billing-address',
+			'checkout-blocks/contact-information',
+			'checkout-blocks/express-payment',
+			'checkout-blocks/fields',
+			'checkout-blocks/order-note',
 			'checkout-blocks/order-summary',
+			'checkout-blocks/order-summary-cart-items',
+			'checkout-blocks/order-summary-coupon-form',
+			'checkout-blocks/order-summary-discount',
+			'checkout-blocks/order-summary-fee',
+			'checkout-blocks/order-summary-shipping',
+			'checkout-blocks/order-summary-subtotal',
+			'checkout-blocks/order-summary-taxes',
+			'checkout-blocks/payment',
+			'checkout-blocks/shipping-address',
+			'checkout-blocks/shipping-methods',
+			'checkout-blocks/terms',
+			'checkout-blocks/totals',
 		];
 		$chunks = preg_filter( '/$/', '-frontend', $blocks );
 		$this->register_chunk_translations( $chunks );

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -15,6 +15,13 @@ class Checkout extends AbstractBlock {
 	protected $block_name = 'checkout';
 
 	/**
+	 * Chunks build folder.
+	 *
+	 * @var string
+	 */
+	protected $chunks_folder = 'checkout-blocks';
+
+	/**
 	 * Get the editor script handle for this block type.
 	 *
 	 * @param string $key Data to get, or default to everything.
@@ -392,7 +399,6 @@ class Checkout extends AbstractBlock {
 		}
 		return $list_item;
 	}
-
 	/**
 	 * Register script and style assets for the block type before it is registered.
 	 *
@@ -400,28 +406,7 @@ class Checkout extends AbstractBlock {
 	 */
 	protected function register_block_type_assets() {
 		parent::register_block_type_assets();
-		$blocks = [
-			'checkout-blocks/actions',
-			'checkout-blocks/billing-address',
-			'checkout-blocks/contact-information',
-			'checkout-blocks/express-payment',
-			'checkout-blocks/fields',
-			'checkout-blocks/order-note',
-			'checkout-blocks/order-summary',
-			'checkout-blocks/order-summary-cart-items',
-			'checkout-blocks/order-summary-coupon-form',
-			'checkout-blocks/order-summary-discount',
-			'checkout-blocks/order-summary-fee',
-			'checkout-blocks/order-summary-shipping',
-			'checkout-blocks/order-summary-subtotal',
-			'checkout-blocks/order-summary-taxes',
-			'checkout-blocks/payment',
-			'checkout-blocks/shipping-address',
-			'checkout-blocks/shipping-methods',
-			'checkout-blocks/terms',
-			'checkout-blocks/totals',
-		];
-		$chunks = preg_filter( '/$/', '-frontend', $blocks );
+		$chunks = $this->get_chunks_paths();
 		$this->register_chunk_translations( $chunks );
 	}
 }

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -483,13 +483,13 @@ class MiniCart extends AbstractBlock {
 		$translations = array();
 
 		$blocks = [
-			'mini-cart-contents-block/filled-cart',
 			'mini-cart-contents-block/empty-cart',
-			'mini-cart-contents-block/title',
+			'mini-cart-contents-block/filled-cart',
+			'mini-cart-contents-block/footer',
 			'mini-cart-contents-block/items',
 			'mini-cart-contents-block/products-table',
-			'mini-cart-contents-block/footer',
 			'mini-cart-contents-block/shopping-button',
+			'mini-cart-contents-block/title',
 		];
 		$chunks = preg_filter( '/$/', '-frontend', $blocks );
 

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -24,6 +24,13 @@ class MiniCart extends AbstractBlock {
 	protected $block_name = 'mini-cart';
 
 	/**
+	 * Chunks build folder.
+	 *
+	 * @var string
+	 */
+	protected $chunks_folder = 'mini-cart-contents-block';
+
+	/**
 	 * Array of scripts that will be lazy loaded when interacting with the block.
 	 *
 	 * @var string[]
@@ -187,9 +194,8 @@ class MiniCart extends AbstractBlock {
 		}
 
 		$this->scripts_to_lazy_load['wc-block-mini-cart-component-frontend'] = array(
-			'src'          => $script_data['src'],
-			'version'      => $script_data['version'],
-			'translations' => $this->get_inner_blocks_translations(),
+			'src'     => $script_data['src'],
+			'version' => $script_data['version'],
 		);
 
 		// Re-add the filter.
@@ -476,33 +482,14 @@ class MiniCart extends AbstractBlock {
 	}
 
 	/**
-	 * Prepare translations for inner blocks and dependencies.
+	 * Register script and style assets for the block type before it is registered.
+	 *
+	 * This registers the scripts; it does not enqueue them.
 	 */
-	protected function get_inner_blocks_translations() {
-		$wp_scripts   = wp_scripts();
-		$translations = array();
-
-		$blocks = [
-			'mini-cart-contents-block/empty-cart',
-			'mini-cart-contents-block/filled-cart',
-			'mini-cart-contents-block/footer',
-			'mini-cart-contents-block/items',
-			'mini-cart-contents-block/products-table',
-			'mini-cart-contents-block/shopping-button',
-			'mini-cart-contents-block/title',
-		];
-		$chunks = preg_filter( '/$/', '-frontend', $blocks );
-
-		foreach ( $chunks as $chunk ) {
-			$handle = 'wc-blocks-' . $chunk . '-chunk';
-			$this->asset_api->register_script( $handle, $this->asset_api->get_block_asset_build_path( $chunk ), [], true );
-			$translations[] = $wp_scripts->print_translations( $handle, false );
-			wp_deregister_script( $handle );
-		}
-
-		$translations = array_filter( $translations );
-
-		return implode( '', $translations );
+	protected function register_block_type_assets() {
+		parent::register_block_type_assets();
+		$chunks = $this->get_chunks_paths();
+		$this->register_chunk_translations( $chunks );
 	}
 
 	/**

--- a/tests/e2e/specs/shopper/cart-checkout/translations.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/translations.test.js
@@ -35,12 +35,13 @@ describe( 'Shopper → Cart & Checkout → Translations', () => {
 		const removeLink = await page.waitForSelector(
 			'.wc-block-cart-item__remove-link'
 		);
-		await expect( removeLink ).toMatch( 'Artikel verwijderen' );
+		await expect( removeLink ).toMatch( 'Verwijder item' );
 
 		const submitButton = await page.waitForSelector(
 			'.wc-block-cart__submit-button'
 		);
-		await expect( submitButton ).toMatch( 'Doorgaan naar afrekenen' );
+
+		await expect( submitButton ).toMatch( 'Ga naar afrekenen' );
 
 		const orderSummary = await page.$(
 			'.wp-block-woocommerce-cart-order-summary-block'
@@ -51,7 +52,7 @@ describe( 'Shopper → Cart & Checkout → Translations', () => {
 		await expect( orderSummary ).toMatch( 'Totaal' );
 	} );
 
-	it( 'USer can view translated Checkout block', async () => {
+	it( 'User can view translated Checkout block', async () => {
 		await shopper.block.goToCheckout();
 
 		const contactHeading = await page.$(
@@ -90,7 +91,7 @@ describe( 'Shopper → Cart & Checkout → Translations', () => {
 		await expect( orderSummary ).toMatch( 'Besteloverzicht' );
 		await expect( orderSummary ).toMatch( 'Subtotaal' );
 		await expect( orderSummary ).toMatch( 'Waardebon code' );
-		await expect( orderSummary ).toMatch( 'Verzendmethoden' );
+		await expect( orderSummary ).toMatch( 'Verzending' );
 		await expect( orderSummary ).toMatch( 'Totaal' );
 	} );
 } );

--- a/tests/e2e/specs/shopper/mini-cart.test.js
+++ b/tests/e2e/specs/shopper/mini-cart.test.js
@@ -594,9 +594,9 @@ describe( 'Shopper → Mini Cart', () => {
 				);
 
 				await expect( page ).toMatchElement(
-					'.wc-block-mini-cart__title',
+					'.wc-block-mini-cart__footer-cart',
 					{
-						text: 'Je winkelwagen (1 stuk)',
+						text: 'Bekijk mijn winkelwagen',
 					}
 				);
 			} );
@@ -626,9 +626,9 @@ describe( 'Shopper → Mini Cart', () => {
 				);
 
 				await expect( page ).toMatchElement(
-					'.wc-block-mini-cart__title',
+					'.wc-block-mini-cart__footer-cart',
 					{
-						text: 'Je winkelwagen (1 stuk)',
+						text: 'Bekijk mijn winkelwagen',
 					}
 				);
 			} );


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR does a couple of things:

### Webpack
It fixes our webpack config by always omitting consistent and stable output names, previously, webpack would try to generate chunks from the good of its heart, but this would result in very awkward file names like:
- `'cart-blocks/order-summary--checkout-blocks/billing-address--checkout-blocks/shipping-address',`.
- `'product-add-to-cart--product-button--product-category-list--product-image--product-price--product-r--a0326d00.js'`.
This is no longer the case, we now control exactly the output of such files and their naming.
Doing that meant degradation in bundle size, I fixed that by omitting external packages and `wordpress-components` related code into separate chunks, this should make the bundle size better.
It should be noted that the overall bundle size increased a bit, because some wordpress/components related code wasn't fully abstracted out, I plan to address that in a future iteration. 

Part of this PR is also switching from `build/${blockName}/block.json` notation for block.json files to `build/${blockName}.block.json`, this reduces the amount of folders we have. It should be noted that PHP `register_block_type_from_metadata` only support files that are named `block.json` or end with `block.json`.

### Translation
To fix this, I needed to do the webpack work, basically we have two issues here:
- When we shift our files output, or split old files into new files, our translation no longer work, because we manually load translation in the backend, we need to update the hardcoded names to reflect that, we failed to do that when we split the summary block, it's now fixed.
- The second issue is that we now have new files, and json translation is a file-name based translation, so we ended up with missing json files and needing to wait until the next release for them to work, this is fine for people who consume our plugin from wp.org but would break our tests, for this, we added a code that will regenerate all json files each time, reflecting the same result you have if you download from wp.org
- The third issue we had is that some translation terms changed between releases, we fixed that (for now) but I know this will come bite us back later.

### Future work
As to not take an eternity here, and given this PR is already doing two things, we have further future improvements to make:
- [ ] Switch from using Dutch to a custom language file that we build and load in E2E.
    - this ensures we have stable terms, and reduces the complexity of needing to download from an external source, as well as changing terms. @dinhtungdu already started experimenting with this in https://github.com/woocommerce/woocommerce-blocks/pull/6424, we might do a custom json or a custom po, up for debate.
- [ ] Further improve splitChunks and shared code.
    - SplitChunks, will working well, increased the bundle size slightly, there are more gains we can get with wordpress components, that we can explore by tweaking the splitChunks params and checks.
- [ ]  Load chunk names dynamically instead of hard-coding.
    - We currently hard-code chunks names for each block, they're now all stable inside a folder `cart-blocks` `checkout-blocks` `mini-cart-content-blocks`, so we can iterate those folders and load names, this is one less step to forget when splitting blocks in the future or adding new blocks.
- [ ] Support plural terms translation in E2E.
    - One weird bug we run into (that I reported [here](https://github.com/wp-cli/i18n-command/issues/324)) is that when updating a `.po` file, plural translation is gone, for that, we needed to refactor some of our tests, this issue happens when using `wp i18n make-pot --merge`, but isn't present if you do `wp i18n make-json` or `msgmerge`, If the issue above is fixed and we switch to a local language, this is also fixed, apart from that, we need to either switch to merging with `msgmerge`, which would require installing `gettext` on docker, or keeping an eye for plural translations in E2E, which isn't fun.
- [ ] Fetch plugin folder name inside `bin/wp-env-config.sh`.
    - To have wp-env-config work locally and in CI, we can't hardcode the plugin name, for that, we pass it as an arg in `bin/wp-env-pre-config.sh`, this isn't the cleanest solution and I prefer if we can have it as a env param somewhere that is shared easily.


<!-- Reference any related issues or PRs here -->

Fixes #6391

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [] Unit tests
  * [x] E2E tests

#### User Facing Testing

### Translation
1. no code testing can happen once we release 7.7.0, for now, you need some code.
2. In your main WordPress folder (the one that contains wp-content, wp-includes, wp-admin), run those commands:
    1. `curl https://translate.wordpress.org/projects/wp-plugins/woo-gutenberg-products-block/stable/nl/default/export-translations/ --output ./wp-content/languages/plugins/woo-gutenberg-products-block-nl_NL.po`
    2. `php -d memory_limit=2024M "$(which wp)" i18n make-pot ./wp-content/plugins/woo-gutenberg-products-block/ ./wp-content/languages/plugins/woo-gutenberg-products-block-nl_NL-updated.po --merge=./wp-content/languages/plugins/woo-gutenberg-products-block-nl_NL.po --domain=woo-gutenberg-products-block --exclude=node_modules,vendor --skip-audit` **Replace `woo-gutenberg-products-block` with your plugin name if you have something else.**
    3. `mv ./wp-content/languages/plugins/woo-gutenberg-products-block-nl_NL-updated.po ./wp-content/languages/plugins/woo-gutenberg-products-block-nl_NL.po`
    4. `php -d memory_limit=2024M "$(which wp)" i18n make-json ./wp-content/languages/plugins/woo-gutenberg-products-block-nl_NL.po`
5. Visit Cart page, everything should be translated and working fine.
6. Visit Checkout page, everything should be translated and working fine.

### Webpack
1. Run `npm run build` and smoke test Cart/Checkou/Mini Cart and make sure there are no console errors and everything is loading fine.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental

### Performance Impact

This increases some of the bundles sizes a bit.

### Changelog

> Fix broken translation in Cart/Checkout blocks.
