### PR TITLE
Fix condition to allow rendering classic templates on the frontend

### DIFF
--- a/src/BlockTypes/ClassicTemplate.php
+++ b/src/BlockTypes/ClassicTemplate.php
@@ -46,7 +46,7 @@ class ClassicTemplate extends AbstractDynamicBlock {
 	 * @return string | void Rendered block type output.
 	 */
 	protected function render( $attributes, $content ) {
-		if ( isset( $attributes['template'] ) ) {
+		if ( ! isset( $attributes['template'] ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes a bug that caused the classic templates to not render on the frontend.

### Testing
#### User Facing Testing

1. Enable a FSE theme.
2. Go to `/shop`.
3. Make sure the products grid is rendered.
