### PR TITLE
check if current folder exist in get_chunks_paths

### DIFF
--- a/src/BlockTypes/AbstractBlock.php
+++ b/src/BlockTypes/AbstractBlock.php
@@ -180,7 +180,7 @@ abstract class AbstractBlock {
 	protected function get_chunks_paths( $chunks_folder ) {
 		$build_path = \Automattic\WooCommerce\Blocks\Package::get_path() . 'build/';
 		$blocks     = [];
-		if ( ! is_dir( $build_path ) ) {
+		if ( ! is_dir( $build_path . $chunks_folder ) ) {
 			return [];
 		}
 		foreach ( new \RecursiveIteratorIterator( new \RecursiveDirectoryIterator( $build_path . $chunks_folder ) ) as $block_name ) {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
Related to #6456, we now check for the actual folder we want to iterate over instead of just build folder. This happens when you run `npm start` and it has a different result than `npm run build`
<!-- Reference any related issues or PRs here -->

### Testing

1. remove `build` folder, load your website, it should load fine.
2. run `npm start`, load the website, it should load.
3. run `npm run build`, again the website should load fine.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->
