### PR TITLE
Update the `previewCart` property we use to get `hasCalculatedShipping` in  `useShippingData` and fix broken JS tests

### DIFF
--- a/assets/js/atomic/blocks/product-elements/image/test/block.test.js
+++ b/assets/js/atomic/blocks/product-elements/image/test/block.test.js
@@ -10,6 +10,7 @@ import { ProductDataContextProvider } from '@woocommerce/shared-context';
 import { Block } from '../block';
 
 jest.mock( '@woocommerce/block-settings', () => ( {
+	...jest.requireActual( '@woocommerce/block-settings' ),
 	__esModule: true,
 	PLACEHOLDER_IMG_SRC: 'placeholder.jpg',
 } ) );

--- a/assets/js/base/context/hooks/shipping/use-shipping-data.ts
+++ b/assets/js/base/context/hooks/shipping/use-shipping-data.ts
@@ -41,7 +41,7 @@ export const useShippingData = (): ShippingData => {
 				? previewCart.needs_shipping
 				: store.getNeedsShipping(),
 			hasCalculatedShipping: isEditor
-				? previewCart.needs_shipping
+				? previewCart.has_calculated_shipping
 				: store.getHasCalculatedShipping(),
 			isLoadingRates: isEditor ? false : store.isCustomerDataUpdating(),
 		};


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR will fix the broken JS tests. For some reason, I don't know why, my changes in #6753 caused them to break but I didn't notice because I skipped over the failing tests, this is due to broken E2E tests being in every PR, so the red ❌ becomes less noticeable.

I also noticed that I used the wrong property to get the value of `hasCalculatedShipping` when using the preview cart, so I updated that too.

In `assets/js/atomic/blocks/product-elements/image/test/block.test.js` the `@woocommerce/block-settings` module was mocked, but only one property of it was mocked, so any consumer further down the stack would only get that single property. By including `...jest.requireActual( '@woocommerce/block-settings' ),` we ensure the module remains intact, but we can still mock the properties we want.

<!-- Reference any related issues or PRs here -->

Fixes #6780 cc @ockham 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->
### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [ ] E2E tests

1. Ensure unit tests pass

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental

### Changelog

> Skip.
