### PR TITLE
ESLint: use `window.localstorage` instead `localstorage` 

### DIFF
--- a/tests/e2e/specs/backend/cart.test.js
+++ b/tests/e2e/specs/backend/cart.test.js
@@ -54,8 +54,7 @@ describe( `${ block.name } Block`, () => {
 			beforeAll( async () => {
 				// make sure CartCheckoutCompatibilityNotice will appear
 				await page.evaluate( () => {
-					// eslint-disable-next-line no-undef
-					localStorage.removeItem(
+					window.localStorage.removeItem(
 						'wc-blocks_dismissed_compatibility_notices'
 					);
 				} );
@@ -73,8 +72,7 @@ describe( `${ block.name } Block`, () => {
 		describe( 'after compatibility notice is dismissed', () => {
 			beforeAll( async () => {
 				await page.evaluate( () => {
-					// eslint-disable-next-line no-undef
-					localStorage.setItem(
+					window.localStorage.setItem(
 						'wc-blocks_dismissed_compatibility_notices',
 						'["cart"]'
 					);
@@ -85,8 +83,7 @@ describe( `${ block.name } Block`, () => {
 
 			afterAll( async () => {
 				await page.evaluate( () => {
-					// eslint-disable-next-line no-undef
-					localStorage.removeItem(
+					window.localStorage.removeItem(
 						'wc-blocks_dismissed_compatibility_notices'
 					);
 				} );

--- a/tests/e2e/specs/backend/checkout.test.js
+++ b/tests/e2e/specs/backend/checkout.test.js
@@ -42,8 +42,7 @@ describe( `${ block.name } Block`, () => {
 			beforeAll( async () => {
 				// make sure CartCheckoutCompatibilityNotice will appear
 				await page.evaluate( () => {
-					// eslint-disable-next-line no-undef
-					localStorage.removeItem(
+					window.localStorage.removeItem(
 						'wc-blocks_dismissed_compatibility_notices'
 					);
 				} );
@@ -61,8 +60,7 @@ describe( `${ block.name } Block`, () => {
 		describe( 'after compatibility notice is dismissed', () => {
 			beforeAll( async () => {
 				await page.evaluate( () => {
-					// eslint-disable-next-line no-undef
-					localStorage.setItem(
+					window.localStorage.setItem(
 						'wc-blocks_dismissed_compatibility_notices',
 						'["checkout"]'
 					);
@@ -72,8 +70,7 @@ describe( `${ block.name } Block`, () => {
 			} );
 			afterAll( async () => {
 				await page.evaluate( () => {
-					// eslint-disable-next-line no-undef
-					localStorage.removeItem(
+					window.localStorage.removeItem(
 						'wc-blocks_dismissed_compatibility_notices'
 					);
 				} );

--- a/tests/e2e/specs/backend/mini-cart.test.js
+++ b/tests/e2e/specs/backend/mini-cart.test.js
@@ -42,8 +42,9 @@ if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 3 ) {
 
 const removeDismissedCompatibilityNoticesFromLocalStorage = async () => {
 	await page.evaluate( () => {
-		// eslint-disable-next-line no-undef
-		localStorage.removeItem( 'wc-blocks_dismissed_compatibility_notices' );
+		window.localStorage.removeItem(
+			'wc-blocks_dismissed_compatibility_notices'
+		);
 	} );
 };
 
@@ -82,8 +83,7 @@ describe( `${ block.name } Block`, () => {
 
 		it( "after the compatibility notice is dismissed, it doesn't appear again", async () => {
 			await page.evaluate( () => {
-				// eslint-disable-next-line no-undef
-				localStorage.setItem(
+				window.localStorage.setItem(
 					'wc-blocks_dismissed_compatibility_notices',
 					'["mini-cart"]'
 				);
@@ -132,8 +132,7 @@ describe( `${ block.name } Block`, () => {
 
 		it( "after the compatibility notice is dismissed, it doesn't appear again", async () => {
 			await page.evaluate( () => {
-				// eslint-disable-next-line no-undef
-				localStorage.setItem(
+				window.localStorage.setItem(
 					'wc-blocks_dismissed_compatibility_notices',
 					'["mini-cart"]'
 				);

--- a/tests/utils/compatibility-notice.js
+++ b/tests/utils/compatibility-notice.js
@@ -1,9 +1,6 @@
-/* global localStorage */
-/* eslint-disable no-unused-expressions */
-
 export async function preventCompatibilityNotice() {
 	await page.evaluate( () => {
-		localStorage.setItem(
+		window.localStorage.setItem(
 			'wc-blocks_dismissed_compatibility_notices',
 			'["checkout"]'
 		);
@@ -12,7 +9,8 @@ export async function preventCompatibilityNotice() {
 
 export async function reactivateCompatibilityNotice() {
 	await page.evaluate( () => {
-		localStorage.removeItem( 'wc-blocks_dismissed_compatibility_notices' );
+		window.localStorage.removeItem(
+			'wc-blocks_dismissed_compatibility_notices'
+		);
 	} );
 }
-4;


### PR DESCRIPTION
After enabling ESLint for E2E test folder (#6413), @opr noticed that we should use `window.localstorage` instead `localstorage`: in this way we avoid disabling ESLint. 

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #6442

### Testing
#### User Facing Testing

Run the following command and be sure that there aren't any errors from the E2E folder.

```
npm run lint:js
```

Run the following command and be sure that there the E2E tests pass (or check GitHub CI)

```
npm run test:e2e
```




* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

