### PR TITLE
Check tax display type before returning the tax lines

### DIFF
--- a/src/StoreApi/Schemas/V1/CartSchema.php
+++ b/src/StoreApi/Schemas/V1/CartSchema.php
@@ -387,12 +387,13 @@ class CartSchema extends AbstractSchema {
 	 * @return array
 	 */
 	protected function get_tax_lines( $cart ) {
-		$cart_tax_totals = $cart->get_tax_totals();
-		$tax_lines       = [];
+		$tax_lines = [];
 
 		if ( 'itemized' !== get_option( 'woocommerce_tax_total_display' ) ) {
 			return $tax_lines;
 		}
+
+		$cart_tax_totals = $cart->get_tax_totals();
 
 		foreach ( $cart_tax_totals as $cart_tax_total ) {
 			$tax_lines[] = array(

--- a/src/StoreApi/Schemas/V1/CartSchema.php
+++ b/src/StoreApi/Schemas/V1/CartSchema.php
@@ -390,6 +390,10 @@ class CartSchema extends AbstractSchema {
 		$cart_tax_totals = $cart->get_tax_totals();
 		$tax_lines       = [];
 
+		if ( 'itemized' !== get_option( 'woocommerce_tax_total_display' ) ) {
+			return $tax_lines;
+		}
+
 		foreach ( $cart_tax_totals as $cart_tax_total ) {
 			$tax_lines[] = array(
 				'name'  => $cart_tax_total->label,


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
If we set display tax totals as a single total, it should display one total tax line, but on WooPay, it displays all the tax lines at the checkout page.  In this PR, we check the tax display type before returning the tax lines, and in [#1271](1271-gh-Automattic/woopay) we display total tax when the tax lines length is 0 and don't display tax when there's no total tax.

#### Acceptance Criteria
* When "Itemized" is selected, we'll display [Tax rate name] [tax rate %] [amount] for each rate
* When "As a single total" is selected, we'll display Tax [amount] (which doesn't reflect the designs) 


<!-- Reference any related issues or PRs here -->
Fixes 788-gh-Automattic/woopay
Related PR 1271-gh-Automattic/woopay

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|<img width="342" alt="Screen Shot 2022-09-07 at 9 32 17 AM" src="https://user-images.githubusercontent.com/56378160/188961012-92cdf237-e7f3-4969-b739-14e01591b392.png">  | <img width="353" alt="Screen Shot 2022-09-07 at 9 31 02 AM" src="https://user-images.githubusercontent.com/56378160/188961117-71349dc4-26ec-46f2-b746-74332b556a98.png">|

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Test the two PRs together ( 1271-gh-Automattic/woopay )
2. Go to WooCommerce / Settings / Tax
3. Set display tax total as a single total
4. Use WooPay checkout and check the total block

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> WooPay: Fixed an issue with WooPay which would display tax totals on multiple lines even when configured otherwise.