### PR TITLE
Add `requireExactMatch` prop to `ComboBox` to prevent wrong country/state values being sent to the server

### DIFF
--- a/assets/js/base/components/combobox/index.tsx
+++ b/assets/js/base/components/combobox/index.tsx
@@ -34,6 +34,7 @@ export interface ComboboxProps {
 	options: ComboboxControlOption[];
 	required?: boolean;
 	value: string;
+	requireExactMatch?: boolean;
 }
 
 /**
@@ -54,6 +55,7 @@ const Combobox = ( {
 	errorId: incomingErrorId,
 	instanceId = '0',
 	autoComplete = 'off',
+	requireExactMatch = false,
 }: ComboboxProps ): JSX.Element => {
 	const {
 		getValidationError,
@@ -136,7 +138,13 @@ const Combobox = ( {
 									normalizedFilterValue
 						);
 						if ( foundOption ) {
-							onChange( foundOption.value );
+							if ( ! requireExactMatch ) {
+								onChange( foundOption.value );
+								return;
+							}
+							if ( foundOption.label === filterValue ) {
+								onChange( foundOption.value );
+							}
 						}
 					}
 				} }

--- a/assets/js/base/components/combobox/test/index.js
+++ b/assets/js/base/components/combobox/test/index.js
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Combobox from '@woocommerce/base-components/combobox';
+
+describe( 'ComboBox', () => {
+	const options = [
+		{ value: 'A', label: 'A value A' },
+		{ value: 'B', label: 'B value B' },
+		{ value: 'C', label: 'C value C' },
+		{ value: 'D', label: 'D value D' },
+		{ value: 'E', label: 'E value E' },
+		{ value: 'F', label: 'F value F' },
+	];
+
+	beforeEach( () => {
+		jest.resetAllMocks();
+	} );
+
+	it( 'calls onChange as soon as a value is changed if requireExactMatch is false or undefined', async () => {
+		const onChange = jest.fn();
+		const label = 'combo-box';
+		render(
+			<Combobox
+				options={ options }
+				value=""
+				onChange={ onChange }
+				label={ label }
+			/>
+		);
+		const input = await screen.findByLabelText( label );
+		await userEvent.type( input, 'A ' );
+		expect( onChange ).toHaveBeenCalledWith( 'A' );
+	} );
+
+	it( 'calls onChange only when the value is equal to one of the options when requireExactMatch is true', async () => {
+		const onChange = jest.fn();
+		const label = 'combo-box';
+		render(
+			<Combobox
+				options={ options }
+				value=""
+				onChange={ onChange }
+				label={ label }
+				requireExactMatch={ true }
+			/>
+		);
+		const input = await screen.findByLabelText( label );
+		await userEvent.type( input, 'A ' );
+		expect( onChange ).not.toHaveBeenCalled();
+		await userEvent.type( input, 'value A' );
+		expect( onChange ).toHaveBeenCalledWith( 'A value A' );
+	} );
+} );

--- a/assets/js/base/components/combobox/test/index.js
+++ b/assets/js/base/components/combobox/test/index.js
@@ -51,6 +51,6 @@ describe( 'ComboBox', () => {
 		await userEvent.type( input, 'A ' );
 		expect( onChange ).not.toHaveBeenCalled();
 		await userEvent.type( input, 'value A' );
-		expect( onChange ).toHaveBeenCalledWith( 'A value A' );
+		expect( onChange ).toHaveBeenCalledWith( 'A' );
 	} );
 } );

--- a/assets/js/base/components/country-input/country-input.tsx
+++ b/assets/js/base/components/country-input/country-input.tsx
@@ -55,6 +55,7 @@ export const CountryInput = ( {
 				errorId={ errorId }
 				errorMessage={ errorMessage }
 				required={ required }
+				autocomplete={ autocomplete }
 				requireExactMatch={ true }
 			/>
 			{ autoComplete !== 'off' && (

--- a/assets/js/base/components/country-input/country-input.tsx
+++ b/assets/js/base/components/country-input/country-input.tsx
@@ -55,7 +55,7 @@ export const CountryInput = ( {
 				errorId={ errorId }
 				errorMessage={ errorMessage }
 				required={ required }
-				autocomplete={ autocomplete }
+				autoComplete={ autoComplete }
 				requireExactMatch={ true }
 			/>
 			{ autoComplete !== 'off' && (

--- a/assets/js/base/components/country-input/country-input.tsx
+++ b/assets/js/base/components/country-input/country-input.tsx
@@ -55,7 +55,7 @@ export const CountryInput = ( {
 				errorId={ errorId }
 				errorMessage={ errorMessage }
 				required={ required }
-				autoComplete={ autoComplete }
+				requireExactMatch={ true }
 			/>
 			{ autoComplete !== 'off' && (
 				<input

--- a/assets/js/base/components/state-input/state-input.tsx
+++ b/assets/js/base/components/state-input/state-input.tsx
@@ -105,6 +105,7 @@ const StateInput = ( {
 					) }
 					required={ required }
 					autoComplete={ autoComplete }
+					requireExactMatch={ true }
 				/>
 				{ autoComplete !== 'off' && (
 					<input


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
Previously, the ComboBox would run `onChange` before an actual value was entered (example: you start slowly typing `United Kingdom` but it would send `United Arab Emirates` to the server because it was the first value encountered when typing `Un....`)

This PR makes the following changes:
- Add an optional prop to the `ComboBox` component called `requireExactMatch` - the purpose of this prop is to make the `ComboBox` only run the `onChange` function if the entered value exactly matches one of the allowed options.
- Add unit tests to verify this is working as intended.

<!-- Reference any related issues or PRs here -->

Fixes #6423

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) .
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md)
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Check your store is set to have no default customer location set (WooCommerce > Settings > General)
2. **In an incognito window** Add an item to your cart that requires shipping.
2. Leave all address fields blank and uncheck `Use same address for billing`.
3. Go to the `Country/Region` input on the Billing Address form
4. Enter `Uni` and wait 3-4 seconds, without leaving the field, scroll up and verify the `Country/Region` in the **Shipping Address** form is still empty.
5. Select `United Kingdom`.
6. Scroll up and verify the `Country/Region` in the **Shipping Address** form is still empty.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental

### Changelog

> Fix an issue where the country in the shipping and billing addresses would update incorrectly.
