### PR TITLE
Replace `gutenberg_build_query_vars_from_query_block` filter with `query_loop_block_query_vars`

### DIFF
--- a/src/BlockTypes/ProductQuery.php
+++ b/src/BlockTypes/ProductQuery.php
@@ -40,7 +40,7 @@ class ProductQuery extends AbstractBlock {
 	/**
 	 * Remove the query block filter and parse the custom query
 	 *
-	 * This function is supposed to be called by the `gutenberg_build_query_vars_from_query_block`
+	 * This function is supposed to be called by the `query_loop_block_query_vars`
 	 * filter. It de-registers the filter to make sure it runs only once and doesn't end
 	 * up hi-jacking future Query Loop blocks.
 	 *
@@ -51,7 +51,7 @@ class ProductQuery extends AbstractBlock {
 	 */
 	public function get_query_by_attributes_once( $query ) {
 		remove_filter(
-			'gutenberg_build_query_vars_from_query_block',
+			'query_loop_block_query_vars',
 			array( $this, 'get_query_by_attributes_once' ),
 			10
 		);
@@ -73,7 +73,7 @@ class ProductQuery extends AbstractBlock {
 		$this->parsed_block = $parsed_block;
 
 		add_filter(
-			'gutenberg_build_query_vars_from_query_block',
+			'query_loop_block_query_vars',
 			array( $this, 'get_query_by_attributes_once' ),
 			10,
 			1


### PR DESCRIPTION
This PR updates the name of the filter used to update the query on the PHP side for the Product Query block. The filter name is changed during the review phase https://github.com/WordPress/gutenberg/pull/43590#issuecomment-1227886817


### Testing
#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Be sure that you are using the Gutenberg trunk version.
2. Add the Product Query Block in a post/page.
3. On the right sidebar, enable the option `Show only products on sale`.
4. Save the post/page and visit the post/page.
5. Be sure that you see only products on sale.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental


### Changelog

> N/A
