### PR TITLE
Add font-weight option to Mini Cart block text

### DIFF
--- a/assets/js/blocks/mini-cart/block.tsx
+++ b/assets/js/blocks/mini-cart/block.tsx
@@ -34,6 +34,7 @@ import QuantityBadge from './quantity-badge';
 import { MiniCartContentsBlock } from './mini-cart-contents/block';
 import './style.scss';
 import { blockName } from './mini-cart-contents/attributes';
+import { useTypographyProps } from '../../hooks/style-attributes';
 
 interface Props {
 	isInitiallyOpen?: boolean;
@@ -44,14 +45,16 @@ interface Props {
 	hasHiddenPrice: boolean;
 }
 
-const MiniCartBlock = ( {
-	isInitiallyOpen = false,
-	colorClassNames,
-	style,
-	contents = '',
-	addToCartBehaviour = 'none',
-	hasHiddenPrice = false,
-}: Props ): JSX.Element => {
+const MiniCartBlock = ( attributes: Props ): JSX.Element => {
+	const {
+		isInitiallyOpen = false,
+		colorClassNames,
+		style,
+		contents = '',
+		addToCartBehaviour = 'none',
+		hasHiddenPrice = false,
+	} = attributes;
+
 	const {
 		cartItemsCount: cartItemsCountFromApi,
 		cartIsLoading,
@@ -201,6 +204,8 @@ const MiniCartBlock = ( {
 		color: style?.color?.text,
 	};
 
+	const typographyProps = useTypographyProps( attributes );
+
 	return (
 		<>
 			<button
@@ -215,7 +220,10 @@ const MiniCartBlock = ( {
 				aria-label={ ariaLabel }
 			>
 				{ ! hasHiddenPrice && (
-					<span className="wc-block-mini-cart__amount">
+					<span
+						className="wc-block-mini-cart__amount"
+						style={ typographyProps.style }
+					>
 						{ formatPrice(
 							subTotal,
 							getCurrencyFromPriceResponse( cartTotals )

--- a/assets/js/blocks/mini-cart/block.tsx
+++ b/assets/js/blocks/mini-cart/block.tsx
@@ -235,10 +235,7 @@ const MiniCartBlock = ( attributes: Props ): JSX.Element => {
 						{ taxLabel }
 					</small>
 				) }
-				<QuantityBadge
-					count={ cartItemsCount }
-					style={ typographyProps.style }
-				/>
+				<QuantityBadge count={ cartItemsCount } />
 			</button>
 			<Drawer
 				className={ classnames(

--- a/assets/js/blocks/mini-cart/block.tsx
+++ b/assets/js/blocks/mini-cart/block.tsx
@@ -235,7 +235,10 @@ const MiniCartBlock = ( attributes: Props ): JSX.Element => {
 						{ taxLabel }
 					</small>
 				) }
-				<QuantityBadge count={ cartItemsCount } />
+				<QuantityBadge
+					count={ cartItemsCount }
+					style={ typographyProps.style }
+				/>
 			</button>
 			<Drawer
 				className={ classnames(

--- a/assets/js/blocks/mini-cart/edit.tsx
+++ b/assets/js/blocks/mini-cart/edit.tsx
@@ -18,6 +18,7 @@ import Noninteractive from '@woocommerce/base-components/noninteractive';
  * Internal dependencies
  */
 import QuantityBadge from './quantity-badge';
+import { useTypographyProps } from '../../hooks/style-attributes';
 
 interface Attributes {
 	addToCartBehaviour: string;
@@ -42,6 +43,8 @@ const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
 
 	const productCount = 0;
 	const productTotal = 0;
+
+	const typographyProps = useTypographyProps( attributes );
 
 	return (
 		<div { ...blockProps }>
@@ -124,7 +127,10 @@ const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
 			<Noninteractive>
 				<button className="wc-block-mini-cart__button">
 					{ ! hasHiddenPrice && (
-						<span className="wc-block-mini-cart__amount">
+						<span
+							className="wc-block-mini-cart__amount"
+							style={ typographyProps.style }
+						>
 							{ formatPrice( productTotal ) }
 						</span>
 					) }

--- a/assets/js/blocks/mini-cart/edit.tsx
+++ b/assets/js/blocks/mini-cart/edit.tsx
@@ -134,10 +134,7 @@ const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
 							{ formatPrice( productTotal ) }
 						</span>
 					) }
-					<QuantityBadge
-						count={ productCount }
-						style={ typographyProps.style }
-					/>
+					<QuantityBadge count={ productCount } />
 				</button>
 			</Noninteractive>
 		</div>

--- a/assets/js/blocks/mini-cart/edit.tsx
+++ b/assets/js/blocks/mini-cart/edit.tsx
@@ -134,7 +134,10 @@ const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
 							{ formatPrice( productTotal ) }
 						</span>
 					) }
-					<QuantityBadge count={ productCount } />
+					<QuantityBadge
+						count={ productCount }
+						style={ typographyProps.style }
+					/>
 				</button>
 			</Noninteractive>
 		</div>

--- a/assets/js/blocks/mini-cart/index.tsx
+++ b/assets/js/blocks/mini-cart/index.tsx
@@ -38,6 +38,8 @@ const settings: BlockConfiguration = {
 			fontSize: true,
 			...( isFeaturePluginBuild() && {
 				__experimentalFontFamily: true,
+				__experimentalFontWeight: true,
+				__experimentalSkipSerialization: true,
 			} ),
 		},
 	},

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -385,7 +385,7 @@ class MiniCart extends AbstractBlock {
 		' . $this->get_include_tax_label_markup() . '
 		<span class="wc-block-mini-cart__quantity-badge">
 			' . $icon . '
-			<span class="wc-block-mini-cart__badge" style="' . esc_attr( $typography_styles ) . '">' . $cart_contents_count . '</span>
+			<span class="wc-block-mini-cart__badge">' . $cart_contents_count . '</span>
 		</span>';
 
 		if ( is_cart() || is_checkout() ) {

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -384,7 +384,7 @@ class MiniCart extends AbstractBlock {
 		' . $this->get_include_tax_label_markup() . '
 		<span class="wc-block-mini-cart__quantity-badge">
 			' . $icon . '
-			<span class="wc-block-mini-cart__badge">' . $cart_contents_count . '</span>
+			<span class="wc-block-mini-cart__badge" style="' . esc_attr( StyleAttributesUtils::get_font_weight_class_and_style( $attributes )['style'] ) . '">' . $cart_contents_count . '</span>
 		</span>';
 
 		if ( is_cart() || is_checkout() ) {

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -303,8 +303,9 @@ class MiniCart extends AbstractBlock {
 		$cart_controller     = $this->get_cart_controller();
 		$cart                = $cart_controller->get_cart_instance();
 		$cart_contents_total = $cart->get_subtotal();
+		$typography_styles   = isset( StyleAttributesUtils::get_font_weight_class_and_style( $attributes )['style'] ) ? StyleAttributesUtils::get_font_weight_class_and_style( $attributes )['style'] : null;
 
-		return '<span class="wc-block-mini-cart__amount" style="' . esc_attr( StyleAttributesUtils::get_font_weight_class_and_style( $attributes )['style'] ) . '">' . esc_html( wp_strip_all_tags( wc_price( $cart_contents_total ) ) ) . '</span>
+		return '<span class="wc-block-mini-cart__amount" style="' . esc_attr( $typography_styles ) . '">' . esc_html( wp_strip_all_tags( wc_price( $cart_contents_total ) ) ) . '</span>
 		' . $this->get_include_tax_label_markup();
 	}
 
@@ -357,9 +358,8 @@ class MiniCart extends AbstractBlock {
 			$cart_contents_total += $cart->get_subtotal_tax();
 		}
 
-		$classes_styles    = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, array( 'text_color', 'background_color', 'font_size', 'font_family' ) );
-		$typography_styles = isset( StyleAttributesUtils::get_font_weight_class_and_style( $attributes )['style'] ) ? StyleAttributesUtils::get_font_weight_class_and_style( $attributes )['style'] : null;
-		$wrapper_classes   = sprintf( 'wc-block-mini-cart wp-block-woocommerce-mini-cart %s', $classes_styles['classes'] );
+		$classes_styles  = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, array( 'text_color', 'background_color', 'font_size', 'font_family' ) );
+		$wrapper_classes = sprintf( 'wc-block-mini-cart wp-block-woocommerce-mini-cart %s', $classes_styles['classes'] );
 		if ( ! empty( $attributes['className'] ) ) {
 			$wrapper_classes .= ' ' . $attributes['className'];
 		}
@@ -381,8 +381,7 @@ class MiniCart extends AbstractBlock {
 			<path fill-rule="evenodd" clip-rule="evenodd" d="M17.3231 18.2769C17.3741 18.2769 17.4154 18.2356 17.4154 18.1846C17.4154 18.1336 17.3741 18.0923 17.3231 18.0923C17.2721 18.0923 17.2308 18.1336 17.2308 18.1846C17.2308 18.2356 17.2721 18.2769 17.3231 18.2769ZM15.5077 18.1846C15.5077 17.182 16.3205 16.3692 17.3231 16.3692C18.3257 16.3692 19.1385 17.182 19.1385 18.1846C19.1385 19.1872 18.3257 20 17.3231 20C16.3205 20 15.5077 19.1872 15.5077 18.1846Z" fill="currentColor"/>
 			<path fill-rule="evenodd" clip-rule="evenodd" d="M20.0631 9.53835L19.4662 12.6685L19.4648 12.6757L19.4648 12.6757C19.3424 13.2919 19.0072 13.8454 18.5178 14.2394C18.031 14.6312 17.4226 14.8404 16.798 14.8308H8.44017C7.81556 14.8404 7.20714 14.6312 6.72038 14.2394C6.2312 13.8456 5.89605 13.2924 5.77352 12.6765L5.77335 12.6757L4.33477 5.48814C4.3286 5.46282 4.32345 5.43711 4.31934 5.41104L3.61815 1.90768H0.953842C0.42705 1.90768 0 1.48063 0 0.953842C0 0.42705 0.42705 0 0.953842 0H4.4C4.85462 0 5.24607 0.320858 5.33529 0.766644L6.04403 4.30769H12.785C13.0114 4.99157 13.3319 5.63258 13.7312 6.21538H6.42585L7.64421 12.3026L7.64449 12.304C7.67966 12.4811 7.77599 12.6402 7.91662 12.7534C8.05725 12.8666 8.23322 12.9267 8.41372 12.9233L8.432 12.9231H16.8062L16.8244 12.9233C17.0049 12.9267 17.1809 12.8666 17.3215 12.7534C17.4614 12.6408 17.5575 12.4828 17.5931 12.3068L17.5937 12.304L18.1649 9.30867C18.762 9.45873 19.387 9.53842 20.0307 9.53842C20.0415 9.53842 20.0523 9.5384 20.0631 9.53835Z" fill="currentColor"/>
 		</svg>';
-		$button_html = '<span class="wc-block-mini-cart__amount" style="' . esc_attr( $typography_styles ) . '">' . esc_html( wp_strip_all_tags( wc_price( $cart_contents_total ) ) ) . '</span>
-		' . $this->get_include_tax_label_markup() . '
+		$button_html = $this->get_cart_price_markup( $attributes ) . '
 		<span class="wc-block-mini-cart__quantity-badge">
 			' . $icon . '
 			<span class="wc-block-mini-cart__badge">' . $cart_contents_count . '</span>

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -357,8 +357,9 @@ class MiniCart extends AbstractBlock {
 			$cart_contents_total += $cart->get_subtotal_tax();
 		}
 
-		$classes_styles  = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, array( 'text_color', 'background_color', 'font_size', 'font_family' ) );
-		$wrapper_classes = sprintf( 'wc-block-mini-cart wp-block-woocommerce-mini-cart %s', $classes_styles['classes'] );
+		$classes_styles    = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, array( 'text_color', 'background_color', 'font_size', 'font_family' ) );
+		$typography_styles = isset( StyleAttributesUtils::get_font_weight_class_and_style( $attributes )['style'] ) ? StyleAttributesUtils::get_font_weight_class_and_style( $attributes )['style'] : null;
+		$wrapper_classes   = sprintf( 'wc-block-mini-cart wp-block-woocommerce-mini-cart %s', $classes_styles['classes'] );
 		if ( ! empty( $attributes['className'] ) ) {
 			$wrapper_classes .= ' ' . $attributes['className'];
 		}
@@ -380,11 +381,11 @@ class MiniCart extends AbstractBlock {
 			<path fill-rule="evenodd" clip-rule="evenodd" d="M17.3231 18.2769C17.3741 18.2769 17.4154 18.2356 17.4154 18.1846C17.4154 18.1336 17.3741 18.0923 17.3231 18.0923C17.2721 18.0923 17.2308 18.1336 17.2308 18.1846C17.2308 18.2356 17.2721 18.2769 17.3231 18.2769ZM15.5077 18.1846C15.5077 17.182 16.3205 16.3692 17.3231 16.3692C18.3257 16.3692 19.1385 17.182 19.1385 18.1846C19.1385 19.1872 18.3257 20 17.3231 20C16.3205 20 15.5077 19.1872 15.5077 18.1846Z" fill="currentColor"/>
 			<path fill-rule="evenodd" clip-rule="evenodd" d="M20.0631 9.53835L19.4662 12.6685L19.4648 12.6757L19.4648 12.6757C19.3424 13.2919 19.0072 13.8454 18.5178 14.2394C18.031 14.6312 17.4226 14.8404 16.798 14.8308H8.44017C7.81556 14.8404 7.20714 14.6312 6.72038 14.2394C6.2312 13.8456 5.89605 13.2924 5.77352 12.6765L5.77335 12.6757L4.33477 5.48814C4.3286 5.46282 4.32345 5.43711 4.31934 5.41104L3.61815 1.90768H0.953842C0.42705 1.90768 0 1.48063 0 0.953842C0 0.42705 0.42705 0 0.953842 0H4.4C4.85462 0 5.24607 0.320858 5.33529 0.766644L6.04403 4.30769H12.785C13.0114 4.99157 13.3319 5.63258 13.7312 6.21538H6.42585L7.64421 12.3026L7.64449 12.304C7.67966 12.4811 7.77599 12.6402 7.91662 12.7534C8.05725 12.8666 8.23322 12.9267 8.41372 12.9233L8.432 12.9231H16.8062L16.8244 12.9233C17.0049 12.9267 17.1809 12.8666 17.3215 12.7534C17.4614 12.6408 17.5575 12.4828 17.5931 12.3068L17.5937 12.304L18.1649 9.30867C18.762 9.45873 19.387 9.53842 20.0307 9.53842C20.0415 9.53842 20.0523 9.5384 20.0631 9.53835Z" fill="currentColor"/>
 		</svg>';
-		$button_html = '<span class="wc-block-mini-cart__amount" style="' . esc_attr( StyleAttributesUtils::get_font_weight_class_and_style( $attributes )['style'] ) . '">' . esc_html( wp_strip_all_tags( wc_price( $cart_contents_total ) ) ) . '</span>
+		$button_html = '<span class="wc-block-mini-cart__amount" style="' . esc_attr( $typography_styles ) . '">' . esc_html( wp_strip_all_tags( wc_price( $cart_contents_total ) ) ) . '</span>
 		' . $this->get_include_tax_label_markup() . '
 		<span class="wc-block-mini-cart__quantity-badge">
 			' . $icon . '
-			<span class="wc-block-mini-cart__badge" style="' . esc_attr( StyleAttributesUtils::get_font_weight_class_and_style( $attributes )['style'] ) . '">' . $cart_contents_count . '</span>
+			<span class="wc-block-mini-cart__badge" style="' . esc_attr( $typography_styles ) . '">' . $cart_contents_count . '</span>
 		</span>';
 
 		if ( is_cart() || is_checkout() ) {

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -304,7 +304,7 @@ class MiniCart extends AbstractBlock {
 		$cart                = $cart_controller->get_cart_instance();
 		$cart_contents_total = $cart->get_subtotal();
 
-		return '<span class="wc-block-mini-cart__amount">' . esc_html( wp_strip_all_tags( wc_price( $cart_contents_total ) ) ) . '</span>
+		return '<span class="wc-block-mini-cart__amount" style="' . esc_attr( StyleAttributesUtils::get_font_weight_class_and_style( $attributes )['style'] ) . '">' . esc_html( wp_strip_all_tags( wc_price( $cart_contents_total ) ) ) . '</span>
 		' . $this->get_include_tax_label_markup();
 	}
 
@@ -380,7 +380,8 @@ class MiniCart extends AbstractBlock {
 			<path fill-rule="evenodd" clip-rule="evenodd" d="M17.3231 18.2769C17.3741 18.2769 17.4154 18.2356 17.4154 18.1846C17.4154 18.1336 17.3741 18.0923 17.3231 18.0923C17.2721 18.0923 17.2308 18.1336 17.2308 18.1846C17.2308 18.2356 17.2721 18.2769 17.3231 18.2769ZM15.5077 18.1846C15.5077 17.182 16.3205 16.3692 17.3231 16.3692C18.3257 16.3692 19.1385 17.182 19.1385 18.1846C19.1385 19.1872 18.3257 20 17.3231 20C16.3205 20 15.5077 19.1872 15.5077 18.1846Z" fill="currentColor"/>
 			<path fill-rule="evenodd" clip-rule="evenodd" d="M20.0631 9.53835L19.4662 12.6685L19.4648 12.6757L19.4648 12.6757C19.3424 13.2919 19.0072 13.8454 18.5178 14.2394C18.031 14.6312 17.4226 14.8404 16.798 14.8308H8.44017C7.81556 14.8404 7.20714 14.6312 6.72038 14.2394C6.2312 13.8456 5.89605 13.2924 5.77352 12.6765L5.77335 12.6757L4.33477 5.48814C4.3286 5.46282 4.32345 5.43711 4.31934 5.41104L3.61815 1.90768H0.953842C0.42705 1.90768 0 1.48063 0 0.953842C0 0.42705 0.42705 0 0.953842 0H4.4C4.85462 0 5.24607 0.320858 5.33529 0.766644L6.04403 4.30769H12.785C13.0114 4.99157 13.3319 5.63258 13.7312 6.21538H6.42585L7.64421 12.3026L7.64449 12.304C7.67966 12.4811 7.77599 12.6402 7.91662 12.7534C8.05725 12.8666 8.23322 12.9267 8.41372 12.9233L8.432 12.9231H16.8062L16.8244 12.9233C17.0049 12.9267 17.1809 12.8666 17.3215 12.7534C17.4614 12.6408 17.5575 12.4828 17.5931 12.3068L17.5937 12.304L18.1649 9.30867C18.762 9.45873 19.387 9.53842 20.0307 9.53842C20.0415 9.53842 20.0523 9.5384 20.0631 9.53835Z" fill="currentColor"/>
 		</svg>';
-		$button_html = $this->get_cart_price_markup( $attributes ) . '
+		$button_html = '<span class="wc-block-mini-cart__amount" style="' . esc_attr( StyleAttributesUtils::get_font_weight_class_and_style( $attributes )['style'] ) . '">' . esc_html( wp_strip_all_tags( wc_price( $cart_contents_total ) ) ) . '</span>
+		' . $this->get_include_tax_label_markup() . '
 		<span class="wc-block-mini-cart__quantity-badge">
 			' . $icon . '
 			<span class="wc-block-mini-cart__badge">' . $cart_contents_count . '</span>

--- a/src/Utils/StyleAttributesUtils.php
+++ b/src/Utils/StyleAttributesUtils.php
@@ -38,6 +38,27 @@ class StyleAttributesUtils {
 	}
 
 	/**
+	 * Get class and style for font-weight from attributes.
+	 *
+	 * @param array $attributes Block attributes.
+	 *
+	 * @return (array | null)
+	 */
+	public static function get_font_weight_class_and_style( $attributes ) {
+
+		$custom_font_weight = $attributes['style']['typography']['fontWeight'] ?? '';
+
+		if ( '' !== $custom_font_weight ) {
+			return array(
+				'class' => null,
+				'style' => sprintf( 'font-weight: %s;', $custom_font_weight ),
+			);
+		}
+		return null;
+	}
+
+
+	/**
 	 * Get class and style for font-family from attributes.
 	 *
 	 * @param array $attributes Block attributes.
@@ -340,6 +361,7 @@ class StyleAttributesUtils {
 			'text_color'       => self::get_text_color_class_and_style( $attributes ),
 			'font_size'        => self::get_font_size_class_and_style( $attributes ),
 			'font_family'      => self::get_font_family_class_and_style( $attributes ),
+			'font_weight'      => self::get_font_weight_class_and_style( $attributes ),
 			'link_color'       => self::get_link_color_class_and_style( $attributes ),
 			'background_color' => self::get_background_color_class_and_style( $attributes ),
 			'border_color'     => self::get_border_color_class_and_style( $attributes ),


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
Adds typography font-weight support to Mini Cart. Previously the rendered output would default to semi-bold (600) but this allows for that weight to be controlled from within the block options in the editor.

<!-- Reference any related issues or PRs here -->

Fixes #6675 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|  ![CleanShot 2022-07-27 at 22 08 03](https://user-images.githubusercontent.com/481776/181405455-31b17d5e-89b2-4b22-a813-9ca06eb028e6.png)    |   ![CleanShot 2022-07-29 at 12 15 15](https://user-images.githubusercontent.com/481776/181801448-e2c15917-e72d-4d2a-bcb9-7f469c6abf7c.png)   |


#### Screen Recordings

Before

https://user-images.githubusercontent.com/481776/181405817-1f53803f-45bf-43a2-bab3-5cf8af16ae0a.mp4

After

https://user-images.githubusercontent.com/481776/181801095-8e88dd5b-17e0-4c1a-8243-4ada0a6e5a61.mp4

### Testing
<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Make sure you have a blocks theme active (like Twenty Twenty-Two).
2. Navigate to **Appearance > Editor (Beta)** and add a Mini Cart block somewhere in your site.
3. In the editor, select the Mini Cart block and, in the block settings, choose Font Weight under the Typography section.
4. Adjust the font weight to something other than the Default.
5. Confirm changes are present in the editor.
6. Save changes and preview the frontend to confirm the changes have persisted.

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental

### Changelog

> Fix: Add font-weight controls to the Mini Cart block text.
