### PR TITLE
Update filter button styles

### DIFF
--- a/assets/js/base/components/price-slider/style.scss
+++ b/assets/js/base/components/price-slider/style.scss
@@ -102,14 +102,14 @@
 	display: flex;
 	gap: $gap-smaller;
 	justify-content: space-between;
-	margin: $gap-large 0;
+	margin: $gap 0;
 
 	.wc-block-components-price-slider__amount {
 		margin: 0;
 		border-radius: 4px;
 		border-width: 1px;
 		width: auto;
-		max-width: 100px;
+		max-width: 80px;
 		min-width: 0;
 		padding: $gap-smaller;
 	}

--- a/assets/js/blocks/attribute-filter/style.scss
+++ b/assets/js/blocks/attribute-filter/style.scss
@@ -67,3 +67,10 @@
 		}
 	}
 }
+
+.editor-styles-wrapper  .wc-block-attribute-filter__button.wc-block-attribute-filter__button,
+.wc-block-attribute-filter__button.wc-block-attribute-filter__button {
+	padding: $gap-smaller $gap;
+	font-size: 0.875em;
+	border-radius: 2px;
+}

--- a/assets/js/blocks/attribute-filter/style.scss
+++ b/assets/js/blocks/attribute-filter/style.scss
@@ -70,7 +70,6 @@
 
 .editor-styles-wrapper  .wc-block-attribute-filter__button.wc-block-attribute-filter__button,
 .wc-block-attribute-filter__button.wc-block-attribute-filter__button {
-	padding: $gap-smaller $gap;
-	font-size: 0.875em;
-	border-radius: 2px;
+	padding: em($gap-smaller) em($gap);
+	@include font-size(small);
 }

--- a/assets/js/blocks/price-filter/style.scss
+++ b/assets/js/blocks/price-filter/style.scss
@@ -26,3 +26,10 @@
 		border-style: solid;
 	}
 }
+
+.editor-styles-wrapper .wc-block-price-filter__button.wc-block-components-price-slider__button,
+.wc-block-price-filter__button.wc-block-components-price-slider__button {
+	padding: $gap-smaller $gap;
+	font-size: 0.875em;
+	border-radius: 2px;
+}

--- a/assets/js/blocks/price-filter/style.scss
+++ b/assets/js/blocks/price-filter/style.scss
@@ -29,7 +29,6 @@
 
 .editor-styles-wrapper .wc-block-price-filter__button.wc-block-components-price-slider__button,
 .wc-block-price-filter__button.wc-block-components-price-slider__button {
-	padding: $gap-smaller $gap;
-	font-size: 0.875em;
-	border-radius: 2px;
+	padding: em($gap-smaller) em($gap);
+	@include font-size(small);
 }

--- a/assets/js/blocks/stock-filter/style.scss
+++ b/assets/js/blocks/stock-filter/style.scss
@@ -21,10 +21,6 @@
 		opacity: 0.6;
 	}
 
-	.wc-block-stock-filter__button {
-		margin-top: $gap-smaller;
-	}
-
 	.wc-block-stock-filter__actions {
 		align-items: center;
 		display: flex;
@@ -38,4 +34,12 @@
 			margin-top: 0;
 		}
 	}
+}
+
+.editor-styles-wrapper .wc-block-stock-filter .wp-block-button__link,
+.wc-block-stock-filter .wc-block-stock-filter__button {
+	margin-top: $gap-smaller;
+	padding: $gap-smaller $gap;
+	font-size: 0.875em;
+	border-radius: 2px;
 }

--- a/assets/js/blocks/stock-filter/style.scss
+++ b/assets/js/blocks/stock-filter/style.scss
@@ -38,8 +38,7 @@
 
 .editor-styles-wrapper .wc-block-stock-filter .wp-block-button__link,
 .wc-block-stock-filter .wc-block-stock-filter__button {
-	margin-top: $gap-smaller;
-	padding: $gap-smaller $gap;
-	font-size: 0.875em;
-	border-radius: 2px;
+	margin-top: em($gap-smaller);
+	padding: em($gap-smaller) em($gap);
+	@include font-size(small);
 }

--- a/assets/js/blocks/stock-filter/style.scss
+++ b/assets/js/blocks/stock-filter/style.scss
@@ -36,7 +36,7 @@
 	}
 }
 
-.editor-styles-wrapper .wc-block-stock-filter .wp-block-button__link,
+.editor-styles-wrapper .wc-block-stock-filter .wc-block-stock-filter__button,
 .wc-block-stock-filter .wc-block-stock-filter__button {
 	margin-top: em($gap-smaller);
 	padding: em($gap-smaller) em($gap);


### PR DESCRIPTION
Update the filter `Apply` buttons to match the new designs.

### Screenshots

| Before | After |
| ------ | ----- |
|     <img width="664" alt="Screenshot 2022-08-22 at 16 03 13" src="https://user-images.githubusercontent.com/186112/185940267-432c2866-c41a-4fda-8b0d-e6fbd3ef397b.png"> |    <img width="684" alt="Screenshot 2022-08-23 at 10 41 03" src="https://user-images.githubusercontent.com/186112/186113450-1e59dfe5-6619-41e9-8f0c-a2e71a8eedde.png">|


### Testing

1. Create a new page and add the `All Products` block and the filter pattern containing all filter blocks.
2. Save it and check the buttons look like the `After` screenshot on the editor and the frontend.

### WooCommerce Visibility

* [x] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental

### Changelog

> Update the filter `Apply` buttons to match the new designs.