### PR TITLE
Remove unused CSS selectors from Filter blocks

### DIFF
--- a/assets/js/blocks/attribute-filter/style.scss
+++ b/assets/js/blocks/attribute-filter/style.scss
@@ -82,11 +82,6 @@
 		}
 	}
 
-	.is-single .wc-block-attribute-filter-list-count,
-	.wc-blocks-components-form-token-field-wrapper .wc-block-attribute-filter-list-count {
-		opacity: 0.6;
-	}
-
 	.wc-blocks-components-form-token-field-wrapper .components-form-token-field__input-container {
 		border: 0;
 		padding: $gap-smaller;

--- a/assets/js/blocks/stock-filter/style.scss
+++ b/assets/js/blocks/stock-filter/style.scss
@@ -38,12 +38,6 @@
 			}
 		}
 	}
-
-	.is-single,
-	.wc-block-dropdown-selector .wc-block-dropdown-selector__list {
-		opacity: 0.6;
-	}
-
 }
 
 .wc-block-stock-filter__actions {


### PR DESCRIPTION
When working on #7139, I noticed we have a couple of CSS selectors which are unused and don't match any element.

### Testing

#### User Facing Testing

1. Create a post or page with the Filter by Attribute, Filter by Stock and All Products block.
2. Visit it in the frontend and verify there are no visual regressions because of the removed CSS selectors.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Remove unused CSS selectors from Filter blocks
