### PR TITLE
Fix pills in the Filter by Attribute block dropdown overlapping with the chevron (second attempt)

### DIFF
--- a/assets/js/blocks/attribute-filter/style.scss
+++ b/assets/js/blocks/attribute-filter/style.scss
@@ -110,8 +110,12 @@
 			}
 		}
 	}
-	.is-single .wc-blocks-components-form-token-field-wrapper .components-form-token-field__input-container {
+	.wc-blocks-components-form-token-field-wrapper:not(.single-selection) .components-form-token-field__input-container {
 		width: calc(100% - 50px);
+
+		.components-form-token-field__suggestions-list {
+			width: calc(100% + 50px);
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-blocks/issues/6982.

That issue was originally fixed in #7039, but later re-introduced in #7088.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
| ![imatge](https://user-images.githubusercontent.com/3616980/189694956-ef57a983-a500-4a7b-86d2-2db2070f20ec.png) | ![imatge](https://user-images.githubusercontent.com/3616980/189694920-11831d2a-f271-417d-a698-8de8e8142083.png) |

### Testing

#### User Facing Testing

1. Add the `Filter by Attribute` block and the `All Products` block to a page.
2. Set the `Filter by Attribute` block display to dropdown and allow selecting multiple options.
3. Play around with the window size and the options you select, and make sure the pills inside the input don't overlap the chevron.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). --> _(testing steps are the same as #7039)_

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
