### PR TITLE
Fix checkbox label when count is zero

### DIFF
--- a/assets/js/base/components/filter-element-label/index.tsx
+++ b/assets/js/base/components/filter-element-label/index.tsx
@@ -14,7 +14,7 @@ interface FilterElementLabelProps {
 	count: number | null;
 }
 /**
- * The label for an filter elements.
+ * The label for a filter element.
  *
  * @param {Object} props       Incoming props for the component.
  * @param {string} props.name  The name for the label.
@@ -27,7 +27,7 @@ const FilterElementLabel = ( {
 	return (
 		<>
 			{ name }
-			{ count && Number.isFinite( count ) && (
+			{ count !== null && Number.isFinite( count ) && (
 				<Label
 					label={ count.toString() }
 					screenReaderLabel={ sprintf(


### PR DESCRIPTION
Fix showing a zero appended to the checkbox label when the count is zero.

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/7069


### Screenshots

| Before | After |
| ------ | ----- |
|   <img width="247" alt="Screenshot 2022-09-06 at 14 45 21" src="https://user-images.githubusercontent.com/186112/188638630-dc30364c-6be3-4edf-9573-ba73841c3110.png"> | <img width="246" alt="Screenshot 2022-09-06 at 14 45 04" src="https://user-images.githubusercontent.com/186112/188638635-77a9d6cf-cc52-46e1-91ae-e4de09966f19.png"> |

### Testing

#### User Facing Testing
1. Make sure you don't have any product with `On backorder` status.
2. Create a page with an `All products` block and a `Filter by stock` block.
3. Save it, go to the page and append this param to the URL `?filter_stock_status=onbackorder`.
4. Check that the on backorder label shows `On backorder (0)`.

### WooCommerce Visibility

* [x] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental

> Fix showing a zero appended to the checkbox label when the count is zero.
