### PR TITLE
Use the archive-product template to render product attributes pages

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -425,6 +425,11 @@ class BlockTemplatesController {
 			$this->block_template_is_available( 'taxonomy-product_tag' )
 		) {
 			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
+		} elseif ( taxonomy_is_product_attribute( get_query_var( 'taxonomy' ) ) &&
+			! BlockTemplateUtils::theme_has_template( 'archive-product' ) &&
+			$this->block_template_is_available( 'archive-product' )
+		) {
+			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
 		} elseif (
 			( is_post_type_archive( 'product' ) || is_page( wc_get_page_id( 'shop' ) ) ) &&
 			! BlockTemplateUtils::theme_has_template( 'archive-product' ) &&

--- a/src/Domain/Bootstrap.php
+++ b/src/Domain/Bootstrap.php
@@ -22,6 +22,7 @@ use Automattic\WooCommerce\Blocks\Payments\Integrations\Cheque;
 use Automattic\WooCommerce\Blocks\Payments\Integrations\PayPal;
 use Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry;
 use Automattic\WooCommerce\Blocks\Registry\Container;
+use Automattic\WooCommerce\Blocks\Templates\ProductAttributeTemplate;
 use Automattic\WooCommerce\StoreApi\StoreApi;
 use Automattic\WooCommerce\StoreApi\RoutesController;
 use Automattic\WooCommerce\StoreApi\SchemaController;
@@ -116,6 +117,7 @@ class Bootstrap {
 		$this->container->get( BlockTypesController::class );
 		$this->container->get( BlockTemplatesController::class );
 		$this->container->get( ProductSearchResultsTemplate::class );
+		$this->container->get( ProductAttributeTemplate::class );
 		$this->container->get( ClassicTemplatesCompatibility::class );
 		if ( $this->package->feature()->is_feature_plugin_build() ) {
 			$this->container->get( PaymentsApi::class );
@@ -247,6 +249,12 @@ class Bootstrap {
 			ProductSearchResultsTemplate::class,
 			function () {
 				return new ProductSearchResultsTemplate();
+			}
+		);
+		$this->container->register(
+			ProductAttributeTemplate::class,
+			function () {
+				return new ProductAttributeTemplate();
 			}
 		);
 		$this->container->register(

--- a/src/Templates/ProductAttributeTemplate.php
+++ b/src/Templates/ProductAttributeTemplate.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Automattic\WooCommerce\Blocks\Templates;
+
+/**
+ * ProductAttributeTemplate class.
+ *
+ * @internal
+ */
+class ProductAttributeTemplate {
+	const SLUG = 'archive-product';
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->init();
+	}
+
+	/**
+	 * Initialization method.
+	 */
+	protected function init() {
+		add_filter( 'taxonomy_template_hierarchy', array( $this, 'update_taxonomy_template_hierarchy' ), 10, 3 );
+	}
+
+	/**
+	 * Render the Archive Product Template for product attributes.
+	 *
+	 * @param array $templates Templates that match the product attributes taxonomy.
+	 */
+	public function update_taxonomy_template_hierarchy( $templates ) {
+		if ( taxonomy_is_product_attribute( get_query_var( 'taxonomy' ) ) && wc_current_theme_is_fse_theme() ) {
+			array_unshift( $templates, self::SLUG );
+		}
+
+		return $templates;
+	}
+}


### PR DESCRIPTION
This PR adds the ability to render the product attribute page using the `archive-product` template. 

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/6757

### Screenshots

| Before | After |
| ------ | ----- |
| <img width="1338" alt="Screenshot 2022-07-27 at 16 38 51" src="https://user-images.githubusercontent.com/186112/181275852-03346db7-efa1-40bc-9e11-17d5c83fafe8.png"> | ![Screenshot 2022-07-27 at 16 38 41](https://user-images.githubusercontent.com/186112/181275933-3b712c54-1c6f-4578-8a25-659052cde175.png)|

### Testing

1. Make sure you have a blocks theme active (like Twenty Twenty-Two).
2. Navigate to `Products` > `Attributes` and edit an existing one or create a new one.
3. Click the `Enable Archives` option and save, go back.
4. Click `Configure terms` next to your attribute.
5. Hover over one of the terms and click the `View` link of one of the attributes.
6. Check that the page is rendered with a header, a footer, and using a product grid.

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental

### Changelog

> Fix: Render the product attribute archive page using the `archive-product` template. 
