### PR TITLE
Fix stock filter placeholder

### DIFF
--- a/assets/js/base/components/filter-placeholder/index.tsx
+++ b/assets/js/base/components/filter-placeholder/index.tsx
@@ -1,13 +1,13 @@
-interface FilterPlaceholderProps {
+interface FilterTitlePlaceholderProps {
 	children?: React.ReactChildren;
 }
 
-const FilterPlaceholder = ( {
+const FilterTitlePlaceholder = ( {
 	children,
-}: FilterPlaceholderProps ): JSX.Element => {
+}: FilterTitlePlaceholderProps ): JSX.Element => {
 	return (
 		<div className="wc-block-filter-title-placeholder">{ children }</div>
 	);
 };
 
-export default FilterPlaceholder;
+export default FilterTitlePlaceholder;

--- a/assets/js/base/components/filter-placeholder/index.tsx
+++ b/assets/js/base/components/filter-placeholder/index.tsx
@@ -1,5 +1,13 @@
-const FilterTitlePlaceholder = (): JSX.Element => {
-	return <div className="wc-block-filter-title-placeholder"></div>;
+interface FilterPlaceholderProps {
+	children?: React.ReactChildren;
+}
+
+const FilterPlaceholder = ( {
+	children,
+}: FilterPlaceholderProps ): JSX.Element => {
+	return (
+		<div className="wc-block-filter-title-placeholder">{ children }</div>
+	);
 };
 
-export default FilterTitlePlaceholder;
+export default FilterPlaceholder;

--- a/assets/js/base/components/filter-placeholder/index.tsx
+++ b/assets/js/base/components/filter-placeholder/index.tsx
@@ -1,0 +1,5 @@
+const FilterTitlePlaceholder = (): JSX.Element => {
+	return <div className="wc-block-filter-title-placeholder"></div>;
+};
+
+export default FilterTitlePlaceholder;

--- a/assets/js/base/components/filter-placeholder/style.scss
+++ b/assets/js/base/components/filter-placeholder/style.scss
@@ -3,9 +3,12 @@
 	background-color: $gray-400 !important;
 	border-radius: em(26px);
 	box-shadow: none;
-	height: 1em;
 	margin-bottom: $gap;
 	min-width: 80px;
-	max-width: 140px !important;
-	width: 25%;
+	max-width: max-content !important;
+
+	.wc-block-stock-filter__title {
+		margin: 0;
+		height: 1em;
+	}
 }

--- a/assets/js/base/components/filter-placeholder/style.scss
+++ b/assets/js/base/components/filter-placeholder/style.scss
@@ -1,0 +1,9 @@
+.wc-block-filter-title-placeholder {
+	@include placeholder();
+	background-color: $gray-400 !important;
+	border-radius: em(26px);
+	box-shadow: none;
+	height: 1em;
+	margin-bottom: $gap;
+	width: 25%;
+}

--- a/assets/js/base/components/filter-placeholder/style.scss
+++ b/assets/js/base/components/filter-placeholder/style.scss
@@ -5,5 +5,7 @@
 	box-shadow: none;
 	height: 1em;
 	margin-bottom: $gap;
+	min-width: 80px;
+	max-width: 140px !important;
 	width: 25%;
 }

--- a/assets/js/blocks/stock-filter/block.tsx
+++ b/assets/js/blocks/stock-filter/block.tsx
@@ -340,6 +340,10 @@ const StockStatusFilterBlock = ( {
 		[ checked, displayedOptions ]
 	);
 
+	if ( ! filteredCountsLoading && displayedOptions.length === 0 ) {
+		return null;
+	}
+
 	const TagName =
 		`h${ blockAttributes.headingLevel }` as keyof JSX.IntrinsicElements;
 	const isLoading =

--- a/assets/js/blocks/stock-filter/block.tsx
+++ b/assets/js/blocks/stock-filter/block.tsx
@@ -362,16 +362,16 @@ const StockStatusFilterBlock = ( {
 		return null;
 	}
 
-	const filterHeading = isLoading ? (
-		<FilterPlaceholder />
-	) : (
-		<TagName
-			className={ classnames( 'wc-block-stock-filter__title', {
-				'show-loading-state': isLoading,
-			} ) }
-		>
+	const heading = (
+		<TagName className="wc-block-stock-filter__title">
 			{ blockAttributes.heading }
 		</TagName>
+	);
+
+	const filterHeading = isLoading ? (
+		<FilterPlaceholder>{ heading }</FilterPlaceholder>
+	) : (
+		heading
 	);
 
 	return (

--- a/assets/js/blocks/stock-filter/block.tsx
+++ b/assets/js/blocks/stock-filter/block.tsx
@@ -20,7 +20,7 @@ import {
 import CheckboxList from '@woocommerce/base-components/checkbox-list';
 import FilterSubmitButton from '@woocommerce/base-components/filter-submit-button';
 import FilterResetButton from '@woocommerce/base-components/filter-reset-button';
-import FilterPlaceholder from '@woocommerce/base-components/filter-placeholder';
+import FilterTitlePlaceholder from '@woocommerce/base-components/filter-placeholder';
 import Label from '@woocommerce/base-components/filter-element-label';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -369,7 +369,7 @@ const StockStatusFilterBlock = ( {
 	);
 
 	const filterHeading = isLoading ? (
-		<FilterPlaceholder>{ heading }</FilterPlaceholder>
+		<FilterTitlePlaceholder>{ heading }</FilterTitlePlaceholder>
 	) : (
 		heading
 	);

--- a/assets/js/blocks/stock-filter/block.tsx
+++ b/assets/js/blocks/stock-filter/block.tsx
@@ -20,6 +20,7 @@ import {
 import CheckboxList from '@woocommerce/base-components/checkbox-list';
 import FilterSubmitButton from '@woocommerce/base-components/filter-submit-button';
 import FilterResetButton from '@woocommerce/base-components/filter-reset-button';
+import FilterPlaceholder from '@woocommerce/base-components/filter-placeholder';
 import Label from '@woocommerce/base-components/filter-element-label';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -361,17 +362,21 @@ const StockStatusFilterBlock = ( {
 		return null;
 	}
 
+	const filterHeading = isLoading ? (
+		<FilterPlaceholder />
+	) : (
+		<TagName
+			className={ classnames( 'wc-block-stock-filter__title', {
+				'show-loading-state': isLoading,
+			} ) }
+		>
+			{ blockAttributes.heading }
+		</TagName>
+	);
+
 	return (
 		<>
-			{ ! isEditor && blockAttributes.heading && (
-				<TagName
-					className={ classnames( 'wc-block-stock-filter__title', {
-						'show-loading-state': isLoading,
-					} ) }
-				>
-					{ blockAttributes.heading }
-				</TagName>
-			) }
+			{ ! isEditor && blockAttributes.heading && filterHeading }
 			<div
 				className={ classnames( 'wc-block-stock-filter', {
 					'show-loading-state': isLoading,

--- a/assets/js/blocks/stock-filter/style.scss
+++ b/assets/js/blocks/stock-filter/style.scss
@@ -9,17 +9,6 @@
 	}
 }
 
-.wc-block-stock-filter__title {
-	&.show-loading-state {
-		@include placeholder();
-		background-color: $gray-400 !important;
-		border-radius: em(26px);
-		box-shadow: none;
-		max-height: 1em;
-		width: max-content;
-	}
-}
-
 .wc-block-stock-filter {
 	&.show-loading-state {
 		@include placeholder();

--- a/assets/js/blocks/stock-filter/style.scss
+++ b/assets/js/blocks/stock-filter/style.scss
@@ -15,6 +15,7 @@
 		background-color: $gray-400 !important;
 		border-radius: em(26px);
 		box-shadow: none;
+		max-height: 1em;
 		width: max-content;
 	}
 }

--- a/assets/js/blocks/stock-filter/style.scss
+++ b/assets/js/blocks/stock-filter/style.scss
@@ -13,7 +13,7 @@
 	&.show-loading-state {
 		@include placeholder();
 		box-shadow: none;
-		border-radius: em(4px) !important;
+		border-radius: 0;
 	}
 
 	margin-bottom: $gap-large;


### PR DESCRIPTION
This PR fixes two issues with the `Filter by stock` placeholder:
- Showing a very wide placeholder when the filter title is very long.
- Showing the placeholder when there are no products.

Related to https://github.com/woocommerce/woocommerce-blocks/issues/6846

| Before | After |
| ------ | ----- |
|  <img width="1034" alt="Screenshot 2022-08-30 at 14 40 43" src="https://user-images.githubusercontent.com/186112/187439097-33ff39cc-1f24-44f1-a371-94919490b5d6.png"> |<img width="1024" alt="Screenshot 2022-08-30 at 14 40 24" src="https://user-images.githubusercontent.com/186112/187439079-954c1362-d3e6-4260-af8b-75d80963b450.png">| 
| ![Screenshot 2022-08-30 at 12 06 52](https://user-images.githubusercontent.com/186112/187438707-ecafa77d-3915-4b78-8814-9f292d2e935f.png)| <img width="1023" alt="Screenshot 2022-08-30 at 14 38 54" src="https://user-images.githubusercontent.com/186112/187438666-35ac4298-0c06-442a-9ea5-fc741ee7edc5.png">|


### Testing

#### User Facing Testing

1. Create a new page with a 30/70 columns block, insert the `Filter by stock` block in the 30% column and the `All Products` block in the 70% columns. Save the page.
2. Open the page in the frontend and check that the `Filter by stock` block shows like the screenshot above while loading.
3. Remove all products in the store and refresh the page you created in step 1. Check that `Filter by stock` placeholder disappears if there are no products.

### WooCommerce Visibility

* [X] WooCommerce Core
* [X] Feature plugin
* [ ] Experimental

