### PR TITLE
Lint markdown files on precommit

### DIFF
--- a/docs/third-party-developers/extensibility/rest-api/available-endpoints-to-extend.md
+++ b/docs/third-party-developers/extensibility/rest-api/available-endpoints-to-extend.md
@@ -3,17 +3,17 @@
 ## Table of Contents <!-- omit in toc -->
 
 - [`wc/store/checkout`](#wcstorecheckout)
-  - [Passed Parameters](#passed-parameters)
-  - [Key](#key)
+    - [Passed Parameters](#passed-parameters)
+    - [Key](#key)
 - [`wc/store/cart`](#wcstorecart)
-  - [Passed Parameters](#passed-parameters-1)
-  - [Key](#key-1)
+    - [Passed Parameters](#passed-parameters-1)
+    - [Key](#key-1)
 - [`wc/store/cart/items`](#wcstorecartitems)
-  - [Passed Parameters](#passed-parameters-2)
-  - [Key](#key-2)
+    - [Passed Parameters](#passed-parameters-2)
+    - [Key](#key-2)
 - [`wc/store/products`](#wcstoreproducts)
-  - [Passed Parameters](#passed-parameters-3)
-  - [Key](#key-3)
+    - [Passed Parameters](#passed-parameters-3)
+    - [Key](#key-3)
 
 To see how to add your data to Store API using ExtendSchema, [check this document](./extend-rest-api-add-data.md). This is a list of available endpoints that you can extend. If you want to add a new endpoint, [check this document](./extend-rest-api-new-endpoint.md).
 

--- a/package.json
+++ b/package.json
@@ -262,6 +262,9 @@
 		"*.php": [
 			"php -d display_errors=1 -l",
 			"composer run-script phpcs"
+		],
+		"*.md": [
+			"npm run lint:md:docs"
 		]
 	},
 	"changelog": {


### PR DESCRIPTION
@dinhtungdu alerted me that https://github.com/woocommerce/woocommerce-blocks/pull/6960 was breaking markdown linting (I missed the broken test). In this PR I fixed that broken file and added testing in precommit.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->
