### PR TITLE
Google Analytics - Support a GT tracking ID

### DIFF
--- a/src/Domain/Services/GoogleAnalytics.php
+++ b/src/Domain/Services/GoogleAnalytics.php
@@ -46,9 +46,10 @@ class GoogleAnalytics {
 	 */
 	public function enqueue_scripts() {
 		$settings = $this->get_google_analytics_settings();
+		$prefix   = strstr( strtoupper( $settings['ga_id'] ), '-', true );
 
 		// Require tracking to be enabled with a valid GA ID.
-		if ( ! stristr( $settings['ga_id'], 'G-' ) ) {
+		if ( ! in_array( $prefix, [ 'G', 'GT' ], true ) ) {
 			return;
 		}
 
@@ -56,10 +57,11 @@ class GoogleAnalytics {
 		 * Filter to disable Google Analytics tracking.
 		 *
 		 * @internal Matches filter name in GA extension.
+		 * @since 4.9.0
 		 *
 		 * @param boolean $disable_tracking If true, tracking will be disabled.
 		 */
-		if ( ! stristr( $settings['ga_id'], 'G-' ) || apply_filters( 'woocommerce_ga_disable_tracking', ! wc_string_to_bool( $settings['ga_event_tracking_enabled'] ) ) ) {
+		if ( apply_filters( 'woocommerce_ga_disable_tracking', ! wc_string_to_bool( $settings['ga_event_tracking_enabled'] ) ) ) {
 			return;
 		}
 


### PR DESCRIPTION
The Google Analytics Integration extension now supports GTAG tracking with ID's prefixed with both `G-` and `GT-`. This PR changes the tracking code to load for both types of prefixes.

> **Note**
The intention is to move this code within the Google Analytics Integration extension, which is being tracked [here](https://github.com/woocommerce/woocommerce-google-analytics-integration/issues/227)

Fixes https://github.com/woocommerce/woocommerce-google-analytics-integration/issues/228

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Install the [Google Analytics Integration Extension](https://github.com/woocommerce/woocommerce-google-analytics-integration)
2. Setup the extension with a GT-X type ID from your Google Analytics account. Google Analytics account is required to test this. This can be retrieved by going to the [analytics dashboard](https://analytics.google.com/) and going to a data stream > Configure Tag Settings, see full instructions [here](https://support.google.com/tagmanager/answer/12002338#zippy=%2Cset-up-your-google-tag-from-google-analytics-instructions)
![image](https://user-images.githubusercontent.com/11388669/191953041-8593adb6-5dec-403c-9e73-45f6337ddb4b.png)
3. Install [Google Analytics Debugger](https://chrome.google.com/webstore/detail/google-analytics-debugger/jnkmfdileelhofjcijamephohjechhna?hl=en) browser extension. It needs to be installed, but do not click it (debug mode should be off).
4. Go to the store and trigger some events using the All Products Block and Cart block. For example an add to cart event.
5. Google Analytics Debugger should indicate that an event was fired.
6. Instead of the Google Analytics Debugger we can also check the Browser Dev Tools > Network and confirm we see requests being sent to a URL similar to: `https://region1.google-analytics.com/g/collect` (region could vary)

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Add - Support for a GT tracking ID for Google Analytics.
