### PR TITLE
Fix an endless loop when using product grid blocks inside product descriptions

### DIFF
--- a/src/Utils/BlocksWpQuery.php
+++ b/src/Utils/BlocksWpQuery.php
@@ -6,7 +6,7 @@ use WP_Query;
 /**
  * BlocksWpQuery query.
  *
- * Wrapper for WP Query with additonal helper methods.
+ * Wrapper for WP Query with additional helper methods.
  * Allows query args to be set and parsed without doing running it, so that a cache can be used.
  *
  * @deprecated 2.5.0

--- a/src/Utils/BlocksWpQuery.php
+++ b/src/Utils/BlocksWpQuery.php
@@ -24,6 +24,25 @@ class BlocksWpQuery extends WP_Query {
 	public function __construct( $query = '' ) {
 		if ( ! empty( $query ) ) {
 			$this->init();
+
+			// Remove current product from query. That might happen if the store
+			// is using Gutenberg in product descriptions.
+			// See https://github.com/woocommerce/woocommerce-blocks/issues/6416.
+			global $post;
+			if ( $post && is_array( $query['post__in'] ) ) {
+				$global_post_id    = $post->ID;
+				$filtered_post__in = array_filter(
+					$query['post__in'],
+					static function ( $post_id ) use ( $global_post_id ) {
+						if ( $global_post_id === $post_id ) {
+							return false;
+						}
+						return true;
+					}
+				);
+				$query['post__in'] = $filtered_post__in;
+			}
+
 			$this->query      = wp_parse_args( $query );
 			$this->query_vars = $this->query;
 			$this->parse_query_vars();

--- a/src/Utils/BlocksWpQuery.php
+++ b/src/Utils/BlocksWpQuery.php
@@ -25,8 +25,8 @@ class BlocksWpQuery extends WP_Query {
 		if ( ! empty( $query ) ) {
 			$this->init();
 
-			// Remove current product from query. That might happen if the store
-			// is using Gutenberg in product descriptions.
+			// Remove current product from query to avoid infinite loops and out of memory issues.
+			// That might happen if the store is using Gutenberg for product descriptions.
 			// See https://github.com/woocommerce/woocommerce-blocks/issues/6416.
 			global $post;
 			if ( $post && array_key_exists( 'post__in', $query ) && is_array( $query['post__in'] ) ) {

--- a/src/Utils/BlocksWpQuery.php
+++ b/src/Utils/BlocksWpQuery.php
@@ -29,7 +29,7 @@ class BlocksWpQuery extends WP_Query {
 			// is using Gutenberg in product descriptions.
 			// See https://github.com/woocommerce/woocommerce-blocks/issues/6416.
 			global $post;
-			if ( $post && is_array( $query['post__in'] ) ) {
+			if ( $post && array_key_exists( 'post__in', $query ) && is_array( $query['post__in'] ) ) {
 				$global_post_id    = $post->ID;
 				$filtered_post__in = array_filter(
 					$query['post__in'],


### PR DESCRIPTION
Works-around https://github.com/woocommerce/woocommerce-blocks/issues/6416 in the frontend.

Inspired by https://github.com/woocommerce/woocommerce-blocks/pull/6454.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. Enable Gutenberg for products adding this code (for example, at the end of `functions.php` of your theme):
```PHP
function ps_activate_gutenberg( $can_edit, $post_type ) {
	if ( 'product' === $post_type ) {
		$can_edit = true;
	}
	return $can_edit;
}
add_filter( 'use_block_editor_for_post_type', 'ps_activate_gutenberg', 10, 2 );
```
2. Create a page and add the _On Sale Products_ block. Then, add a _Hand-Picked Products_ block choosing the same three products that appeared on the On Sale Products block.
3. Copy both blocks.
4. Edit one of the On Sale products. Notice it will open the block editor.
5. Paste the blocks you copied in step 2.
6. Verify the editor doesn't crash.
7. Preview the product in the frontend, and verify it renders properly.
8. I recommend undoing the changes you did in step 4 or moving that product to trash because there are still some things not working properly when a product tries to query itself.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix an endless loop when using product grid blocks inside product descriptions
