### PR TITLE
Remove compatibility notice for Mini Cart block

### DIFF
--- a/assets/js/blocks/mini-cart/edit.tsx
+++ b/assets/js/blocks/mini-cart/edit.tsx
@@ -4,7 +4,6 @@
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import type { ReactElement } from 'react';
 import { formatPrice } from '@woocommerce/price-format';
-import { CartCheckoutCompatibilityNotice } from '@woocommerce/editor-components/compatibility-notices';
 import { PanelBody, ExternalLink, SelectControl } from '@wordpress/components';
 import { getSetting } from '@woocommerce/settings';
 import { __ } from '@wordpress/i18n';
@@ -108,7 +107,6 @@ const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
 					<QuantityBadge count={ productCount } />
 				</button>
 			</Noninteractive>
-			<CartCheckoutCompatibilityNotice blockName="mini-cart" />
 		</div>
 	);
 };

--- a/assets/js/editor-components/compatibility-notices/cart-checkout-compatibility-notice.tsx
+++ b/assets/js/editor-components/compatibility-notices/cart-checkout-compatibility-notice.tsx
@@ -14,7 +14,7 @@ import { useCompatibilityNotice } from './use-compatibility-notice';
 import WooImage from './woo-image';
 
 interface CartCheckoutCompatibilityNoticeProps {
-	blockName: 'cart' | 'checkout' | 'mini-cart';
+	blockName: 'cart' | 'checkout';
 }
 
 export function CartCheckoutCompatibilityNotice( {

--- a/tests/e2e/specs/backend/mini-cart.test.js
+++ b/tests/e2e/specs/backend/mini-cart.test.js
@@ -19,7 +19,6 @@ import {
 	goToSiteEditor,
 	useTheme,
 	waitForCanvas,
-	addBlockToFSEArea,
 } from '../../utils.js';
 
 const block = {
@@ -30,8 +29,6 @@ const block = {
 		insertButton: "//button//span[text()='Mini Cart']",
 		insertButtonDisabled:
 			"//button[@aria-disabled]//span[text()='Mini Cart']",
-		compatibilityNoticeTitle:
-			"//h1[contains(text(), 'Compatibility notice')]",
 	},
 };
 
@@ -39,14 +36,6 @@ if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 3 ) {
 	// eslint-disable-next-line jest/no-focused-tests, jest/expect-expect
 	test.only( `skipping ${ block.name } tests`, () => {} );
 }
-
-const removeDismissedCompatibilityNoticesFromLocalStorage = async () => {
-	await page.evaluate( () => {
-		window.localStorage.removeItem(
-			'wc-blocks_dismissed_compatibility_notices'
-		);
-	} );
-};
 
 const addBlockToWidgetsArea = async () => {
 	await closeModalIfExists();
@@ -58,10 +47,6 @@ const addBlockToWidgetsArea = async () => {
 
 describe( `${ block.name } Block`, () => {
 	describe( 'in widget editor', () => {
-		beforeAll( async () => {
-			await removeDismissedCompatibilityNoticesFromLocalStorage();
-		} );
-
 		beforeEach( async () => {
 			await openWidgetEditor();
 		} );
@@ -71,28 +56,6 @@ describe( `${ block.name } Block`, () => {
 			expect( await isBlockInsertedInWidgetsArea( block.slug ) ).toBe(
 				true
 			);
-		} );
-
-		it( 'the compatibility notice appears', async () => {
-			await addBlockToWidgetsArea();
-			const compatibilityNoticeTitle = await page.$x(
-				block.selectors.compatibilityNoticeTitle
-			);
-			expect( compatibilityNoticeTitle.length ).toBe( 1 );
-		} );
-
-		it( "after the compatibility notice is dismissed, it doesn't appear again", async () => {
-			await page.evaluate( () => {
-				window.localStorage.setItem(
-					'wc-blocks_dismissed_compatibility_notices',
-					'["mini-cart"]'
-				);
-			} );
-			await addBlockToWidgetsArea();
-			const compatibilityNoticeTitle = await page.$x(
-				block.selectors.compatibilityNoticeTitle
-			);
-			expect( compatibilityNoticeTitle.length ).toBe( 0 );
 		} );
 
 		it( 'can only be inserted once', async () => {
@@ -113,35 +76,12 @@ describe( `${ block.name } Block`, () => {
 			await goToSiteEditor(
 				process.env.GUTENBERG_EDITOR_CONTEXT || 'core'
 			);
-			await removeDismissedCompatibilityNoticesFromLocalStorage();
 			await waitForCanvas();
 		} );
 
 		it( 'can be inserted in FSE area', async () => {
 			await insertBlock( block.name );
 			await expect( canvas() ).toMatchElement( block.class );
-		} );
-
-		it( 'the compatibility notice appears', async () => {
-			await addBlockToFSEArea( block.name );
-			const compatibilityNoticeTitle = await page.$x(
-				block.selectors.compatibilityNoticeTitle
-			);
-			expect( compatibilityNoticeTitle.length ).toBe( 1 );
-		} );
-
-		it( "after the compatibility notice is dismissed, it doesn't appear again", async () => {
-			await page.evaluate( () => {
-				window.localStorage.setItem(
-					'wc-blocks_dismissed_compatibility_notices',
-					'["mini-cart"]'
-				);
-			} );
-			await addBlockToFSEArea( block.name );
-			const compatibilityNoticeTitle = await page.$x(
-				block.selectors.compatibilityNoticeTitle
-			);
-			expect( compatibilityNoticeTitle.length ).toBe( 0 );
 		} );
 
 		it( 'can only be inserted once', async () => {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #6802

This PR removes the compatibility notice for the Mini Cart block which was added in https://github.com/woocommerce/woocommerce-blocks/pull/4945. `Cart` and `Checkout` blocks are unaffected.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

N/A
<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Clear the local storage.
2. With a block theme, add the Mini Cart block to the header template part.
3. Don't see compatibility notice.
4. Create a new page > Add the Cart block to that page.
5. See the compatibility notice as normal.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

N/A
<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Mini Cart block: Remove the compatibility notice.
