### PR TITLE
Add `markdownlint` extension in the recommended extensions list

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -10,6 +10,7 @@
 		"neilbrayfield.php-docblocker",
 		"valeryanm.vscode-phpsab",
 		"editorconfig.editorconfig",
-		"stylelint.vscode-stylelint"
+		"stylelint.vscode-stylelint",
+		"DavidAnson.vscode-markdownlint"
 	]
 }


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR adds [`markdownlint`](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint) as a recommended extension. This is very useful now that we have markdown linter enabled.


### Testing

#### User Facing Testing

How to test the changes in this Pull Request:

Check out this branch

1. Open the project with VSCode. Be sure that you don't have already `markdownlint` extension installed.
2. Check if VSCode shows on the bottom right a box for installing the recommended extensions.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental


