### PR TITLE
Fix: Attribute filter flaky test

### DIFF
--- a/tests/e2e/specs/shopper/filter-products-by-attribute.test.ts
+++ b/tests/e2e/specs/shopper/filter-products-by-attribute.test.ts
@@ -121,12 +121,15 @@ describe( `${ block.name } Block`, () => {
 			);
 			await canvasEl.click( selectors.editor.doneButton );
 			await saveTemplate();
-			await goToShopPage();
 		} );
 
 		afterAll( async () => {
 			await deleteAllTemplates( 'wp_template' );
 			await deleteAllTemplates( 'wp_template_part' );
+		} );
+
+		beforeEach( async () => {
+			await goToShopPage();
 		} );
 
 		it( 'should render', async () => {

--- a/tests/e2e/specs/shopper/filter-products-by-attribute.test.ts
+++ b/tests/e2e/specs/shopper/filter-products-by-attribute.test.ts
@@ -87,6 +87,8 @@ describe( `${ block.name } Block`, () => {
 		it( 'should show only products that match the filter', async () => {
 			const isRefreshed = jest.fn( () => void 0 );
 			page.on( 'load', isRefreshed );
+
+			await page.waitForSelector( selectors.frontend.filter );
 			await page.click( selectors.frontend.filter );
 			await waitForAllProductsBlockLoaded();
 			const products = await page.$$( selectors.frontend.productsList );
@@ -144,6 +146,8 @@ describe( `${ block.name } Block`, () => {
 			} );
 
 			expect( isRefreshed ).not.toBeCalled();
+
+			await page.waitForSelector( selectors.frontend.filter );
 
 			await Promise.all( [
 				page.waitForNavigation(),


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes woocommerce/woocommerce#42613

This PR fixes the flaky test that happens to the attribute filter E2E test by:
- Navigating to the shop page for each test under the PHP template test section.
- Wait for the filter attribute input before clicking on it.

The flaky test case has been tested 100 times [here](https://github.com/dinhtungdu/woocommerce-blocks/actions/runs/2804671917) to verify this fix.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

N/A.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests

#### User Facing Testing

N/A.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact
N/A.
<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

N/A.
