### PR TITLE
Refactor Product Query to use the latest Gutenberg APIs

### DIFF
--- a/assets/js/blocks/product-query/constants.ts
+++ b/assets/js/blocks/product-query/constants.ts
@@ -1,20 +1,24 @@
 /**
  * External dependencies
  */
-import { InnerBlockTemplate } from '@wordpress/blocks';
+import type { InnerBlockTemplate } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
-import { QueryBlockQuery } from './types';
+import { QueryBlockAttributes } from './types';
 
-export const QUERY_DEFAULT_ATTRIBUTES: {
-	query: QueryBlockQuery;
-	displayLayout: {
-		type: 'flex' | 'list';
-		columns?: number;
-	};
-} = {
+export const DEFAULT_CORE_ALLOWED_CONTROLS = [ 'order', 'taxQuery', 'search' ];
+
+export const ALL_PRODUCT_QUERY_CONTROLS = [ 'onSale' ];
+
+export const DEFAULT_ALLOWED_CONTROLS = [
+	...DEFAULT_CORE_ALLOWED_CONTROLS,
+	...ALL_PRODUCT_QUERY_CONTROLS,
+];
+
+export const QUERY_DEFAULT_ATTRIBUTES: QueryBlockAttributes = {
+	allowControls: DEFAULT_ALLOWED_CONTROLS,
 	displayLayout: {
 		type: 'flex',
 		columns: 3,
@@ -39,7 +43,7 @@ export const INNER_BLOCKS_TEMPLATE: InnerBlockTemplate[] = [
 		'core/post-template',
 		{},
 		[
-			[ 'woocommerce/product-image', undefined, [] ],
+			[ 'woocommerce/product-image' ],
 			[
 				'core/post-title',
 				{
@@ -50,6 +54,6 @@ export const INNER_BLOCKS_TEMPLATE: InnerBlockTemplate[] = [
 			],
 		],
 	],
-	[ 'core/query-pagination', undefined, [] ],
-	[ 'core/query-no-results', undefined, [] ],
+	[ 'core/query-pagination' ],
+	[ 'core/query-no-results' ],
 ];

--- a/assets/js/blocks/product-query/inspector-controls.tsx
+++ b/assets/js/blocks/product-query/inspector-controls.tsx
@@ -12,7 +12,11 @@ import { ElementType } from 'react';
  * Internal dependencies
  */
 import { ProductQueryBlock } from './types';
-import { isWooQueryBlockVariation, setCustomQueryAttribute } from './utils';
+import {
+	isWooQueryBlockVariation,
+	setCustomQueryAttribute,
+	useAllowedControls,
+} from './utils';
 
 export const INSPECTOR_CONTROLS = {
 	onSale: ( props: ProductQueryBlock ) => (
@@ -21,12 +25,9 @@ export const INSPECTOR_CONTROLS = {
 				'Show only products on sale',
 				'woo-gutenberg-products-block'
 			) }
-			checked={
-				props.attributes.__woocommerceVariationProps?.attributes?.query
-					?.onSale || false
-			}
-			onChange={ ( onSale ) => {
-				setCustomQueryAttribute( props, { onSale } );
+			checked={ props.attributes.query.__woocommerceOnSale || false }
+			onChange={ ( __woocommerceOnSale ) => {
+				setCustomQueryAttribute( props, { __woocommerceOnSale } );
 			} }
 		/>
 	),
@@ -35,17 +36,16 @@ export const INSPECTOR_CONTROLS = {
 export const withProductQueryControls =
 	< T extends EditorBlock< T > >( BlockEdit: ElementType ) =>
 	( props: ProductQueryBlock ) => {
+		const allowedControls = useAllowedControls( props.attributes );
 		return isWooQueryBlockVariation( props ) ? (
 			<>
 				<BlockEdit { ...props } />
 				<InspectorControls>
 					{ Object.entries( INSPECTOR_CONTROLS ).map(
 						( [ key, Control ] ) =>
-							props.attributes.__woocommerceVariationProps.attributes?.disabledInspectorControls?.includes(
-								key
-							) ? null : (
+							allowedControls?.includes( key ) ? (
 								<Control { ...props } />
-							)
+							) : null
 					) }
 				</InspectorControls>
 			</>

--- a/assets/js/blocks/product-query/types.ts
+++ b/assets/js/blocks/product-query/types.ts
@@ -77,7 +77,7 @@ export interface QueryBlockQuery {
 
 export enum QueryVariation {
 	/** The main, fully customizable, Product Query block */
-	PRODUCT_QUERY = 'product-query',
+	PRODUCT_QUERY = 'woocommerce/product-query',
 	/** Only shows products on sale */
-	PRODUCTS_ON_SALE = 'query-products-on-sale',
+	PRODUCTS_ON_SALE = 'woocommerce/query-products-on-sale',
 }

--- a/assets/js/blocks/product-query/types.ts
+++ b/assets/js/blocks/product-query/types.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { BlockInstance } from '@wordpress/blocks';
 import type { EditorBlock } from '@woocommerce/types';
 
 export interface ProductQueryArguments {
@@ -28,11 +27,14 @@ export interface ProductQueryArguments {
 	 * )
 	 * ```
 	 */
-	onSale?: boolean;
+	// Disabling naming convention because we are namespacing our
+	// custom attributes inside a core block. Prefixing with underscores
+	// will help signify our intentions.
+	// eslint-disable-next-line @typescript-eslint/naming-convention
+	__woocommerceOnSale?: boolean;
 }
 
-export type ProductQueryBlock =
-	WooCommerceBlockVariation< ProductQueryAttributes >;
+export type ProductQueryBlock = EditorBlock< QueryBlockAttributes >;
 
 export interface ProductQueryAttributes {
 	/**
@@ -45,6 +47,16 @@ export interface ProductQueryAttributes {
 	 * Query attributes that define which products will be fetched.
 	 */
 	query?: ProductQueryArguments;
+}
+
+export interface QueryBlockAttributes {
+	allowControls?: string[];
+	displayLayout?: {
+		type: 'flex' | 'list';
+		columns?: number;
+	};
+	namespace?: string;
+	query: QueryBlockQuery & ProductQueryArguments;
 }
 
 export interface QueryBlockQuery {
@@ -69,11 +81,3 @@ export enum QueryVariation {
 	/** Only shows products on sale */
 	PRODUCTS_ON_SALE = 'query-products-on-sale',
 }
-
-export type WooCommerceBlockVariation< T > = EditorBlock< {
-	// Disabling naming convention because we are namespacing our
-	// custom attributes inside a core block. Prefixing with underscores
-	// will help signify our intentions.
-	// eslint-disable-next-line @typescript-eslint/naming-convention
-	__woocommerceVariationProps: Partial< BlockInstance< T > >;
-} >;

--- a/assets/js/blocks/product-query/utils.tsx
+++ b/assets/js/blocks/product-query/utils.tsx
@@ -30,10 +30,8 @@ export function ArrayXOR< T extends Array< unknown > >( a: T, b: T ) {
 export function isWooQueryBlockVariation( block: ProductQueryBlock ) {
 	return (
 		block.name === 'core/query' &&
-		block.attributes.__woocommerceVariationProps &&
 		Object.values( QueryVariation ).includes(
-			block.attributes.__woocommerceVariationProps
-				.name as unknown as QueryVariation
+			block.attributes.namespace as QueryVariation
 		)
 	);
 }

--- a/assets/js/blocks/product-query/utils.tsx
+++ b/assets/js/blocks/product-query/utils.tsx
@@ -1,4 +1,10 @@
 /**
+ * External dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { store as WP_BLOCKS_STORE } from '@wordpress/blocks';
+
+/**
  * Internal dependencies
  */
 import {
@@ -6,6 +12,13 @@ import {
 	ProductQueryBlock,
 	QueryVariation,
 } from './types';
+
+/**
+ * Creates an array that is the symmetric difference of the given arrays
+ */
+export function ArrayXOR< T extends Array< unknown > >( a: T, b: T ) {
+	return a.filter( ( el ) => ! b.includes( el ) );
+}
 
 /**
  * Identifies if a block is a Query block variation from our conventions
@@ -35,20 +48,35 @@ export function isWooQueryBlockVariation( block: ProductQueryBlock ) {
  */
 export function setCustomQueryAttribute(
 	block: ProductQueryBlock,
-	attributes: Partial< ProductQueryArguments >
+	queryParams: Partial< ProductQueryArguments >
 ) {
-	const { __woocommerceVariationProps } = block.attributes;
+	const { query } = block.attributes;
 
 	block.setAttributes( {
-		__woocommerceVariationProps: {
-			...__woocommerceVariationProps,
-			attributes: {
-				...__woocommerceVariationProps.attributes,
-				query: {
-					...__woocommerceVariationProps.attributes?.query,
-					...attributes,
-				},
-			},
+		query: {
+			...query,
+			...queryParams,
 		},
 	} );
+}
+
+/**
+ * Hook that returns the query properties' names defined by the active
+ * block variation, to determine which block inspector controls to show.
+ *
+ * @param {Object} attributes Block attributes.
+ * @return {string[]} An array of the controls keys.
+ */
+export function useAllowedControls(
+	attributes: ProductQueryBlock[ 'attributes' ]
+) {
+	return useSelect(
+		( select ) =>
+			select( WP_BLOCKS_STORE ).getActiveBlockVariation(
+				'core/query',
+				attributes
+			)?.allowControls,
+
+		[ attributes ]
+	);
 }

--- a/assets/js/blocks/product-query/variations/product-query.tsx
+++ b/assets/js/blocks/product-query/variations/product-query.tsx
@@ -10,18 +10,20 @@ import { sparkles } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import { INNER_BLOCKS_TEMPLATE, QUERY_DEFAULT_ATTRIBUTES } from '../constants';
+import {
+	DEFAULT_ALLOWED_CONTROLS,
+	INNER_BLOCKS_TEMPLATE,
+	QUERY_DEFAULT_ATTRIBUTES,
+} from '../constants';
+
+const VARIATION_NAME = 'woocommerce/product-query';
 
 if ( isExperimentalBuild() ) {
 	registerBlockVariation( 'core/query', {
-		name: 'woocommerce/product-query',
+		name: VARIATION_NAME,
 		title: __( 'Product Query', 'woo-gutenberg-products-block' ),
-		isActive: ( attributes ) => {
-			return (
-				attributes?.__woocommerceVariationProps?.name ===
-				'product-query'
-			);
-		},
+		isActive: ( blockAttributes ) =>
+			blockAttributes.namespace === VARIATION_NAME,
 		icon: {
 			src: (
 				<Icon
@@ -32,10 +34,13 @@ if ( isExperimentalBuild() ) {
 		},
 		attributes: {
 			...QUERY_DEFAULT_ATTRIBUTES,
-			__woocommerceVariationProps: {
-				name: 'product-query',
-			},
+			namespace: VARIATION_NAME,
 		},
+		// Gutenberg doesn't support this type yet, discussion here:
+		// https://github.com/WordPress/gutenberg/pull/43632
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
+		allowControls: DEFAULT_ALLOWED_CONTROLS,
 		innerBlocks: INNER_BLOCKS_TEMPLATE,
 		scope: [ 'block', 'inserter' ],
 	} );

--- a/assets/js/blocks/product-query/variations/products-on-sale.tsx
+++ b/assets/js/blocks/product-query/variations/products-on-sale.tsx
@@ -9,17 +9,23 @@ import { Icon, percent } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import { INNER_BLOCKS_TEMPLATE, QUERY_DEFAULT_ATTRIBUTES } from '../constants';
+import {
+	DEFAULT_CORE_ALLOWED_CONTROLS,
+	INNER_BLOCKS_TEMPLATE,
+	QUERY_DEFAULT_ATTRIBUTES,
+} from '../constants';
+import { ArrayXOR } from '../utils';
+
+const VARIATION_NAME = 'woocommerce/query-products-on-sale';
+const DISABLED_INSPECTOR_CONTROLS = [ 'onSale' ];
 
 if ( isExperimentalBuild() ) {
 	registerBlockVariation( 'core/query', {
-		name: 'woocommerce/query-products-on-sale',
+		name: VARIATION_NAME,
 		title: __( 'Products on Sale', 'woo-gutenberg-products-block' ),
 		isActive: ( blockAttributes ) =>
-			blockAttributes?.__woocommerceVariationProps?.name ===
-				'query-products-on-sale' ||
-			blockAttributes?.__woocommerceVariationProps?.query?.onSale ===
-				true,
+			blockAttributes.namespace === VARIATION_NAME ||
+			blockAttributes.query?.__woocommerceOnSale === true,
 		icon: {
 			src: (
 				<Icon
@@ -30,15 +36,20 @@ if ( isExperimentalBuild() ) {
 		},
 		attributes: {
 			...QUERY_DEFAULT_ATTRIBUTES,
-			__woocommerceVariationProps: {
-				name: 'query-products-on-sale',
-				attributes: {
-					query: {
-						onSale: true,
-					},
-				},
+			namespace: VARIATION_NAME,
+			query: {
+				...QUERY_DEFAULT_ATTRIBUTES.query,
+				__woocommerceOnSale: true,
 			},
 		},
+		// Gutenberg doesn't support this type yet, discussion here:
+		// https://github.com/WordPress/gutenberg/pull/43632
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
+		allowControls: ArrayXOR(
+			DEFAULT_CORE_ALLOWED_CONTROLS,
+			DISABLED_INSPECTOR_CONTROLS
+		),
 		innerBlocks: INNER_BLOCKS_TEMPLATE,
 		scope: [ 'block', 'inserter' ],
 	} );

--- a/src/BlockTypes/ProductQuery.php
+++ b/src/BlockTypes/ProductQuery.php
@@ -91,7 +91,7 @@ class ProductQuery extends AbstractBlock {
 			'orderby'        => $query['orderby'],
 			'order'          => $query['order'],
 		);
-		$on_sale_query       = $this->get_on_sale_products_query( $query );
+		$on_sale_query       = $this->get_on_sale_products_query( $parsed_block['attrs']['query'] );
 
 		return array_merge( $query, $common_query_values, $on_sale_query );
 	}
@@ -99,11 +99,11 @@ class ProductQuery extends AbstractBlock {
 	/**
 	 * Return a query for on sale products.
 	 *
-	 * @param array $query Block query parameters.
+	 * @param array $query_params Block query parameters.
 	 * @return array
 	 */
-	private function get_on_sale_products_query( $query ) {
-		if ( ! isset( $query['__woocommerceOnSale'] ) || true !== $query['__woocommerceOnSale'] ) {
+	private function get_on_sale_products_query( $query_params ) {
+		if ( ! isset( $query_params['__woocommerceOnSale'] ) || true !== $query_params['__woocommerceOnSale'] ) {
 			return array();
 		}
 

--- a/src/BlockTypes/ProductQuery.php
+++ b/src/BlockTypes/ProductQuery.php
@@ -37,6 +37,17 @@ class ProductQuery extends AbstractBlock {
 
 	}
 
+	/**
+	 * Check if a given block
+	 *
+	 * @param array $parsed_block The block being rendered.
+	 * @return boolean
+	 */
+	private function is_woocommerce_variation( $parsed_block ) {
+		return isset( $parsed_block['attrs']['namespace'] )
+		&& substr( $parsed_block['attrs']['namespace'], 0, 11 ) === 'woocommerce';
+	}
+
 
 	/**
 	 * Update the query for the product query block.
@@ -51,7 +62,7 @@ class ProductQuery extends AbstractBlock {
 
 		$this->parsed_block = $parsed_block;
 
-		if ( isset( $parsed_block['attrs']['__woocommerceVariationProps'] ) ) {
+		if ( $this->is_woocommerce_variation( $parsed_block ) ) {
 			add_filter(
 				'query_loop_block_query_vars',
 				array( $this, 'get_query_by_attributes' ),
@@ -69,11 +80,10 @@ class ProductQuery extends AbstractBlock {
 	 */
 	public function get_query_by_attributes( $query ) {
 		$parsed_block = $this->parsed_block;
-		if ( ! isset( $parsed_block['attrs']['__woocommerceVariationProps'] ) ) {
+		if ( ! $this->is_woocommerce_variation( $parsed_block ) ) {
 			return $query;
 		}
 
-		$variation_props     = $parsed_block['attrs']['__woocommerceVariationProps'];
 		$common_query_values = array(
 			'post_type'      => 'product',
 			'post_status'    => 'publish',
@@ -81,7 +91,7 @@ class ProductQuery extends AbstractBlock {
 			'orderby'        => $query['orderby'],
 			'order'          => $query['order'],
 		);
-		$on_sale_query       = $this->get_on_sale_products_query( $variation_props );
+		$on_sale_query       = $this->get_on_sale_products_query( $query );
 
 		return array_merge( $query, $common_query_values, $on_sale_query );
 	}
@@ -89,11 +99,11 @@ class ProductQuery extends AbstractBlock {
 	/**
 	 * Return a query for on sale products.
 	 *
-	 * @param array $variation_props Dedicated attributes for the variation.
+	 * @param array $query Block query parameters.
 	 * @return array
 	 */
-	private function get_on_sale_products_query( $variation_props ) {
-		if ( ! isset( $variation_props['attributes']['query']['onSale'] ) || true !== $variation_props['attributes']['query']['onSale'] ) {
+	private function get_on_sale_products_query( $query ) {
+		if ( ! isset( $query['__woocommerceOnSale'] ) || true !== $query['__woocommerceOnSale'] ) {
 			return array();
 		}
 


### PR DESCRIPTION
As we worked with Gutenberg folks in WordPress/gutenberg#43590, WordPress/gutenberg#43632 and WordPress/gutenberg#44093 we have created a standard API that could be used for our use-case. This PR refactors our WIP experimental work to use that standardized API.

### Screenshots

![Screenshot 2022-09-16 at 20 24 26](https://user-images.githubusercontent.com/1847066/190706610-33cb8787-4a60-4622-90e6-8a9ac8bbd79c.png)

![Screenshot 2022-09-16 at 20 24 40](https://user-images.githubusercontent.com/1847066/190706649-c53c9c74-77bd-4c6b-a6e5-b0af4c4334f1.png)

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Go to the Editor
2. Make sure that “Product Query” and “Products on Sale” show up on the Gutenberg inserter
3. Insert “Product Query”
4. Make sure the products show up in the editor and front-end
5. Make sure the the only inspector controls that show up in the editor are the following: `Layout`, `Columns`, `Order by`, `Filters > Keywords`, `Filters > Taxonomies`, `Show Products on Sale`, `Color`, `Advanced` (see screenshot above).
6. Make sure you can toggle the Show Products on Sale and that it works on the front-end
7. Repeat steps 3–5 for the “Products on Sale” except for the fact that the inspector controls should not display the `Show Products on Sale` toggle (see screenshot above).

 > **Warning**
> It is normal that the preview won't update with the products on sale. This is being worked on in #6975.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental