### PR TITLE
Fix e2e test - `Filter products by stock` block

### DIFF
--- a/tests/e2e/specs/backend/filter-products-by-stock.test.js
+++ b/tests/e2e/specs/backend/filter-products-by-stock.test.js
@@ -43,7 +43,9 @@ describe( `${ block.name } Block`, () => {
 		} );
 
 		it( 'product count can be toggled', async () => {
-			const toggleLabel = await findLabelWithText( 'Product count' );
+			const toggleLabel = await findLabelWithText(
+				'Display product count'
+			);
 			await expect( toggleLabel ).toToggleElement(
 				`${ block.class } .wc-filter-element-label-list-count`
 			);


### PR DESCRIPTION
This PR fixes an E2E test failure relative to the `Filter products by stock` block introduced with #7045.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->


### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Be sure that any E2E test relative to the `Filter products by stock` block fail.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental



### Changelog

> N/A
