### PR TITLE
Use the eslint config at the root of the repo

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+	root: true,
 	extends: [
 		'plugin:@woocommerce/eslint-plugin/recommended',
 		'plugin:you-dont-need-lodash-underscore/compatible',


### PR DESCRIPTION
Eslint uses both the parent and the current repo's eslint config file. It should ignore parent .eslintrc configuration.
The change uses the eslint config at the root of the repo.

Fixes #7148 
Similar PR https://github.com/woocommerce/woocommerce-gateway-stripe/pull/2414

### Screenshots
<img width="983" alt="Screen Shot 2022-09-13 at 10 24 46 PM" src="https://user-images.githubusercontent.com/56378160/190068252-f9abc039-17f1-48b6-858d-96fa0e682cdf.png">


### Testing
1. Create a `woopay` docker instance
2. Clone the `woocommerce-blocks` plugin to `woopay/docker/wordpress/wp-content/plugins/woocommerce-blocks`
3. Run `npx eslint --debug .eslintrc.js` to see eslint is not using the config file from `woopay`

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests


* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->