### PR TITLE
Remove unnecessary filter by price label style

### DIFF
--- a/assets/js/blocks/price-filter/editor.scss
+++ b/assets/js/blocks/price-filter/editor.scss
@@ -6,9 +6,11 @@
 		&::-webkit-slider-thumb {
 			pointer-events: none;
 		}
+
 		&::-moz-range-thumb {
 			pointer-events: none;
 		}
+
 		&::-ms-thumb {
 			pointer-events: none;
 		}
@@ -23,11 +25,6 @@
 	}
 }
 
-.components-base-control__label {
-	text-transform: uppercase;
-	@include font-size(small);
-}
-
 .wc-block-price-slider {
 	.components-placeholder__instructions {
 		border-bottom: 1px solid #e0e2e6;
@@ -35,13 +32,16 @@
 		padding-bottom: 1em;
 		margin-bottom: 2em;
 	}
+
 	.components-placeholder__label svg {
 		fill: currentColor;
 		margin-right: 1ch;
 	}
+
 	.components-placeholder__fieldset {
 		display: block; /* Disable flex box */
 	}
+
 	.wc-block-price-slider__add-product-button {
 		margin: 0 0 1em;
 		vertical-align: middle;
@@ -54,6 +54,7 @@
 			vertical-align: middle;
 		}
 	}
+
 	.wc-block-price-slider__read_more_button {
 		display: block;
 		margin-bottom: 1em;


### PR DESCRIPTION
The uppercase style was too generic and was affecting other labels.

**Note**: labels will be uppercase in the feature because of [this change](https://github.com/WordPress/gutenberg/pull/42789) in Gutenberg. We are removing this style to avoid the side-effect that it was causing.
#### User Facing Testing

1. Create a page with a filter by price block and a handpicked products block.
2. Open the filter by price block settings and check that the `Price Range Selector` label is **not** uppercase. 
3. Open the handpicked products block settings and check that the `Columns` label is **not** uppercase.

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental

