### PR TITLE
Add link to ZIP file only ones

### DIFF
--- a/.github/workflows/generate-zip.yml
+++ b/.github/workflows/generate-zip.yml
@@ -57,7 +57,7 @@ jobs:
             ```
             https://wcblocks.wpcomstaging.com/wp-content/uploads/woocommerce-gutenberg-products-block-${{ github.event.pull_request.number }}.zip
             ```
-          allow-repeats: true
+          allow-repeats: false
 
       - name: Delete ZIP file
         run: rm -rf wc-blocks-pr-release__temp

--- a/test.txt
+++ b/test.txt
@@ -1,1 +1,0 @@
-This is a plain text file for testing https://github.com/woocommerce/woocommerce-blocks/pull/6769.

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,1 @@
+This is a plain text file for testing https://github.com/woocommerce/woocommerce-blocks/pull/6769.


### PR DESCRIPTION
In #6661, we added a GitHub Action that generates a ZIP file for each PR. Currently, every time a change gets pushed to the PR, a comment with the ZIP file gets added. This PR aims to only add the link ones.