### PR TITLE
Fix PHP notice in Mini Cart when prices included taxes

### DIFF
--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -433,7 +433,7 @@ class MiniCart extends AbstractBlock {
 				);
 			}
 			return array(
-				'label_including_tax'               => '',
+				'tax_label'                         => '',
 				'display_cart_prices_including_tax' => true,
 			);
 		}


### PR DESCRIPTION
Fixes #6536. For more context: in d356862d5cb78c20c353c72026c7604f9baea64c `label_including_tax` was renamed to `tax_label` but we missed one instance.

### Screenshots

| Before | After |
| ------ | ----- |
| ![imatge](https://user-images.githubusercontent.com/3616980/172639823-1b671ac0-58ea-4f4b-9b00-aa481d4acd72.png) | ![imatge](https://user-images.githubusercontent.com/3616980/172639911-7a1416fe-f49d-4c58-90b7-7e07637b1777.png) |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. Go to _WooCommerce_ > _Settings_ and check _Enable tax rates and calculations_.
2. Go to the _Tax_ tab in the settings and check _Yes, I will enter prices inclusive of tax_ and _Display prices during cart and checkout: Including tax_.
3. Add the Mini Cart block to a post or page.
4. Visit that post or page in the frontend, and verify there isn't a PHP notice.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix PHP notice in Mini Cart when prices included taxes
