### PR TITLE
Access correct property of package destination in Store API

### DIFF
--- a/src/StoreApi/Schemas/V1/CartShippingRateSchema.php
+++ b/src/StoreApi/Schemas/V1/CartShippingRateSchema.php
@@ -240,7 +240,7 @@ class CartShippingRateSchema extends AbstractSchema {
 	protected function prepare_package_destination_response( $package ) {
 		return (object) $this->prepare_html_response(
 			[
-				'address_1' => $package['destination']['address_1'],
+				'address_1' => $package['destination']['address'],
 				'address_2' => $package['destination']['address_2'],
 				'city'      => $package['destination']['city'],
 				'state'     => $package['destination']['state'],

--- a/src/StoreApi/Schemas/V1/CartShippingRateSchema.php
+++ b/src/StoreApi/Schemas/V1/CartShippingRateSchema.php
@@ -238,9 +238,11 @@ class CartShippingRateSchema extends AbstractSchema {
 	 * @return object
 	 */
 	protected function prepare_package_destination_response( $package ) {
+		// If address_1 fails check address for back compatability.
+		$address = isset( $package['destination']['address_1'] ) ? $package['destination']['address_1'] : $package['destination']['address'];
 		return (object) $this->prepare_html_response(
 			[
-				'address_1' => $package['destination']['address'],
+				'address_1' => $address,
 				'address_2' => $package['destination']['address_2'],
 				'city'      => $package['destination']['city'],
 				'state'     => $package['destination']['state'],


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR will change the `CartShippingRateSchema` so it checks the `address_1` property of the `$package['destination']` array, and if it's not found it checks `address`.

Some older plugins for managing packages use `address` instead of `address_1`.

<!-- Reference any related issues or PRs here -->

Fixes #6468

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. Install this free plugin from the WP plugin repository: "Multiple Packages for WooCommerce"
2. Navigate to WooCommerce -> Settings -> Multiple Packages
3. Adjust the settings to work based on "Per Product".
4. Add multiple items to your cart.
5. Go to the Checkout/Cart Block.
6. Ensure you see no errors.

Optionally repeat the above steps using `WooCommerce Advanced Shipping Packages` if you have access to it. Note you will need to set up shipping groups for this to work. I set up one for the product `Belt` and one for `Hoodie with zipper` and added both of these to my cart.

I made a group called `Leather Goods` with the following settings

<img width="612" alt="image" src="https://user-images.githubusercontent.com/5656702/170536802-f7e09027-4c2e-44d8-8597-b35037832847.png">


and one called `Cloth goods` with the following settings:

<img width="609" alt="image" src="https://user-images.githubusercontent.com/5656702/170536600-4e925440-918c-4f2d-8b4c-74297165a448.png">


* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Prevent warnings appearing when using some plugins for managing shipping packages.
