### PR TITLE
POC: use the filter `query.entityRecordsArgs` to customize the getEntityRecords behavior

### DIFF
--- a/assets/js/blocks/product-query/inspector-controls.tsx
+++ b/assets/js/blocks/product-query/inspector-controls.tsx
@@ -6,13 +6,17 @@ import { InspectorControls } from '@wordpress/block-editor';
 import { ToggleControl } from '@wordpress/components';
 import { addFilter } from '@wordpress/hooks';
 import { EditorBlock } from '@woocommerce/types';
-import { ElementType } from 'react';
+import { ElementType, useEffect } from 'react';
 
 /**
  * Internal dependencies
  */
 import { ProductQueryBlock } from './types';
-import { isWooQueryBlockVariation, setCustomQueryAttribute } from './utils';
+import {
+	fetchAndRenderProducts,
+	isWooQueryBlockVariation,
+	setCustomQueryAttribute,
+} from './utils';
 
 export const INSPECTOR_CONTROLS = {
 	onSale: ( props: ProductQueryBlock ) => (
@@ -35,7 +39,15 @@ export const INSPECTOR_CONTROLS = {
 export const withProductQueryControls =
 	< T extends EditorBlock< T > >( BlockEdit: ElementType ) =>
 	( props: ProductQueryBlock ) => {
-		return isWooQueryBlockVariation( props ) ? (
+		if ( ! isWooQueryBlockVariation( props ) ) {
+			return <BlockEdit { ...props } />;
+		}
+
+		useEffect( () => {
+			fetchAndRenderProducts( props );
+		}, [ props ] );
+
+		return (
 			<>
 				<BlockEdit { ...props } />
 				<InspectorControls>
@@ -49,8 +61,6 @@ export const withProductQueryControls =
 					) }
 				</InspectorControls>
 			</>
-		) : (
-			<BlockEdit { ...props } />
 		);
 	};
 

--- a/assets/js/blocks/product-query/types.ts
+++ b/assets/js/blocks/product-query/types.ts
@@ -71,6 +71,7 @@ export enum QueryVariation {
 }
 
 export type WooCommerceBlockVariation< T > = EditorBlock< {
+	query: QueryBlockQuery;
 	// Disabling naming convention because we are namespacing our
 	// custom attributes inside a core block. Prefixing with underscores
 	// will help signify our intentions.

--- a/assets/js/blocks/product-query/utils.tsx
+++ b/assets/js/blocks/product-query/utils.tsx
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+
+/**
  * Internal dependencies
  */
 import {
@@ -51,4 +56,47 @@ export function setCustomQueryAttribute(
 			},
 		},
 	} );
+}
+
+const getQueryArgumentsByCustomQuery = ( key: string, value: string ) => {
+	switch ( key ) {
+		case 'onSale':
+			return {
+				on_sale: value,
+			};
+		case 'offset':
+			return {
+				offset: value,
+			};
+		case 'perPage':
+			return {
+				per_page: value,
+			};
+
+		default:
+			return {};
+	}
+};
+
+export function fetchAndRenderProducts( props: ProductQueryBlock ) {
+	const customQueries = Object.entries(
+		props?.attributes?.__woocommerceVariationProps?.attributes?.query || {}
+	);
+
+	const stockQueries = Object.entries( props?.attributes?.query );
+	const queryArguments = [ ...customQueries, ...stockQueries ].reduce(
+		( acc, [ key, value ] ) => {
+			return {
+				...acc,
+				...getQueryArgumentsByCustomQuery( key, value ),
+			};
+		},
+		{}
+	);
+
+	addFilter( 'query.entityRecordsArgs', 'core/query', ( { query } ) => ( {
+		usedPostType: 'products',
+		postType: 'root',
+		query: { ...query, ...queryArguments },
+	} ) );
 }

--- a/assets/js/blocks/product-query/variations/product-query.tsx
+++ b/assets/js/blocks/product-query/variations/product-query.tsx
@@ -4,6 +4,7 @@
 import { isExperimentalBuild } from '@woocommerce/block-settings';
 import { registerBlockVariation } from '@wordpress/blocks';
 import { Icon } from '@wordpress/components';
+import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { sparkles } from '@wordpress/icons';
 
@@ -13,6 +14,14 @@ import { sparkles } from '@wordpress/icons';
 import { INNER_BLOCKS_TEMPLATE, QUERY_DEFAULT_ATTRIBUTES } from '../constants';
 
 if ( isExperimentalBuild() ) {
+	dispatch( 'core' ).addEntities( [
+		{
+			name: 'products',
+			kind: 'root',
+			baseURL: '/wc/store/v1/products',
+		},
+	] );
+
 	registerBlockVariation( 'core/query', {
 		name: 'woocommerce/product-query',
 		title: __( 'Product Query', 'woo-gutenberg-products-block' ),


### PR DESCRIPTION
This is another attempt (#6975) to have a live preview experience for the Product Query on the editor side. 
With this attempt, I want to try to customize the getEntityRecords behavior with the JS filters.

Thanks to the JS filter, it is possible to customize the endpoint that `getEntityRecords` fetches. This allows us to use WooCommerce API instead of WordPress API. In this way, we could fetch products with a specific filter (by price, on sale, [etc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/src/StoreApi/docs/products.md#list-products)).

Unfortunately, there are also disadvantages/blockers to this approach:
1. A 3rd plugin can easily break the Query Loop block.
2. With multiple Product Query blocks it could be very hard to handle this filter (how could we enable the filter, execute it only for that specific block, and after that remove it? Keep in mind when the user edits a page that contains multiple Query Loop/Product Query blocks, all the queries are done in parallel).
3. At this stage, the preview still doesn't update when the user toggle settings. We should force the re-render of the block.


⚠️  This is just a POC to check different paths and have feedback and ideas. Does it make sense to continue to explore this path? IMHO, this is not the right solution to take, we over-complicated a lot of code, and it potentially could be the main blocker (2-3) that could require more changes on the Gutenberg side.

Gutenberg PR https://github.com/sunyatasattva/gutenberg/pull/4 
Gutenberg Issue https://github.com/WordPress/gutenberg/issues/34201



