### PR TITLE
Update Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,9 @@ updates:
           interval: 'monthly'
       open-pull-requests-limit: 10
       labels:
-      - "skip-changelog"
+        - "skip-changelog"
+        - "type: dependencies"
+        - "github_actions"
 
       # Maintain dependencies for npm
     - package-ecosystem: 'npm'
@@ -17,7 +19,9 @@ updates:
           interval: 'weekly'
       open-pull-requests-limit: 10
       labels:
-      - "skip-changelog"
+        - "skip-changelog"
+        - "type: dependencies"
+        - "javascript"
 
       # Maintain dependencies for Composer
     - package-ecosystem: 'composer'
@@ -26,4 +30,6 @@ updates:
           interval: 'weekly'
       open-pull-requests-limit: 10
       labels:
-      - "skip-changelog"
+        - "skip-changelog"
+        - "type: dependencies"
+        - "php"


### PR DESCRIPTION
Follow-up of #6836. If added, the labels option override the default configuration, so I added more labels.

