### PR TITLE
Product Query Block POC (Phase 1)

### DIFF
--- a/assets/js/blocks/product-query/constants.ts
+++ b/assets/js/blocks/product-query/constants.ts
@@ -1,0 +1,20 @@
+/**
+ * Internal dependencies
+ */
+import { QueryBlockQuery } from './types';
+
+export const QUERY_DEFAULT_ATTRIBUTES: { query: QueryBlockQuery } = {
+	query: {
+		perPage: 6,
+		pages: 0,
+		offset: 0,
+		postType: 'product',
+		order: 'desc',
+		orderBy: 'date',
+		author: '',
+		search: '',
+		exclude: [],
+		sticky: '',
+		inherit: false,
+	},
+};

--- a/assets/js/blocks/product-query/index.tsx
+++ b/assets/js/blocks/product-query/index.tsx
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import { Block } from '@wordpress/blocks';
+import { addFilter } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import './inspector-controls';
+import './variations/product-query';
+import './variations/products-on-sale';
+
+function registerProductQueryVariationAttributes(
+	props: Block,
+	blockName: string
+) {
+	if ( blockName === 'core/query' ) {
+		// Gracefully handle if settings.attributes is undefined.
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore -- We need this because `attributes` is marked as `readonly`
+		props.attributes = {
+			...props.attributes,
+			__woocommerceVariationProps: {
+				type: 'object',
+			},
+		};
+	}
+	return props;
+}
+
+addFilter(
+	'blocks.registerBlockType',
+	'core/custom-class-name/attribute',
+	registerProductQueryVariationAttributes
+);

--- a/assets/js/blocks/product-query/inspector-controls.tsx
+++ b/assets/js/blocks/product-query/inspector-controls.tsx
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { InspectorControls } from '@wordpress/block-editor';
+import { ToggleControl } from '@wordpress/components';
+import { addFilter } from '@wordpress/hooks';
+import { EditorBlock } from '@woocommerce/types';
+import { ElementType } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { ProductQueryBlock } from './types';
+import { isWooQueryBlockVariation, setCustomQueryAttribute } from './utils';
+
+export const INSPECTOR_CONTROLS = {
+	onSale: ( props: ProductQueryBlock ) => (
+		<ToggleControl
+			label={ __(
+				'Show only products on sale',
+				'woo-gutenberg-products-block'
+			) }
+			checked={
+				props.attributes.__woocommerceVariationProps?.attributes?.query
+					?.onSale || false
+			}
+			onChange={ ( onSale ) => {
+				setCustomQueryAttribute( props, { onSale } );
+			} }
+		/>
+	),
+};
+
+export const withProductQueryControls =
+	< T extends EditorBlock< T > >( BlockEdit: ElementType ) =>
+	( props: ProductQueryBlock ) => {
+		return isWooQueryBlockVariation( props ) ? (
+			<>
+				<BlockEdit { ...props } />
+				<InspectorControls>
+					{ Object.entries( INSPECTOR_CONTROLS ).map(
+						( [ key, Control ] ) =>
+							props.attributes.__woocommerceVariationProps.attributes?.disabledInspectorControls?.includes(
+								key
+							) ? null : (
+								<Control { ...props } />
+							)
+					) }
+				</InspectorControls>
+			</>
+		) : (
+			<BlockEdit { ...props } />
+		);
+	};
+
+addFilter( 'editor.BlockEdit', 'core/query', withProductQueryControls );

--- a/assets/js/blocks/product-query/types.ts
+++ b/assets/js/blocks/product-query/types.ts
@@ -66,7 +66,8 @@ export interface QueryBlockQuery {
 export enum QueryVariation {
 	/** The main, fully customizable, Product Query block */
 	PRODUCT_QUERY = 'product-query',
-	PRODUCTS_ON_SALE = 'query-on-sale',
+	/** Only shows products on sale */
+	PRODUCTS_ON_SALE = 'query-products-on-sale',
 }
 
 export type WooCommerceBlockVariation< T > = EditorBlock< {

--- a/assets/js/blocks/product-query/types.ts
+++ b/assets/js/blocks/product-query/types.ts
@@ -1,0 +1,78 @@
+/**
+ * External dependencies
+ */
+import { BlockInstance } from '@wordpress/blocks';
+import type { EditorBlock } from '@woocommerce/types';
+
+export interface ProductQueryArguments {
+	/**
+	 * Display only products on sale.
+	 *
+	 * Will generate the following `meta_query`:
+	 *
+	 * ```
+	 * array(
+	 *   'relation' => 'OR',
+	 *   array( // Simple products type
+	 *     'key'     => '_sale_price',
+	 *     'value'   => 0,
+	 *     'compare' => '>',
+	 *     'type'    => 'numeric',
+	 *   ),
+	 *   array( // Variable products type
+	 *     'key'     => '_min_variation_sale_price',
+	 *     'value'   => 0,
+	 *     'compare' => '>',
+	 *     'type'    => 'numeric',
+	 *   ),
+	 * )
+	 * ```
+	 */
+	onSale?: boolean;
+}
+
+export type ProductQueryBlock =
+	WooCommerceBlockVariation< ProductQueryAttributes >;
+
+export interface ProductQueryAttributes {
+	/**
+	 * An array of controls to disable in the inspector.
+	 *
+	 * @example  `[ 'stockStatus' ]`  will not render the dropdown for stock status.
+	 */
+	disabledInspectorControls?: string[];
+	/**
+	 * Query attributes that define which products will be fetched.
+	 */
+	query?: ProductQueryArguments;
+}
+
+export interface QueryBlockQuery {
+	author?: string;
+	exclude?: string[];
+	inherit: boolean;
+	offset?: number;
+	order: 'asc' | 'desc';
+	orderBy: 'date' | 'relevance';
+	pages?: number;
+	parents?: number[];
+	perPage?: number;
+	postType: string;
+	search?: string;
+	sticky?: string;
+	taxQuery?: string;
+}
+
+export enum QueryVariation {
+	/** The main, fully customizable, Product Query block */
+	PRODUCT_QUERY = 'product-query',
+	PRODUCTS_ON_SALE = 'query-on-sale',
+}
+
+export type WooCommerceBlockVariation< T > = EditorBlock< {
+	// Disabling naming convention because we are namespacing our
+	// custom attributes inside a core block. Prefixing with underscores
+	// will help signify our intentions.
+	// eslint-disable-next-line @typescript-eslint/naming-convention
+	__woocommerceVariationProps: Partial< BlockInstance< T > >;
+} >;

--- a/assets/js/blocks/product-query/utils.tsx
+++ b/assets/js/blocks/product-query/utils.tsx
@@ -1,0 +1,54 @@
+/**
+ * Internal dependencies
+ */
+import {
+	ProductQueryArguments,
+	ProductQueryBlock,
+	QueryVariation,
+} from './types';
+
+/**
+ * Identifies if a block is a Query block variation from our conventions
+ *
+ * We are extending Gutenberg's core Query block with our variations, and
+ * also adding extra namespaced attributes. If those namespaced attributes
+ * are present, we can be fairly sure it is our own registered variation.
+ */
+export function isWooQueryBlockVariation( block: ProductQueryBlock ) {
+	return (
+		block.name === 'core/query' &&
+		block.attributes.__woocommerceVariationProps &&
+		Object.values( QueryVariation ).includes(
+			block.attributes.__woocommerceVariationProps
+				.name as unknown as QueryVariation
+		)
+	);
+}
+
+/**
+ * Sets the new query arguments of a Product Query block
+ *
+ * Because we add a new set of deeply nested attributes to the query
+ * block, this utility function makes it easier to change just the
+ * options relating to our custom query, while keeping the code
+ * clean.
+ */
+export function setCustomQueryAttribute(
+	block: ProductQueryBlock,
+	attributes: Partial< ProductQueryArguments >
+) {
+	const { __woocommerceVariationProps } = block.attributes;
+
+	block.setAttributes( {
+		__woocommerceVariationProps: {
+			...__woocommerceVariationProps,
+			attributes: {
+				...__woocommerceVariationProps.attributes,
+				query: {
+					...__woocommerceVariationProps.attributes?.query,
+					...attributes,
+				},
+			},
+		},
+	} );
+}

--- a/assets/js/blocks/product-query/variations/product-query.tsx
+++ b/assets/js/blocks/product-query/variations/product-query.tsx
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import { isExperimentalBuild } from '@woocommerce/block-settings';
+import { registerBlockVariation } from '@wordpress/blocks';
+import { Icon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { sparkles } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import { QUERY_DEFAULT_ATTRIBUTES } from '../constants';
+
+if ( isExperimentalBuild() ) {
+	registerBlockVariation( 'core/query', {
+		name: 'woocommerce/product-query',
+		title: __( 'Product Query', 'woo-gutenberg-products-block' ),
+		isActive: ( attributes ) => {
+			return (
+				attributes?.__woocommerceVariationProps?.name ===
+				'product-query'
+			);
+		},
+		icon: {
+			src: (
+				<Icon
+					icon={ sparkles }
+					className="wc-block-editor-components-block-icon wc-block-editor-components-block-icon--sparkles"
+				/>
+			),
+		},
+		attributes: {
+			...QUERY_DEFAULT_ATTRIBUTES,
+			__woocommerceVariationProps: {
+				name: 'product-query',
+			},
+		},
+		innerBlocks: [
+			[
+				'core/post-template',
+				{},
+				[ [ 'core/post-title' ], [ 'core/post-featured-image' ] ],
+			],
+			[ 'core/query-pagination' ],
+			[ 'core/query-no-results' ],
+		],
+		scope: [ 'block', 'inserter' ],
+	} );
+}

--- a/assets/js/blocks/product-query/variations/products-on-sale.tsx
+++ b/assets/js/blocks/product-query/variations/products-on-sale.tsx
@@ -1,0 +1,53 @@
+/**
+ * External dependencies
+ */
+import { isExperimentalBuild } from '@woocommerce/block-settings';
+import { registerBlockVariation } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
+import { Icon, percent } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import { QUERY_DEFAULT_ATTRIBUTES } from '../constants';
+
+if ( isExperimentalBuild() ) {
+	registerBlockVariation( 'core/query', {
+		name: 'woocommerce/query-products-on-sale',
+		title: __( 'Products on Sale', 'woo-gutenberg-products-block' ),
+		isActive: ( blockAttributes ) =>
+			blockAttributes?.__woocommerceVariationProps?.name ===
+				'query-products-on-sale' ||
+			blockAttributes?.__woocommerceVariationProps?.query?.onSale ===
+				true,
+		icon: {
+			src: (
+				<Icon
+					icon={ percent }
+					className="wc-block-editor-components-block-icon wc-block-editor-components-block-icon--percent"
+				/>
+			),
+		},
+		attributes: {
+			...QUERY_DEFAULT_ATTRIBUTES,
+			__woocommerceVariationProps: {
+				name: 'query-products-on-sale',
+				attributes: {
+					query: {
+						onSale: true,
+					},
+				},
+			},
+		},
+		innerBlocks: [
+			[
+				'core/post-template',
+				{},
+				[ [ 'core/post-title' ], [ 'core/post-featured-image' ] ],
+			],
+			[ 'core/query-pagination' ],
+			[ 'core/query-no-results' ],
+		],
+		scope: [ 'block', 'inserter' ],
+	} );
+}

--- a/assets/js/types/type-defs/blocks.ts
+++ b/assets/js/types/type-defs/blocks.ts
@@ -1,7 +1,10 @@
 /**
  * External dependencies
  */
+import type { BlockEditProps, BlockInstance } from '@wordpress/blocks';
 import { LazyExoticComponent } from 'react';
+
+export type EditorBlock< T > = BlockInstance< T > & BlockEditProps< T >;
 
 export type RegisteredBlockComponent =
 	| LazyExoticComponent< React.ComponentType< unknown > >

--- a/bin/webpack-configs.js
+++ b/bin/webpack-configs.js
@@ -261,7 +261,7 @@ const getMainConfig = ( options = {} ) => {
 			new CopyWebpackPlugin( {
 				patterns: [
 					{
-						from: './assets/js/blocks/**/block.json',
+						from: './assets/js/**/block.json',
 						to( { absoluteFilename } ) {
 							/**
 							 * Getting the block name from the JSON metadata is less error prone

--- a/bin/webpack-entries.js
+++ b/bin/webpack-entries.js
@@ -57,6 +57,9 @@ const blocks = {
 	'legacy-template': {
 		customDir: 'classic-template',
 	},
+	'product-query': {
+		isExperimental: true,
+	},
 };
 
 // Returns the entries for each block given a relative path (ie: `index.js`,

--- a/src/BlockTypes/ProductQuery.php
+++ b/src/BlockTypes/ProductQuery.php
@@ -1,0 +1,111 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\BlockTypes;
+
+/**
+ * ProductQuery class.
+ */
+class ProductQuery extends AbstractBlock {
+	/**
+	 * Block name.
+	 *
+	 * @var string
+	 */
+	protected $block_name = 'product-query';
+
+	/**
+	 * Initialize this block type.
+	 *
+	 * - Hook into WP lifecycle.
+	 * - Register the block with WordPress.
+	 * - Hook into pre_render_block to update the query.
+	 */
+	protected function initialize() {
+		parent::initialize();
+		add_filter(
+			'pre_render_block',
+			array( $this, 'update_query' ),
+			10,
+			2
+		);
+
+	}
+
+	/**
+	 * Update the query for the product query block.
+	 *
+	 * @param string|null $pre_render   The pre-rendered content. Default null.
+	 * @param array       $parsed_block The block being rendered.
+	 */
+	public function update_query( $pre_render, $parsed_block ) {
+
+		if ( 'core/query' !== $parsed_block['blockName'] ) {
+			return;
+		}
+
+		add_filter(
+			'gutenberg_build_query_vars_from_query_block',
+			function( $query, $block, $page ) use ( $parsed_block ) {
+				return $this->get_query_by_attributes( $query, $parsed_block );
+			},
+			10,
+			3
+		);
+	}
+
+	/**
+	 * Return a custom query based on the attributes.
+	 *
+	 * @param WP_Query $query         The WordPress Query.
+	 * @param WP_Block $parsed_block  The block being rendered.
+	 * @return array
+	 */
+	public function get_query_by_attributes( $query, $parsed_block ) {
+		if ( ! isset( $parsed_block['attrs']['__woocommerceVariationProps'] ) ) {
+			return $query;
+		}
+
+		$variation_props     = $parsed_block['attrs']['__woocommerceVariationProps'];
+		$common_query_values = array(
+			'post_type'      => 'product',
+			'post_status'    => 'publish',
+			'posts_per_page' => $query['posts_per_page'],
+			'orderby'        => $query['orderby'],
+			'order'          => $query['order'],
+		);
+		$on_sale_query       = $this->get_on_sale_products_query( $variation_props );
+
+		return array_merge( $query, $common_query_values, $on_sale_query );
+	}
+
+	/**
+	 * Return a query for on sale products.
+	 *
+	 * @param array $variation_props Dedicated attributes for the variation.
+	 * @return array
+	 */
+	private function get_on_sale_products_query( $variation_props ) {
+		if ( ! isset( $variation_props['attributes']['query']['onSale'] ) || true !== $variation_props['attributes']['query']['onSale'] ) {
+			return array();
+		}
+
+		return array(
+			// Ignoring the warning of not using meta queries.
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+			'meta_query' => array(
+				'relation' => 'OR',
+				array(
+					'key'     => '_sale_price',
+					'value'   => 0,
+					'compare' => '>',
+					'type'    => 'numeric',
+				),
+				array(
+					'key'     => '_min_variation_sale_price',
+					'value'   => 0,
+					'compare' => '>',
+					'type'    => 'numeric',
+				),
+			),
+		);
+	}
+}

--- a/src/BlockTypes/ProductQuery.php
+++ b/src/BlockTypes/ProductQuery.php
@@ -37,14 +37,13 @@ class ProductQuery extends AbstractBlock {
 	 * @param array       $parsed_block The block being rendered.
 	 */
 	public function update_query( $pre_render, $parsed_block ) {
-
 		if ( 'core/query' !== $parsed_block['blockName'] ) {
 			return;
 		}
 
 		add_filter(
 			'gutenberg_build_query_vars_from_query_block',
-			function( $query, $block, $page ) use ( $parsed_block ) {
+			function( $query ) use ( $parsed_block ) {
 				return $this->get_query_by_attributes( $query, $parsed_block );
 			},
 			10,

--- a/src/BlockTypesController.php
+++ b/src/BlockTypesController.php
@@ -198,6 +198,7 @@ final class BlockTypesController {
 			'ProductTitle',
 			'MiniCart',
 			'MiniCartContents',
+			'ProductQuery',
 		];
 
 		$block_types = array_merge( $block_types, Cart::get_cart_block_types(), Checkout::get_checkout_block_types() );


### PR DESCRIPTION
> **Note**
> This PR implements Phase 1 of the Product Query block as described [here](https://woofse.wordpress.com/2022/07/18/pt-poc-of-the-product-grid-block/#comment-1145).

The Product Query block is supposed to be the basis for all future blocks that will allow the merchants to select which products to show and how they are going to look. The block is based on creating a variation of the Gutenberg provided Query Loop block, and will have several WooCommerce-specific options.

Phase 1 is the first proof of concept, under an experimental flag, and will only be available within the experimental builds of the repo.

This PR introduces 3 main changes:

1. On the Editor side, merchants will be able to select the Product Query directly from the inserter (icon TBD). This block is a variation of the Query Loop block and shows all the settings from that one, alongside the default inner blocks of title and image, which will work out of the box with WooCommerce. This block will furthermore show an additional setting to “Show only products on sale” to demonstrate a proof of concept of how adding settings on the sidebar will be possible.
2. Still on the Editor side, another variation called “Products on Sale” will demonstrate how such settings can, not only be enabled by default on certain variations, but also be completely disabled and hidden from the users, as to create more specific and targeted blocks, which will require less effort from the users.
3. On the front-end side, the block is fully SSR'ed and has support for custom, WooCommerce related, queries by hooking into a filter that we hope to merge into Gutenberg core as soon as possible. **In order to use the changes on this PR, you will  need to have a [custom fork of Gutenberg](https://github.com/sunyatasattva/gutenberg/tree/add/build-query-vars-from-query-block-filter) installed**.

In order to achieve all of these three things, we had to extend the attributes that can be passed to the Query Loop block with our own. The way we decided to design this new API is the following:

1. We want to make sure those new attributes do not conflict with anything present and future, so we went ahead and namespaced everything under a double-underscore prefixed property name (`__woocommerceVariationProps`).
2. We named it in such a way that this is not going to be limited to only this specific use-case, but that can be the way we extend all block variations from core in the future.
3. We wanted to keep the API consistent with existing blocks and also predictable. So we decided that `__woocommerceVariationProps` will have the shape of any other `BlockInstance`, except for the fact that all the props are optional. This allows to have things such as names, version, supports and other things that might be useful in the future (for now, we mostly use the `name`, as variations can't otherwise have names that are readable at runtime to check if a variation itself is active). Inside of it, we have an `attributes` object which will contain any further custom attributes that we might add in the future, making it very flexible. All of this is fully typed, to make sure we make our interfaces clear.

https://user-images.githubusercontent.com/4463174/184930002-6aa83e51-226e-40ed-af5b-aaddd1c4fb57.mp4

### Testing

> **Warning**
> In order to use the changes on this PR, you will need to have a [custom fork of Gutenberg](https://github.com/sunyatasattva/gutenberg/tree/add/build-query-vars-from-query-block-filter) installed.

1. Create a post/page and add the `Product Query` block.
5. Save it. On the front-end be sure that the products are rendered correctly.
6. Edit the same post/page and enable the setting `Show only products on sale`. 
7. On the front-end be sure that only the on-sale products are rendered correctly.
8. Create another post/page and add the `Products on sale` block. 
9. Save it. On the front end be sure that only the on-sale products are rendered correctly.

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental


### Changelog

> Product Query block: added a first experimental proof of concept of a Product Query block.