### PR TITLE
Add global styles to Product Categories List block in WC core

### DIFF
--- a/assets/js/blocks/product-categories/block.json
+++ b/assets/js/blocks/product-categories/block.json
@@ -4,6 +4,18 @@
   "category": "woocommerce",
   "description": "Show all product categories as a list or dropdown.",
   "keywords": [ "WooCommerce" ],
+  "supports": {
+    "align": [ "wide", "full" ],
+    "html": false,
+    "color": {
+      "background": false,
+      "link": true
+    },
+    "typography": {
+      "fontSize": true,
+      "lineHeight": true
+    }
+  },
   "attributes": {
     "align": {
       "type": "string"

--- a/assets/js/blocks/product-categories/index.tsx
+++ b/assets/js/blocks/product-categories/index.tsx
@@ -3,7 +3,6 @@
  */
 import { createBlock, registerBlockType } from '@wordpress/blocks';
 import { Icon, listView } from '@wordpress/icons';
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies
@@ -22,21 +21,6 @@ registerBlockType( metadata, {
 			/>
 		),
 	},
-	supports: {
-		align: [ 'wide', 'full' ],
-		html: false,
-		...( isFeaturePluginBuild() && {
-			color: {
-				background: false,
-				link: true,
-			},
-			typography: {
-				fontSize: true,
-				lineHeight: true,
-			},
-		} ),
-	},
-
 	transforms: {
 		from: [
 			{


### PR DESCRIPTION
Fixes an issue setting styles to the Product Categories List block.

Related PR: #5133.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|    ![imatge](https://user-images.githubusercontent.com/3616980/184815030-8724340a-560a-4ffa-a8a8-79c9e8dfb47f.png)    |   ![imatge](https://user-images.githubusercontent.com/3616980/184814406-b9f5ec04-c2cb-4093-b7c5-c9f97ab2b945.png)    |

### Testing

#### User Facing Testing

1. Add a Product Categories List block in a post or page.
2. In the sidebar, make some style changes (change the color of the text or link and change typography settings).
3. Verify the block doesn't crash.
4. If you are using a block theme, go to Appearance > Site Editor > Styles > Blocks > Product Categories List.
5. Modify some of the styles there.
6. Add a Product Categories List block in a post or page again and verify global styles are applied as well.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Enable in WC core global styles (text color, link color, line height, and font size) for the Product Title block.
