### PR TITLE
Fix phpunit path after the repo renaming

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
 		"test:help": "wp-scripts test-unit-js --help",
 		"pretest:php": "npm run wp-env run composer 'install --no-interaction'",
 		"test:performance": "npm run wp-env:config && cross-env NODE_CONFIG_DIR=tests/e2e/config wp-scripts test-e2e --config tests/e2e/config/jest.performance.config.js -- performance",
-		"test:php": "npm run wp-env run phpunit 'phpunit -c /var/www/html/wp-content/plugins/woocommerce-blocks/phpunit.xml.dist'",
+		"test:php": "npm run wp-env run phpunit 'phpunit -c /var/www/html/wp-content/plugins/$(basename $(pwd))/phpunit.xml.dist'",
 		"test:update": "wp-scripts test-unit-js --updateSnapshot --config tests/js/jest.config.json",
 		"test:watch": "npm run test -- --watch",
 		"ts:check": "tsc --build",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
 		"test:help": "wp-scripts test-unit-js --help",
 		"pretest:php": "npm run wp-env run composer 'install --no-interaction'",
 		"test:performance": "npm run wp-env:config && cross-env NODE_CONFIG_DIR=tests/e2e/config wp-scripts test-e2e --config tests/e2e/config/jest.performance.config.js -- performance",
-		"test:php": "npm run wp-env run phpunit 'phpunit -c /var/www/html/wp-content/plugins/woocommerce-gutenberg-products-block/phpunit.xml.dist'",
+		"test:php": "npm run wp-env run phpunit 'phpunit -c /var/www/html/wp-content/plugins/woocommerce-blocks/phpunit.xml.dist'",
 		"test:update": "wp-scripts test-unit-js --updateSnapshot --config tests/js/jest.config.json",
 		"test:watch": "npm run test -- --watch",
 		"ts:check": "tsc --build",


### PR DESCRIPTION
After the repo was renamed to `woocommerce-blocks` phpunit tests are failing because of a wrong path, this PR updates the path to be independent from the plugin directory name.
