### PR TITLE
Correct mistake in checkout.md

### DIFF
--- a/src/StoreApi/docs/checkout.md
+++ b/src/StoreApi/docs/checkout.md
@@ -76,13 +76,13 @@ This endpoint will return an error unless a valid [Nonce Token](nonce-tokens.md)
 POST /wc/store/v1/checkout
 ```
 
-| Attribute          | Type    | Required | Description                                                         |
-| :----------------- | :------ | :------: | :------------------------------------------------------------------ |
-| `billing_address`  | array   |   Yes    | Array of updated billing address data for the customer.             |
-| `shipping_address` | integer |   Yes    | Array of updated shipping address data for the customer.            |
-| `customer_note`    | string  |    No    | Note added to the order by the customer during checkout.            |
-| `payment_method`   | string  |   Yes    | The ID of the payment method being used to process the payment.     |
-| `payment_data`     | array   |    No    | Data to pass through to the payment method when processing payment. |
+| Attribute          | Type   | Required | Description                                                         |
+| :----------------- | :----- | :------: | :------------------------------------------------------------------ |
+| `billing_address`  | array  |   Yes    | Array of updated billing address data for the customer.             |
+| `shipping_address` | array  |   Yes    | Array of updated shipping address data for the customer.            |
+| `customer_note`    | string |    No    | Note added to the order by the customer during checkout.            |
+| `payment_method`   | string |   Yes    | The ID of the payment method being used to process the payment.     |
+| `payment_data`     | array  |    No    | Data to pass through to the payment method when processing payment. |
 
 ```sh
 curl --header "Nonce: 12345" --request POST https://example-store.com/wp-json/wc/store/v1/checkout?payment_method=paypal&payment_data[0][key]=test-key&payment_data[0][value]=test-value
@@ -130,11 +130,10 @@ curl --header "Nonce: 12345" --request POST https://example-store.com/wp-json/wc
 }
 ```
 
-<!-- FEEDBACK -->
----
+## <!-- FEEDBACK -->
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./src/StoreApi/docs/checkout.md)
-<!-- /FEEDBACK -->
 
+<!-- /FEEDBACK -->


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
There was a typo in the src/StoreApi/docs/checkout.md that gave `shipping_address` the type `integer`, when it should actually be `array`

<!-- Reference any related issues or PRs here -->

Fixes #6518



### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
