### PR TITLE
Add Product Query Support for Atomic Price Block

### DIFF
--- a/assets/js/atomic/blocks/product-elements/price/attributes.js
+++ b/assets/js/atomic/blocks/product-elements/price/attributes.js
@@ -8,6 +8,10 @@ let blockAttributes = {
 		type: 'number',
 		default: 0,
 	},
+	isDescendentOfQueryLoop: {
+		type: 'boolean',
+		default: false,
+	},
 };
 
 if ( isFeaturePluginBuild() ) {

--- a/assets/js/atomic/blocks/product-elements/price/edit.js
+++ b/assets/js/atomic/blocks/product-elements/price/edit.js
@@ -8,6 +8,7 @@ import {
 	useBlockProps,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
+import { useEffect } from 'react';
 
 /**
  * Internal dependencies
@@ -16,8 +17,15 @@ import Block from './block';
 import withProductSelector from '../shared/with-product-selector';
 import { BLOCK_TITLE, BLOCK_ICON } from './constants';
 
-const PriceEdit = ( { attributes, setAttributes } ) => {
+const PriceEdit = ( { attributes, setAttributes, context } ) => {
 	const blockProps = useBlockProps();
+	const isDescendentOfQueryLoop = Number.isFinite( context.queryId );
+
+	useEffect(
+		() => setAttributes( { isDescendentOfQueryLoop } ),
+		[ setAttributes, isDescendentOfQueryLoop ]
+	);
+
 	return (
 		<>
 			<BlockControls>
@@ -31,7 +39,7 @@ const PriceEdit = ( { attributes, setAttributes } ) => {
 				) }
 			</BlockControls>
 			<div { ...blockProps }>
-				<Block { ...attributes } />
+				<Block { ...{ ...attributes, ...context } } />
 			</div>
 		</>
 	);

--- a/assets/js/atomic/blocks/product-elements/price/edit.js
+++ b/assets/js/atomic/blocks/product-elements/price/edit.js
@@ -19,6 +19,10 @@ import { BLOCK_TITLE, BLOCK_ICON } from './constants';
 
 const PriceEdit = ( { attributes, setAttributes, context } ) => {
 	const blockProps = useBlockProps();
+	const blockAttrs = {
+		...attributes,
+		...context,
+	};
 	const isDescendentOfQueryLoop = Number.isFinite( context.queryId );
 
 	useEffect(
@@ -39,7 +43,7 @@ const PriceEdit = ( { attributes, setAttributes, context } ) => {
 				) }
 			</BlockControls>
 			<div { ...blockProps }>
-				<Block { ...{ ...attributes, ...context } } />
+				<Block { ...blockAttrs } />
 			</div>
 		</>
 	);

--- a/assets/js/atomic/blocks/product-elements/price/index.js
+++ b/assets/js/atomic/blocks/product-elements/price/index.js
@@ -22,6 +22,13 @@ const blockConfig = {
 	apiVersion: 2,
 	title,
 	description,
+	parent: [ 'core/group' ],
+	ancestor: [
+		'@woocommerce/all-products',
+		'@woocommerce/single-product',
+		'core/post-template',
+	],
+	usesContext: [ 'query', 'queryId', 'postId' ],
 	icon: { src: icon },
 	attributes,
 	edit,

--- a/assets/js/atomic/blocks/product-elements/price/index.js
+++ b/assets/js/atomic/blocks/product-elements/price/index.js
@@ -9,7 +9,6 @@ import { registerBlockType } from '@wordpress/blocks';
  */
 import sharedConfig from '../shared/config';
 import edit from './edit';
-import { Save } from './save';
 import attributes from './attributes';
 import {
 	BLOCK_TITLE as title,
@@ -32,7 +31,6 @@ const blockConfig = {
 	icon: { src: icon },
 	attributes,
 	edit,
-	save: Save,
 	supports: {
 		...sharedConfig.supports,
 		...( isFeaturePluginBuild() && {

--- a/src/BlockTypes/ProductPrice.php
+++ b/src/BlockTypes/ProductPrice.php
@@ -45,12 +45,44 @@ class ProductPrice extends AbstractBlock {
 	}
 
 	/**
-	 * Register script and style assets for the block type before it is registered.
-	 *
-	 * This registers the scripts; it does not enqueue them.
+	 * It is necessary to register and enqueues assets during the render phase because we want to load assets only if the block has the content.
 	 */
 	protected function register_block_type_assets() {
-		parent::register_block_type_assets();
-		$this->register_chunk_translations( [ $this->block_name ] );
+		return null;
+	}
+
+	/**
+	 * Register the context.
+	 */
+	protected function get_block_type_uses_context() {
+		return [ 'query', 'queryId', 'postId' ];
+	}
+
+	/**
+	 * Include and render the block.
+	 *
+	 * @param array    $attributes Block attributes. Default empty array.
+	 * @param string   $content    Block content. Default empty string.
+	 * @param WP_Block $block      Block instance.
+	 * @return string Rendered block type output.
+	 */
+	protected function render( $attributes, $content, $block ) {
+		if ( ! empty( $content ) ) {
+			parent::register_block_type_assets();
+			$this->register_chunk_translations( [ $this->block_name ] );
+			return $content;
+		}
+
+		$post_id = $block->context['postId'];
+		$product = wc_get_product( $post_id );
+
+		if ( $product ) {
+			return sprintf(
+				'<div class="wc-block-components-product-price wc-block-grid__product-price">
+					%s
+				</div>',
+				$product->get_price_html()
+			);
+		}
 	}
 }

--- a/src/BlockTypes/ProductPrice.php
+++ b/src/BlockTypes/ProductPrice.php
@@ -45,7 +45,10 @@ class ProductPrice extends AbstractBlock {
 	}
 
 	/**
-	 * It is necessary to register and enqueues assets during the render phase because we want to load assets only if the block has the content.
+	 * Overwrite parent method to prevent script registration.
+	 *
+	 * It is necessary to register and enqueues assets during the render
+	 * phase because we want to load assets only if the block has the content.
 	 */
 	protected function register_block_type_assets() {
 		return null;


### PR DESCRIPTION
Adds Product Query support for the atomic Price block.

On the client side, when the Price Block is used within the Product Query block, the markup will be rendered on the server side - no javascript related to the Price block will be loaded.

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #6786

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->


### Testing

1. Add the `woocommerce/product-price` block to the Product Query `INNER_BLOCKS_TEMPLATE` in `assets/js/blocks/product-query/constants.ts` under line 54 (only for testing, remove afterwards).
1. Create a post/page and add the Product Query block.
1. Save it.
1. Open the frontend side and confirm that:
    - No JS related to the Product Price block is loaded (search in your network tab for `product-price-frontend.js`).
    - The UI of the block is identical to on the editor side.
    - That the settings are reflected correctly (eg: custom style).
1. For comparison, switch to trunk and add the All Products block to confirm that the aforementioned `product-price-frontend.js` _is_ loaded.

_Note that this block has a different behavior when it is used in the Product Query block as respect when it is used in All Products. We will address this issue in the next iteration #6949._

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental
