### PR TITLE
Update block template descriptions

### DIFF
--- a/src/Utils/BlockTemplateUtils.php
+++ b/src/Utils/BlockTemplateUtils.php
@@ -298,23 +298,23 @@ class BlockTemplateUtils {
 		$plugin_template_types = array(
 			'single-product'                   => array(
 				'title'       => _x( 'Single Product', 'Template name', 'woo-gutenberg-products-block' ),
-				'description' => __( 'Template used to display the single product.', 'woo-gutenberg-products-block' ),
+				'description' => __( 'Displays a single product.', 'woo-gutenberg-products-block' ),
 			),
 			'archive-product'                  => array(
 				'title'       => _x( 'Product Catalog', 'Template name', 'woo-gutenberg-products-block' ),
-				'description' => __( 'Template used to display products.', 'woo-gutenberg-products-block' ),
+				'description' => __( 'Displays your products.', 'woo-gutenberg-products-block' ),
 			),
 			'taxonomy-product_cat'             => array(
 				'title'       => _x( 'Products by Category', 'Template name', 'woo-gutenberg-products-block' ),
-				'description' => __( 'Template used to display products by category.', 'woo-gutenberg-products-block' ),
+				'description' => __( 'Displays products filtered by a category.', 'woo-gutenberg-products-block' ),
 			),
 			'taxonomy-product_tag'             => array(
 				'title'       => _x( 'Products by Tag', 'Template name', 'woo-gutenberg-products-block' ),
-				'description' => __( 'Template used to display products by tag.', 'woo-gutenberg-products-block' ),
+				'description' => __( 'Displays products filtered by a tag.', 'woo-gutenberg-products-block' ),
 			),
 			ProductSearchResultsTemplate::SLUG => array(
 				'title'       => _x( 'Product Search Results', 'Template name', 'woo-gutenberg-products-block' ),
-				'description' => __( 'Template used to display search results for products.', 'woo-gutenberg-products-block' ),
+				'description' => __( 'Displays search results for your store.', 'woo-gutenberg-products-block' ),
 			),
 			MiniCartTemplate::SLUG             => array(
 				'title'       => _x( 'Mini Cart', 'Template name', 'woo-gutenberg-products-block' ),


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

This PR adds a few updates to the block template descriptions as suggested by @vivialice in https://github.com/woocommerce/woocommerce-blocks/issues/6659.

Closes https://github.com/woocommerce/woocommerce-blocks/issues/6659

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) .
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md)
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|   <img width="732" alt="Screenshot 2022-07-08 at 14 23 22" src="https://user-images.githubusercontent.com/1562646/177992284-a7610520-e4b6-4bbe-9a28-bd25a808b6b2.png">     |  <img width="704" alt="Screenshot 2022-07-08 at 14 23 34" src="https://user-images.githubusercontent.com/1562646/177992322-dc1ba2e9-106c-4f47-b17e-721566824abc.png">     |


### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

### Manual Testing

How to test the changes in this Pull Request:

**Testing template descriptions**
1. Activate a **block** theme, like Twenty Twenty-Two.
2. Open the **Appearance > Editor (Beta)**.
3. Using the dropdown arrow next to the Template name, select the **Browse all templates** button.
4. Confirm the updated WooCommerce templates' descriptions.

### User Facing Testing
These are steps for user testing (where "user" is someone interacting with this change that is not editing any code).
* [x] Same as above

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Update WooCommerce block template descriptions.
