### PR TITLE
Only assign a reviewer when a PR is ready for review

### DIFF
--- a/.github/workflows/automate-team-review-assignment-config.yml
+++ b/.github/workflows/automate-team-review-assignment-config.yml
@@ -1,9 +1,11 @@
 name: 'Automate assigning team for review.'
 on:
     pull_request:
-        types: [ready_for_review]
+        types: [opened, ready_for_review]
+
 jobs:
     add-reviews:
+        if: ! github.event.pull_request.draft
         runs-on: ubuntu-latest
         steps:
             - name: Check config and assign reviews

--- a/.github/workflows/automate-team-review-assignment-config.yml
+++ b/.github/workflows/automate-team-review-assignment-config.yml
@@ -1,13 +1,13 @@
 name: 'Automate assigning team for review.'
-on: 
-  pull_request:
-    types: [ opened ]
+on:
+    pull_request:
+        types: [ready_for_review]
 jobs:
-  add-reviews:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check config and assign reviews
-        uses: acq688/Request-Reviewer-For-Team-Action@v1.1
-        with:
-          config: ".github/automate-team-review-assignment-config.yml"
-          GITHUB_TOKEN: ${{ secrets.PAT_FOR_ACTIONS }}
+    add-reviews:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Check config and assign reviews
+              uses: acq688/Request-Reviewer-For-Team-Action@v1.1
+              with:
+                  config: '.github/automate-team-review-assignment-config.yml'
+                  GITHUB_TOKEN: ${{ secrets.PAT_FOR_ACTIONS }}

--- a/.github/workflows/automate-team-review-assignment-config.yml
+++ b/.github/workflows/automate-team-review-assignment-config.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
     add-reviews:
-        if: ! github.event.pull_request.draft
+        if: github.event.pull_request.draft == false
         runs-on: ubuntu-latest
         steps:
             - name: Check config and assign reviews


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR fixes the github action that auto assigns a reviewer to only happen when a PR is ready for review, excluding draft PRs. 

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Create a draft PR that merges into this one
2. Check that the "Automate assigning team for review." action has not run and there is no reviewer assigned
3. Convert the PR to "ready for review"
4. Check the github action in step 2 runs and that someone has been assigned for review
5. Close the PR you just opened
6. Open another PR off this branch and this time create it as a normal PR
7. Repeat steps 2-5 above.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->
