### PR TITLE
Add: editor version check

### DIFF
--- a/assets/js/blocks/product-search/block.js
+++ b/assets/js/blocks/product-search/block.js
@@ -1,0 +1,89 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import classnames from 'classnames';
+import PropTypes from 'prop-types';
+import { HOME_URL } from '@woocommerce/settings';
+
+/**
+ * Internal dependencies
+ */
+import './editor.scss';
+import './style.scss';
+
+/**
+ * Component displaying a product search form.
+ *
+ * @param {Object}  props                        Incoming props for the component.
+ * @param {Object}  props.attributes             Incoming block attributes.
+ * @param {string}  props.attributes.label
+ * @param {string}  props.attributes.placeholder
+ * @param {string}  props.attributes.formId
+ * @param {string}  props.attributes.className
+ * @param {boolean} props.attributes.hasLabel
+ * @param {string}  props.attributes.align
+ */
+const ProductSearchBlock = ( {
+	attributes: { label, placeholder, formId, className, hasLabel, align },
+} ) => {
+	const classes = classnames(
+		'wc-block-product-search',
+		align ? 'align' + align : '',
+		className
+	);
+
+	return (
+		<div className={ classes }>
+			<form role="search" method="get" action={ HOME_URL }>
+				<label
+					htmlFor={ formId }
+					className={
+						hasLabel
+							? 'wc-block-product-search__label'
+							: 'wc-block-product-search__label screen-reader-text'
+					}
+				>
+					{ label }
+				</label>
+				<div className="wc-block-product-search__fields">
+					<input
+						type="search"
+						id={ formId }
+						className="wc-block-product-search__field"
+						placeholder={ placeholder }
+						name="s"
+					/>
+					<input type="hidden" name="post_type" value="product" />
+					<button
+						type="submit"
+						className="wc-block-product-search__button"
+						label={ __( 'Search', 'woo-gutenberg-products-block' ) }
+					>
+						<svg
+							aria-hidden="true"
+							role="img"
+							focusable="false"
+							className="dashicon dashicons-arrow-right-alt2"
+							xmlns="http://www.w3.org/2000/svg"
+							width="20"
+							height="20"
+							viewBox="0 0 20 20"
+						>
+							<path d="M6 15l5-5-5-5 1-2 7 7-7 7z" />
+						</svg>
+					</button>
+				</div>
+			</form>
+		</div>
+	);
+};
+
+ProductSearchBlock.propTypes = {
+	/**
+	 * The attributes for this block.
+	 */
+	attributes: PropTypes.object.isRequired,
+};
+
+export default ProductSearchBlock;

--- a/assets/js/blocks/product-search/edit.js
+++ b/assets/js/blocks/product-search/edit.js
@@ -1,0 +1,160 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import classnames from 'classnames';
+import PropTypes from 'prop-types';
+import { InspectorControls, PlainText } from '@wordpress/block-editor';
+import { PanelBody, ToggleControl, TextControl } from '@wordpress/components';
+import { withInstanceId } from '@wordpress/compose';
+import { useEffect } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import './editor.scss';
+import './style.scss';
+
+/**
+ * Component displaying a product search form.
+ *
+ * @param {Object}            props                        Incoming props for the component.
+ * @param {Object}            props.attributes             Incoming block attributes.
+ * @param {string}            props.attributes.label
+ * @param {string}            props.attributes.placeholder
+ * @param {string}            props.attributes.formId
+ * @param {string}            props.attributes.className
+ * @param {boolean}           props.attributes.hasLabel
+ * @param {string}            props.attributes.align
+ * @param {string}            props.instanceId
+ * @param {function(any):any} props.setAttributes          Setter for block attributes.
+ */
+const Edit = ( {
+	attributes: { label, placeholder, formId, className, hasLabel, align },
+	instanceId,
+	setAttributes,
+} ) => {
+	const classes = classnames(
+		'wc-block-product-search',
+		align ? 'align' + align : '',
+		className
+	);
+
+	useEffect( () => {
+		if ( ! formId ) {
+			setAttributes( {
+				formId: `wc-block-product-search-${ instanceId }`,
+			} );
+		}
+	}, [ formId, setAttributes, instanceId ] );
+
+	return (
+		<>
+			<InspectorControls key="inspector">
+				<PanelBody
+					title={ __( 'Content', 'woo-gutenberg-products-block' ) }
+					initialOpen
+				>
+					<ToggleControl
+						label={ __(
+							'Show search field label',
+							'woo-gutenberg-products-block'
+						) }
+						help={
+							hasLabel
+								? __(
+										'Label is visible.',
+										'woo-gutenberg-products-block'
+								  )
+								: __(
+										'Label is hidden.',
+										'woo-gutenberg-products-block'
+								  )
+						}
+						checked={ hasLabel }
+						onChange={ () =>
+							setAttributes( { hasLabel: ! hasLabel } )
+						}
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<div className={ classes }>
+				{ !! hasLabel && (
+					<>
+						<label
+							className="screen-reader-text"
+							htmlFor="wc-block-product-search__label"
+						>
+							{ __(
+								'Search Label',
+								'woo-gutenberg-products-block'
+							) }
+						</label>
+						<PlainText
+							className="wc-block-product-search__label"
+							id="wc-block-product-search__label"
+							value={ label }
+							onChange={ ( value ) =>
+								setAttributes( { label: value } )
+							}
+						/>
+					</>
+				) }
+				<div className="wc-block-product-search__fields">
+					<TextControl
+						className="wc-block-product-search__field input-control"
+						value={ placeholder }
+						placeholder={ __(
+							'Enter search placeholder text',
+							'woo-gutenberg-products-block'
+						) }
+						onChange={ ( value ) =>
+							setAttributes( { placeholder: value } )
+						}
+					/>
+					<button
+						type="submit"
+						className="wc-block-product-search__button"
+						label={ __( 'Search', 'woo-gutenberg-products-block' ) }
+						onClick={ ( e ) => e.preventDefault() }
+						tabIndex="-1"
+					>
+						<svg
+							aria-hidden="true"
+							role="img"
+							focusable="false"
+							className="dashicon dashicons-arrow-right-alt2"
+							xmlns="http://www.w3.org/2000/svg"
+							width="20"
+							height="20"
+							viewBox="0 0 20 20"
+						>
+							<path d="M6 15l5-5-5-5 1-2 7 7-7 7z" />
+						</svg>
+					</button>
+				</div>
+			</div>
+		</>
+	);
+};
+
+Edit.propTypes = {
+	/**
+	 * The attributes for this block.
+	 */
+	attributes: PropTypes.object.isRequired,
+	/**
+	 * A unique ID for identifying the label for the select dropdown.
+	 */
+	instanceId: PropTypes.number,
+	/**
+	 * Whether it's in the editor or frontend display.
+	 */
+	isEditor: PropTypes.bool,
+	/**
+	 * A callback to update attributes.
+	 */
+	setAttributes: PropTypes.func,
+};
+
+export default withInstanceId( Edit );

--- a/assets/js/blocks/product-search/index.tsx
+++ b/assets/js/blocks/product-search/index.tsx
@@ -8,6 +8,7 @@ import { __ } from '@wordpress/i18n';
 import { Icon, search } from '@wordpress/icons';
 import { getSettingWithCoercion } from '@woocommerce/settings';
 import { isBoolean } from '@woocommerce/types';
+import { Button } from '@wordpress/components';
 import {
 	// @ts-ignore waiting for @types/wordpress__blocks update
 	registerBlockVariation,
@@ -73,7 +74,7 @@ const PRODUCT_SEARCH_ATTRIBUTES = {
 };
 
 /**
- * editor.scss and style.scss are required
+ * editor.scss and styggle.scss are required
  * to gracefully handle old block deprecation
  */
 const DeprecatedBlockEdit = ( { clientId }: { clientId: string } ) => {
@@ -85,17 +86,15 @@ const DeprecatedBlockEdit = ( { clientId }: { clientId: string } ) => {
 			createBlock( 'core/search', PRODUCT_SEARCH_ATTRIBUTES )
 		);
 	};
+	const actions = [
+		<Button key="update" onClick={ updateBlock } variant="primary">
+			Update to Search Block variant
+		</Button>,
+	];
 
 	return (
-		<Warning>
+		<Warning actions={ actions }>
 			Old Product Search block is deprecated.
-			<br />
-			<small>
-				<button onClick={ updateBlock }>
-					Update to Search Block variant
-				</button>
-				.
-			</small>
 		</Warning>
 	);
 };

--- a/assets/js/blocks/product-search/index.tsx
+++ b/assets/js/blocks/product-search/index.tsx
@@ -74,7 +74,7 @@ const PRODUCT_SEARCH_ATTRIBUTES = {
 };
 
 /**
- * editor.scss and styggle.scss are required
+ * editor.scss and style.scss are required
  * to gracefully handle old block deprecation
  */
 const DeprecatedBlockEdit = ( { clientId }: { clientId: string } ) => {
@@ -117,7 +117,7 @@ registerBlockType( 'woocommerce/product-search', {
 	),
 	supports: {
 		align: [ 'wide', 'full' ],
-		inserter: isBlockVariationAvailable ? false : true,
+		inserter: ! isBlockVariationAvailable,
 	},
 	example: {
 		attributes: {

--- a/src/BlockTypes/ProductSearch.php
+++ b/src/BlockTypes/ProductSearch.php
@@ -124,4 +124,40 @@ class ProductSearch extends AbstractBlock {
 			$label_markup . $field_markup
 		);
 	}
+
+	/**
+	 * Extra data passed through from server to client for block.
+	 *
+	 * @param array $attributes  Any attributes that currently are available from the block.
+	 *                           Note, this will be empty in the editor context when the block is
+	 *                           not in the post content on editor load.
+	 */
+	protected function enqueue_data( array $attributes = [] ) {
+		parent::enqueue_data( $attributes );
+
+		$gutenberg_version = '';
+
+		if ( is_plugin_active( 'gutenberg/gutenberg.php' ) ) {
+			if ( defined( 'GUTENBERG_VERSION' ) ) {
+				$gutenberg_version = GUTENBERG_VERSION;
+			}
+			if ( ! $gutenberg_version ) {
+				$gutenberg_data    = get_file_data(
+					WP_PLUGIN_DIR . '/gutenberg/gutenberg.php',
+					array( 'Version' => 'Version' )
+				);
+				$gutenberg_version = $gutenberg_data['Version'];
+			}
+		}
+
+		$this->asset_data_registry->add(
+			'isBlockVariationAvailable',
+			version_compare( get_bloginfo( 'version' ), '6.1', '>=' ) || version_compare( $gutenberg_version, '13.4', '>=' )
+		);
+
+		/**
+		 * Fires after cart block data is registered.
+		 */
+		do_action( 'woocommerce_blocks_cart_enqueue_data' );
+	}
 }

--- a/src/BlockTypes/ProductSearch.php
+++ b/src/BlockTypes/ProductSearch.php
@@ -141,6 +141,7 @@ class ProductSearch extends AbstractBlock {
 			if ( defined( 'GUTENBERG_VERSION' ) ) {
 				$gutenberg_version = GUTENBERG_VERSION;
 			}
+
 			if ( ! $gutenberg_version ) {
 				$gutenberg_data    = get_file_data(
 					WP_PLUGIN_DIR . '/gutenberg/gutenberg.php',
@@ -154,10 +155,5 @@ class ProductSearch extends AbstractBlock {
 			'isBlockVariationAvailable',
 			version_compare( get_bloginfo( 'version' ), '6.1', '>=' ) || version_compare( $gutenberg_version, '13.4', '>=' )
 		);
-
-		/**
-		 * Fires after cart block data is registered.
-		 */
-		do_action( 'woocommerce_blocks_cart_enqueue_data' );
 	}
 }


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Improves #6191

This PR:
- Adds an editor version check to the Product Search block to only register the search variation when using WP ≥ 6.1 or Gutenberg ≥ 13.4.
- Adds the legacy block back:
  - Ensures the legacy block work before users convert it to Core Search variation in the Editor.
  - Even WooCommerce Blocks has L0 support policy, we need to care about backward compatiability if we want to merge https://github.com/woocommerce/woocommerce-blocks/issues/6191 to WC Core, so adding legacy block back is neccessary.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Ensure Gutenberg version is ≥ 13.4 and it is deactivated.
2. With a block theme (2022 for example), add the Product Search block to the header.
3. See the Product Search is the independent block (as it is in `trunk`), not a variation of the Search block. See the block is editable in the editor and working as expected on the front end.
4.  Activate Gutenberg.
5. On the front end, see the block is still working as expected and is still a WC block (notice the classes, search icon).
6. Edit the header, see the Deprecation notice, and a call to action button to upgrade the search block to search variation.
7. Click on the CTA button, see the block is converted to WC variation of the core search block.
8. Save and see the block functions flawlessly on the front end.
9. Edit the header again, try adding the Product Search block, only variation is available in the inserter. The legacy can't be found and inserted from the inserter.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->