### PR TITLE
Add option to hide/show price in Mini Cart block 

### DIFF
--- a/assets/js/blocks/mini-cart/block.tsx
+++ b/assets/js/blocks/mini-cart/block.tsx
@@ -41,6 +41,7 @@ interface Props {
 	style?: Record< string, Record< string, string > >;
 	contents: string;
 	addToCartBehaviour: string;
+	hasHiddenPrice: boolean;
 }
 
 const MiniCartBlock = ( {
@@ -49,6 +50,7 @@ const MiniCartBlock = ( {
 	style,
 	contents = '',
 	addToCartBehaviour = 'none',
+	hasHiddenPrice = false,
 }: Props ): JSX.Element => {
 	const {
 		cartItemsCount: cartItemsCountFromApi,
@@ -212,13 +214,15 @@ const MiniCartBlock = ( {
 				} }
 				aria-label={ ariaLabel }
 			>
-				<span className="wc-block-mini-cart__amount">
-					{ formatPrice(
-						subTotal,
-						getCurrencyFromPriceResponse( cartTotals )
-					) }
-				</span>
-				{ taxLabel !== '' && subTotal !== 0 && (
+				{ hasHiddenPrice && (
+					<span className="wc-block-mini-cart__amount">
+						{ formatPrice(
+							subTotal,
+							getCurrencyFromPriceResponse( cartTotals )
+						) }
+					</span>
+				) }
+				{ taxLabel !== '' && subTotal !== 0 && hasHiddenPrice && (
 					<small className="wc-block-mini-cart__tax-label">
 						{ taxLabel }
 					</small>

--- a/assets/js/blocks/mini-cart/block.tsx
+++ b/assets/js/blocks/mini-cart/block.tsx
@@ -214,7 +214,7 @@ const MiniCartBlock = ( {
 				} }
 				aria-label={ ariaLabel }
 			>
-				{ hasHiddenPrice && (
+				{ ! hasHiddenPrice && (
 					<span className="wc-block-mini-cart__amount">
 						{ formatPrice(
 							subTotal,
@@ -222,7 +222,7 @@ const MiniCartBlock = ( {
 						) }
 					</span>
 				) }
-				{ taxLabel !== '' && subTotal !== 0 && hasHiddenPrice && (
+				{ taxLabel !== '' && subTotal !== 0 && ! hasHiddenPrice && (
 					<small className="wc-block-mini-cart__tax-label">
 						{ taxLabel }
 					</small>

--- a/assets/js/blocks/mini-cart/component-frontend.tsx
+++ b/assets/js/blocks/mini-cart/component-frontend.tsx
@@ -42,7 +42,7 @@ const renderMiniCartFrontend = () => {
 				colorClassNames,
 				style: el.dataset.style ? JSON.parse( el.dataset.style ) : {},
 				addToCartBehaviour: el.dataset.addToCartBehaviour || 'none',
-				hasHiddenPrice: el.dataset.hasHiddenPrice === 'false',
+				hasHiddenPrice: el.dataset.hasHiddenPrice,
 				contents:
 					el.querySelector( '.wc-block-mini-cart__template-part' )
 						?.innerHTML ?? '',

--- a/assets/js/blocks/mini-cart/component-frontend.tsx
+++ b/assets/js/blocks/mini-cart/component-frontend.tsx
@@ -42,6 +42,7 @@ const renderMiniCartFrontend = () => {
 				colorClassNames,
 				style: el.dataset.style ? JSON.parse( el.dataset.style ) : {},
 				addToCartBehaviour: el.dataset.addToCartBehaviour || 'none',
+				hasHiddenPrice: el.dataset.hasHiddenPrice === 'false',
 				contents:
 					el.querySelector( '.wc-block-mini-cart__template-part' )
 						?.innerHTML ?? '',

--- a/assets/js/blocks/mini-cart/edit.tsx
+++ b/assets/js/blocks/mini-cart/edit.tsx
@@ -4,7 +4,12 @@
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import type { ReactElement } from 'react';
 import { formatPrice } from '@woocommerce/price-format';
-import { PanelBody, ExternalLink, SelectControl } from '@wordpress/components';
+import {
+	PanelBody,
+	ExternalLink,
+	SelectControl,
+	ToggleControl,
+} from '@wordpress/components';
 import { getSetting } from '@woocommerce/settings';
 import { __ } from '@wordpress/i18n';
 import Noninteractive from '@woocommerce/base-components/noninteractive';
@@ -16,6 +21,7 @@ import QuantityBadge from './quantity-badge';
 
 interface Attributes {
 	addToCartBehaviour: string;
+	hasVisiblePrice: boolean;
 }
 
 interface Props {
@@ -24,7 +30,7 @@ interface Props {
 }
 
 const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
-	const { addToCartBehaviour } = attributes;
+	const { addToCartBehaviour, hasVisiblePrice } = attributes;
 	const blockProps = useBlockProps( {
 		className: `wc-block-mini-cart`,
 	} );
@@ -76,6 +82,22 @@ const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
 							},
 						] }
 					/>
+					<ToggleControl
+						label={ __(
+							'Cart Price Visibility',
+							'woo-gutenberg-products-block'
+						) }
+						help={ __(
+							'Toggles the visibility of the Mini Cart price.',
+							'woo-gutenberg-products-block'
+						) }
+						checked={ hasVisiblePrice }
+						onChange={ () =>
+							setAttributes( {
+								hasVisiblePrice: ! hasVisiblePrice,
+							} )
+						}
+					/>
 				</PanelBody>
 				{ templatePartEditUri && (
 					<PanelBody
@@ -101,9 +123,11 @@ const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
 			</InspectorControls>
 			<Noninteractive>
 				<button className="wc-block-mini-cart__button">
-					<span className="wc-block-mini-cart__amount">
-						{ formatPrice( productTotal ) }
-					</span>
+					{ hasVisiblePrice && (
+						<span className="wc-block-mini-cart__amount">
+							{ formatPrice( productTotal ) }
+						</span>
+					) }
 					<QuantityBadge count={ productCount } />
 				</button>
 			</Noninteractive>

--- a/assets/js/blocks/mini-cart/edit.tsx
+++ b/assets/js/blocks/mini-cart/edit.tsx
@@ -21,7 +21,7 @@ import QuantityBadge from './quantity-badge';
 
 interface Attributes {
 	addToCartBehaviour: string;
-	hasVisiblePrice: boolean;
+	hasHiddenPrice: boolean;
 }
 
 interface Props {
@@ -30,7 +30,7 @@ interface Props {
 }
 
 const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
-	const { addToCartBehaviour, hasVisiblePrice } = attributes;
+	const { addToCartBehaviour, hasHiddenPrice } = attributes;
 	const blockProps = useBlockProps( {
 		className: `wc-block-mini-cart`,
 	} );
@@ -84,17 +84,17 @@ const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
 					/>
 					<ToggleControl
 						label={ __(
-							'Cart Price Visibility',
+							'Hide Cart Price',
 							'woo-gutenberg-products-block'
 						) }
 						help={ __(
 							'Toggles the visibility of the Mini Cart price.',
 							'woo-gutenberg-products-block'
 						) }
-						checked={ hasVisiblePrice }
+						checked={ hasHiddenPrice }
 						onChange={ () =>
 							setAttributes( {
-								hasVisiblePrice: ! hasVisiblePrice,
+								hasHiddenPrice: ! hasHiddenPrice,
 							} )
 						}
 					/>
@@ -123,7 +123,7 @@ const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
 			</InspectorControls>
 			<Noninteractive>
 				<button className="wc-block-mini-cart__button">
-					{ hasVisiblePrice && (
+					{ ! hasHiddenPrice && (
 						<span className="wc-block-mini-cart__amount">
 							{ formatPrice( productTotal ) }
 						</span>

--- a/assets/js/blocks/mini-cart/index.tsx
+++ b/assets/js/blocks/mini-cart/index.tsx
@@ -56,9 +56,9 @@ const settings: BlockConfiguration = {
 			type: 'string',
 			default: 'none',
 		},
-		hasVisiblePrice: {
+		hasHiddenPrice: {
 			type: 'boolean',
-			default: true,
+			default: false,
 		},
 	},
 

--- a/assets/js/blocks/mini-cart/index.tsx
+++ b/assets/js/blocks/mini-cart/index.tsx
@@ -56,6 +56,10 @@ const settings: BlockConfiguration = {
 			type: 'string',
 			default: 'none',
 		},
+		hasVisiblePrice: {
+			type: 'boolean',
+			default: true,
+		},
 	},
 
 	edit,

--- a/assets/js/blocks/mini-cart/test/block.js
+++ b/assets/js/blocks/mini-cart/test/block.js
@@ -5,6 +5,7 @@ import {
 	act,
 	render,
 	screen,
+	queryByText,
 	waitFor,
 	waitForElementToBeRemoved,
 } from '@testing-library/react';
@@ -122,6 +123,28 @@ describe( 'Testing Mini Cart', () => {
 			expect(
 				screen.getByLabelText( /3 items in cart/i )
 			).toBeInTheDocument()
+		);
+	} );
+
+	it( 'renders cart price if "Hide Cart Price" setting is not enabled', async () => {
+		mockEmptyCart();
+		render( <MiniCartBlock /> );
+		await waitFor( () => expect( fetchMock ).toHaveBeenCalled() );
+
+		await waitFor( () =>
+			expect( screen.getByText( '$0.00' ) ).toBeInTheDocument()
+		);
+	} );
+
+	it( 'does not render cart price if "Hide Cart Price" setting is enabled', async () => {
+		mockEmptyCart();
+		const { container } = render(
+			<MiniCartBlock hasHiddenPrice={ true } />
+		);
+		await waitFor( () => expect( fetchMock ).toHaveBeenCalled() );
+
+		await waitFor( () =>
+			expect( queryByText( container, '$0.00' ) ).not.toBeInTheDocument()
 		);
 	} );
 } );

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -289,6 +289,26 @@ class MiniCart extends AbstractBlock {
 	}
 
 	/**
+	 * Returns the markup for the cart price.
+	 *
+	 * @param array $attributes Block attributes.
+	 *
+	 * @return string
+	 */
+	protected function get_cart_price_markup( $attributes ) {
+		if ( isset( $attributes['hasHiddenPrice'] ) && false !== $attributes['hasHiddenPrice'] ) {
+			return;
+		}
+
+		$cart_controller     = $this->get_cart_controller();
+		$cart                = $cart_controller->get_cart_instance();
+		$cart_contents_total = $cart->get_subtotal();
+
+		return '<span class="wc-block-mini-cart__amount">' . esc_html( wp_strip_all_tags( wc_price( $cart_contents_total ) ) ) . '</span>
+		' . $this->get_include_tax_label_markup();
+	}
+
+	/**
 	 * Returns the markup for render the tax label.
 	 *
 	 * @return string
@@ -360,8 +380,7 @@ class MiniCart extends AbstractBlock {
 			<path fill-rule="evenodd" clip-rule="evenodd" d="M17.3231 18.2769C17.3741 18.2769 17.4154 18.2356 17.4154 18.1846C17.4154 18.1336 17.3741 18.0923 17.3231 18.0923C17.2721 18.0923 17.2308 18.1336 17.2308 18.1846C17.2308 18.2356 17.2721 18.2769 17.3231 18.2769ZM15.5077 18.1846C15.5077 17.182 16.3205 16.3692 17.3231 16.3692C18.3257 16.3692 19.1385 17.182 19.1385 18.1846C19.1385 19.1872 18.3257 20 17.3231 20C16.3205 20 15.5077 19.1872 15.5077 18.1846Z" fill="currentColor"/>
 			<path fill-rule="evenodd" clip-rule="evenodd" d="M20.0631 9.53835L19.4662 12.6685L19.4648 12.6757L19.4648 12.6757C19.3424 13.2919 19.0072 13.8454 18.5178 14.2394C18.031 14.6312 17.4226 14.8404 16.798 14.8308H8.44017C7.81556 14.8404 7.20714 14.6312 6.72038 14.2394C6.2312 13.8456 5.89605 13.2924 5.77352 12.6765L5.77335 12.6757L4.33477 5.48814C4.3286 5.46282 4.32345 5.43711 4.31934 5.41104L3.61815 1.90768H0.953842C0.42705 1.90768 0 1.48063 0 0.953842C0 0.42705 0.42705 0 0.953842 0H4.4C4.85462 0 5.24607 0.320858 5.33529 0.766644L6.04403 4.30769H12.785C13.0114 4.99157 13.3319 5.63258 13.7312 6.21538H6.42585L7.64421 12.3026L7.64449 12.304C7.67966 12.4811 7.77599 12.6402 7.91662 12.7534C8.05725 12.8666 8.23322 12.9267 8.41372 12.9233L8.432 12.9231H16.8062L16.8244 12.9233C17.0049 12.9267 17.1809 12.8666 17.3215 12.7534C17.4614 12.6408 17.5575 12.4828 17.5931 12.3068L17.5937 12.304L18.1649 9.30867C18.762 9.45873 19.387 9.53842 20.0307 9.53842C20.0415 9.53842 20.0523 9.5384 20.0631 9.53835Z" fill="currentColor"/>
 		</svg>';
-		$button_html = '<span class="wc-block-mini-cart__amount">' . esc_html( wp_strip_all_tags( wc_price( $cart_contents_total ) ) ) . '</span>
-		' . $this->get_include_tax_label_markup() . '
+		$button_html = $this->get_cart_price_markup( $attributes ) . '
 		<span class="wc-block-mini-cart__quantity-badge">
 			' . $icon . '
 			<span class="wc-block-mini-cart__badge">' . $cart_contents_count . '</span>


### PR DESCRIPTION
Adds a toggle in the Mini Cart block's sidebar settings to hide/show the block price visibility.

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #6677 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
| ![CleanShot 2022-08-01 at 12 46 14](https://user-images.githubusercontent.com/481776/182202021-dc3eb8b3-0767-48b2-8eb4-91c68c968dc7.png) | ![CleanShot 2022-08-01 at 12 51 00](https://user-images.githubusercontent.com/481776/182202042-4cfd50cc-8e8b-41a6-b72b-509935c77b35.png) |

### Testing

#### Automated Tests
* [x] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Make sure you have a blocks theme active (like Twenty Twenty-Two).
2. Navigate to Appearance > Editor (Beta) and add a Mini Cart block somewhere in your site.
3. In the editor, select the Mini Cart block and, in the block settings sidebar, confirm that there is a "**Hide Cart Price**" toggle present in the **Mini Cart Settings** section.
4. Confirm the toggle behaves as expected - the **on** setting should hide the price in the block and the **off** setting should show it.
5. Save the post in both states and confirm changes are present on the front-end.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Update: Add option to hide/show price in Mini Cart block.
