### PR TITLE
Switch up token for zip generation automation.

### DIFF
--- a/.github/workflows/generate-zip.yml
+++ b/.github/workflows/generate-zip.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Add release ZIP URL as comment to the PR
         uses: mshick/add-pr-comment@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.PAT_FOR_ACTIONS }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           message: |
             The release ZIP for this PR is accessible via:
@@ -61,4 +61,3 @@ jobs:
 
       - name: Delete ZIP file
         run: rm -rf wc-blocks-pr-release__temp
-        


### PR DESCRIPTION
Switch up the token used to zip generation automation so it's not using rubikuserbot and instead uses github-actions.

This PR should emit a ZIP link using github-actions, and no one from the team is going to get notified in their email for this PR.