### PR TITLE
Remove qm/debug action

### DIFF
--- a/src/BlockTypes/ProductQuery.php
+++ b/src/BlockTypes/ProductQuery.php
@@ -100,8 +100,6 @@ class ProductQuery extends AbstractBlock {
 			'meta_query'     => array(),
 		);
 
-		do_action( 'qm/debug', $parsed_block );
-
 		$queries_attributes = $this->get_queries_by_attributes( $parsed_block );
 		$queries_filters    = $this->get_queries_by_applied_filters();
 


### PR DESCRIPTION
This PR removes a `qm/debug action` from trunk that was added when I merged #7162.