### PR TITLE
Change Type for shipping_address and billing_address to object

### DIFF
--- a/src/StoreApi/docs/checkout.md
+++ b/src/StoreApi/docs/checkout.md
@@ -83,8 +83,8 @@ POST /wc/store/v1/checkout
 
 | Attribute          | Type   | Required | Description                                                         |
 | :----------------- | :----- | :------: | :------------------------------------------------------------------ |
-| `billing_address`  | array  |   Yes    | Array of updated billing address data for the customer.             |
-| `shipping_address` | array  |   Yes    | Array of updated shipping address data for the customer.            |
+| `billing_address`  | object |   Yes    | Array of updated billing address data for the customer.             |
+| `shipping_address` | object |   Yes    | Array of updated shipping address data for the customer.            |
 | `customer_note`    | string |    No    | Note added to the order by the customer during checkout.            |
 | `payment_method`   | string |   Yes    | The ID of the payment method being used to process the payment.     |
 | `payment_data`     | array  |    No    | Data to pass through to the payment method when processing payment. |

--- a/src/StoreApi/docs/checkout.md
+++ b/src/StoreApi/docs/checkout.md
@@ -83,8 +83,8 @@ POST /wc/store/v1/checkout
 
 | Attribute          | Type   | Required | Description                                                         |
 | :----------------- | :----- | :------: | :------------------------------------------------------------------ |
-| `billing_address`  | object |   Yes    | Array of updated billing address data for the customer.             |
-| `shipping_address` | object |   Yes    | Array of updated shipping address data for the customer.            |
+| `billing_address`  | object |   Yes    | Object of updated billing address data for the customer.            |
+| `shipping_address` | object |   Yes    | Object of updated shipping address data for the customer.           |
 | `customer_note`    | string |    No    | Note added to the order by the customer during checkout.            |
 | `payment_method`   | string |   Yes    | The ID of the payment method being used to process the payment.     |
 | `payment_data`     | array  |    No    | Data to pass through to the payment method when processing payment. |


### PR DESCRIPTION
Changed the type for `billing_address` and `shipping_address` in the Checkout API document.

Fixes #6884





### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [ ] E2E tests

#### Testing Steps

1. Go to [Process Order and Payment](https://github.com/woocommerce/woocommerce-blocks/blob/fix/6884-Store-API-checkout-docs/src/StoreApi/docs/checkout.md) section of Checkout API doc. 
2. Confirm the type for `shipping_address` and `billing_address` is an object. 

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->
