### PR TITLE
Disable page scroll when Mini Cart drawer is open

### DIFF
--- a/assets/js/blocks/mini-cart/block.tsx
+++ b/assets/js/blocks/mini-cart/block.tsx
@@ -79,6 +79,17 @@ const MiniCartBlock = ( {
 	}, [] );
 
 	useEffect( () => {
+		const body = document.querySelector( 'body' );
+		if ( body ) {
+			if ( isOpen ) {
+				Object.assign( body.style, { overflow: 'hidden' } );
+			} else {
+				Object.assign( body.style, { overflow: '' } );
+			}
+		}
+	}, [ isOpen ] );
+
+	useEffect( () => {
 		if ( contentsNode instanceof Element ) {
 			const container = contentsNode.querySelector(
 				'.wp-block-woocommerce-mini-cart-contents'


### PR DESCRIPTION
This PR disables scrolling the page when the Mini Cart drawer is open. The current behavior was specially confusing on mobile because you could scroll the page without noticing when the Mini Cart was open and covering the entire screen.

### Screenshots

![imatge](https://user-images.githubusercontent.com/3616980/172384267-b9ddebcf-71e6-47fe-8084-5ee7c337186d.png)

### Testing

#### User Facing Testing

1. Add the Mini Cart block to a post, page, or in the Site Editor.
2. In the frontend, click on the Mini Cart button so the drawer opens.
3. Try scrolling the page and verify you can't.
4. Close the drawer and verify you can scroll again.

* [ ] Do not include in the Testing Notes

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Disable page scroll when Mini Cart drawer is open
