### PR TITLE
Fix not enough margin for Filter blocks  #7018

### DIFF
--- a/assets/js/blocks/active-filters/style.scss
+++ b/assets/js/blocks/active-filters/style.scss
@@ -13,11 +13,6 @@
 			height: 1em;
 		}
 	}
-
-	> .wc-block-active-filters__title {
-		margin-top: $gap-small;
-		margin-bottom: $gap-small;
-	}
 }
 
 .wc-block-active-filters {

--- a/assets/js/blocks/attribute-filter/style.scss
+++ b/assets/js/blocks/attribute-filter/style.scss
@@ -11,11 +11,6 @@
 	h6 {
 		text-transform: inherit;
 	}
-
-	> .wc-block-attribute-filter__title {
-		margin-top: $gap-small;
-		margin-bottom: $gap-small;
-	}
 }
 
 .wc-block-attribute-filter {

--- a/assets/js/blocks/price-filter/style.scss
+++ b/assets/js/blocks/price-filter/style.scss
@@ -11,11 +11,6 @@
 	h6 {
 		text-transform: inherit;
 	}
-
-	> .wc-block-price-filter__title {
-		margin-top: $gap-small;
-		margin-bottom: $gap-small;
-	}
 }
 
 .wc-block-price-slider {

--- a/assets/js/blocks/stock-filter/style.scss
+++ b/assets/js/blocks/stock-filter/style.scss
@@ -7,11 +7,6 @@
 	h6 {
 		text-transform: inherit;
 	}
-
-	> .wc-block-stock-filter__title {
-		margin-top: $gap-small;
-		margin-bottom: $gap-small;
-	}
 }
 
 .wc-block-stock-filter {


### PR DESCRIPTION
## Why is this change needed?

As we can see in the screenshot below, the margin between Filter by Size & Filter by Stock status is smaller than expected.

![https://user-images.githubusercontent.com/16707866/191943672-180f7e3f-5865-48ab-8b53-92ab5009cc06.png](https://user-images.githubusercontent.com/16707866/191943672-180f7e3f-5865-48ab-8b53-92ab5009cc06.png)

Here are few more screenshot with measurements:

![https://user-images.githubusercontent.com/16707866/191943744-c9822878-20e8-4ef2-b0e3-8ba4b0583f91.png](https://user-images.githubusercontent.com/16707866/191943744-c9822878-20e8-4ef2-b0e3-8ba4b0583f91.png)

![https://user-images.githubusercontent.com/16707866/191943769-4cb15ff8-1823-4e8d-9625-f7bff6b24749.png](https://user-images.githubusercontent.com/16707866/191943769-4cb15ff8-1823-4e8d-9625-f7bff6b24749.png)

As we can see in screenshots above, space between *Filter by Price & Filter by Size* is **41.9px** but Space between *Filter by Size & Filter by stock status* is **24px**.
**Expected behavior:** Space between these blocks should be consistent & equal to ~41.9px.

## Debugging

Seems like this issue occurred after implementing skeleton loading states for filters.

Skeleton Parent task link: [https://github.com/woocommerce/woocommerce-blocks/issues/6846](https://github.com/woocommerce/woocommerce-blocks/issues/6846)

Loading skeletons were added to the following Filters:

1. Filter by stock
2. Filter by price
3. Active filters
4. Filter by attribute

This issue is happening for all of the above Filter except `Filter by attribute`.

### Let’s take `Filter by stock` for example.

As per my understanding this CSS is causing the issue which was added recently:

```css
.wc-block-stock-filter__title {
	margin-top: $gap-small;
	margin-bottom: $gap-small;
}

```

Which was added in [[this commit](https://github.com/woocommerce/woocommerce-blocks/pull/6990/commits/409bc52cb6aeedb8732a7b015f9016add1490a53)](https://github.com/woocommerce/woocommerce-blocks/pull/6990/commits/409bc52cb6aeedb8732a7b015f9016add1490a53).
But in [[this commit](https://github.com/woocommerce/woocommerce-blocks/pull/7077/commits/7511ddee596738b8f41248504d112375c8f8b6e6)](https://github.com/woocommerce/woocommerce-blocks/pull/7077/commits/7511ddee596738b8f41248504d112375c8f8b6e6) child selector `>` was added:

```css
> .wc-block-stock-filter__title {
	margin-top: $gap-small;
	margin-bottom: $gap-small;
}
```

Similar CSS was added for other filter blocks too which is causing this margin issue.

### Why it’s not happening for Filter by attribute block?

I thought this might be happening for Filter by attribute block too because it has the same kind of CSS:

```
.wp-block-woocommerce-attribute-filter {
	...

	> .wc-block-attribute-filter__title {
		margin-top: $gap-small;
		margin-bottom: $gap-small;
	}
}

```

But it’s not happening for Filter by Attribute blocks because header(in my case `h6`) isn’t direct children, therefore `> .wc-block-attribute-filter__title`(child selector) rule doesn’t apply. Here is the screenshot:

![https://user-images.githubusercontent.com/16707866/191946014-f79adc0c-2549-4591-a6cb-3c3205199bb8.png](https://user-images.githubusercontent.com/16707866/191946014-f79adc0c-2549-4591-a6cb-3c3205199bb8.png)

## Fixing the issue

Let’s take Filter by stock status as an example. Here is how skeleton UI looks like when following CSS is present:

```css
.wc-block-stock-filter__title {
	margin-top: $gap-small;
	margin-bottom: $gap-small;
}
```

![image](https://user-images.githubusercontent.com/16707866/192132163-711260cd-7ef2-4684-b80f-ed30e4510978.png)

But later child selector was added & here is how UI of skeleton looks like with child selector:

```css
> .wc-block-stock-filter__title {
	margin-top: $gap-small;
	margin-bottom: $gap-small;
}
```

![image](https://user-images.githubusercontent.com/16707866/192132168-a829d51e-e602-4421-8899-f8fa04e1f810.png)

After the removing the above CSS, UI looks same i.e.

![image](https://user-images.githubusercontent.com/16707866/192132171-67898b47-0b37-4fc4-be0a-5837d61374eb.png)

**Conclusion:** My debugging suggests that we can remove this CSS from all our filter blocks which will fix our margin issue too. As per my understanding, CSS was added to style the header of skeleton but looks like we don’t need that style anymore because then we added child selector to remove the style. I have removed the CSS in this PR. 

@albarin & @tjcafferkey : May I know if this CSS is serving any other purpose too? May be I misunderstood something? 🙂

Fixes #7018 #7117

### Testing

### Automated Tests

- [ ]  Changes in this PR are covered by Automated Tests.
    - [ ]  Unit tests
    - [ ]  E2E tests

### User Facing Testing

Add All products block and than add filter blocks i.e. Filter by Price, Filter by Size, Filter by stock status & Filter by color as shown in screenshot below.

- Before Fix: In screenshot below you will notice that margin top & margin bottom is smaller than expected for following blocks: Filter by price, Filter by stock status & Active filters.
![image](https://user-images.githubusercontent.com/16707866/192132178-93e83d62-66ac-4465-9596-453dd984555b.png)

- After Fix: As shown in screenshot below, space between filter blocks should be equal.
![image](https://user-images.githubusercontent.com/16707866/192132186-5bd3dec3-993b-4705-aa92-1652c2af7ecc.png)

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility
* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental