### PR TITLE
Fix invisible Reset filter button in some themes

### DIFF
--- a/assets/js/base/components/filter-reset-button/style.scss
+++ b/assets/js/base/components/filter-reset-button/style.scss
@@ -1,8 +1,6 @@
 .wc-block-components-filter-reset-button {
-	background: transparent;
-	border: none;
+	@include text-button();
 	cursor: pointer;
-	font-size: inherit;
 
 	&:not([disabled]):hover {
 		text-decoration: underline;


### PR DESCRIPTION
In some themes, the _Reset_ button from filter blocks was not visible. That's because we were resetting the background color but no the text color. Luckily, we have a [`text-button()` mixin](https://github.com/woocommerce/woocommerce-blocks/blob/d4e3247ec07bda51c51d8c1e0ca4216e7ff4d4a0/assets/css/abstracts/_mixins.scss#L147-L161) that takes care of theme compatibility when making a button to be shown as a text.

### Testing

#### User Facing Testing

0. Install and enable the Twenty Twenty theme.
1. Add the Filter by Price and All Products blocks to a post or page.
2. Move the Filter by Price slider.
3. Verify the Reset button is visible.

| Before | After |
| ------ | ----- |
| ![imatge](https://user-images.githubusercontent.com/3616980/189666502-48f17460-93a2-4c7c-b310-98c21fb518ee.png) | ![imatge](https://user-images.githubusercontent.com/3616980/189666412-706a99a7-68ca-4d5d-a10a-a6797934857f.png) |

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix invisible Reset filter button in some themes
