### PR TITLE
Fix: All translations related to JS blocks are loaded even if the block is not used

### DIFF
--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -187,12 +187,28 @@ function load_woocommerce_core_json_translation( $file, $handle, $domain ) {
 		return $file;
 	}
 
+	global $wp_scripts;
+
+	if ( ! isset( $wp_scripts->registered[ $handle ], $wp_scripts->registered[ $handle ]->src ) ) {
+		return $file;
+	}
+
+	$handle_src      = explode( '/build/', $wp_scripts->registered[ $handle ]->src );
+	$handle_filename = $handle_src[1];
+	$locale          = determine_locale();
+	$lang_dir        = WP_LANG_DIR . '/plugins';
+
+	// Translations are always based on the unminified filename.
+	if ( substr( $handle_filename, -7 ) === '.min.js' ) {
+		$handle_filename = substr( $handle_filename, 0, -7 ) . '.js';
+	}
+
 	/**
 	 * Return file path of the corresponding translation file in the WC Core
 	 * here is enough because `load_script_translations()` will check for its
 	 * existence before loading it.
 	 */
-	return str_replace( "/plugins/{$domain}-", '/plugins/woocommerce-', $file );
+	return $lang_dir . '/woocommerce-' . $locale . '-' . md5( 'packages/woocommerce-blocks/build/' . $handle_filename ) . '.json';
 }
 
 add_filter( 'load_script_translation_file', 'load_woocommerce_core_json_translation', 10, 3 );

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -192,7 +192,7 @@ function load_woocommerce_core_json_translation( $file, $handle, $domain ) {
 	 * here is enough because `load_script_translations()` will check for its
 	 * existence before loading it.
 	 */
-	return str_replace( $file, "/plugins/{$domain}-", '/plugins/woocommerce-' );
+	return str_replace( "/plugins/{$domain}-", '/plugins/woocommerce-', $file );
 }
 
 add_filter( 'load_script_translation_file', 'load_woocommerce_core_json_translation', 10, 3 );

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -153,90 +153,49 @@ if ( is_readable( $autoloader ) ) {
 add_action( 'plugins_loaded', array( '\Automattic\WooCommerce\Blocks\Package', 'init' ) );
 
 /**
- * Pre-filters script translations for the given file, script handle and text domain.
+ * WordPress will look for translation in the following order:
+ * - wp-content/plugins/woocommerce-blocks/languages/woo-gutenberg-products-block-{locale}-{handle}.json
+ * - wp-content/plugins/woocommerce-blocks/languages/woo-gutenberg-products-block-{locale}-{md5-handle}.json
+ * - wp-content/languages/plugins/woo-gutenberg-products-block-{locale}-{md5-handle}.json
  *
- * @param string|false|null $translations JSON-encoded translation data. Default null.
- * @param string|false      $file         Path to the translation file to load. False if there isn't one.
- * @param string            $handle       Name of the script to register a translation domain to.
- * @param string            $domain       The text domain.
- * @return string JSON translations.
+ * We check if the last one exists, and if it doesn't we try to load the
+ * corresponding JSON file from the WC Core.
+ *
+ * @param string|false $file   Path to the translation file to load. False if there isn't one.
+ * @param string       $handle Name of the script to register a translation domain to.
+ * @param string       $domain The text domain.
+ *
+ * @return string|false        Path to the translation file to load. False if there isn't one.
  */
-function woocommerce_blocks_get_i18n_data_json( $translations, $file, $handle, $domain ) {
+function load_woocommerce_core_json_translation( $file, $handle, $domain ) {
 	if ( 'woo-gutenberg-products-block' !== $domain ) {
-		return $translations;
+		return $file;
 	}
 
-	global $wp_scripts;
+	$lang_dir = WP_LANG_DIR . '/plugins';
 
-	if ( ! isset( $wp_scripts->registered[ $handle ], $wp_scripts->registered[ $handle ]->src ) ) {
-		return $translations;
+	/**
+	 * We only care about the translation file of the feature plugin in the
+	 * wp-content/languages folder.
+	 */
+	if ( false === strpos( $file, $lang_dir ) ) {
+		return $file;
 	}
 
-	$handle_src      = explode( '/build/', $wp_scripts->registered[ $handle ]->src );
-	$handle_filename = $handle_src[1];
-	$locale          = determine_locale();
-	$lang_dir        = WP_LANG_DIR . '/plugins';
-
-	// Translations are always based on the unminified filename.
-	if ( substr( $handle_filename, -7 ) === '.min.js' ) {
-		$handle_filename = substr( $handle_filename, 0, -7 ) . '.js';
+	// If the translation file for feature plugin exist, use it.
+	if ( is_readable( $file ) ) {
+		return $file;
 	}
 
-	// WordPress 5.0 uses md5 hashes of file paths to associate translation
-	// JSON files with the file they should be included for. This is an md5
-	// of 'packages/woocommerce-blocks/build/FILENAME.js'.
-	$core_path_md5     = md5( 'packages/woocommerce-blocks/build/' . $handle_filename );
-	$core_json_file    = $lang_dir . '/woocommerce-' . $locale . '-' . $core_path_md5 . '.json';
-	$json_translations = is_file( $core_json_file ) && is_readable( $core_json_file ) ? file_get_contents( $core_json_file ) : false; // phpcs:ignore
-
-	if ( ! $json_translations ) {
-		return $translations;
-	}
-
-	// Rather than short circuit pre_load_script_translations, we will output
-	// core translations using an inline script. This will allow us to continue
-	// to load feature-plugin translations which may exist as well.
-	$output = <<<JS
-	( function( domain, translations ) {
-		var localeData = translations.locale_data[ domain ] || translations.locale_data.messages;
-		localeData[""].domain = domain;
-		wp.i18n.setLocaleData( localeData, domain );
-	} )( "{$domain}", {$json_translations} );
-JS;
-
-	if ( empty( $wp_scripts->done ) ) {
-		// If we hadn't printed any script into the page, let's enqueue the translations.
-		// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.NoExplicitVersion
-		wp_register_script( $handle_filename, '', array( 'wp-i18n' ), false, true );
-		wp_enqueue_script( $handle_filename );
-		wp_add_inline_script(
-			$handle_filename,
-			$output
-		);
-	} else {
-		// If we have already printed scripts into the page, there is a chance that
-		// scripts have finished being printed. That means that if we enqueued them here,
-		// they would never be printed. Instead of enqueuing, then, let's print directly
-		// the script tag.
-		printf( "<script type='text/javascript'>\n%s\n</script>\n", $output ); // phpcs:ignore
-	}
-
-	// Finally, short circuit the pre_load_script_translations hook by returning
-	// the translation JSON from the feature plugin, if it exists so this hook
-	// does not run again for the current handle.
-	$path_md5     = md5( 'build/' . $handle_filename );
-	$json_file    = $lang_dir . '/' . $domain . '-' . $locale . '-' . $path_md5 . '.json';
-	$translations = is_file( $json_file ) && is_readable( $json_file ) ? file_get_contents( $json_file ) : false; // phpcs:ignore
-
-	if ( $translations ) {
-		return $translations;
-	}
-
-	// Return valid empty Jed locale.
-	return '{ "locale_data": { "messages": { "": {} } } }';
+	/**
+	 * Return file path of the corresponding translation file in the WC Core
+	 * here is enough because `load_script_translations()` will check for its
+	 * existence before loading it.
+	 */
+	return str_replace( $file, "/plugins/{$domain}-", '/plugins/woocommerce-' );
 }
 
-add_filter( 'pre_load_script_translations', 'woocommerce_blocks_get_i18n_data_json', 10, 4 );
+add_filter( 'load_script_translation_file', 'load_woocommerce_core_json_translation', 10, 3 );
 
 /**
  * Filter translations so we can retrieve translations from Core when the original and the translated

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -203,12 +203,14 @@ function load_woocommerce_core_json_translation( $file, $handle, $domain ) {
 		$handle_filename = substr( $handle_filename, 0, -7 ) . '.js';
 	}
 
+	$core_path_md5 = md5( 'packages/woocommerce-blocks/build/' . $handle_filename );
+
 	/**
-	 * Return file path of the corresponding translation file in the WC Core
-	 * here is enough because `load_script_translations()` will check for its
-	 * existence before loading it.
+	 * Return file path of the corresponding translation file in the WC Core is
+	 * enough because `load_script_translations()` will check for its existence
+	 * before loading it.
 	 */
-	return $lang_dir . '/woocommerce-' . $locale . '-' . md5( 'packages/woocommerce-blocks/build/' . $handle_filename ) . '.json';
+	return $lang_dir . '/woocommerce-' . $locale . '-' . $core_path_md5 . '.json';
 }
 
 add_filter( 'load_script_translation_file', 'load_woocommerce_core_json_translation', 10, 3 );


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #6023

We're using `pre_load_script_translations` to load the WC Core JSON translation. This is a filter but we also print some script inside the callback, which leads to the issue detailed in #6023.

This PR fixes and refactors our approach to using the `load_script_translation_file` filter. Instead of doing complex calculations inside our filter callback, we rely on WordPress to calculate and prepare the translation file. Then we only try loading the WooCommerce Core translation when the feature plugin translation doesn't exist.

##### Additional fix

This PR also fixes the translation loading for Mini Cart inner blocks. The Mini Cart block is a special block, we only load it partially (the icon and the lazy load script) initially. The remaining scripts are only loaded when it's actually used (customers open the Mini Cart or add a product to the cart). The translations of those lazy-loaded scripts should be lazy-loaded too.

The correct behavior has been implemented in https://github.com/woocommerce/woocommerce-blocks/pull/6158/files#diff-4c8bd3d0cfbd21fce3d29b5b50c28a5172490edbdabe90867fbf4f36dd5d3cb4 but accidentally removed in https://github.com/woocommerce/woocommerce-blocks/pull/6420/files#diff-4c8bd3d0cfbd21fce3d29b5b50c28a5172490edbdabe90867fbf4f36dd5d3cb4. This PR adds that behavior back with new improvements introduced in #6420 to avoid hard-coding build files.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) .
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md)
- [x] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|        |       |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

0. Change the language to the Netherlands then update all translations.
1. Visit a page without any blocks on the front end.
2. View source (don't use the Inspector).
3. See no unnecessary translations as the screenshot in #6023 shows.
4. Create a page with the All Products block.
5. See translations work as expected in the editor and on the front end.
6. See the translation of Cart and Checkout blocks (and their inner blocks) are working as expected.
7. Check the page source of the pages containing WooCommerce Blocks, see only related translations are loaded.

**For Mini Cart block:**
1. Add Mini Cart block to Header template.
2. Visite the home page, and see the Mini Cart.
3. Open the Mini Cart, and see the translation works as expected for both Empty and Filled views.
4. View the source of the home page.
5. DON'T see the translation for Mini Cart inner blocks.
6. Open the inspector of the home page, and see the translation of Mini Cart inner blocks.

**Test WC Core translation fallback:**
1. Remove all translation files for `woo-gutenberg-products-block` text-domain in `wp-content/languages/plugins`.
2. Keep translation files for `woocommerce` text-domain.
3. See the translation still work for our blocks. Some translation can be missed due to the lag between the feature plugin and the `woocommerce-blocks` package bundled in WC Core.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Fix: Only enqueue the relevant translations script.