### PR TITLE
Disable render blockified Product Grid Block

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -371,9 +371,10 @@ class BlockTemplatesController {
 			return $this->template_parts_directory;
 		}
 
-		if ( $this->package->is_experimental_build() && BlockTemplateUtils::should_use_blockified_product_grid_templates() ) {
-			return $this->templates_directory . '/blockified';
-		}
+		// When the blockified Product Grid Block will be implemented, we need to use the blockified templates.
+		// if ( $this->package->is_experimental_build() && BlockTemplateUtils::should_use_blockified_product_grid_templates() ) {
+		// return $this->templates_directory . '/blockified';
+		// }.
 
 		return $this->templates_directory;
 	}

--- a/tests/e2e/specs/shopper/filter-products-by-stock.test.ts
+++ b/tests/e2e/specs/shopper/filter-products-by-stock.test.ts
@@ -126,13 +126,8 @@ describe( `${ block.name } Block`, () => {
 			} );
 
 			expect( isRefreshed ).not.toBeCalled();
-
-			await Promise.all( [
-				page.waitForNavigation( {
-					waitUntil: 'networkidle0',
-				} ),
-				page.click( selectors.frontend.filter ),
-			] );
+			await page.click( selectors.frontend.filter );
+			await page.waitForNetworkIdle();
 
 			const products = await page.$$(
 				selectors.frontend.classicProductsList


### PR DESCRIPTION
This PR disables the new logic that we added to load the blockified template. We will uncomment it when the blockified templates will be ready.

This is necessary for not breaking the developer experience: without this PR, if someone builds the plugin will not be able to see the classic PHP templates (for example `/shop` page).