### PR TITLE
Add the button to migrate to the blockified version of the Product Grid Block 

### DIFF
--- a/assets/js/blocks/classic-template/editor.scss
+++ b/assets/js/blocks/classic-template/editor.scss
@@ -34,3 +34,15 @@
 		display: block;
 	}
 }
+
+
+.wp-block-woocommerce-classic-template__placeholder-wireframe {
+	display: flex;
+	flex-direction: column;
+}
+
+.wp-block-woocommerce-classic-template__placeholder-migration-button-container {
+	justify-content: center;
+	align-items: center;
+	margin: 0 auto;
+}

--- a/assets/js/blocks/classic-template/index.tsx
+++ b/assets/js/blocks/classic-template/index.tsx
@@ -1,12 +1,16 @@
 /**
  * External dependencies
  */
-import { registerBlockType } from '@wordpress/blocks';
-import { WC_BLOCKS_IMAGE_URL } from '@woocommerce/block-settings';
+import { createBlock, registerBlockType } from '@wordpress/blocks';
+import {
+	isExperimentalBuild,
+	WC_BLOCKS_IMAGE_URL,
+} from '@woocommerce/block-settings';
 import { useBlockProps } from '@wordpress/block-editor';
-import { Placeholder } from '@wordpress/components';
+import { Button, Placeholder } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { box, Icon } from '@wordpress/icons';
+import { useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -20,9 +24,12 @@ interface Props {
 		template: string;
 		align: string;
 	};
+	clientId: string;
 }
 
-const Edit = ( { attributes }: Props ) => {
+const Edit = ( { clientId, attributes }: Props ) => {
+	const { replaceBlock } = useDispatch( 'core/block-editor' );
+
 	const blockProps = useBlockProps();
 	const templateTitle =
 		TEMPLATES[ attributes.template ]?.title ?? attributes.template;
@@ -60,6 +67,27 @@ const Edit = ( { attributes }: Props ) => {
 					</p>
 				</div>
 				<div className="wp-block-woocommerce-classic-template__placeholder-wireframe">
+					{ isExperimentalBuild() && (
+						<div className="wp-block-woocommerce-classic-template__placeholder-migration-button-container">
+							<Button
+								isPrimary
+								onClick={ () => {
+									replaceBlock(
+										clientId,
+										// TODO: Replace with the blockified version of the Product Grid Block when it will be available.
+										createBlock( 'core/paragraph', {
+											content:
+												'Instead of this block, the new Product Grid Block will be rendered',
+										} )
+									);
+								} }
+								text={ __(
+									'Use the blockified Product Grid Block',
+									'woo-gutenberg-products-block'
+								) }
+							/>
+						</div>
+					) }
 					<img
 						className="wp-block-woocommerce-classic-template__placeholder-image"
 						src={ `${ WC_BLOCKS_IMAGE_URL }template-placeholders/${ templatePlaceholder }.svg` }


### PR DESCRIPTION
This PR adds the possibility for the user to migrate in an easy way to the blockified version of the `Product Grid Block`.

I'm not sure about the text of the button. Open to feedback, in any case, we can change it in the future.


<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #6483 


### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

![Screen Capture on 2022-05-30 at 15-40-24](https://user-images.githubusercontent.com/4463174/171004546-b43a5da5-0f9c-47d0-9ccb-bf3d3f035bd4.gif)


### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

Check out this branch.

1. Be sure that you are using a block theme.
2. Open the FSE and click on the templates on the left sidebar.
3. Open a template that uses the `Classic Product Grid Block` (e.g. `Product Catalog`),
3. Check that button is rendered and when you click on it, a `Paragraph block` replace the current one. (check the gif)

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental


