### PR TITLE
Fix images hidden by default in Product grid blocks

### DIFF
--- a/assets/js/editor-components/grid-content-control/index.js
+++ b/assets/js/editor-components/grid-content-control/index.js
@@ -14,12 +14,15 @@ import { ToggleControl } from '@wordpress/components';
  */
 const GridContentControl = ( { onChange, settings } ) => {
 	const { image, button, price, rating, title } = settings;
+	// If `image` is undefined, that might be because it's a block that was
+	// created before the `image` attribute existed, so we default to true.
+	const imageIsVisible = image !== false;
 	return (
 		<>
 			<ToggleControl
 				label={ __( 'Product image', 'woo-gutenberg-products-block' ) }
 				help={
-					image
+					imageIsVisible
 						? __(
 								'Product image is visible.',
 								'woo-gutenberg-products-block'
@@ -29,8 +32,10 @@ const GridContentControl = ( { onChange, settings } ) => {
 								'woo-gutenberg-products-block'
 						  )
 				}
-				checked={ image }
-				onChange={ () => onChange( { ...settings, image: ! image } ) }
+				checked={ imageIsVisible }
+				onChange={ () =>
+					onChange( { ...settings, image: ! imageIsVisible } )
+				}
 			/>
 			<ToggleControl
 				label={ __( 'Product title', 'woo-gutenberg-products-block' ) }

--- a/src/BlockTypes/AbstractProductGrid.php
+++ b/src/BlockTypes/AbstractProductGrid.php
@@ -519,7 +519,7 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 	 * @return string
 	 */
 	protected function get_image_html( $product ) {
-		if ( empty( $this->attributes['contentVisibility']['image'] ) ) {
+		if ( array_key_exists( 'image', $this->attributes['contentVisibility'] ) && false === $this->attributes['contentVisibility']['image'] ) {
 			return '';
 		}
 


### PR DESCRIPTION
See user reports in the forums:

https://wordpress.org/support/topic/product-block-image-setting-switched-of-after-6-6/
https://wordpress.org/support/topic/product-image-is-visible-hand-picked-products/

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
| ![imatge](https://user-images.githubusercontent.com/3616980/174588765-7e570a5b-d428-4604-b2af-6534e388b550.png) | ![imatge](https://user-images.githubusercontent.com/3616980/174588822-9cdb7813-05d1-4f97-ae55-1d4392c9f65a.png) |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. With WC core 6.5.1 and WC Blocks disabled, add a Handpicked Products block to a post or page.
2. Hide the Product price and Product rating using the sidebar toggles.
3. Publish the post or page.
4. Update to WC core to 6.6.0.
5. Notice the images are no longer visible.
6. Enable WC Blocks (with this branch).
7. Verify images are visible by default.
8. Verify you can still toggle the images.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix images hidden by default in Product grid blocks after WC 6.6 update.
