### PR TITLE
Style the Filter by Price block based on the wrapper width

### DIFF
--- a/assets/js/base/components/price-slider/style.scss
+++ b/assets/js/base/components/price-slider/style.scss
@@ -112,6 +112,10 @@
 		max-width: 100px;
 		min-width: 0;
 		padding: $gap-smaller;
+
+		.wc-block-components-price-slider--is-input-inline & {
+			max-width: 60px;
+		}
 	}
 }
 

--- a/tests/e2e/specs/shopper/filter-products-by-price.test.ts
+++ b/tests/e2e/specs/shopper/filter-products-by-price.test.ts
@@ -39,7 +39,7 @@ const block = {
 			submitButton: '.wc-block-components-filter-submit-button',
 		},
 	},
-	urlSearchParamWhenFilterIsApplied: '?max_price=1.99',
+	urlSearchParamWhenFilterIsApplied: '?max_price=2',
 	foundProduct: '32GB USB Stick',
 };
 
@@ -56,7 +56,7 @@ const setMaxPrice = async () => {
 	await page.keyboard.down( 'Shift' );
 	await page.keyboard.press( 'Home' );
 	await page.keyboard.up( 'Shift' );
-	await page.keyboard.type( '1.99' );
+	await page.keyboard.type( '2' );
 	await page.keyboard.press( 'Tab' );
 };
 


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #6942

This PR calculates the wrapper width on render, then use that width to control the inline layout of the price silder.

- When the width of the wrapper is ≤ `300px`, the `Inline input fields` is forced disabled.
- When the `Inline input fields` is enabled or the wrapper width ≤ `300px`, the input field width is always set to `60px`.

These additional conditions make the price slider works as expected with any screen size.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|    <img width="735" alt="image" src="https://user-images.githubusercontent.com/5423135/185596210-db38045b-2236-4c75-bef1-5da1861dc410.png">    |    <img width="736" alt="image" src="https://user-images.githubusercontent.com/5423135/185596301-aab7bb95-7312-4f81-94cd-f432b1267c4f.png">   |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Before checking out this PR, create a new page then add a 3-7 columns block.
2. Add the Filter by price block to the smaller column, and All products block to the bigger column.
3. On the front end, collapse the browser windows to make the small column width less than `300px`.
4. See the issue as captured in the screenshot above.
5. Check out this PR and built.
6. On the frontend, reload the page, ensure the width of the smaller column is less than `300px`.
7. See the input fields now are below the slider and have the width set to 60px.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental

### Performance Impact
N/a
<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

N/a