### PR TITLE
Update Active Filters "remove filter" icon to use Icon component

### DIFF
--- a/assets/js/blocks/active-filters/style.scss
+++ b/assets/js/blocks/active-filters/style.scss
@@ -127,6 +127,10 @@
 				max-width: 200px;
 			}
 		}
+
+		> .wc-block-active-filters__list-item .wc-block-active-filters__list-item-name {
+			margin: 9px 0 0;
+		}
 	}
 
 	.wc-block-active-filters__list-item-type {

--- a/assets/js/blocks/active-filters/style.scss
+++ b/assets/js/blocks/active-filters/style.scss
@@ -151,9 +151,12 @@
 	}
 
 	.wc-block-active-filters__list-item-remove {
-		background: transparent;
+		@include font-size(smaller);
+		background: $gray-200;
 		border: 0;
+		border-radius: 25px;
 		appearance: none;
+		padding: 0;
 		height: 16px;
 		width: 16px;
 		line-height: 16px;
@@ -161,8 +164,13 @@
 		margin: 0 0.5em 0 0;
 		color: currentColor;
 
-		&:hover {
-			color: $gray-600;
+		&:hover,
+		&:focus {
+			background: $gray-600;
+
+			.wc-block-components-chip__remove-icon {
+				fill: #fff;
+			}
 		}
 
 		&:disabled {

--- a/assets/js/blocks/active-filters/utils.tsx
+++ b/assets/js/blocks/active-filters/utils.tsx
@@ -7,6 +7,7 @@ import { RemovableChip } from '@woocommerce/base-components/chip';
 import Label from '@woocommerce/base-components/label';
 import { getQueryArgs, addQueryArgs, removeQueryArgs } from '@wordpress/url';
 import { changeUrl } from '@woocommerce/utils';
+import { Icon, closeSmall } from '@wordpress/icons';
 
 /**
  * Format a min/max price range to display.
@@ -108,39 +109,11 @@ export const renderRemovableListItem = ( {
 						className="wc-block-active-filters__list-item-remove"
 						onClick={ removeCallback }
 					>
-						<svg
-							width="16"
-							height="16"
-							viewBox="0 0 16 16"
-							fill="none"
-							xmlns="http://www.w3.org/2000/svg"
-						>
-							<ellipse
-								cx="8"
-								cy="8"
-								rx="8"
-								ry="8"
-								transform="rotate(-180 8 8)"
-								fill="currentColor"
-								fillOpacity="0.7"
-							/>
-							<rect
-								x="10.636"
-								y="3.94983"
-								width="2"
-								height="9.9466"
-								transform="rotate(45 10.636 3.94983)"
-								fill="white"
-							/>
-							<rect
-								x="12.0503"
-								y="11.0209"
-								width="2"
-								height="9.9466"
-								transform="rotate(135 12.0503 11.0209)"
-								fill="white"
-							/>
-						</svg>
+						<Icon
+							className="wc-block-components-chip__remove-icon"
+							icon={ closeSmall }
+							size={ 16 }
+						/>
 						<Label screenReaderLabel={ removeText } />
 					</button>
 					{ prefixedName }


### PR DESCRIPTION
To be consistent with the button icon used on the Chips view, this replaces the native `svg` element used in the List view with the same `Icon` component from WP Core.

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #6915 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|  ![CleanShot 2022-08-31 at 16 48 11](https://user-images.githubusercontent.com/481776/187812070-f2d2e861-8611-4fa9-9125-21e574635043.png)  |  ![CleanShot 2022-08-31 at 16 38 34](https://user-images.githubusercontent.com/481776/187812115-ac898c70-1b26-4f3f-ada3-fca71e170cf2.png)  |

### Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Add the Active Filters block, in List view alongside some other Filters blocks.
3. Apply some filters to the page.
4. Confirm the remove button matches the After screenshot above. Also confirm that the remove button is visually consistent with the remove button in Chips view.
5. Confirm the remove buttons for each active filter have a hover state of an alternate shade of grey - also confirm they function as expected.
6. Confirm no JS or PHP errors.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental

### Changelog

> Enhancement - update "remove filter" icon on the Active Filters block to use Icon component in both layouts.
