### PR TITLE
Fix z-index issue in Filter by Attribute dropdowns

### DIFF
--- a/assets/js/blocks/attribute-filter/style.scss
+++ b/assets/js/blocks/attribute-filter/style.scss
@@ -17,7 +17,6 @@
 	margin-bottom: $gap;
 	border-radius: inherit;
 	border-color: inherit;
-	z-index: 30;
 
 	&.style-dropdown {
 		position: relative;
@@ -30,11 +29,6 @@
 		.wc-block-components-filter-submit-button {
 			height: 36px;
 			line-height: 1;
-		}
-
-		> .wc-blocks-components-form-token-field-wrapper {
-			position: relative;
-			z-index: 2;
 		}
 
 		> svg {

--- a/assets/js/blocks/attribute-filter/style.scss
+++ b/assets/js/blocks/attribute-filter/style.scss
@@ -36,7 +36,6 @@
 			right: 20px;
 			top: 50%;
 			transform: translateY(-50%);
-			z-index: 1;
 		}
 	}
 


### PR DESCRIPTION
Fixes #6979.

### Screenshots

| Before | After |
| ------ | ----- |
| ![imatge](https://user-images.githubusercontent.com/3616980/186651819-292fbcc3-c3cc-4304-bbb9-f74a64bb38cc.png) |    ![imatge](https://user-images.githubusercontent.com/3616980/186651706-6db6bfee-dd0c-4103-ba8b-7b163e6f43ea.png) |

### Testing

#### User Facing Testing

1. Add two Filter by Attribute blocks one over the other and an All Products block into a page.
2. Set both Filter by Attribute blocks to display a dropdown.
3. In the frontend, open the dropdown of the first block and make sure it overlaps the input field of the second one.
4. Play around with the blocks position: changing if they allow multiple or single properties, adding a Filter by Price block between both, etc. and verify the dropdown always overlaps all contents below.

I'm excluding this from testing notes because it was introduced in #6920, which hasn't been released yet.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental