### PR TITLE
Add Cart & Checkout testing steps to Feature plugin only section in 7.7.0 testing instructions

### DIFF
--- a/docs/internal-developers/testing/releases/770.md
+++ b/docs/internal-developers/testing/releases/770.md
@@ -22,6 +22,8 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 3. Verify product price and product summary are not bold.
 4. Verify there are no regressions in the All Products block and in the Shop page.
 
+## Feature plugin only
+
 ### Fix an issue where the Cart & Checkout could have some of the locked inner blocks removed. ([6419](https://github.com/woocommerce/woocommerce-blocks/pull/6419))
 
 1. Install WordPress beta tester plugin and update to WP 6.0.


### PR DESCRIPTION
Cart & Checkout testing steps were not categorized properly in 7.7.0 testing instructions. This PR fixes that.