### PR TITLE
Add/checkout prefer collection toggle

### DIFF
--- a/src/StoreApi/Routes/V1/CartUpdateCustomer.php
+++ b/src/StoreApi/Routes/V1/CartUpdateCustomer.php
@@ -39,7 +39,7 @@ class CartUpdateCustomer extends AbstractCartRoute {
 				'callback'            => [ $this, 'get_response' ],
 				'permission_callback' => '__return_true',
 				'args'                => [
-					'billing_address'  => [
+					'billing_address'   => [
 						'description'       => __( 'Billing address.', 'woo-gutenberg-products-block' ),
 						'type'              => 'object',
 						'context'           => [ 'view', 'edit' ],
@@ -47,13 +47,18 @@ class CartUpdateCustomer extends AbstractCartRoute {
 						'sanitize_callback' => [ $this->schema->billing_address_schema, 'sanitize_callback' ],
 						'validate_callback' => [ $this->schema->billing_address_schema, 'validate_callback' ],
 					],
-					'shipping_address' => [
+					'shipping_address'  => [
 						'description'       => __( 'Shipping address.', 'woo-gutenberg-products-block' ),
 						'type'              => 'object',
 						'context'           => [ 'view', 'edit' ],
 						'properties'        => $this->schema->shipping_address_schema->get_properties(),
 						'sanitize_callback' => [ $this->schema->shipping_address_schema, 'sanitize_callback' ],
 						'validate_callback' => [ $this->schema->shipping_address_schema, 'validate_callback' ],
+					],
+					'prefer_collection' => [
+						'description' => __( 'This is true when the customer would prefer to collect rather than pay for shipping. This filters shipping methods based on selection.', 'woo-gutenberg-products-block' ),
+						'type'        => 'boolean',
+						'context'     => [ 'view', 'edit' ],
 					],
 				],
 			],
@@ -104,6 +109,8 @@ class CartUpdateCustomer extends AbstractCartRoute {
 				'shipping_phone'      => $shipping['phone'] ?? null,
 			)
 		);
+
+		$customer->update_meta_data( 'prefer_collection', $request['prefer_collection'] ?? false );
 
 		wc_do_deprecated_action(
 			'woocommerce_blocks_cart_update_customer_from_request',

--- a/src/StoreApi/Routes/V1/CartUpdateCustomer.php
+++ b/src/StoreApi/Routes/V1/CartUpdateCustomer.php
@@ -110,7 +110,7 @@ class CartUpdateCustomer extends AbstractCartRoute {
 			)
 		);
 
-		$customer->update_meta_data( 'prefer_collection', $request['prefer_collection'] ?? false );
+		$customer->update_meta_data( 'prefer_collection', wc_bool_to_string( ( $request['prefer_collection'] ?? false ) ) );
 
 		wc_do_deprecated_action(
 			'woocommerce_blocks_cart_update_customer_from_request',

--- a/src/StoreApi/Schemas/V1/CartSchema.php
+++ b/src/StoreApi/Schemas/V1/CartSchema.php
@@ -345,7 +345,7 @@ class CartSchema extends AbstractSchema {
 		$has_calculated_shipping = $cart->show_shipping();
 
 		// Get shipping packages to return in the response from the cart.
-		$prefer_collection = true; // (bool) wc()->customer->get_meta_data( 'prefer_collection' );
+		$prefer_collection = (bool) wc()->customer->get_meta_data( 'prefer_collection' );
 		$shipping_packages = $has_calculated_shipping ? $controller->get_shipping_packages( true, $prefer_collection ) : [];
 
 		// Get visible cross sells products.

--- a/src/StoreApi/Schemas/V1/CartSchema.php
+++ b/src/StoreApi/Schemas/V1/CartSchema.php
@@ -185,6 +185,12 @@ class CartSchema extends AbstractSchema {
 				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
 			],
+			'prefer_collection'       => [
+				'description' => __( 'This is true when the customer would prefer to collect rather than pay for shipping. This filters shipping methods based on selection.', 'woo-gutenberg-products-block' ),
+				'type'        => 'boolean',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
 			'has_calculated_shipping' => [
 				'description' => __( 'True if the cart meets the criteria for showing shipping costs, and rates have been calculated and included in the totals.', 'woo-gutenberg-products-block' ),
 				'type'        => 'boolean',
@@ -339,7 +345,8 @@ class CartSchema extends AbstractSchema {
 		$has_calculated_shipping = $cart->show_shipping();
 
 		// Get shipping packages to return in the response from the cart.
-		$shipping_packages = $has_calculated_shipping ? $controller->get_shipping_packages() : [];
+		$prefer_collection = true; // (bool) wc()->customer->get_meta_data( 'prefer_collection' );
+		$shipping_packages = $has_calculated_shipping ? $controller->get_shipping_packages( true, $prefer_collection ) : [];
 
 		// Get visible cross sells products.
 		$cross_sells = array_filter( array_map( 'wc_get_product', $cart->get_cross_sells() ), 'wc_products_array_filter_visible' );
@@ -355,6 +362,7 @@ class CartSchema extends AbstractSchema {
 			'cross_sells'             => $this->get_item_responses_from_schema( $this->cross_sells_item_schema, $cross_sells ),
 			'needs_payment'           => $cart->needs_payment(),
 			'needs_shipping'          => $cart->needs_shipping(),
+			'prefer_collection'       => $prefer_collection,
 			'has_calculated_shipping' => $has_calculated_shipping,
 			'fees'                    => $this->get_item_responses_from_schema( $this->fee_schema, $cart->get_fees() ),
 			'totals'                  => (object) $this->prepare_currency_response(

--- a/src/StoreApi/Schemas/V1/CartSchema.php
+++ b/src/StoreApi/Schemas/V1/CartSchema.php
@@ -345,7 +345,7 @@ class CartSchema extends AbstractSchema {
 		$has_calculated_shipping = $cart->show_shipping();
 
 		// Get shipping packages to return in the response from the cart.
-		$prefer_collection = (bool) wc()->customer->get_meta_data( 'prefer_collection' );
+		$prefer_collection = wc_string_to_bool( wc()->customer->get_meta( 'prefer_collection' ) );
 		$shipping_packages = $has_calculated_shipping ? $controller->get_shipping_packages( true, $prefer_collection ) : [];
 
 		// Get visible cross sells products.

--- a/src/StoreApi/Utilities/CartController.php
+++ b/src/StoreApi/Utilities/CartController.php
@@ -778,22 +778,14 @@ class CartController {
 	 * @todo this can be refactored once https://github.com/woocommerce/woocommerce/pull/26101 lands.
 	 *
 	 * @param bool $calculate_rates Should rates for the packages also be returned.
-	 * @param bool $prefer_collection If true, only local pickup rates are returned.
 	 * @return array
 	 */
-	public function get_shipping_packages( $calculate_rates = true, $prefer_collection = false ) {
+	public function get_shipping_packages( $calculate_rates = true ) {
 		$cart = $this->get_cart_instance();
 
 		// See if we need to calculate anything.
 		if ( ! $cart->needs_shipping() ) {
 			return [];
-		}
-
-		/**
-		 * Experimental functionality to return only local pickup rates when $prefer_collection is true.
-		 */
-		if ( Package::feature()->is_experimental_build() ) {
-			add_filter( 'woocommerce_get_shipping_methods', $prefer_collection ? [ $this, 'return_local_pickup_methods' ] : [ $this, 'remove_local_pickup_methods' ] );
 		}
 
 		$packages = $cart->get_shipping_packages();
@@ -813,11 +805,6 @@ class CartController {
 		}
 
 		$packages = $calculate_rates ? wc()->shipping()->calculate_shipping( $packages ) : $packages;
-
-		if ( Package::feature()->is_experimental_build() ) {
-			remove_filter( 'woocommerce_get_shipping_methods', [ $this, 'return_local_pickup_methods' ] );
-			remove_filter( 'woocommerce_get_shipping_methods', [ $this, 'remove_local_pickup_methods' ] );
-		}
 
 		return $packages;
 	}


### PR DESCRIPTION
Builds upon https://github.com/woocommerce/woocommerce-blocks/pull/7177 to fix rate selection, and filter local pickup methods based on customer preference. 

cc @senadir 

### Screenshots

![Screenshot 2022-09-28 at 15 30 52](https://user-images.githubusercontent.com/90977/192806496-203d5e08-6cd5-47fc-ac41-3339713a86a0.png)

### Testing

This can be tested via the API endpoint `/wp-json/wc/store/v1/cart/update-customer`.

0. You need this PR from WooCommerce core https://github.com/woocommerce/woocommerce/pull/34729.
1. In WooCommerce Settings, add local pickup rates in both worldwide zone, and some other zones you create.
2. Send a POST request to `/wp-json/wc/store/v1/cart/update-customer` with the following payload:

```json
{
	"prefer_collection": true
}
```

Check that only LOCAL PICKUP rates are returned as options.

Now send:

```json
{
	"prefer_collection": false
}
```

Check that no local pickup rates are returned as options.

#### User Facing Testing

This toggle has no UI at present, so to test how this impacts checkout you can edit line 354 of `CartSchema.php` to change `$prefer_collection` to true or false.

When set to true:

1. When set to true, check only local pickup methods are displayed in the checkout shipping methods section.
2. When set to false, check no local pickup methods are displayed in the checkout shipping methods section.
3. Confirm you can select methods and rates are updated, as well as totals.

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental

### Changelog

> Experimental Store API return local pickup options based on customer "prefer_collection" preference.
