### PR TITLE
Revert changes to webpack build output

### DIFF
--- a/bin/webpack-configs.js
+++ b/bin/webpack-configs.js
@@ -122,7 +122,9 @@ woocommerce_blocks_env = ${ NODE_ENV }
 			// Only concatenate modules in production, when not analyzing bundles.
 			concatenateModules:
 				isProduction && ! process.env.WP_BUNDLE_ANALYZER,
-			splitChunks: false,
+			splitChunks: {
+				automaticNameDelimiter: '--',
+			},
 			minimizer: [
 				new TerserPlugin( {
 					cache: true,
@@ -220,7 +222,7 @@ const getMainConfig = ( options = {} ) => {
 			concatenateModules:
 				isProduction && ! process.env.WP_BUNDLE_ANALYZER,
 			splitChunks: {
-				minSize: 10000, // makes the smallest chunk file 10kbs, this doesn't affect lazy loaded chunks.
+				minSize: 0,
 				automaticNameDelimiter: '--',
 				cacheGroups: {
 					commons: {
@@ -259,31 +261,31 @@ const getMainConfig = ( options = {} ) => {
 				patterns: [
 					{
 						from: './assets/js/blocks/checkout/block.json',
-						to: './checkout.block.json',
+						to: './checkout/block.json',
 					},
 					{
 						from:
 							'./assets/js/blocks/featured-items/featured-category/block.json',
-						to: './featured-category.block.json',
+						to: './featured-category/block.json',
 					},
 					{
 						from:
 							'./assets/js/blocks/featured-items/featured-product/block.json',
-						to: './featured-product.block.json',
+						to: './featured-product/block.json',
 					},
 					{
 						from:
 							'./assets/js/blocks/handpicked-products/block.json',
-						to: './handpicked-products.block.json',
+						to: './handpicked-products/block.json',
 					},
 					{
 						from: './assets/js/blocks/product-tag/block.json',
-						to: './product-tag.block.json',
+						to: './product-tag/block.json',
 					},
 					{
 						from:
 							'./assets/js/blocks/products-by-attribute/block.json',
-						to: './products-by-attribute.block.json',
+						to: './products-by-attribute/block.json',
 					},
 				],
 			} ),
@@ -376,39 +378,7 @@ const getFrontConfig = ( options = {} ) => {
 			concatenateModules:
 				isProduction && ! process.env.WP_BUNDLE_ANALYZER,
 			splitChunks: {
-				cacheGroups: {
-					default: false,
-					vendors: {
-						test: /[\\/]node_modules[\\/]/,
-						name( module ) {
-							const moduleFileName = module
-								.identifier()
-								.split( '/' )
-								.reduceRight( ( item ) => item );
-							return `vendor/${ moduleFileName }`;
-						},
-						automaticNameDelimiter: '--',
-						minSize: 20000,
-						priority: -20,
-					},
-					'wp-components': {
-						test: ( module ) => {
-							if (
-								module?.resource?.match(
-									/wordpress-components/
-								)
-							) {
-								return true;
-							}
-						},
-						name: 'wp/wp-components.js',
-						automaticNameDelimiter: '--',
-						reuseExistingChunk: true,
-						enforce: true,
-						minSize: 20000,
-						priority: -10,
-					},
-				},
+				automaticNameDelimiter: '--',
 			},
 			minimizer: [
 				new TerserPlugin( {

--- a/src/Assets/Api.php
+++ b/src/Assets/Api.php
@@ -68,7 +68,7 @@ class Api {
 	 * @return string|boolean False if metadata file is not found for the block.
 	 */
 	public function get_block_metadata_path( $block_name ) {
-		$path_to_metadata_from_plugin_root = $this->package->get_path( 'build/' . $block_name . '.block.json' );
+		$path_to_metadata_from_plugin_root = $this->package->get_path( 'build/' . $block_name . '/block.json' );
 		if ( ! file_exists( $path_to_metadata_from_plugin_root ) ) {
 			return false;
 		}

--- a/src/BlockTypes/AbstractBlock.php
+++ b/src/BlockTypes/AbstractBlock.php
@@ -180,6 +180,9 @@ abstract class AbstractBlock {
 	protected function get_chunks_paths( $chunks_folder ) {
 		$build_path = \Automattic\WooCommerce\Blocks\Package::get_path() . 'build/';
 		$blocks     = [];
+		if ( ! is_dir( $build_path ) ) {
+			return [];
+		}
 		foreach ( new \RecursiveIteratorIterator( new \RecursiveDirectoryIterator( $build_path . $chunks_folder ) ) as $block_name ) {
 			$blocks[] = str_replace( $build_path, '', $block_name );
 		}

--- a/src/BlockTypes/AbstractBlock.php
+++ b/src/BlockTypes/AbstractBlock.php
@@ -175,8 +175,9 @@ abstract class AbstractBlock {
 	 * Generate an array of chunks paths for loading translation.
 	 */
 	protected function get_chunks_paths() {
-		foreach ( glob( \Automattic\WooCommerce\Blocks\Package::get_path() . "build/{$this->chunks_folder}/*-frontend.js" ) as $block_name ) {
-			$blocks[] = "{$this->chunks_folder}/" . basename( $block_name );
+		$build_path = \Automattic\WooCommerce\Blocks\Package::get_path() . 'build/';
+		foreach ( new \RecursiveIteratorIterator( new \RecursiveDirectoryIterator( $build_path . $this->chunks_folder ) ) as $block_name ) {
+			$blocks[] = str_replace( $build_path, '', $block_name );
 		}
 
 		$chunks = preg_filter( '/.js/', '', $blocks );

--- a/src/BlockTypes/AbstractBlock.php
+++ b/src/BlockTypes/AbstractBlock.php
@@ -173,10 +173,14 @@ abstract class AbstractBlock {
 
 	/**
 	 * Generate an array of chunks paths for loading translation.
+	 *
+	 * @param string $chunks_folder The folder to iterate over.
+	 * @return string[] $chunks list of chunks to load.
 	 */
-	protected function get_chunks_paths() {
+	protected function get_chunks_paths( $chunks_folder ) {
 		$build_path = \Automattic\WooCommerce\Blocks\Package::get_path() . 'build/';
-		foreach ( new \RecursiveIteratorIterator( new \RecursiveDirectoryIterator( $build_path . $this->chunks_folder ) ) as $block_name ) {
+		$blocks     = [];
+		foreach ( new \RecursiveIteratorIterator( new \RecursiveDirectoryIterator( $build_path . $chunks_folder ) ) as $block_name ) {
 			$blocks[] = str_replace( $build_path, '', $block_name );
 		}
 

--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -241,7 +241,9 @@ class Cart extends AbstractBlock {
 	 */
 	protected function register_block_type_assets() {
 		parent::register_block_type_assets();
-		$chunks = $this->get_chunks_paths();
-		$this->register_chunk_translations( $chunks );
+		$chunks        = $this->get_chunks_paths( $this->chunks_folder );
+		$vendor_chunks = $this->get_chunks_paths( 'vendors--cart-blocks' );
+
+		$this->register_chunk_translations( array_merge( $chunks, $vendor_chunks ) );
 	}
 }

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -406,7 +406,9 @@ class Checkout extends AbstractBlock {
 	 */
 	protected function register_block_type_assets() {
 		parent::register_block_type_assets();
-		$chunks = $this->get_chunks_paths();
-		$this->register_chunk_translations( $chunks );
+		$chunks        = $this->get_chunks_paths( $this->chunks_folder );
+		$vendor_chunks = $this->get_chunks_paths( 'vendors--cart-blocks' );
+		$shared_chunks = [ 'cart-blocks/order-summary-shipping--checkout-blocks/order-summary-shipping-frontend' ];
+		$this->register_chunk_translations( array_merge( $chunks, $vendor_chunks, $shared_chunks ) );
 	}
 }

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -488,8 +488,10 @@ class MiniCart extends AbstractBlock {
 	 */
 	protected function register_block_type_assets() {
 		parent::register_block_type_assets();
-		$chunks = $this->get_chunks_paths();
-		$this->register_chunk_translations( $chunks );
+		$chunks        = $this->get_chunks_paths( $this->chunks_folder );
+		$vendor_chunks = $this->get_chunks_paths( 'vendors--mini-cart-contents-block' );
+		$shared_chunks = [ 'cart-blocks/cart-line-items--mini-cart-contents-block/products-table-frontend' ];
+		$this->register_chunk_translations( array_merge( $chunks, $vendor_chunks, $shared_chunks ) );
 	}
 
 	/**


### PR DESCRIPTION
This PR reverts changes we made to webpack in https://github.com/woocommerce/woocommerce-blocks/pull/6420, this ensures no translation is broken in future releases, however, this issue will still bite us again in future releases if we add them again :/

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Load this PR, run `npm run build`
2. Change site language to Dutch or Arabic
3. In WordPress settings, download translations again.
4. Go to Cart/Checkout, most translation if not all should load.
5. Some missing translations like Proceed to Checkout will be fixed once WooCommerce 6.6.0 is out, that's because we changed their names in https://github.com/woocommerce/woocommerce-blocks/pull/6190 and WooCommerce Core 6.5.0 don't have that PR.

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [X] Feature plugin
* [ ] Experimental
