### PR TITLE
Ensure shipping rate names show when multiple packages are used

### DIFF
--- a/assets/js/base/components/cart-checkout/shipping-rates-control/index.tsx
+++ b/assets/js/base/components/cart-checkout/shipping-rates-control/index.tsx
@@ -66,7 +66,7 @@ const Packages = ( {
 					collapsible={ collapsible }
 					collapse={ collapse }
 					showItems={
-						showItems || packageData.shipping_rates.length > 1
+						showItems || packageData?.shipping_rates?.length > 1
 					}
 					noResultsMessage={ noResultsMessage }
 					renderOption={ renderOption }

--- a/assets/js/base/components/cart-checkout/shipping-rates-control/index.tsx
+++ b/assets/js/base/components/cart-checkout/shipping-rates-control/index.tsx
@@ -65,7 +65,9 @@ const Packages = ( {
 					packageData={ packageData }
 					collapsible={ collapsible }
 					collapse={ collapse }
-					showItems={ showItems }
+					showItems={
+						showItems || packageData.shipping_rates.length > 1
+					}
 					noResultsMessage={ noResultsMessage }
 					renderOption={ renderOption }
 				/>

--- a/assets/js/base/context/hooks/shipping/use-shipping-data.ts
+++ b/assets/js/base/context/hooks/shipping/use-shipping-data.ts
@@ -14,6 +14,7 @@ import { isObject } from '@woocommerce/types';
  * Internal dependencies
  */
 import { useSelectShippingRate } from './use-select-shipping-rate';
+import { previewCart } from '@woocommerce/resource-previews';
 
 interface ShippingData extends SelectShippingRateType {
 	needsShipping: Cart[ 'needsShipping' ];
@@ -30,12 +31,19 @@ export const useShippingData = (): ShippingData => {
 		hasCalculatedShipping,
 		isLoadingRates,
 	} = useSelect( ( select ) => {
+		const isEditor = !! select( 'core/editor' );
 		const store = select( storeKey );
 		return {
-			shippingRates: store.getShippingRates(),
-			needsShipping: store.getNeedsShipping(),
-			hasCalculatedShipping: store.getHasCalculatedShipping(),
-			isLoadingRates: store.isCustomerDataUpdating(),
+			shippingRates: isEditor
+				? previewCart.shipping_rates
+				: store.getShippingRates(),
+			needsShipping: isEditor
+				? previewCart.needs_shipping
+				: store.getNeedsShipping(),
+			hasCalculatedShipping: isEditor
+				? previewCart.needs_shipping
+				: store.getHasCalculatedShipping(),
+			isLoadingRates: isEditor ? false : store.isCustomerDataUpdating(),
 		};
 	} );
 	const { isSelectingRate, selectShippingRate } = useSelectShippingRate();

--- a/assets/js/base/context/hooks/shipping/use-shipping-data.ts
+++ b/assets/js/base/context/hooks/shipping/use-shipping-data.ts
@@ -9,12 +9,12 @@ import { useEffect, useRef } from '@wordpress/element';
 import { deriveSelectedShippingRates } from '@woocommerce/base-utils';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 import { isObject } from '@woocommerce/types';
+import { previewCart } from '@woocommerce/resource-previews';
 
 /**
  * Internal dependencies
  */
 import { useSelectShippingRate } from './use-select-shipping-rate';
-import { previewCart } from '@woocommerce/resource-previews';
 
 interface ShippingData extends SelectShippingRateType {
 	needsShipping: Cart[ 'needsShipping' ];


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR will ensure shipping rate names show when multiple shipping packages are in the cart. It will also fix an issue in the editor where shipping rates don't show.

To fix shipping rates not showing in the editor: in the `useShippingData` hook, we now check if we're in the editor, and if so show the values from `previewShippingRates`, or else we get it from the `wc/store/cart` data store.

To fix the issue of names not showing, I checked the value of `packageData?.shipping_rates?.length` in `ShippingRatesControl`. This is then used in the condition that determines whether to show the name or not
https://github.com/woocommerce/woocommerce-blocks/blob/5545c38c4bef7e0d9768c29802426d4956716f2c/assets/js/base/components/cart-checkout/shipping-rates-control-package/index.tsx#L72-L76
it defaulted to false.


<!-- Reference any related issues or PRs here -->

Fixes #6437

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
| <img src="https://user-images.githubusercontent.com/6944811/169669731-e783c2e1-3d12-4b9d-8cdd-c2eb0c8ce339.png" /> | <img width="490" alt="image" src="https://user-images.githubusercontent.com/5656702/180825265-553e6c81-9f79-4a25-ac80-efcbd239ecf4.png"> |

👆🏻 **note the spacing is fixed in #6740** 👆🏻

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Install the ["Multiple Packages for WooCommerce" plugin](https://wordpress.org/plugins/multiple-packages-for-woocommerce/)
2. Navigate to WooCommerce -> Settings -> Multiple Packages
3. Adjust the settings to work based on "Per Product"
4. Add two/three/four different products to the cart and typically need shipping.
5. Go the checkout page and look at the shipping options, ensure there is a title for each one.
6. Disable the plugin and reload the Checkout Block, ensure the shipping section still looks OK.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Ensure shipping package names are shown correctly in the Checkout Block when a cart contains multiple packages.
