### PR TITLE
Run `site-editing-templates` test that does snapshot only when Gutenberg is disabled

### DIFF
--- a/tests/e2e/config/setup.js
+++ b/tests/e2e/config/setup.js
@@ -2,8 +2,9 @@
 /**
  * External dependencies
  */
+import path from 'path';
 import { setup as setupPuppeteer } from 'jest-environment-puppeteer';
-const { truncateSync, existsSync } = require( 'fs' );
+const { truncateSync, existsSync, unlinkSync } = require( 'fs' );
 /**
  * Internal dependencies
  */
@@ -23,8 +24,22 @@ import {
 	disableAttributeLookup,
 } from '../fixtures/fixture-loaders';
 import { PERFORMANCE_REPORT_FILENAME } from '../../utils/constants';
+import { GUTENBERG_EDITOR_CONTEXT } from '../utils';
 
 module.exports = async ( globalConfig ) => {
+	/**
+	 * We have to remove snapshots to avoid "obsolete snapshot" errors.
+	 *
+	 * @todo Remove this logic when WordPress 6.1 is released.
+	 */
+	if ( GUTENBERG_EDITOR_CONTEXT !== 'core' ) {
+		unlinkSync(
+			path.join(
+				__dirname,
+				'../specs/backend/__snapshots__/site-editing-templates.test.js.snap'
+			)
+		);
+	}
 	// we need to load puppeteer global setup here.
 	await setupPuppeteer( globalConfig );
 

--- a/tests/e2e/specs/backend/site-editing-templates.test.js
+++ b/tests/e2e/specs/backend/site-editing-templates.test.js
@@ -24,6 +24,7 @@ import {
 	getAllTemplates,
 	goToTemplateEditor,
 	goToTemplatesList,
+	GUTENBERG_EDITOR_CONTEXT,
 	saveTemplate,
 	useTheme,
 } from '../../utils';
@@ -122,6 +123,21 @@ const CUSTOMIZED_STRING = 'My awesome customization';
 const WOOCOMMERCE_ID = 'woocommerce/woocommerce';
 const WOOCOMMERCE_PARSED_ID = 'WooCommerce';
 
+/**
+ * This is a workaround to avoid the E2E test suite failing when the test site has Gutenberg enabled.
+ * The problem is that the current version of Gutenberg in WordPress Core and the version of the plugin Gutenberg generate different snapshots.
+ * It is not easy having different snapshots for the same test: theoretically, we should have a dedicated snapshot when Gutenberg is enabled and another one when Gutenberg is disabled.
+ * We can remove this workaround when WordPress 6.1 is released.
+ *
+ * @todo Remove runOnlyWhenGutenbergIsDisabled function and relative workarounds when WordPress 6.1 is released.
+ */
+
+const runOnlyWhenGutenbergIsDisabled = ( fn ) => {
+	if ( GUTENBERG_EDITOR_CONTEXT === 'core' ) {
+		fn();
+	}
+};
+
 describe( 'Store Editing Templates', () => {
 	useTheme( 'emptytheme' );
 
@@ -151,23 +167,26 @@ describe( 'Store Editing Templates', () => {
 			}
 		} );
 
-		it( 'should contain the "WooCommerce Single Product Block" classic template', async () => {
-			await goToTemplateEditor( {
-				postId: 'woocommerce/woocommerce//single-product',
-			} );
+		runOnlyWhenGutenbergIsDisabled( () =>
+			it( 'should contain the "WooCommerce Single Product Block" classic template', async () => {
+				await goToTemplateEditor( {
+					postId: 'woocommerce/woocommerce//single-product',
+				} );
 
-			const [ classicBlock ] = await filterCurrentBlocks(
-				( block ) => block.name === BLOCK_DATA[ 'single-product' ].name
-			);
+				const [ classicBlock ] = await filterCurrentBlocks(
+					( block ) =>
+						block.name === BLOCK_DATA[ 'single-product' ].name
+				);
 
-			// Comparing only the `template` property currently
-			// because the other properties seem to be slightly unreliable.
-			// Investigation pending.
-			expect( classicBlock.attributes.template ).toBe(
-				BLOCK_DATA[ 'single-product' ].attributes.template
-			);
-			expect( await getCurrentSiteEditorContent() ).toMatchSnapshot();
-		} );
+				// Comparing only the `template` property currently
+				// because the other properties seem to be slightly unreliable.
+				// Investigation pending.
+				expect( classicBlock.attributes.template ).toBe(
+					BLOCK_DATA[ 'single-product' ].attributes.template
+				);
+				expect( await getCurrentSiteEditorContent() ).toMatchSnapshot();
+			} )
+		);
 
 		it( 'should show the action menu if the template has been customized by the user', async () => {
 			const EXPECTED_TEMPLATE = {
@@ -244,20 +263,23 @@ describe( 'Store Editing Templates', () => {
 			}
 		} );
 
-		it( 'should contain the "WooCommerce Product Grid Block" classic template', async () => {
-			await goToTemplateEditor( {
-				postId: 'woocommerce/woocommerce//archive-product',
-			} );
+		runOnlyWhenGutenbergIsDisabled( () =>
+			it( 'should contain the "WooCommerce Product Grid Block" classic template', async () => {
+				await goToTemplateEditor( {
+					postId: 'woocommerce/woocommerce//archive-product',
+				} );
 
-			const [ classicBlock ] = await filterCurrentBlocks(
-				( block ) => block.name === BLOCK_DATA[ 'archive-product' ].name
-			);
+				const [ classicBlock ] = await filterCurrentBlocks(
+					( block ) =>
+						block.name === BLOCK_DATA[ 'archive-product' ].name
+				);
 
-			expect( classicBlock.attributes.template ).toBe(
-				BLOCK_DATA[ 'archive-product' ].attributes.template
-			);
-			expect( await getCurrentSiteEditorContent() ).toMatchSnapshot();
-		} );
+				expect( classicBlock.attributes.template ).toBe(
+					BLOCK_DATA[ 'archive-product' ].attributes.template
+				);
+				expect( await getCurrentSiteEditorContent() ).toMatchSnapshot();
+			} )
+		);
 
 		it( 'should show the action menu if the template has been customized by the user', async () => {
 			const EXPECTED_TEMPLATE = {
@@ -337,21 +359,23 @@ describe( 'Store Editing Templates', () => {
 			}
 		} );
 
-		it( 'should contain the "WooCommerce Product Taxonomy Block" classic template', async () => {
-			await goToTemplateEditor( {
-				postId: 'woocommerce/woocommerce//taxonomy-product_cat',
-			} );
+		runOnlyWhenGutenbergIsDisabled( () =>
+			it( 'should contain the "WooCommerce Product Taxonomy Block" classic template', async () => {
+				await goToTemplateEditor( {
+					postId: 'woocommerce/woocommerce//taxonomy-product_cat',
+				} );
 
-			const [ classicBlock ] = await filterCurrentBlocks(
-				( block ) =>
-					block.name === BLOCK_DATA[ 'taxonomy-product_cat' ].name
-			);
+				const [ classicBlock ] = await filterCurrentBlocks(
+					( block ) =>
+						block.name === BLOCK_DATA[ 'taxonomy-product_cat' ].name
+				);
 
-			expect( classicBlock.attributes.template ).toBe(
-				BLOCK_DATA[ 'taxonomy-product_cat' ].attributes.template
-			);
-			expect( await getCurrentSiteEditorContent() ).toMatchSnapshot();
-		} );
+				expect( classicBlock.attributes.template ).toBe(
+					BLOCK_DATA[ 'taxonomy-product_cat' ].attributes.template
+				);
+				expect( await getCurrentSiteEditorContent() ).toMatchSnapshot();
+			} )
+		);
 
 		it( 'should show the action menu if the template has been customized by the user', async () => {
 			const EXPECTED_TEMPLATE = {
@@ -425,21 +449,23 @@ describe( 'Store Editing Templates', () => {
 			}
 		} );
 
-		it( 'should contain the "WooCommerce Product Taxonomy Block" classic template', async () => {
-			await goToTemplateEditor( {
-				postId: 'woocommerce/woocommerce//taxonomy-product_tag',
-			} );
+		runOnlyWhenGutenbergIsDisabled( () =>
+			it( 'should contain the "WooCommerce Product Taxonomy Block" classic template', async () => {
+				await goToTemplateEditor( {
+					postId: 'woocommerce/woocommerce//taxonomy-product_tag',
+				} );
 
-			const [ classicBlock ] = await filterCurrentBlocks(
-				( block ) =>
-					block.name === BLOCK_DATA[ 'taxonomy-product_tag' ].name
-			);
+				const [ classicBlock ] = await filterCurrentBlocks(
+					( block ) =>
+						block.name === BLOCK_DATA[ 'taxonomy-product_tag' ].name
+				);
 
-			expect( classicBlock.attributes.template ).toBe(
-				BLOCK_DATA[ 'taxonomy-product_tag' ].attributes.template
-			);
-			expect( await getCurrentSiteEditorContent() ).toMatchSnapshot();
-		} );
+				expect( classicBlock.attributes.template ).toBe(
+					BLOCK_DATA[ 'taxonomy-product_tag' ].attributes.template
+				);
+				expect( await getCurrentSiteEditorContent() ).toMatchSnapshot();
+			} )
+		);
 
 		it( 'should show the action menu if the template has been customized by the user', async () => {
 			const EXPECTED_TEMPLATE = {
@@ -513,20 +539,23 @@ describe( 'Store Editing Templates', () => {
 			}
 		} );
 
-		it( 'should contain the "WooCommerce Product Grid Block" classic template', async () => {
-			await goToTemplateEditor( {
-				postId: 'woocommerce/woocommerce//product-search-results',
-			} );
+		runOnlyWhenGutenbergIsDisabled( () =>
+			it( 'should contain the "WooCommerce Product Grid Block" classic template', async () => {
+				await goToTemplateEditor( {
+					postId: 'woocommerce/woocommerce//product-search-results',
+				} );
 
-			const [ classicBlock ] = await filterCurrentBlocks(
-				( block ) => block.name === BLOCK_DATA[ 'archive-product' ].name
-			);
+				const [ classicBlock ] = await filterCurrentBlocks(
+					( block ) =>
+						block.name === BLOCK_DATA[ 'archive-product' ].name
+				);
 
-			expect( classicBlock.attributes.template ).toBe(
-				BLOCK_DATA[ 'product-search-results' ].attributes.template
-			);
-			expect( await getCurrentSiteEditorContent() ).toMatchSnapshot();
-		} );
+				expect( classicBlock.attributes.template ).toBe(
+					BLOCK_DATA[ 'product-search-results' ].attributes.template
+				);
+				expect( await getCurrentSiteEditorContent() ).toMatchSnapshot();
+			} )
+		);
 
 		it( 'should show the action menu if the template has been customized by the user', async () => {
 			const EXPECTED_TEMPLATE = {


### PR DESCRIPTION
This PR introduces a workaround to avoid the `site-editing-templates.test` test failing when the Gutenberg plugin is enabled.

The current version of Gutenberg in Core and the version of the plugin Gutenberg generate different snapshots. It is not easy having different snapshots for the same test. So, this PR:
- doesn't check snapshots for the test that fails when Gutenberg is enabled.
- removes snapshot when Gutenberg is enabled to avoid "obsolete snapshot" errors.

This logic will be removed when WordPress 6.1 is released. After the merge, I will create an issue to track the necessary work after the release.


Internal discussion -> `p1662387816231119-slack-C02UBB1EPEF`


<!-- Reference any related issues or PRs here -->

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Check that E2E test suite doesn't fail

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> N/A



