### PR TITLE
Fix Remove button alignment in Filter by Attribute block

### DIFF
--- a/assets/js/blocks/attribute-filter/style.scss
+++ b/assets/js/blocks/attribute-filter/style.scss
@@ -90,7 +90,6 @@
 
 	.wc-blocks-components-form-token-field-wrapper .components-form-token-field__input-container {
 		border: 0;
-		width: calc(100% - 50px);
 		padding: $gap-smaller;
 
 		.components-form-token-field__input::placeholder {
@@ -111,6 +110,9 @@
 				padding: $gap-small;
 			}
 		}
+	}
+	.is-single .wc-blocks-components-form-token-field-wrapper .components-form-token-field__input-container {
+		width: calc(100% - 50px);
 	}
 }
 
@@ -164,8 +166,7 @@
 		border: 1px solid;
 		border-right: 0;
 		border-radius: 25px 0 0 25px;
-		padding: em($gap-smallest);
-		padding-left: em($gap-small);
+		padding: em($gap-smallest) em($gap-smaller) em($gap-smallest) em($gap-small);
 	}
 
 	.components-button.components-form-token-field__remove-token {
@@ -173,7 +174,7 @@
 		border: 1px solid;
 		border-left: 0;
 		border-radius: 0 25px 25px 0;
-		padding: 0 em($gap-smaller) 0 0;
+		padding: 1px em($gap-smallest) 0 0;
 
 		&.has-icon svg {
 			background-color: $gray-200;


### PR DESCRIPTION
Makes a small change to the remove button of the Filter by Attribute block (with dropdown display style).

Changes included in this PR:
- When the selection mode is set to single, the remove button is properly aligned to the right.
- When the selection mode is set to multiple, the remove button is better aligned to the end of the chip.

### Testing

#### User Facing Testing

1. Create a page with the filter blocks and the All Products block. Make sure to add two Filter by Attribute blocks with display style set to dropdown. One allowing single selection and the other one allowing multiple selection.
2. Add some attribute filters.
3. Verify the remove icons are properly aligned.
4. If you can, try with different themes (I tried with Storefront and Twenty Twenty Two).

| Before | After |
| ------ | ----- |
|  <img src="https://user-images.githubusercontent.com/3616980/189088145-1723a855-1389-49f8-af35-12ead11c5087.png" alt="" width="220" /> | <img src="https://user-images.githubusercontent.com/3616980/189088116-1af556da-aeb9-4245-bbc3-cc4b9d046d3c.png" alt="" width="220" /> |

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Improve the alignment of the Remove button in the Filter by Attribute block.
