### PR TITLE
Fix `markdownlint` violation

### DIFF
--- a/docs/internal-developers/testing/releases/821.md
+++ b/docs/internal-developers/testing/releases/821.md
@@ -8,7 +8,7 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 
 1.  Install Stripe, set it up so you can use it at Checkout.
 2. Add items to your cart and go to checkout. Add a credit/debit card via stripe and choose `Save payment information to my account for future purchases.`
-3. Check out. Repeat step 2 once more with a different card number. **Ensure the new card you use ends in four different numbers than the first one!** You can see test cards here: https://stripe.com/docs/testing
+3. Check out. Repeat step 2 once more with a different card number. **Ensure the new card you use ends in four different numbers than the first one!** You can see test cards here: <https://stripe.com/docs/testing>
 4. Add items to your cart and go to checkout a third time. This time ensure you can switch between saved cards.
    <img width="662" alt="image" src="https://user-images.githubusercontent.com/5656702/182586601-d0cd308f-b8fa-45f3-9ce6-1b2f142d13c3.png">
 5. Check out successfully, and then go to the back end of your site. Go to the orders you made (WooCommerce -> Orders) and for each order check the payment method used (you'll need to follow this through to Stripe), and ensure the card number used matches the one you chose in the Checkout block. (Click the link on the order page)


### PR DESCRIPTION
The testing instructions for release 8.2.1 have a `markdownlint` violation. This PR fixes the violation.

## Testing

### Manual testing
1. Be sure that the CI job `JavaScript, CSS and Markdown Linting ` doesn't return any error.

