### PR TITLE
Fix corrupt Classic Template placeholders for specific products.

### DIFF
--- a/assets/js/blocks/classic-template/constants.ts
+++ b/assets/js/blocks/classic-template/constants.ts
@@ -2,10 +2,14 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-
 export const BLOCK_SLUG = 'woocommerce/legacy-template';
 
-export const TEMPLATES: Record< string, Record< string, string > > = {
+/**
+ * Internal dependencies
+ */
+import { TemplateDetails } from './types';
+
+export const TEMPLATES: TemplateDetails = {
 	'single-product': {
 		title: __(
 			'WooCommerce Single Product Block',

--- a/assets/js/blocks/classic-template/index.tsx
+++ b/assets/js/blocks/classic-template/index.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import {
-	Block,
 	BlockEditProps,
 	createBlock,
 	getBlockType,
@@ -26,20 +25,11 @@ import { useEffect } from '@wordpress/element';
 import './editor.scss';
 import './style.scss';
 import { BLOCK_SLUG, TEMPLATES } from './constants';
-
-const templates = Object.keys( TEMPLATES );
-
-const getTemplateDetailsBySlug = ( parsedTemplate: string ) => {
-	let templateSlug = null;
-	for ( let i = 0; templates.length > i; i++ ) {
-		if ( parsedTemplate.includes( templates[ i ] ) ) {
-			templateSlug = templates[ i ];
-			break;
-		}
-	}
-
-	return templateSlug ? TEMPLATES[ templateSlug ] : null;
-};
+import {
+	isClassicTemplateBlockRegisteredWithAnotherTitle,
+	hasTemplateSupportForClassicTemplateBlock,
+	getTemplateDetailsBySlug,
+} from './utils';
 
 type Attributes = {
 	template: string;
@@ -212,26 +202,6 @@ const registerClassicTemplateBlock = ( {
 		},
 		save: () => null,
 	} );
-};
-
-const isClassicTemplateBlockRegisteredWithAnotherTitle = (
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	block: Block< any > | undefined,
-	parsedTemplate: string
-) => block?.title !== TEMPLATES[ parsedTemplate ].title;
-
-const hasTemplateSupportForClassicTemplateBlock = (
-	parsedTemplate: string
-) => {
-	let hasSupport = false;
-	for ( let i = 0; templates.length > i; i++ ) {
-		if ( parsedTemplate.includes( templates[ i ] ) ) {
-			hasSupport = true;
-			break;
-		}
-	}
-
-	return hasSupport;
 };
 
 // @todo Refactor when there will be possible to show a block according on a template/post with a Gutenberg API. https://github.com/WordPress/gutenberg/pull/41718

--- a/assets/js/blocks/classic-template/index.tsx
+++ b/assets/js/blocks/classic-template/index.tsx
@@ -44,7 +44,10 @@ const Edit = ( {
 	const { replaceBlock } = useDispatch( 'core/block-editor' );
 
 	const blockProps = useBlockProps();
-	const templateDetails = getTemplateDetailsBySlug( attributes.template );
+	const templateDetails = getTemplateDetailsBySlug(
+		attributes.template,
+		TEMPLATES
+	);
 	const templateTitle = templateDetails?.title ?? attributes.template;
 	const templatePlaceholder = templateDetails?.placeholder ?? 'fallback';
 
@@ -228,7 +231,10 @@ if ( isExperimentalBuild() ) {
 
 		if (
 			block !== undefined &&
-			( ! hasTemplateSupportForClassicTemplateBlock( parsedTemplate ) ||
+			( ! hasTemplateSupportForClassicTemplateBlock(
+				parsedTemplate,
+				TEMPLATES
+			) ||
 				isClassicTemplateBlockRegisteredWithAnotherTitle(
 					block,
 					parsedTemplate
@@ -241,7 +247,10 @@ if ( isExperimentalBuild() ) {
 
 		if (
 			block === undefined &&
-			hasTemplateSupportForClassicTemplateBlock( parsedTemplate )
+			hasTemplateSupportForClassicTemplateBlock(
+				parsedTemplate,
+				TEMPLATES
+			)
 		) {
 			registerClassicTemplateBlock( {
 				template: parsedTemplate,

--- a/assets/js/blocks/classic-template/index.tsx
+++ b/assets/js/blocks/classic-template/index.tsx
@@ -27,6 +27,20 @@ import './editor.scss';
 import './style.scss';
 import { BLOCK_SLUG, TEMPLATES } from './constants';
 
+const templates = Object.keys( TEMPLATES );
+
+const getTemplateDetailsBySlug = ( parsedTemplate: string ) => {
+	let templateSlug = null;
+	for ( let i = 0; templates.length > i; i++ ) {
+		if ( parsedTemplate.includes( templates[ i ] ) ) {
+			templateSlug = templates[ i ];
+			break;
+		}
+	}
+
+	return templateSlug ? TEMPLATES[ templateSlug ] : null;
+};
+
 type Attributes = {
 	template: string;
 	align: string;
@@ -40,10 +54,9 @@ const Edit = ( {
 	const { replaceBlock } = useDispatch( 'core/block-editor' );
 
 	const blockProps = useBlockProps();
-	const templateTitle =
-		TEMPLATES[ attributes.template ]?.title ?? attributes.template;
-	const templatePlaceholder =
-		TEMPLATES[ attributes.template ]?.placeholder ?? 'fallback';
+	const templateDetails = getTemplateDetailsBySlug( attributes.template );
+	const templateTitle = templateDetails?.title ?? attributes.template;
+	const templatePlaceholder = templateDetails?.placeholder ?? 'fallback';
 
 	useEffect(
 		() =>
@@ -118,8 +131,6 @@ const Edit = ( {
 	);
 };
 
-const templates = Object.keys( TEMPLATES );
-
 const registerClassicTemplateBlock = ( {
 	template,
 	inserter,
@@ -136,12 +147,13 @@ const registerClassicTemplateBlock = ( {
 	 * See https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5861 for more context
 	 */
 	registerBlockType( BLOCK_SLUG, {
-		title: template
-			? TEMPLATES[ template ].title
-			: __(
-					'WooCommerce Classic Template',
-					'woo-gutenberg-products-block'
-			  ),
+		title:
+			template && TEMPLATES[ template ]
+				? TEMPLATES[ template ].title
+				: __(
+						'WooCommerce Classic Template',
+						'woo-gutenberg-products-block'
+				  ),
 		icon: (
 			<Icon
 				icon={ box }
@@ -208,8 +220,19 @@ const isClassicTemplateBlockRegisteredWithAnotherTitle = (
 	parsedTemplate: string
 ) => block?.title !== TEMPLATES[ parsedTemplate ].title;
 
-const hasTemplateSupportForClassicTemplateBlock = ( parsedTemplate: string ) =>
-	templates.includes( parsedTemplate );
+const hasTemplateSupportForClassicTemplateBlock = (
+	parsedTemplate: string
+) => {
+	let hasSupport = false;
+	for ( let i = 0; templates.length > i; i++ ) {
+		if ( parsedTemplate.includes( templates[ i ] ) ) {
+			hasSupport = true;
+			break;
+		}
+	}
+
+	return hasSupport;
+};
 
 // @todo Refactor when there will be possible to show a block according on a template/post with a Gutenberg API. https://github.com/WordPress/gutenberg/pull/41718
 

--- a/assets/js/blocks/classic-template/test/utils.ts
+++ b/assets/js/blocks/classic-template/test/utils.ts
@@ -1,0 +1,47 @@
+/**
+ * Internal dependencies
+ */
+import { getTemplateDetailsBySlug } from '../utils';
+
+const TEMPLATES = {
+	'single-product': {
+		title: 'Single Product Title',
+		placeholder: 'Single Product Placeholder',
+	},
+	'archive-product': {
+		title: 'Product Archive Title',
+		placeholder: 'Product Archive Placeholder',
+	},
+	'archive-product': {
+		title: 'Product Archive Title',
+		placeholder: 'Product Archive Placeholder',
+	},
+	'taxonomy-product_cat': {
+		title: 'Product Taxonomy Title',
+		placeholder: 'Product Taxonomy Placeholder',
+	},
+};
+
+describe( 'getTemplateDetailsBySlug', function () {
+	it( 'should return single-product object when given an exact match', () => {
+		expect(
+			getTemplateDetailsBySlug( 'single-product', TEMPLATES )
+		).toBeTruthy();
+		expect(
+			getTemplateDetailsBySlug( 'single-product', TEMPLATES )
+		).toStrictEqual( TEMPLATES[ 'single-product' ] );
+	} );
+
+	it( 'should return single-product object when given a partial match', () => {
+		expect(
+			getTemplateDetailsBySlug( 'single-product-hoodie', TEMPLATES )
+		).toBeTruthy();
+		expect(
+			getTemplateDetailsBySlug( 'single-product-hoodie', TEMPLATES )
+		).toStrictEqual( TEMPLATES[ 'single-product' ] );
+	} );
+
+	it( 'should return null object when given an incorrect match', () => {
+		expect( getTemplateDetailsBySlug( 'void', TEMPLATES ) ).toBeNull();
+	} );
+} );

--- a/assets/js/blocks/classic-template/types.ts
+++ b/assets/js/blocks/classic-template/types.ts
@@ -1,0 +1,1 @@
+export type TemplateDetails = Record< string, Record< string, string > >;

--- a/assets/js/blocks/classic-template/utils.ts
+++ b/assets/js/blocks/classic-template/utils.ts
@@ -1,0 +1,50 @@
+/**
+ * External dependencies
+ */
+import { Block } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { TEMPLATES } from './constants';
+
+const templateKeys = Object.keys( TEMPLATES );
+
+// Finds the most appropriate template details object for specific template keys such as single-product-hoodie.
+export function getTemplateDetailsBySlug( parsedTemplate: string ) {
+	let templateDetails = null;
+
+	for ( let i = 0; templateKeys.length > i; i++ ) {
+		const keyToMatch = parsedTemplate.substr( 0, templateKeys[ i ].length );
+		const maybeTemplate = TEMPLATES[ keyToMatch ];
+		if ( maybeTemplate ) {
+			templateDetails = maybeTemplate;
+			break;
+		}
+	}
+
+	return templateDetails;
+}
+
+export function isClassicTemplateBlockRegisteredWithAnotherTitle(
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	block: Block< any > | undefined,
+	parsedTemplate: string
+) {
+	const templateDetails = getTemplateDetailsBySlug( parsedTemplate );
+	return block?.title !== templateDetails?.title;
+}
+
+export function hasTemplateSupportForClassicTemplateBlock(
+	parsedTemplate: string
+) {
+	let hasSupport = false;
+	for ( let i = 0; templateKeys.length > i; i++ ) {
+		if ( parsedTemplate.includes( templateKeys[ i ] ) ) {
+			hasSupport = true;
+			break;
+		}
+	}
+
+	return hasSupport;
+}

--- a/assets/js/blocks/classic-template/utils.ts
+++ b/assets/js/blocks/classic-template/utils.ts
@@ -7,16 +7,19 @@ import { Block } from '@wordpress/blocks';
  * Internal dependencies
  */
 import { TEMPLATES } from './constants';
-
-const templateKeys = Object.keys( TEMPLATES );
+import { TemplateDetails } from './types';
 
 // Finds the most appropriate template details object for specific template keys such as single-product-hoodie.
-export function getTemplateDetailsBySlug( parsedTemplate: string ) {
+export function getTemplateDetailsBySlug(
+	parsedTemplate: string,
+	templates: TemplateDetails
+) {
+	const templateKeys = Object.keys( templates );
 	let templateDetails = null;
 
 	for ( let i = 0; templateKeys.length > i; i++ ) {
 		const keyToMatch = parsedTemplate.substr( 0, templateKeys[ i ].length );
-		const maybeTemplate = TEMPLATES[ keyToMatch ];
+		const maybeTemplate = templates[ keyToMatch ];
 		if ( maybeTemplate ) {
 			templateDetails = maybeTemplate;
 			break;
@@ -31,20 +34,16 @@ export function isClassicTemplateBlockRegisteredWithAnotherTitle(
 	block: Block< any > | undefined,
 	parsedTemplate: string
 ) {
-	const templateDetails = getTemplateDetailsBySlug( parsedTemplate );
+	const templateDetails = getTemplateDetailsBySlug(
+		parsedTemplate,
+		TEMPLATES
+	);
 	return block?.title !== templateDetails?.title;
 }
 
 export function hasTemplateSupportForClassicTemplateBlock(
-	parsedTemplate: string
-) {
-	let hasSupport = false;
-	for ( let i = 0; templateKeys.length > i; i++ ) {
-		if ( parsedTemplate.includes( templateKeys[ i ] ) ) {
-			hasSupport = true;
-			break;
-		}
-	}
-
-	return hasSupport;
+	parsedTemplate: string,
+	templates: TemplateDetails
+): boolean {
+	return getTemplateDetailsBySlug( parsedTemplate, templates ) ? true : false;
 }


### PR DESCRIPTION
When using the Gutenberg plugin, you can create specific templates for products, categories and tags via the Appearance > Editor > Add New button. At the moment in the code for the Classic Template Block placeholder we don't accommodate for these specific slugs e.g. `single-product-hoodie` so we get an unsupported block notice in the editor as seen below.

This PR introduces a change finds the closest matching template. For example `single-product-hoodie` will match the template details for `single-product` (and the same for product categories/tags too).

<img width="1904" alt="CleanShot 2022-08-31 at 09 35 51@2x" src="https://user-images.githubusercontent.com/8639742/187886124-3116a442-28c4-477d-bd82-2cf5f857b212.png">

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|        |       |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [x] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

Reproduce the original issue:

1. Before checking out this PR, activate Gutenberg plugin
2. Go to Appearance > Editor > Add New to add a new template
3. Click "Single Item: Product" template and create a product specific template
4. Observe the block compatibility error as seen in the screenshot above.

Test the fix:

1. Checkout this PR, and activate Gutenberg plugin
2. Go to Appearance > Editor > Add New to add a new template
3. Click "Single Item: Product" template and create a product specific template
4. The block should render the placeholder for the Single Product.
5. Make changes to this template, and save them. Make sure these are represented on the frontend. Then clear the customizations and do the same.
6. Complete steps 3-5 again but instead create Product Category and Product Tag templates.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Fix incompatible Classic Template block notice in the Editor for Woo specific templates
