### PR TITLE
Featured items: ensure valid DOM nesting in inspector controls

### DIFF
--- a/assets/js/blocks/featured-items/inspector-controls.tsx
+++ b/assets/js/blocks/featured-items/inspector-controls.tsx
@@ -155,18 +155,23 @@ export const InspectorControls = ( {
 								<ToggleGroupControl
 									help={
 										<>
-											<p>
+											<span
+												style={ {
+													display: 'block',
+													marginBottom: '1em',
+												} }
+											>
 												{ __(
 													'Choose “Cover” if you want the image to scale automatically to always fit its container.',
 													'woo-gutenberg-products-block'
 												) }
-											</p>
-											<p>
+											</span>
+											<span>
 												{ __(
 													'Note: by choosing “Cover” you will lose the ability to freely move the focal point precisely.',
 													'woo-gutenberg-products-block'
 												) }
-											</p>
+											</span>
 										</>
 									}
 									label={ __(


### PR DESCRIPTION
This PR is a follow-up on one of a couple of small issues we discovered since the recent updates of the featured item blocks (the other issue was fixed in https://github.com/woocommerce/woocommerce-blocks/pull/6499).

This PR aims to resolve a console error that's being thrown when interacting with the Featured Product/Category blocks. The issue occurred in the help text being added in the editor sidebar. It was caused by a block-level element being included in a `<p>` element, which must only contain inline containers.

### Screenshots
<img width="539" alt="Screenshot 2022-05-31 at 15 45 53" src="https://user-images.githubusercontent.com/1562646/171188665-aa0f82e8-2d74-4936-b0ad-122ee301925b.png">

<img width="266" alt="Screenshot 2022-05-31 at 14 28 01" src="https://user-images.githubusercontent.com/1562646/171189159-48bf6f3b-504b-4dee-9eab-f6ca8cc079c0.png">

### Testing

1. Create a new page and add a `Featured Product` or a `Featured Category` block and open the console.
2. Click on the added block, edit some settings and check the error shown on the screenshot above does not appear.
