### PR TITLE
Add comment to prevent PHP linting error in `src/BlockTemplatesController.php`

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -300,6 +300,7 @@ class BlockTemplatesController {
 		foreach ( $template_files as $template_file ) {
 			// Skip the template if it's blockified, and we should only use classic ones.
 			// Until the blockified Product Grid Block is implemented, we need to always skip the blockified templates.
+			// phpcs:ignore Squiz.PHP.CommentedOutCode
 			if ( // $this->package->is_experimental_build() &&
 				// ! BlockTemplateUtils::should_use_blockified_product_grid_templates() &&
 				strpos( $template_file, 'blockified' ) !== false ) {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
In #6682 at https://github.com/woocommerce/woocommerce-blocks/commit/ceb091174311a2700df59011e0d4c55010a82df9 some code was commented out. This causes `Squiz.PHP.CommentedOutCode` to issue a warning when running `npm run lint:php`.

It looks like this code may be reinstated in future, which is why it wasn't removed completely.

This PR will add a comment to prevent that warning.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### Manual testing
Run `npm run lint:php` and ensure no errors appear.

#### User Facing Testing
None required.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Skip.
