### PR TITLE
Only show items if there are multiple packages in the cart

### DIFF
--- a/assets/js/base/components/cart-checkout/shipping-rates-control/index.tsx
+++ b/assets/js/base/components/cart-checkout/shipping-rates-control/index.tsx
@@ -65,9 +65,7 @@ const Packages = ( {
 					packageData={ packageData }
 					collapsible={ !! collapsible }
 					collapse={ !! collapse }
-					showItems={
-						showItems || packageData?.shipping_rates?.length > 1
-					}
+					showItems={ showItems || packages.length > 1 }
 					noResultsMessage={ noResultsMessage }
 					renderOption={ renderOption }
 				/>


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
Thanks to @senadir for pointing out this bug. This change will only show the items in the shipping packages if there are multiple packages.

If there's a single package, we don't need to show which items are in it, because it'll contain all items. If there are multiple packages we should show which items are in each package.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
| <img width="300" alt="image" src="https://user-images.githubusercontent.com/5656702/184617859-2b87751a-b8e0-4538-a8e4-daad7ea07815.png"> | <img width="323" alt="image" src="https://user-images.githubusercontent.com/5656702/184617948-d3eb3430-cbf0-4ae5-b98f-729199ac7c94.png"> |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Set up shipping zones so you have multiple methods for your country (flat rate and free is fine) and a single method for a different country.
2. Install the ["Multiple Packages for WooCommerce" plugin](https://wordpress.org/plugins/multiple-packages-for-woocommerce/)
3. Navigate to WooCommerce -> Settings -> Multiple Packages
4. Adjust the settings to work based on "Per Product"
5. Add two items that require shipping to your cart.
6. Go to the Cart block. Ensure you see the item name listed under each package.
7. Remove one of the items, ensure the list of shipping options updates and does not include the item name.
8. Change your address to one that only has a single shipping method. Repeat steps 5-7.
9. Repeat 5-7 on the Checkout block too.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental


### Changelog

> Prevent unnecessarily showing the item names in a shipping package if it's the only package.
