### PR TITLE
Fix failing unit test in `data/payment-methods/test/selectors`

### DIFF
--- a/assets/js/data/payment-methods/test/selectors.js
+++ b/assets/js/data/payment-methods/test/selectors.js
@@ -24,7 +24,8 @@ import {
 	CheckoutExpressPayment,
 	SavedPaymentMethodOptions,
 } from '../../../blocks/cart-checkout-shared/payment-methods';
-import { defaultCartState } from '../../../data/cart/default-state';
+import { checkPaymentMethodsCanPay } from '../../payment-methods/check-payment-methods';
+import { defaultCartState } from '../../cart/default-state';
 
 const originalSelect = jest.requireActual( '@wordpress/data' ).select;
 jest.spyOn( wpDataFunctions, 'select' ).mockImplementation( ( storeName ) => {
@@ -131,6 +132,8 @@ const registerMockPaymentMethods = ( savedCards = true ) => {
 			},
 		} );
 	} );
+	checkPaymentMethodsCanPay();
+	checkPaymentMethodsCanPay( true );
 };
 
 const resetMockPaymentMethods = () => {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR addresses a failing unit test caused by the payment state not being reset correctly for each test.

The `checkPaymentMethodsCanPay` function needs to be called to get the data store to update with the new payment methods.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. Ensure unit tests pass in CI.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Skipping
