### PR TITLE
Ensure addresses sync correctly when loading the Checkout Shipping Address Block

### DIFF
--- a/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/block.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/block.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useMemo, useEffect, Fragment } from '@wordpress/element';
+import { useMemo, useEffect, Fragment, useState } from '@wordpress/element';
 import { AddressForm } from '@woocommerce/base-components/cart-checkout';
 import {
 	useCheckoutAddress,
@@ -48,12 +48,28 @@ const Block = ( {
 	const { dispatchCheckoutEvent } = useStoreEvents();
 	const { isEditor } = useEditorContext();
 
+	// This is used to track whether the "Use shipping as billing" checkbox was checked on first load and if we synced
+	// the shipping address to the billing address if it was. This is not used on further toggles of the checkbox.
+	const [ addressesSynced, setAddressesSynced ] = useState( false );
+
 	// Clears data if fields are hidden.
 	useEffect( () => {
 		if ( ! showPhoneField ) {
 			setShippingPhone( '' );
 		}
 	}, [ showPhoneField, setShippingPhone ] );
+
+	// Run this on first render to ensure addresses sync if needed, there is no need to re-run this when toggling the
+	// checkbox.
+	useEffect( () => {
+		if ( addressesSynced ) {
+			return;
+		}
+		if ( useShippingAsBilling ) {
+			setBillingAddress( shippingAddress );
+		}
+		setAddressesSynced( true );
+	}, [ setBillingAddress, shippingAddress, useShippingAsBilling ] );
 
 	const addressFieldsConfig = useMemo( () => {
 		return {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR will add a useEffect in the `checkout-shipping-address-block` which runs on first render only. It checks to see if the `Use shipping as billing` box is checked, and if it is, then set the billing address to the same value as the shipping address.

<!-- Reference any related issues or PRs here -->

Fixes #6389

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Add items to your cart.
2. Go to the Checkout Block
3. Uncheck "use shipping as billing" and fill out different addresses for shipping and billing.
4. Place the order and verify on the order confirmation screen that the addresses were different.
5. Add another item to your cart then go to the Checkout Block. 
6. Leave "use shipping as billing" checked.
7. Place order, check the thank you page, ensure the billing and shipping addresses match.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Ensure using the "Use shipping as billing" checkbox in the Checkout Block correctly syncs the addresses when making the order.
