### PR TITLE
Store API: Coupon batch delete returns cart instance

### DIFF
--- a/src/StoreApi/Routes/V1/CartCoupons.php
+++ b/src/StoreApi/Routes/V1/CartCoupons.php
@@ -122,7 +122,7 @@ class CartCoupons extends AbstractCartRoute {
 		$cart->remove_coupons();
 		$cart->calculate_totals();
 
-		return new \WP_REST_Response( [], 200 );
+		return rest_ensure_response( $this->cart_schema->get_item_response( $cart ) );
 	}
 
 	/**

--- a/src/StoreApi/docs/cart-coupons.md
+++ b/src/StoreApi/docs/cart-coupons.md
@@ -2,11 +2,11 @@
 
 ## Table of Contents <!-- omit in toc -->
 
-- [List Cart Coupons](#list-cart-coupons)
-- [Single Cart Coupon](#single-cart-coupon)
-- [Add Cart Coupon](#add-cart-coupon)
-- [Delete Single Cart Coupon](#delete-single-cart-coupon)
-- [Delete All Cart Coupons](#delete-all-cart-coupons)
+-   [List Cart Coupons](#list-cart-coupons)
+-   [Single Cart Coupon](#single-cart-coupon)
+-   [Add Cart Coupon](#add-cart-coupon)
+-   [Delete Single Cart Coupon](#delete-single-cart-coupon)
+-   [Delete All Cart Coupons](#delete-all-cart-coupons)
 
 ## List Cart Coupons
 
@@ -156,12 +156,6 @@ There are no parameters required for this endpoint.
 curl --request DELETE https://example-store.com/wp-json/wc/store/v1/cart/coupons
 ```
 
-**Example response:**
-
-```json
-[]
-```
-
 <!-- FEEDBACK -->
 
 ---
@@ -171,4 +165,3 @@ curl --request DELETE https://example-store.com/wp-json/wc/store/v1/cart/coupons
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-blocks/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./src/StoreApi/docs/cart-coupons.md)
 
 <!-- /FEEDBACK -->
-

--- a/tests/php/StoreApi/Routes/CartCoupons.php
+++ b/tests/php/StoreApi/Routes/CartCoupons.php
@@ -149,8 +149,7 @@ class CartCoupons extends ControllerTestCase {
 		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
 		$this->assertAPIResponse(
 			$request,
-			200,
-			array()
+			200
 		);
 	}
 


### PR DESCRIPTION
Currently, a `DELETE` request towards the `cart/coupons` end-point would delete all the applied coupons and return an empty array. This is at odds with several things:

1. It is not consistent with how other routes work, as pointed by @sitver in #6879, which return the updated cart instance. According to some places in our docs, this should be the expected response, as updating the cart should return the updated cart for convenience. This happens, e.g., when removing one coupon from the cart (notice that, however, that is a `POST` request, rather than a `DELETE`). 
2. Other places in our docs state that `DELETE` requests are different, and should instead return a `204` response.

The current implementation did neither. I believe the way to go here would be to be consistent and return the new cart instance. This PR implements that change.

Fixes #6879 

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Testing

#### Automated Tests
* [x] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. Add one or more coupons to your cart.
2. Send a `DELETE` request to the `cart/coupon` end-point.
3. Notice that the response is the cart instance JSON and not an empty array.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Batch deleting coupons from the Store API now returns the Cart Instance instead of an empty array.