### PR TITLE
Fix broken contributing links

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thanks for your interest in contributing to WooCommerce Blocks!
 
-If you wish to contribute code, to get started we recommend first reading our [Getting Started Guide](../docs/contributors/getting-started.md).
+If you wish to contribute code, to get started we recommend first reading our [Getting Started Guide](../docs/contributors/contributing/getting-started.md).
 
 All other documentation for contributors can be found [in the docs directory](../docs/README.md).
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Run through the ["Writing Your First Block Type" tutorial](https://wordpress.org
 
 For deeper dive, try looking at the [core blocks code,](https://github.com/WordPress/gutenberg/tree/master/packages/block-library/src) or see what [components are available.](https://github.com/WordPress/gutenberg/tree/master/packages/components/src)
 
-To begin contributing to the WooCommerce Blocks plugin, see our [getting started guide](./docs/contributors/getting-started.md) and [developer handbook](./docs/README.md).
+To begin contributing to the WooCommerce Blocks plugin, see our [getting started guide](./docs/contributors/contributing/getting-started.md) and [developer handbook](./docs/README.md).
 
 Other useful docs to explore:
 

--- a/docs/contributors/README.md
+++ b/docs/contributors/README.md
@@ -2,15 +2,15 @@
 
 This folder contains documentation for developers and contributors looking to get started with WooCommerce Block Development.
 
-| Document                                             | Description                                                                              |
-| ---------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| [Getting Started](getting-started.md)                | This doc covers tooling and creating builds during development.                          |
-| [Coding Guidelines](coding-guidelines.md)            | This doc covers development best practices.                                              |
-| [JavaScript Testing](javascript-testing.md)          | This doc explains how to run automated JavaScript tests.                                 |
-| [Developing Components (& Storybook)](components.md) | This doc outlines where our reusable components live, and how to test them in Storybook. |
-| [Block Script Assets](block-assets.md)               | This doc explains how Block Script Assets are loaded and used.                           |
-| [JS build system](js-build-system.md)                | This doc explains how JavaScript files are built.                                        |
-| [CSS build system](css-build-system.md)              | This doc explains how CSS is built.                                                      |
+| Document                                                    | Description                                                                              |
+|-------------------------------------------------------------| ---------------------------------------------------------------------------------------- |
+| [Getting Started](contributing/getting-started.md)          | This doc covers tooling and creating builds during development.                          |
+| [Coding Guidelines](contributing/coding-guidelines.md)      | This doc covers development best practices.                                              |
+| [JavaScript Testing](contributing/javascript-testing.md)    | This doc explains how to run automated JavaScript tests.                                 |
+| [Developing Components (& Storybook)](components.md)        | This doc outlines where our reusable components live, and how to test them in Storybook. |
+| [Block Script Assets](contributing/block-assets.md)         | This doc explains how Block Script Assets are loaded and used.                           |
+| [JS build system](contributing/javascript-build-system.mdd) | This doc explains how JavaScript files are built.                                        |
+| [CSS build system](contributing/css-build-system.md)        | This doc explains how CSS is built.                                                      |
 
 <!-- FEEDBACK -->
 

--- a/docs/contributors/README.md
+++ b/docs/contributors/README.md
@@ -2,15 +2,15 @@
 
 This folder contains documentation for developers and contributors looking to get started with WooCommerce Block Development.
 
-| Document                                                    | Description                                                                              |
-|-------------------------------------------------------------| ---------------------------------------------------------------------------------------- |
-| [Getting Started](contributing/getting-started.md)          | This doc covers tooling and creating builds during development.                          |
-| [Coding Guidelines](contributing/coding-guidelines.md)      | This doc covers development best practices.                                              |
-| [JavaScript Testing](contributing/javascript-testing.md)    | This doc explains how to run automated JavaScript tests.                                 |
-| [Developing Components (& Storybook)](components.md)        | This doc outlines where our reusable components live, and how to test them in Storybook. |
-| [Block Script Assets](contributing/block-assets.md)         | This doc explains how Block Script Assets are loaded and used.                           |
-| [JS build system](contributing/javascript-build-system.mdd) | This doc explains how JavaScript files are built.                                        |
-| [CSS build system](contributing/css-build-system.md)        | This doc explains how CSS is built.                                                      |
+| Document                                                   | Description                                                                              |
+|------------------------------------------------------------| ---------------------------------------------------------------------------------------- |
+| [Getting Started](contributing/getting-started.md)         | This doc covers tooling and creating builds during development.                          |
+| [Coding Guidelines](contributing/coding-guidelines.md)     | This doc covers development best practices.                                              |
+| [JavaScript Testing](contributing/javascript-testing.md)   | This doc explains how to run automated JavaScript tests.                                 |
+| [Developing Components (& Storybook)](components.md)       | This doc outlines where our reusable components live, and how to test them in Storybook. |
+| [Block Script Assets](contributing/block-assets.md)        | This doc explains how Block Script Assets are loaded and used.                           |
+| [JS build system](contributing/javascript-build-system.md) | This doc explains how JavaScript files are built.                                        |
+| [CSS build system](contributing/css-build-system.md)       | This doc explains how CSS is built.                                                      |
 
 <!-- FEEDBACK -->
 


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

While working on another PR, I discovered that some links that point to Getting Started and other related pages don't work anymore. I fix those links in this PR.

<!-- Reference any related issues or PRs here -->


<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Test Getting started links in main `README.md` file
2. Test links in `/docs/contributors/README.md`

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->
