### PR TITLE
Revert "Add static class name for product-details (#6914)"

### DIFF
--- a/assets/js/base/components/cart-checkout/product-details/index.tsx
+++ b/assets/js/base/components/cart-checkout/product-details/index.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { kebabCase } from 'lodash';
 import { decodeEntities } from '@wordpress/html-entities';
 import type { ProductResponseItemData } from '@woocommerce/type-defs/product-response';
 
@@ -31,10 +32,15 @@ const ProductDetails = ( {
 			{ details.map( ( detail ) => {
 				// Support both `key` and `name` props
 				const name = detail?.key || detail.name || '';
+				const className = name
+					? `wc-block-components-product-details__${ kebabCase(
+							name
+					  ) }`
+					: '';
 				return (
 					<li
 						key={ name + ( detail.display || detail.value ) }
-						className="wc-block-components-product-details__item"
+						className={ className }
 					>
 						{ name && (
 							<>

--- a/assets/js/base/components/cart-checkout/product-details/test/__snapshots__/index.js.snap
+++ b/assets/js/base/components/cart-checkout/product-details/test/__snapshots__/index.js.snap
@@ -5,7 +5,7 @@ exports[`ProductDetails should not render hidden details 1`] = `
   className="wc-block-components-product-details"
 >
   <li
-    className="wc-block-components-product-details__item"
+    className="wc-block-components-product-details__lorem"
   >
     <span
       className="wc-block-components-product-details__name"
@@ -32,7 +32,7 @@ exports[`ProductDetails should render details 1`] = `
   className="wc-block-components-product-details"
 >
   <li
-    className="wc-block-components-product-details__item"
+    className="wc-block-components-product-details__lorem"
   >
     <span
       className="wc-block-components-product-details__name"
@@ -48,7 +48,7 @@ exports[`ProductDetails should render details 1`] = `
     </span>
   </li>
   <li
-    className="wc-block-components-product-details__item"
+    className="wc-block-components-product-details__lorem"
   >
     <span
       className="wc-block-components-product-details__name"
@@ -64,7 +64,7 @@ exports[`ProductDetails should render details 1`] = `
     </span>
   </li>
   <li
-    className="wc-block-components-product-details__item"
+    className=""
   >
     
     <span


### PR DESCRIPTION
This reverts commit c410644e9441897ef512f5fa464d972bf90cbd64. We deleted a dynamic classname from the product details block because a user reported that the classname string was being translated. We are yet to get confirmation that this is the case and it turns out people need this class.

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Add an item to your cart that has multiple variants. E.g. Hoodie (Blue, Logo)
2. Go to the Cart Block
3. Inspect the text for one of the variants (e.g. Colour: Blue)
4. Make sure there is a class called `wc-block-components-product-details__{name of your variant}`

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Fix a bug with the product details block where we removed the css class on each option inside the product details block
