### PR TITLE
Fix proceed to checkout button on Cart

### DIFF
--- a/src/BlockTypes/ProceedToCheckoutBlock.php
+++ b/src/BlockTypes/ProceedToCheckoutBlock.php
@@ -11,4 +11,16 @@ class ProceedToCheckoutBlock extends AbstractInnerBlock {
 	 * @var string
 	 */
 	protected $block_name = 'proceed-to-checkout-block';
+
+
+	/**
+	 * Extra data passed through from server to client for block.
+	 *
+	 * @param array $attributes  Any attributes that currently are available from the block.
+	 *                           Note, this will be empty in the editor context when the block is
+	 *                           not in the post content on editor load.
+	 */
+	protected function enqueue_data( array $attributes = [] ) {
+		$this->asset_data_registry->register_page_id( isset( $attributes['checkoutPageId'] ) ? $attributes['checkoutPageId'] : 0 );
+	}
 }


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

This PR fixes the issue with proceed to checkout button not working because the attribute was not being honored.
<!-- Reference any related issues or PRs here -->

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/6684

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->


### Testing

1. In a new page, insert Cart block.
2. Select Proceed to Checkout block.
3. In the sidebar, change the link to something else.
4. On frontend, add an item to cart, go that newly created cart page, and click the proceed to checkout button.
5. It should take you to your new page. 

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### Changelog

> Fix proceed to checkout button not working for custom links.
