### PR TITLE
Update the stale bot workflow to use correct number of days and remove wording relating to closing the PR/Issue

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -18,7 +18,7 @@ jobs:
                   remove-stale-when-updated: true
                   exempt-issue-labels: 'priority: critical,priority: high,Epic,type: technical debt,category: refactor,type: documentation,plugin incompatibility'
                   exempt-pr-labels: 'priority: critical,priority: high,Epic,type: technical debt,category: refactor,type: documentation,plugin incompatibility'
-                  stale-issue-message: "This issue has been marked as `stale` because it has not seen any activity within the past 60 days. Our team uses this tool to help surface issues for review. If you are the author of the issue there's no need to comment as it will be looked at. \n\n###### Internal: After 10 days with no activity this issue will be automatically be closed."
-                  stale-pr-message: "This PR has been marked as `stale` because it has not seen any activity within the past 60 days. Our team uses this tool to help surface pull requests that have slipped through review. \n\n###### If deemed still relevant, the pr can be kept active by ensuring it's up to date with the main branch and removing the stale label - otherwise it will automatically be closed after 10 days."
+                  stale-issue-message: "This issue has been marked as `stale` because it has not seen any activity within the past 60 days. Our team uses this tool to help surface issues for review. If you are the author of the issue there's no need to comment as it will be looked at."
+                  stale-pr-message: "This PR has been marked as `stale` because it has not seen any activity within the past 7 days. Our team uses this tool to help surface pull requests that have slipped through review. \n\n###### If deemed still relevant, the pr can be kept active by ensuring it's up to date with the main branch and removing the stale label."
                   stale-issue-label: 'stale'
                   stale-pr-label: 'stale'


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR will remove the wording relating to closing the issues (since https://github.com/woocommerce/woocommerce-blocks/issues/6872 we don't close the issues/PRs anymore) and also updates the number of days mentioned before a PR goes stale (PRs go stale after 10 days).

### Testing

To test this PR you would need an "unforked fork" of our repo with some old PRs/issues in it so the workflow can mark these as stale.

I already had this and you can see my workflow runs on https://github.com/opr/woocommerce-gutenberg-products-block/actions/runs/2992730684 where I tested with each of the exempt labels. I added an exempt label to [issue 171](https://github.com/opr/woocommerce-gutenberg-products-block/pull/171) and re-ran the workflow to ensure it didn't get marked as stale. You can see this line in the workflow run: `Skipping this pull request because it has an exempt label`

To test issues not closing after a set time period, I added `ignore-updates: true` to the config, which will ignore updates (comments, commits etc.) and only consider the open date of the PR. With this enabled, the workflow run did not close PRs older than 7 days.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Skipping.
