### PR TITLE
Fix being able to remove Cart Totals block

### DIFF
--- a/assets/js/blocks/cart/inner-blocks/cart-totals-block/block.json
+++ b/assets/js/blocks/cart/inner-blocks/cart-totals-block/block.json
@@ -9,7 +9,8 @@
 		"html": false,
 		"multiple": false,
 		"reusable": false,
-		"inserter": false
+		"inserter": false,
+		"lock": false
 	},
 	"attributes": {
 		"checkbox": {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR fixes a missed block from [this PR](https://github.com/woocommerce/woocommerce-blocks/pull/6419), which aims to disable support for locking/unlocking some of the inner blocks of the Cart and Checkout. The Cart Totals block could be unlocked and removed and was missed from the original PR. Thank you @opr !

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Install WordPress beta tester plugin and update to WP 6.0 beta 2.
2. Go to the Cart page in the editor
3. Click on list view
4. Try to unlock the Cart Totals block. This should not be possible.
6. Try to delete the Cart Totals block. This should not be possible.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Fix a bug that made removing one of the inner blocks of the Cart block possible
