### PR TITLE
Make the inlineInput default to false to avoid changing existing blocks behaviour

### DIFF
--- a/assets/js/blocks/price-filter/block.json
+++ b/assets/js/blocks/price-filter/block.json
@@ -29,7 +29,7 @@
 		},
 		"inlineInput": {
 			"type": "boolean",
-			"default": true
+			"default": false
 		},
 		"showFilterButton": {
 			"type": "boolean",

--- a/assets/js/blocks/price-filter/frontend.ts
+++ b/assets/js/blocks/price-filter/frontend.ts
@@ -14,7 +14,7 @@ const getProps = ( el: HTMLElement ) => {
 	return {
 		attributes: {
 			showInputFields: el.dataset.showinputfields === 'true',
-			inlineInput: el.dataset.inlineInput !== 'false',
+			inlineInput: el.dataset.inlineInput === 'true',
 			showFilterButton: el.dataset.showfilterbutton === 'true',
 			heading: el.dataset.heading || blockAttributes.heading.default,
 			headingLevel: el.dataset.headingLevel


### PR DESCRIPTION
`Filter by Price` block Inline input fields option should be disabled by default to not change the behavior for users that already have it installed.

For more context see: p1661156225172759-slack-C02SGH7JBGS
Fixes https://github.com/woocommerce/woocommerce-blocks/issues/6954

### Testing

#### User Facing Testing

1. Create a new page and add a `Filter by price` block.
2. Make sure the `Inline input fields` is disabled by default.
3. Save the page and check the block is rendered as expected without the input fields inline.

* [x] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental
