### PR TITLE
E2E: Try improving product list loading state detection and fix Site Editor URL

### DIFF
--- a/assets/js/base/components/product-list/product-list.tsx
+++ b/assets/js/base/components/product-list/product-list.tsx
@@ -238,7 +238,11 @@ const ProductList = ( {
 			) }
 			{ ! hasProducts && ! hasFilters && <NoProducts /> }
 			{ hasProducts && (
-				<ul className={ `${ parentClassName }__products` }>
+				<ul
+					className={ classnames( `${ parentClassName }__products`, {
+						'is-loading-products': productsLoading,
+					} ) }
+				>
 					{ listProducts.map( ( product = {}, i: number ) => (
 						<ProductListItem
 							key={ product.id || i }

--- a/tests/e2e/specs/backend/mini-cart.test.js
+++ b/tests/e2e/specs/backend/mini-cart.test.js
@@ -72,10 +72,7 @@ describe( `${ block.name } Block`, () => {
 		useTheme( 'emptytheme' );
 
 		beforeEach( async () => {
-			// TODO: Update to always use site-editor.php once WordPress 6.0 is released and fix is verified.
-			await goToSiteEditor(
-				process.env.GUTENBERG_EDITOR_CONTEXT || 'core'
-			);
+			await goToSiteEditor();
 			await waitForCanvas();
 		} );
 

--- a/tests/e2e/specs/shopper/filter-products-by-price.test.ts
+++ b/tests/e2e/specs/shopper/filter-products-by-price.test.ts
@@ -71,6 +71,7 @@ describe( `${ block.name } Block`, () => {
 
 			await insertBlock( block.name );
 			await insertBlock( 'All Products' );
+			await insertBlock( 'Active Product Filters' );
 			await publishPost();
 
 			const link = await page.evaluate( () =>
@@ -90,12 +91,18 @@ describe( `${ block.name } Block`, () => {
 			const isRefreshed = jest.fn( () => void 0 );
 			page.on( 'load', isRefreshed );
 			await setMaxPrice();
+			await expect( page ).toMatchElement(
+				'.wc-block-active-filters__title',
+				{
+					text: 'Active filters',
+				}
+			);
 			await waitForAllProductsBlockLoaded();
 
-			await page.waitForSelector( selectors.frontend.productsList );
 			const products = await page.$$( selectors.frontend.productsList );
 
 			expect( isRefreshed ).not.toBeCalled();
+
 			expect( products ).toHaveLength( 1 );
 
 			await expect( page ).toMatch( block.foundProduct );

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -157,46 +157,29 @@ export const isBlockInsertedInWidgetsArea = async ( blockName ) => {
 /**
  * Visits site editor dependening on used WordPress version and how Gutenberg is installed.
  *
- * 1. `themes.php?page=gutenberg-edit-site` this is a legacy editor access used for WP <=5.8.
- * 2. `site-editor.php` is the new way of accessing the editor in WP >=5.9+.
- *
- * @param {'core' | 'gutenberg'}               [editorContext='core']          Whether to go to the Gutenberg URL or the Core one.
  * @param {Object}                             params                          Query parameters to add to the URL.
  * @param {string}                             [params.postId]                 ID of the template if we want to access template editor.
  * @param {'wp_template' | 'wp_template_part'} [params.postType='wp_template'] Type of template.
  */
-export async function goToSiteEditor( editorContext = 'core', params ) {
-	// There is a bug in Gutenberg/WPCore now that makes it impossible to rely on site-editor.php on setups
-	// with locally installed Gutenberg. Details in https://github.com/WordPress/gutenberg/issues/39639.
-	// TODO: Update to always use site-editor.php once WordPress 6.0 is released and fix is verified.
-	// 		 Remove usage of goToSiteEditor and GUTENBERG_EDITOR_CONTEXT from from here and from workflows.
-	let editorPath;
-	const queryParams = { ...params };
-
-	if ( editorContext === 'gutenberg' ) {
-		editorPath = 'themes.php';
-		queryParams.page = 'gutenberg-edit-site';
-	} else {
-		editorPath = 'site-editor.php';
-	}
-
-	return await visitAdminPage( editorPath, addQueryArgs( '', queryParams ) );
+export async function goToSiteEditor( params = {} ) {
+	return await visitAdminPage(
+		'site-editor.php',
+		addQueryArgs( '', params )
+	);
 }
 
 /**
  * Visits the Site Editor template edit view.
  *
  * @param {Object}                             params
- * @param {string}                             params.postId                   ID of the template if we want to access template editor.
- * @param {'core' | 'gutenberg'}               [params.editorContext='core']   Whether to go to the Gutenberg URL or the Core one.
+ * @param {string}                             [params.postId]                 ID of the template if we want to access template editor.
  * @param {'wp_template' | 'wp_template_part'} [params.postType='wp_template'] Type of template.
  */
 export async function goToTemplateEditor( {
 	postId,
 	postType = 'wp_template',
-	editorContext = GUTENBERG_EDITOR_CONTEXT,
 } = {} ) {
-	await goToSiteEditor( editorContext, {
+	await goToSiteEditor( {
 		postType,
 		postId,
 	} );
@@ -209,16 +192,14 @@ export async function goToTemplateEditor( {
  * Visits the Site Editor templates list view.
  *
  * @param {Object}                             params
- * @param {'core' | 'gutenberg'}               [params.editorContext='core']   Whether to go to the Gutenberg URL or the Core one.
  * @param {'wp_template' | 'wp_template_part'} [params.postType='wp_template'] Type of template.
  * @param {'list' | 'actions'}                 [params.waitFor='false']        Wait for list or for actions to be present - tempalte actions can take a moment to load, we can wait for them to be present if needed.
  */
 export async function goToTemplatesList( {
 	postType = 'wp_template',
-	editorContext = GUTENBERG_EDITOR_CONTEXT,
 	waitFor = 'list',
 } = {} ) {
-	await goToSiteEditor( editorContext, { postType } );
+	await goToSiteEditor( { postType } );
 
 	if ( waitFor === 'actions' ) {
 		await page.waitForSelector(

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -64,7 +64,7 @@ const SELECTORS = {
 		savePrompt: '.entities-saved-states__text-prompt',
 	},
 	allProductsBlock: {
-		productsList: '.wc-block-grid__products > li > div:not(.is-loading)',
+		productsList: '.wc-block-grid__products:not(.is-loading-products)',
 	},
 };
 
@@ -456,5 +456,4 @@ export const openBlockEditorSettings = async ( { isFSEEditor = false } ) => {
  */
 export const waitForAllProductsBlockLoaded = async () => {
 	await page.waitForSelector( SELECTORS.allProductsBlock.productsList );
-	await page.waitForTimeout( 5000 );
 };


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #6695

This PR fixes the flaky tests related to products loading detection for the All Products block by introducing a new class `is-loading-products`. Instead of using a timeout, we detect the loading state by watching the newly added class for more reliable and consistent test results.

This PR also fixes the Site Editor URL issue that breaks our E2E tests recently by using only `site-editor.php`. I decided to remove the backward compatibility because we always test against the latest Core/Gutenberg versions.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

N/A.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

Ensure E2E tests pass locally.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact
N/A.
<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

N/A.
