### PR TITLE
Fix: Mini Cart content scrolling issue

### DIFF
--- a/assets/js/blocks/mini-cart/mini-cart-contents/editor.scss
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/editor.scss
@@ -12,7 +12,7 @@
 	.wp-block-woocommerce-filled-mini-cart-contents-block > .block-editor-inner-blocks > .block-editor-block-list__layout {
 		display: flex;
 		flex-direction: column;
-		min-height: 100vh;
+		height: 100vh;
 	}
 
 	.wp-block-woocommerce-mini-cart-items-block {

--- a/assets/js/blocks/mini-cart/style.scss
+++ b/assets/js/blocks/mini-cart/style.scss
@@ -100,13 +100,12 @@ h2.wc-block-mini-cart__title {
 	display: flex;
 	flex-direction: column;
 	flex-grow: 1;
-	overflow-y: hidden;
+	overflow-y: auto;
 	padding: $gap $gap 0;
 
 	.wc-block-mini-cart__products-table {
 		margin-bottom: auto;
 		margin-right: -$gap;
-		overflow-y: auto;
 		padding-right: $gap;
 
 		.wc-block-cart-items__row {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #6563

This PR fixes the scrolling issue of the Filled Mini Cart Content block.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) .
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md)
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|     ![](https://user-images.githubusercontent.com/5423135/173493967-1009d322-351e-451c-a10c-c6456ec08f52.png)   | ![](https://user-images.githubusercontent.com/5423135/173533745-41cda7ed-a068-4d5d-b948-7e2038f3d21c.png)    |
| <img width="1571" alt="image" src="https://user-images.githubusercontent.com/5423135/173493990-c15572f2-fca1-4c9c-8909-178c108b83d1.png"> | <img width="1615" alt="image" src="https://user-images.githubusercontent.com/5423135/173535254-bd08ddae-6cc2-45d7-b727-43a24902610a.png"> |


### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. With a block theme like 2022. Edit the Mini Cart template part.
2. Add some blocks to the Mini Cart Items section to make the content overflow.
3. See the footer inside the viewport, and the Mini Cart Items block is now scrollable to view the underneath content.
4. Save the template.
5. On the front end, add a product to the cart then open the Mini Cart.
6. See the Mini Cart Items section is scrollable, with the product table on top.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Fix: scrolling issue of the Filled Mini Cart Contents block.