### PR TITLE
Replace instances of wp_is_block_theme() with wc_current_theme_is_fse_theme()

### DIFF
--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -199,8 +199,7 @@ class MiniCart extends AbstractBlock {
 
 		if (
 			current_user_can( 'edit_theme_options' ) &&
-			function_exists( 'wp_is_block_theme' ) &&
-			wp_is_block_theme()
+			wc_current_theme_is_fse_theme()
 		) {
 			$theme_slug      = BlockTemplateUtils::theme_has_template_part( 'mini-cart' ) ? wp_get_theme()->get_stylesheet() : BlockTemplateUtils::PLUGIN_SLUG;
 			$site_editor_uri = admin_url( 'site-editor.php' );

--- a/src/Templates/ProductSearchResultsTemplate.php
+++ b/src/Templates/ProductSearchResultsTemplate.php
@@ -33,7 +33,7 @@ class ProductSearchResultsTemplate {
 	 * @param array $templates Templates that match the search hierarchy.
 	 */
 	public function update_search_template_hierarchy( $templates ) {
-		if ( ( is_search() && is_post_type_archive( 'product' ) ) && wp_is_block_theme() ) {
+		if ( ( is_search() && is_post_type_archive( 'product' ) ) && wc_current_theme_is_fse_theme() ) {
 			return [ self::SLUG ];
 		}
 		return $templates;

--- a/src/Utils/BlockTemplateUtils.php
+++ b/src/Utils/BlockTemplateUtils.php
@@ -366,7 +366,7 @@ class BlockTemplateUtils {
 	 */
 	public static function supports_block_templates() {
 		if (
-			( ! function_exists( 'wp_is_block_theme' ) || ! wp_is_block_theme() ) &&
+			! wc_current_theme_is_fse_theme() &&
 			( ! function_exists( 'gutenberg_supports_block_templates' ) || ! gutenberg_supports_block_templates() )
 		) {
 			return false;


### PR DESCRIPTION
Fixes this issue reported in WooCommerce .org forums: https://wordpress.org/support/topic/search-error-after-6-0-update/

WC core needs to support WP 5.8, where `wp_is_block_theme()` didn't exist. We have a wrapper function in core named [`wc_current_theme_is_fse_theme()`](https://github.com/woocommerce/woocommerce/blob/0a381f422b94e6c9866b73d5790e2bace8186ca6/plugins/woocommerce/includes/wc-conditional-functions.php#L506) which we can use instead of directly calling `wp_is_block_theme()`. This PR replaces all instances of `wp_is_block_theme()` with `wc_current_theme_is_fse_theme()`.

### Testing

#### User Facing Testing

**Templates logic:**
1. With a block theme.
2. Go to Appearance > Editor and verify you can modify the WooCommerce templates: Products by Tag, Products by Category, Single Product or Product Catalog (don't test Product Search template yet).
3. Do some smoke testing: make an edit, save it, go to the frontend and verify the change has been applied, restore the template, etc.).

**Product Search template:**
1. With a block theme.
2. Go to Appearance > Editor and verify you can modify the Product Search Results template.
3. Do some smoke testing: make an edit, save it, go to the frontend and verify the change has been applied, restore the template, etc.).

**Mini Cart link:**
1. With a block theme.
2. In a post or page, add the Mini Cart block. 
3. In the sidebar, click on _Edit Mini Cart template part(opens in a new tab)_.
4. Verify you land in the template part editor, editing the Mini Cart block.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix error Uncaught Error: Call to undefined function Automattic\WooCommerce\Blocks\Templates\wp_is_block_theme() in WP 5.8.
