### PR TITLE
Prevent `Featured Product` block from breaking when product is out of stock + hidden from catalog

### DIFF
--- a/assets/js/hocs/with-product-variations.js
+++ b/assets/js/hocs/with-product-variations.js
@@ -124,7 +124,7 @@ const withProductVariations = createHigherOrderComponent(
 						p.variations &&
 						p.variations.find( ( { id } ) => id === variationId )
 				);
-				return parentProduct[ 0 ].id;
+				return parentProduct[ 0 ]?.id;
 			}
 
 			getExpandedProduct() {


### PR DESCRIPTION
This PR prevents the `Featured Product` block from breaking in the editor when the product is out of stock and the Inventory is set to hide out of stock items from the catalog.
It prevents accessing the `parentProduct` array when it's empty (which was causing the JS error) but the out of stock product won't be available to pick from the list of products.

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/5344

### Testing
### Manual Testing
1. Add a Featured Product block to a page and save.
2. Head to the product and set the product to Out of Stock.
3. Under WooCommerce > Settings > Products > Inventory, check the box that says "Hide out of stock items from the catalog".
4. Return to the page with your Featured Product block, select it, and select "Edit" to choose a new product to feature.
5. Make sure the block can still be edited to choose a new product.

### Changelog
> Fix Featured Product: prevent the block from breaking for out-of-stock products hidden from the catalog.
