### PR TITLE
Fix crash when the user saves Mini Cart Template

### DIFF
--- a/src/Templates/MiniCartTemplate.php
+++ b/src/Templates/MiniCartTemplate.php
@@ -1,0 +1,13 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\Templates;
+
+/**
+ * MiniCartTemplate class.
+ *
+ * @internal
+ */
+class MiniCartTemplate {
+
+	const SLUG = 'mini-cart';
+
+}

--- a/src/Utils/BlockTemplateUtils.php
+++ b/src/Utils/BlockTemplateUtils.php
@@ -3,6 +3,7 @@ namespace Automattic\WooCommerce\Blocks\Utils;
 
 use Automattic\WooCommerce\Blocks\Templates\ProductSearchResultsTemplate;
 use Automattic\WooCommerce\Blocks\Domain\Services\FeatureGating;
+use Automattic\WooCommerce\Blocks\Templates\MiniCartTemplate;
 
 /**
  * Utility methods used for serving block templates from WooCommerce Blocks.
@@ -283,6 +284,7 @@ class BlockTemplateUtils {
 		if ( isset( $plugin_template_types[ $template_slug ] ) ) {
 			return $plugin_template_types[ $template_slug ]['description'];
 		}
+		return '';
 	}
 
 	/**
@@ -312,6 +314,10 @@ class BlockTemplateUtils {
 			ProductSearchResultsTemplate::SLUG => array(
 				'title'       => _x( 'Product Search Results', 'Template name', 'woo-gutenberg-products-block' ),
 				'description' => __( 'Template used to display search results for products.', 'woo-gutenberg-products-block' ),
+			),
+			MiniCartTemplate::SLUG             => array(
+				'title'       => _x( 'Mini Cart', 'Template name', 'woo-gutenberg-products-block' ),
+				'description' => __( 'Template used to display the Mini Cart drawer.', 'woo-gutenberg-products-block' ),
 			),
 		);
 


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

This PR:
1. fixes an error when the user saves the `Mini Cart Template`.
2. adds description for the `Mini Cart Template`.

### 1: Fixes an error when the user saves the `Mini Cart Template`.

We noticed that #6345 adds a regression. Now, the user has an error when trying to save the `Mini Cart Template`. The reason is that the `block_template_object` must have a description (https://github.com/woocommerce/woocommerce-blocks/blob/a243b0b8f23a7c24b5ce0cdf9c65ba1e6bb2dbe0/src/Utils/BlockTemplateUtils.php/#L223-L237) even if it is an empty string. #6345 introduces the util `get_block_template_description` that doesn't return an empty string if the description is not defined. This PR adds the fallback.

### 2: Adds description for the `Mini Cart Template`.

This PR adds `Template used to display the Mini Cart drawer.` as the description for the `Mini Cart Template`.


### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

Check out this branch

1. Open the FSE.
2. Edit the Mini Cart Template (template parts section).
3. Save it.
4. Be sure that you don't see any errors and if you refresh the page, you can see the changes.
5. Check if, on the frontend side, you see the changes.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

