### PR TITLE
Fix padding for the Featured Product block

### DIFF
--- a/src/BlockTypes/FeaturedProduct.php
+++ b/src/BlockTypes/FeaturedProduct.php
@@ -205,9 +205,13 @@ class FeaturedProduct extends AbstractDynamicBlock {
 	private function render_wrapper( $attributes ) {
 		$min_height = $attributes['minHeight'] ?? wc_get_theme_support( 'featured_block::default_height', 500 );
 
+		$style = '';
 		if ( isset( $attributes['minHeight'] ) ) {
 			$style = sprintf( 'min-height:%dpx;', intval( $min_height ) );
 		}
+
+		$global_style_style = StyleAttributesUtils::get_styles_by_attributes( $attributes, $this->global_style_wrapper );
+		$style             .= $global_style_style;
 
 		return sprintf( '<div class="wc-block-featured-product__wrapper" style="%s">', esc_attr( $style ) );
 	}


### PR DESCRIPTION
This PRs fixes an issue with the `Featured Product` block that made the padding setting not work.

### Testing

#### Automated Tests
* [x] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests

#### User Facing Testing

1. Create a new page and add the `Featured Product` block.
2. Set the alignment to the left, add padding and save.
3. Check that the padding is correctly rendered on the frontend.


