### PR TITLE
Select the correct inner button for the "Featured Item" button to update its url

### DIFF
--- a/assets/js/blocks/featured-items/with-update-button-attributes.tsx
+++ b/assets/js/blocks/featured-items/with-update-button-attributes.tsx
@@ -51,7 +51,7 @@ export const withUpdateButtonAttributes =
 		const Block = useSelect( ( select ) => {
 			return select( 'core/block-editor' ).getBlock( clientId );
 		} );
-		const InnerButton = Block?.innerBlocks[ 0 ];
+		const InnerButton = Block?.innerBlocks[ 0 ]?.innerBlocks[ 0 ];
 		const buttonBlockId = InnerButton?.clientId || '';
 		const currentButtonAttributes = useMemo(
 			() => InnerButton?.attributes || {},

--- a/assets/js/blocks/featured-items/with-update-button-attributes.tsx
+++ b/assets/js/blocks/featured-items/with-update-button-attributes.tsx
@@ -48,14 +48,14 @@ export const withUpdateButtonAttributes =
 			( item as WP_REST_API_Category )?.link ||
 			( item as ProductResponseItem )?.permalink;
 
-		const Block = useSelect( ( select ) => {
+		const block = useSelect( ( select ) => {
 			return select( 'core/block-editor' ).getBlock( clientId );
 		} );
-		const InnerButton = Block?.innerBlocks[ 0 ]?.innerBlocks[ 0 ];
-		const buttonBlockId = InnerButton?.clientId || '';
+		const innerBlock = block?.innerBlocks[ 0 ]?.innerBlocks[ 0 ];
+		const buttonBlockId = innerBlock?.clientId || '';
 		const currentButtonAttributes = useMemo(
-			() => InnerButton?.attributes || {},
-			[ InnerButton ]
+			() => innerBlock?.attributes || {},
+			[ innerBlock ]
 		);
 		const { url } = currentButtonAttributes;
 


### PR DESCRIPTION
When changing the `product`/`category` of a `Featured Product`/`Featured Category` block the button URL was not updated, this PR fixes that issue by selecting the appropriate inner button block.

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/6721

### Testing

#### User Facing Testing

1. Create a new page and add a `Featured Product` block.
2. Edit the block and select a different product.
3. Make sure the button URL on the block is updated to the new product link.
4. Duplicate the block and change the new block to a different product.
5. Make sure the button URL on the block is updated to the new product link.
6. Repeat 1-5 for the `Featured Category` block.

### WooCommerce Visibility
* [x] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental

### Changelog
> Fix: Featured Items blocks don't update their inner link when the item is replaced.
