### PR TITLE
Mini Cart Block: additional classes are visible on the frontend page #5581

### DIFF
--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -339,7 +339,10 @@ class MiniCart extends AbstractBlock {
 
 		$classes_styles  = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, array( 'text_color', 'background_color', 'font_size', 'font_family' ) );
 		$wrapper_classes = sprintf( 'wc-block-mini-cart wp-block-woocommerce-mini-cart %s', $classes_styles['classes'] );
-		$wrapper_styles  = $classes_styles['styles'];
+		if ( ! empty( $attributes['className'] ) ) {
+			$wrapper_classes .= ' ' . $attributes['className'];
+		}
+		$wrapper_styles = $classes_styles['styles'];
 
 		$aria_label = sprintf(
 		/* translators: %1$d is the number of products in the cart. %2$s is the cart total */


### PR DESCRIPTION
With this refactor (#5985), we removed the code that appends the additional classes and render them on the frontend ([source](https://github.com/woocommerce/woocommerce-blocks/pull/5985/files#diff-4c8bd3d0cfbd21fce3d29b5b50c28a5172490edbdabe90867fbf4f36dd5d3cb4L329-L331)). This PR restores the feature 👍 

Fixes #5881

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->



### Testing



#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Open the FSE editor.
2. Add the Mini Cart block.
3. Get focused on it.
4. On the right sidebar, on the block settings -> advanced section, add custom classes.
5. Save.
6. On the frontend page, inspect the Mini Cart Block element.
7. Check that the custom classes are added.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> N/A
