### PR TITLE
Fix: Add support to apply filters via URL for All Products block

### DIFF
--- a/assets/js/blocks/active-filters/active-attribute-filters.tsx
+++ b/assets/js/blocks/active-filters/active-attribute-filters.tsx
@@ -101,33 +101,33 @@ const ActiveAttributeFilters = ( {
 						name: decodeEntities( termObject.name || slug ),
 						prefix,
 						removeCallback: () => {
-							if ( filteringForPhpTemplate ) {
-								const currentAttribute = productAttributes.find(
-									( { attribute } ) =>
-										attribute ===
-										`pa_${ attributeObject.name }`
+							const currentAttribute = productAttributes.find(
+								( { attribute } ) =>
+									attribute === `pa_${ attributeObject.name }`
+							);
+
+							// If only one attribute was selected, we remove both filter and query type from the URL.
+							if ( currentAttribute?.slug.length === 1 ) {
+								removeArgsFromFilterUrl(
+									`query_type_${ attributeObject.name }`,
+									`filter_${ attributeObject.name }`
 								);
-
-								// If only one attribute was selected, we remove both filter and query type from the URL.
-								if ( currentAttribute?.slug.length === 1 ) {
-									return removeArgsFromFilterUrl(
-										`query_type_${ attributeObject.name }`,
-										`filter_${ attributeObject.name }`
-									);
-								}
-
+							} else {
 								// Remove only the slug from the URL.
-								return removeArgsFromFilterUrl( {
+								removeArgsFromFilterUrl( {
 									[ `filter_${ attributeObject.name }` ]:
 										slug,
 								} );
 							}
-							removeAttributeFilterBySlug(
-								productAttributes,
-								setProductAttributes,
-								attributeObject,
-								slug
-							);
+
+							if ( ! filteringForPhpTemplate ) {
+								removeAttributeFilterBySlug(
+									productAttributes,
+									setProductAttributes,
+									attributeObject,
+									slug
+								);
+							}
 						},
 						showLabel: false,
 						displayStyle,

--- a/assets/js/blocks/active-filters/block.tsx
+++ b/assets/js/blocks/active-filters/block.tsx
@@ -76,17 +76,17 @@ const ActiveFiltersBlock = ( {
 				type: __( 'Stock Status', 'woo-gutenberg-products-block' ),
 				name: STOCK_STATUS_OPTIONS[ slug ],
 				removeCallback: () => {
-					if ( filteringForPhpTemplate ) {
-						return removeArgsFromFilterUrl( {
-							filter_stock_status: slug,
-						} );
+					removeArgsFromFilterUrl( {
+						filter_stock_status: slug,
+					} );
+					if ( ! filteringForPhpTemplate ) {
+						const newStatuses = productStockStatus.filter(
+							( status ) => {
+								return status !== slug;
+							}
+						);
+						setProductStockStatus( newStatuses );
 					}
-					const newStatuses = productStockStatus.filter(
-						( status ) => {
-							return status !== slug;
-						}
-					);
-					setProductStockStatus( newStatuses );
 				},
 				displayStyle: blockAttributes.displayStyle,
 			} );

--- a/assets/js/blocks/active-filters/block.tsx
+++ b/assets/js/blocks/active-filters/block.tsx
@@ -107,9 +107,7 @@ const ActiveFiltersBlock = ( {
 			type: __( 'Price', 'woo-gutenberg-products-block' ),
 			name: formatPriceRange( minPrice, maxPrice ),
 			removeCallback: () => {
-				if ( filteringForPhpTemplate ) {
-					return removeArgsFromFilterUrl( 'max_price', 'min_price' );
-				}
+				removeArgsFromFilterUrl( 'max_price', 'min_price' );
 				setMinPrice( undefined );
 				setMaxPrice( undefined );
 			},
@@ -121,7 +119,6 @@ const ActiveFiltersBlock = ( {
 		blockAttributes.displayStyle,
 		setMinPrice,
 		setMaxPrice,
-		filteringForPhpTemplate,
 	] );
 
 	const activeAttributeFilters = useMemo( () => {
@@ -289,9 +286,7 @@ const ActiveFiltersBlock = ( {
 				<button
 					className="wc-block-active-filters__clear-all"
 					onClick={ () => {
-						if ( filteringForPhpTemplate ) {
-							return cleanFilterUrl();
-						}
+						cleanFilterUrl();
 						setMinPrice( undefined );
 						setMaxPrice( undefined );
 						setProductAttributes( [] );

--- a/assets/js/blocks/active-filters/block.tsx
+++ b/assets/js/blocks/active-filters/block.tsx
@@ -108,8 +108,10 @@ const ActiveFiltersBlock = ( {
 			name: formatPriceRange( minPrice, maxPrice ),
 			removeCallback: () => {
 				removeArgsFromFilterUrl( 'max_price', 'min_price' );
-				setMinPrice( undefined );
-				setMaxPrice( undefined );
+				if ( ! filteringForPhpTemplate ) {
+					setMinPrice( undefined );
+					setMaxPrice( undefined );
+				}
 			},
 			displayStyle: blockAttributes.displayStyle,
 		} );
@@ -119,6 +121,7 @@ const ActiveFiltersBlock = ( {
 		blockAttributes.displayStyle,
 		setMinPrice,
 		setMaxPrice,
+		filteringForPhpTemplate,
 	] );
 
 	const activeAttributeFilters = useMemo( () => {
@@ -287,10 +290,12 @@ const ActiveFiltersBlock = ( {
 					className="wc-block-active-filters__clear-all"
 					onClick={ () => {
 						cleanFilterUrl();
-						setMinPrice( undefined );
-						setMaxPrice( undefined );
-						setProductAttributes( [] );
-						setProductStockStatus( [] );
+						if ( ! filteringForPhpTemplate ) {
+							setMinPrice( undefined );
+							setMaxPrice( undefined );
+							setProductAttributes( [] );
+							setProductStockStatus( [] );
+						}
 					} }
 				>
 					<Label

--- a/assets/js/blocks/active-filters/utils.tsx
+++ b/assets/js/blocks/active-filters/utils.tsx
@@ -198,7 +198,7 @@ export const removeArgsFromFilterUrl = (
 	if ( filteringForPhpTemplate ) {
 		window.location.href = newUrl;
 	} else {
-		window.history.pushState( {}, '', newUrl );
+		window.history.replaceState( {}, '', newUrl );
 	}
 };
 
@@ -236,6 +236,6 @@ export const cleanFilterUrl = () => {
 	if ( filteringForPhpTemplate ) {
 		window.location.href = newUrl;
 	} else {
-		window.history.pushState( {}, '', newUrl );
+		window.history.replaceState( {}, '', newUrl );
 	}
 };

--- a/assets/js/blocks/active-filters/utils.tsx
+++ b/assets/js/blocks/active-filters/utils.tsx
@@ -9,6 +9,12 @@ import { getQueryArgs, addQueryArgs, removeQueryArgs } from '@wordpress/url';
 import { getSettingWithCoercion } from '@woocommerce/settings';
 import { isBoolean } from '@woocommerce/types';
 
+const filteringForPhpTemplate = getSettingWithCoercion(
+	'is_rendering_php_template',
+	false,
+	isBoolean
+);
+
 /**
  * Format a min/max price range to display.
  *
@@ -187,12 +193,6 @@ export const removeArgsFromFilterUrl = (
 		Object.entries( currentQuery ).filter( ( [ , value ] ) => value )
 	);
 
-	const filteringForPhpTemplate = getSettingWithCoercion(
-		'is_rendering_php_template',
-		false,
-		isBoolean
-	);
-
 	const newUrl = addQueryArgs( cleanUrl, filteredQuery );
 
 	if ( filteringForPhpTemplate ) {
@@ -232,12 +232,6 @@ export const cleanFilterUrl = () => {
 	);
 
 	const newUrl = addQueryArgs( cleanUrl, remainingArgs );
-
-	const filteringForPhpTemplate = getSettingWithCoercion(
-		'is_rendering_php_template',
-		false,
-		isBoolean
-	);
 
 	if ( filteringForPhpTemplate ) {
 		window.location.href = newUrl;

--- a/assets/js/blocks/active-filters/utils.tsx
+++ b/assets/js/blocks/active-filters/utils.tsx
@@ -6,14 +6,7 @@ import { formatPrice } from '@woocommerce/price-format';
 import { RemovableChip } from '@woocommerce/base-components/chip';
 import Label from '@woocommerce/base-components/label';
 import { getQueryArgs, addQueryArgs, removeQueryArgs } from '@wordpress/url';
-import { getSettingWithCoercion } from '@woocommerce/settings';
-import { isBoolean } from '@woocommerce/types';
-
-const filteringForPhpTemplate = getSettingWithCoercion(
-	'is_rendering_php_template',
-	false,
-	isBoolean
-);
+import { changeUrl } from '@woocommerce/utils';
 
 /**
  * Format a min/max price range to display.
@@ -195,11 +188,7 @@ export const removeArgsFromFilterUrl = (
 
 	const newUrl = addQueryArgs( cleanUrl, filteredQuery );
 
-	if ( filteringForPhpTemplate ) {
-		window.location.href = newUrl;
-	} else {
-		window.history.replaceState( {}, '', newUrl );
-	}
+	changeUrl( newUrl );
 };
 
 /**
@@ -233,9 +222,5 @@ export const cleanFilterUrl = () => {
 
 	const newUrl = addQueryArgs( cleanUrl, remainingArgs );
 
-	if ( filteringForPhpTemplate ) {
-		window.location.href = newUrl;
-	} else {
-		window.history.replaceState( {}, '', newUrl );
-	}
+	changeUrl( newUrl );
 };

--- a/assets/js/blocks/active-filters/utils.tsx
+++ b/assets/js/blocks/active-filters/utils.tsx
@@ -166,7 +166,7 @@ export const renderRemovableListItem = ( {
 export const removeArgsFromFilterUrl = (
 	...args: ( string | Record< string, string > )[]
 ) => {
-	if ( ! window || ! document ) {
+	if ( ! window ) {
 		return;
 	}
 
@@ -198,7 +198,7 @@ export const removeArgsFromFilterUrl = (
 	if ( filteringForPhpTemplate ) {
 		window.location.href = newUrl;
 	} else {
-		window.history.pushState( {}, document.title, newUrl );
+		window.history.pushState( {}, '', newUrl );
 	}
 };
 
@@ -206,7 +206,7 @@ export const removeArgsFromFilterUrl = (
  * Clean the filter URL.
  */
 export const cleanFilterUrl = () => {
-	if ( ! window || ! document ) {
+	if ( ! window ) {
 		return;
 	}
 
@@ -236,6 +236,6 @@ export const cleanFilterUrl = () => {
 	if ( filteringForPhpTemplate ) {
 		window.location.href = newUrl;
 	} else {
-		window.history.pushState( {}, document.title, newUrl );
+		window.history.pushState( {}, '', newUrl );
 	}
 };

--- a/assets/js/blocks/attribute-filter/block.tsx
+++ b/assets/js/blocks/attribute-filter/block.tsx
@@ -506,10 +506,14 @@ const AttributeFilterBlock = ( {
 	 * Try get the current attribute filter from the URl.
 	 */
 	useEffect( () => {
-		if ( ! hasSetFilterDefaultsFromUrl && ! attributeTermsLoading ) {
-			setHasSetFilterDefaultsFromUrl( true );
+		if (
+			initialFilters.length > 0 &&
+			! hasSetFilterDefaultsFromUrl &&
+			! attributeTermsLoading
+		) {
 			updateCheckedFilters( initialFilters, true );
 		}
+		setHasSetFilterDefaultsFromUrl( true );
 	}, [
 		attributeObject,
 		hasSetFilterDefaultsFromUrl,

--- a/assets/js/blocks/attribute-filter/block.tsx
+++ b/assets/js/blocks/attribute-filter/block.tsx
@@ -284,7 +284,7 @@ const AttributeFilterBlock = ( {
 				if ( filteringForPhpTemplate ) {
 					window.location.href = newUrl;
 				} else {
-					window.history.pushState( {}, '', newUrl );
+					window.history.replaceState( {}, '', newUrl );
 				}
 			} else {
 				const newUrl = formatParams( pageUrl, query );
@@ -295,7 +295,7 @@ const AttributeFilterBlock = ( {
 					if ( filteringForPhpTemplate ) {
 						window.location.href = newUrl;
 					} else {
-						window.history.pushState( {}, '', newUrl );
+						window.history.replaceState( {}, '', newUrl );
 					}
 				}
 			}

--- a/assets/js/blocks/attribute-filter/block.tsx
+++ b/assets/js/blocks/attribute-filter/block.tsx
@@ -29,6 +29,7 @@ import {
 	objectHasProp,
 } from '@woocommerce/types';
 import {
+	changeUrl,
 	PREFIX_QUERY_ARG_FILTER_TYPE,
 	PREFIX_QUERY_ARG_QUERY_TYPE,
 } from '@woocommerce/utils';
@@ -281,26 +282,18 @@ const AttributeFilterBlock = ( {
 				);
 
 				const newUrl = formatParams( url, query );
-				if ( filteringForPhpTemplate ) {
-					window.location.href = newUrl;
-				} else {
-					window.history.replaceState( {}, '', newUrl );
-				}
+				changeUrl( newUrl );
 			} else {
 				const newUrl = formatParams( pageUrl, query );
 				const currentQueryArgs = getQueryArgs( window.location.href );
 				const newUrlQueryArgs = getQueryArgs( newUrl );
 
 				if ( ! isQueryArgsEqual( currentQueryArgs, newUrlQueryArgs ) ) {
-					if ( filteringForPhpTemplate ) {
-						window.location.href = newUrl;
-					} else {
-						window.history.replaceState( {}, '', newUrl );
-					}
+					changeUrl( newUrl );
 				}
 			}
 		},
-		[ pageUrl, attributeObject?.taxonomy, filteringForPhpTemplate ]
+		[ pageUrl, attributeObject?.taxonomy ]
 	);
 
 	const onSubmit = ( checkedFilters: string[] ) => {

--- a/assets/js/blocks/attribute-filter/block.tsx
+++ b/assets/js/blocks/attribute-filter/block.tsx
@@ -511,15 +511,20 @@ const AttributeFilterBlock = ( {
 			! hasSetFilterDefaultsFromUrl &&
 			! attributeTermsLoading
 		) {
+			setHasSetFilterDefaultsFromUrl( true );
 			updateCheckedFilters( initialFilters, true );
 		}
-		setHasSetFilterDefaultsFromUrl( true );
+
+		if ( ! filteringForPhpTemplate && ! hasSetFilterDefaultsFromUrl ) {
+			setHasSetFilterDefaultsFromUrl( true );
+		}
 	}, [
 		attributeObject,
 		hasSetFilterDefaultsFromUrl,
 		attributeTermsLoading,
 		updateCheckedFilters,
 		initialFilters,
+		filteringForPhpTemplate,
 	] );
 
 	if ( ! hasFilterableProducts ) {

--- a/assets/js/blocks/attribute-filter/block.tsx
+++ b/assets/js/blocks/attribute-filter/block.tsx
@@ -91,7 +91,7 @@ const AttributeFilterBlock = ( {
 		isString
 	);
 
-	const [ hasSetPhpFilterDefaults, setHasSetPhpFilterDefaults ] =
+	const [ hasSetFilterDefaultsFromUrl, setHasSetFilterDefaultsFromUrl ] =
 		useState( false );
 
 	const attributeObject =
@@ -99,9 +99,12 @@ const AttributeFilterBlock = ( {
 			? previewAttributeObject
 			: getAttributeFromID( blockAttributes.attributeId );
 
-	const [ checked, setChecked ] = useState(
-		getActiveFilters( filteringForPhpTemplate, attributeObject )
+	const initialFilters = useMemo(
+		() => getActiveFilters( attributeObject ),
+		[ attributeObject ]
 	);
+
+	const [ checked, setChecked ] = useState( initialFilters );
 
 	const [ displayedOptions, setDisplayedOptions ] = useState<
 		DisplayOption[]
@@ -250,7 +253,7 @@ const AttributeFilterBlock = ( {
 	 * @param {Object}  query             The object containing the active filter query.
 	 * @param {boolean} allFiltersRemoved If there are active filters or not.
 	 */
-	const redirectPageForPhpTemplate = useCallback(
+	const updateFilterUrl = useCallback(
 		( query, allFiltersRemoved = false ) => {
 			if ( allFiltersRemoved ) {
 				if ( ! attributeObject?.taxonomy ) {
@@ -278,18 +281,30 @@ const AttributeFilterBlock = ( {
 				);
 
 				const newUrl = formatParams( url, query );
-				window.location.href = newUrl;
+				if ( filteringForPhpTemplate ) {
+					window.location.href = newUrl;
+				} else {
+					window.history.pushState( null, document.title, newUrl );
+				}
 			} else {
 				const newUrl = formatParams( pageUrl, query );
 				const currentQueryArgs = getQueryArgs( window.location.href );
 				const newUrlQueryArgs = getQueryArgs( newUrl );
 
 				if ( ! isQueryArgsEqual( currentQueryArgs, newUrlQueryArgs ) ) {
-					window.location.href = newUrl;
+					if ( filteringForPhpTemplate ) {
+						window.location.href = newUrl;
+					} else {
+						window.history.pushState(
+							null,
+							document.title,
+							newUrl
+						);
+					}
 				}
 			}
 		},
-		[ pageUrl, attributeObject?.taxonomy ]
+		[ pageUrl, attributeObject?.taxonomy, filteringForPhpTemplate ]
 	);
 
 	const onSubmit = ( checkedFilters: string[] ) => {
@@ -301,20 +316,17 @@ const AttributeFilterBlock = ( {
 			blockAttributes.queryType === 'or' ? 'in' : 'and'
 		);
 
-		// This is for PHP rendered template filtering only.
-		if ( filteringForPhpTemplate ) {
-			redirectPageForPhpTemplate( query, checkedFilters.length === 0 );
-		}
+		updateFilterUrl( query, checkedFilters.length === 0 );
 	};
 
 	const updateCheckedFilters = useCallback(
-		( checkedFilters: string[] ) => {
+		( checkedFilters: string[], force = false ) => {
 			if ( isEditor ) {
 				return;
 			}
 
 			setChecked( checkedFilters );
-			if ( ! blockAttributes.showFilterButton ) {
+			if ( force || ! blockAttributes.showFilterButton ) {
 				updateAttributeFilter(
 					productAttributesQuery,
 					setProductAttributesQuery,
@@ -464,34 +476,25 @@ const AttributeFilterBlock = ( {
 	);
 
 	/**
-	 * Important: For PHP rendered block templates only.
-	 *
-	 * When we render the PHP block template (e.g. Classic Block) we need to set the default checked values,
-	 * and also update the URL when the filters are clicked/updated.
+	 * Update the filter URL on state change.
 	 */
 	useEffect( () => {
-		if ( filteringForPhpTemplate && attributeObject ) {
-			if (
-				areAllFiltersRemoved( {
-					currentCheckedFilters: checked,
-					hasSetPhpFilterDefaults,
-				} )
-			) {
-				if ( ! blockAttributes.showFilterButton ) {
-					setChecked( [] );
-					redirectPageForPhpTemplate( productAttributesQuery, true );
-				}
-			}
-
-			if ( ! blockAttributes.showFilterButton ) {
-				setChecked( checked );
-				redirectPageForPhpTemplate( productAttributesQuery, false );
-			}
+		if ( ! attributeObject || blockAttributes.showFilterButton ) {
+			return;
+		}
+		if (
+			areAllFiltersRemoved( {
+				currentCheckedFilters: checked,
+				hasSetFilterDefaultsFromUrl,
+			} )
+		) {
+			updateFilterUrl( productAttributesQuery, true );
+		} else {
+			updateFilterUrl( productAttributesQuery, false );
 		}
 	}, [
-		hasSetPhpFilterDefaults,
-		redirectPageForPhpTemplate,
-		filteringForPhpTemplate,
+		hasSetFilterDefaultsFromUrl,
+		updateFilterUrl,
 		productAttributesQuery,
 		attributeObject,
 		checked,
@@ -499,32 +502,23 @@ const AttributeFilterBlock = ( {
 	] );
 
 	/**
-	 * Important: For PHP rendered block templates only.
-	 *
-	 * When we set the default parameter values which we get from the URL in the above useEffect(),
-	 * we need to run updateCheckedFilters which will set these values in state for the Active Filters block.
+	 * Try get the current attribute filter from the URl.
 	 */
 	useEffect( () => {
-		if ( filteringForPhpTemplate ) {
-			const activeFilters = getActiveFilters(
-				filteringForPhpTemplate,
-				attributeObject
-			);
-			if (
-				activeFilters.length > 0 &&
-				! hasSetPhpFilterDefaults &&
-				! attributeTermsLoading
-			) {
-				setHasSetPhpFilterDefaults( true );
-				updateCheckedFilters( activeFilters );
-			}
+		if (
+			initialFilters.length > 0 &&
+			! hasSetFilterDefaultsFromUrl &&
+			! attributeTermsLoading
+		) {
+			setHasSetFilterDefaultsFromUrl( true );
+			updateCheckedFilters( initialFilters, true );
 		}
 	}, [
 		attributeObject,
-		filteringForPhpTemplate,
-		hasSetPhpFilterDefaults,
+		hasSetFilterDefaultsFromUrl,
 		attributeTermsLoading,
 		updateCheckedFilters,
+		initialFilters,
 	] );
 
 	if ( ! hasFilterableProducts ) {

--- a/assets/js/blocks/attribute-filter/block.tsx
+++ b/assets/js/blocks/attribute-filter/block.tsx
@@ -284,7 +284,7 @@ const AttributeFilterBlock = ( {
 				if ( filteringForPhpTemplate ) {
 					window.location.href = newUrl;
 				} else {
-					window.history.pushState( null, document.title, newUrl );
+					window.history.pushState( {}, '', newUrl );
 				}
 			} else {
 				const newUrl = formatParams( pageUrl, query );
@@ -295,11 +295,7 @@ const AttributeFilterBlock = ( {
 					if ( filteringForPhpTemplate ) {
 						window.location.href = newUrl;
 					} else {
-						window.history.pushState(
-							null,
-							document.title,
-							newUrl
-						);
+						window.history.pushState( {}, '', newUrl );
 					}
 				}
 			}

--- a/assets/js/blocks/attribute-filter/block.tsx
+++ b/assets/js/blocks/attribute-filter/block.tsx
@@ -482,6 +482,7 @@ const AttributeFilterBlock = ( {
 		if ( ! attributeObject || blockAttributes.showFilterButton ) {
 			return;
 		}
+
 		if (
 			areAllFiltersRemoved( {
 				currentCheckedFilters: checked,
@@ -505,11 +506,7 @@ const AttributeFilterBlock = ( {
 	 * Try get the current attribute filter from the URl.
 	 */
 	useEffect( () => {
-		if (
-			initialFilters.length > 0 &&
-			! hasSetFilterDefaultsFromUrl &&
-			! attributeTermsLoading
-		) {
+		if ( ! hasSetFilterDefaultsFromUrl && ! attributeTermsLoading ) {
 			setHasSetFilterDefaultsFromUrl( true );
 			updateCheckedFilters( initialFilters, true );
 		}

--- a/assets/js/blocks/attribute-filter/block.tsx
+++ b/assets/js/blocks/attribute-filter/block.tsx
@@ -506,16 +506,17 @@ const AttributeFilterBlock = ( {
 	 * Try get the current attribute filter from the URl.
 	 */
 	useEffect( () => {
-		if (
-			initialFilters.length > 0 &&
-			! hasSetFilterDefaultsFromUrl &&
-			! attributeTermsLoading
-		) {
-			setHasSetFilterDefaultsFromUrl( true );
-			updateCheckedFilters( initialFilters, true );
+		if ( hasSetFilterDefaultsFromUrl || attributeTermsLoading ) {
+			return;
 		}
 
-		if ( ! filteringForPhpTemplate && ! hasSetFilterDefaultsFromUrl ) {
+		if ( initialFilters.length > 0 ) {
+			setHasSetFilterDefaultsFromUrl( true );
+			updateCheckedFilters( initialFilters, true );
+			return;
+		}
+
+		if ( ! filteringForPhpTemplate ) {
 			setHasSetFilterDefaultsFromUrl( true );
 		}
 	}, [

--- a/assets/js/blocks/attribute-filter/utils.ts
+++ b/assets/js/blocks/attribute-filter/utils.ts
@@ -44,17 +44,16 @@ export const formatParams = ( url: string, params: Array< Param > = [] ) => {
 
 export const areAllFiltersRemoved = ( {
 	currentCheckedFilters,
-	hasSetPhpFilterDefaults,
+	hasSetFilterDefaultsFromUrl,
 }: {
 	currentCheckedFilters: Array< string >;
-	hasSetPhpFilterDefaults: boolean;
-} ) => hasSetPhpFilterDefaults && currentCheckedFilters.length === 0;
+	hasSetFilterDefaultsFromUrl: boolean;
+} ) => hasSetFilterDefaultsFromUrl && currentCheckedFilters.length === 0;
 
 export const getActiveFilters = (
-	isFilteringForPhpTemplateEnabled: boolean,
 	attributeObject: AttributeObject | undefined
 ) => {
-	if ( isFilteringForPhpTemplateEnabled && attributeObject ) {
+	if ( attributeObject ) {
 		const defaultAttributeParam = getUrlParameter(
 			`filter_${ attributeObject.name }`
 		);

--- a/assets/js/blocks/price-filter/block.tsx
+++ b/assets/js/blocks/price-filter/block.tsx
@@ -190,7 +190,7 @@ const PriceFilterBlock = ( {
 					}
 
 					// When filtering All Products block, we only update the URL.
-					window.history.pushState( {}, '', newUrl );
+					window.history.replaceState( {}, '', newUrl );
 				}
 			}
 

--- a/assets/js/blocks/price-filter/block.tsx
+++ b/assets/js/blocks/price-filter/block.tsx
@@ -189,8 +189,8 @@ const PriceFilterBlock = ( {
 						return ( window.location.href = newUrl );
 					}
 
-					// When filtering Products Grid block, we only update the URL.
-					window.history.pushState( {}, document.title, newUrl );
+					// When filtering All Products block, we only update the URL.
+					window.history.pushState( {}, '', newUrl );
 				}
 			}
 

--- a/assets/js/blocks/price-filter/block.tsx
+++ b/assets/js/blocks/price-filter/block.tsx
@@ -157,7 +157,7 @@ const PriceFilterBlock = ( {
 	 * for the filter to work alongside the Active Filters block.
 	 */
 	useEffect( () => {
-		if ( ! hasSetPhpFilterDefaults && filteringForPhpTemplate ) {
+		if ( ! hasSetPhpFilterDefaults ) {
 			setMinPriceQuery(
 				formatPrice( minPriceParam, currency.minorUnit )
 			);
@@ -169,7 +169,6 @@ const PriceFilterBlock = ( {
 		}
 	}, [
 		currency.minorUnit,
-		filteringForPhpTemplate,
 		hasSetPhpFilterDefaults,
 		maxPriceParam,
 		minPriceParam,
@@ -190,19 +189,24 @@ const PriceFilterBlock = ( {
 					: newMinPrice;
 
 			// For block templates that render the PHP Classic Template block we need to add the filters as params and reload the page.
-			if ( filteringForPhpTemplate && window ) {
+			if ( window ) {
 				const newUrl = formatParams( window.location.href, {
 					min_price: finalMinPrice / 10 ** currency.minorUnit,
 					max_price: finalMaxPrice / 10 ** currency.minorUnit,
 				} );
+
 				// If the params have changed, lets reload the page.
 				if ( window.location.href !== newUrl ) {
-					window.location.href = newUrl;
+					if ( filteringForPhpTemplate ) {
+						window.location.href = newUrl;
+					} else {
+						window.history.pushState( {}, document.title, newUrl );
+					}
 				}
-			} else {
-				setMinPriceQuery( finalMinPrice );
-				setMaxPriceQuery( finalMaxPrice );
 			}
+
+			setMinPriceQuery( finalMinPrice );
+			setMaxPriceQuery( finalMaxPrice );
 		},
 		[
 			minConstraint,

--- a/assets/js/blocks/price-filter/block.tsx
+++ b/assets/js/blocks/price-filter/block.tsx
@@ -113,14 +113,10 @@ const PriceFilterBlock = ( {
 			: undefined
 	);
 
-	const [ minPriceQuery, setMinPriceQuery ] = useQueryStateByKey(
-		'min_price',
-		formatPrice( minPriceParam, currency.minorUnit ) || null
-	);
-	const [ maxPriceQuery, setMaxPriceQuery ] = useQueryStateByKey(
-		'max_price',
-		formatPrice( maxPriceParam, currency.minorUnit ) || null
-	);
+	const [ minPriceQuery, setMinPriceQuery ] =
+		useQueryStateByKey( 'min_price' );
+	const [ maxPriceQuery, setMaxPriceQuery ] =
+		useQueryStateByKey( 'max_price' );
 
 	const [ minPrice, setMinPrice ] = useState(
 		formatPrice( minPriceParam, currency.minorUnit ) || null

--- a/assets/js/blocks/price-filter/block.tsx
+++ b/assets/js/blocks/price-filter/block.tsx
@@ -198,10 +198,10 @@ const PriceFilterBlock = ( {
 				// If the params have changed, lets reload the page.
 				if ( window.location.href !== newUrl ) {
 					if ( filteringForPhpTemplate ) {
-						window.location.href = newUrl;
-					} else {
-						window.history.pushState( {}, document.title, newUrl );
+						return ( window.location.href = newUrl );
 					}
+
+					window.history.pushState( {}, document.title, newUrl );
 				}
 			}
 

--- a/assets/js/blocks/price-filter/block.tsx
+++ b/assets/js/blocks/price-filter/block.tsx
@@ -14,6 +14,7 @@ import PropTypes from 'prop-types';
 import { getCurrencyFromPriceResponse } from '@woocommerce/price-format';
 import { getSettingWithCoercion } from '@woocommerce/settings';
 import { addQueryArgs, removeQueryArgs } from '@wordpress/url';
+import { changeUrl, getUrlParameter } from '@woocommerce/utils';
 import {
 	CurrencyResponse,
 	isBoolean,
@@ -25,7 +26,6 @@ import {
  * Internal dependencies
  */
 import usePriceConstraints from './use-price-constraints';
-import { getUrlParameter } from '../../utils/filters';
 import './style.scss';
 import { Attributes } from './types';
 
@@ -184,13 +184,7 @@ const PriceFilterBlock = ( {
 
 				// If the params have changed, lets update the filter URL.
 				if ( window.location.href !== newUrl ) {
-					// When filtering on the PHP template, we need to reload the page.
-					if ( filteringForPhpTemplate ) {
-						return ( window.location.href = newUrl );
-					}
-
-					// When filtering All Products block, we only update the URL.
-					window.history.replaceState( {}, '', newUrl );
+					changeUrl( newUrl );
 				}
 			}
 
@@ -202,7 +196,6 @@ const PriceFilterBlock = ( {
 			maxConstraint,
 			setMinPriceQuery,
 			setMaxPriceQuery,
-			filteringForPhpTemplate,
 			currency.minorUnit,
 		]
 	);

--- a/assets/js/blocks/price-filter/block.tsx
+++ b/assets/js/blocks/price-filter/block.tsx
@@ -96,11 +96,7 @@ const PriceFilterBlock = ( {
 		isBoolean
 	);
 
-	/**
-	 * Important: Only used on the PHP rendered Block pages to track
-	 * the price filter defaults coming from the URL
-	 */
-	const [ hasSetPhpFilterDefaults, setHasSetPhpFilterDefaults ] =
+	const [ hasSetFilterDefaultsFromUrl, setHasSetFilterDefaultsFromUrl ] =
 		useState( false );
 
 	const minPriceParam = getUrlParameter( 'min_price' );
@@ -150,14 +146,10 @@ const PriceFilterBlock = ( {
 	} );
 
 	/**
-	 * Important: For PHP rendered block templates only.
-	 *
-	 * When we render the PHP block template (e.g. Classic Block) we need
-	 * to set the default min_price and max_price values from the URL
-	 * for the filter to work alongside the Active Filters block.
+	 * Try get the min and/or max price from the URL.
 	 */
 	useEffect( () => {
-		if ( ! hasSetPhpFilterDefaults ) {
+		if ( ! hasSetFilterDefaultsFromUrl ) {
 			setMinPriceQuery(
 				formatPrice( minPriceParam, currency.minorUnit )
 			);
@@ -165,11 +157,11 @@ const PriceFilterBlock = ( {
 				formatPrice( maxPriceParam, currency.minorUnit )
 			);
 
-			setHasSetPhpFilterDefaults( true );
+			setHasSetFilterDefaultsFromUrl( true );
 		}
 	}, [
 		currency.minorUnit,
-		hasSetPhpFilterDefaults,
+		hasSetFilterDefaultsFromUrl,
 		maxPriceParam,
 		minPriceParam,
 		setMaxPriceQuery,
@@ -188,19 +180,20 @@ const PriceFilterBlock = ( {
 					? undefined
 					: newMinPrice;
 
-			// For block templates that render the PHP Classic Template block we need to add the filters as params and reload the page.
 			if ( window ) {
 				const newUrl = formatParams( window.location.href, {
 					min_price: finalMinPrice / 10 ** currency.minorUnit,
 					max_price: finalMaxPrice / 10 ** currency.minorUnit,
 				} );
 
-				// If the params have changed, lets reload the page.
+				// If the params have changed, lets update the filter URL.
 				if ( window.location.href !== newUrl ) {
+					// When filtering on the PHP template, we need to reload the page.
 					if ( filteringForPhpTemplate ) {
 						return ( window.location.href = newUrl );
 					}
 
+					// When filtering Products Grid block, we only update the URL.
 					window.history.pushState( {}, document.title, newUrl );
 				}
 			}
@@ -233,7 +226,7 @@ const PriceFilterBlock = ( {
 
 			if (
 				filteringForPhpTemplate &&
-				hasSetPhpFilterDefaults &&
+				hasSetFilterDefaultsFromUrl &&
 				! attributes.showFilterButton
 			) {
 				debouncedUpdateQuery( prices[ 0 ], prices[ 1 ] );
@@ -245,7 +238,7 @@ const PriceFilterBlock = ( {
 			setMinPrice,
 			setMaxPrice,
 			filteringForPhpTemplate,
-			hasSetPhpFilterDefaults,
+			hasSetFilterDefaultsFromUrl,
 			debouncedUpdateQuery,
 			attributes.showFilterButton,
 		]

--- a/assets/js/blocks/stock-filter/block.tsx
+++ b/assets/js/blocks/stock-filter/block.tsx
@@ -24,7 +24,7 @@ import isShallowEqual from '@wordpress/is-shallow-equal';
 import { decodeEntities } from '@wordpress/html-entities';
 import { isBoolean, objectHasProp } from '@woocommerce/types';
 import { addQueryArgs, removeQueryArgs } from '@wordpress/url';
-import { PREFIX_QUERY_ARG_FILTER_TYPE } from '@woocommerce/utils';
+import { changeUrl, PREFIX_QUERY_ARG_FILTER_TYPE } from '@woocommerce/utils';
 
 /**
  * Internal dependencies
@@ -180,13 +180,9 @@ const StockStatusFilterBlock = ( {
 	/**
 	 * Used to redirect the page when filters are changed so templates using the Classic Template block can filter.
 	 *
-	 * @param {Array}   checkedOptions Array of checked stock options.
-	 * @param {boolean} isPhpTemplate  Whether filters are being used for a PHP template.
+	 * @param {Array} checkedOptions Array of checked stock options.
 	 */
-	const updateFilterUrl = (
-		checkedOptions: string[],
-		isPhpTemplate: boolean
-	) => {
+	const updateFilterUrl = ( checkedOptions: string[] ) => {
 		if ( ! window ) {
 			return;
 		}
@@ -197,11 +193,7 @@ const StockStatusFilterBlock = ( {
 			);
 
 			if ( url !== window.location.href ) {
-				if ( isPhpTemplate ) {
-					window.location.href = url;
-				} else {
-					window.history.replaceState( {}, '', url );
-				}
+				changeUrl( url );
 			}
 
 			return;
@@ -215,11 +207,7 @@ const StockStatusFilterBlock = ( {
 			return;
 		}
 
-		if ( isPhpTemplate ) {
-			window.location.href = newUrl;
-		} else {
-			window.history.replaceState( {}, '', newUrl );
-		}
+		changeUrl( newUrl );
 	};
 
 	const onSubmit = useCallback(
@@ -231,7 +219,7 @@ const StockStatusFilterBlock = ( {
 				setProductStockStatusQuery( checked );
 			}
 
-			updateFilterUrl( checked, filteringForPhpTemplate );
+			updateFilterUrl( checked );
 		},
 		[
 			isEditor,

--- a/assets/js/blocks/stock-filter/block.tsx
+++ b/assets/js/blocks/stock-filter/block.tsx
@@ -187,7 +187,7 @@ const StockStatusFilterBlock = ( {
 		checkedOptions: string[],
 		isPhpTemplate: boolean
 	) => {
-		if ( ! window || ! document ) {
+		if ( ! window ) {
 			return;
 		}
 		if ( checkedOptions.length === 0 ) {
@@ -200,7 +200,7 @@ const StockStatusFilterBlock = ( {
 				if ( isPhpTemplate ) {
 					window.location.href = url;
 				} else {
-					window.history.pushState( {}, document.title, url );
+					window.history.pushState( {}, '', url );
 				}
 			}
 
@@ -218,7 +218,7 @@ const StockStatusFilterBlock = ( {
 		if ( isPhpTemplate ) {
 			window.location.href = newUrl;
 		} else {
-			window.history.pushState( {}, document.title, newUrl );
+			window.history.pushState( {}, '', newUrl );
 		}
 	};
 

--- a/assets/js/blocks/stock-filter/block.tsx
+++ b/assets/js/blocks/stock-filter/block.tsx
@@ -200,7 +200,7 @@ const StockStatusFilterBlock = ( {
 				if ( isPhpTemplate ) {
 					window.location.href = url;
 				} else {
-					window.history.pushState( {}, '', url );
+					window.history.replaceState( {}, '', url );
 				}
 			}
 
@@ -218,7 +218,7 @@ const StockStatusFilterBlock = ( {
 		if ( isPhpTemplate ) {
 			window.location.href = newUrl;
 		} else {
-			window.history.pushState( {}, '', newUrl );
+			window.history.replaceState( {}, '', newUrl );
 		}
 	};
 

--- a/assets/js/utils/filters.ts
+++ b/assets/js/utils/filters.ts
@@ -2,6 +2,14 @@
  * External dependencies
  */
 import { getQueryArg } from '@wordpress/url';
+import { getSettingWithCoercion } from '@woocommerce/settings';
+import { isBoolean } from '@woocommerce/types';
+
+const filteringForPhpTemplate = getSettingWithCoercion(
+	'is_rendering_php_template',
+	false,
+	isBoolean
+);
 
 /**
  * Returns specified parameter from URL
@@ -17,4 +25,17 @@ export function getUrlParameter( name: string ) {
 		return null;
 	}
 	return getQueryArg( window.location.href, name );
+}
+
+/**
+ * Change the URL and reload the page if filtering for PHP templates.
+ *
+ * @param {string} newUrl New URL to be set.
+ */
+export function changeUrl( newUrl: string ) {
+	if ( filteringForPhpTemplate ) {
+		window.location.href = newUrl;
+	} else {
+		window.history.replaceState( {}, '', newUrl );
+	}
 }

--- a/src/BlockTypes/ClassicTemplate.php
+++ b/src/BlockTypes/ClassicTemplate.php
@@ -3,6 +3,7 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
 use Automattic\WooCommerce\Blocks\Templates\ProductSearchResultsTemplate;
 use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
+use WC_Query;
 
 /**
  * Classic Single Product class
@@ -32,8 +33,7 @@ class ClassicTemplate extends AbstractDynamicBlock {
 	protected function initialize() {
 		parent::initialize();
 		add_filter( 'render_block', array( $this, 'add_alignment_class_to_wrapper' ), 10, 2 );
-		add_filter( 'query_vars', array( $this, 'add_query_vars_filter' ) );
-		add_filter( 'woocommerce_product_query_meta_query', array( $this, 'filter_products_by_stock' ), 10, 2 );
+		add_filter( 'woocommerce_product_query_meta_query', array( $this, 'filter_products_by_stock' ) );
 
 	}
 
@@ -272,12 +272,18 @@ class ClassicTemplate extends AbstractDynamicBlock {
 	 * @return array
 	 */
 	public function filter_products_by_stock( $meta_query ) {
-		if ( is_admin() ) {
+		global $wp_query;
+
+		if (
+			is_admin() ||
+			! $wp_query->is_main_query() ||
+			! isset( $_GET[ self::FILTER_PRODUCTS_BY_STOCK_QUERY_PARAM ] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		) {
 			return $meta_query;
 		}
 
 		$stock_status = array_keys( wc_get_product_stock_status_options() );
-		$values       = get_query_var( self::FILTER_PRODUCTS_BY_STOCK_QUERY_PARAM );
+		$values       = sanitize_text_field( wp_unslash( $_GET[ self::FILTER_PRODUCTS_BY_STOCK_QUERY_PARAM ] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 		$values_to_array = explode( ',', $values );
 
@@ -297,18 +303,6 @@ class ClassicTemplate extends AbstractDynamicBlock {
 			);
 		}
 		return $meta_query;
-	}
-
-
-	/**
-	 * Add custom query params
-	 *
-	 * @param array $vars Query vars.
-	 * @return array Query vars.
-	 */
-	public function add_query_vars_filter( $vars ) {
-		$vars[] = self::FILTER_PRODUCTS_BY_STOCK_QUERY_PARAM;
-		return $vars;
 	}
 
 }


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #6441

With this PR, when filtering for the All Products block:

- The URL is updated on filter state changes.
- Only the URL is updated, no page reload occurs.
- Initial filters are set from the URL like PHP templates.

This PR also:
- simplifies the logic that set the initial filters from the URL and makes the filter blocks more stable.
- fixes the issue with the Filter Products by Stock Status when filtering the All Products block on the homepage (see [screenshot](https://user-images.githubusercontent.com/5423135/176631335-607f075e-22bc-4f9f-bd7f-5901fd823508.png)).

#### To reviewers:

- Should we disable the new behavior by default and let developers enable it by a filter or setting?
- The codebase of filter blocks are similar and I think we should refactor and extract the common logic to share between them during the cooldown periods.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) .
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md)
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->


https://user-images.githubusercontent.com/5423135/176621151-db1644d8-3e86-4615-b8fe-eba095dcfb34.mov


### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

For each filter block, ensure:
- No regression when used with PHP templates.
- The URL is updated when checking or unchecking filters.
- For filter blocks using the filter button, the URL is updated after clicking the filter button.
- With the updated URL, all selected filters are set correctly after reloading the page. Filter blocks with or without the filter button should work the same.
- Removing the filter from the Active Filters block should update the URL and the corresponding filter block.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Add filter URL support to filter blocks when filtering for All Products block.