### PR TITLE
Prevent showing the blockified templates until they are implemented

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -299,8 +299,9 @@ class BlockTemplatesController {
 
 		foreach ( $template_files as $template_file ) {
 			// Skip the template if it's blockified, and we should only use classic ones.
-			if ( $this->package->is_experimental_build() &&
-				! BlockTemplateUtils::should_use_blockified_product_grid_templates() &&
+			// Until the blockified Product Grid Block is implemented, we need to always skip the blockified templates.
+			if ( // $this->package->is_experimental_build() &&
+				// ! BlockTemplateUtils::should_use_blockified_product_grid_templates() &&
 				strpos( $template_file, 'blockified' ) !== false ) {
 				continue;
 			}


### PR DESCRIPTION
Skip all the templates in the `blockified` folder until the actual templates are implemented.

### Testing

1. Create a new site and install WooCommerce and this version of the WooCommerce Blocks.
2. Go to `/wp-admin/site-editor.php?postType=wp_template` 
3. Open all the WooCommerce templates and make sure the classic version is loaded for all of them.
