### PR TITLE
Active Filters Loading Placeholders

### DIFF
--- a/assets/js/base/hooks/index.js
+++ b/assets/js/base/hooks/index.js
@@ -8,3 +8,4 @@ export * from './use-spacing-props';
 export * from './use-typography-props';
 export * from './use-color-props';
 export * from './use-border-props';
+export * from './use-is-mounted';

--- a/assets/js/base/hooks/use-is-mounted.ts
+++ b/assets/js/base/hooks/use-is-mounted.ts
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import { useCallback, useEffect, useRef } from '@wordpress/element';
+
+/**
+ * Returns a boolean value based on whether the current component has been mounted.
+ *
+ * @return {boolean} If the component has been mounted.
+ *
+ * @example
+ *
+ * ```js
+ * const App = () => {
+ * 	const isMounted = useIsMounted();
+ *
+ * 	if ( ! isMounted() ) {
+ * 	    return null;
+ * 	}
+ *
+ * 	return </div>;
+ * };
+ * ```
+ */
+
+export function useIsMounted() {
+	const isMounted = useRef( false );
+
+	useEffect( () => {
+		isMounted.current = true;
+
+		return () => {
+			isMounted.current = false;
+		};
+	}, [] );
+
+	return useCallback( () => isMounted.current, [] );
+}

--- a/assets/js/blocks/active-filters/active-attribute-filters.tsx
+++ b/assets/js/blocks/active-filters/active-attribute-filters.tsx
@@ -63,32 +63,14 @@ const ActiveAttributeFilters = ( {
 	}, [ isLoading, isLoadingCallback ] );
 
 	if (
-		! isLoading &&
-		( ! Array.isArray( results ) ||
-			! isAttributeTermCollection( results ) ||
-			! isAttributeQueryCollection( productAttributes ) )
+		! Array.isArray( results ) ||
+		! isAttributeTermCollection( results ) ||
+		! isAttributeQueryCollection( productAttributes )
 	) {
 		return null;
 	}
 
 	const attributeLabel = attributeObject.label;
-
-	if ( isLoading ) {
-		return [ ...Array( displayStyle === 'list' ? 2 : 3 ) ].map(
-			( x, i ) => (
-				<li
-					className={
-						displayStyle === 'list'
-							? 'show-loading-state-list'
-							: 'show-loading-state-chips'
-					}
-					key={ i }
-				>
-					<span className="show-loading-state__inner" />
-				</li>
-			)
-		);
-	}
 
 	const filteringForPhpTemplate = getSettingWithCoercion(
 		'is_rendering_php_template',

--- a/assets/js/blocks/active-filters/active-attribute-filters.tsx
+++ b/assets/js/blocks/active-filters/active-attribute-filters.tsx
@@ -83,7 +83,9 @@ const ActiveAttributeFilters = ( {
 							: 'show-loading-state-chips'
 					}
 					key={ i }
-				/>
+				>
+					<span className="show-loading-state__inner" />
+				</li>
 			)
 		);
 	}

--- a/assets/js/blocks/active-filters/active-attribute-filters.tsx
+++ b/assets/js/blocks/active-filters/active-attribute-filters.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { useEffect } from '@wordpress/element';
 import {
 	useCollection,
 	useQueryStateByKey,
@@ -26,22 +27,25 @@ interface ActiveAttributeFiltersProps {
 	operator: 'and' | 'in';
 	slugs: string[];
 	attributeObject: AttributeObject;
+	isLoadingCallback: ( val: boolean ) => void;
 }
 
 /**
  * Component that renders active attribute (terms) filters.
  *
- * @param {Object} props                 Incoming props for the component.
- * @param {Object} props.attributeObject The attribute object.
- * @param {Array}  props.slugs           The slugs for attributes.
- * @param {string} props.operator        The operator for the filter.
- * @param {string} props.displayStyle    The style used for displaying the filters.
+ * @param {Object} props                   Incoming props for the component.
+ * @param {Object} props.attributeObject   The attribute object.
+ * @param {Array}  props.slugs             The slugs for attributes.
+ * @param {string} props.operator          The operator for the filter.
+ * @param {string} props.displayStyle      The style used for displaying the filters.
+ * @param {string} props.isLoadingCallback The callback to trigger the loading complete state.
  */
 const ActiveAttributeFilters = ( {
 	attributeObject,
 	slugs = [],
 	operator = 'in',
 	displayStyle,
+	isLoadingCallback,
 }: ActiveAttributeFiltersProps ) => {
 	const { results, isLoading } = useCollection( {
 		namespace: '/wc/store/v1',
@@ -54,16 +58,35 @@ const ActiveAttributeFilters = ( {
 		[]
 	);
 
+	useEffect( () => {
+		isLoadingCallback( isLoading );
+	}, [ isLoading, isLoadingCallback ] );
+
 	if (
-		isLoading ||
-		! Array.isArray( results ) ||
-		! isAttributeTermCollection( results ) ||
-		! isAttributeQueryCollection( productAttributes )
+		! isLoading &&
+		( ! Array.isArray( results ) ||
+			! isAttributeTermCollection( results ) ||
+			! isAttributeQueryCollection( productAttributes ) )
 	) {
 		return null;
 	}
 
 	const attributeLabel = attributeObject.label;
+
+	if ( isLoading ) {
+		return [ ...Array( displayStyle === 'list' ? 2 : 3 ) ].map(
+			( x, i ) => (
+				<li
+					className={
+						displayStyle === 'list'
+							? 'show-loading-state-list'
+							: 'show-loading-state-chips'
+					}
+					key={ i }
+				/>
+			)
+		);
+	}
 
 	const filteringForPhpTemplate = getSettingWithCoercion(
 		'is_rendering_php_template',
@@ -100,6 +123,7 @@ const ActiveAttributeFilters = ( {
 						type: attributeLabel,
 						name: decodeEntities( termObject.name || slug ),
 						prefix,
+						isLoading,
 						removeCallback: () => {
 							const currentAttribute = productAttributes.find(
 								( { attribute } ) =>

--- a/assets/js/blocks/active-filters/block.tsx
+++ b/assets/js/blocks/active-filters/block.tsx
@@ -149,8 +149,7 @@ const ActiveFiltersBlock = ( {
 		if (
 			( ! isAttributeQueryCollection( productAttributes ) &&
 				componentHasMounted ) ||
-			( componentHasMounted &&
-				! productAttributes.length &&
+			( ! productAttributes.length &&
 				! urlContainsAttributeFilter( STORE_ATTRIBUTES ) )
 		) {
 			setIsLoading( false );
@@ -259,12 +258,7 @@ const ActiveFiltersBlock = ( {
 		);
 	};
 
-	if (
-		componentHasMounted &&
-		! shouldShowLoadingPlaceholders &&
-		! hasFilters() &&
-		! isEditor
-	) {
+	if ( ! shouldShowLoadingPlaceholders && ! hasFilters() && ! isEditor ) {
 		return null;
 	}
 

--- a/assets/js/blocks/active-filters/block.tsx
+++ b/assets/js/blocks/active-filters/block.tsx
@@ -30,6 +30,7 @@ import {
 	removeArgsFromFilterUrl,
 	cleanFilterUrl,
 	maybeUrlContainsFilters,
+	urlContainsFilter,
 } from './utils';
 import ActiveAttributeFilters from './active-attribute-filters';
 import FilterPlaceholders from './filter-placeholders';
@@ -145,8 +146,19 @@ const ActiveFiltersBlock = ( {
 
 	const activeAttributeFilters = useMemo( () => {
 		if (
-			! isAttributeQueryCollection( productAttributes ) ||
-			( componentHasMounted && productAttributes.length === 0 )
+			! isAttributeQueryCollection( productAttributes ) &&
+			componentHasMounted
+		) {
+			setIsLoading( false );
+			return null;
+		}
+
+		// We have no way of knowing if productAttributes is returning its default value.
+		// so we have to check the URL for possible attribute filters ('filter_') as well.
+		if (
+			componentHasMounted &&
+			! productAttributes.length &&
+			! urlContainsFilter( 'filter_' )
 		) {
 			setIsLoading( false );
 			return null;

--- a/assets/js/blocks/active-filters/block.tsx
+++ b/assets/js/blocks/active-filters/block.tsx
@@ -261,6 +261,7 @@ const ActiveFiltersBlock = ( {
 	const listClasses = classnames( 'wc-block-active-filters__list', {
 		'wc-block-active-filters__list--chips':
 			blockAttributes.displayStyle === 'chips',
+		'wc-block-active-filters--loading': shouldShowLoadingPlaceholders,
 	} );
 
 	return (
@@ -302,29 +303,33 @@ const ActiveFiltersBlock = ( {
 						</>
 					) }
 				</ul>
-				<button
-					className="wc-block-active-filters__clear-all"
-					onClick={ () => {
-						cleanFilterUrl();
-						if ( ! filteringForPhpTemplate ) {
-							setMinPrice( undefined );
-							setMaxPrice( undefined );
-							setProductAttributes( [] );
-							setProductStockStatus( [] );
-						}
-					} }
-				>
-					<Label
-						label={ __(
-							'Clear All',
-							'woo-gutenberg-products-block'
-						) }
-						screenReaderLabel={ __(
-							'Clear All Filters',
-							'woo-gutenberg-products-block'
-						) }
-					/>
-				</button>
+				{ shouldShowLoadingPlaceholders ? (
+					<span className="wc-block-active-filters__clear-all-placeholder" />
+				) : (
+					<button
+						className="wc-block-active-filters__clear-all"
+						onClick={ () => {
+							cleanFilterUrl();
+							if ( ! filteringForPhpTemplate ) {
+								setMinPrice( undefined );
+								setMaxPrice( undefined );
+								setProductAttributes( [] );
+								setProductStockStatus( [] );
+							}
+						} }
+					>
+						<Label
+							label={ __(
+								'Clear All',
+								'woo-gutenberg-products-block'
+							) }
+							screenReaderLabel={ __(
+								'Clear All Filters',
+								'woo-gutenberg-products-block'
+							) }
+						/>
+					</button>
+				) }
 			</div>
 		</>
 	);

--- a/assets/js/blocks/active-filters/block.tsx
+++ b/assets/js/blocks/active-filters/block.tsx
@@ -53,6 +53,12 @@ const ActiveFiltersBlock = ( {
 		isBoolean
 	);
 	const [ isLoading, setIsLoading ] = useState( true );
+	/*
+		activeAttributeFilters is the only async query in this block. Because of this the rest of the filters will render null
+		when in a loading state and activeAttributeFilters renders the placeholders.
+	 */
+	const shouldShowLoadingPlaceholders =
+		maybeUrlContainsFilters() && ! isEditor && isLoading;
 	const [ productAttributes, setProductAttributes ] = useQueryStateByKey(
 		'attributes',
 		[]
@@ -67,6 +73,7 @@ const ActiveFiltersBlock = ( {
 	const STOCK_STATUS_OPTIONS = getSetting( 'stockStatusOptions', [] );
 	const activeStockStatusFilters = useMemo( () => {
 		if (
+			shouldShowLoadingPlaceholders ||
 			productStockStatus.length === 0 ||
 			! isStockStatusQueryCollection( productStockStatus ) ||
 			! isStockStatusOptions( STOCK_STATUS_OPTIONS )
@@ -95,6 +102,7 @@ const ActiveFiltersBlock = ( {
 			} );
 		} );
 	}, [
+		shouldShowLoadingPlaceholders,
 		STOCK_STATUS_OPTIONS,
 		productStockStatus,
 		setProductStockStatus,
@@ -103,7 +111,10 @@ const ActiveFiltersBlock = ( {
 	] );
 
 	const activePriceFilters = useMemo( () => {
-		if ( ! Number.isFinite( minPrice ) && ! Number.isFinite( maxPrice ) ) {
+		if (
+			shouldShowLoadingPlaceholders ||
+			( ! Number.isFinite( minPrice ) && ! Number.isFinite( maxPrice ) )
+		) {
 			return null;
 		}
 		return renderRemovableListItem( {
@@ -119,6 +130,7 @@ const ActiveFiltersBlock = ( {
 			displayStyle: blockAttributes.displayStyle,
 		} );
 	}, [
+		shouldShowLoadingPlaceholders,
 		minPrice,
 		maxPrice,
 		blockAttributes.displayStyle,
@@ -181,6 +193,7 @@ const ActiveFiltersBlock = ( {
 
 	const activeRatingFilters = useMemo( () => {
 		if (
+			shouldShowLoadingPlaceholders ||
 			productRatings.length === 0 ||
 			! isRatingQueryCollection( productRatings )
 		) {
@@ -210,6 +223,7 @@ const ActiveFiltersBlock = ( {
 			} );
 		} );
 	}, [
+		shouldShowLoadingPlaceholders,
 		productRatings,
 		setProductRatings,
 		blockAttributes.displayStyle,
@@ -229,9 +243,6 @@ const ActiveFiltersBlock = ( {
 	if ( ! hasFilters() && ! isEditor ) {
 		return null;
 	}
-
-	const shouldShowLoadingPlaceholders =
-		maybeUrlContainsFilters() && ! isEditor && isLoading;
 
 	const TagName =
 		`h${ blockAttributes.headingLevel }` as keyof JSX.IntrinsicElements;

--- a/assets/js/blocks/active-filters/block.tsx
+++ b/assets/js/blocks/active-filters/block.tsx
@@ -30,7 +30,7 @@ import {
 	removeArgsFromFilterUrl,
 	cleanFilterUrl,
 	maybeUrlContainsFilters,
-	urlContainsFilter,
+	urlContainsAttributeFilter,
 } from './utils';
 import ActiveAttributeFilters from './active-attribute-filters';
 import FilterPlaceholders from './filter-placeholders';
@@ -76,6 +76,7 @@ const ActiveFiltersBlock = ( {
 	const [ maxPrice, setMaxPrice ] = useQueryStateByKey( 'max_price' );
 
 	const STOCK_STATUS_OPTIONS = getSetting( 'stockStatusOptions', [] );
+	const STORE_ATTRIBUTES = getSetting( 'attributes', [] );
 	const activeStockStatusFilters = useMemo( () => {
 		if (
 			shouldShowLoadingPlaceholders ||
@@ -146,19 +147,11 @@ const ActiveFiltersBlock = ( {
 
 	const activeAttributeFilters = useMemo( () => {
 		if (
-			! isAttributeQueryCollection( productAttributes ) &&
-			componentHasMounted
-		) {
-			setIsLoading( false );
-			return null;
-		}
-
-		// We have no way of knowing if productAttributes is returning its default value.
-		// so we have to check the URL for possible attribute filters ('filter_') as well.
-		if (
-			componentHasMounted &&
-			! productAttributes.length &&
-			! urlContainsFilter( 'filter_' )
+			( ! isAttributeQueryCollection( productAttributes ) &&
+				componentHasMounted ) ||
+			( componentHasMounted &&
+				! productAttributes.length &&
+				! urlContainsAttributeFilter( STORE_ATTRIBUTES ) )
 		) {
 			setIsLoading( false );
 			return null;

--- a/assets/js/blocks/active-filters/block.tsx
+++ b/assets/js/blocks/active-filters/block.tsx
@@ -50,6 +50,7 @@ const ActiveFiltersBlock = ( {
 	isEditor?: boolean;
 } ) => {
 	const isMounted = useIsMounted();
+	const componentHasMounted = isMounted();
 	const filteringForPhpTemplate = getSettingWithCoercion(
 		'is_rendering_php_template',
 		false,
@@ -145,7 +146,7 @@ const ActiveFiltersBlock = ( {
 	const activeAttributeFilters = useMemo( () => {
 		if (
 			! isAttributeQueryCollection( productAttributes ) ||
-			( isMounted() && productAttributes.length === 0 )
+			( componentHasMounted && productAttributes.length === 0 )
 		) {
 			setIsLoading( false );
 			return null;
@@ -172,7 +173,12 @@ const ActiveFiltersBlock = ( {
 				/>
 			);
 		} );
-	}, [ setIsLoading, productAttributes, blockAttributes.displayStyle ] );
+	}, [
+		componentHasMounted,
+		setIsLoading,
+		productAttributes,
+		blockAttributes.displayStyle,
+	] );
 
 	const [ productRatings, setProductRatings ] =
 		useQueryStateByKey( 'ratings' );
@@ -248,7 +254,12 @@ const ActiveFiltersBlock = ( {
 		);
 	};
 
-	if ( ! hasFilters() && ! isEditor ) {
+	if (
+		componentHasMounted &&
+		! shouldShowLoadingPlaceholders &&
+		! hasFilters() &&
+		! isEditor
+	) {
 		return null;
 	}
 

--- a/assets/js/blocks/active-filters/block.tsx
+++ b/assets/js/blocks/active-filters/block.tsx
@@ -17,6 +17,7 @@ import {
 } from '@woocommerce/types';
 import { getUrlParameter } from '@woocommerce/utils';
 import FilterTitlePlaceholder from '@woocommerce/base-components/filter-placeholder';
+import { useIsMounted } from '@woocommerce/base-hooks';
 
 /**
  * Internal dependencies
@@ -48,6 +49,7 @@ const ActiveFiltersBlock = ( {
 	attributes: Attributes;
 	isEditor?: boolean;
 } ) => {
+	const isMounted = useIsMounted();
 	const filteringForPhpTemplate = getSettingWithCoercion(
 		'is_rendering_php_template',
 		false,
@@ -143,7 +145,7 @@ const ActiveFiltersBlock = ( {
 	const activeAttributeFilters = useMemo( () => {
 		if (
 			! isAttributeQueryCollection( productAttributes ) ||
-			productAttributes.length === 0
+			( isMounted() && productAttributes.length === 0 )
 		) {
 			setIsLoading( false );
 			return null;

--- a/assets/js/blocks/active-filters/block.tsx
+++ b/assets/js/blocks/active-filters/block.tsx
@@ -31,6 +31,7 @@ import {
 	maybeUrlContainsFilters,
 } from './utils';
 import ActiveAttributeFilters from './active-attribute-filters';
+import FilterPlaceholders from './filter-placeholders';
 import { Attributes } from './types';
 
 /**
@@ -140,7 +141,11 @@ const ActiveFiltersBlock = ( {
 	] );
 
 	const activeAttributeFilters = useMemo( () => {
-		if ( ! isAttributeQueryCollection( productAttributes ) ) {
+		if (
+			! isAttributeQueryCollection( productAttributes ) ||
+			productAttributes.length === 0
+		) {
+			setIsLoading( false );
 			return null;
 		}
 
@@ -150,6 +155,7 @@ const ActiveFiltersBlock = ( {
 			);
 
 			if ( ! attributeObject ) {
+				setIsLoading( false );
 				return null;
 			}
 
@@ -164,7 +170,7 @@ const ActiveFiltersBlock = ( {
 				/>
 			);
 		} );
-	}, [ productAttributes, blockAttributes.displayStyle ] );
+	}, [ setIsLoading, productAttributes, blockAttributes.displayStyle ] );
 
 	const [ productRatings, setProductRatings ] =
 		useQueryStateByKey( 'ratings' );
@@ -307,6 +313,10 @@ const ActiveFiltersBlock = ( {
 						</>
 					) : (
 						<>
+							<FilterPlaceholders
+								isLoading={ shouldShowLoadingPlaceholders }
+								displayStyle={ blockAttributes.displayStyle }
+							/>
 							{ activePriceFilters }
 							{ activeStockStatusFilters }
 							{ activeAttributeFilters }

--- a/assets/js/blocks/active-filters/block.tsx
+++ b/assets/js/blocks/active-filters/block.tsx
@@ -4,7 +4,7 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { useQueryStateByKey } from '@woocommerce/base-context/hooks';
 import { getSetting, getSettingWithCoercion } from '@woocommerce/settings';
-import { useMemo, useEffect } from '@wordpress/element';
+import { useMemo, useEffect, useState } from '@wordpress/element';
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import Label from '@woocommerce/base-components/label';
@@ -16,6 +16,7 @@ import {
 	isStockStatusOptions,
 } from '@woocommerce/types';
 import { getUrlParameter } from '@woocommerce/utils';
+import FilterTitlePlaceholder from '@woocommerce/base-components/filter-placeholder';
 
 /**
  * Internal dependencies
@@ -27,6 +28,7 @@ import {
 	renderRemovableListItem,
 	removeArgsFromFilterUrl,
 	cleanFilterUrl,
+	maybeUrlContainsFilters,
 } from './utils';
 import ActiveAttributeFilters from './active-attribute-filters';
 import { Attributes } from './types';
@@ -50,6 +52,7 @@ const ActiveFiltersBlock = ( {
 		false,
 		isBoolean
 	);
+	const [ isLoading, setIsLoading ] = useState( true );
 	const [ productAttributes, setProductAttributes ] = useQueryStateByKey(
 		'attributes',
 		[]
@@ -145,6 +148,7 @@ const ActiveFiltersBlock = ( {
 					slugs={ attribute.slug }
 					key={ attribute.attribute }
 					operator={ attribute.operator }
+					isLoadingCallback={ setIsLoading }
 				/>
 			);
 		} );
@@ -226,8 +230,24 @@ const ActiveFiltersBlock = ( {
 		return null;
 	}
 
+	const shouldShowLoadingPlaceholders =
+		maybeUrlContainsFilters() && ! isEditor && isLoading;
+
 	const TagName =
 		`h${ blockAttributes.headingLevel }` as keyof JSX.IntrinsicElements;
+
+	const heading = (
+		<TagName className="wc-block-active-filters__title">
+			{ blockAttributes.heading }
+		</TagName>
+	);
+
+	const filterHeading = shouldShowLoadingPlaceholders ? (
+		<FilterTitlePlaceholder>{ heading }</FilterTitlePlaceholder>
+	) : (
+		heading
+	);
+
 	const hasFilterableProducts = getSettingWithCoercion(
 		'has_filterable_products',
 		false,
@@ -245,11 +265,7 @@ const ActiveFiltersBlock = ( {
 
 	return (
 		<>
-			{ ! isEditor && blockAttributes.heading && (
-				<TagName className="wc-block-active-filters__title">
-					{ blockAttributes.heading }
-				</TagName>
-			) }
+			{ ! isEditor && blockAttributes.heading && filterHeading }
 			<div className="wc-block-active-filters">
 				<ul className={ listClasses }>
 					{ isEditor ? (

--- a/assets/js/blocks/active-filters/filter-placeholders.tsx
+++ b/assets/js/blocks/active-filters/filter-placeholders.tsx
@@ -1,0 +1,30 @@
+const FilterPlaceholders = ( {
+	displayStyle,
+	isLoading,
+}: {
+	isLoading: boolean;
+	displayStyle: string;
+} ) => {
+	if ( ! isLoading ) {
+		return null;
+	}
+
+	return (
+		<>
+			{ [ ...Array( displayStyle === 'list' ? 2 : 3 ) ].map( ( x, i ) => (
+				<li
+					className={
+						displayStyle === 'list'
+							? 'show-loading-state-list'
+							: 'show-loading-state-chips'
+					}
+					key={ i }
+				>
+					<span className="show-loading-state__inner" />
+				</li>
+			) ) }
+		</>
+	);
+};
+
+export default FilterPlaceholders;

--- a/assets/js/blocks/active-filters/style.scss
+++ b/assets/js/blocks/active-filters/style.scss
@@ -56,6 +56,41 @@
 		> li:first-child {
 			margin: 0;
 		}
+		li.show-loading-state-list {
+			@include placeholder();
+			box-shadow: none;
+			border-radius: 0;
+			margin-bottom: $gap;
+			margin-top: $gap;
+			height: 1em;
+			width: 100%;
+		}
+
+		li.show-loading-state-chips {
+			@include placeholder();
+			display: inline-block !important;
+			box-shadow: none;
+			border-radius: 13px;
+			margin-bottom: $gap;
+			margin-top: $gap;
+			height: 1em;
+			width: 100%;
+			min-width: 70px;
+			margin-right: 15px !important;
+
+			&:last-of-type {
+				margin-right: 0 !important;
+			}
+
+			&:nth-child(1),
+			&:nth-child(2) {
+				width: calc(20% - 15px);
+			}
+
+			&:nth-child(3) {
+				width: calc(60% - 15px);
+			}
+		}
 	}
 
 	.wc-block-active-filters__list-item-type {

--- a/assets/js/blocks/active-filters/style.scss
+++ b/assets/js/blocks/active-filters/style.scss
@@ -48,6 +48,7 @@
 		width: 80px;
 		height: 1em;
 		float: right;
+		border-radius: 0;
 	}
 
 	.wc-block-active-filters__list {

--- a/assets/js/blocks/active-filters/style.scss
+++ b/assets/js/blocks/active-filters/style.scss
@@ -7,6 +7,17 @@
 	h6 {
 		text-transform: inherit;
 	}
+
+	.wc-block-filter-title-placeholder {
+		.wc-block-active-filters__title {
+			height: 1em;
+		}
+	}
+
+	.wc-block-active-filters__title {
+		margin-top: $gap-small;
+		margin-bottom: $gap-small;
+	}
 }
 
 .wc-block-active-filters {
@@ -36,6 +47,20 @@
 		list-style: none outside;
 		clear: both;
 
+		&.wc-block-active-filters--loading {
+			margin-top: $gap-small;
+			display: flex;
+			flex-direction: column;
+			flex-wrap: nowrap;
+
+			&.wc-block-active-filters__list--chips {
+				flex-direction: row;
+				flex-wrap: wrap;
+				align-items: flex-end;
+				gap: 0 10px;
+			}
+		}
+
 		li {
 			margin: 9px 0 0;
 			padding: 0;
@@ -57,38 +82,39 @@
 			margin: 0;
 		}
 		li.show-loading-state-list {
-			@include placeholder();
-			box-shadow: none;
-			border-radius: 0;
-			margin-bottom: $gap;
-			margin-top: $gap;
-			height: 1em;
-			width: 100%;
+			display: inline-block;
+
+			> span {
+				@include placeholder();
+				display: inline-block;
+				box-shadow: none;
+				border-radius: 0;
+				height: 1em;
+				width: 100%;
+			}
 		}
 
 		li.show-loading-state-chips {
-			@include placeholder();
-			display: inline-block !important;
-			box-shadow: none;
-			border-radius: 13px;
-			margin-bottom: $gap;
-			margin-top: $gap;
-			height: 1em;
-			width: 100%;
-			min-width: 70px;
-			margin-right: 15px !important;
+			display: inline-block;
 
-			&:last-of-type {
+			> span {
+				@include placeholder();
+				display: inline-block;
+				box-shadow: none;
+				border-radius: 13px;
+				height: 1em;
+				width: 100%;
+				min-width: 70px;
+				margin-right: 15px !important;
+			}
+
+			&:last-of-type > span {
 				margin-right: 0 !important;
 			}
 
-			&:nth-child(1),
-			&:nth-child(2) {
-				width: calc(20% - 15px);
-			}
-
 			&:nth-child(3) {
-				width: calc(60% - 15px);
+				flex-grow: 1;
+				max-width: 200px;
 			}
 		}
 	}

--- a/assets/js/blocks/active-filters/style.scss
+++ b/assets/js/blocks/active-filters/style.scss
@@ -31,6 +31,7 @@
 		padding: 0;
 		text-decoration: underline;
 		cursor: pointer;
+		float: right;
 
 		&,
 		&:hover,
@@ -39,6 +40,14 @@
 			background: transparent;
 			color: inherit;
 		}
+	}
+
+	.wc-block-active-filters__clear-all-placeholder {
+		@include placeholder();
+		display: inline-block;
+		width: 80px;
+		height: 1em;
+		float: right;
 	}
 
 	.wc-block-active-filters__list {

--- a/assets/js/blocks/active-filters/utils.tsx
+++ b/assets/js/blocks/active-filters/utils.tsx
@@ -44,6 +44,7 @@ interface RemovableListItemProps {
 	name: string;
 	prefix?: string | JSX.Element;
 	showLabel?: boolean;
+	isLoading?: boolean;
 	displayStyle: string;
 	removeCallback?: () => void;
 }
@@ -191,6 +192,35 @@ export const removeArgsFromFilterUrl = (
 };
 
 /**
+ * Prefixes typically expected before filters in the URL.
+ */
+const FILTER_QUERY_VALUES = [
+	'min_price',
+	'max_price',
+	'rating_filter',
+	'filter_',
+	'query_type_',
+];
+
+/**
+ * Check if the URL contains arguments that could be Woo filter keys.
+ */
+const keyIsAFilter = ( key: string ): boolean => {
+	let keyIsFilter = false;
+
+	for ( let i = 0; FILTER_QUERY_VALUES.length > i; i++ ) {
+		const keyToMatch = FILTER_QUERY_VALUES[ i ];
+		const trimmedKey = key.substring( 0, keyToMatch.length );
+		if ( keyToMatch === trimmedKey ) {
+			keyIsFilter = true;
+			break;
+		}
+	}
+
+	return keyIsFilter;
+};
+
+/**
  * Clean the filter URL.
  */
 export const cleanFilterUrl = () => {
@@ -204,13 +234,7 @@ export const cleanFilterUrl = () => {
 	const remainingArgs = Object.fromEntries(
 		Object.keys( args )
 			.filter( ( arg ) => {
-				if (
-					arg.includes( 'min_price' ) ||
-					arg.includes( 'max_price' ) ||
-					arg.includes( 'rating_filter' ) ||
-					arg.includes( 'filter_' ) ||
-					arg.includes( 'query_type_' )
-				) {
+				if ( keyIsAFilter( arg ) ) {
 					return false;
 				}
 
@@ -222,4 +246,25 @@ export const cleanFilterUrl = () => {
 	const newUrl = addQueryArgs( cleanUrl, remainingArgs );
 
 	changeUrl( newUrl );
+};
+
+export const maybeUrlContainsFilters = (): boolean => {
+	if ( ! window ) {
+		return false;
+	}
+
+	const url = window.location.href;
+	const args = getQueryArgs( url );
+	const filterKeys = Object.keys( args );
+	let maybeHasFilter = false;
+
+	for ( let i = 0; filterKeys.length > i; i++ ) {
+		const key = filterKeys[ i ];
+		if ( keyIsAFilter( key ) ) {
+			maybeHasFilter = true;
+			break;
+		}
+	}
+
+	return maybeHasFilter;
 };

--- a/assets/js/blocks/active-filters/utils.tsx
+++ b/assets/js/blocks/active-filters/utils.tsx
@@ -268,3 +268,25 @@ export const maybeUrlContainsFilters = (): boolean => {
 
 	return maybeHasFilter;
 };
+
+export const urlContainsFilter = ( key: string ): boolean => {
+	if ( ! window ) {
+		return false;
+	}
+
+	const url = window.location.href;
+	const args = getQueryArgs( url );
+	const urlFilterKeys = Object.keys( args );
+	let filterIsInUrl = false;
+
+	for ( let i = 0; urlFilterKeys.length > i; i++ ) {
+		const urlKey = urlFilterKeys[ i ];
+		const trimmedKey = urlKey.substring( 0, key.length );
+		if ( trimmedKey === key && urlKey !== 'filter_stock_status' ) {
+			filterIsInUrl = true;
+			break;
+		}
+	}
+
+	return filterIsInUrl;
+};

--- a/assets/js/blocks/active-filters/utils.tsx
+++ b/assets/js/blocks/active-filters/utils.tsx
@@ -269,10 +269,25 @@ export const maybeUrlContainsFilters = (): boolean => {
 	return maybeHasFilter;
 };
 
-export const urlContainsFilter = ( key: string ): boolean => {
+interface StoreAttributes {
+	attribute_id: string;
+	attribute_label: string;
+	attribute_name: string;
+	attribute_orderby: string;
+	attribute_public: number;
+	attribute_type: string;
+}
+
+export const urlContainsAttributeFilter = (
+	attributes: StoreAttributes[]
+): boolean => {
 	if ( ! window ) {
 		return false;
 	}
+
+	const storeAttributeKeys = attributes.map(
+		( attr ) => `filter_${ attr.attribute_name }`
+	);
 
 	const url = window.location.href;
 	const args = getQueryArgs( url );
@@ -281,8 +296,7 @@ export const urlContainsFilter = ( key: string ): boolean => {
 
 	for ( let i = 0; urlFilterKeys.length > i; i++ ) {
 		const urlKey = urlFilterKeys[ i ];
-		const trimmedKey = urlKey.substring( 0, key.length );
-		if ( trimmedKey === key && urlKey !== 'filter_stock_status' ) {
+		if ( storeAttributeKeys.includes( urlKey ) ) {
 			filterIsInUrl = true;
 			break;
 		}


### PR DESCRIPTION
This PR adds loading placeholders to the Active Filters block.

Some things worth noting:
* The only filter that determines the loading state is the attribute filter as this is the only asynchronous action.
* This is because all the other filters are synchronously picked from state so theres no real delay in getting those values, and no way to know when they're "_loading_" vs "_not present_".

| List | Chips |
| ------ | ----- |
|![Screenshot 2022-09-08 at 11 17 04](https://user-images.githubusercontent.com/8639742/189098324-940a2a66-9eb2-4025-9d6f-a770bb20c3a4.png) | ![Screenshot 2022-09-08 at 11 16 50](https://user-images.githubusercontent.com/8639742/189098368-f61594ff-6930-4b44-88df-8f5d06cacd2a.png) |





<!-- Reference any related issues or PRs here -->

Related to https://github.com/woocommerce/woocommerce-blocks/issues/6846

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Enable TT2 theme. Create a new page with an `All Products` block and a `Active Filters` block with other filter blocks. Save the page.
2. Open the page in the frontend and check that the `Active Filters` block shows like the screenshot above while loading.
3. Try different combinations of settings (show the `Apply` button, Chips vs List etc) and make sure the loading state makes sense and there are no regressions.
4. Repeat steps 1-3 with the Storefront theme.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Add loading placeholders to Active Filters block
