### PR TITLE
Fix linting errors in WC Blocks 7.8.1 testing instructions

### DIFF
--- a/docs/testing/releases/781.md
+++ b/docs/testing/releases/781.md
@@ -1,10 +1,10 @@
-## Testing notes and ZIP for release 7.8.1
+# Testing notes and ZIP for release 7.8.1
 
 Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.com/woocommerce/woocommerce-blocks/files/8891266/woocommerce-gutenberg-products-block.zip)
 
 ## Feature plugin and package inclusion in WooCommerce
 
-###  Fix PHP notice in Mini Cart when prices included taxes. ([6537](https://github.com/woocommerce/woocommerce-blocks/pull/6537))
+### Fix PHP notice in Mini Cart when prices included taxes. ([6537](https://github.com/woocommerce/woocommerce-blocks/pull/6537))
 
 1. Go to _WooCommerce_ > _Settings_ and check _Enable tax rates and calculations_.
 2. Go to the _Tax_ tab in the settings and check _Yes, I will enter prices inclusive of tax_ and _Display prices during cart and checkout: Including tax_.


### PR DESCRIPTION
It looks like I introduced some linting errors in WC Blocks 7.8.1 testing instructions. :sweat_smile: This PR should fix them.

### Testing

#### User Facing Testing

1. Verify Lint MD job passes.

* [x] Do not include in the Testing Notes
