### PR TITLE
Refactor registration of payment methods and update unit tests for payment data store

### DIFF
--- a/assets/js/base/context/hooks/payment-methods/use-payment-method-interface.ts
+++ b/assets/js/base/context/hooks/payment-methods/use-payment-method-interface.ts
@@ -24,7 +24,7 @@ import { useStoreCart } from '../cart/use-store-cart';
 import { useStoreCartCoupons } from '../cart/use-store-cart-coupons';
 import { noticeContexts, responseTypes } from '../../event-emit';
 import { useCheckoutEventsContext } from '../../providers/cart-checkout/checkout-events';
-import { usePaymentMethodDataContext } from '../../providers/cart-checkout/payment-methods';
+import { usePaymentMethodEventsContext } from '../../providers/cart-checkout/payment-methods';
 import { useShippingDataContext } from '../../providers/cart-checkout/shipping';
 import { useCustomerDataContext } from '../../providers/cart-checkout/customer';
 import { prepareTotalItems } from './utils';
@@ -69,7 +69,7 @@ export const usePaymentMethodInterface = (): PaymentMethodInterface => {
 		PAYMENT_METHOD_DATA_STORE_KEY
 	);
 
-	const { onPaymentProcessing } = usePaymentMethodDataContext();
+	const { onPaymentProcessing } = usePaymentMethodEventsContext();
 	const {
 		shippingErrorStatus,
 		shippingErrorTypes,

--- a/assets/js/base/context/hooks/payment-methods/use-payment-methods.ts
+++ b/assets/js/base/context/hooks/payment-methods/use-payment-methods.ts
@@ -6,6 +6,10 @@ import type {
 	PaymentMethods,
 	ExpressPaymentMethods,
 } from '@woocommerce/type-defs/payments';
+import {
+	getPaymentMethods,
+	getExpressPaymentMethods,
+} from '@woocommerce/blocks-registry';
 import { useSelect } from '@wordpress/data';
 import { PAYMENT_METHOD_DATA_STORE_KEY } from '@woocommerce/block-data';
 
@@ -21,27 +25,23 @@ interface ExpressPaymentMethodState {
 const usePaymentMethodState = (
 	express = false
 ): PaymentMethodState | ExpressPaymentMethodState => {
-	const {
-		paymentMethodsInitialized,
-		expressPaymentMethodsInitialized,
-		availablePaymentMethods,
-		availableExpressPaymentMethods,
-	} = useSelect( ( select ) => {
-		const store = select( PAYMENT_METHOD_DATA_STORE_KEY );
+	const { paymentMethodsInitialized, expressPaymentMethodsInitialized } =
+		useSelect( ( select ) => {
+			const store = select( PAYMENT_METHOD_DATA_STORE_KEY );
 
-		return {
-			paymentMethodsInitialized: store.paymentMethodsInitialized(),
-			expressPaymentMethodsInitialized:
-				store.expressPaymentMethodsInitialized(),
-			availablePaymentMethods: store.getAvailablePaymentMethods(),
-			availableExpressPaymentMethods:
-				store.getAvailableExpressPaymentMethods(),
-		};
-	} );
+			return {
+				paymentMethodsInitialized: store.paymentMethodsInitialized(),
+				expressPaymentMethodsInitialized:
+					store.expressPaymentMethodsInitialized(),
+			};
+		} );
 
-	const currentPaymentMethods = useShallowEqual( availablePaymentMethods );
+	const paymentMethods = getPaymentMethods();
+	const expressPaymentMethods = getExpressPaymentMethods();
+
+	const currentPaymentMethods = useShallowEqual( paymentMethods );
 	const currentExpressPaymentMethods = useShallowEqual(
-		availableExpressPaymentMethods
+		expressPaymentMethods
 	);
 
 	return {

--- a/assets/js/base/context/hooks/test/use-checkout-submit.js
+++ b/assets/js/base/context/hooks/test/use-checkout-submit.js
@@ -12,24 +12,22 @@ import {
 	CHECKOUT_STORE_KEY,
 	config as checkoutStoreConfig,
 } from '../../../../data/checkout';
+import {
+	PAYMENT_METHOD_DATA_STORE_KEY,
+	config as paymentDataStoreConfig,
+} from '../../../../data/payment-methods';
 
-const mockUseCheckoutEventsContext = {
-	onSubmit: jest.fn(),
-};
-const mockUsePaymentMethodDataContext = {
-	activePaymentMethod: '',
-	currentStatus: {
-		isDoingExpressPayment: false,
-	},
-};
-
-jest.mock( '../../providers/cart-checkout/checkout-events', () => ( {
-	useCheckoutEventsContext: () => mockUseCheckoutEventsContext,
-} ) );
-
-jest.mock( '../../providers/cart-checkout/payment-methods', () => ( {
-	usePaymentMethodDataContext: () => mockUsePaymentMethodDataContext,
-} ) );
+jest.mock( '../../providers/cart-checkout/checkout-events', () => {
+	const original = jest.requireActual(
+		'../../providers/cart-checkout/checkout-events'
+	);
+	return {
+		...original,
+		useCheckoutEventsContext: () => {
+			return { onSubmit: jest.fn() };
+		},
+	};
+} );
 
 describe( 'useCheckoutSubmit', () => {
 	let registry, renderer;
@@ -48,11 +46,12 @@ describe( 'useCheckoutSubmit', () => {
 	beforeEach( () => {
 		registry = createRegistry( {
 			[ CHECKOUT_STORE_KEY ]: checkoutStoreConfig,
+			[ PAYMENT_METHOD_DATA_STORE_KEY ]: paymentDataStoreConfig,
 		} );
 		renderer = null;
 	} );
 
-	it( 'onSubmit calls the correct action in the checkout context', () => {
+	it( 'onSubmit calls the correct action in the checkout events context', () => {
 		const TestComponent = getTestComponent();
 
 		act( () => {
@@ -66,8 +65,6 @@ describe( 'useCheckoutSubmit', () => {
 
 		onSubmit();
 
-		expect( mockUseCheckoutEventsContext.onSubmit ).toHaveBeenCalledTimes(
-			1
-		);
+		expect( onSubmit ).toHaveBeenCalledTimes( 1 );
 	} );
 } );

--- a/assets/js/base/context/providers/cart-checkout/payment-methods/index.ts
+++ b/assets/js/base/context/providers/cart-checkout/payment-methods/index.ts
@@ -1,4 +1,4 @@
 export {
 	PaymentMethodDataProvider,
-	usePaymentMethodDataContext,
-} from './payment-method-data-context';
+	usePaymentMethodEventsContext,
+} from './payment-method-events-context';

--- a/assets/js/blocks-registry/payment-methods/registry.ts
+++ b/assets/js/blocks-registry/payment-methods/registry.ts
@@ -48,11 +48,7 @@ export const registerPaymentMethod = (
 		paymentMethodConfig = new PaymentMethodConfig( options );
 	}
 	if ( paymentMethodConfig instanceof PaymentMethodConfig ) {
-		const { updateAvailablePaymentMethods } = dispatch(
-			PAYMENT_METHOD_DATA_STORE_KEY
-		);
 		paymentMethods[ paymentMethodConfig.name ] = paymentMethodConfig;
-		updateAvailablePaymentMethods();
 	}
 };
 
@@ -78,11 +74,7 @@ export const registerExpressPaymentMethod = (
 		paymentMethodConfig = new ExpressPaymentMethodConfig( options );
 	}
 	if ( paymentMethodConfig instanceof ExpressPaymentMethodConfig ) {
-		const { updateAvailableExpressPaymentMethods } = dispatch(
-			PAYMENT_METHOD_DATA_STORE_KEY
-		);
 		expressPaymentMethods[ paymentMethodConfig.name ] = paymentMethodConfig;
-		updateAvailableExpressPaymentMethods();
 	}
 };
 

--- a/assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-options.js
+++ b/assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-options.js
@@ -6,10 +6,7 @@ import {
 	useStoreEvents,
 } from '@woocommerce/base-context/hooks';
 import { cloneElement, useCallback } from '@wordpress/element';
-import {
-	useEditorContext,
-	usePaymentMethodDataContext,
-} from '@woocommerce/base-context';
+import { useEditorContext } from '@woocommerce/base-context';
 import classNames from 'classnames';
 import RadioControlAccordion from '@woocommerce/base-components/radio-control-accordion';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -28,30 +25,26 @@ import { STORE_KEY as PAYMENT_METHOD_DATA_STORE_KEY } from '../../../data/paymen
  * @return {*} The rendered component.
  */
 const PaymentMethodOptions = () => {
-	const { savedPaymentMethods } = usePaymentMethodDataContext(); //TODO: Move this state from the context file
-
 	const {
 		activeSavedToken,
 		activePaymentMethod,
 		isExpressPaymentMethodActive,
+		savedPaymentMethods,
+		availablePaymentMethods,
 	} = useSelect( ( select ) => {
 		const store = select( PAYMENT_METHOD_DATA_STORE_KEY );
 		return {
 			activeSavedToken: store.getActiveSavedToken(),
 			activePaymentMethod: store.getActivePaymentMethod(),
 			isExpressPaymentMethodActive: store.isExpressPaymentMethodActive(),
+			savedPaymentMethods: store.getSavedPaymentMethods(),
+			availablePaymentMethods: store.getAvailablePaymentMethods(),
 		};
 	} );
 	const { setActivePaymentMethod } = useDispatch(
 		PAYMENT_METHOD_DATA_STORE_KEY
 	);
 	const paymentMethods = getPaymentMethods();
-	const { availablePaymentMethods } = useSelect( ( select ) => {
-		const store = select( PAYMENT_METHOD_DATA_STORE_KEY );
-		return {
-			availablePaymentMethods: store.getAvailablePaymentMethods(),
-		};
-	} );
 	const { ...paymentMethodInterface } = usePaymentMethodInterface();
 	const { removeNotice } = useDispatch( 'core/notices' );
 	const { dispatchCheckoutEvent } = useStoreEvents();

--- a/assets/js/blocks/cart-checkout-shared/payment-methods/test/payment-methods.js
+++ b/assets/js/blocks/cart-checkout-shared/payment-methods/test/payment-methods.js
@@ -14,12 +14,13 @@ import {
 	__experimentalDeRegisterPaymentMethod,
 } from '@woocommerce/blocks-registry';
 import userEvent from '@testing-library/user-event';
+import { dispatch } from '@wordpress/data';
+
 /**
  * Internal dependencies
  */
 import PaymentMethods from '../payment-methods';
 import { defaultCartState } from '../../../../data/cart/default-state';
-import { dispatch } from '@wordpress/data';
 
 jest.mock( '../saved-payment-method-options', () => ( { onChange } ) => {
 	return (
@@ -45,7 +46,7 @@ jest.mock(
 );
 
 const originalSelect = jest.requireActual( '@wordpress/data' ).select;
-let selectMock = jest
+const selectMock = jest
 	.spyOn( wpDataFunctions, 'select' )
 	.mockImplementation( ( storeName ) => {
 		const originalStore = originalSelect( storeName );
@@ -61,22 +62,6 @@ let selectMock = jest
 						paymentMethodsInitialized: true,
 					};
 				},
-			};
-		}
-
-		if ( storeName === CART_STORE_KEY ) {
-			return {
-				...originalStore,
-				hasFinishedResolution: jest
-					.fn()
-					.mockImplementation( ( selectorName ) => {
-						if ( selectorName === 'getCartTotals' ) {
-							return true;
-						}
-						return originalStore.hasFinishedResolution(
-							selectorName
-						);
-					} ),
 			};
 		}
 		return originalStore;
@@ -142,32 +127,12 @@ describe( 'PaymentMethods', () => {
 			// creates an extra `div` with the notice contents used for a11y.
 			expect( noPaymentMethods.length ).toBeGreaterThanOrEqual( 1 );
 
+			// Reset the mock back to how it was because we don't need it anymore after this test.
 			selectMock.mockRestore();
 		} );
 	} );
 
 	test( 'selecting new payment method', async () => {
-		selectMock = jest
-			.spyOn( wpDataFunctions, 'select' )
-			.mockImplementation( ( storeName ) => {
-				const originalStore = originalSelect( storeName );
-				if ( storeName === CART_STORE_KEY ) {
-					return {
-						...originalStore,
-						hasFinishedResolution: jest
-							.fn()
-							.mockImplementation( ( selectorName ) => {
-								if ( selectorName === 'getCartTotals' ) {
-									return true;
-								}
-								return originalStore.hasFinishedResolution(
-									selectorName
-								);
-							} ),
-					};
-				}
-				return originalStore;
-			} );
 		const ShowActivePaymentMethod = () => {
 			const { activePaymentMethod, activeSavedToken } =
 				wpDataFunctions.useSelect( ( select ) => {

--- a/assets/js/blocks/cart-checkout-shared/payment-methods/test/payment-methods.js
+++ b/assets/js/blocks/cart-checkout-shared/payment-methods/test/payment-methods.js
@@ -19,6 +19,7 @@ import userEvent from '@testing-library/user-event';
  */
 import PaymentMethods from '../payment-methods';
 import { defaultCartState } from '../../../../data/cart/default-state';
+import { dispatch } from '@wordpress/data';
 
 jest.mock( '../saved-payment-method-options', () => ( { onChange } ) => {
 	return (
@@ -98,6 +99,9 @@ const registerMockPaymentMethods = () => {
 			ariaLabel: name,
 		} );
 	} );
+	dispatch(
+		PAYMENT_METHOD_DATA_STORE_KEY
+	).initializePaymentMethodDataStore();
 };
 
 const resetMockPaymentMethods = () => {
@@ -182,7 +186,18 @@ describe( 'PaymentMethods', () => {
 				</>
 			);
 		};
-		registerMockPaymentMethods();
+
+		act( () => {
+			registerMockPaymentMethods();
+		} );
+		// Wait for the payment methods to finish loading before rendering.
+		await waitFor( () => {
+			expect(
+				wpDataFunctions
+					.select( PAYMENT_METHOD_DATA_STORE_KEY )
+					.getActivePaymentMethod()
+			).toBe( 'cod' );
+		} );
 
 		render(
 			<>

--- a/assets/js/data/cart/index.ts
+++ b/assets/js/data/cart/index.ts
@@ -1,7 +1,11 @@
 /**
  * External dependencies
  */
-import { dispatch, registerStore, select } from '@wordpress/data';
+import {
+	dispatch as wpDataDispatch,
+	registerStore,
+	select as wpDataSelect,
+} from '@wordpress/data';
 import { controls as dataControls } from '@wordpress/data-controls';
 
 /**
@@ -36,9 +40,9 @@ registeredStore.subscribe( async () => {
 const unsubscribeInitializePaymentMethodDataStore = registeredStore.subscribe(
 	async () => {
 		const cartLoaded =
-			select( STORE_KEY ).hasFinishedResolution( 'getCartTotals' );
+			wpDataSelect( STORE_KEY ).hasFinishedResolution( 'getCartTotals' );
 		if ( cartLoaded ) {
-			dispatch(
+			wpDataDispatch(
 				'wc/store/payment-methods'
 			).initializePaymentMethodDataStore();
 			unsubscribeInitializePaymentMethodDataStore();

--- a/assets/js/data/cart/index.ts
+++ b/assets/js/data/cart/index.ts
@@ -17,7 +17,6 @@ import { controls } from './controls';
 import type { SelectFromMap, DispatchFromMap } from '../mapped-types';
 import { pushChanges } from './push-changes';
 import { checkPaymentMethodsCanPay } from '../payment-methods/check-payment-methods';
-import { initializePaymentMethodDataStore } from '../payment-methods/actions';
 
 const registeredStore = registerStore< State >( STORE_KEY, {
 	reducer,

--- a/assets/js/data/cart/index.ts
+++ b/assets/js/data/cart/index.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { registerStore } from '@wordpress/data';
+import { dispatch, registerStore, select } from '@wordpress/data';
 import { controls as dataControls } from '@wordpress/data-controls';
 
 /**
@@ -17,6 +17,7 @@ import { controls } from './controls';
 import type { SelectFromMap, DispatchFromMap } from '../mapped-types';
 import { pushChanges } from './push-changes';
 import { checkPaymentMethodsCanPay } from '../payment-methods/check-payment-methods';
+import { initializePaymentMethodDataStore } from '../payment-methods/actions';
 
 const registeredStore = registerStore< State >( STORE_KEY, {
 	reducer,
@@ -32,6 +33,19 @@ registeredStore.subscribe( async () => {
 	await checkPaymentMethodsCanPay();
 	await checkPaymentMethodsCanPay( true );
 } );
+
+const unsubscribeInitializePaymentMethodDataStore = registeredStore.subscribe(
+	async () => {
+		const cartLoaded =
+			select( STORE_KEY ).hasFinishedResolution( 'getCartTotals' );
+		if ( cartLoaded ) {
+			dispatch(
+				'wc/store/payment-methods'
+			).initializePaymentMethodDataStore();
+			unsubscribeInitializePaymentMethodDataStore();
+		}
+	}
+);
 
 export const CART_STORE_KEY = STORE_KEY;
 

--- a/assets/js/data/checkout/index.ts
+++ b/assets/js/data/checkout/index.ts
@@ -32,22 +32,21 @@ export const config = {
 const store = createReduxStore( STORE_KEY, config );
 register( store );
 
-subscribe( async () => {
-	await checkPaymentMethodsCanPay();
-	await checkPaymentMethodsCanPay( true );
-} );
+const isEditor = !! wpDataSelect( 'core/editor' );
 
-const unsubscribeInitializePaymentMethodDataStore = subscribe( async () => {
-	const cartLoaded =
-		wpDataSelect( STORE_KEY ).hasFinishedResolution( 'getCartTotals' );
-	const isEditor = !! wpDataSelect( 'core/editor' );
-	if ( cartLoaded || isEditor ) {
+if ( isEditor ) {
+	subscribe( async () => {
+		await checkPaymentMethodsCanPay();
+		await checkPaymentMethodsCanPay( true );
+	} );
+
+	const unsubscribeInitializePaymentMethodDataStore = subscribe( async () => {
 		wpDataDispatch(
 			'wc/store/payment-methods'
 		).initializePaymentMethodDataStore();
 		unsubscribeInitializePaymentMethodDataStore();
-	}
-} );
+	} );
+}
 
 export const CHECKOUT_STORE_KEY = STORE_KEY;
 declare module '@wordpress/data' {

--- a/assets/js/data/checkout/index.ts
+++ b/assets/js/data/checkout/index.ts
@@ -1,7 +1,13 @@
 /**
  * External dependencies
  */
-import { createReduxStore, register } from '@wordpress/data';
+import {
+	createReduxStore,
+	register,
+	subscribe,
+	select as wpDataSelect,
+	dispatch as wpDataDispatch,
+} from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -11,6 +17,7 @@ import * as selectors from './selectors';
 import * as actions from './actions';
 import reducer from './reducers';
 import { DispatchFromMap, SelectFromMap } from '../mapped-types';
+import { checkPaymentMethodsCanPay } from '../payment-methods/check-payment-methods';
 
 export const config = {
 	reducer,
@@ -24,6 +31,22 @@ export const config = {
 
 const store = createReduxStore( STORE_KEY, config );
 register( store );
+
+subscribe( async () => {
+	await checkPaymentMethodsCanPay();
+	await checkPaymentMethodsCanPay( true );
+} );
+
+const unsubscribeInitializePaymentMethodDataStore = subscribe( async () => {
+	const cartLoaded =
+		wpDataSelect( STORE_KEY ).hasFinishedResolution( 'getCartTotals' );
+	if ( cartLoaded ) {
+		wpDataDispatch(
+			'wc/store/payment-methods'
+		).initializePaymentMethodDataStore();
+		unsubscribeInitializePaymentMethodDataStore();
+	}
+} );
 
 export const CHECKOUT_STORE_KEY = STORE_KEY;
 declare module '@wordpress/data' {

--- a/assets/js/data/checkout/index.ts
+++ b/assets/js/data/checkout/index.ts
@@ -40,7 +40,8 @@ subscribe( async () => {
 const unsubscribeInitializePaymentMethodDataStore = subscribe( async () => {
 	const cartLoaded =
 		wpDataSelect( STORE_KEY ).hasFinishedResolution( 'getCartTotals' );
-	if ( cartLoaded ) {
+	const isEditor = !! wpDataSelect( 'core/editor' );
+	if ( cartLoaded || isEditor ) {
 		wpDataDispatch(
 			'wc/store/payment-methods'
 		).initializePaymentMethodDataStore();

--- a/assets/js/data/payment-methods/actions.ts
+++ b/assets/js/data/payment-methods/actions.ts
@@ -79,6 +79,8 @@ export const setAvailablePaymentMethods = (
 ) => {
 	return async ( { dispatch } ) => {
 		// If the currently selected method is not in this new list, then we need to select a new one, or select a default.
+
+		// TODO See if we can stop this being dispatched if the currently selected method is still available.
 		await setDefaultPaymentMethod( paymentMethods );
 		dispatch( {
 			type: ACTION_TYPES.SET_AVAILABLE_PAYMENT_METHODS,

--- a/assets/js/data/payment-methods/actions.ts
+++ b/assets/js/data/payment-methods/actions.ts
@@ -118,28 +118,13 @@ export const removeRegisteredExpressPaymentMethod = ( name: string ) => ( {
 	name,
 } );
 
-/**
- * Checks the payment methods held in the registry can make a payment
- * and updates the available payment methods in the store.
- */
-export function updateAvailablePaymentMethods() {
+export function initializePaymentMethodDataStore() {
 	return async ( { dispatch } ) => {
-		const registered = await checkPaymentMethodsCanPay();
-		if ( registered ) {
-			dispatch( setPaymentMethodsInitialized( true ) );
-		}
-	};
-}
-
-/**
- * Checks the express payment methods held in the registry can make a payment
- * and updates the available express payment methods in the store.
- */
-export function updateAvailableExpressPaymentMethods() {
-	return async ( { dispatch } ) => {
-		const registered = await checkPaymentMethodsCanPay( true );
-		if ( registered ) {
+		const expressRegistered = await checkPaymentMethodsCanPay( true, true );
+		const registered = await checkPaymentMethodsCanPay( false, true );
+		if ( registered && expressRegistered ) {
 			dispatch( setExpressPaymentMethodsInitialized( true ) );
+			dispatch( setPaymentMethodsInitialized( true ) );
 		}
 	};
 }

--- a/assets/js/data/payment-methods/actions.ts
+++ b/assets/js/data/payment-methods/actions.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { select as wpDataSelect } from '@wordpress/data';
 import {
 	PaymentMethods,
 	ExpressPaymentMethods,
@@ -14,7 +13,6 @@ import { ACTION_TYPES } from './action-types';
 import { checkPaymentMethodsCanPay } from './check-payment-methods';
 import { setDefaultPaymentMethod } from './set-default-payment-method';
 import { PaymentStatus } from './types';
-import { CART_STORE_KEY } from '../cart';
 
 // `Thunks are functions that can be dispatched, similar to actions creators
 export * from './thunks';

--- a/assets/js/data/payment-methods/actions.ts
+++ b/assets/js/data/payment-methods/actions.ts
@@ -125,11 +125,7 @@ export const removeRegisteredExpressPaymentMethod = ( name: string ) => ( {
 export function updateAvailablePaymentMethods() {
 	return async ( { dispatch } ) => {
 		const registered = await checkPaymentMethodsCanPay();
-		const cartTotalsLoaded =
-			wpDataSelect( CART_STORE_KEY ).hasFinishedResolution(
-				'getCartTotals'
-			);
-		if ( registered && cartTotalsLoaded ) {
+		if ( registered ) {
 			dispatch( setPaymentMethodsInitialized( true ) );
 		}
 	};
@@ -142,11 +138,7 @@ export function updateAvailablePaymentMethods() {
 export function updateAvailableExpressPaymentMethods() {
 	return async ( { dispatch } ) => {
 		const registered = await checkPaymentMethodsCanPay( true );
-		const cartTotalsLoaded =
-			wpDataSelect( CART_STORE_KEY ).hasFinishedResolution(
-				'getCartTotals'
-			);
-		if ( registered && cartTotalsLoaded ) {
+		if ( registered ) {
 			dispatch( setExpressPaymentMethodsInitialized( true ) );
 		}
 	};

--- a/assets/js/data/payment-methods/actions.ts
+++ b/assets/js/data/payment-methods/actions.ts
@@ -120,8 +120,8 @@ export const removeRegisteredExpressPaymentMethod = ( name: string ) => ( {
 
 export function initializePaymentMethodDataStore() {
 	return async ( { dispatch } ) => {
-		const expressRegistered = await checkPaymentMethodsCanPay( true, true );
-		const registered = await checkPaymentMethodsCanPay( false, true );
+		const expressRegistered = await checkPaymentMethodsCanPay( true );
+		const registered = await checkPaymentMethodsCanPay( false );
 		if ( registered && expressRegistered ) {
 			dispatch( setExpressPaymentMethodsInitialized( true ) );
 			dispatch( setPaymentMethodsInitialized( true ) );

--- a/assets/js/data/payment-methods/check-payment-methods.ts
+++ b/assets/js/data/payment-methods/check-payment-methods.ts
@@ -25,12 +25,7 @@ import { noticeContexts } from '../../base/context/event-emit';
 
 export const checkPaymentMethodsCanPay = async ( express = false ) => {
 	const isEditor = !! select( 'core/editor' );
-	const cartTotalsLoaded =
-		select( CART_STORE_KEY ).hasFinishedResolution( 'getCartTotals' );
-	// The cart hasn't finished resolving yet. The "cartTotalsLoaded" is always "false" in the editor mode
-	if ( ! cartTotalsLoaded && ! isEditor ) {
-		return false;
-	}
+
 	let availablePaymentMethods = {};
 	const paymentMethods = express
 		? getExpressPaymentMethods()

--- a/assets/js/data/payment-methods/check-payment-methods.ts
+++ b/assets/js/data/payment-methods/check-payment-methods.ts
@@ -129,26 +129,12 @@ export const checkPaymentMethodsCanPay = async ( express = false ) => {
 		return true;
 	}
 
-	const {
-		setAvailablePaymentMethods,
-		setAvailableExpressPaymentMethods,
-		setPaymentMethodsInitialized,
-		setExpressPaymentMethodsInitialized,
-	} = dispatch( PAYMENT_METHOD_DATA_STORE_KEY );
+	const { setAvailablePaymentMethods, setAvailableExpressPaymentMethods } =
+		dispatch( PAYMENT_METHOD_DATA_STORE_KEY );
 	if ( express ) {
 		setAvailableExpressPaymentMethods( availablePaymentMethods );
-
-		// Note: Some 4rd party payment methods use the `canMakePayment` callback to initialize / setup.
-		// That's why we track "is initialized" state here.
-		setExpressPaymentMethodsInitialized( true );
-
 		return true;
 	}
 	setAvailablePaymentMethods( availablePaymentMethods );
-
-	// Note: Some 4rd party payment methods use the `canMakePayment` callback to initialize / setup.
-	// That's why we track "is initialized" state here.
-	setPaymentMethodsInitialized( true );
-
 	return true;
 };

--- a/assets/js/data/payment-methods/check-payment-methods.ts
+++ b/assets/js/data/payment-methods/check-payment-methods.ts
@@ -108,7 +108,6 @@ export const checkPaymentMethodsCanPay = async ( express = false ) => {
 					context: noticeContext,
 					id: `wc-${ paymentMethod.paymentMethodId }-registration-error`,
 				} );
-				return false;
 			}
 		}
 	}

--- a/assets/js/data/payment-methods/check-payment-methods.ts
+++ b/assets/js/data/payment-methods/check-payment-methods.ts
@@ -36,9 +36,10 @@ export const checkPaymentMethodsCanPay = async ( express = false ) => {
 			| PaymentMethodConfigInstance
 			| ExpressPaymentMethodConfigInstance
 	) => {
+		const { name } = paymentMethod;
 		availablePaymentMethods = {
 			...availablePaymentMethods,
-			[ paymentMethod.name ]: paymentMethod,
+			[ paymentMethod.name ]: { name },
 		};
 	};
 

--- a/assets/js/data/payment-methods/test/reducers.js
+++ b/assets/js/data/payment-methods/test/reducers.js
@@ -23,8 +23,8 @@ describe( 'paymentMethodDataReducer', () => {
 			isSuccessful: false,
 			isDoingExpressPayment: false,
 		},
-		registeredPaymentMethods: [],
-		registeredExpressPaymentMethods: [],
+		availablePaymentMethods: {},
+		availableExpressPaymentMethods: {},
 		paymentMethodData: {},
 		paymentMethodsInitialized: false,
 		expressPaymentMethodsInitialized: false,
@@ -35,10 +35,10 @@ describe( 'paymentMethodDataReducer', () => {
 		activeSavedToken: '',
 	} );
 
-	it( 'sets state as expected when adding a registered payment method', () => {
+	it( 'sets state as expected when adding a payment method', () => {
 		const nextState = reducer( originalState, {
-			type: ACTION_TYPES.ADD_REGISTERED_PAYMENT_METHOD,
-			name: 'my-new-method',
+			type: ACTION_TYPES.SET_AVAILABLE_PAYMENT_METHODS,
+			paymentMethods: { 'my-new-method': { express: false } },
 		} );
 		expect( nextState ).toEqual( {
 			paymentStatuses: PAYMENT_METHOD_STATUS,
@@ -52,8 +52,8 @@ describe( 'paymentMethodDataReducer', () => {
 				isSuccessful: false,
 				isDoingExpressPayment: false,
 			},
-			registeredPaymentMethods: [ 'my-new-method' ],
-			registeredExpressPaymentMethods: [],
+			availablePaymentMethods: { 'my-new-method': { express: false } },
+			availableExpressPaymentMethods: {},
 			paymentMethodData: {},
 			paymentMethodsInitialized: false,
 			expressPaymentMethodsInitialized: false,
@@ -65,7 +65,7 @@ describe( 'paymentMethodDataReducer', () => {
 		} );
 	} );
 
-	it( 'sets state as expected when removing a registered payment method', () => {
+	it( 'sets state as expected when removing a payment method', () => {
 		const stateWithRegisteredMethod = deepFreeze( {
 			paymentStatuses: PAYMENT_METHOD_STATUS,
 			currentStatus: {
@@ -78,8 +78,8 @@ describe( 'paymentMethodDataReducer', () => {
 				isSuccessful: false,
 				isDoingExpressPayment: false,
 			},
-			registeredPaymentMethods: [ 'my-new-method' ],
-			registeredExpressPaymentMethods: [],
+			availablePaymentMethods: { 'my-new-method': { express: false } },
+			availableExpressPaymentMethods: {},
 			paymentMethodData: {},
 			paymentMethodsInitialized: false,
 			expressPaymentMethodsInitialized: false,
@@ -90,7 +90,7 @@ describe( 'paymentMethodDataReducer', () => {
 			activeSavedToken: '',
 		} );
 		const nextState = reducer( stateWithRegisteredMethod, {
-			type: ACTION_TYPES.REMOVE_REGISTERED_PAYMENT_METHOD,
+			type: ACTION_TYPES.REMOVE_AVAILABLE_PAYMENT_METHOD,
 			name: 'my-new-method',
 		} );
 		expect( nextState ).toEqual( {
@@ -105,8 +105,8 @@ describe( 'paymentMethodDataReducer', () => {
 				isSuccessful: false,
 				isDoingExpressPayment: false,
 			},
-			registeredPaymentMethods: [],
-			registeredExpressPaymentMethods: [],
+			availablePaymentMethods: {},
+			availableExpressPaymentMethods: {},
 			paymentMethodData: {},
 			paymentMethodsInitialized: false,
 			expressPaymentMethodsInitialized: false,
@@ -118,10 +118,10 @@ describe( 'paymentMethodDataReducer', () => {
 		} );
 	} );
 
-	it( 'sets state as expected when adding a registered express payment method', () => {
+	it( 'sets state as expected when adding an express payment method', () => {
 		const nextState = reducer( originalState, {
-			type: ACTION_TYPES.ADD_REGISTERED_EXPRESS_PAYMENT_METHOD,
-			name: 'my-new-method',
+			type: ACTION_TYPES.SET_AVAILABLE_EXPRESS_PAYMENT_METHODS,
+			paymentMethods: { 'my-new-method': { express: true } },
 		} );
 		expect( nextState ).toEqual( {
 			paymentStatuses: PAYMENT_METHOD_STATUS,
@@ -135,8 +135,10 @@ describe( 'paymentMethodDataReducer', () => {
 				isSuccessful: false,
 				isDoingExpressPayment: false,
 			},
-			registeredPaymentMethods: [],
-			registeredExpressPaymentMethods: [ 'my-new-method' ],
+			availablePaymentMethods: {},
+			availableExpressPaymentMethods: {
+				'my-new-method': { express: true },
+			},
 			paymentMethodData: {},
 			paymentMethodsInitialized: false,
 			expressPaymentMethodsInitialized: false,
@@ -148,7 +150,7 @@ describe( 'paymentMethodDataReducer', () => {
 		} );
 	} );
 
-	it( 'sets state as expected when removing a registered express payment method', () => {
+	it( 'sets state as expected when removing an express payment method', () => {
 		const stateWithRegisteredMethod = deepFreeze( {
 			paymentStatuses: PAYMENT_METHOD_STATUS,
 			currentStatus: {
@@ -161,8 +163,8 @@ describe( 'paymentMethodDataReducer', () => {
 				isSuccessful: false,
 				isDoingExpressPayment: false,
 			},
-			registeredPaymentMethods: [],
-			registeredExpressPaymentMethods: [ 'my-new-method' ],
+			availablePaymentMethods: {},
+			availableExpressPaymentMethods: [ 'my-new-method' ],
 			paymentMethodData: {},
 			paymentMethodsInitialized: false,
 			expressPaymentMethodsInitialized: false,
@@ -173,7 +175,7 @@ describe( 'paymentMethodDataReducer', () => {
 			activeSavedToken: '',
 		} );
 		const nextState = reducer( stateWithRegisteredMethod, {
-			type: ACTION_TYPES.REMOVE_REGISTERED_EXPRESS_PAYMENT_METHOD,
+			type: ACTION_TYPES.REMOVE_AVAILABLE_EXPRESS_PAYMENT_METHOD,
 			name: 'my-new-method',
 		} );
 		expect( nextState ).toEqual( {
@@ -188,8 +190,8 @@ describe( 'paymentMethodDataReducer', () => {
 				isSuccessful: false,
 				isDoingExpressPayment: false,
 			},
-			registeredPaymentMethods: [],
-			registeredExpressPaymentMethods: [],
+			availablePaymentMethods: {},
+			availableExpressPaymentMethods: {},
 			paymentMethodData: {},
 			paymentMethodsInitialized: false,
 			expressPaymentMethodsInitialized: false,

--- a/assets/js/data/payment-methods/test/selectors.js
+++ b/assets/js/data/payment-methods/test/selectors.js
@@ -25,6 +25,7 @@ import {
 	SavedPaymentMethodOptions,
 } from '../../../../../../blocks/cart-checkout-shared/payment-methods';
 import { defaultCartState } from '../../../../../../data/cart/default-state';
+
 const originalSelect = jest.requireActual( '@wordpress/data' ).select;
 jest.spyOn( wpDataFunctions, 'select' ).mockImplementation( ( storeName ) => {
 	const originalStore = originalSelect( storeName );

--- a/assets/js/data/payment-methods/test/selectors.js
+++ b/assets/js/data/payment-methods/test/selectors.js
@@ -23,8 +23,8 @@ import { default as fetchMock } from 'jest-fetch-mock';
 import {
 	CheckoutExpressPayment,
 	SavedPaymentMethodOptions,
-} from '../../../../../../blocks/cart-checkout-shared/payment-methods';
-import { defaultCartState } from '../../../../../../data/cart/default-state';
+} from '../../../blocks/cart-checkout-shared/payment-methods';
+import { defaultCartState } from '../../../data/cart/default-state';
 
 const originalSelect = jest.requireActual( '@wordpress/data' ).select;
 jest.spyOn( wpDataFunctions, 'select' ).mockImplementation( ( storeName ) => {

--- a/assets/js/data/payment-methods/test/selectors.js
+++ b/assets/js/data/payment-methods/test/selectors.js
@@ -141,7 +141,7 @@ const resetMockPaymentMethods = () => {
 	} );
 };
 
-describe( 'Testing Payment Method Data Context Provider', () => {
+describe( 'Testing Payment Method Registration', () => {
 	beforeEach( () => {
 		act( () => {
 			registerMockPaymentMethods( false );
@@ -225,7 +225,7 @@ describe( 'Testing Payment Method Data Context Provider', () => {
 	} );
 } );
 
-describe( 'Testing Payment Method Data Context Provider with saved cards turned on', () => {
+describe( 'Testing Payment Methods work correctly with saved cards turned on', () => {
 	beforeEach( () => {
 		act( () => {
 			registerMockPaymentMethods( true );

--- a/assets/js/data/payment-methods/test/selectors.js
+++ b/assets/js/data/payment-methods/test/selectors.js
@@ -141,7 +141,7 @@ const resetMockPaymentMethods = () => {
 	} );
 };
 
-describe( 'Testing Payment Method Registration', () => {
+describe( 'Payment method data store selectors/thunks', () => {
 	beforeEach( () => {
 		act( () => {
 			registerMockPaymentMethods( false );

--- a/assets/js/data/payment-methods/test/set-default-payment-method.ts
+++ b/assets/js/data/payment-methods/test/set-default-payment-method.ts
@@ -1,0 +1,143 @@
+/* eslint-disable no-unused-expressions */
+/**
+ * External dependencies
+ */
+import * as wpDataFunctions from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { setDefaultPaymentMethod } from '../set-default-payment-method';
+import { PaymentMethods } from '../../../types';
+import { PAYMENT_METHOD_DATA_STORE_KEY } from '..';
+
+const originalSelect = jest.requireActual( '@wordpress/data' ).select;
+
+describe( 'setDefaultPaymentMethod', () => {
+	afterEach( () => {
+		jest.resetAllMocks();
+		jest.resetModules();
+	} );
+
+	const paymentMethods: PaymentMethods = {
+		'wc-payment-gateway-1': {
+			name: 'wc-payment-gateway-1',
+		},
+		'wc-payment-gateway-2': {
+			name: 'wc-payment-gateway-2',
+		},
+	};
+
+	it( ' correctly sets the first payment method in the list of available payment methods', async () => {
+		jest.spyOn( wpDataFunctions, 'select' ).mockImplementation(
+			( storeName ) => {
+				const originalStore = originalSelect( storeName );
+				if ( storeName === PAYMENT_METHOD_DATA_STORE_KEY ) {
+					return {
+						...originalStore,
+						getAvailableExpressPaymentMethods: () => {
+							return {
+								express_payment_1: {
+									name: 'express_payment_1',
+								},
+							};
+						},
+						getSavedPaymentMethods: () => {
+							return {};
+						},
+					};
+				}
+				return originalStore;
+			}
+		);
+
+		const originalDispatch =
+			jest.requireActual( '@wordpress/data' ).dispatch;
+		const setActivePaymentMethodMock = jest.fn();
+		jest.spyOn( wpDataFunctions, 'dispatch' ).mockImplementation(
+			( storeName ) => {
+				const originalStore = originalDispatch( storeName );
+				if ( storeName === PAYMENT_METHOD_DATA_STORE_KEY ) {
+					return {
+						...originalStore,
+						setActivePaymentMethod: setActivePaymentMethodMock,
+					};
+				}
+				return originalStore;
+			}
+		);
+		await setDefaultPaymentMethod( paymentMethods );
+		expect( setActivePaymentMethodMock ).toHaveBeenCalledWith(
+			'wc-payment-gateway-1'
+		);
+	} );
+	it( ' correctly sets the saved payment method if one is available', async () => {
+		jest.spyOn( wpDataFunctions, 'select' ).mockImplementation(
+			( storeName ) => {
+				const originalStore = originalSelect( storeName );
+				if ( storeName === PAYMENT_METHOD_DATA_STORE_KEY ) {
+					return {
+						...originalStore,
+						getAvailableExpressPaymentMethods: () => {
+							return {
+								express_payment_1: {
+									name: 'express_payment_1',
+								},
+							};
+						},
+						getSavedPaymentMethods: () => {
+							return {
+								cc: [
+									{
+										method: {
+											gateway: 'saved-method',
+											last4: '4242',
+											brand: 'Visa',
+										},
+										expires: '04/44',
+										is_default: true,
+										actions: {
+											delete: {
+												url: 'https://example.com/delete',
+												name: 'Delete',
+											},
+										},
+										tokenId: 2,
+									},
+								],
+							};
+						},
+					};
+				}
+				return originalStore;
+			}
+		);
+
+		const originalDispatch =
+			jest.requireActual( '@wordpress/data' ).dispatch;
+		const setActivePaymentMethodMock = jest.fn();
+		jest.spyOn( wpDataFunctions, 'dispatch' ).mockImplementation(
+			( storeName ) => {
+				const originalStore = originalDispatch( storeName );
+				if ( storeName === PAYMENT_METHOD_DATA_STORE_KEY ) {
+					return {
+						...originalStore,
+						setActivePaymentMethod: setActivePaymentMethodMock,
+						setPaymentStatus: () => void 0,
+					};
+				}
+				return originalStore;
+			}
+		);
+		await setDefaultPaymentMethod( paymentMethods );
+		expect( setActivePaymentMethodMock ).toHaveBeenCalledWith(
+			'saved-method',
+			{
+				isSavedToken: true,
+				payment_method: 'saved-method',
+				token: '2',
+				'wc-saved-method-payment-token': '2',
+			}
+		);
+	} );
+} );

--- a/assets/js/data/payment-methods/types.ts
+++ b/assets/js/data/payment-methods/types.ts
@@ -85,9 +85,7 @@ export type PaymentMethodCurrentStatusType = {
 	isDoingExpressPayment: boolean;
 };
 
-export type PaymentMethodDataContextType = {
-	// Returns the customer payment for the customer if it exists.
-	savedPaymentMethods: SavedPaymentMethods;
+export type PaymentMethodEventsContextType = {
 	// Event registration callback for registering observers for the payment processing event.
 	onPaymentProcessing: ReturnType< typeof emitterCallback >;
 };

--- a/docs/internal-developers/block-client-apis/checkout/checkout-flow-and-events.md
+++ b/docs/internal-developers/block-client-apis/checkout/checkout-flow-and-events.md
@@ -113,7 +113,7 @@ The possible _internal_ statuses that may be set are:
 -   `FAILED`: This status is set after an observer hooked into the payment processing event returns a fail response. This in turn will end up causing the checkout `hasError` flag to be set to true.
 -   `ERROR`: This status is set after an observer hooked into the payment processing event returns an error response. This in turn will end up causing the checkout `hasError` flag to be set to true.
 
-The provider exposes the current status of the payment method data context via the `currentStatus` object. You can retrieve this via the `usePaymentMethodDataContext` hook.
+The provider exposes the current status of the payment method data context via the `currentStatus` object. You can retrieve this via the `usePaymentMethodEventsContext` hook.
 
 The `currentStatus` object has the following properties:
 
@@ -304,16 +304,16 @@ If the response object doesn't match any of the above conditions, then the fallb
 
 When the payment status is set to `SUCCESS` and the checkout status is `PROCESSING`, the `CheckoutProcessor` component will trigger the request to the server for processing the order.
 
-This event emitter subscriber can be obtained via the checkout context using the `usePaymentMethodDataContext` hook or to payment method extensions as a prop on their registered component:
+This event emitter subscriber can be obtained via the checkout context using the `usePaymentMethodEventsContext` hook or to payment method extensions as a prop on their registered component:
 
 _For internal development:_
 
 ```jsx
-import { usePaymentMethodDataContext } from '@woocommerce/base-contexts';
+import { usePaymentMethodEventsContext } from '@woocommerce/base-contexts';
 import { useEffect } from '@wordpress/element';
 
 const Component = () => {
-	const { onPaymentProcessing } = usePaymentMethodDataContext();
+	const { onPaymentProcessing } = usePaymentMethodEventsContext();
 	useEffect( () => {
 		const unsubscribe = onPaymentProcessing( () => true );
 		return unsubscribe;

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@woocommerce/block-library",
-			"version": "8.3.0-dev",
+			"version": "8.4.0-dev",
 			"hasInstallScript": true,
 			"license": "GPL-3.0+",
 			"dependencies": {

--- a/tests/js/jest.config.json
+++ b/tests/js/jest.config.json
@@ -45,7 +45,7 @@
 		"<rootDir>/node_modules/",
 		"<rootDir>/vendor/"
 	],
-	"transformIgnorePatterns": [ "node_modules/(?!(simple-html-tokenizer)/)" ],
+	"transformIgnorePatterns": [ "/node_modules/(?!(simple-html-tokenizer|@wordpress\/redux-routine)/)/" ],
 	"testEnvironment": "jsdom",
 	"preset": "@wordpress/jest-preset-default",
 	"transform": {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

Please review #6672  and merge into this branch before reviewing!

This PR updates the flow of registering payment methods. Once the cart has been initialised, we will run a thunk on the `wc/store/payment-methods` data store to signify that the store is initialized. This will allow us to set default payment methods and choose the active one.

This PR also refactors the `PaymentMethodOptions` component to get the saved methods from the data store instead of context. The reason this was done in this PR is because it was coupled with a unit test, so if I made a new PR for it, the changes to the tests here would need to be included there too. 

The PR also updates unit tests relating to the payment method context, which has been moved to the data store.

the changes made in this PR in summary are:

- `assets/js/base/context/hooks/test/use-checkout-submit.js` Changed to add the payment method store to the mock registry, removed `mockUsePaymentMethodDataContext` as it was not necessary.
- `assets/js/blocks-registry/payment-methods/registry.ts` - remove the calls to `updateAvailableExpressPaymentMethods` because this is no longer needed, the cart data store does this action **once**, rather than the payment method registry doing it once for each payment method.
- `assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-options.js` - get the saved payment methods from the data store, and consolidate calls to `useSelect` into a single call.
- `assets/js/blocks/cart-checkout-shared/payment-methods/test/payment-methods.js` - mock the store so the "No payment methods" error shows correctly.
- `assets/js/blocks/cart-checkout-shared/payment-methods/saved-payment-method-options.js` - add an `onChange` to the radio control, because of https://github.com/woocommerce/woocommerce-blocks/pull/6636/files#diff-2f98fdd4a7fc8f68f912240d507f845faa1a86076185b1f2b405bf3243363a85R18
- `assets/js/data/cart/index.ts`- When the cart is loaded, run the actions that will fully register and set the default payment methods in the `wc/store/payment-methods` data store.
- `assets/js/data/payment-methods/actions.ts` remove unused thunks, and create `initializePaymentMethodDataStore` action.
- `assets/js/data/payment-methods/test/selectors.js` moved this file from the payment method data context directory, this covers setting the payment method back to what it was before interacting with express payment methods.
- `assets/js/data/payment-methods/test/reducers.js` - fix tests to remove unused action types.
- `assets/js/data/payment-methods/check-payment-methods.ts` - Remove the check for whether the cart is loaded, this is no longer needed as this method is called once by the cart data store when it's loaded.

<!-- Reference any related issues or PRs here -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [ ] E2E tests

#### User Facing Testing
<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Smoke test the checkout, use lots of different payment methods.
2. Use saved payment methods, express payment methods etc.
3. Try with different shipping options.
4. Optionally try with subscription products in your cart.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental

### Changelog

> Add suggested changelog entry here.
