### PR TITLE
When converting the Filter Products by Price widget into the Filter by Price block, don't use inline input

### DIFF
--- a/assets/js/blocks/price-filter/index.tsx
+++ b/assets/js/blocks/price-filter/index.tsx
@@ -51,7 +51,7 @@ registerBlockType( metadata, {
 								'woo-gutenberg-products-block'
 							),
 						headingLevel: 3,
-						inlineInput: true,
+						inlineInput: false,
 					} ),
 			},
 		],


### PR DESCRIPTION
### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
| ![imatge](https://user-images.githubusercontent.com/3616980/185907784-0e99ebc7-4ff7-4a21-8df2-1934a5f9feaa.png) | ![imatge](https://user-images.githubusercontent.com/3616980/185907527-385743b9-5395-4615-b779-19168a9accc5.png) |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. Install an old version of WooCommerce (I tested with 6.3.1) and make sure you have WC Blocks disabled.
2. Enable a classic theme (ie: Storefront).
3. Go to Appearance > Widgets and add the Filter Products by Price legacy widget.
4. Go to Plugins and update WooCommerce to the latest version and enable WC Blocks.
5. Transform the Filter Products by Price legacy widget into the Filter by Price block.
![imatge](https://user-images.githubusercontent.com/3616980/185909186-8f625ce1-258c-465c-a64a-134a697a6526.png)
6. Change the _Price Range Selector_ to _Editable_.
7. Verify _Inline input fields_ is unchecked and input fields are rendered below the slider.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

Skipping the changelog because this was introduced in #6877, so if this PR is merged by 8.4.0, a changelog entry isn't required.