### PR TITLE
`SearchListControl`: Fix preserving case of original item

### DIFF
--- a/assets/js/editor-components/search-list-control/test/__snapshots__/index.js.snap
+++ b/assets/js/editor-components/search-list-control/test/__snapshots__/index.js.snap
@@ -54,13 +54,13 @@ Object {
             >
               <label
                 class="components-base-control__label css-13ck15n-StyledLabel e1puf3u1"
-                for="inspector-text-control-10"
+                for="inspector-text-control-11"
               >
                 Search for items
               </label>
               <input
                 class="components-text-control__input"
-                id="inspector-text-control-10"
+                id="inspector-text-control-11"
                 type="search"
                 value=""
               />
@@ -73,12 +73,12 @@ Object {
           <li>
             <label
               class=" woocommerce-search-list__item depth-0"
-              for="search-list-item-10-1"
+              for="search-list-item-11-1"
             >
               <input
                 class="woocommerce-search-list__item-input"
-                id="search-list-item-10-1"
-                name="search-list-item-10"
+                id="search-list-item-11-1"
+                name="search-list-item-11"
                 type="checkbox"
                 value=""
               />
@@ -96,12 +96,12 @@ Object {
           <li>
             <label
               class=" woocommerce-search-list__item depth-1"
-              for="search-list-item-10-2"
+              for="search-list-item-11-2"
             >
               <input
                 class="woocommerce-search-list__item-input"
-                id="search-list-item-10-2"
-                name="search-list-item-10"
+                id="search-list-item-11-2"
+                name="search-list-item-11"
                 type="checkbox"
                 value=""
               />
@@ -124,12 +124,12 @@ Object {
           <li>
             <label
               class=" woocommerce-search-list__item depth-1"
-              for="search-list-item-10-3"
+              for="search-list-item-11-3"
             >
               <input
                 class="woocommerce-search-list__item-input"
-                id="search-list-item-10-3"
-                name="search-list-item-10"
+                id="search-list-item-11-3"
+                name="search-list-item-11"
                 type="checkbox"
                 value=""
               />
@@ -152,12 +152,12 @@ Object {
           <li>
             <label
               class=" woocommerce-search-list__item depth-2"
-              for="search-list-item-10-4"
+              for="search-list-item-11-4"
             >
               <input
                 class="woocommerce-search-list__item-input"
-                id="search-list-item-10-4"
-                name="search-list-item-10"
+                id="search-list-item-11-4"
+                name="search-list-item-11"
                 type="checkbox"
                 value=""
               />
@@ -180,12 +180,12 @@ Object {
           <li>
             <label
               class=" woocommerce-search-list__item depth-0"
-              for="search-list-item-10-5"
+              for="search-list-item-11-5"
             >
               <input
                 class="woocommerce-search-list__item-input"
-                id="search-list-item-10-5"
-                name="search-list-item-10"
+                id="search-list-item-11-5"
+                name="search-list-item-11"
                 type="checkbox"
                 value=""
               />
@@ -203,12 +203,12 @@ Object {
           <li>
             <label
               class=" woocommerce-search-list__item depth-0"
-              for="search-list-item-10-6"
+              for="search-list-item-11-6"
             >
               <input
                 class="woocommerce-search-list__item-input"
-                id="search-list-item-10-6"
-                name="search-list-item-10"
+                id="search-list-item-11-6"
+                name="search-list-item-11"
                 type="checkbox"
                 value=""
               />
@@ -253,13 +253,13 @@ Object {
           >
             <label
               class="components-base-control__label css-13ck15n-StyledLabel e1puf3u1"
-              for="inspector-text-control-10"
+              for="inspector-text-control-11"
             >
               Search for items
             </label>
             <input
               class="components-text-control__input"
-              id="inspector-text-control-10"
+              id="inspector-text-control-11"
               type="search"
               value=""
             />
@@ -272,12 +272,12 @@ Object {
         <li>
           <label
             class=" woocommerce-search-list__item depth-0"
-            for="search-list-item-10-1"
+            for="search-list-item-11-1"
           >
             <input
               class="woocommerce-search-list__item-input"
-              id="search-list-item-10-1"
-              name="search-list-item-10"
+              id="search-list-item-11-1"
+              name="search-list-item-11"
               type="checkbox"
               value=""
             />
@@ -295,12 +295,12 @@ Object {
         <li>
           <label
             class=" woocommerce-search-list__item depth-1"
-            for="search-list-item-10-2"
+            for="search-list-item-11-2"
           >
             <input
               class="woocommerce-search-list__item-input"
-              id="search-list-item-10-2"
-              name="search-list-item-10"
+              id="search-list-item-11-2"
+              name="search-list-item-11"
               type="checkbox"
               value=""
             />
@@ -323,12 +323,12 @@ Object {
         <li>
           <label
             class=" woocommerce-search-list__item depth-1"
-            for="search-list-item-10-3"
+            for="search-list-item-11-3"
           >
             <input
               class="woocommerce-search-list__item-input"
-              id="search-list-item-10-3"
-              name="search-list-item-10"
+              id="search-list-item-11-3"
+              name="search-list-item-11"
               type="checkbox"
               value=""
             />
@@ -351,12 +351,12 @@ Object {
         <li>
           <label
             class=" woocommerce-search-list__item depth-2"
-            for="search-list-item-10-4"
+            for="search-list-item-11-4"
           >
             <input
               class="woocommerce-search-list__item-input"
-              id="search-list-item-10-4"
-              name="search-list-item-10"
+              id="search-list-item-11-4"
+              name="search-list-item-11"
               type="checkbox"
               value=""
             />
@@ -379,12 +379,12 @@ Object {
         <li>
           <label
             class=" woocommerce-search-list__item depth-0"
-            for="search-list-item-10-5"
+            for="search-list-item-11-5"
           >
             <input
               class="woocommerce-search-list__item-input"
-              id="search-list-item-10-5"
-              name="search-list-item-10"
+              id="search-list-item-11-5"
+              name="search-list-item-11"
               type="checkbox"
               value=""
             />
@@ -402,12 +402,12 @@ Object {
         <li>
           <label
             class=" woocommerce-search-list__item depth-0"
-            for="search-list-item-10-6"
+            for="search-list-item-11-6"
           >
             <input
               class="woocommerce-search-list__item-input"
-              id="search-list-item-10-6"
-              name="search-list-item-10"
+              id="search-list-item-11-6"
+              name="search-list-item-11"
               type="checkbox"
               value=""
             />
@@ -1431,13 +1431,13 @@ Object {
             >
               <label
                 class="components-base-control__label css-13ck15n-StyledLabel e1puf3u1"
-                for="inspector-text-control-9"
+                for="inspector-text-control-10"
               >
                 Search for items
               </label>
               <input
                 class="components-text-control__input"
-                id="inspector-text-control-9"
+                id="inspector-text-control-10"
                 type="search"
                 value=""
               />
@@ -1513,13 +1513,13 @@ Object {
           >
             <label
               class="components-base-control__label css-13ck15n-StyledLabel e1puf3u1"
-              for="inspector-text-control-9"
+              for="inspector-text-control-10"
             >
               Search for items
             </label>
             <input
               class="components-text-control__input"
-              id="inspector-text-control-9"
+              id="inspector-text-control-10"
               type="search"
               value=""
             />
@@ -1676,13 +1676,13 @@ Object {
             >
               <label
                 class="components-base-control__label css-13ck15n-StyledLabel e1puf3u1"
-                for="inspector-text-control-8"
+                for="inspector-text-control-9"
               >
                 Testing search label
               </label>
               <input
                 class="components-text-control__input"
-                id="inspector-text-control-8"
+                id="inspector-text-control-9"
                 type="search"
                 value=""
               />
@@ -1695,12 +1695,12 @@ Object {
           <li>
             <label
               class=" woocommerce-search-list__item depth-0"
-              for="search-list-item-8-1"
+              for="search-list-item-9-1"
             >
               <input
                 class="woocommerce-search-list__item-input"
-                id="search-list-item-8-1"
-                name="search-list-item-8"
+                id="search-list-item-9-1"
+                name="search-list-item-9"
                 type="checkbox"
                 value=""
               />
@@ -1718,12 +1718,12 @@ Object {
           <li>
             <label
               class=" woocommerce-search-list__item depth-0"
-              for="search-list-item-8-2"
+              for="search-list-item-9-2"
             >
               <input
                 class="woocommerce-search-list__item-input"
-                id="search-list-item-8-2"
-                name="search-list-item-8"
+                id="search-list-item-9-2"
+                name="search-list-item-9"
                 type="checkbox"
                 value=""
               />
@@ -1741,12 +1741,12 @@ Object {
           <li>
             <label
               class=" woocommerce-search-list__item depth-0"
-              for="search-list-item-8-3"
+              for="search-list-item-9-3"
             >
               <input
                 class="woocommerce-search-list__item-input"
-                id="search-list-item-8-3"
-                name="search-list-item-8"
+                id="search-list-item-9-3"
+                name="search-list-item-9"
                 type="checkbox"
                 value=""
               />
@@ -1764,12 +1764,12 @@ Object {
           <li>
             <label
               class=" woocommerce-search-list__item depth-0"
-              for="search-list-item-8-4"
+              for="search-list-item-9-4"
             >
               <input
                 class="woocommerce-search-list__item-input"
-                id="search-list-item-8-4"
-                name="search-list-item-8"
+                id="search-list-item-9-4"
+                name="search-list-item-9"
                 type="checkbox"
                 value=""
               />
@@ -1787,12 +1787,12 @@ Object {
           <li>
             <label
               class=" woocommerce-search-list__item depth-0"
-              for="search-list-item-8-5"
+              for="search-list-item-9-5"
             >
               <input
                 class="woocommerce-search-list__item-input"
-                id="search-list-item-8-5"
-                name="search-list-item-8"
+                id="search-list-item-9-5"
+                name="search-list-item-9"
                 type="checkbox"
                 value=""
               />
@@ -1810,12 +1810,12 @@ Object {
           <li>
             <label
               class=" woocommerce-search-list__item depth-0"
-              for="search-list-item-8-6"
+              for="search-list-item-9-6"
             >
               <input
                 class="woocommerce-search-list__item-input"
-                id="search-list-item-8-6"
-                name="search-list-item-8"
+                id="search-list-item-9-6"
+                name="search-list-item-9"
                 type="checkbox"
                 value=""
               />
@@ -1860,13 +1860,13 @@ Object {
           >
             <label
               class="components-base-control__label css-13ck15n-StyledLabel e1puf3u1"
-              for="inspector-text-control-8"
+              for="inspector-text-control-9"
             >
               Testing search label
             </label>
             <input
               class="components-text-control__input"
-              id="inspector-text-control-8"
+              id="inspector-text-control-9"
               type="search"
               value=""
             />
@@ -1879,12 +1879,12 @@ Object {
         <li>
           <label
             class=" woocommerce-search-list__item depth-0"
-            for="search-list-item-8-1"
+            for="search-list-item-9-1"
           >
             <input
               class="woocommerce-search-list__item-input"
-              id="search-list-item-8-1"
-              name="search-list-item-8"
+              id="search-list-item-9-1"
+              name="search-list-item-9"
               type="checkbox"
               value=""
             />
@@ -1902,12 +1902,12 @@ Object {
         <li>
           <label
             class=" woocommerce-search-list__item depth-0"
-            for="search-list-item-8-2"
+            for="search-list-item-9-2"
           >
             <input
               class="woocommerce-search-list__item-input"
-              id="search-list-item-8-2"
-              name="search-list-item-8"
+              id="search-list-item-9-2"
+              name="search-list-item-9"
               type="checkbox"
               value=""
             />
@@ -1925,12 +1925,12 @@ Object {
         <li>
           <label
             class=" woocommerce-search-list__item depth-0"
-            for="search-list-item-8-3"
+            for="search-list-item-9-3"
           >
             <input
               class="woocommerce-search-list__item-input"
-              id="search-list-item-8-3"
-              name="search-list-item-8"
+              id="search-list-item-9-3"
+              name="search-list-item-9"
               type="checkbox"
               value=""
             />
@@ -1948,12 +1948,12 @@ Object {
         <li>
           <label
             class=" woocommerce-search-list__item depth-0"
-            for="search-list-item-8-4"
+            for="search-list-item-9-4"
           >
             <input
               class="woocommerce-search-list__item-input"
-              id="search-list-item-8-4"
-              name="search-list-item-8"
+              id="search-list-item-9-4"
+              name="search-list-item-9"
               type="checkbox"
               value=""
             />
@@ -1971,12 +1971,12 @@ Object {
         <li>
           <label
             class=" woocommerce-search-list__item depth-0"
-            for="search-list-item-8-5"
+            for="search-list-item-9-5"
           >
             <input
               class="woocommerce-search-list__item-input"
-              id="search-list-item-8-5"
-              name="search-list-item-8"
+              id="search-list-item-9-5"
+              name="search-list-item-9"
               type="checkbox"
               value=""
             />
@@ -1994,12 +1994,12 @@ Object {
         <li>
           <label
             class=" woocommerce-search-list__item depth-0"
-            for="search-list-item-8-6"
+            for="search-list-item-9-6"
           >
             <input
               class="woocommerce-search-list__item-input"
-              id="search-list-item-8-6"
-              name="search-list-item-8"
+              id="search-list-item-9-6"
+              name="search-list-item-9"
               type="checkbox"
               value=""
             />
@@ -2342,13 +2342,13 @@ Object {
             >
               <label
                 class="components-base-control__label css-13ck15n-StyledLabel e1puf3u1"
-                for="inspector-text-control-7"
+                for="inspector-text-control-8"
               >
                 Search for items
               </label>
               <input
                 class="components-text-control__input"
-                id="inspector-text-control-7"
+                id="inspector-text-control-8"
                 type="search"
                 value=""
               />
@@ -2361,12 +2361,12 @@ Object {
           <li>
             <label
               class=" woocommerce-search-list__item depth-0"
-              for="search-list-item-7-1"
+              for="search-list-item-8-1"
             >
               <input
                 class="woocommerce-search-list__item-input"
-                id="search-list-item-7-1"
-                name="search-list-item-7"
+                id="search-list-item-8-1"
+                name="search-list-item-8"
                 type="checkbox"
                 value=""
               />
@@ -2384,12 +2384,12 @@ Object {
           <li>
             <label
               class=" woocommerce-search-list__item depth-0"
-              for="search-list-item-7-2"
+              for="search-list-item-8-2"
             >
               <input
                 class="woocommerce-search-list__item-input"
-                id="search-list-item-7-2"
-                name="search-list-item-7"
+                id="search-list-item-8-2"
+                name="search-list-item-8"
                 type="checkbox"
                 value=""
               />
@@ -2407,12 +2407,12 @@ Object {
           <li>
             <label
               class=" woocommerce-search-list__item depth-0"
-              for="search-list-item-7-3"
+              for="search-list-item-8-3"
             >
               <input
                 class="woocommerce-search-list__item-input"
-                id="search-list-item-7-3"
-                name="search-list-item-7"
+                id="search-list-item-8-3"
+                name="search-list-item-8"
                 type="checkbox"
                 value=""
               />
@@ -2430,12 +2430,12 @@ Object {
           <li>
             <label
               class=" woocommerce-search-list__item depth-0"
-              for="search-list-item-7-4"
+              for="search-list-item-8-4"
             >
               <input
                 class="woocommerce-search-list__item-input"
-                id="search-list-item-7-4"
-                name="search-list-item-7"
+                id="search-list-item-8-4"
+                name="search-list-item-8"
                 type="checkbox"
                 value=""
               />
@@ -2453,12 +2453,12 @@ Object {
           <li>
             <label
               class=" woocommerce-search-list__item depth-0"
-              for="search-list-item-7-5"
+              for="search-list-item-8-5"
             >
               <input
                 class="woocommerce-search-list__item-input"
-                id="search-list-item-7-5"
-                name="search-list-item-7"
+                id="search-list-item-8-5"
+                name="search-list-item-8"
                 type="checkbox"
                 value=""
               />
@@ -2476,12 +2476,12 @@ Object {
           <li>
             <label
               class=" woocommerce-search-list__item depth-0"
-              for="search-list-item-7-6"
+              for="search-list-item-8-6"
             >
               <input
                 class="woocommerce-search-list__item-input"
-                id="search-list-item-7-6"
-                name="search-list-item-7"
+                id="search-list-item-8-6"
+                name="search-list-item-8"
                 type="checkbox"
                 value=""
               />
@@ -2526,13 +2526,13 @@ Object {
           >
             <label
               class="components-base-control__label css-13ck15n-StyledLabel e1puf3u1"
-              for="inspector-text-control-7"
+              for="inspector-text-control-8"
             >
               Search for items
             </label>
             <input
               class="components-text-control__input"
-              id="inspector-text-control-7"
+              id="inspector-text-control-8"
               type="search"
               value=""
             />
@@ -2545,12 +2545,12 @@ Object {
         <li>
           <label
             class=" woocommerce-search-list__item depth-0"
-            for="search-list-item-7-1"
+            for="search-list-item-8-1"
           >
             <input
               class="woocommerce-search-list__item-input"
-              id="search-list-item-7-1"
-              name="search-list-item-7"
+              id="search-list-item-8-1"
+              name="search-list-item-8"
               type="checkbox"
               value=""
             />
@@ -2568,12 +2568,12 @@ Object {
         <li>
           <label
             class=" woocommerce-search-list__item depth-0"
-            for="search-list-item-7-2"
+            for="search-list-item-8-2"
           >
             <input
               class="woocommerce-search-list__item-input"
-              id="search-list-item-7-2"
-              name="search-list-item-7"
+              id="search-list-item-8-2"
+              name="search-list-item-8"
               type="checkbox"
               value=""
             />
@@ -2591,12 +2591,12 @@ Object {
         <li>
           <label
             class=" woocommerce-search-list__item depth-0"
-            for="search-list-item-7-3"
+            for="search-list-item-8-3"
           >
             <input
               class="woocommerce-search-list__item-input"
-              id="search-list-item-7-3"
-              name="search-list-item-7"
+              id="search-list-item-8-3"
+              name="search-list-item-8"
               type="checkbox"
               value=""
             />
@@ -2614,12 +2614,12 @@ Object {
         <li>
           <label
             class=" woocommerce-search-list__item depth-0"
-            for="search-list-item-7-4"
+            for="search-list-item-8-4"
           >
             <input
               class="woocommerce-search-list__item-input"
-              id="search-list-item-7-4"
-              name="search-list-item-7"
+              id="search-list-item-8-4"
+              name="search-list-item-8"
               type="checkbox"
               value=""
             />
@@ -2637,12 +2637,12 @@ Object {
         <li>
           <label
             class=" woocommerce-search-list__item depth-0"
-            for="search-list-item-7-5"
+            for="search-list-item-8-5"
           >
             <input
               class="woocommerce-search-list__item-input"
-              id="search-list-item-7-5"
-              name="search-list-item-7"
+              id="search-list-item-8-5"
+              name="search-list-item-8"
               type="checkbox"
               value=""
             />
@@ -2660,12 +2660,12 @@ Object {
         <li>
           <label
             class=" woocommerce-search-list__item depth-0"
-            for="search-list-item-7-6"
+            for="search-list-item-8-6"
           >
             <input
               class="woocommerce-search-list__item-input"
-              id="search-list-item-7-6"
-              name="search-list-item-7"
+              id="search-list-item-8-6"
+              name="search-list-item-8"
               type="checkbox"
               value=""
             />
@@ -3248,7 +3248,7 @@ Object {
                 class="components-text-control__input"
                 id="inspector-text-control-6"
                 type="search"
-                value=""
+                value="BeRrY"
               />
             </div>
           </div>
@@ -3256,52 +3256,6 @@ Object {
         <ul
           class="woocommerce-search-list__list"
         >
-          <li>
-            <label
-              class=" woocommerce-search-list__item depth-0"
-              for="search-list-item-6-1"
-            >
-              <input
-                class="woocommerce-search-list__item-input"
-                id="search-list-item-6-1"
-                name="search-list-item-6"
-                type="checkbox"
-                value=""
-              />
-              <span
-                class="woocommerce-search-list__item-label"
-              >
-                <span
-                  class="woocommerce-search-list__item-name"
-                >
-                  Apricots
-                </span>
-              </span>
-            </label>
-          </li>
-          <li>
-            <label
-              class=" woocommerce-search-list__item depth-0"
-              for="search-list-item-6-2"
-            >
-              <input
-                class="woocommerce-search-list__item-input"
-                id="search-list-item-6-2"
-                name="search-list-item-6"
-                type="checkbox"
-                value=""
-              />
-              <span
-                class="woocommerce-search-list__item-label"
-              >
-                <span
-                  class="woocommerce-search-list__item-name"
-                >
-                  Clementine
-                </span>
-              </span>
-            </label>
-          </li>
           <li>
             <label
               class=" woocommerce-search-list__item depth-0"
@@ -3320,53 +3274,11 @@ Object {
                 <span
                   class="woocommerce-search-list__item-name"
                 >
-                  Elderberry
-                </span>
-              </span>
-            </label>
-          </li>
-          <li>
-            <label
-              class=" woocommerce-search-list__item depth-0"
-              for="search-list-item-6-4"
-            >
-              <input
-                class="woocommerce-search-list__item-input"
-                id="search-list-item-6-4"
-                name="search-list-item-6"
-                type="checkbox"
-                value=""
-              />
-              <span
-                class="woocommerce-search-list__item-label"
-              >
-                <span
-                  class="woocommerce-search-list__item-name"
-                >
-                  Guava
-                </span>
-              </span>
-            </label>
-          </li>
-          <li>
-            <label
-              class=" woocommerce-search-list__item depth-0"
-              for="search-list-item-6-5"
-            >
-              <input
-                class="woocommerce-search-list__item-input"
-                id="search-list-item-6-5"
-                name="search-list-item-6"
-                type="checkbox"
-                value=""
-              />
-              <span
-                class="woocommerce-search-list__item-label"
-              >
-                <span
-                  class="woocommerce-search-list__item-name"
-                >
-                  Lychee
+                  Elder
+                  <strong>
+                    berry
+                  </strong>
+                  
                 </span>
               </span>
             </label>
@@ -3389,7 +3301,11 @@ Object {
                 <span
                   class="woocommerce-search-list__item-name"
                 >
-                  Mulberry
+                  Mul
+                  <strong>
+                    berry
+                  </strong>
+                  
                 </span>
               </span>
             </label>
@@ -3432,7 +3348,7 @@ Object {
               class="components-text-control__input"
               id="inspector-text-control-6"
               type="search"
-              value=""
+              value="BeRrY"
             />
           </div>
         </div>
@@ -3440,52 +3356,6 @@ Object {
       <ul
         class="woocommerce-search-list__list"
       >
-        <li>
-          <label
-            class=" woocommerce-search-list__item depth-0"
-            for="search-list-item-6-1"
-          >
-            <input
-              class="woocommerce-search-list__item-input"
-              id="search-list-item-6-1"
-              name="search-list-item-6"
-              type="checkbox"
-              value=""
-            />
-            <span
-              class="woocommerce-search-list__item-label"
-            >
-              <span
-                class="woocommerce-search-list__item-name"
-              >
-                Apricots
-              </span>
-            </span>
-          </label>
-        </li>
-        <li>
-          <label
-            class=" woocommerce-search-list__item depth-0"
-            for="search-list-item-6-2"
-          >
-            <input
-              class="woocommerce-search-list__item-input"
-              id="search-list-item-6-2"
-              name="search-list-item-6"
-              type="checkbox"
-              value=""
-            />
-            <span
-              class="woocommerce-search-list__item-label"
-            >
-              <span
-                class="woocommerce-search-list__item-name"
-              >
-                Clementine
-              </span>
-            </span>
-          </label>
-        </li>
         <li>
           <label
             class=" woocommerce-search-list__item depth-0"
@@ -3504,53 +3374,11 @@ Object {
               <span
                 class="woocommerce-search-list__item-name"
               >
-                Elderberry
-              </span>
-            </span>
-          </label>
-        </li>
-        <li>
-          <label
-            class=" woocommerce-search-list__item depth-0"
-            for="search-list-item-6-4"
-          >
-            <input
-              class="woocommerce-search-list__item-input"
-              id="search-list-item-6-4"
-              name="search-list-item-6"
-              type="checkbox"
-              value=""
-            />
-            <span
-              class="woocommerce-search-list__item-label"
-            >
-              <span
-                class="woocommerce-search-list__item-name"
-              >
-                Guava
-              </span>
-            </span>
-          </label>
-        </li>
-        <li>
-          <label
-            class=" woocommerce-search-list__item depth-0"
-            for="search-list-item-6-5"
-          >
-            <input
-              class="woocommerce-search-list__item-input"
-              id="search-list-item-6-5"
-              name="search-list-item-6"
-              type="checkbox"
-              value=""
-            />
-            <span
-              class="woocommerce-search-list__item-label"
-            >
-              <span
-                class="woocommerce-search-list__item-name"
-              >
-                Lychee
+                Elder
+                <strong>
+                  berry
+                </strong>
+                
               </span>
             </span>
           </label>
@@ -3573,7 +3401,11 @@ Object {
               <span
                 class="woocommerce-search-list__item-name"
               >
-                Mulberry
+                Mul
+                <strong>
+                  berry
+                </strong>
+                
               </span>
             </span>
           </label>

--- a/assets/js/editor-components/search-list-control/test/index.js
+++ b/assets/js/editor-components/search-list-control/test/index.js
@@ -1,13 +1,18 @@
 /**
  * External dependencies
  */
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import { noop } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import { SearchListControl } from '../';
+
+const SELECTORS = {
+	listItems: '.woocommerce-search-list__list > li',
+	searchInput: '.components-text-control__input[type="search"]',
+};
 
 const list = [
 	{ id: 1, name: 'Apricots' },
@@ -108,13 +113,50 @@ describe( 'SearchListControl', () => {
 			<SearchListControl
 				instanceId={ 1 }
 				list={ list }
-				search="bERry"
 				selected={ [] }
 				onChange={ noop }
 				debouncedSpeak={ noop }
 			/>
 		);
+
+		fireEvent.change(
+			component.container.querySelector( SELECTORS.searchInput ),
+			{ target: { value: 'BeRrY' } }
+		);
+
 		expect( component ).toMatchSnapshot();
+
+		const $listItems = component.container.querySelectorAll(
+			SELECTORS.listItems
+		);
+
+		expect( $listItems ).toHaveLength( 2 );
+	} );
+
+	// @see https://github.com/woocommerce/woocommerce-blocks/issues/6524
+	test( "should render search results in their original case regardless of user's input case", () => {
+		const EXPECTED = [ 'Elderberry', 'Mulberry' ];
+
+		const component = render(
+			<SearchListControl
+				instanceId={ 1 }
+				list={ list }
+				selected={ [] }
+				onChange={ noop }
+				debouncedSpeak={ noop }
+			/>
+		);
+
+		fireEvent.change(
+			component.container.querySelector( SELECTORS.searchInput ),
+			{ target: { value: 'BeRrY' } }
+		);
+
+		const listItems = Array.from(
+			component.container.querySelectorAll( SELECTORS.listItems )
+		).map( ( $el ) => $el.textContent );
+
+		expect( listItems ).toEqual( expect.arrayContaining( EXPECTED ) );
 	} );
 
 	test( 'should render a search box with a search term, and no matching options', () => {

--- a/assets/js/editor-components/search-list-control/utils.tsx
+++ b/assets/js/editor-components/search-list-control/utils.tsx
@@ -3,7 +3,6 @@
  */
 import { groupBy, keyBy } from 'lodash';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -114,20 +113,13 @@ export const getHighlightedName = (
 	}
 	const re = new RegExp(
 		// Escaping.
-		search.replace( /[-\/\\^$*+?.()|[\]{}]/g, '\\$&' ),
+		`(${ search.replace( /[-\/\\^$*+?.()|[\]{}]/g, '\\$&' ) })`,
 		'ig'
 	);
 	const nameParts = name.split( re );
-	return nameParts.map( ( part, i ) => {
-		if ( i === 0 ) {
-			return part;
-		}
-		return (
-			<Fragment key={ i }>
-				<strong>{ search }</strong>
-				{ part }
-			</Fragment>
-		);
+
+	return nameParts.map( ( part ) => {
+		return re.test( part ) ? <strong>{ part }</strong> : part;
 	} );
 };
 

--- a/assets/js/editor-components/search-list-control/utils.tsx
+++ b/assets/js/editor-components/search-list-control/utils.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { groupBy, keyBy } from 'lodash';
-import { Fragment } from 'react';
+import { Fragment } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 
 /**

--- a/assets/js/editor-components/search-list-control/utils.tsx
+++ b/assets/js/editor-components/search-list-control/utils.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { groupBy, keyBy } from 'lodash';
+import { Fragment } from 'react';
 import { __, _n, sprintf } from '@wordpress/i18n';
 
 /**
@@ -118,8 +119,12 @@ export const getHighlightedName = (
 	);
 	const nameParts = name.split( re );
 
-	return nameParts.map( ( part ) => {
-		return re.test( part ) ? <strong>{ part }</strong> : part;
+	return nameParts.map( ( part, i ) => {
+		return re.test( part ) ? (
+			<strong key={ i }>{ part }</strong>
+		) : (
+			<Fragment key={ i }>{ part }</Fragment>
+		);
 	} );
 };
 


### PR DESCRIPTION
This PR fixes an issue where the `SearchListControl` component (for example, used in the Hand-picked Products block) would render the search results list with highlighted text borrowing the case from the user's input instead of the original item's name. So, if the original item's name was `Hoodie`, but the user's input was `hOoDiE`, search results would display the latter, rather than the former.

Search still is case insensitive, but preserves the original item's case.

Also, this PR adds a test for this bug and fixes a previous test case which wasn't actually testing for this at all.

Fixes #6524

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
| <img width="747" alt="172268138-7445fbf1-ad25-4716-8b5a-ee4b463af54b" src="https://user-images.githubusercontent.com/1847066/173202016-249f5fe1-08f1-4ab9-aec5-18507c754d68.png"> |  ![Screenshot 2022-06-11 at 21 16 42](https://user-images.githubusercontent.com/1847066/173202019-aa3659e5-0dd4-454b-95bd-f2ead03ee40d.png) |

### Testing

#### Automated Tests
* [x] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Add a “Hand-picked Products” block to your page.
2. Type the name of one of your products with the incorrect case (e.g. if you have imported the sample data, type “hOoDiE”.
3. Make sure all matching products appear on the list.
4. Make sure all items on the list preserve their original case.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Fixes an issue where search lists would not preserve the case of the original item.
