### PR TITLE
Fix: Flaky test caused by `setMaxPrice`

### DIFF
--- a/tests/e2e/specs/shopper/filter-products-by-price.test.ts
+++ b/tests/e2e/specs/shopper/filter-products-by-price.test.ts
@@ -56,7 +56,6 @@ const setMaxPrice = async () => {
 	await page.keyboard.down( 'Shift' );
 	await page.keyboard.press( 'Home' );
 	await page.keyboard.up( 'Shift' );
-	await page.keyboard.press( 'Backspace' );
 	await page.keyboard.type( '1.99' );
 	await page.keyboard.press( 'Tab' );
 };


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes woocommerce/woocommerce#42613

This PR is another attempt to fix the flaky test issue related to the (updated) `setMaxPrice` function. I stress-tested this PR  [here](https://github.com/dinhtungdu/woocommerce-blocks/runs/7892416528?check_suite_focus=true) to confirm the fix:
- There is no flaky test testing again WP with Gutenberg.
- On WP latest:
  - The test using the fix from this PR passes 99/100 times.
  - The test using the current `setMaxPrice` passes 94/100 times.

Even we don't hit 100%, I still think this PR is valuable to merge as the rate is still higher.
### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

See https://github.com/dinhtungdu/woocommerce-blocks/runs/7892416528?check_suite_focus=true

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental

### Performance Impact
n/a

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

n/a
