### PR TITLE
[Experiment] Product search block Elements API support

### DIFF
--- a/assets/js/blocks/product-search/edit.js
+++ b/assets/js/blocks/product-search/edit.js
@@ -1,10 +1,16 @@
+/* eslint-disable @wordpress/no-unsafe-wp-apis */
+
 /**
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
-import { InspectorControls, PlainText } from '@wordpress/block-editor';
+import {
+	InspectorControls,
+	PlainText,
+	__experimentalElementButtonClassName,
+} from '@wordpress/block-editor';
 import { PanelBody, ToggleControl, TextControl } from '@wordpress/components';
 import { withInstanceId } from '@wordpress/compose';
 import { useEffect } from '@wordpress/element';
@@ -114,7 +120,10 @@ const Edit = ( {
 					/>
 					<button
 						type="submit"
-						className="wc-block-product-search__button"
+						className={ classnames(
+							'wc-block-product-search__button',
+							__experimentalElementButtonClassName
+						) }
 						label={ __( 'Search', 'woo-gutenberg-products-block' ) }
 						onClick={ ( e ) => e.preventDefault() }
 						tabIndex="-1"

--- a/assets/js/blocks/product-search/editor.scss
+++ b/assets/js/blocks/product-search/editor.scss
@@ -13,4 +13,7 @@
 			flex-grow: 1;
 		}
 	}
+	.wc-block-product-search__field {
+		border: 0;
+	}
 }

--- a/assets/js/blocks/product-search/style.scss
+++ b/assets/js/blocks/product-search/style.scss
@@ -1,4 +1,4 @@
-.wc-block-product-search {
+:where(.wc-block-product-search) {
 	.wc-block-product-search__fields {
 		display: flex;
 	}
@@ -6,11 +6,21 @@
 		padding: 6px 8px;
 		line-height: 1.8;
 		flex-grow: 1;
+		border-style: solid;
+		border-width: 1px;
 	}
+
+	.wc-block-product-search__field,
+	.wc-block-product-search__field > * {
+		display: flex;
+		flex-grow: 1;
+	}
+
 	.wc-block-product-search__button {
 		display: flex;
 		align-items: center;
-		margin: 0 0 0 6px;
+		border: 1px solid #ccc;
+		margin: 0 0 0 0.625em;
 		cursor: pointer;
 		padding: 0 0.5em;
 		position: relative;

--- a/src/BlockTypes/ProductSearch.php
+++ b/src/BlockTypes/ProductSearch.php
@@ -102,7 +102,7 @@ class ProductSearch extends AbstractBlock {
 			esc_attr( $attributes['placeholder'] )
 		);
 		$button_markup = sprintf(
-			'<button type="submit" class="wc-block-product-search__button" aria-label="%s">
+			'<button type="submit" class="wc-block-product-search__button wp-element-button" aria-label="%s">
 				<svg aria-hidden="true" role="img" focusable="false" class="dashicon dashicons-arrow-right-alt2" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
 					<path d="M6 15l5-5-5-5 1-2 7 7-7 7z" />
 				</svg>


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

**Note: Experiment, don't review.** This is part of an exploration into how the Elements API functions and I mainly pushed this Draft PR to accompany a P2 post on the topic.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->


#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Build the latest Gutenberg from `trunk` (needs to include [this change](https://github.com/WordPress/gutenberg/pull/41393), which is not yet in the plugin).
2. Use https://github.com/Automattic/themes/pull/5849 for the Archeo theme and activate it.
3. Check out this PR and use it to build WooCommerce Blocks.
4. Create a new page and add the Product Search block to your page. The submit button should have the Elements API properties defined in the Archeo theme applied.

|before|after|
|-|-|
|<img width="681" alt="archeo-current-editor" src="https://user-images.githubusercontent.com/1562646/173356715-ca5ed3cf-9097-494e-941d-39ea62a9f031.png">|<img width="670" alt="archeo-elements-editor" src="https://user-images.githubusercontent.com/1562646/173356673-5850d410-5166-4a85-8cc3-6e7f06506f5e.png">|

