### PR TITLE
Mark sidebar notices as side effectful code.

### DIFF
--- a/assets/js/blocks/cart/edit.js
+++ b/assets/js/blocks/cart/edit.js
@@ -28,6 +28,7 @@ import {
 	useForcedLayout,
 	BlockSettings,
 } from '../cart-checkout-shared';
+import '../cart-checkout-shared/sidebar-notices';
 import { CartBlockContext } from './context';
 
 // This is adds a class to body to signal if the selected block is locked

--- a/assets/js/blocks/checkout/edit.tsx
+++ b/assets/js/blocks/checkout/edit.tsx
@@ -32,6 +32,7 @@ import {
 	BlockSettings,
 	useBlockPropsWithLocking,
 } from '../cart-checkout-shared';
+import '../cart-checkout-shared/sidebar-notices';
 import { CheckoutBlockContext, CheckoutBlockControlsContext } from './context';
 import type { Attributes } from './types';
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
 		"./assets/js/blocks/cart/inner-blocks/**/index.tsx",
 		"./assets/js/blocks/cart/inner-blocks/register-components.ts",
 		"./assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/**/index.tsx",
-		"./assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/register-components.ts"
+		"./assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/register-components.ts",
+		"./assets/js/blocks/cart-checkout-shared/sidebar-notices/index.tsx"
 	],
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
This PR marks side effectful code in sidebar notices so it is not tree shaken.


#### User Facing Testing

1. Run `npm run build`
2. Check that compatibility notice and feedback notices are visible on all inner blocks.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

