### PR TITLE
Mini Cart: Fix loading deps when WordPress is installed in a subdir 

### DIFF
--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -276,8 +276,12 @@ class MiniCart extends AbstractBlock {
 		if ( ! $script->src ) {
 			return;
 		}
+
+		$site_url = get_site_url();
+		$path     = wp_parse_url( $site_url )['path'] ?? '';
+
 		$this->scripts_to_lazy_load[ $script->handle ] = array(
-			'src'          => $script->src,
+			'src'          => wp_http_validate_url( $script->src ) ? $script->src : $path . $script->src,
 			'version'      => $script->ver,
 			'before'       => $wp_scripts->print_inline_script( $script->handle, 'before', false ),
 			'after'        => $wp_scripts->print_inline_script( $script->handle, 'after', false ),

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -277,11 +277,10 @@ class MiniCart extends AbstractBlock {
 			return;
 		}
 
-		$site_url = get_site_url();
-		$path     = wp_parse_url( $site_url )['path'] ?? '';
+		$site_url = site_url() ?? wp_guess_url();
 
 		$this->scripts_to_lazy_load[ $script->handle ] = array(
-			'src'          => wp_http_validate_url( $script->src ) ? $script->src : $path . $script->src,
+			'src'          => preg_match( '|^(https?:)?//|', $script->src ) ? $script->src : $site_url . $script->src,
 			'version'      => $script->ver,
 			'before'       => $wp_scripts->print_inline_script( $script->handle, 'before', false ),
 			'after'        => $wp_scripts->print_inline_script( $script->handle, 'after', false ),


### PR DESCRIPTION
This PR fixes the loading of Mini Cart deps when WordPress is installed in a subdirectory. Fixes #6500.

Without these changes, the Mini Cart deps are ALWAYS loading from the root of the website, but this is wrong because WordPress could be installed in a subdirectory.

### How to reproduce the error

For reproducing the error, it is necessary installing WordPress in a subdirectory. The quickest and easiest way that I found it is:
- Install WordPress with LocalWP.
- Follow [this guide](https://wordpress.org/support/article/giving-wordpress-its-own-directory/#method-ii-with-url-change). I installed the website in a subdir called `wordpress` (as the guide suggests).
- Add the Mini Cart Block and save it.
- View the post/page and open the console/network tool. You can see a lot of 404 errors. The reason is that the URLs are wrong because WP isn't installed in the root but in a subdirectory.



![image](https://user-images.githubusercontent.com/4463174/178263430-eff34fab-5516-40e1-8b53-5da714af3cf2.png)

![image](https://user-images.githubusercontent.com/4463174/178263539-9e188440-2f57-4262-8dc6-983fc12c6cbe.png)
*wrong request (missing `/wordpress`)*


![image](https://user-images.githubusercontent.com/4463174/178263764-09583123-e7e5-4f0e-8886-bc5de4fd1c23.png)
*with the changes of this PR, the browser fetches deps from the right URLs*


### Testing


#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

Check out this branch

1. Install WordPress with LocalWP.
2.  Follow [this guide](https://wordpress.org/support/article/giving-wordpress-its-own-directory/#method-ii-with-url-change).
3. Add the Mini Cart Block and save.
4. Be sure that the Mini Cart Block works correctly.
5. Check that the Mini Cart Block works correctly with a classic installation too.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental



