### PR TITLE
Featured Item: Fix default color being overridden by themes

### DIFF
--- a/assets/js/blocks/featured-items/featured-category/block.json
+++ b/assets/js/blocks/featured-items/featured-category/block.json
@@ -1,104 +1,107 @@
 {
-    "name": "woocommerce/featured-category",
-    "version": "1.0.0",
-    "title": "Featured Category",
-    "category": "woocommerce",
-    "keywords": [
-        "WooCommerce"
-    ],
-    "description": "Visually highlight a product category and encourage prompt action.",
-    "supports": {
-        "align": [
-            "wide",
-            "full"
-        ],
-        "html": false,
-        "color": {
-            "background": true,
-            "text": true,
-            "__experimentalDuotone": ".wc-block-featured-category__background-image"
-        },
-        "spacing": {
-            "padding": true,
-            "__experimentalDefaultControls": {
-                "padding": true
-            },
-            "__experimentalSkipSerialization": true
-        },
-        "__experimentalBorder": {
-            "color": true,
-            "radius": true,
-            "width": true,
-            "__experimentalSkipSerialization": true
-        }
-    },
-    "attributes": {
-        "alt": {
-            "type": "string",
-            "default": ""
-        },
-        "contentAlign": {
-            "type": "string",
-            "default": "center"
-        },
-        "dimRatio": {
-            "type": "number",
-            "default": 50
-        },
-        "editMode": {
-            "type": "boolean",
-            "default": true
-        },
-        "focalPoint": {
-            "type": "object",
-            "default": false
-        },
-        "imageFit": {
-            "type": "string",
-            "default": "none"
-        },
-        "hasParallax": {
-            "type": "boolean",
-            "default": false
-        },
-        "isRepeated": {
-            "type": "boolean",
-            "default": false
-        },
-        "mediaId": {
-            "type": "number",
-            "default": 0
-        },
-        "mediaSrc": {
-            "type": "string",
-            "default": ""
-        },
-        "minHeight": {
-            "type": "number",
-            "default": 500
-        },
-        "linkText": {
-            "type": "string"
-        },
-        "categoryId": {
-            "type": "number"
-        },
-        "overlayColor": {
-            "type": "string",
-            "default": "#000000"
-        },
-        "overlayGradient": {
-            "type": "string"
-        },
-        "previewCategory": {
-            "type": "object",
-            "default": null
-        },
-        "showDesc": {
-            "type": "boolean",
-            "default": true
-        }
-    },
-    "textdomain": "woo-gutenberg-products-block",
-    "apiVersion": 2
+	"name": "woocommerce/featured-category",
+	"version": "1.0.0",
+	"title": "Featured Category",
+	"category": "woocommerce",
+	"keywords": [ "WooCommerce" ],
+	"description": "Visually highlight a product category and encourage prompt action.",
+	"supports": {
+		"align": [ "wide", "full" ],
+		"html": false,
+		"color": {
+			"background": true,
+			"text": true,
+			"__experimentalDuotone": ".wc-block-featured-category__background-image"
+		},
+		"spacing": {
+			"padding": true,
+			"__experimentalDefaultControls": {
+				"padding": true
+			},
+			"__experimentalSkipSerialization": true
+		},
+		"__experimentalBorder": {
+			"color": true,
+			"radius": true,
+			"width": true,
+			"__experimentalSkipSerialization": true
+		}
+	},
+	"attributes": {
+		"alt": {
+			"type": "string",
+			"default": ""
+		},
+		"contentAlign": {
+			"type": "string",
+			"default": "center"
+		},
+		"dimRatio": {
+			"type": "number",
+			"default": 50
+		},
+		"editMode": {
+			"type": "boolean",
+			"default": true
+		},
+		"focalPoint": {
+			"type": "object",
+			"default": false
+		},
+		"imageFit": {
+			"type": "string",
+			"default": "none"
+		},
+		"hasParallax": {
+			"type": "boolean",
+			"default": false
+		},
+		"isRepeated": {
+			"type": "boolean",
+			"default": false
+		},
+		"mediaId": {
+			"type": "number",
+			"default": 0
+		},
+		"mediaSrc": {
+			"type": "string",
+			"default": ""
+		},
+		"minHeight": {
+			"type": "number",
+			"default": 500
+		},
+		"linkText": {
+			"type": "string"
+		},
+		"categoryId": {
+			"type": "number"
+		},
+		"overlayColor": {
+			"type": "string",
+			"default": "#000000"
+		},
+		"overlayGradient": {
+			"type": "string"
+		},
+		"previewCategory": {
+			"type": "object",
+			"default": null
+		},
+		"showDesc": {
+			"type": "boolean",
+			"default": true
+		},
+		"style": {
+			"type": "object",
+			"default": {
+				"color": {
+					"text": "#ffffff"
+				}
+			}
+		}
+	},
+	"textdomain": "woo-gutenberg-products-block",
+	"apiVersion": 2
 }

--- a/assets/js/blocks/featured-items/featured-product/block.json
+++ b/assets/js/blocks/featured-items/featured-product/block.json
@@ -1,108 +1,113 @@
 {
-    "name": "woocommerce/featured-product",
-    "version": "1.0.0",
-    "title": "Featured Product",
-    "description": "Visually highlight a product or variation and encourage prompt action.",
-    "category": "woocommerce",
-    "keywords": [ "WooCommerce" ],
-    "supports": {
-        "align": [
-            "wide",
-            "full"
-        ],
-        "html": false,
-        "color": {
-            "background": true,
-            "text": true,
-            "__experimentalDuotone": ".wc-block-featured-product__background-image"
-        },
-        "spacing": {
-            "padding": true,
-            "__experimentalDefaultControls": {
-                "padding": true
-            },
-            "__experimentalSkipSerialization": true
-        },
-        "__experimentalBorder": {
-            "color": true,
-            "radius": true,
-            "width": true,
-            "__experimentalSkipSerialization": true
-        },
-        "multiple": true
-    },
-    "attributes": {
-        "alt": {
-            "type": "string",
-            "default": ""
-        },
-        "contentAlign": {
-            "type": "string",
-            "default": "center"
-        },
-        "dimRatio": {
-            "type": "number",
-            "default": 50
-        },
-        "editMode": {
-            "type": "boolean",
-            "default": true
-        },
-        "focalPoint": {
-            "type": "object",
-            "default": false
-        },
-        "imageFit": {
-            "type": "string",
-            "default": "none"
-        },
-        "hasParallax": {
-            "type": "boolean",
-            "default": false
-        },
-        "isRepeated": {
-            "type": "boolean",
-            "default": false
-        },
-        "mediaId": {
-            "type": "number",
-            "default": 0
-        },
-        "mediaSrc": {
-            "type": "string",
-            "default": ""
-        },
-        "minHeight": {
-            "type": "number",
-            "default": 500
-        },
-        "linkText": {
-            "type": "string",
-            "default": "Shop now"
-        },
-        "overlayColor": {
-            "type": "string",
-            "default": "#000000"
-        },
-        "overlayGradient": {
-            "type": "string"
-        },
-        "productId": {
-            "type": "number"
-        },
-        "previewProduct": {
-            "type": "object",
-            "default": null
-        },
-        "showDesc": {
-            "type": "boolean",
-            "default": true
-        },
-        "showPrice": {
-            "type": "boolean",
-            "default": true
-        }
-    },
-    "textdomain": "woo-gutenberg-products-block",
-    "apiVersion": 2
+	"name": "woocommerce/featured-product",
+	"version": "1.0.0",
+	"title": "Featured Product",
+	"description": "Visually highlight a product or variation and encourage prompt action.",
+	"category": "woocommerce",
+	"keywords": [ "WooCommerce" ],
+	"supports": {
+		"align": [ "wide", "full" ],
+		"html": false,
+		"color": {
+			"background": true,
+			"text": true,
+			"__experimentalDuotone": ".wc-block-featured-product__background-image"
+		},
+		"spacing": {
+			"padding": true,
+			"__experimentalDefaultControls": {
+				"padding": true
+			},
+			"__experimentalSkipSerialization": true
+		},
+		"__experimentalBorder": {
+			"color": true,
+			"radius": true,
+			"width": true,
+			"__experimentalSkipSerialization": true
+		},
+		"multiple": true
+	},
+	"attributes": {
+		"alt": {
+			"type": "string",
+			"default": ""
+		},
+		"contentAlign": {
+			"type": "string",
+			"default": "center"
+		},
+		"dimRatio": {
+			"type": "number",
+			"default": 50
+		},
+		"editMode": {
+			"type": "boolean",
+			"default": true
+		},
+		"focalPoint": {
+			"type": "object",
+			"default": false
+		},
+		"imageFit": {
+			"type": "string",
+			"default": "none"
+		},
+		"hasParallax": {
+			"type": "boolean",
+			"default": false
+		},
+		"isRepeated": {
+			"type": "boolean",
+			"default": false
+		},
+		"mediaId": {
+			"type": "number",
+			"default": 0
+		},
+		"mediaSrc": {
+			"type": "string",
+			"default": ""
+		},
+		"minHeight": {
+			"type": "number",
+			"default": 500
+		},
+		"linkText": {
+			"type": "string",
+			"default": "Shop now"
+		},
+		"overlayColor": {
+			"type": "string",
+			"default": "#000000"
+		},
+		"overlayGradient": {
+			"type": "string"
+		},
+		"productId": {
+			"type": "number"
+		},
+		"previewProduct": {
+			"type": "object",
+			"default": null
+		},
+		"showDesc": {
+			"type": "boolean",
+			"default": true
+		},
+		"showPrice": {
+			"type": "boolean",
+			"default": true
+		},
+		"style": {
+			"type": "object",
+			"default": {
+				"color": {
+					"text": "#ffffff"
+				}
+			}
+		}
+	},
+	"textdomain": "woo-gutenberg-products-block",
+	"apiVersion": 2
 }

--- a/assets/js/blocks/featured-items/style.scss
+++ b/assets/js/blocks/featured-items/style.scss
@@ -152,7 +152,8 @@
 		}
 	}
 
-	&__title {
+	& &__title {
+		color: inherit;
 		margin-top: 0;
 
 		div {

--- a/assets/js/blocks/featured-items/with-featured-item.tsx
+++ b/assets/js/blocks/featured-items/with-featured-item.tsx
@@ -70,9 +70,12 @@ interface FeaturedItemRequiredProps< T > {
 		| FeaturedProductRequiredAttributes
 	 ) &
 		EditorBlock< T >[ 'attributes' ] & {
-			// This is hardcoded because border is not yet included in Gutenberg's
-			// official types.
-			style: { border?: { radius?: number } };
+			// This is hardcoded because  and color ar not yet included
+			//  in Gutenberg's official types.
+			style: {
+				border?: { radius?: number };
+				color?: { text?: string };
+			};
 		};
 	isLoading: boolean;
 	setAttributes: ( attrs: Partial< FeaturedItemRequiredAttributes > ) => void;
@@ -187,6 +190,7 @@ export const withFeaturedItem = ( {
 
 		const containerStyle = {
 			borderRadius: style?.border?.radius,
+			color: style?.color?.text,
 		};
 
 		const wrapperStyle = {

--- a/assets/js/blocks/featured-items/with-featured-item.tsx
+++ b/assets/js/blocks/featured-items/with-featured-item.tsx
@@ -70,8 +70,8 @@ interface FeaturedItemRequiredProps< T > {
 		| FeaturedProductRequiredAttributes
 	 ) &
 		EditorBlock< T >[ 'attributes' ] & {
-			// This is hardcoded because  and color ar not yet included
-			//  in Gutenberg's official types.
+			// This is hardcoded because border and color are not yet included
+			// in Gutenberg's official types.
 			style: {
 				border?: { radius?: number };
 				color?: { text?: string };


### PR DESCRIPTION
This PR fixes a problem in which certain themes would override the default color of the Featured Item blocks, possibly leading to contrast and unexpected issues. While fixing this, I also noticed that custom colors wouldn't be applied to the text, only palette colors would, so that's fixed too.

Fixes #6489

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|    ![before](https://user-images.githubusercontent.com/3616980/171025759-80071c62-e924-4a8a-93cd-211e1952b90d.png)    |  ![after](https://user-images.githubusercontent.com/1847066/171045209-5bcb5e59-59f0-433f-962a-5abbc2906975.png) |

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Activate the Storefront theme.
2. Add the Featured Product block to the page.
3. Select a product.
4. Notice that the default color of the text inside should be white.
5. Change the color using the picker to a custom one (not included in the default palette).
6. The color of the text should change.
7. Repeat steps 2–6 with the Featured Category block.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Featured Item Blocks: fix an issue where the default color could be overridden by a theme, and where custom colors where not applied correctly.