### PR TITLE
Allow values to cause autocompletion in combobox

### DIFF
--- a/assets/js/base/components/combobox/index.tsx
+++ b/assets/js/base/components/combobox/index.tsx
@@ -144,9 +144,7 @@ const Combobox = ( {
 							}
 							if (
 								foundOption.label.toLocaleUpperCase() ===
-									normalizedFilterValue ||
-								foundOption.value.toLocaleUpperCase() ===
-									normalizedFilterValue
+								normalizedFilterValue
 							) {
 								onChange( foundOption.value );
 							}

--- a/assets/js/base/components/combobox/index.tsx
+++ b/assets/js/base/components/combobox/index.tsx
@@ -142,7 +142,12 @@ const Combobox = ( {
 								onChange( foundOption.value );
 								return;
 							}
-							if ( foundOption.label === filterValue ) {
+							if (
+								foundOption.label.toLocaleUpperCase() ===
+									normalizedFilterValue ||
+								foundOption.value.toLocaleUpperCase() ===
+									normalizedFilterValue
+							) {
 								onChange( foundOption.value );
 							}
 						}

--- a/assets/js/base/components/combobox/test/index.js
+++ b/assets/js/base/components/combobox/test/index.js
@@ -7,12 +7,12 @@ import Combobox from '@woocommerce/base-components/combobox';
 
 describe( 'ComboBox', () => {
 	const options = [
-		{ value: 'A', label: 'A value A' },
-		{ value: 'B', label: 'B value B' },
-		{ value: 'C', label: 'C value C' },
-		{ value: 'D', label: 'D value D' },
-		{ value: 'E', label: 'E value E' },
-		{ value: 'F', label: 'F value F' },
+		{ value: 'AA', label: 'A value A' },
+		{ value: 'BB', label: 'B value B' },
+		{ value: 'CC', label: 'C value C' },
+		{ value: 'DD', label: 'D value D' },
+		{ value: 'EE', label: 'E value E' },
+		{ value: 'FF', label: 'F value F' },
 	];
 
 	beforeEach( () => {
@@ -32,7 +32,7 @@ describe( 'ComboBox', () => {
 		);
 		const input = await screen.findByLabelText( label );
 		await userEvent.type( input, 'A ' );
-		expect( onChange ).toHaveBeenCalledWith( 'A' );
+		expect( onChange ).toHaveBeenCalledWith( 'AA' );
 	} );
 
 	it( 'calls onChange only when the value is equal to one of the options when requireExactMatch is true', async () => {
@@ -48,9 +48,9 @@ describe( 'ComboBox', () => {
 			/>
 		);
 		const input = await screen.findByLabelText( label );
-		await userEvent.type( input, 'A ' );
+		await userEvent.type( input, 'B ' );
 		expect( onChange ).not.toHaveBeenCalled();
-		await userEvent.type( input, 'value A' );
-		expect( onChange ).toHaveBeenCalledWith( 'A' );
+		await userEvent.type( input, 'value B' );
+		expect( onChange ).toHaveBeenCalledWith( 'BB' );
 	} );
 } );


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR fixes an issue introduced in #6426 where the input was not normalised.

This PR changes `ComboBox` to disallow autocompletion by **value** if `requireExactMatch` on the combobox is true.

e.g. the user is entering their US State, and types: `AK` then immediately tabs out of the input, this will _not_ result in `Alaska` being shown. They will need to type `Alaska`.

I have also improved the unit tests for this component to make them reflect the real use of the component more closely.
### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Check your store is set to have no default customer location set (WooCommerce > Settings > General)
2. **In an incognito window** Add an item to your cart that requires shipping.
2. Leave all address fields blank and uncheck `Use same address for billing`.
3. Go to the `Country/Region` input on any Address form
4. Enter `US` and leave the input without pressing enter, just tab out of it or click away.
5. Verify that the input remains blank.
6. Re-enter the `Country/Region` input and choose `United States (US)`, ensure the value is saved into the field when you leave it.
7. Go to the `State` input - Type `CA` and leave the input, don't press enter, just tab out or click away.
8. Verify it remains blank when you leave. 
9. Go back to the input, choose `California` and verify it remains when you leave.
10. Place the order and verify it goes through successfully.
11. Check the order in the Admin dashboard, ensure the address details are correct.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->
