### PR TITLE
Fix: Fatal error if the plugin is built with `npm start`

### DIFF
--- a/src/BlockTypes/AbstractBlock.php
+++ b/src/BlockTypes/AbstractBlock.php
@@ -180,7 +180,7 @@ abstract class AbstractBlock {
 	protected function get_chunks_paths( $chunks_folder ) {
 		$build_path = \Automattic\WooCommerce\Blocks\Package::get_path() . 'build/';
 		$blocks     = [];
-		if ( ! is_dir( $build_path ) ) {
+		if ( ! is_dir( $build_path ) || ! is_dir( $build_path . $chunks_folder ) ) {
 			return [];
 		}
 		foreach ( new \RecursiveIteratorIterator( new \RecursiveDirectoryIterator( $build_path . $chunks_folder ) ) as $block_name ) {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #6463 

This PR fixes the fatal error caused by the `get_chunks_paths()` method by ensuring the path exists before scanning.

@senadir `npm start` and `npm run build` generate different sets of build files which causes the fatal error. While we still should check if the path exists before scanning, we also should unify the build output of those two commands IMO.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Build the plugin with `npm start`.
2. Visit the site on the front end.
3. Don't see the fatal error

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog
