### PR TITLE
Fix error with usage of Cart::deep_sort_with_accents

### DIFF
--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -229,7 +229,7 @@ class Cart extends AbstractBlock {
 				array_map(
 					'html_entity_decode',
 					array_map(
-						function ($element) {
+						function ( $element ) {
 							if ( is_array( $element ) ) {
 								return $this->deep_sort_with_accents( $element );
 							}

--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -222,9 +222,23 @@ class Cart extends AbstractBlock {
 			return $array;
 		}
 
-		if ( is_array( reset( $array ) ) ) {
-			return array_map( [ $this, 'deep_sort_with_accents' ], $array );
-		}
+		$array_without_accents = array_map(
+			'remove_accents',
+			array_map(
+				'wc_strtolower',
+				array_map(
+					'html_entity_decode',
+					array_map(
+						function ($element) {
+							if ( is_array( $element ) ) {
+								return $this->deep_sort_with_accents( $element );
+							}
+						},
+						$array
+					)
+				)
+			)
+		);
 
 		$array_without_accents = array_map( 'remove_accents', array_map( 'wc_strtolower', array_map( 'html_entity_decode', $array ) ) );
 		asort( $array_without_accents );

--- a/tests/php/BlockTypes/Cart.php
+++ b/tests/php/BlockTypes/Cart.php
@@ -16,17 +16,17 @@ class Cart extends \WP_UnitTestCase {
 	}
 
 	public function test_deep_sort_with_accents() {
-		$test_array_1 = [
+		$test_array_1 = array(
 			'0',
 			'1',
-			[ '2', '3' ]
-		];
-		$test_array_2 = [
-			[ '0', '1' ],
+			array( '2', '3' ),
+		);
+		$test_array_2 = array(
+			array( '0', '1' ),
 			'2',
 			'3',
-		];
-		$this->assertEquals( $test_array_1, $this->cart_block_instance->deep_sort_test( $test_array_1 ) );
-		$this->assertEquals( $test_array_2, $this->cart_block_instance->deep_sort_test( $test_array_2 ) );
+		);
+		$this->assertEquals( $test_array_1, $this->cart_block_instance->deep_sort_test( $test_array_1 ), '' );
+		$this->assertEquals( $test_array_2, $this->cart_block_instance->deep_sort_test( $test_array_2 ), '' );
 	}
 }

--- a/tests/php/BlockTypes/Cart.php
+++ b/tests/php/BlockTypes/Cart.php
@@ -9,12 +9,23 @@ use Automattic\WooCommerce\Blocks\Tests\Mocks\CartMock;
  * @since $VID:$
  */
 class Cart extends \WP_UnitTestCase {
+	/**
+	 * This variable holds our cart object.
+	 *
+	 * @var CartMock
+	 */
 	private $cart_block_instance;
 
+	/**
+	 * Initiate the cart mock.
+	 */
 	public function setUp() {
-		$this->$cart_block_instance = new CartMock();
+		$this->cart_block_instance = new CartMock();
 	}
 
+	/**
+	 * We ensure deep sort works with all sort of arrays.
+	 */
 	public function test_deep_sort_with_accents() {
 		$test_array_1 = array(
 			'0',

--- a/tests/php/BlockTypes/Cart.php
+++ b/tests/php/BlockTypes/Cart.php
@@ -1,0 +1,32 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\Tests\BlockTypes;
+
+use Automattic\WooCommerce\Blocks\Tests\Mocks\CartMock;
+
+/**
+ * Tests for the Cart block type
+ *
+ * @since $VID:$
+ */
+class Cart extends \WP_UnitTestCase {
+	private $cart_block_instance;
+
+	public function setUp() {
+		$this->$cart_block_instance = new CartMock();
+	}
+
+	public function test_deep_sort_with_accents() {
+		$test_array_1 = [
+			'0',
+			'1',
+			[ '2', '3' ]
+		];
+		$test_array_2 = [
+			[ '0', '1' ],
+			'2',
+			'3',
+		];
+		$this->assertEquals( $test_array_1, $this->cart_block_instance->deep_sort_test( $test_array_1 ) );
+		$this->assertEquals( $test_array_2, $this->cart_block_instance->deep_sort_test( $test_array_2 ) );
+	}
+}

--- a/tests/php/mocks/CartMock.php
+++ b/tests/php/mocks/CartMock.php
@@ -2,8 +2,20 @@
 namespace Automattic\WooCommerce\Blocks\Tests\Mocks;
 
 use Automattic\WooCommerce\Blocks\BlockTypes\Cart;
+use Automattic\WooCommerce\Blocks\Package;
+use Automattic\WooCommerce\Blocks\Assets\Api;
+use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
+use Automattic\WooCommerce\Blocks\Integrations\IntegrationRegistry
 
 class CartMock extends Cart {
+
+	public function __construct() {
+		parent::__construct(
+			Package::container()->get( API::class ),
+			Package::container()->get( AssetDataRegistry::class ),
+			Package::container()->get( IntegrationRegistry::class ),
+		);
+	}
 
 	/**
 	 * For now don't need to initialize anything in tests so let's

--- a/tests/php/mocks/CartMock.php
+++ b/tests/php/mocks/CartMock.php
@@ -5,7 +5,7 @@ use Automattic\WooCommerce\Blocks\BlockTypes\Cart;
 use Automattic\WooCommerce\Blocks\Package;
 use Automattic\WooCommerce\Blocks\Assets\Api;
 use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
-use Automattic\WooCommerce\Blocks\Integrations\IntegrationRegistry
+use Automattic\WooCommerce\Blocks\Integrations\IntegrationRegistry;
 
 class CartMock extends Cart {
 

--- a/tests/php/mocks/CartMock.php
+++ b/tests/php/mocks/CartMock.php
@@ -1,0 +1,22 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\Tests\Mocks;
+
+use Automattic\WooCommerce\Blocks\BlockTypes\Cart;
+
+class CartMock extends Cart {
+
+	/**
+	 * For now don't need to initialize anything in tests so let's
+	 * just override the default behaviour.
+	 */
+	protected function initialize() {
+		return;
+	}
+
+	/**
+	 * Protected test wrapper for deep_sort_with_accents.
+	 */
+	public function deep_sort_test( $array ) {
+		return $this->deep_sort_with_accents( $array );
+	}
+}

--- a/tests/php/mocks/CartMock.php
+++ b/tests/php/mocks/CartMock.php
@@ -7,13 +7,19 @@ use Automattic\WooCommerce\Blocks\Assets\Api;
 use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
 use Automattic\WooCommerce\Blocks\Integrations\IntegrationRegistry;
 
+/**
+ * CartMock used to test cart block functions.
+ */
 class CartMock extends Cart {
 
+	/**
+	 * We initaite our mock class.
+	 */
 	public function __construct() {
 		parent::__construct(
 			Package::container()->get( API::class ),
 			Package::container()->get( AssetDataRegistry::class ),
-			Package::container()->get( IntegrationRegistry::class ),
+			new IntegrationRegistry(),
 		);
 	}
 
@@ -22,11 +28,12 @@ class CartMock extends Cart {
 	 * just override the default behaviour.
 	 */
 	protected function initialize() {
-		return;
 	}
 
 	/**
 	 * Protected test wrapper for deep_sort_with_accents.
+	 *
+	 * @param array $array The array we want to sort.
 	 */
 	public function deep_sort_test( $array ) {
 		return $this->deep_sort_with_accents( $array );


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

A fatal error was reported in this [forum thread](https://wordpress.org/support/topic/woocommerce-blocks-cart-page-gives-fatal-error/):

> Message Uncaught TypeError: html_entity_decode(): Argument woocommerce/woocommerce-blocks#12058 ($string) must be of type string, array given in /home/516558.cloudwaysapps.com/yucfgwgahw/public_html/wp-content/plugins/woo-gutenberg-products-block/src/BlockTypes/Cart.php:226 

After some debugging isolated to potential uses of `Automattic\WooCommerce\Blocks\BlockTypes\Cart::deep_sort_with_accents` (which is where the fatal error is triggered), I discovered that the current implementation expects the incoming `$array` argument to either have the first element be an array, or all elements to be strings. In particular the logic in these lines here will only execute when the first element is an array on the first call to the recursive function:

https://github.com/woocommerce/woocommerce-blocks/blob/c5bdcfffc49b38c6e110d44c775290e9aaea300d/src/BlockTypes/Cart.php#L222-L224

Thus the error is happening on this user's site because an unexpected data shape is coming into this function on this user's site.

This code has been in place for a while, however, given the critical path of this code (for the Cart block), I decided to get a PR up for this.

This PR fixes the issue by ensuring that when the element is iterated over, we recursively call `deep_sort_with_accents` _only_ on elements that are arrays.

I've also added a basic unit test to demonstrate the bug is fixed. I didn't cover all use-cases for this method, it might be a good idea to do that in a separate PR.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

Does not apply

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

Does not apply

### Testing

#### Automated Tests
* [x] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Configure multiple shipping countries.
2. Setup the cart block for use on the site.
3. Verify there are no errors when displaying the cart in the editor or on the frontend (especially around any shipping options).

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental

### Performance Impact

There should be no performance impact.

### Changelog

> Fixes a fatal error with Cart Block usage in specific site configurations with multiple shipping countries.
