### PR TITLE
Layout Updates to Active Filters Block

### DIFF
--- a/assets/js/base/components/chip/style.scss
+++ b/assets/js/base/components/chip/style.scss
@@ -15,8 +15,8 @@
 	&:focus,
 	&:active {
 		background: transparent;
-		color: $gray-900;
-		border: 1px solid $gray-900;
+		color: inherit;
+		border: 1px solid;
 	}
 
 	&.wc-block-components-chip--radius-small {
@@ -47,11 +47,11 @@
 		height: 16px;
 		width: 16px;
 		margin: 0;
-		color: $gray-900;
 	}
 
 	.wc-block-components-chip__remove-icon {
 		vertical-align: middle;
+		fill: $gray-900;
 	}
 }
 
@@ -71,8 +71,11 @@ button.wc-block-components-chip:hover > .wc-block-components-chip__remove,
 button.wc-block-components-chip:focus > .wc-block-components-chip__remove,
 .wc-block-components-chip__remove:hover,
 .wc-block-components-chip__remove:focus {
-	fill: #fff;
-	background: #7956ad;
+	background: $gray-600;
+
+	.wc-block-components-chip__remove-icon {
+		fill: #fff;
+	}
 }
 
 button.wc-block-components-chip:disabled > .wc-block-components-chip__remove,

--- a/assets/js/base/components/chip/style.scss
+++ b/assets/js/base/components/chip/style.scss
@@ -71,11 +71,12 @@ button.wc-block-components-chip:hover > .wc-block-components-chip__remove,
 button.wc-block-components-chip:focus > .wc-block-components-chip__remove,
 .wc-block-components-chip__remove:hover,
 .wc-block-components-chip__remove:focus {
-	fill: $alert-red;
+	fill: #fff;
+	background: #7956ad;
 }
 
 button.wc-block-components-chip:disabled > .wc-block-components-chip__remove,
 .wc-block-components-chip__remove:disabled {
-	fill: $gray-600;
+	fill: #fff;
 	cursor: not-allowed;
 }

--- a/assets/js/base/components/chip/style.scss
+++ b/assets/js/base/components/chip/style.scss
@@ -3,7 +3,7 @@
 	align-items: center;
 	border: 0;
 	display: inline-flex;
-	padding: em($gap-smallest * 0.5) 0.5em em($gap-smallest);
+	padding: em($gap-smallest) 0.5em;
 	margin: 0 0.365em 0.365em 0;
 	border-radius: 0;
 	line-height: 1;
@@ -14,8 +14,9 @@
 	&:hover,
 	&:focus,
 	&:active {
-		background: $gray-200;
+		background: transparent;
 		color: $gray-900;
+		border: 1px solid $gray-900;
 	}
 
 	&.wc-block-components-chip--radius-small {
@@ -30,20 +31,23 @@
 		padding-right: 0.75em;
 	}
 	.wc-block-components-chip__text {
+		@include font-size(smaller);
 		flex-grow: 1;
-	}
-	&.is-removable {
-		padding-right: 0.5em;
 	}
 	&.is-removable .wc-block-components-chip__text {
 		padding-right: 0.25em;
 	}
 	.wc-block-components-chip__remove {
 		@include font-size(smaller);
-		background: transparent;
+		background: $gray-200;
 		border: 0;
+		border-radius: 25px;
 		appearance: none;
 		padding: 0;
+		height: 16px;
+		width: 16px;
+		margin: 0;
+		color: $gray-900;
 	}
 
 	.wc-block-components-chip__remove-icon {

--- a/assets/js/blocks/active-filters/edit.tsx
+++ b/assets/js/blocks/active-filters/edit.tsx
@@ -38,7 +38,7 @@ const Edit = ( {
 			<InspectorControls key="inspector">
 				<PanelBody
 					title={ __(
-						'Block Settings',
+						'Display Settings',
 						'woo-gutenberg-products-block'
 					) }
 				>
@@ -53,6 +53,7 @@ const Edit = ( {
 								displayStyle: value,
 							} )
 						}
+						className="wc-block-active-filter__style-toggle"
 					>
 						<ToggleGroupControlOption
 							value="list"

--- a/assets/js/blocks/active-filters/edit.tsx
+++ b/assets/js/blocks/active-filters/edit.tsx
@@ -21,6 +21,7 @@ import {
  */
 import Block from './block';
 import type { Attributes } from './types';
+import './editor.scss';
 
 const Edit = ( {
 	attributes,

--- a/assets/js/blocks/active-filters/editor.scss
+++ b/assets/js/blocks/active-filters/editor.scss
@@ -3,3 +3,7 @@
 		margin-top: 9px;
 	}
 }
+
+.wc-block-active-filter__style-toggle {
+	width: 100%;
+}

--- a/assets/js/blocks/active-filters/editor.scss
+++ b/assets/js/blocks/active-filters/editor.scss
@@ -1,0 +1,8 @@
+.wc-block-active-filters {
+	.wc-block-active-filters__list-item-name {
+		margin-top: 9px;
+	}
+	.wc-block-active-filters__list-item-remove:hover {
+		color: #7956ad;
+	}
+}

--- a/assets/js/blocks/active-filters/editor.scss
+++ b/assets/js/blocks/active-filters/editor.scss
@@ -2,7 +2,4 @@
 	.wc-block-active-filters__list-item-name {
 		margin-top: 9px;
 	}
-	.wc-block-active-filters__list-item-remove:hover {
-		color: #7956ad;
-	}
 }

--- a/assets/js/blocks/active-filters/style.scss
+++ b/assets/js/blocks/active-filters/style.scss
@@ -91,7 +91,7 @@
 		color: currentColor;
 
 		&:hover {
-			color: #7956ad;
+			color: $gray-600;
 		}
 
 		&:disabled {

--- a/assets/js/blocks/active-filters/style.scss
+++ b/assets/js/blocks/active-filters/style.scss
@@ -93,6 +93,11 @@
 		&:hover {
 			color: #7956ad;
 		}
+
+		&:disabled {
+			color: $gray-200;
+			cursor: not-allowed;
+		}
 	}
 
 	.wc-block-active-filters__list--chips {

--- a/assets/js/blocks/active-filters/style.scss
+++ b/assets/js/blocks/active-filters/style.scss
@@ -14,9 +14,9 @@
 	overflow: hidden;
 
 	.wc-block-active-filters__clear-all {
-		@include font-size(regular);
-		float: right;
+		@include font-size(smaller);
 		border: none;
+		margin-top: 15px;
 		padding: 0;
 		text-decoration: underline;
 		cursor: pointer;
@@ -58,6 +58,7 @@
 
 	.wc-block-active-filters__list-item-type {
 		@include font-size(smaller);
+		font-weight: bold;
 		text-transform: uppercase;
 		letter-spacing: 0.1em;
 		margin: $gap 0 0;
@@ -70,10 +71,11 @@
 	}
 
 	.wc-block-active-filters__list-item-name {
-		font-weight: bold;
-		display: block;
+		@include font-size(smaller);
+		display: flex;
+		align-items: center;
 		position: relative;
-		padding: 0 16px 0 0;
+		padding: 0;
 	}
 
 	.wc-block-active-filters__list-item-remove {
@@ -83,10 +85,7 @@
 		height: 16px;
 		width: 16px;
 		padding: 0;
-		position: absolute;
-		right: 0;
-		top: 50%;
-		margin: -8px 0 0 0;
+		margin: 0 16px 0 0;
 		color: currentColor;
 	}
 

--- a/assets/js/blocks/active-filters/style.scss
+++ b/assets/js/blocks/active-filters/style.scss
@@ -37,10 +37,9 @@
 		clear: both;
 
 		li {
-			margin: 0;
+			margin: 9px 0 0;
 			padding: 0;
 			list-style: none outside;
-			clear: both;
 
 			ul {
 				margin: 0;
@@ -53,6 +52,9 @@
 					margin: 0;
 				}
 			}
+		}
+		> li:first-child {
+			margin: 0;
 		}
 	}
 
@@ -87,6 +89,10 @@
 		padding: 0;
 		margin: 0 16px 0 0;
 		color: currentColor;
+
+		&:hover {
+			color: #7956ad;
+		}
 	}
 
 	.wc-block-active-filters__list--chips {

--- a/assets/js/blocks/active-filters/utils.tsx
+++ b/assets/js/blocks/active-filters/utils.tsx
@@ -103,7 +103,6 @@ export const renderRemovableListItem = ( {
 				/>
 			) : (
 				<span className="wc-block-active-filters__list-item-name">
-					{ prefixedName }
 					<button
 						className="wc-block-active-filters__list-item-remove"
 						onClick={ removeCallback }
@@ -141,9 +140,9 @@ export const renderRemovableListItem = ( {
 								fill="white"
 							/>
 						</svg>
-
 						<Label screenReaderLabel={ removeText } />
 					</button>
+					{ prefixedName }
 				</span>
 			) }
 		</li>

--- a/tests/e2e/specs/shopper/active-filters.test.ts
+++ b/tests/e2e/specs/shopper/active-filters.test.ts
@@ -84,7 +84,7 @@ const getActiveFilterTypeText = () =>
 const getActiveFilterNameText = () =>
 	page.$eval(
 		selectors.frontend.activeFilterName,
-		( el ) => ( el as HTMLElement ).childNodes[ 0 ].textContent
+		( el ) => ( el as HTMLElement ).childNodes[ 1 ].textContent
 	);
 
 describe( 'Shopper → Active Filters Block', () => {


### PR DESCRIPTION
Update layouts for the Chips and List views on the Active Filters block, according to the new design proposal (pdnLyh-1SH-p2).

_Note that the alternate color options and layouts will be done in a follow-up task._

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #6844

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|  <img width="725" alt="CleanShot 2022-08-24 at 09 22 27@2x" src="https://user-images.githubusercontent.com/481776/186429719-de3cb516-467a-4635-b336-64bf63b96f9e.png">  |  <img width="650" alt="CleanShot 2022-08-24 at 09 19 27@2x" src="https://user-images.githubusercontent.com/481776/186429883-6bfe4c9d-d7a4-4caf-a31f-72dbd33f88a7.png">  |
|  |  |
|  <img width="725" alt="CleanShot 2022-08-24 at 09 21 47@2x" src="https://user-images.githubusercontent.com/481776/186430028-2f076c50-d6c9-4931-b5d1-347c844c43d1.png">  |  <img width="650" alt="CleanShot 2022-08-24 at 09 20 16@2x" src="https://user-images.githubusercontent.com/481776/186430096-b2841edf-bbc3-47dc-8f36-7b568e697310.png">  |


### Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Add the Active Filters block alongside some other Filters blocks.
2. Apply some filters to the page.
3. Confirm the layout matches the **After** screenshot above.
4. Confirm the **Remove Filter** buttons for each active filter have a hover state of an alternate shade of grey - also confirm they function as expected.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental

### Changelog

> Enhancement - layout updates to the Active Filters block.
