### PR TITLE
Update RenovateBot configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -32,7 +32,8 @@
 			"updateTypes": [ "major", "minor", "patch", "pin", "digest" ],
 			"depTypeList": [ "devDependencies" ],
 			"automerge": true,
-			"rangeStrategy": "bump"
+			"rangeStrategy": "bump",
+			"prPriority": 1
 		}
 	],
 	"rebaseWhen": "conflicted"

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
 	"extends": [ "config:base" ],
 	"lockFileMaintenance": { "enabled": true },
 	"ignoreDeps": [ "husky" ],
+	"prConcurrentLimit": 5,
 	"schedule": [ "before 3am on wednesday" ],
 	"composer": {
 		"enabled": false
@@ -16,13 +17,22 @@
 			"rangeStrategy": "bump"
 		},
 		{
-			"updateTypes": [ "minor", "patch", "pin", "digest" ],
-			"automerge": true
+			"updateTypes": [ "patch", "pin", "digest" ],
+			"depTypeList": [ "dev" ],
+			"automerge": true,
+			"rangeStrategy": "bump"
+		},
+		{
+			"updateTypes": [ "major", "minor" ],
+			"depTypeList": [ "dev" ],
+			"automerge": false,
+			"rangeStrategy": "bump"
 		},
 		{
 			"updateTypes": [ "major", "minor", "patch", "pin", "digest" ],
 			"depTypeList": [ "devDependencies" ],
-			"automerge": true
+			"automerge": true,
+			"rangeStrategy": "bump"
 		}
 	],
 	"rebaseWhen": "conflicted"


### PR DESCRIPTION
This PR updated the RenovateBot configuration. 

Even if we have configurated RenovateBot for handling the major update of our `devDeps`, this is not happening. Maybe this is caused by the `rangeStrategy`. 

This PR:
- changes the `rangeStrategy` to `bump` ([docs](https://docs.renovatebot.com/configuration-options/#rangestrategy))
- enables major updates for deps.
- disables `automerge` for the major and minor updates for deps.
- Sets the limit of a maximum of 5 PR open at the same time.