### PR TITLE
Document the selectors for the wc/store/validation data store

### DIFF
--- a/docs/third-party-developers/extensibility/data-store/README.md
+++ b/docs/third-party-developers/extensibility/data-store/README.md
@@ -3,6 +3,7 @@
 ## Table of Contents
 
 -   [wc/store/checkout](checkout.md)
+-   [wc/store/validation](checkout.md)
 
 <!-- FEEDBACK -->
 

--- a/docs/third-party-developers/extensibility/data-store/README.md
+++ b/docs/third-party-developers/extensibility/data-store/README.md
@@ -3,7 +3,7 @@
 ## Table of Contents
 
 -   [wc/store/checkout](checkout.md)
--   [wc/store/validation](checkout.md)
+-   [wc/store/validation](validation.md)
 
 <!-- FEEDBACK -->
 

--- a/docs/third-party-developers/extensibility/data-store/validation.md
+++ b/docs/third-party-developers/extensibility/data-store/validation.md
@@ -1,0 +1,44 @@
+# wc/store/validation
+
+## Table of Contents
+
+-   [Selectors](#selectors)
+    -   [getValidationError](#getvalidationerror)
+    -   [getValidationErrorId](#getvalidationerrorid)
+    -   [hasValidationErrors](#hasvalidationerrors)
+
+## Selectors
+
+### getValidationError
+
+Returns the validation error.
+
+#### _Returns_
+
+-   `string`: The validation error.
+
+### getValidationErrorId
+
+Returns the validation error ID.
+
+#### _Returns_
+
+-   `string`: The validation error ID.
+
+### hasValidationErrors
+
+Returns true if validation errors occured, and false otherwise.
+
+#### _Returns_
+
+-   `boolean`: Weather validation errors occured.
+
+<!-- FEEDBACK -->
+
+---
+
+[We're hiring!](https://woocommerce.com/careers/) Come work with us!
+
+🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-blocks/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/third-party-developers/extensibility/checkout-payment-methods/checkout-flow-and-events.md)
+
+<!-- /FEEDBACK -->

--- a/docs/third-party-developers/extensibility/data-store/validation.md
+++ b/docs/third-party-developers/extensibility/data-store/validation.md
@@ -9,7 +9,11 @@
     -   [hasValidationErrors](#hasvalidationerrors)
 -   [Actions](#actions)
     -   [clearValidationErrors](#clearvalidationerrors)
+    -   [clearAllValidationErrors](#clearallvalidationerrors)
     -   [setValidationErrors](#setvalidationerrors)
+    -   [hideValidationError](#hidevalidationerror)
+    -   [showValidationError](#showvalidationerror)
+    -   [showAllValidationErrors](#showallvalidationerrors)
 
 ## Overview
 

--- a/docs/third-party-developers/extensibility/data-store/validation.md
+++ b/docs/third-party-developers/extensibility/data-store/validation.md
@@ -13,9 +13,21 @@
 
 Returns the validation error.
 
+#### _Parameters_
+
+- _errorId_ `string` - The error ID to get validation errors for.
+
+#### Example
+
+```js
+const store = select( 'wc/store/validation' );
+const billingFirstNameError = store.getValidationError( 'billing-first-name' );
+```
+
+
 #### _Returns_
 
--   `string`: The validation error.
+-   `object`: The validation error which is an object containing _message_ (`string`) and _hidden_ (`boolean`).
 
 ### getValidationErrorId
 

--- a/docs/third-party-developers/extensibility/data-store/validation.md
+++ b/docs/third-party-developers/extensibility/data-store/validation.md
@@ -118,6 +118,22 @@ const { hideValidationError } = dispatch( 'wc/store/validation' );
 hideValidationError( 'billing-first-name' );
 ```
 
+### showValidationError
+
+Shows a validation error by setting the `hidden` property to `false`.
+
+#### _Parameters_
+
+-   _errorId_ `string`: The error ID to show.
+
+#### Example
+
+```js
+const { dispatch } = wp.data;
+const { showValidationError } = dispatch( 'wc/store/validation' );
+
+showValidationError( 'billing-first-name' );
+```
 
 <!-- FEEDBACK -->
 

--- a/docs/third-party-developers/extensibility/data-store/validation.md
+++ b/docs/third-party-developers/extensibility/data-store/validation.md
@@ -101,6 +101,23 @@ const { clearAllValidationErrors } = dispatch( 'wc/store/validation' );
 clearAllValidationErrors();
 ```
 
+### hideValidationError
+
+Hides a validation error by setting the `hidden` property to `true`.
+
+#### _Parameters_
+
+-   _errorId_ `string`: The error ID to hide.
+
+#### Example
+
+```js
+const { dispatch } = wp.data;
+const { hideValidationError } = dispatch( 'wc/store/validation' );
+
+hideValidationError( 'billing-first-name' );
+```
+
 
 <!-- FEEDBACK -->
 

--- a/docs/third-party-developers/extensibility/data-store/validation.md
+++ b/docs/third-party-developers/extensibility/data-store/validation.md
@@ -60,6 +60,10 @@ Returns true if validation errors occurred, and false otherwise.
 
 Clears the validation errors.
 
+### clearAllValidationErrors
+
+Clears all validation errors.
+
 ### setValidationErrors
 
 #### _Parameters_
@@ -87,6 +91,16 @@ setValidationErrors( {
     },
 } );
 ```
+
+#### Example
+
+```js
+const { dispatch } = wp.data;
+const { clearAllValidationErrors } = dispatch( 'wc/store/validation' );
+
+clearAllValidationErrors();
+```
+
 
 <!-- FEEDBACK -->
 

--- a/docs/third-party-developers/extensibility/data-store/validation.md
+++ b/docs/third-party-developers/extensibility/data-store/validation.md
@@ -45,7 +45,7 @@ the validation error does not exist in the store.
 
 ### hasValidationErrors
 
-Returns true if validation errors occured, and false otherwise.
+Returns true if validation errors occurred, and false otherwise.
 
 #### _Returns_
 

--- a/docs/third-party-developers/extensibility/data-store/validation.md
+++ b/docs/third-party-developers/extensibility/data-store/validation.md
@@ -31,11 +31,17 @@ const billingFirstNameError = store.getValidationError( 'billing-first-name' );
 
 ### getValidationErrorId
 
-Returns the validation error ID.
+Gets a validation error ID for use in HTML which can be used as a CSS selector, or to reference an error message.
+This will return the error ID prefixed with `validate-error-`, unless the validation error has `hidden` set to true, or
+the validation error does not exist in the store.
+
+#### _Parameters_
+
+- _errorId_ `string` - The error ID to get the validation error ID for.
 
 #### _Returns_
 
--   `string`: The validation error ID.
+-   `string`: The validation error ID for use in HTML.
 
 ### hasValidationErrors
 

--- a/docs/third-party-developers/extensibility/data-store/validation.md
+++ b/docs/third-party-developers/extensibility/data-store/validation.md
@@ -163,6 +163,19 @@ const { showValidationError } = dispatch( 'wc/store/validation' );
 showValidationError( 'billing-first-name' );
 ```
 
+### showAllValidationErrors
+
+Shows all validation errors by setting the `hidden` property to `false`.
+
+#### Example
+
+```js
+const { dispatch } = wp.data;
+const { showAllValidationErrors } = dispatch( 'wc/store/validation' );
+
+showAllValidationErrors();
+```
+
 <!-- FEEDBACK -->
 
 ---

--- a/docs/third-party-developers/extensibility/data-store/validation.md
+++ b/docs/third-party-developers/extensibility/data-store/validation.md
@@ -131,7 +131,7 @@ clearAllValidationErrors();
 
 ### hideValidationError
 
-Hides a validation error by setting the `hidden` property to `true`.
+Hides a validation error by setting the `hidden` property to `true`. This will _not_ clear it from the data store!
 
 #### _Parameters_
 

--- a/docs/third-party-developers/extensibility/data-store/validation.md
+++ b/docs/third-party-developers/extensibility/data-store/validation.md
@@ -2,6 +2,7 @@
 
 ## Table of Contents
 
+-   [Overview](#overview)
 -   [Selectors](#selectors)
     -   [getValidationError](#getvalidationerror)
     -   [getValidationErrorId](#getvalidationerrorid)
@@ -9,6 +10,33 @@
 -   [Actions](#actions)
     -   [clearValidationErrors](#clearvalidationerrors)
     -   [setValidationErrors](#setvalidationerrors)
+
+## Overview
+
+The validation data store provides a way to show errors for fields in the Cart or Checkout blocks.
+
+The data in the store should be a single object, the keys of which are the _error IDs_ and values are the data
+associated with that error message. The values in the object should contain _message_ and _hidden_. The _message_
+is the error message to display and _hidden_ is a boolean indicating whether the error should be shown or not.
+
+An example of how the data should be structured:
+
+```js
+{
+    "error-id-1": {
+        message: "This is an error message",
+        hidden: false,
+    },
+    "error-id-2": {
+        message: "This is another error message",
+        hidden: true,
+    },
+}
+```
+
+When the checkout process begins, it will check if this data store has any entries, and if so, it will stop the checkout
+process from proceeding. It will also show any errors that are hidden. Setting an error to hidden will not clear it from
+the data store!
 
 ## Selectors
 

--- a/docs/third-party-developers/extensibility/data-store/validation.md
+++ b/docs/third-party-developers/extensibility/data-store/validation.md
@@ -84,7 +84,7 @@ Returns true if validation errors occurred, and false otherwise.
 
 #### _Returns_
 
--   `boolean`: Whether validation errors occured.
+-   `boolean`: Whether validation errors occurred.
 
 ## Actions
 

--- a/docs/third-party-developers/extensibility/data-store/validation.md
+++ b/docs/third-party-developers/extensibility/data-store/validation.md
@@ -31,7 +31,7 @@ Returns true if validation errors occured, and false otherwise.
 
 #### _Returns_
 
--   `boolean`: Weather validation errors occured.
+-   `boolean`: Whether validation errors occured.
 
 <!-- FEEDBACK -->
 

--- a/docs/third-party-developers/extensibility/data-store/validation.md
+++ b/docs/third-party-developers/extensibility/data-store/validation.md
@@ -8,7 +8,7 @@
     -   [getValidationErrorId](#getvalidationerrorid)
     -   [hasValidationErrors](#hasvalidationerrors)
 -   [Actions](#actions)
-    -   [clearValidationErrors](#clearvalidationerrors)
+    -   [clearValidationError](#clearvalidationerror)
     -   [clearAllValidationErrors](#clearallvalidationerrors)
     -   [setValidationErrors](#setvalidationerrors)
     -   [hideValidationError](#hidevalidationerror)
@@ -88,9 +88,20 @@ Returns true if validation errors occurred, and false otherwise.
 
 ## Actions
 
-### clearValidationErrors
+### clearValidationError
 
-Clears the validation errors.
+Clears a validation error.
+
+#### _Parameters_
+
+- _errorId_ `string` - The error ID to clear validation errors for.
+
+#### Example
+
+```js
+const store = dispatch( 'wc/store/validation' );
+store.clearValidationError( 'billing-first-name' );
+```
 
 ### clearAllValidationErrors
 

--- a/docs/third-party-developers/extensibility/data-store/validation.md
+++ b/docs/third-party-developers/extensibility/data-store/validation.md
@@ -6,6 +6,8 @@
     -   [getValidationError](#getvalidationerror)
     -   [getValidationErrorId](#getvalidationerrorid)
     -   [hasValidationErrors](#hasvalidationerrors)
+-   [Actions](#actions)
+    -   [clearValidationErrors](#clearvalidationerrors)
 
 ## Selectors
 
@@ -50,6 +52,12 @@ Returns true if validation errors occurred, and false otherwise.
 #### _Returns_
 
 -   `boolean`: Whether validation errors occured.
+
+## Actions
+
+### clearValidationErrors
+
+Clears the validation errors.
 
 <!-- FEEDBACK -->
 

--- a/docs/third-party-developers/extensibility/data-store/validation.md
+++ b/docs/third-party-developers/extensibility/data-store/validation.md
@@ -8,6 +8,7 @@
     -   [hasValidationErrors](#hasvalidationerrors)
 -   [Actions](#actions)
     -   [clearValidationErrors](#clearvalidationerrors)
+    -   [setValidationErrors](#setvalidationerrors)
 
 ## Selectors
 
@@ -58,6 +59,34 @@ Returns true if validation errors occurred, and false otherwise.
 ### clearValidationErrors
 
 Clears the validation errors.
+
+### setValidationErrors
+
+#### _Parameters_
+
+-   _errors_ `object`: An object containing new validation errors, the keys of the object are the validation error IDs,
+and the values should be objects containing _message_ (`string`) and _hidden_ `boolean`.
+
+Sets the validation errors. The entries in _errors_ will be _added_ to the list of validation errors. Any entries that
+already exist in the list will be _updated_ with the new values.
+
+#### Example
+
+```js
+const { dispatch } = wp.data;
+const { setValidationErrors } = dispatch( 'wc/store/validation' );
+
+setValidationErrors( {
+    'billing-first-name': {
+        message: 'First name is required.',
+        hidden: false,
+    },
+    'billing-last-name': {
+        message: 'Last name is required.',
+        hidden: false,
+    },
+} );
+```
 
 <!-- FEEDBACK -->
 


### PR DESCRIPTION
Fixes #6947 

## Notes

In #6612, we ran a Data Store Migration. This PR aims to create the external documentation for the `wc/store/checkout` data store.

### Testing

1. Open https://github.com/woocommerce/woocommerce-blocks/blob/361b48b6220f57fab8a62b9a9272757530d6f14a/assets/js/data/validation/selectors.ts
2. Verify that `validation.md` from this PR documents all selector that appear in the document mentioned before.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->