### PR TITLE
Improve public-facing texts and labels

### DIFF
--- a/assets/js/atomic/blocks/product-elements/category-list/constants.tsx
+++ b/assets/js/atomic/blocks/product-elements/category-list/constants.tsx
@@ -12,6 +12,6 @@ export const BLOCK_ICON: JSX.Element = (
 	<Icon icon={ archive } className="wc-block-editor-components-block-icon" />
 );
 export const BLOCK_DESCRIPTION: string = __(
-	'Display a list of categories belonging to a product.',
+	'Display the list of categories that are assigned to a product.',
 	'woo-gutenberg-products-block'
 );

--- a/assets/js/atomic/blocks/product-elements/image/edit.js
+++ b/assets/js/atomic/blocks/product-elements/image/edit.js
@@ -74,7 +74,7 @@ const Edit = ( { attributes, setAttributes, context } ) => {
 							'woo-gutenberg-products-block'
 						) }
 						help={ __(
-							'Overlay a "sale" badge if the product is on-sale.',
+							'Display a “sale” badge if the product is on-sale.',
 							'woo-gutenberg-products-block'
 						) }
 						checked={ showSaleBadge }

--- a/assets/js/atomic/blocks/product-elements/tag-list/constants.js
+++ b/assets/js/atomic/blocks/product-elements/tag-list/constants.js
@@ -12,6 +12,6 @@ export const BLOCK_ICON = (
 	<Icon icon={ tag } className="wc-block-editor-components-block-icon" />
 );
 export const BLOCK_DESCRIPTION = __(
-	'Display a list of tags belonging to a product.',
+	'Display the list of tags that are assigned to a product.',
 	'woo-gutenberg-products-block'
 );

--- a/assets/js/base/context/providers/add-to-cart-form/form-state/index.js
+++ b/assets/js/base/context/providers/add-to-cart-form/form-state/index.js
@@ -245,7 +245,7 @@ export const AddToCartFormStateContextProvider = ( {
 						const message =
 							data.processingResponse?.message ||
 							__(
-								'Something went wrong. Please contact us to get assistance.',
+								'Something went wrong. Please contact us for assistance. Please contact us to get assistance.',
 								'woo-gutenberg-products-block'
 							);
 						createErrorNotice( message, {

--- a/assets/js/base/context/providers/add-to-cart-form/form-state/index.js
+++ b/assets/js/base/context/providers/add-to-cart-form/form-state/index.js
@@ -245,7 +245,7 @@ export const AddToCartFormStateContextProvider = ( {
 						const message =
 							data.processingResponse?.message ||
 							__(
-								'Something went wrong. Please contact us for assistance. Please contact us to get assistance.',
+								'Something went wrong. Please contact us for assistance.',
 								'woo-gutenberg-products-block'
 							);
 						createErrorNotice( message, {

--- a/assets/js/base/context/providers/add-to-cart-form/form/submit/index.js
+++ b/assets/js/base/context/providers/add-to-cart-form/form/submit/index.js
@@ -101,7 +101,7 @@ const FormSubmit = () => {
 						} else {
 							createErrorNotice(
 								__(
-									'Something went wrong. Please contact us for assistance. Please contact us for assistance. Please contact us for assistance. Please contact us to get assistance.',
+									'Something went wrong. Please contact us for assistance.',
 									'woo-gutenberg-products-block'
 								),
 								{

--- a/assets/js/base/context/providers/add-to-cart-form/form/submit/index.js
+++ b/assets/js/base/context/providers/add-to-cart-form/form/submit/index.js
@@ -101,7 +101,7 @@ const FormSubmit = () => {
 						} else {
 							createErrorNotice(
 								__(
-									'Something went wrong. Please contact us to get assistance.',
+									'Something went wrong. Please contact us for assistance. Please contact us for assistance. Please contact us for assistance. Please contact us to get assistance.',
 									'woo-gutenberg-products-block'
 								),
 								{

--- a/assets/js/base/context/providers/cart-checkout/checkout-processor.js
+++ b/assets/js/base/context/providers/cart-checkout/checkout-processor.js
@@ -257,7 +257,7 @@ const CheckoutProcessor = () => {
 							),
 							errorResponse?.message ??
 								__(
-									'Something went wrong.',
+									'Something went wrong. Please contact us for assistance.',
 									'woo-gutenberg-products-block'
 								)
 						),

--- a/assets/js/base/context/providers/cart-checkout/checkout-state/index.tsx
+++ b/assets/js/base/context/providers/cart-checkout/checkout-state/index.tsx
@@ -265,7 +265,7 @@ export const CheckoutStateProvider = ( {
 							const message =
 								data.processingResponse?.message ||
 								__(
-									'Something went wrong. Please contact us to get assistance.',
+									'Something went wrong. Please contact us for assistance. Please contact us to get assistance.',
 									'woo-gutenberg-products-block'
 								);
 							createErrorNotice( message, {

--- a/assets/js/base/context/providers/cart-checkout/checkout-state/index.tsx
+++ b/assets/js/base/context/providers/cart-checkout/checkout-state/index.tsx
@@ -265,7 +265,7 @@ export const CheckoutStateProvider = ( {
 							const message =
 								data.processingResponse?.message ||
 								__(
-									'Something went wrong. Please contact us for assistance. Please contact us to get assistance.',
+									'Something went wrong. Please contact us for assistance.',
 									'woo-gutenberg-products-block'
 								);
 							createErrorNotice( message, {

--- a/assets/js/base/context/providers/cart-checkout/checkout-state/utils.ts
+++ b/assets/js/base/context/providers/cart-checkout/checkout-state/utils.ts
@@ -53,7 +53,7 @@ export const getPaymentResultFromCheckoutResponse = (
 		response.data.status > 299
 	) {
 		paymentResult.message = __(
-			'Something went wrong. Please contact us to get assistance.',
+			'Something went wrong. Please contact us for assistance. Please contact us to get assistance.',
 			'woo-gutenberg-products-block'
 		);
 	}

--- a/assets/js/base/context/providers/cart-checkout/checkout-state/utils.ts
+++ b/assets/js/base/context/providers/cart-checkout/checkout-state/utils.ts
@@ -53,7 +53,7 @@ export const getPaymentResultFromCheckoutResponse = (
 		response.data.status > 299
 	) {
 		paymentResult.message = __(
-			'Something went wrong. Please contact us for assistance. Please contact us to get assistance.',
+			'Something went wrong. Please contact us for assistance.',
 			'woo-gutenberg-products-block'
 		);
 	}

--- a/assets/js/base/utils/errors.js
+++ b/assets/js/base/utils/errors.js
@@ -52,7 +52,7 @@ export const formatStoreApiErrorMessage = ( response ) => {
 	return response?.message
 		? decodeEntities( response.message )
 		: __(
-				'Something went wrong. Please contact us to get assistance.',
+				'Something went wrong. Please contact us for assistance. Please contact us to get assistance.',
 				'woo-gutenberg-products-block'
 		  );
 };

--- a/assets/js/base/utils/errors.js
+++ b/assets/js/base/utils/errors.js
@@ -52,7 +52,7 @@ export const formatStoreApiErrorMessage = ( response ) => {
 	return response?.message
 		? decodeEntities( response.message )
 		: __(
-				'Something went wrong. Please contact us for assistance. Please contact us to get assistance.',
+				'Something went wrong. Please contact us to get assistance.',
 				'woo-gutenberg-products-block'
 		  );
 };

--- a/assets/js/blocks/active-filters/active-attribute-filters.tsx
+++ b/assets/js/blocks/active-filters/active-attribute-filters.tsx
@@ -91,7 +91,7 @@ const ActiveAttributeFilters = ( {
 					if ( index > 0 && operator === 'and' ) {
 						prefix = (
 							<span className="wc-block-active-filters__list-item-operator">
-								{ __( 'and', 'woo-gutenberg-products-block' ) }
+								{ __( 'All', 'woo-gutenberg-products-block' ) }
 							</span>
 						);
 					}

--- a/assets/js/blocks/active-filters/block.json
+++ b/assets/js/blocks/active-filters/block.json
@@ -2,7 +2,7 @@
 	"name": "woocommerce/active-filters",
 	"version": "1.0.0",
 	"title": "Active Product Filters",
-	"description": "Show the currently active product filters. Works in combination with the All Products and filters blocks.",
+	"description": "Display the currently active product filters.",
 	"category": "woocommerce",
 	"keywords": [ "WooCommerce" ],
 	"supports": {

--- a/assets/js/blocks/active-filters/index.tsx
+++ b/assets/js/blocks/active-filters/index.tsx
@@ -19,7 +19,7 @@ import { Attributes } from './types';
 registerBlockType( metadata, {
 	title: __( 'Active Product Filters', 'woo-gutenberg-products-block' ),
 	description: __(
-		'Show the currently active product filters. Works in combination with the All Products and filters blocks.',
+		'Display the currently active product filters.',
 		'woo-gutenberg-products-block'
 	),
 	icon: {

--- a/assets/js/blocks/attribute-filter/block.json
+++ b/assets/js/blocks/attribute-filter/block.json
@@ -2,7 +2,7 @@
 	"name": "woocommerce/attribute-filter",
 	"version": "1.0.0",
 	"title": "Filter by Attribute",
-	"description": "Allow customers to filter the grid by product attribute, such as color.",
+	"description": "Enable customers to filter the product grid by selecting one or more attributes, such as color.",
 	"category": "woocommerce",
 	"keywords": [ "WooCommerce" ],
 	"supports": {
@@ -48,7 +48,7 @@
 		},
 		"selectType": {
 			"type": "string",
-			"default": "multiple" 
+			"default": "multiple"
 		},
 		"isPreview": {
 			"type": "boolean",

--- a/assets/js/blocks/attribute-filter/block.tsx
+++ b/assets/js/blocks/attribute-filter/block.tsx
@@ -493,7 +493,7 @@ const AttributeFilterBlock = ( {
 				<Notice status="warning" isDismissible={ false }>
 					<p>
 						{ __(
-							'The selected attribute does not have any term assigned to products.',
+							'There are no products with the selected attributes.',
 							'woo-gutenberg-products-block'
 						) }
 					</p>

--- a/assets/js/blocks/attribute-filter/edit.tsx
+++ b/assets/js/blocks/attribute-filter/edit.tsx
@@ -176,17 +176,6 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak }: EditProps ) => {
 							'Include product count',
 							'woo-gutenberg-products-block'
 						) }
-						help={
-							showCounts
-								? __(
-										'Show the product count with results.',
-										'woo-gutenberg-products-block'
-								  )
-								: __(
-										'Product count is hidden.',
-										'woo-gutenberg-products-block'
-								  )
-						}
 						checked={ showCounts }
 						onChange={ () =>
 							setAttributes( {
@@ -314,11 +303,11 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak }: EditProps ) => {
 						help={
 							showFilterButton
 								? __(
-										'Products will only update when the button is pressed.',
+										'Products will only update when the button is clicked.',
 										'woo-gutenberg-products-block'
 								  )
 								: __(
-										'Products will update as options are selected.',
+										'Products will update as soon as attributes are selected.',
 										'woo-gutenberg-products-block'
 								  )
 						}
@@ -352,7 +341,7 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak }: EditProps ) => {
 				'woo-gutenberg-products-block'
 			) }
 			instructions={ __(
-				'Display a list of filters based on a chosen attribute.',
+				'Display a list of filters based on the selected attributes.',
 				'woo-gutenberg-products-block'
 			) }
 		>
@@ -387,7 +376,7 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak }: EditProps ) => {
 		setIsEditing( false );
 		debouncedSpeak(
 			__(
-				'Showing Filter by Attribute block preview.',
+				'Now displaying a preview of the Filter Products by Attribute block.',
 				'woo-gutenberg-products-block'
 			)
 		);
@@ -403,7 +392,7 @@ const Edit = ( { attributes, setAttributes, debouncedSpeak }: EditProps ) => {
 					'woo-gutenberg-products-block'
 				) }
 				instructions={ __(
-					'Display a list of filters based on a chosen attribute.',
+					'Display a list of filters based on the selected attributes.',
 					'woo-gutenberg-products-block'
 				) }
 			>

--- a/assets/js/blocks/attribute-filter/index.tsx
+++ b/assets/js/blocks/attribute-filter/index.tsx
@@ -19,7 +19,7 @@ import metadata from './block.json';
 registerBlockType( metadata, {
 	title: __( 'Filter by Attribute', 'woo-gutenberg-products-block' ),
 	description: __(
-		'Allow customers to filter the grid by product attribute, such as color.',
+		'Enable customers to filter the product grid by selecting one or more attributes, such as color.',
 		'woo-gutenberg-products-block'
 	),
 	icon: {

--- a/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment/cart-express-payment.js
+++ b/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment/cart-express-payment.js
@@ -66,7 +66,7 @@ const CartExpressPayment = () => {
 			</LoadingMask>
 			<div className="wc-block-components-express-payment-continue-rule wc-block-components-express-payment-continue-rule--cart">
 				{ /* translators: Shown in the Cart block between the express payment methods and the Proceed to Checkout button */ }
-				{ __( 'Or', 'woo-gutenberg-products-block' ) }
+				{ __( 'Any', 'woo-gutenberg-products-block' ) }
 			</div>
 		</>
 	);

--- a/assets/js/blocks/cart-checkout-shared/payment-methods/no-payment-methods/index.js
+++ b/assets/js/blocks/cart-checkout-shared/payment-methods/no-payment-methods/index.js
@@ -38,7 +38,7 @@ const NoPaymentMethodsPlaceholder = () => {
 		>
 			<span className="wc-block-checkout__no-payment-methods-placeholder-description">
 				{ __(
-					'Your store does not have any payment methods configured that support the checkout block. Once you have configured a compatible payment method it will be shown here.',
+					'Your store does not have any payment methods that support the Checkout block. Once you have configured a compatible payment method it will be displayed here.',
 					'woo-gutenberg-products-block'
 				) }
 			</span>

--- a/assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-error-boundary.js
+++ b/assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-error-boundary.js
@@ -24,7 +24,7 @@ class PaymentMethodErrorBoundary extends Component {
 
 		if ( hasError ) {
 			let errorText = __(
-				'This site is experiencing difficulties with this payment method. Please contact the owner of the site for assistance.',
+				'We are experiencing difficulties with this payment method. Please contact us for assistance.',
 				'woo-gutenberg-products-block'
 			);
 			if ( isEditor || CURRENT_USER_IS_ADMIN ) {

--- a/assets/js/blocks/cart/block.js
+++ b/assets/js/blocks/cart/block.js
@@ -74,7 +74,10 @@ const ScrollOnError = ( { scrollToTop } ) => {
 };
 const Block = ( { attributes, children, scrollToTop } ) => (
 	<BlockErrorBoundary
-		header={ __( 'Something went wrong…', 'woo-gutenberg-products-block' ) }
+		header={ __(
+			'Something went wrong. Please contact us for assistance.',
+			'woo-gutenberg-products-block'
+		) }
 		text={ __(
 			'The cart has encountered an unexpected error. If the error persists, please get in touch with us for help.',
 			'woo-gutenberg-products-block'

--- a/assets/js/blocks/cart/inner-blocks/cart-express-payment-block/edit.tsx
+++ b/assets/js/blocks/cart/inner-blocks/cart-express-payment-block/edit.tsx
@@ -27,7 +27,7 @@ const NoExpressPaymentMethodsPlaceholder = () => {
 		>
 			<span className="wp-block-woocommerce-checkout-express-payment-block-placeholder__description">
 				{ __(
-					"Your store doesn't have any Payment Methods that support the Express Checkout Block. If they are added, they will be shown here.",
+					'Your store does not have any payment methods that support the Express Checkout block. Once you have configured a compatible payment method, it will be displayed here.',
 					'woo-gutenberg-products-block'
 				) }
 			</span>

--- a/assets/js/blocks/checkout/block.tsx
+++ b/assets/js/blocks/checkout/block.tsx
@@ -145,7 +145,7 @@ const Block = ( {
 	return (
 		<BlockErrorBoundary
 			header={ __(
-				'Something went wrong…',
+				'Something went wrong. Please contact us for assistance.',
 				'woo-gutenberg-products-block'
 			) }
 			text={ createInterpolateElement(

--- a/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/attributes.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/attributes.tsx
@@ -12,7 +12,7 @@ export default {
 	...formStepAttributes( {
 		defaultTitle: __( 'Billing address', 'woo-gutenberg-products-block' ),
 		defaultDescription: __(
-			'Enter the address that matches your card or payment method.',
+			'Enter the billing address that matches your payment method.',
 			'woo-gutenberg-products-block'
 		),
 	} ),

--- a/assets/js/blocks/checkout/inner-blocks/checkout-express-payment-block/edit.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-express-payment-block/edit.tsx
@@ -27,7 +27,7 @@ const NoExpressPaymentMethodsPlaceholder = () => {
 		>
 			<span className="wp-block-woocommerce-checkout-express-payment-block-placeholder__description">
 				{ __(
-					"Your store doesn't have any Payment Methods that support the Express Checkout Block. If they are added, they will be shown here.",
+					'Your store does not have any payment methods that support the Express Checkout block. Once you have configured a compatible payment method, it will be displayed here.',
 					'woo-gutenberg-products-block'
 				) }
 			</span>

--- a/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/edit.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/edit.tsx
@@ -65,7 +65,7 @@ export const Edit = ( {
 					>
 						<p className="wc-block-checkout__controls-text">
 							{ __(
-								'You currently have the following shipping integrations active.',
+								'The following shipping integrations are active on your store.',
 								'woo-gutenberg-products-block'
 							) }
 						</p>

--- a/assets/js/blocks/checkout/inner-blocks/checkout-terms-block/block.json
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-terms-block/block.json
@@ -2,7 +2,7 @@
 	"name": "woocommerce/checkout-terms-block",
 	"version": "1.0.0",
 	"title": "Terms and Conditions",
-	"description": "Ensure customers agree to your terms and conditions and privacy policy.",
+	"description": "Ensure that customers agree to your Terms & Conditions and Privacy Policy.",
 	"category": "woocommerce",
 	"supports": {
 		"align": false,

--- a/assets/js/blocks/checkout/inner-blocks/checkout-terms-block/edit.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-terms-block/edit.tsx
@@ -134,7 +134,7 @@ export const Edit = ( {
 				>
 					<p>
 						{ __(
-							"You don't seem to have a Terms and Conditions and/or a Privacy Policy pages setup.",
+							"You don't have any Terms and Conditions and/or Privacy Policy pages set up.",
 							'woo-gutenberg-products-block'
 						) }
 					</p>

--- a/assets/js/blocks/checkout/inner-blocks/checkout-terms-block/test/edit.js
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-terms-block/test/edit.js
@@ -59,7 +59,7 @@ describe( 'Edit', () => {
 		expect(
 			queryByText(
 				container,
-				"You don't seem to have a Terms and Conditions and/or a Privacy Policy pages setup."
+				"You don't have any Terms and Conditions and/or Privacy Policy pages set up."
 			)
 		).toBeInTheDocument();
 	} );

--- a/assets/js/blocks/classic-template/index.tsx
+++ b/assets/js/blocks/classic-template/index.tsx
@@ -65,12 +65,12 @@ const Edit = ( {
 					<p className="wp-block-woocommerce-classic-template__placeholder-warning">
 						<strong>
 							{ __(
-								'Attention: Do not remove this block!',
+								'Do not remove this block!',
 								'woo-gutenberg-products-block'
 							) }
 						</strong>{ ' ' }
 						{ __(
-							'Removal will cause unintended effects on your store.',
+							'Removing this will cause unintended effects on your store.',
 							'woo-gutenberg-products-block'
 						) }
 					</p>
@@ -78,7 +78,7 @@ const Edit = ( {
 						{ sprintf(
 							/* translators: %s is the template title */
 							__(
-								'This is an editor placeholder for the %s. On your store this will be replaced by the template and display with your product image(s), title, price, etc. You can move this placeholder around and add further blocks around it to extend the template.',
+								'This is a placeholder for the %s. In your store it will display the actual product image, title, price, etc. You can move this placeholder around and add more blocks around it to customize the template.',
 								'woo-gutenberg-products-block'
 							),
 							templateTitle

--- a/assets/js/blocks/featured-items/featured-product/block.json
+++ b/assets/js/blocks/featured-items/featured-product/block.json
@@ -2,16 +2,11 @@
 	"name": "woocommerce/featured-product",
 	"version": "1.0.0",
 	"title": "Featured Product",
-	"description": "Visually highlight a product or variation and encourage prompt action.",
+	"description": "Highlight a product or variation.",
 	"category": "woocommerce",
-	"keywords": [
-		"WooCommerce"
-	],
+	"keywords": [ "WooCommerce" ],
 	"supports": {
-		"align": [
-			"wide",
-			"full"
-		],
+		"align": [ "wide", "full" ],
 		"html": false,
 		"color": {
 			"background": true,

--- a/assets/js/blocks/featured-items/featured-product/block.tsx
+++ b/assets/js/blocks/featured-items/featured-product/block.tsx
@@ -41,7 +41,7 @@ const CONTENT_CONFIG = {
 const EDIT_MODE_CONFIG = {
 	...GENERIC_CONFIG,
 	description: __(
-		'Visually highlight a product or variation and encourage prompt action',
+		'Highlight a product or variation.',
 		'woo-gutenberg-products-block'
 	),
 	editLabel: __(

--- a/assets/js/blocks/featured-items/inspector-controls.tsx
+++ b/assets/js/blocks/featured-items/inspector-controls.tsx
@@ -162,13 +162,13 @@ export const InspectorControls = ( {
 												} }
 											>
 												{ __(
-													'Choose “Cover” if you want the image to scale automatically to always fit its container.',
+													'Select “Cover” to have the image automatically fit its container.',
 													'woo-gutenberg-products-block'
 												) }
 											</span>
 											<span>
 												{ __(
-													'Note: by choosing “Cover” you will lose the ability to freely move the focal point precisely.',
+													'This may affect your ability to freely move the focal point of the image.',
 													'woo-gutenberg-products-block'
 												) }
 											</span>

--- a/assets/js/blocks/handpicked-products/edit-mode.tsx
+++ b/assets/js/blocks/handpicked-products/edit-mode.tsx
@@ -30,7 +30,7 @@ export const HandpickedProductsEditMode = (
 		setIsEditing( ! isEditing );
 		debouncedSpeak(
 			__(
-				'Showing Hand-picked Products block preview.',
+				'Now displaying a preview of the Hand-picked Products block.',
 				'woo-gutenberg-products-block'
 			)
 		);

--- a/assets/js/blocks/mini-cart/edit.tsx
+++ b/assets/js/blocks/mini-cart/edit.tsx
@@ -111,7 +111,7 @@ const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
 					>
 						<p>
 							{ __(
-								'Edit the appearance of your empty and filled mini cart contents.',
+								'Edit the appearance of the Mini Cart.',
 								'woo-gutenberg-products-block'
 							) }
 						</p>

--- a/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/empty-mini-cart-contents-block/block.json
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/empty-mini-cart-contents-block/block.json
@@ -1,8 +1,8 @@
 {
 	"name": "woocommerce/empty-mini-cart-contents-block",
 	"version": "1.0.0",
-	"title": "Empty Mini Cart Contents",
-	"description": "Contains blocks that are displayed when the mini cart is empty.",
+	"title": "Empty Mini Cart view.",
+	"description": "Blocks that are displayed when the Mini Cart is empty.",
 	"category": "woocommerce",
 	"supports": {
 		"align": false,

--- a/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/filled-mini-cart-contents-block/block.json
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/filled-mini-cart-contents-block/block.json
@@ -1,8 +1,8 @@
 {
 	"name": "woocommerce/filled-mini-cart-contents-block",
 	"version": "1.0.0",
-	"title": "Filled Mini Cart Contents",
-	"description": "Contains blocks that are displayed when the mini cart has products.",
+	"title": "Filled Mini Cart view",
+	"description": "Contains blocks that display the content of the Mini Cart.",
 	"category": "woocommerce",
 	"supports": {
 		"align": false,

--- a/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-shopping-button-block/block.json
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-shopping-button-block/block.json
@@ -2,7 +2,7 @@
 	"name": "woocommerce/mini-cart-shopping-button-block",
 	"version": "1.0.0",
 	"title": "Mini Cart Shopping Button",
-	"description": "Block that displays the shopping button for the Mini Cart block.",
+	"description": "Block that displays the shopping button when the Mini Cart is empty.",
 	"category": "woocommerce",
 	"supports": {
 		"align": false,

--- a/assets/js/blocks/price-filter/block.json
+++ b/assets/js/blocks/price-filter/block.json
@@ -2,7 +2,7 @@
 	"name": "woocommerce/price-filter",
 	"version": "1.0.0",
 	"title": "Filter by Price",
-	"description": "Allow customers to filter products by price range.",
+	"description": "Enable customers to filter the product grid by choosing a price range.",
 	"category": "woocommerce",
 	"keywords": [ "WooCommerce" ],
 	"supports": {

--- a/assets/js/blocks/price-filter/edit.tsx
+++ b/assets/js/blocks/price-filter/edit.tsx
@@ -102,7 +102,7 @@ export default function ( {
 						help={
 							showFilterButton
 								? __(
-										'Products will only update when the button is pressed.',
+										'Products will only update when the button is clicked.',
 										'woo-gutenberg-products-block'
 								  )
 								: __(
@@ -149,7 +149,7 @@ export default function ( {
 		>
 			<p>
 				{ __(
-					"Products with prices are needed for filtering by price. You haven't created any products yet.",
+					'To filter your products by price you first need to assign prices to your products.',
 					'woo-gutenberg-products-block'
 				) }
 			</p>

--- a/assets/js/blocks/product-categories/block.js
+++ b/assets/js/blocks/product-categories/block.js
@@ -27,7 +27,7 @@ const EmptyPlaceholder = () => (
 		className="wc-block-product-categories"
 	>
 		{ __(
-			"This block shows product categories for your store. To use it, you'll first need to create a product and assign it to a category.",
+			'This block displays the product categories for your store. To use it you first need to create a product and assign it to a category.',
 			'woo-gutenberg-products-block'
 		) }
 	</Placeholder>
@@ -92,17 +92,6 @@ const ProductCategoriesBlock = ( { attributes, setAttributes, name } ) => {
 							'Show product count',
 							'woo-gutenberg-products-block'
 						) }
-						help={
-							hasCount
-								? __(
-										'Product count is visible.',
-										'woo-gutenberg-products-block'
-								  )
-								: __(
-										'Product count is hidden.',
-										'woo-gutenberg-products-block'
-								  )
-						}
 						checked={ hasCount }
 						onChange={ () =>
 							setAttributes( { hasCount: ! hasCount } )
@@ -136,17 +125,6 @@ const ProductCategoriesBlock = ( { attributes, setAttributes, name } ) => {
 							'Show hierarchy',
 							'woo-gutenberg-products-block'
 						) }
-						help={
-							isHierarchical
-								? __(
-										'Hierarchy is visible.',
-										'woo-gutenberg-products-block'
-								  )
-								: __(
-										'Hierarchy is hidden.',
-										'woo-gutenberg-products-block'
-								  )
-						}
 						checked={ isHierarchical }
 						onChange={ () =>
 							setAttributes( {
@@ -159,17 +137,6 @@ const ProductCategoriesBlock = ( { attributes, setAttributes, name } ) => {
 							'Show empty categories',
 							'woo-gutenberg-products-block'
 						) }
-						help={
-							hasEmpty
-								? __(
-										'Empty categories are visible.',
-										'woo-gutenberg-products-block'
-								  )
-								: __(
-										'Empty categories are hidden.',
-										'woo-gutenberg-products-block'
-								  )
-						}
 						checked={ hasEmpty }
 						onChange={ () =>
 							setAttributes( { hasEmpty: ! hasEmpty } )

--- a/assets/js/blocks/product-category/edit-mode.tsx
+++ b/assets/js/blocks/product-category/edit-mode.tsx
@@ -47,7 +47,7 @@ export const ProductsByCategoryEditMode = (
 		save();
 		debouncedSpeak(
 			__(
-				'Showing Products by Category block preview.',
+				'Now displaying a preview of the reviews for the products in the selected categories.',
 				'woo-gutenberg-products-block'
 			)
 		);
@@ -57,7 +57,7 @@ export const ProductsByCategoryEditMode = (
 		stopEditing();
 		debouncedSpeak(
 			__(
-				'Showing Products by Category block preview.',
+				'Now displaying a preview of the reviews for the products in the selected categories.',
 				'woo-gutenberg-products-block'
 			)
 		);

--- a/assets/js/blocks/product-search/edit.js
+++ b/assets/js/blocks/product-search/edit.js
@@ -60,17 +60,6 @@ const Edit = ( {
 							'Show search field label',
 							'woo-gutenberg-products-block'
 						) }
-						help={
-							hasLabel
-								? __(
-										'Label is visible.',
-										'woo-gutenberg-products-block'
-								  )
-								: __(
-										'Label is hidden.',
-										'woo-gutenberg-products-block'
-								  )
-						}
 						checked={ hasLabel }
 						onChange={ () =>
 							setAttributes( { hasLabel: ! hasLabel } )

--- a/assets/js/blocks/product-tag/block.js
+++ b/assets/js/blocks/product-tag/block.js
@@ -311,7 +311,7 @@ class ProductsByTagBlock extends Component {
 				className="wc-block-products-grid wc-block-product-tag"
 			>
 				{ __(
-					"This block displays products from selected tags. In order to preview this you'll first need to create a product and assign it some tags.",
+					'This block displays products from selected tags. To use it you first need to create products and assign tags to them.',
 					'woo-gutenberg-products-block'
 				) }
 			</Placeholder>

--- a/assets/js/blocks/products/all-products/edit.js
+++ b/assets/js/blocks/products/all-products/edit.js
@@ -149,7 +149,7 @@ class Editor extends Component {
 						{
 							icon: 'edit',
 							title: __(
-								'Edit inner product layout',
+								'Edit the layout of each product',
 								'woo-gutenberg-products-block'
 							),
 							onClick: () => this.togglePreview(),
@@ -208,7 +208,7 @@ class Editor extends Component {
 				<div className="wc-block-all-products-grid-item-template">
 					<Tip>
 						{ __(
-							'Edit the blocks inside the preview below to change the content displayed for each product within the product grid.',
+							'Edit the blocks inside the example below to change the content displayed for all products within the product grid.',
 							'woo-gutenberg-products-block'
 						) }
 					</Tip>

--- a/assets/js/blocks/reviews/reviews-by-category/edit.js
+++ b/assets/js/blocks/reviews/reviews-by-category/edit.js
@@ -94,7 +94,7 @@ const ReviewsByCategoryEditor = ( {
 			setAttributes( { editMode: false } );
 			debouncedSpeak(
 				__(
-					'Showing Reviews by Category block preview.',
+					'Now displaying a preview of the reviews for the products in the selected categories.',
 					'woo-gutenberg-products-block'
 				)
 			);

--- a/assets/js/blocks/reviews/reviews-by-product/index.js
+++ b/assets/js/blocks/reviews/reviews-by-product/index.js
@@ -30,7 +30,7 @@ registerBlockType( 'woocommerce/reviews-by-product', {
 	category: 'woocommerce',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
 	description: __(
-		'Show reviews of your products to build trust.',
+		'Display reviews for your products.',
 		'woo-gutenberg-products-block'
 	),
 	supports: {

--- a/assets/js/blocks/stock-filter/edit.tsx
+++ b/assets/js/blocks/stock-filter/edit.tsx
@@ -40,20 +40,9 @@ const Edit = ( {
 				>
 					<ToggleControl
 						label={ __(
-							'Product count',
+							'Display product count',
 							'woo-gutenberg-products-block'
 						) }
-						help={
-							showCounts
-								? __(
-										'Product count is visible.',
-										'woo-gutenberg-products-block'
-								  )
-								: __(
-										'Product count is hidden.',
-										'woo-gutenberg-products-block'
-								  )
-						}
 						checked={ showCounts }
 						onChange={ () =>
 							setAttributes( {
@@ -73,11 +62,11 @@ const Edit = ( {
 						help={
 							showFilterButton
 								? __(
-										'Products will only update when the button is pressed.',
+										'Products will only update when the button is clicked.',
 										'woo-gutenberg-products-block'
 								  )
 								: __(
-										'Products will update as options are selected.',
+										'Products will update as soon as attributes are selected.',
 										'woo-gutenberg-products-block'
 								  )
 						}

--- a/assets/js/blocks/stock-filter/index.tsx
+++ b/assets/js/blocks/stock-filter/index.tsx
@@ -18,7 +18,7 @@ import type { Attributes } from './types';
 registerBlockType( metadata, {
 	title: __( 'Filter Products by Stock', 'woo-gutenberg-products-block' ),
 	description: __(
-		'Allow customers to filter the grid by products stock status. Works in combination with the All Products block.',
+		'Enable customers to filter the product grid by stock status.',
 		'woo-gutenberg-products-block'
 	),
 	icon: {

--- a/assets/js/editor-components/error-placeholder/error-message.tsx
+++ b/assets/js/editor-components/error-placeholder/error-message.tsx
@@ -19,7 +19,7 @@ export interface ErrorMessageProps {
 const getErrorMessage = ( { message, type }: ErrorObject ) => {
 	if ( ! message ) {
 		return __(
-			'An unknown error occurred which prevented the block from being updated.',
+			'An error has prevented the block from being updated.',
 			'woo-gutenberg-products-block'
 		);
 	}

--- a/assets/js/editor-components/grid-content-control/index.js
+++ b/assets/js/editor-components/grid-content-control/index.js
@@ -21,17 +21,6 @@ const GridContentControl = ( { onChange, settings } ) => {
 		<>
 			<ToggleControl
 				label={ __( 'Product image', 'woo-gutenberg-products-block' ) }
-				help={
-					imageIsVisible
-						? __(
-								'Product image is visible.',
-								'woo-gutenberg-products-block'
-						  )
-						: __(
-								'Product image is hidden.',
-								'woo-gutenberg-products-block'
-						  )
-				}
 				checked={ imageIsVisible }
 				onChange={ () =>
 					onChange( { ...settings, image: ! imageIsVisible } )
@@ -39,49 +28,16 @@ const GridContentControl = ( { onChange, settings } ) => {
 			/>
 			<ToggleControl
 				label={ __( 'Product title', 'woo-gutenberg-products-block' ) }
-				help={
-					title
-						? __(
-								'Product title is visible.',
-								'woo-gutenberg-products-block'
-						  )
-						: __(
-								'Product title is hidden.',
-								'woo-gutenberg-products-block'
-						  )
-				}
 				checked={ title }
 				onChange={ () => onChange( { ...settings, title: ! title } ) }
 			/>
 			<ToggleControl
 				label={ __( 'Product price', 'woo-gutenberg-products-block' ) }
-				help={
-					price
-						? __(
-								'Product price is visible.',
-								'woo-gutenberg-products-block'
-						  )
-						: __(
-								'Product price is hidden.',
-								'woo-gutenberg-products-block'
-						  )
-				}
 				checked={ price }
 				onChange={ () => onChange( { ...settings, price: ! price } ) }
 			/>
 			<ToggleControl
 				label={ __( 'Product rating', 'woo-gutenberg-products-block' ) }
-				help={
-					rating
-						? __(
-								'Product rating is visible.',
-								'woo-gutenberg-products-block'
-						  )
-						: __(
-								'Product rating is hidden.',
-								'woo-gutenberg-products-block'
-						  )
-				}
 				checked={ rating }
 				onChange={ () => onChange( { ...settings, rating: ! rating } ) }
 			/>
@@ -90,17 +46,6 @@ const GridContentControl = ( { onChange, settings } ) => {
 					'Add to Cart button',
 					'woo-gutenberg-products-block'
 				) }
-				help={
-					button
-						? __(
-								'Add to Cart button is visible.',
-								'woo-gutenberg-products-block'
-						  )
-						: __(
-								'Add to Cart button is hidden.',
-								'woo-gutenberg-products-block'
-						  )
-				}
 				checked={ button }
 				onChange={ () => onChange( { ...settings, button: ! button } ) }
 			/>

--- a/assets/js/editor-components/grid-layout-control/index.js
+++ b/assets/js/editor-components/grid-layout-control/index.js
@@ -57,13 +57,13 @@ const GridLayoutControl = ( {
 			/>
 			<ToggleControl
 				label={ __(
-					'Align Last Block',
+					'Align the last block to the bottom',
 					'woo-gutenberg-products-block'
 				) }
 				help={
 					alignButtons
 						? __(
-								'The last inner block will be aligned vertically.',
+								'Align the last block to the bottom.',
 								'woo-gutenberg-products-block'
 						  )
 						: __(

--- a/assets/js/editor-components/product-tag-control/index.js
+++ b/assets/js/editor-components/product-tag-control/index.js
@@ -103,7 +103,7 @@ class ProductTagControl extends Component {
 			),
 			list: __( 'Product Tags', 'woo-gutenberg-products-block' ),
 			noItems: __(
-				"Your store doesn't have any product tags.",
+				'You have not set up any product tags on your store.',
 				'woo-gutenberg-products-block'
 			),
 			search: __(

--- a/docs/internal-developers/testing/releases/790.md
+++ b/docs/internal-developers/testing/releases/790.md
@@ -18,8 +18,8 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 
 ### Fix images hidden by default in Product grid blocks. ([6599](https://github.com/woocommerce/woocommerce-blocks/pull/6599))
 
-| Before | After |
-| ------ | ----- |
+| Before                                                                                                          | After                                                                                                           |
+| --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
 | ![imatge](https://user-images.githubusercontent.com/3616980/174588765-7e570a5b-d428-4604-b2af-6534e388b550.png) | ![imatge](https://user-images.githubusercontent.com/3616980/174588822-9cdb7813-05d1-4f97-ae55-1d4392c9f65a.png) |
 
 1. With WC core 6.5.1 and WC Blocks disabled, add a Handpicked Products block to a post or page.
@@ -31,13 +31,12 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 7. Verify images are visible by default.
 8. Verify you can still toggle the images.
 
-### Fix: Scrolling issue of the Filled Mini Cart Contents block. ([6565](https://github.com/woocommerce/woocommerce-blocks/pull/6565))
+### Fix: Scrolling issue of the Filled Mini Cart view block. ([6565](https://github.com/woocommerce/woocommerce-blocks/pull/6565))
 
-| Before | After |
-| ------ | ----- |
-|     ![Before](https://user-images.githubusercontent.com/5423135/173493967-1009d322-351e-451c-a10c-c6456ec08f52.png)   | ![After](https://user-images.githubusercontent.com/5423135/173533745-41cda7ed-a068-4d5d-b948-7e2038f3d21c.png)    |
+| Before                                                                                                                                    | After                                                                                                                                     |
+| ----------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| ![Before](https://user-images.githubusercontent.com/5423135/173493967-1009d322-351e-451c-a10c-c6456ec08f52.png)                           | ![After](https://user-images.githubusercontent.com/5423135/173533745-41cda7ed-a068-4d5d-b948-7e2038f3d21c.png)                            |
 | <img width="1571" alt="image" src="https://user-images.githubusercontent.com/5423135/173493990-c15572f2-fca1-4c9c-8909-178c108b83d1.png"> | <img width="1615" alt="image" src="https://user-images.githubusercontent.com/5423135/173535254-bd08ddae-6cc2-45d7-b727-43a24902610a.png"> |
-
 
 1. With a block theme like 2022. Edit the Mini Cart template part.
 2. Add some blocks to the Mini Cart Items section to make the content overflow.
@@ -48,13 +47,11 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 
 ### Added descriptions to the FSE WooCommerce Templates in the Editor UI. ([6345](https://github.com/woocommerce/woocommerce-blocks/pull/6345))
 
+| Before                                                                                                              | After                                                                                                                 |
+| ------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| ![bifor_fixed](https://user-images.githubusercontent.com/905781/165815026-408dccff-ea16-4766-8a65-9696866e6f92.jpg) | ![after_-_fixed](https://user-images.githubusercontent.com/905781/165815040-723bb981-5cc2-4787-a38d-d9dee3e12757.jpg) |
 
-|Before|After|
-|-|-|
-|![bifor_fixed](https://user-images.githubusercontent.com/905781/165815026-408dccff-ea16-4766-8a65-9696866e6f92.jpg)|![after_-_fixed](https://user-images.githubusercontent.com/905781/165815040-723bb981-5cc2-4787-a38d-d9dee3e12757.jpg)|
-
-
-#### Testing template descriptions**
+#### Testing template descriptions\*\*
 
 1. Activate a **block** theme, like Twenty Twenty Two
 2. Open the **Appearance > Editor (Beta)**
@@ -63,13 +60,11 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 5. Open a template (like Mini cart)
 6. make sure you can edit and save the content.
 
-
-#### Testing the search template**
+#### Testing the search template\*\*
 
 1. Activate a **block** theme, like Twenty Twenty Two
 2. Make sure there's at least 1 product added
 3. Run a product search: `?s={keyword}&post_type=product` and make sure the products are being displayed correctly in a grid (using the search template, instead of the default one).
-
 
 ## Feature plugin only
 
@@ -81,7 +76,7 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 4. Add multiple items to your cart.
 5. Go to the Checkout/Cart Block.
 6. Ensure you see no errors.
-<!-- FEEDBACK -->
+ <!-- FEEDBACK -->
 
 ---
 
@@ -90,4 +85,3 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-blocks/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/internal-developers/testing/releases/790.md)
 
 <!-- /FEEDBACK -->
-

--- a/docs/internal-developers/translations/translation-loading.md
+++ b/docs/internal-developers/translations/translation-loading.md
@@ -76,7 +76,7 @@ msgstr ""
 #: assets/js/blocks/featured-product/block.json
 #: build/featured-product/block.json
 msgctxt "block description"
-msgid "Visually highlight a product or variation and encourage prompt action."
+msgid "Highlight a product or variation."
 msgstr "Ein Produkt oder eine Variante visuell hervorheben und zum sofortigen Handeln auffordern."
 
 #: assets/js/blocks/featured-product/block.json
@@ -306,4 +306,3 @@ add_filter( 'load_script_translation_file', 'load_woocommerce_core_json_translat
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-blocks/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/internal-developers/translations/translation-loading.md)
 
 <!-- /FEEDBACK -->
-

--- a/docs/internal-developers/translations/translations-in-FSE-templates.md
+++ b/docs/internal-developers/translations/translations-in-FSE-templates.md
@@ -83,7 +83,7 @@ public function register_empty_cart_message_block_pattern() {
     register_block_pattern(
         'woocommerce/mini-cart-empty-cart-message',
         array(
-            'title'    => __( 'Mini Cart Empty Cart Message', 'woo-gutenberg-products-block' ),
+            'title'    => __( 'Empty Mini Cart Message', 'woo-gutenberg-products-block' ),
             'inserter' => false,
             'content'  => '<!-- wp:paragraph {"align":"center"} --><p class="has-text-align-center"><strong>' . __( 'Your cart is currently empty!', 'woo-gutenberg-products-block' ) . '</strong></p><!-- /wp:paragraph -->',
         )
@@ -117,4 +117,3 @@ The PR for the implementation above can be found on <https://github.com/woocomme
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-blocks/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/internal-developers/translations/translations-in-FSE-templates.md)
 
 <!-- /FEEDBACK -->
-

--- a/readme.txt
+++ b/readme.txt
@@ -174,7 +174,7 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 #### Bug Fixes
 
 - Fix images hidden by default in Product grid blocks after WC 6.6 update. ([6599](https://github.com/woocommerce/woocommerce-blocks/pull/6599))
-- Fix: Scrolling issue of the Filled Mini Cart Contents block. ([6565](https://github.com/woocommerce/woocommerce-blocks/pull/6565))
+- Fix: Scrolling issue of the Filled Mini Cart view block. ([6565](https://github.com/woocommerce/woocommerce-blocks/pull/6565))
 - Fix an endless loop when using product grid blocks inside product descriptions. ([6471](https://github.com/woocommerce/woocommerce-blocks/pull/6471))
 
 #### Various
@@ -258,7 +258,7 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 
 #### Bug Fixes
 
-- Fix: Align Empty Mini Cart Contents block center in the Site Editor. ([6379](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/6379))
+- Fix: Align Empty Mini Cart view. block center in the Site Editor. ([6379](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/6379))
 - Remove the Template panel from the Setting Sidebar for Shop page. ([6366](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/6366))
 - Parse categories coming from the back-end as a json array. ([6358](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/6358))
 - Update the default width of Classic Template to Wide width. ([6356](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/6356))

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -523,7 +523,7 @@ class MiniCart extends AbstractBlock {
 		register_block_pattern(
 			'woocommerce/mini-cart-empty-cart-message',
 			array(
-				'title'    => __( 'Mini Cart Empty Cart Message', 'woo-gutenberg-products-block' ),
+				'title'    => __( 'Empty Mini Cart Message', 'woo-gutenberg-products-block' ),
 				'inserter' => false,
 				'content'  => '<!-- wp:paragraph {"align":"center"} --><p class="has-text-align-center"><strong>' . __( 'Your cart is currently empty!', 'woo-gutenberg-products-block' ) . '</strong></p><!-- /wp:paragraph -->',
 			)

--- a/src/Domain/Bootstrap.php
+++ b/src/Domain/Bootstrap.php
@@ -149,7 +149,7 @@ class Bootstrap {
 						if ( should_display_compatibility_notices() ) {
 							?>
 							<div class="notice notice-error">
-								<p><?php esc_html_e( 'The WooCommerce Blocks feature plugin requires a more recent version of WooCommerce and has been paused. Please update WooCommerce to the latest version to continue enjoying WooCommerce Blocks.', 'woo-gutenberg-products-block' ); ?></p>
+								<p><?php esc_html_e( 'The WooCommerce Blocks plugin requires a more recent version of WooCommerce and has been deactivated. Please update to the latest version of WooCommerce.', 'woo-gutenberg-products-block' ); ?></p>
 							</div>
 							<?php
 						}

--- a/src/Domain/Services/Email/CustomerNewAccount.php
+++ b/src/Domain/Services/Email/CustomerNewAccount.php
@@ -55,7 +55,7 @@ class CustomerNewAccount extends \WC_Email {
 		$this->id                    = 'customer_new_account';
 		$this->customer_email        = true;
 		$this->title                 = __( 'New account', 'woo-gutenberg-products-block' );
-		$this->description           = __( 'Customer "new account" emails are sent to the customer when a customer signs up via checkout or account blocks.', 'woo-gutenberg-products-block' );
+		$this->description           = __( '“New Account” emails are sent when a customer signs up via the checkout flow.', 'woo-gutenberg-products-block' );
 		$this->template_html         = 'emails/customer-new-account-blocks.php';
 		$this->template_plain        = 'emails/plain/customer-new-account-blocks.php';
 		$this->default_template_path = $package->get_path( '/templates/' );

--- a/src/StoreApi/Routes/V1/ProductCollectionData.php
+++ b/src/StoreApi/Routes/V1/ProductCollectionData.php
@@ -193,7 +193,7 @@ class ProductCollectionData extends AbstractRoute {
 						'readonly'    => true,
 					],
 					'query_type' => [
-						'description' => __( 'Query type being performed which may affect counts. Valid values include "and" and "or".', 'woo-gutenberg-products-block' ),
+						'description' => __( 'Filter condition	 being performed which may affect counts. Valid values include "and" and "or".', 'woo-gutenberg-products-block' ),
 						'type'        => 'string',
 						'enum'        => [ 'and', 'or' ],
 						'context'     => [ 'view', 'edit' ],


### PR DESCRIPTION
We noticed that oftentimes our labels and text tend to be overly technical or unclear. We decided to do a bulk pass to improve the readability to non-technical users. I understand that this is a big PR that touches loads of files. Also, we need to find a way to relay to our community of translators that work is required. As such, we also need to decide when it would be best to publish this PR, as it would indeed break many translations. So, for example, I think it might be best to publish it soon after we merge into core, in order to give translators a full release cycle time to fix their translations.

Feel free to use this PR as a hub of discussion for that.

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #6916

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Improved many of the labels to be less technical and more user-friendly.