### PR TITLE
Add steps to retrieve products variations in Store API docs

### DIFF
--- a/src/StoreApi/docs/products.md
+++ b/src/StoreApi/docs/products.md
@@ -191,6 +191,14 @@ curl "https://example-store.com/wp-json/wc/store/v1/products/34"
 }
 ```
 
+## Product Variations
+
+By default, Store API excludes product variations. You can retrieve the variations for a product by using the `type=variation`.
+
+```sh
+curl "https://example-store.com/wp-json/wc/store/v1/products?type=variation"
+```
+
 <!-- FEEDBACK -->
 
 ---


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #6873




#### User Facing Testing


1. Go through the [Product Variations section added through this branch](https://github.com/woocommerce/woocommerce-blocks/blob/update/6873-store-api-product-doc/src/StoreApi/docs/products.md#product-variations) 
2. Confirm the content in the section is correct. 


* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Add steps to retrieve products variations in Store API docs