### PR TITLE
Fix: Handle taxes for local pickup shipping

### DIFF
--- a/src/StoreApi/Utilities/OrderController.php
+++ b/src/StoreApi/Utilities/OrderController.php
@@ -44,6 +44,9 @@ class OrderController {
 	 * @param \WC_Order $order The order object to update.
 	 */
 	public function update_order_from_cart( \WC_Order $order ) {
+		// Ensures Local pickups are accounted for.
+		add_filter( 'woocommerce_order_get_tax_location', array( $this, 'handle_local_pickup_taxes' ) );
+
 		// Ensure cart is current.
 		wc()->cart->calculate_shipping();
 		wc()->cart->calculate_totals();
@@ -434,6 +437,23 @@ class OrderController {
 		return 'checkout-draft';
 	}
 
+	/**
+	 * Passes the correct base for local pick orders
+	 *
+	 * @todo: Remove custom local pickup handling once WooCommerce 6.8.0 is the minimum version.
+	 *
+	 * @param array $location Taxes location.
+	 * @return array updated location that accounts for local pickup.
+	 */
+	public function handle_local_pickup_taxes( $location ) {
+		$customer = wc()->customer;
+
+		if ( ! empty( $customer ) ) {
+			return $customer->get_taxable_address();
+		}
+
+		return $location;
+	}
 	/**
 	 * Create order line items.
 	 *


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR fixes an issue in which taxes are calculated against the user address for local pickups orders. A niche issue, but an important one.
<!-- Reference any related issues or PRs here -->

Fixes #6480

### Why did this issue happen in Store API

Shortcode Checkout has a function called `process_checkout` that handles submitting an order, that functions passes `$_POST` data around, it also creates an order just when you finish an order. Store API can't that function, because we can't support `$_POST` via a rest api, and because we create an order early on.

For this purpose, Store API has its own `process_checkout` function, the `get_route_post_response` function of /checkout route.

WooCommerce Shortcode also calculates the order totals using `wc()->cart->calculate_totals` it then copies that result to the created order.

Store API augments the order with all correct informations, than calls `WC_Order::calculate_totals`.

The issue here is that those two functions are slightly different, exactly around how they calculate taxes.

The cart version decides on what address it should calculate taxes using the `WC_Customer::get_taxable_address` function.

The order version uses `WC_Abstract_Order::get_tax_location`.

The problem stems from the fact that `WC_Customer::get_taxable_address` checks if the cart has local pickup selected (in which it defaults to `base` location), but `WC_Abstract_Order::get_tax_location` doesn't do any of that, and just checks the value of `woocommerce_tax_based_on` setting.

This is a long standing issue, that is simply hard to discover because most Checkout block users. who have local pickup probably have their customers locations in the same place as the shop, so the taxes are the same.

Good news is that @iamdharmesh discovered the same issue from WooCommerce Admin side and fixed the issue in WooCommerce core https://github.com/woocommerce/woocommerce/pull/33330, the fix will land in **WooCommerce Core 6.8.0** which is still 3 months away for us (we do L-1 for WC core when we can).

This PR does a workaround by calling `WC_Customer::get_taxable_address` instead, and we should remove it once WC Core 6.8.0 is the min version.


### Testing

#### User Facing Testing


1. Set store address to `123 Test Street, 90210 Beverly Hills, CA, USA`
3. Enable taxes
4. Add a `"Standard" tax rates` in US, CA. Set it to: `10%`
5. Add the following shipping methods: "Flat rate" for $10 and "Local pickup" for free.
6. Add a payment option (e.g., Cash on delivery).
7. Add a physical product to the cart.
8. Use an outside state address on the front-end. (e.g., `60 29th Street #343, 35005 birmingham, AL, USA`)
9. Go to the Cart block and select the `Local pickup` shipping method. Check that we have a tax of 10% applied.
10. Go to the Checkout block and select the `Local pickup` shipping method. Check that we have a tax of 10% applied.
11. Place your order. Check on the `Order received` page that the displayed tax **is actually added to the total.**
12. Go to `Edit Order`. Check that taxes were **applied correctly there as well.**
13. On Checkout again, select flat rate, using the same external address, and make sure taxes are not applied.

### Changelog

> Fix: Correctly calculacte taxes for local pickups.
