### PR TITLE
Only load shipping countries and states when shipping is needed

### DIFF
--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -155,21 +155,23 @@ class Cart extends AbstractBlock {
 	 */
 	protected function enqueue_data( array $attributes = [] ) {
 		parent::enqueue_data( $attributes );
+		if ( wc_shipping_enabled() ) {
+			$this->asset_data_registry->add(
+				'shippingCountries',
+				function() {
+					return $this->deep_sort_with_accents( WC()->countries->get_shipping_countries() );
+				},
+				true
+			);
+			$this->asset_data_registry->add(
+				'shippingStates',
+				function() {
+					return $this->deep_sort_with_accents( WC()->countries->get_shipping_country_states() );
+				},
+				true
+			);
+		}
 
-		$this->asset_data_registry->add(
-			'shippingCountries',
-			function() {
-				return $this->deep_sort_with_accents( WC()->countries->get_shipping_countries() );
-			},
-			true
-		);
-		$this->asset_data_registry->add(
-			'shippingStates',
-			function() {
-				return $this->deep_sort_with_accents( WC()->countries->get_shipping_country_states() );
-			},
-			true
-		);
 		$this->asset_data_registry->add(
 			'countryLocale',
 			function() {

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -181,20 +181,23 @@ class Checkout extends AbstractBlock {
 			},
 			true
 		);
-		$this->asset_data_registry->add(
-			'shippingCountries',
-			function() {
-				return $this->deep_sort_with_accents( WC()->countries->get_shipping_countries() );
-			},
-			true
-		);
-		$this->asset_data_registry->add(
-			'shippingStates',
-			function() {
-				return $this->deep_sort_with_accents( WC()->countries->get_shipping_country_states() );
-			},
-			true
-		);
+		if ( wc_shipping_enabled() ) {
+			$this->asset_data_registry->add(
+				'shippingCountries',
+				function() {
+					return $this->deep_sort_with_accents( WC()->countries->get_shipping_countries() );
+				},
+				true
+			);
+			$this->asset_data_registry->add(
+				'shippingStates',
+				function() {
+					return $this->deep_sort_with_accents( WC()->countries->get_shipping_country_states() );
+				},
+				true
+			);
+		}
+
 		$this->asset_data_registry->add(
 			'countryLocale',
 			function() {


### PR DESCRIPTION
This PR is a small performance fix. We print (via wc_settings) all shipping countries and states even when shipping is disabled. This PR fixes that.

### Testing

1. Visit Cart and Checkout, make sure you can select a country and state in shipping address.
2. In WooCommerce Settings, disable shipping.
3. Visit Cart and Checkout again, make sure you can select a country and state in the billing address.

### Developer testing (not required)

1. In WooCommerce settings, disable shipping
<img width="670" alt="image" src="https://user-images.githubusercontent.com/6165348/184639846-88c35438-6f20-4157-91eb-1a2d8e636bee.png">

2. Load Cart or Checkout blocks, in the console, type `wcSettings.shippingStates`. It should return `undefined`.
3. Type `wcSettings.shippingCountries`, it should return `undefined`.
4. Enable Shipping in settings, go back to Cart and Checkout, type the same codes above, you should get an object with country codes and states.


### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

This should have a positive performance impact. I noticed up to 20kb of saved HTML when loading the page.
<img width="663" alt="image" src="https://user-images.githubusercontent.com/6165348/184640499-cc8f52f6-13ff-4c9e-91ec-7f5079b6a469.png">

### Developer note

> `wcSettings` values `shippingCountries` and `shippingStates` are no longer available if the store has shipping disabled, this is true for the editor and frontend of Cart and Checkout blocks.