### PR TITLE
Use default .editorconfig settings for *.md files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,7 +18,7 @@ trim_trailing_whitespace = true
 [*.txt]
 trim_trailing_whitespace = false
 
-[*.{md,json,yml}]
+[*.{json,yml}]
 trim_trailing_whitespace = false
 indent_style = space
 indent_size = 2


### PR DESCRIPTION
In #6462, we adjusted the formatting for *.md files. While creating the PR, I overlooked a setting for *.md files in [.editorconfig](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/.editorconfig), which is in contradiction to the settings in [.markdownlint.json](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/.markdownlint.json). This PR aims to correct this.

### Testing

#### User Facing Testing

1. Look up the changed .editorconfig file.
2. Verify that *.md files inherit their settings from `[*]`.
3. Verify that these settings are in synch with the settings from [.markdownlint.json](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/.markdownlint.json).

* [x] Do not include in the Testing Notes