### PR TITLE
Add Apply button placeholders to filters and adjust title margins

### DIFF
--- a/assets/js/base/components/filter-placeholder/style.scss
+++ b/assets/js/base/components/filter-placeholder/style.scss
@@ -4,6 +4,8 @@
 	border-radius: em(26px);
 	box-shadow: none;
 	min-width: 80px;
+	margin-top: $gap-small;
+	margin-bottom: $gap-small;
 	max-width: max-content !important;
 
 	&::after {

--- a/assets/js/base/components/filter-placeholder/style.scss
+++ b/assets/js/base/components/filter-placeholder/style.scss
@@ -12,6 +12,7 @@
 
 	.wc-block-stock-filter__title,
 	.wc-block-price-filter__title,
+	.wc-block-active-filters__title,
 	.wc-block-attribute-filter__title {
 		margin: 0;
 		height: 1em;

--- a/assets/js/base/components/filter-submit-button/index.tsx
+++ b/assets/js/base/components/filter-submit-button/index.tsx
@@ -35,7 +35,7 @@ const FilterSubmitButton = ( {
 				'wp-block-button__link',
 				'wc-block-filter-submit-button',
 				'wc-block-components-filter-submit-button',
-				{ 'show-loading-state': isLoading },
+				{ 'is-loading': isLoading },
 				className
 			) }
 			disabled={ disabled }

--- a/assets/js/base/components/filter-submit-button/index.tsx
+++ b/assets/js/base/components/filter-submit-button/index.tsx
@@ -12,6 +12,7 @@ import './style.scss';
 
 interface FilterSubmitButtonProps {
 	className?: string;
+	isLoading?: boolean;
 	disabled?: boolean;
 	label?: string;
 	onClick: () => void;
@@ -20,6 +21,7 @@ interface FilterSubmitButtonProps {
 
 const FilterSubmitButton = ( {
 	className,
+	isLoading,
 	disabled,
 	/* translators: Submit button text for filters. */
 	label = __( 'Apply', 'woo-gutenberg-products-block' ),
@@ -33,6 +35,7 @@ const FilterSubmitButton = ( {
 				'wp-block-button__link',
 				'wc-block-filter-submit-button',
 				'wc-block-components-filter-submit-button',
+				{ 'show-loading-state': isLoading },
 				className
 			) }
 			disabled={ disabled }

--- a/assets/js/base/components/filter-submit-button/style.scss
+++ b/assets/js/base/components/filter-submit-button/style.scss
@@ -4,7 +4,7 @@
 	margin-left: auto;
 	white-space: nowrap;
 
-	&.show-loading-state {
+	&.is-loading {
 		@include placeholder();
 		margin-top: $gap;
 		width: max-content;

--- a/assets/js/base/components/filter-submit-button/style.scss
+++ b/assets/js/base/components/filter-submit-button/style.scss
@@ -10,5 +10,6 @@
 		width: max-content;
 		box-shadow: none;
 		border-radius: 0;
+		line-height: initial;
 	}
 }

--- a/assets/js/base/components/filter-submit-button/style.scss
+++ b/assets/js/base/components/filter-submit-button/style.scss
@@ -3,4 +3,12 @@
 	display: block;
 	margin-left: auto;
 	white-space: nowrap;
+
+	&.show-loading-state {
+		@include placeholder();
+		margin-top: $gap;
+		width: max-content;
+		box-shadow: none;
+		border-radius: 0;
+	}
 }

--- a/assets/js/base/components/price-slider/index.tsx
+++ b/assets/js/base/components/price-slider/index.tsx
@@ -492,11 +492,8 @@ const PriceSlider = ( {
 						) }
 					{ showFilterButton && (
 						<FilterSubmitButton
-							className={ classnames(
-								'wc-block-price-filter__button',
-								'wc-block-components-price-slider__button',
-								{ 'show-loading-state': isUpdating }
-							) }
+							className="wc-block-price-filter__button wc-block-components-price-slider__button"
+							isLoading={ isUpdating }
 							disabled={ isLoading || ! hasValidConstraints }
 							onClick={ onSubmit }
 							screenReaderLabel={ __(

--- a/assets/js/base/components/price-slider/index.tsx
+++ b/assets/js/base/components/price-slider/index.tsx
@@ -471,24 +471,32 @@ const PriceSlider = ( {
 						/>
 					</div>
 				) }
-			{ ! isUpdating && (
+			{
 				<div className="wc-block-components-price-slider__actions">
-					{ ( minPrice !== minConstraint ||
-						maxPrice !== maxConstraint ) && (
-						<FilterResetButton
-							onClick={ () => {
-								onChange( [ minConstraint, maxConstraint ] );
-								debouncedUpdateQuery();
-							} }
-							screenReaderLabel={ __(
-								'Reset price filter',
-								'woo-gutenberg-products-block'
-							) }
-						/>
-					) }
+					{ ! isUpdating &&
+						( minPrice !== minConstraint ||
+							maxPrice !== maxConstraint ) && (
+							<FilterResetButton
+								onClick={ () => {
+									onChange( [
+										minConstraint,
+										maxConstraint,
+									] );
+									debouncedUpdateQuery();
+								} }
+								screenReaderLabel={ __(
+									'Reset price filter',
+									'woo-gutenberg-products-block'
+								) }
+							/>
+						) }
 					{ showFilterButton && (
 						<FilterSubmitButton
-							className="wc-block-price-filter__button wc-block-components-price-slider__button"
+							className={ classnames(
+								'wc-block-price-filter__button',
+								'wc-block-components-price-slider__button',
+								{ 'show-loading-state': isUpdating }
+							) }
 							disabled={ isLoading || ! hasValidConstraints }
 							onClick={ onSubmit }
 							screenReaderLabel={ __(
@@ -498,7 +506,7 @@ const PriceSlider = ( {
 						/>
 					) }
 				</div>
-			) }
+			}
 		</div>
 	);
 };

--- a/assets/js/base/components/price-slider/style.scss
+++ b/assets/js/base/components/price-slider/style.scss
@@ -152,16 +152,6 @@
 		margin-top: 0;
 		margin-left: 0;
 	}
-
-	.wc-block-price-filter__button {
-		&.show-loading-state {
-			@include placeholder();
-			margin-top: $gap;
-			width: max-content;
-			box-shadow: none;
-			border-radius: 0;
-		}
-	}
 }
 
 .wc-block-components-price-slider__range-input {

--- a/assets/js/base/components/price-slider/style.scss
+++ b/assets/js/base/components/price-slider/style.scss
@@ -23,9 +23,11 @@
 		@include thumbFocus;
 	}
 }
+
 @mixin thumbFocus {
 	background: $gray-900;
 }
+
 /* stylelint-enable */
 @mixin track {
 	cursor: default;
@@ -35,6 +37,7 @@
 	-moz-appearance: none;
 	appearance: none;
 }
+
 @mixin reset {
 	margin: 0;
 	/* Use !important to prevent theme input styles from breaking the component.
@@ -149,6 +152,16 @@
 		margin-top: 0;
 		margin-left: 0;
 	}
+
+	.wc-block-price-filter__button {
+		&.show-loading-state {
+			@include placeholder();
+			margin-top: $gap;
+			width: max-content;
+			box-shadow: none;
+			border-radius: 0;
+		}
+	}
 }
 
 .wc-block-components-price-slider__range-input {
@@ -166,10 +179,12 @@
 	&::-webkit-slider-runnable-track {
 		@include track;
 	}
+
 	&::-webkit-slider-thumb {
 		@include thumb;
 		margin: -5px 0 0 0;
 	}
+
 	&::-webkit-slider-progress {
 		@include reset;
 	}
@@ -177,12 +192,15 @@
 	&::-moz-focus-outer {
 		border: 0;
 	}
+
 	&::-moz-range-track {
 		@include track;
 	}
+
 	&::-moz-range-progress {
 		@include reset;
 	}
+
 	&::-moz-range-thumb {
 		@include thumb;
 	}
@@ -195,9 +213,11 @@
 		&::-webkit-slider-thumb {
 			@include thumbFocus;
 		}
+
 		&::-moz-range-thumb {
 			@include thumbFocus;
 		}
+
 		&::-ms-thumb {
 			@include thumbFocus;
 		}
@@ -210,10 +230,12 @@
 			margin-left: -2px;
 			background-position-x: left;
 		}
+
 		&::-moz-range-thumb {
 			background-position-x: left;
 			transform: translate(-2px, 2px);
 		}
+
 		&::-ms-thumb {
 			background-position-x: left;
 		}
@@ -226,10 +248,12 @@
 			background-position-x: right;
 			margin-left: 2px;
 		}
+
 		&::-moz-range-thumb {
 			background-position-x: right;
 			transform: translate(2px, 2px);
 		}
+
 		&::-ms-thumb {
 			background-position-x: right;
 		}
@@ -270,16 +294,20 @@
 			/*remove default tick marks*/
 			color: transparent;
 		}
+
 		&::-ms-fill-lower {
 			background: #e1e1e1;
 			box-shadow: 0 0 0 1px inset #b8b8b8;
 		}
+
 		&::-ms-fill-upper {
 			background: transparent;
 		}
+
 		&::-ms-tooltip {
 			display: none;
 		}
+
 		&::-ms-thumb {
 			transform: translate(1px, 0);
 			pointer-events: auto;
@@ -290,6 +318,7 @@
 			background: #e1e1e1;
 			box-shadow: 0 0 0 1px inset #b8b8b8;
 		}
+
 		&::-ms-fill-lower {
 			background: transparent;
 		}
@@ -345,9 +374,11 @@
 			&::-webkit-slider-thumb {
 				filter: none;
 			}
+
 			&::-moz-range-thumb {
 				filter: none;
 			}
+
 			&::-ms-thumb {
 				filter: none;
 			}

--- a/assets/js/blocks/active-filters/style.scss
+++ b/assets/js/blocks/active-filters/style.scss
@@ -7,6 +7,11 @@
 	h6 {
 		text-transform: inherit;
 	}
+
+	> .wc-block-active-filters__title {
+		margin-top: $gap-small;
+		margin-bottom: $gap-small;
+	}
 }
 
 .wc-block-active-filters {

--- a/assets/js/blocks/attribute-filter/block.tsx
+++ b/assets/js/blocks/attribute-filter/block.tsx
@@ -671,10 +671,8 @@ const AttributeFilterBlock = ( {
 				) }
 				{ blockAttributes.showFilterButton && (
 					<FilterSubmitButton
-						className={ classnames(
-							'wc-block-attribute-filter__button',
-							{ 'show-loading-state': isLoading }
-						) }
+						className="wc-block-attribute-filter__button"
+						isLoading={ isLoading }
 						disabled={
 							termsLoading ||
 							countsLoading ||

--- a/assets/js/blocks/attribute-filter/block.tsx
+++ b/assets/js/blocks/attribute-filter/block.tsx
@@ -543,7 +543,7 @@ const AttributeFilterBlock = ( {
 							key={ remountKey }
 							className={ classnames( borderProps.className, {
 								'single-selection': ! multiple,
-								'show-loading-state': isLoading,
+								'is-loading': isLoading,
 							} ) }
 							style={ {
 								...borderProps.style,

--- a/assets/js/blocks/attribute-filter/block.tsx
+++ b/assets/js/blocks/attribute-filter/block.tsx
@@ -669,9 +669,12 @@ const AttributeFilterBlock = ( {
 						) }
 					/>
 				) }
-				{ blockAttributes.showFilterButton && ! isLoading && (
+				{ blockAttributes.showFilterButton && (
 					<FilterSubmitButton
-						className="wc-block-attribute-filter__button"
+						className={ classnames(
+							'wc-block-attribute-filter__button',
+							{ 'show-loading-state': isLoading }
+						) }
 						disabled={
 							termsLoading ||
 							countsLoading ||

--- a/assets/js/blocks/attribute-filter/checkbox-filter.tsx
+++ b/assets/js/blocks/attribute-filter/checkbox-filter.tsx
@@ -26,8 +26,8 @@ const CheckboxFilter = ( {
 	if ( isLoading ) {
 		return (
 			<>
-				<span className="show-loading-state"></span>
-				<span className="show-loading-state"></span>
+				<span className="is-loading"></span>
+				<span className="is-loading"></span>
 			</>
 		);
 	}

--- a/assets/js/blocks/attribute-filter/style.scss
+++ b/assets/js/blocks/attribute-filter/style.scss
@@ -12,7 +12,7 @@
 		text-transform: inherit;
 	}
 
-	.wc-block-attribute-filter__title {
+	> .wc-block-attribute-filter__title {
 		margin-top: $gap-small;
 		margin-bottom: $gap-small;
 	}

--- a/assets/js/blocks/attribute-filter/style.scss
+++ b/assets/js/blocks/attribute-filter/style.scss
@@ -23,7 +23,7 @@
 	border-radius: inherit;
 	border-color: inherit;
 
-	.show-loading-state {
+	.is-loading {
 		@include placeholder();
 		box-shadow: none;
 		border-radius: 0;
@@ -72,12 +72,12 @@
 		width: 0;
 		height: max-content;
 
-		&:not(.show-loading-state) {
+		&:not(.is-loading) {
 			border: 1px solid $gray-700 !important;
 			border-radius: 4px;
 		}
 
-		&.show-loading-state {
+		&.is-loading {
 			border-radius: em(4px);
 		}
 	}

--- a/assets/js/blocks/attribute-filter/style.scss
+++ b/assets/js/blocks/attribute-filter/style.scss
@@ -143,14 +143,6 @@
 			opacity: 0.6;
 			cursor: auto;
 		}
-
-		&.show-loading-state {
-			@include placeholder();
-			margin-top: $gap;
-			width: max-content;
-			box-shadow: none;
-			border-radius: 0;
-		}
 	}
 
 	.wc-block-filter-submit-button.wc-block-components-filter-submit-button.wc-block-attribute-filter__button {

--- a/assets/js/blocks/attribute-filter/style.scss
+++ b/assets/js/blocks/attribute-filter/style.scss
@@ -28,6 +28,7 @@
 		box-shadow: none;
 		border-radius: 0;
 		height: 1em;
+		margin-top: $gap;
 	}
 
 	&.style-dropdown {
@@ -185,4 +186,7 @@
 .wc-block-attribute-filter__button.wc-block-attribute-filter__button {
 	padding: em($gap-smaller) em($gap);
 	@include font-size(small);
+	height: max-content;
+	line-height: normal;
+	width: max-content;
 }

--- a/assets/js/blocks/attribute-filter/style.scss
+++ b/assets/js/blocks/attribute-filter/style.scss
@@ -27,8 +27,6 @@
 		@include placeholder();
 		box-shadow: none;
 		border-radius: 0;
-		margin-bottom: $gap;
-		margin-top: $gap;
 		height: 1em;
 	}
 
@@ -144,6 +142,14 @@
 		&:disabled {
 			opacity: 0.6;
 			cursor: auto;
+		}
+
+		&.show-loading-state {
+			@include placeholder();
+			margin-top: $gap;
+			width: max-content;
+			box-shadow: none;
+			border-radius: 0;
 		}
 	}
 

--- a/assets/js/blocks/price-filter/style.scss
+++ b/assets/js/blocks/price-filter/style.scss
@@ -12,7 +12,7 @@
 		text-transform: inherit;
 	}
 
-	.wc-block-price-filter__title {
+	> .wc-block-price-filter__title {
 		margin-top: $gap-small;
 		margin-bottom: $gap-small;
 	}

--- a/assets/js/blocks/stock-filter/block.tsx
+++ b/assets/js/blocks/stock-filter/block.tsx
@@ -390,30 +390,33 @@ const StockStatusFilterBlock = ( {
 					isLoading={ isLoading }
 					isDisabled={ isDisabled }
 				/>
-				{ ! isLoading && (
-					<div className="wc-block-stock-filter__actions">
-						{ checked.length > 0 && (
-							<FilterResetButton
-								onClick={ () => {
-									setChecked( [] );
-									onSubmit( [] );
-								} }
-								screenReaderLabel={ __(
-									'Reset stock filter',
-									'woo-gutenberg-products-block'
-								) }
-							/>
-						) }
-						{ blockAttributes.showFilterButton && (
-							<FilterSubmitButton
-								className="wc-block-stock-filter__button"
-								disabled={ isLoading || isDisabled }
-								onClick={ () => onSubmit( checked ) }
-							/>
-						) }
-					</div>
-				) }
 			</div>
+			{
+				<div className="wc-block-stock-filter__actions">
+					{ checked.length > 0 && ! isLoading && (
+						<FilterResetButton
+							onClick={ () => {
+								setChecked( [] );
+								onSubmit( [] );
+							} }
+							screenReaderLabel={ __(
+								'Reset stock filter',
+								'woo-gutenberg-products-block'
+							) }
+						/>
+					) }
+					{ blockAttributes.showFilterButton && (
+						<FilterSubmitButton
+							className={ classnames(
+								'wc-block-stock-filter__button',
+								{ 'show-loading-state': isLoading }
+							) }
+							disabled={ isLoading || isDisabled }
+							onClick={ () => onSubmit( checked ) }
+						/>
+					) }
+				</div>
+			}
 		</>
 	);
 };

--- a/assets/js/blocks/stock-filter/block.tsx
+++ b/assets/js/blocks/stock-filter/block.tsx
@@ -407,10 +407,8 @@ const StockStatusFilterBlock = ( {
 					) }
 					{ blockAttributes.showFilterButton && (
 						<FilterSubmitButton
-							className={ classnames(
-								'wc-block-stock-filter__button',
-								{ 'show-loading-state': isLoading }
-							) }
+							className="wc-block-stock-filter__button"
+							isLoading={ isLoading }
 							disabled={ isLoading || isDisabled }
 							onClick={ () => onSubmit( checked ) }
 						/>

--- a/assets/js/blocks/stock-filter/block.tsx
+++ b/assets/js/blocks/stock-filter/block.tsx
@@ -379,7 +379,7 @@ const StockStatusFilterBlock = ( {
 			{ ! isEditor && blockAttributes.heading && filterHeading }
 			<div
 				className={ classnames( 'wc-block-stock-filter', {
-					'show-loading-state': isLoading,
+					'is-loading': isLoading,
 				} ) }
 			>
 				<CheckboxList

--- a/assets/js/blocks/stock-filter/style.scss
+++ b/assets/js/blocks/stock-filter/style.scss
@@ -15,7 +15,7 @@
 }
 
 .wc-block-stock-filter {
-	&.show-loading-state {
+	&.is-loading {
 		@include placeholder();
 		margin-top: $gap;
 		box-shadow: none;

--- a/assets/js/blocks/stock-filter/style.scss
+++ b/assets/js/blocks/stock-filter/style.scss
@@ -63,14 +63,6 @@
 		margin-top: em($gap-smaller);
 		padding: em($gap-smaller) em($gap);
 		@include font-size(small);
-
-		&.show-loading-state {
-			@include placeholder();
-			margin-top: $gap;
-			width: max-content;
-			box-shadow: none;
-			border-radius: 0;
-		}
 	}
 }
 

--- a/assets/js/blocks/stock-filter/style.scss
+++ b/assets/js/blocks/stock-filter/style.scss
@@ -8,7 +8,7 @@
 		text-transform: inherit;
 	}
 
-	.wc-block-stock-filter__title {
+	> .wc-block-stock-filter__title {
 		margin-top: $gap-small;
 		margin-bottom: $gap-small;
 	}

--- a/assets/js/blocks/stock-filter/style.scss
+++ b/assets/js/blocks/stock-filter/style.scss
@@ -44,23 +44,37 @@
 		opacity: 0.6;
 	}
 
-	.wc-block-stock-filter__actions {
-		align-items: center;
-		display: flex;
-		gap: $gap;
-		justify-content: flex-end;
-		margin-top: $gap;
+}
 
-		// The specificity here is needed to overwrite the margin-top that is inherited on WC block template pages such as Shop.
-		button[type="submit"]:not(.wp-block-search__button).wc-block-components-filter-submit-button {
-			margin-left: 0;
-			margin-top: 0;
+.wc-block-stock-filter__actions {
+	align-items: center;
+	display: flex;
+	gap: $gap;
+	justify-content: flex-end;
+	margin-top: $gap;
+
+	// The specificity here is needed to overwrite the margin-top that is inherited on WC block template pages such as Shop.
+	button[type="submit"]:not(.wp-block-search__button).wc-block-components-filter-submit-button {
+		margin-left: 0;
+		margin-top: 0;
+	}
+
+	.wc-block-stock-filter__button {
+		margin-top: em($gap-smaller);
+		padding: em($gap-smaller) em($gap);
+		@include font-size(small);
+
+		&.show-loading-state {
+			@include placeholder();
+			margin-top: $gap;
+			width: max-content;
+			box-shadow: none;
+			border-radius: 0;
 		}
 	}
 }
 
-.editor-styles-wrapper .wc-block-stock-filter .wc-block-stock-filter__button,
-.wc-block-stock-filter .wc-block-stock-filter__button {
+.editor-styles-wrapper .wc-block-stock-filter .wc-block-stock-filter__button {
 	margin-top: em($gap-smaller);
 	padding: em($gap-smaller) em($gap);
 	@include font-size(small);

--- a/assets/js/blocks/stock-filter/test/__snapshots__/block.js.snap
+++ b/assets/js/blocks/stock-filter/test/__snapshots__/block.js.snap
@@ -102,10 +102,10 @@ exports[`Testing stock filter renders the stock filter block 1`] = `
         </div>
       </li>
     </ul>
-    <div
-      class="wc-block-stock-filter__actions"
-    />
   </div>
+  <div
+    class="wc-block-stock-filter__actions"
+  />
 </div>
 `;
 
@@ -211,25 +211,25 @@ exports[`Testing stock filter renders the stock filter block with the filter but
         </div>
       </li>
     </ul>
-    <div
-      class="wc-block-stock-filter__actions"
+  </div>
+  <div
+    class="wc-block-stock-filter__actions"
+  >
+    <button
+      class="wp-block-button__link wc-block-filter-submit-button wc-block-components-filter-submit-button wc-block-stock-filter__button"
+      type="submit"
     >
-      <button
-        class="wp-block-button__link wc-block-filter-submit-button wc-block-components-filter-submit-button wc-block-stock-filter__button"
-        type="submit"
+      <span
+        aria-hidden="true"
       >
-        <span
-          aria-hidden="true"
-        >
-          Apply
-        </span>
-        <span
-          class="screen-reader-text"
-        >
-          Apply filter
-        </span>
-      </button>
-    </div>
+        Apply
+      </span>
+      <span
+        class="screen-reader-text"
+      >
+        Apply filter
+      </span>
+    </button>
   </div>
 </div>
 `;
@@ -378,9 +378,9 @@ exports[`Testing stock filter renders the stock filter block with the product co
         </div>
       </li>
     </ul>
-    <div
-      class="wc-block-stock-filter__actions"
-    />
   </div>
+  <div
+    class="wc-block-stock-filter__actions"
+  />
 </div>
 `;


### PR DESCRIPTION
This PR adds placeholders to the Apply button on filters when they are enabled and adjust title margins.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|     <img width="363" alt="Screenshot 2022-09-09 at 11 00 23" src="https://user-images.githubusercontent.com/186112/189313767-6a8e7ac1-2855-4312-85f9-f96e0f3e139f.png">   |     <img width="366" alt="Screenshot 2022-09-09 at 11 00 03" src="https://user-images.githubusercontent.com/186112/189313776-ce1fc0fa-a7fc-42a9-8af4-c32c3f1bfb0a.png">  |

### Testing

#### User Facing Testing

1. Create a page with the filter blocks and the `All Products` block. Make sure to enable the `Show Apply filter button` setting on all of them.
2. Save and open the page on the front-end and make sure the placeholders show the apply button while loading and they look like the screenshot above.

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental


