### PR TITLE
Remove `__experimentalDuotone` from block.json

### DIFF
--- a/assets/js/blocks/featured-items/featured-category/block.json
+++ b/assets/js/blocks/featured-items/featured-category/block.json
@@ -3,15 +3,19 @@
 	"version": "1.0.0",
 	"title": "Featured Category",
 	"category": "woocommerce",
-	"keywords": [ "WooCommerce" ],
+	"keywords": [
+		"WooCommerce"
+	],
 	"description": "Visually highlight a product category and encourage prompt action.",
 	"supports": {
-		"align": [ "wide", "full" ],
+		"align": [
+			"wide",
+			"full"
+		],
 		"html": false,
 		"color": {
 			"background": true,
-			"text": true,
-			"__experimentalDuotone": ".wc-block-featured-category__background-image"
+			"text": true
 		},
 		"spacing": {
 			"padding": true,
@@ -106,5 +110,6 @@
 		}
 	},
 	"textdomain": "woo-gutenberg-products-block",
-	"apiVersion": 2
+	"apiVersion": 2,
+	"$schema": "https://schemas.wp.org/trunk/block.json"
 }

--- a/assets/js/blocks/featured-items/featured-product/block.json
+++ b/assets/js/blocks/featured-items/featured-product/block.json
@@ -4,14 +4,18 @@
 	"title": "Featured Product",
 	"description": "Visually highlight a product or variation and encourage prompt action.",
 	"category": "woocommerce",
-	"keywords": [ "WooCommerce" ],
+	"keywords": [
+		"WooCommerce"
+	],
 	"supports": {
-		"align": [ "wide", "full" ],
+		"align": [
+			"wide",
+			"full"
+		],
 		"html": false,
 		"color": {
 			"background": true,
-			"text": true,
-			"__experimentalDuotone": ".wc-block-featured-product__background-image"
+			"text": true
 		},
 		"spacing": {
 			"padding": true,
@@ -112,5 +116,6 @@
 		}
 	},
 	"textdomain": "woo-gutenberg-products-block",
-	"apiVersion": 2
+	"apiVersion": 2,
+	"$schema": "https://schemas.wp.org/trunk/block.json"
 }


### PR DESCRIPTION
The `__experimentalDuotone` property in the block's `Supports` attribute (`block.json`) was preventing the Global Styles from being applied in the Editor. Removing the property remedies the issue.

This also adds a Schema property to improve development in supported editors. See [this support doc](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#benefits-using-the-metadata-file) for additional details.

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #6988 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|  ![CleanShot 2022-08-26 at 21 44 23](https://user-images.githubusercontent.com/481776/187009521-b4f35f35-b31f-4df3-b0ae-f773175b29e0.png)  |  ![CleanShot 2022-08-26 at 21 36 42](https://user-images.githubusercontent.com/481776/187009536-ce0e1aaa-387c-40ef-9022-9e0be86c91f5.png)  |

### Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Install a block theme (e.g., Twenty Twenty Two).
2. Open **Appearance > Editor (beta)**.
3. Add a Featured Product and a Featured Category block.
4. Customize the global styles for those blocks (click on the Styles button on the top toolbar and then the Blocks section towards the bottom - _see screenshots below_).
5. Add some style adjustments and confirm they are reflected in the editor.
6. Save your changes and view a page driven by the modified Template on the front-end.
7. Confirm the adjusted styles are rendered to the front-end, as expected.

| Global Styles Panel | Blocks Settings |
| ------ | ----- |
|  ![CleanShot 2022-08-26 at 22 05 58](https://user-images.githubusercontent.com/481776/187010061-8c68fcb6-14f5-4509-99ce-2ad3bff43369.png)  |  ![CleanShot 2022-08-26 at 22 03 00](https://user-images.githubusercontent.com/481776/187009972-4c0bc853-4202-457e-8331-0f5b15d9f5e6.png)  |

_**Note:** the text color settings for this block are driven by inline styles that are added based on the Overlay and Color setting defaults. I imagine we want to keep those defaults in place so. To adjust this in the Editor, edit/remove those default settings on the block directly._

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Update - remove __experimentalDuotone from Featured Product and Featured Category blocks.
