### PR TITLE
Cart: ensure express checkout placeholder does not stick to checkout button

### DIFF
--- a/assets/js/blocks/cart/inner-blocks/cart-express-payment-block/editor.scss
+++ b/assets/js/blocks/cart/inner-blocks/cart-express-payment-block/editor.scss
@@ -20,7 +20,10 @@
 
 	.wp-block-woocommerce-cart-express-payment-block &,
 	.wp-block-woocommerce-checkout-express-payment-block-placeholder__description {
-		display: block;
 		margin: 0 0 1em;
+	}
+
+	.wp-block-woocommerce-checkout-express-payment-block-placeholder__description {
+		display: block;
 	}
 }

--- a/assets/js/blocks/cart/inner-blocks/cart-express-payment-block/editor.scss
+++ b/assets/js/blocks/cart/inner-blocks/cart-express-payment-block/editor.scss
@@ -18,6 +18,7 @@
 		pointer-events: all; // Overrides parent disabled component in editor context
 	}
 
+	.wp-block-woocommerce-cart-express-payment-block &,
 	.wp-block-woocommerce-checkout-express-payment-block-placeholder__description {
 		display: block;
 		margin: 0 0 1em;


### PR DESCRIPTION


<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

While looking into how our WooCommerce buttons interact with the elements API on a new store, I noticed that the "Proceed to Checkout" button sticks to the Express Checkout placeholder when no express payment methods are set up. This looks visually unintended so this PR introduces the same gap we're using in the surrounding elements.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|     <img width="687" alt="Screenshot 2022-06-10 at 11 46 29" src="https://user-images.githubusercontent.com/1562646/173040051-84699926-bc6d-4c2f-ae3c-79f970230a9e.png">   |   <img width="693" alt="Screenshot 2022-06-10 at 12 08 55" src="https://user-images.githubusercontent.com/1562646/173043629-6ed5afd2-f8aa-49cd-9ef8-9e93ee9710db.png">   |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Use a site that doesn't have Express Payment methods set up (or remove them).
2. Add the Cart block to a page.
3. Confirm the button now doesn't stick to the placeholder anymore.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Minor visual fix so we'll `skip-changelog`.
