### PR TITLE
Featured Item: Fix colors from default palette not being applied

### DIFF
--- a/assets/js/blocks/featured-items/with-featured-item.tsx
+++ b/assets/js/blocks/featured-items/with-featured-item.tsx
@@ -76,6 +76,7 @@ interface FeaturedItemRequiredProps< T > {
 				border?: { radius?: number };
 				color?: { text?: string };
 			};
+			textColor?: string;
 		};
 	isLoading: boolean;
 	setAttributes: ( attrs: Partial< FeaturedItemRequiredAttributes > ) => void;
@@ -170,6 +171,7 @@ export const withFeaturedItem = ( {
 			showDesc,
 			showPrice,
 			style,
+			textColor,
 		} = attributes;
 
 		const classes = classnames(
@@ -190,7 +192,9 @@ export const withFeaturedItem = ( {
 
 		const containerStyle = {
 			borderRadius: style?.border?.radius,
-			color: style?.color?.text,
+			color: textColor
+				? `var(--wp--preset--color--${ textColor })`
+				: style?.color?.text,
 		};
 
 		const wrapperStyle = {


### PR DESCRIPTION
Gutenberg uses two different attributes for text colors:

* `style.color.text`, and
* `textColor`

However, the second one is used only when a color from the default palette is selected AND the post is saved and reloaded.

With this fix we use the human readable string from the default palette as a CSS variable.

Please note that while Gutenberg correctly assigns the appropriate CSS class to render the right color, the problem is that if the color is handled by a class, it can be overridden for example by themes (see #6492).

Fixes #6522

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Add the Featured Category block.
2. Select it and go to the “Text” option of the inspector bar.
3. Select a color from the default palette.
4. Note that the color gets correctly applied to the text within the block.
5. Save the post.
6. Reload the page.
7. Make sure the color is still correctly applied.
8. Visit the page and make sure the color is correctly applied on the frontend too.
9. Repeat steps 2–8 for the Featured Product block.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Featured Item block: fixed an issue where the custom color wouldn't be applied if part of the default palette.