### PR TITLE
Set the default value for `focalPoint` on `block.json`

### DIFF
--- a/assets/js/blocks/featured-items/featured-category/block.json
+++ b/assets/js/blocks/featured-items/featured-category/block.json
@@ -51,7 +51,10 @@
         },
         "focalPoint": {
             "type": "object",
-            "default": false
+            "default": {
+                "x": 0.5,
+                "y": 0.5
+            }
         },
         "imageFit": {
             "type": "string",

--- a/assets/js/blocks/featured-items/featured-product/block.json
+++ b/assets/js/blocks/featured-items/featured-product/block.json
@@ -50,7 +50,10 @@
         },
         "focalPoint": {
             "type": "object",
-            "default": false
+            "default": {
+                "x": 0.5,
+                "y": 0.5
+            }
         },
         "imageFit": {
             "type": "string",

--- a/assets/js/blocks/featured-items/inspector-controls.tsx
+++ b/assets/js/blocks/featured-items/inspector-controls.tsx
@@ -87,7 +87,7 @@ export const InspectorControls = ( {
 	backgroundImageSrc,
 	contentPanel,
 	dimRatio,
-	focalPoint = { x: 0.5, y: 0.5 },
+	focalPoint,
 	hasParallax,
 	imageFit,
 	isRepeated,


### PR DESCRIPTION
The default value for the focal point attribute was set to false on the `block.json` which is not a valid value for the property. That was causing an error in the console when editing the `Featured Product` and `Featured Category` blocks.

### Screenshots
<img width="802" alt="Screenshot 2022-05-31 at 12 31 54" src="https://user-images.githubusercontent.com/186112/171153985-f4227ec0-9bd0-4a8e-823f-5ce396a3985d.png">

### Testing

1. Create a new page and add a `Featured Product` or a `Featured Category` block and open the console.
2. Save the page and refresh the editor.
3. Click on the added block, edit some settings and check the error shown on the screenshot above does not appear.
4. Edit the focal point, save the block and check the block is rendered correctly on the edit page and on the frontend.

