### PR TITLE
Make chevron clickable in Filter by Product block input

### DIFF
--- a/assets/js/blocks/attribute-filter/style.scss
+++ b/assets/js/blocks/attribute-filter/style.scss
@@ -44,9 +44,9 @@
 
 		> svg {
 			position: absolute;
-			right: 20px;
-			top: 50%;
-			transform: translateY(-50%);
+			right: 8px;
+			bottom: 8px;
+			pointer-events: none;
 		}
 	}
 
@@ -110,13 +110,6 @@
 			}
 		}
 	}
-	.wc-blocks-components-form-token-field-wrapper:not(.single-selection) .components-form-token-field__input-container {
-		width: calc(100% - 50px);
-
-		.components-form-token-field__suggestions-list {
-			width: calc(100% + 50px);
-		}
-	}
 }
 
 .wc-block-attribute-filter__multiple-toggle,
@@ -164,12 +157,20 @@
 }
 
 .wc-blocks-components-form-token-field-wrapper:not(.single-selection) .components-form-token-field__input-container {
+	padding: $gap-smallest $gap-smaller;
+
 	.components-form-token-field__token-text {
 		background-color: $white;
 		border: 1px solid;
 		border-right: 0;
 		border-radius: 25px 0 0 25px;
 		padding: em($gap-smallest) em($gap-smaller) em($gap-smallest) em($gap-small);
+		line-height: 22px;
+	}
+
+	> .components-form-token-field__input {
+		padding-right: 30px;
+		margin: em($gap-smallest) 0;
 	}
 
 	.components-button.components-form-token-field__remove-token {

--- a/assets/js/blocks/attribute-filter/style.scss
+++ b/assets/js/blocks/attribute-filter/style.scss
@@ -45,7 +45,8 @@
 		> svg {
 			position: absolute;
 			right: 8px;
-			bottom: 8px;
+			top: 50%;
+			transform: translateY(-50%);
 			pointer-events: none;
 		}
 	}
@@ -157,7 +158,7 @@
 }
 
 .wc-blocks-components-form-token-field-wrapper:not(.single-selection) .components-form-token-field__input-container {
-	padding: $gap-smallest $gap-smaller;
+	padding: $gap-smallest 30px $gap-smallest  $gap-smaller;
 
 	.components-form-token-field__token-text {
 		background-color: $white;
@@ -169,7 +170,6 @@
 	}
 
 	> .components-form-token-field__input {
-		padding-right: 30px;
 		margin: em($gap-smallest) 0;
 	}
 


### PR DESCRIPTION
Fixes #7123.

This PR implements a different approach to avoid chips overlapping the chevron (which was fixed in #7039 and #7112), so that the chevron is still clickable.

I also realigned items so the _Remove_ button (when it's in single selection) and the chevron (when in multiple selection) are aligned:

![imatge](https://user-images.githubusercontent.com/3616980/189931618-79c94ddb-f8ee-4db0-89a8-ba45e97e89a7.png)

### Testing


#### User Facing Testing

1. Add the `Filter by Attribute` block and the `All Products` block to a page.
2. Set the `Filter by Attribute` block display to dropdown and allow selecting multiple options.
3. Play around with the window size and the options you select, and make sure the pills inside the input don't overlap the chevron.
4. Verify that when you click on the chevron, the options dropdown appear.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Make chevron clickable in Filter by Product block input
