### PR TITLE
Fix experimental interface document link in release initial checklist

### DIFF
--- a/.github/release-initial-checklist.md
+++ b/.github/release-initial-checklist.md
@@ -22,7 +22,7 @@ The release pull request has been created! This checklist is a guide to follow f
 * [ ] Run `npm ci`
 * [ ] Run `npm run package-plugin:deploy`. This will create a zip of the current branch build locally.
   *  Note: The zip file is functionally equivalent to what gets released except the version bump.
-* [ ] Create the testing notes for the release. 
+* [ ] Create the testing notes for the release.
   * [ ] For each pull request that belongs to the current release, grab the `User Facing Testing` notes from the PR's description. Be sure that the `Do not include in the Testing Notes is not flagged` checkbox is unchecked.
   * [ ] Add the notes to `docs/internal-developers/testing/releases`
   * [ ] Update the `docs/internal-developers/testing/releases/README.md` file index.
@@ -63,7 +63,7 @@ Each porter is responsible for testing the PRs that fall under the focus of thei
   * Note: the script automatically updates version numbers on Github (commits on your behalf).
   * **ALERT**: This script will ask you if this release will be deployed to WordPress.org. You should answer yes for this release even if it is a pre-release.
   * A GitHub release will automatically be created and this will trigger a workflow that automatically deploys the plugin to WordPress.org.
-  
+
 
 ## If this release is deployed to WordPress.org...
 
@@ -93,20 +93,20 @@ Each porter is responsible for testing the PRs that fall under the focus of thei
 
 This only needs to be done if this release is the last release of the feature plugin before code freeze in the WooCommerce core cycle. If this condition doesn't exist you can skip this section.
 
-* [ ] Remind whoever is porter this week to audit our codebase to ensure this [experimental interface document](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/blocks/feature-flags-and-experimental-interfaces.md) is up to date. See Pca54o-rM-p2 for more details.
+* [ ] Remind whoever is porter this week to audit our codebase to ensure this [experimental interface document](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md) is up to date. See Pca54o-rM-p2 for more details.
 * [ ] Create a pull request for updating the package in the [WooCommerce Core Repository](https://github.com/woocommerce/woocommerce/) that [bumps the package version](https://github.com/woocommerce/woocommerce/blob/747cb6b7184ba9fdc875ab104da5839cfda8b4be/plugins/woocommerce/composer.json) for the Woo Blocks package to the version you are releasing.
     - The content for the pull release can follow [this example](https://github.com/woocommerce/woocommerce/pull/32627).
         -   [ ] Increase the version of `woocommerce/woocommerce-blocks` in the `plugins/woocommerce/composer.json` file
         -   [ ] Run `composer update woocommerce/woocommerce-blocks` and make sure `composer-lock.json` was updated
         -   [ ] Add a new file similar to this one [plugins/woocommerce/changelog/update-woocommerce-blocks-7.4.1](https://github.com/woocommerce/woocommerce/blob/5040a10d01896bcf40fd0ac538f2b7bc584ffe0a/plugins/woocommerce/changelog/update-woocommerce-blocks-7.4.1) with a similar content as below. For the Significance entry we’ll always use `minor`, or `patch` when including a patch release
-                
+
                 ```
                 Significance: minor
                 Type: update
-    
+
                 Update WooCommerce Blocks to 7.4.1
                 ```
-                
+
     - The PR description can follow [this example](https://github.com/woocommerce/woocommerce/pull/32627).
         - It lists all the WooCommerce Blocks versions that are being included since the last version that you edited in `plugins/woocommerce/composer.json`. Each version should have a link for the `Release PR`, `Testing instructions` and `Release post` (if available).
         - The changelog should be aggregated from all the releases included in the package bump and grouped per type: `Enhancements`, `Bug Fixes`, `Various` etc. This changelog will be used in the release notes for the WooCommerce release. That's why it should only list the PRs that have WooCoomerce Core in the WooCommerce Visibility section of their description. Don't include changes available in the feature plugin or development builds.


### PR DESCRIPTION
This PR fixes experimental interface document link in release initial checklist


### Testing

#### Automated Tests
* [x] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. Go to [release-initial-checklist](https://github.com/woocommerce/woocommerce-blocks/blob/fix/experimental-interface-document-link/.github/release-initial-checklist.md) doc of this branch. 
2. Confirm the link for `experimental interface document` under `Pull request in WooCommerce Core for Package update` section is correct

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->
