### PR TITLE
Adds manual sorting to hand picked products block

### DIFF
--- a/assets/js/blocks/handpicked-products/block.json
+++ b/assets/js/blocks/handpicked-products/block.json
@@ -57,7 +57,8 @@
 				"price_desc",
 				"rating",
 				"title",
-				"menu_order"
+				"menu_order",
+				"post__in"
 			],
 			"default": "date"
 		},

--- a/assets/js/blocks/handpicked-products/edit-mode.tsx
+++ b/assets/js/blocks/handpicked-products/edit-mode.tsx
@@ -52,6 +52,7 @@ export const HandpickedProductsEditMode = (
 			<div className="wc-block-handpicked-products__selection">
 				<ProductsControl
 					selected={ attributes.products }
+					sortable={ attributes.orderby }
 					onChange={ ( value = [] ) => {
 						const ids = value.map( ( { id } ) => id );
 						setAttributes( { products: ids } );

--- a/assets/js/blocks/handpicked-products/inspector-controls.tsx
+++ b/assets/js/blocks/handpicked-products/inspector-controls.tsx
@@ -75,6 +75,7 @@ export const HandpickedProductsInspectorControls = (
 				<ProductOrderbyControl
 					setAttributes={ setAttributes }
 					value={ orderby }
+					allowCustomSorting={ true }
 				/>
 			</PanelBody>
 			<PanelBody

--- a/assets/js/editor-components/product-orderby-control/index.js
+++ b/assets/js/editor-components/product-orderby-control/index.js
@@ -8,63 +8,65 @@ import PropTypes from 'prop-types';
 /**
  * A pre-configured SelectControl for product orderby settings.
  *
- * @param {Object}            props               Incoming props for the component.
+ * @param {Object}            props                    Incoming props for the component.
  * @param {string}            props.value
- * @param {function(any):any} props.setAttributes Setter for block attributes.
+ * @param {function(any):any} props.setAttributes      Setter for block attributes.
+ * @param {boolean}           props.allowCustomSorting Flag to allow/disallow the custom sorting option.
  */
-const ProductOrderbyControl = ( { value, setAttributes } ) => {
+const ProductOrderbyControl = ( {
+	value,
+	setAttributes,
+	allowCustomSorting = false,
+} ) => {
+	const orderOptions = [
+		{
+			label: __(
+				'Newness - newest first',
+				'woo-gutenberg-products-block'
+			),
+			value: 'date',
+		},
+		{
+			label: __( 'Price - low to high', 'woo-gutenberg-products-block' ),
+			value: 'price_asc',
+		},
+		{
+			label: __( 'Price - high to low', 'woo-gutenberg-products-block' ),
+			value: 'price_desc',
+		},
+		{
+			label: __(
+				'Rating - highest first',
+				'woo-gutenberg-products-block'
+			),
+			value: 'rating',
+		},
+		{
+			label: __( 'Sales - most first', 'woo-gutenberg-products-block' ),
+			value: 'popularity',
+		},
+		{
+			label: __( 'Title - alphabetical', 'woo-gutenberg-products-block' ),
+			value: 'title',
+		},
+		{
+			label: __( 'Menu Order', 'woo-gutenberg-products-block' ),
+			value: 'menu_order',
+		},
+	];
+
+	if ( allowCustomSorting === true ) {
+		orderOptions.push( {
+			label: __( 'Custom Order', 'woo-gutenberg-products-block' ),
+			value: 'post__in',
+		} );
+	}
+
 	return (
 		<SelectControl
 			label={ __( 'Order products by', 'woo-gutenberg-products-block' ) }
 			value={ value }
-			options={ [
-				{
-					label: __(
-						'Newness - newest first',
-						'woo-gutenberg-products-block'
-					),
-					value: 'date',
-				},
-				{
-					label: __(
-						'Price - low to high',
-						'woo-gutenberg-products-block'
-					),
-					value: 'price_asc',
-				},
-				{
-					label: __(
-						'Price - high to low',
-						'woo-gutenberg-products-block'
-					),
-					value: 'price_desc',
-				},
-				{
-					label: __(
-						'Rating - highest first',
-						'woo-gutenberg-products-block'
-					),
-					value: 'rating',
-				},
-				{
-					label: __(
-						'Sales - most first',
-						'woo-gutenberg-products-block'
-					),
-					value: 'popularity',
-				},
-				{
-					label: __(
-						'Title - alphabetical',
-						'woo-gutenberg-products-block'
-					),
-					value: 'title',
-				},
-				{
-					label: __( 'Menu Order', 'woo-gutenberg-products-block' ),
-					value: 'menu_order',
-				},
-			] }
+			options={ orderOptions }
 			onChange={ ( orderby ) => setAttributes( { orderby } ) }
 		/>
 	);
@@ -79,6 +81,10 @@ ProductOrderbyControl.propTypes = {
 	 * The selected order setting.
 	 */
 	value: PropTypes.string.isRequired,
+	/**
+	 * Is the custom order sorting option available?
+	 */
+	allowCustomSorting: PropTypes.bool,
 };
 
 export default ProductOrderbyControl;

--- a/assets/js/editor-components/products-control/index.js
+++ b/assets/js/editor-components/products-control/index.js
@@ -16,10 +16,10 @@ import ErrorMessage from '@woocommerce/editor-components/error-placeholder/error
  * @param {Function} props.onChange  Callback fired when the selected item changes
  * @param {Function} props.onSearch  Callback fired when a search is triggered
  * @param {Array}    props.selected  An array of selected products.
+ * @param {string}   props.sortable  The current product sorting order.
  * @param {Array}    props.products  An array of products to select from.
  * @param {boolean}  props.isLoading Whether or not the products are being loaded.
  * @param {boolean}  props.isCompact Whether or not the control should have compact styles.
- *
  * @return {Function} A functional component.
  */
 const ProductsControl = ( {
@@ -27,6 +27,7 @@ const ProductsControl = ( {
 	onChange,
 	onSearch,
 	selected,
+	sortable,
 	products,
 	isLoading,
 	isCompact,
@@ -77,12 +78,19 @@ const ProductsControl = ( {
 			} ) }
 			isCompact={ isCompact }
 			isLoading={ isLoading }
-			selected={ products.filter( ( { id } ) =>
-				selected.includes( id )
-			) }
+			selected={
+				sortable === 'post__in'
+					? selected.map( ( id ) => {
+							return products.find(
+								( product ) => product.id === id
+							);
+					  } )
+					: products.filter( ( { id } ) => selected.includes( id ) )
+			}
 			onSearch={ onSearch }
 			onChange={ onChange }
 			messages={ messages }
+			sortable={ sortable }
 		/>
 	);
 };
@@ -94,6 +102,7 @@ ProductsControl.propTypes = {
 	products: PropTypes.array,
 	isCompact: PropTypes.bool,
 	isLoading: PropTypes.bool,
+	sortable: PropTypes.string,
 };
 
 ProductsControl.defaultProps = {
@@ -101,6 +110,7 @@ ProductsControl.defaultProps = {
 	products: [],
 	isCompact: false,
 	isLoading: true,
+	sortable: '',
 };
 
 export default withSearchedProducts( ProductsControl );

--- a/assets/js/editor-components/search-list-control/search-list-control.tsx
+++ b/assets/js/editor-components/search-list-control/search-list-control.tsx
@@ -15,7 +15,7 @@ import {
 	useCallback,
 	Fragment,
 } from '@wordpress/element';
-import { Icon, info } from '@wordpress/icons';
+import { chevronLeft, chevronRight, Icon, info } from '@wordpress/icons';
 import classnames from 'classnames';
 import { useInstanceId } from '@wordpress/compose';
 
@@ -94,6 +94,7 @@ const SelectedListItems = ( {
 	isLoading,
 	isSingle,
 	selected,
+	sortable = false,
 	messages,
 	onChange,
 	onRemove,
@@ -105,6 +106,13 @@ const SelectedListItems = ( {
 		return null;
 	}
 	const selectedCount = selected.length;
+	const sortTag = ( position, movement ) => {
+		selected.splice(
+			position + movement,
+			0,
+			selected.splice( position, 1 )[ 0 ]
+		);
+	};
 	return (
 		<div className="woocommerce-search-list__selected">
 			<div className="woocommerce-search-list__selected-header">
@@ -123,7 +131,43 @@ const SelectedListItems = ( {
 			{ selectedCount > 0 ? (
 				<ul>
 					{ selected.map( ( item, i ) => (
-						<li key={ i }>
+						<li
+							key={ i }
+							className={
+								sortable === 'post__in' ? 'sortable' : null
+							}
+						>
+							{ sortable === 'post__in' && i !== 0 && (
+								<Button
+									isSmall={ true }
+									icon={ chevronLeft }
+									iconSize={ 16 }
+									label={ __(
+										'Move up list',
+										'woo-gutenberg-products-block'
+									) }
+									onClick={ () => {
+										sortTag( i, -1 );
+										onChange( selected );
+									} }
+								/>
+							) }
+							{ sortable === 'post__in' &&
+								i < selectedCount - 1 && (
+									<Button
+										isSmall={ true }
+										icon={ chevronRight }
+										iconSize={ 16 }
+										label={ __(
+											'Move down list',
+											'woo-gutenberg-products-block'
+										) }
+										onClick={ () => {
+											sortTag( i, 1 );
+											onChange( selected );
+										} }
+									/>
+								) }
 							<Tag
 								label={ item.name }
 								id={ item.id }

--- a/assets/js/editor-components/search-list-control/style.scss
+++ b/assets/js/editor-components/search-list-control/style.scss
@@ -26,8 +26,32 @@
 	ul {
 		list-style: none;
 
+		&::after {
+			display: block;
+			clear: both;
+			content: "";
+		}
+
 		li {
 			float: left;
+
+			&.sortable {
+				display: flex;
+				background: $gray-100;
+				border-radius: 12px;
+				margin: 0 $gap-small $gap-small 0;
+
+				button.is-small.has-icon:not(.has-text) {
+					padding: 0;
+					margin: 0;
+					width: 20px;
+					min-width: 20px;
+				}
+
+				.woocommerce-tag.has-remove .woocommerce-tag__text {
+					padding-left: 0;
+				}
+			}
 		}
 	}
 }
@@ -103,9 +127,9 @@
 		border-bottom: 1px solid $gray-100;
 		color: $gray-700;
 
-		&:hover,
 		&:active,
-		&:focus {
+		&:focus,
+		&:hover {
 			background: $gray-100;
 		}
 
@@ -135,7 +159,6 @@
 		&:not(.depth-0) + .depth-0 {
 			border-top: 1px solid $gray-100;
 		}
-
 		// Anything deeper than 5 levels will use this fallback depth
 		&[class*="depth-"] .woocommerce-search-list__item-label::before {
 			margin-right: $gap-smallest;
@@ -146,7 +169,6 @@
 			margin-right: 0;
 			content: "";
 		}
-
 		@for $i from 1 to 5 {
 			&.depth-#{$i} .woocommerce-search-list__item-label::before {
 				content: str-repeat("— ", $i);

--- a/src/BlockTypes/AbstractProductGrid.php
+++ b/src/BlockTypes/AbstractProductGrid.php
@@ -148,7 +148,7 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 	protected function get_schema_orderby() {
 		return array(
 			'type'    => 'string',
-			'enum'    => array( 'date', 'popularity', 'price_asc', 'price_desc', 'rating', 'title', 'menu_order' ),
+			'enum'    => array( 'date', 'popularity', 'price_asc', 'price_desc', 'rating', 'title', 'menu_order', 'post__in' ),
 			'default' => 'date',
 		);
 	}
@@ -236,6 +236,7 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 			$query_args,
 			WC()->query->get_catalog_ordering_args( $query_args['orderby'], $query_args['order'] )
 		);
+
 	}
 
 	/**


### PR DESCRIPTION
Adds a manual sorting options to the hand-picked products block, as mentioned/requested in woocommerce/woocommerce#42663 

This PR adds a `post__in` sorting option to the `ProductOrderbyControl` component that is only available to the hand-picked products block currently, but could be extended to other blocks as needed.

There are a few steps involved to activate manual sorting currently:

1. Add the hand picked products block
2. Set the product ordering dropdown to `Custom order`
3. The tags above the product list in the edit view of Hand-picked products now have sorting arrows

#### Accessibility

No new animations or colour styling added.

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) .
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md)
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
| ![Screenshot 2022-07-08 at 11 29 57](https://user-images.githubusercontent.com/3149464/177975462-b53ebfe6-5842-401d-8769-aeec9f0dc963.png) | ![Screenshot 2022-07-08 at 11 30 06](https://user-images.githubusercontent.com/3149464/177975498-b8758c17-39e4-4ed0-9dd3-1c113d7fd061.png) |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Add the Hand-picked products block to a page.
2. Add products to the block
3. In the product order dropdown select "custom order"
4. Use the arrows on the product name tags to adjust the list order
5. Save and view, products will now appear in the chosen order

* [ ] Do not include in the Testing Notes 

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

No known performance impact.

### Changelog

> Added custom sorting option to hand-picked products block.
