### PR TITLE
Add default value to the $block parameter

### DIFF
--- a/src/BlockTypes/AbstractBlock.php
+++ b/src/BlockTypes/AbstractBlock.php
@@ -76,10 +76,10 @@ abstract class AbstractBlock {
 	 *
 	 * @param array|WP_Block $attributes Block attributes, or an instance of a WP_Block. Defaults to an empty array.
 	 * @param string         $content    Block content. Default empty string.
-	 * @param WP_Block       $block      Block instance.
+	 * @param WP_Block|null  $block      Block instance.
 	 * @return string Rendered block type output.
 	 */
-	public function render_callback( $attributes = [], $content = '', $block ) {
+	public function render_callback( $attributes = [], $content = '', $block = null ) {
 
 		$render_callback_attributes = $this->parse_render_callback_attributes( $attributes );
 		if ( ! is_admin() && ! WC()->is_rest_api_request() ) {

--- a/src/BlockTypes/AbstractProductGrid.php
+++ b/src/BlockTypes/AbstractProductGrid.php
@@ -67,12 +67,12 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 	/**
 	 * Include and render the dynamic block.
 	 *
-	 * @param array    $attributes Block attributes. Default empty array.
-	 * @param string   $content    Block content. Default empty string.
-	 * @param WP_Block $block      Block instance.
+	 * @param array         $attributes Block attributes. Default empty array.
+	 * @param string        $content    Block content. Default empty string.
+	 * @param WP_Block|null $block      Block instance.
 	 * @return string Rendered block type output.
 	 */
-	protected function render( $attributes = array(), $content = '', $block ) {
+	protected function render( $attributes = array(), $content = '', $block = null ) {
 		$this->attributes = $this->parse_attributes( $attributes );
 		$this->content    = $content;
 		$this->query_args = $this->parse_query_args();


### PR DESCRIPTION
With PHP 8.0 it was introduced a deprecation notice when there are required parameters after optional parameters in function/method signatures ([source](https://php.watch/versions/8.0/deprecate-required-param-after-optional)).

The PR #6911 [introduced a new parameter without setting a default value](https://github.com/woocommerce/woocommerce-blocks/pull/6911/files#diff-d1b778e863fef808d0b34565afe0c8bc172cc3d9e3e99324b402a19577f1fbf1R82). This PR set a default value to the $block parameter.

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #7060

### Testing


#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Enable PHP 8
2. Go to your site's dashboard
3. Check the `debug.log` file and be sure that any deprecation notice `PHP Deprecated:  Required parameter $block follows optional parameter $attributes` is showed


* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog
N/A
