### PR TITLE
Ensure package names display correctly if only one item is in package

### DIFF
--- a/assets/js/base/components/cart-checkout/shipping-rates-control/index.tsx
+++ b/assets/js/base/components/cart-checkout/shipping-rates-control/index.tsx
@@ -63,8 +63,8 @@ const Packages = ( {
 					key={ packageId }
 					packageId={ packageId }
 					packageData={ packageData }
-					collapsible={ collapsible }
-					collapse={ collapse }
+					collapsible={ !! collapsible }
+					collapse={ !! collapse }
 					showItems={
 						showItems || packageData?.shipping_rates?.length >= 1
 					}

--- a/assets/js/base/components/cart-checkout/shipping-rates-control/index.tsx
+++ b/assets/js/base/components/cart-checkout/shipping-rates-control/index.tsx
@@ -66,7 +66,7 @@ const Packages = ( {
 					collapsible={ collapsible }
 					collapse={ collapse }
 					showItems={
-						showItems || packageData?.shipping_rates?.length > 1
+						showItems || packageData?.shipping_rates?.length >= 1
 					}
 					noResultsMessage={ noResultsMessage }
 					renderOption={ renderOption }

--- a/assets/js/base/components/cart-checkout/shipping-rates-control/index.tsx
+++ b/assets/js/base/components/cart-checkout/shipping-rates-control/index.tsx
@@ -66,7 +66,7 @@ const Packages = ( {
 					collapsible={ !! collapsible }
 					collapse={ !! collapse }
 					showItems={
-						showItems || packageData?.shipping_rates?.length >= 1
+						showItems || packageData?.shipping_rates?.length > 1
 					}
 					noResultsMessage={ noResultsMessage }
 					renderOption={ renderOption }
@@ -167,6 +167,7 @@ const ShippingRatesControl = ( {
 			ShippingRatesControlPackage,
 		},
 		context,
+		shippingRates,
 	};
 	const { isEditor } = useEditorContext();
 
@@ -192,6 +193,7 @@ const ShippingRatesControl = ( {
 					/>
 					<ExperimentalOrderShippingPackages>
 						<Packages
+							showItems={ shippingRates.length > 1 }
 							packages={ shippingRates }
 							noResultsMessage={ noResultsMessage }
 							renderOption={ renderOption }

--- a/packages/checkout/components/order-shipping-packages/index.js
+++ b/packages/checkout/components/order-shipping-packages/index.js
@@ -23,9 +23,10 @@ const Slot = ( {
 	cart,
 	components,
 	context,
+	shippingRates,
 } ) => {
 	const { fills } = useSlot( slotName );
-	const hasMultiplePackages = fills.length > 1;
+	const hasMultiplePackages = fills.length > 1 || shippingRates?.length > 1;
 	return (
 		<OrderShippingPackagesSlot
 			className={ classnames(


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR makes some changes to the way package names are displayed.

There is a Slot/Fill that renders the shipping packages on Cart and Checkout which needs to correctly display items/rates when there are multiple packages.

The component used to display these packages is different if there is something filling the slot or not.

This PR will ensure the `showItems` value gets correctly set in the Slot and in the standalone `Packages` component.
<!-- Reference any related issues or PRs here -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/5656702/182359838-35b75832-e58c-42e0-806b-3cf308a6e904.png) | <img width="533" alt="image" src="https://user-images.githubusercontent.com/5656702/182359958-d951f905-1679-4d25-bb2c-4fde70a1a878.png"> |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Install the ["Multiple Packages for WooCommerce" plugin](https://wordpress.org/plugins/multiple-packages-for-woocommerce/)
2. Navigate to WooCommerce -> Settings -> Multiple Packages
3. Adjust the settings to work based on "Per Product"
4. Add two/three/four different products to the cart and typically need shipping.
5. Ensure your shipping zone only has ONE valid shipping method.
6. Go the checkout page and look at the shipping options, ensure there is a title for each one and the items in each package are listed.
7. Disable the plugin and reload the Checkout Block, ensure the shipping section still looks OK.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental

### Changelog

> Skipping as there is a changelog in place already.
