### PR TITLE
Remove bold styles from All Products block

### DIFF
--- a/assets/js/atomic/blocks/product-elements/title/style.scss
+++ b/assets/js/atomic/blocks/product-elements/title/style.scss
@@ -14,13 +14,6 @@
 
 }
 
-.wc-block-grid {
-	line-height: 1.5;
-	font-weight: 700;
-	padding: 0;
-	display: block;
-}
-
 .is-loading {
 	.wc-block-components-product-title::before {
 		@include placeholder();


### PR DESCRIPTION
We had a CSS ruleset that forced all content in the All Products block to be bold. I don't think that was intended. The issue was specially visible if the Product Summary inner block was in there. This PR removes that CSS ruleset.

### Screenshots

| Before | After |
| ------ | ----- |
|  ![imatge](https://user-images.githubusercontent.com/3616980/169530618-49b0a06f-a034-4858-a26e-12b5db419715.png) | ![imatge](https://user-images.githubusercontent.com/3616980/169530682-d5e6a5f4-594f-496e-91e3-d0497d3c697f.png) |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. Create a post or page and add the All Products block. Optionally, edit the inner blocks and add the Product Summary inner block (this will make the issue more visible).
2. Preview the post in the frontend.
3. Verify product price and product summary are not bold.
4. Verify there are no regressions in the All Products block and in the Shop page.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Remove bold styles from All Products block
