### PR TITLE
Fix `useForcedLayout` to re-select inner blocks after we manually insert one

### DIFF
--- a/assets/js/blocks/cart-checkout-shared/use-forced-layout.ts
+++ b/assets/js/blocks/cart-checkout-shared/use-forced-layout.ts
@@ -67,7 +67,7 @@ export const useForcedLayout = ( {
 			insertBlock( newBlock, position, clientId, false );
 			setForcedBlocksInserted( forcedBlocksInserted + 1 );
 		},
-		[ clientId, insertBlock ]
+		[ clientId, insertBlock, forcedBlocksInserted ]
 	);
 
 	const lockedBlockTypes = useMemo(

--- a/assets/js/blocks/cart-checkout-shared/use-forced-layout.ts
+++ b/assets/js/blocks/cart-checkout-shared/use-forced-layout.ts
@@ -8,7 +8,7 @@ import {
 	useMemo,
 	useState,
 } from '@wordpress/element';
-import { useSelect, useDispatch, select } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	createBlock,
 	getBlockType,
@@ -49,10 +49,10 @@ export const useForcedLayout = ( {
 		useDispatch( 'core/block-editor' );
 
 	const { innerBlocks, registeredBlockTypes } = useSelect(
-		( mapSelect ) => {
+		( select ) => {
 			return {
 				innerBlocks:
-					mapSelect( 'core/block-editor' ).getBlocks( clientId ),
+					select( 'core/block-editor' ).getBlocks( clientId ),
 				registeredBlockTypes: currentRegisteredBlocks.current.map(
 					( blockName ) => getBlockType( blockName )
 				),


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR will change `useForcedLayout` so the `useSelect` responsible for selecting the inner blocks of a client block re-runs if the inner blocks change. Previously, the deps of `useSelect` were only `clientId` and `currentRegisteredBlocks.current` which do not change after dispatching `core/block-editor`s `insertBlock` action.

Instead, we will keep track of the number of blocks we have inserted, and use this as a dependency of the `useSelect` too.

The other alternative would be to remove the deps, but this could cause multiple selects even if nothing has changed.

### Screenshots

| Before | After |
| ------ | ----- |
| <img width="470" alt="image" src="https://user-images.githubusercontent.com/5656702/178464536-972f2ce2-4679-4e7e-9222-1408713154d2.png"> | <img width="479" alt="image" src="https://user-images.githubusercontent.com/5656702/178462926-506778e6-6576-4c7d-b32e-84fbebf6795e.png"> |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. Install the https://github.com/woocommerce/newsletter-test plugin to your site
2. Go to the Checkout block in your editor
3. Observe the `I want to receive updates about products and promotions.` checkbox in the customer information block. Ensure it only displays once.
4. Save the page and ensure the newsletter signup block is still only shown once.
5. Visit the block on the front-end and ensure the newsletter signup block only shows once.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Prevent locked inner blocks from sometimes displaying twice.
