### PR TITLE
Update automatic reviewer assignment to Woo FSE team name

### DIFF
--- a/.github/automate-team-review-assignment-config.yml
+++ b/.github/automate-team-review-assignment-config.yml
@@ -9,9 +9,9 @@ when:
         - rubik
   - author:
       teamIs:
-        - kirigami
+        - woo-fse
       ignore:
         nameIs:
     assign:
       teams:
-        - kirigami
+        - woo-fse


### PR DESCRIPTION
We changed the team name, so we also need to update this automation.

I don't think there is any way to test other than merging it and then check that it works.