### PR TITLE
Adjust empty cart icon in Twenty Twenty-Two theme

### DIFF
--- a/assets/css/editor.scss
+++ b/assets/css/editor.scss
@@ -85,3 +85,10 @@ svg.wc-block-editor-components-block-icon--sparkles path {
 		}
 	}
 }
+
+.theme-twentytwentytwo {
+	.wp-block-image.aligncenter {
+		margin-left: auto;
+		margin-right: auto;
+	}
+}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -337,6 +337,11 @@
 			text-decoration: none;
 		}
 	}
+
+	.wp-block-image.aligncenter {
+		margin-left: auto;
+		margin-right: auto;
+	}
 }
 
 // Default screen-reader styles. Included as a fallback for themes that don't have support.


### PR DESCRIPTION
Fixes #7102 

### Notes

In #7102, @gglobalstep reported that the empty cart icon is not centred when using the Twenty Twenty-Two theme. This PR aims to fix this problem.

### Screenshots

#### Editor

<table>
<tr>
<td>Before:
<br><br>

![#7102-before-editor](https://user-images.githubusercontent.com/3323310/189297290-cf5012d2-15ef-424b-9e9d-9e99603b1cb4.png)
</td>
<td>After:
<br><br>

![#7102-after-editor](https://user-images.githubusercontent.com/3323310/189297259-25229ca8-57bf-47e7-8407-e5400c55a737.png)
</td>
</tr>
</table>

#### Frontend

<table>
<tr>
<td>Before:
<br><br>

![#7102-before](https://user-images.githubusercontent.com/3323310/189297294-d08787d1-b8ae-455a-a114-ff7d65a2b727.png)
</td>
<td>After:
<br><br>

![#7102-after](https://user-images.githubusercontent.com/3323310/189297276-c51f9764-7f10-43d4-98be-c3077559b85f.png)
</td>
</tr>
</table>

### Testing

#### User Facing Testing

1. Ensure that the [Twenty Twenty-Two theme](https://wordpress.org/themes/twentytwentytwo/) is active.
2. Create a test page and add the cart block.
3. Switch the view to `Empty cart`.
4. Verify that the empty cart icon is centred in the editor.
5. Save the test page and open it in the frontend.
6. Verify that the empty cart icon is centred in the frontend.

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Ensure that empty cart icon appears centred when using the Twenty Twenty-Two theme theme.
