### PR TITLE
Refactor Product Categories block to use block.json

### DIFF
--- a/assets/js/blocks/product-categories/block.json
+++ b/assets/js/blocks/product-categories/block.json
@@ -1,0 +1,41 @@
+{
+  "name": "woocommerce/product-categories",
+  "title": "Product Categories List",
+  "category": "woocommerce",
+  "description": "Show all product categories as a list or dropdown.",
+  "keywords": [ "WooCommerce" ],
+  "attributes": {
+    "align": {
+      "type": "string"
+    },
+    "hasCount": {
+      "type": "boolean",
+      "default": true
+    },
+    "hasImage": {
+      "type": "boolean",
+      "default": false
+    },
+    "hasEmpty": {
+      "type": "boolean",
+      "default": false
+    },
+    "isDropdown": {
+      "type": "boolean",
+      "default": false
+    },
+    "isHierarchical": {
+      "type": "boolean",
+      "default": true
+    }
+  },
+  "example": {
+    "attributes": {
+      "hasCount": true,
+      "hasImage": false
+    }
+  },
+  "textdomain": "woo-gutenberg-products-block",
+  "apiVersion": 2,
+  "$schema": "https://schemas.wp.org/trunk/block.json"
+}

--- a/assets/js/blocks/product-categories/edit.tsx
+++ b/assets/js/blocks/product-categories/edit.tsx
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+import { useBlockProps } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import Block from './block';
+import './editor.scss';
+
+export const Edit = ( props: unknown ): JSX.Element => {
+	const blockProps = useBlockProps();
+
+	return (
+		<div { ...blockProps }>
+			<Block { ...props } />
+		</div>
+	);
+};

--- a/assets/js/blocks/product-categories/index.tsx
+++ b/assets/js/blocks/product-categories/index.tsx
@@ -1,21 +1,19 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { createBlock, registerBlockType } from '@wordpress/blocks';
 import { Icon, listView } from '@wordpress/icons';
-
 import { isFeaturePluginBuild } from '@woocommerce/block-settings';
+
 /**
  * Internal dependencies
  */
 import './editor.scss';
+import metadata from './block.json';
 import './style.scss';
-import Block from './block.js';
+import { Edit } from './edit';
 
-registerBlockType( 'woocommerce/product-categories', {
-	apiVersion: 2,
-	title: __( 'Product Categories List', 'woo-gutenberg-products-block' ),
+registerBlockType( metadata, {
 	icon: {
 		src: (
 			<Icon
@@ -24,12 +22,6 @@ registerBlockType( 'woocommerce/product-categories', {
 			/>
 		),
 	},
-	category: 'woocommerce',
-	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
-	description: __(
-		'Show all product categories as a list or dropdown.',
-		'woo-gutenberg-products-block'
-	),
 	supports: {
 		align: [ 'wide', 'full' ],
 		html: false,
@@ -43,60 +35,6 @@ registerBlockType( 'woocommerce/product-categories', {
 				lineHeight: true,
 			},
 		} ),
-	},
-	example: {
-		attributes: {
-			hasCount: true,
-			hasImage: false,
-		},
-	},
-	attributes: {
-		/**
-		 * Alignment of the block.
-		 */
-		align: {
-			type: 'string',
-		},
-
-		/**
-		 * Whether to show the product count in each category.
-		 */
-		hasCount: {
-			type: 'boolean',
-			default: true,
-		},
-
-		/**
-		 * Whether to show the category image in each category.
-		 */
-		hasImage: {
-			type: 'boolean',
-			default: false,
-		},
-
-		/**
-		 * Whether to show empty categories in the list.
-		 */
-		hasEmpty: {
-			type: 'boolean',
-			default: false,
-		},
-
-		/**
-		 * Whether to display product categories as a dropdown (true) or list (false).
-		 */
-		isDropdown: {
-			type: 'boolean',
-			default: false,
-		},
-
-		/**
-		 * Whether the product categories should display with hierarchy.
-		 */
-		isHierarchical: {
-			type: 'boolean',
-			default: true,
-		},
 	},
 
 	transforms: {
@@ -197,14 +135,7 @@ registerBlockType( 'woocommerce/product-categories', {
 		},
 	],
 
-	/**
-	 * Renders and manages the block.
-	 *
-	 * @param {Object} props Props to pass to block.
-	 */
-	edit( props ) {
-		return <Block { ...props } />;
-	},
+	edit: Edit,
 
 	/**
 	 * Save nothing; rendered by server.


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

I refactor the block to use `block.json` schema. The block schema internally extends the main `block.json` schema, and it fixes an issue that occurs on WPCOM.

<!-- Reference any related issues or PRs here -->

Fixes https://github.com/Automattic/wp-calypso/issues/62337

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

##### WooCommerce Blocks

1. Add Product Categories List block as a widget (Appearance → Widgets)
2. Open block settings
3. Test block controls, save, and review if it still renders correctly in the frontend

##### WPCOM

1. Add Product Categories List block as a widget (Appearance → Widgets)
2. Open block settings
3. Open Advanced and click on "Add new rule" under Visibility

Users should be able to add new visibility rules, with a real-time preview of the block

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Refactor Product Categories block to use block.json
