### PR TITLE
Open Terms and Conditions and Privacy Policy links in a new tab in Checkout

### DIFF
--- a/assets/js/blocks/checkout/inner-blocks/checkout-terms-block/constants.js
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-terms-block/constants.js
@@ -5,14 +5,14 @@ import { __, sprintf } from '@wordpress/i18n';
 import { PRIVACY_URL, TERMS_URL } from '@woocommerce/block-settings';
 
 const termsPageLink = TERMS_URL
-	? `<a href="${ TERMS_URL }">${ __(
+	? `<a href="${ TERMS_URL }" target="_blank">${ __(
 			'Terms and Conditions',
 			'woo-gutenberg-products-block'
 	  ) }</a>`
 	: __( 'Terms and Conditions', 'woo-gutenberg-products-block' );
 
 const privacyPageLink = PRIVACY_URL
-	? `<a href="${ PRIVACY_URL }">${ __(
+	? `<a href="${ PRIVACY_URL }" target="_blank">${ __(
 			'Privacy Policy',
 			'woo-gutenberg-products-block'
 	  ) }</a>`


### PR DESCRIPTION
This PR changes the default behavior for Checkout's terms link to open in a new tab, matching Checkout shortcode behavior.

This can be changed on the editor by clicking on the link disabling "open in new tab"

Fixes #6850


### Testing

1. Insert Checkout page and save the page.
2. On frontend, click on the terms or privacy links in the checkout block.
3. They should open in a new tab.

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Terms and conditions, and Privacy policy links open in a new tab by default.
