### PR TITLE
Minor Refactor to Prod Image Backend Render Functions

### DIFF
--- a/src/BlockTypes/ProductImage.php
+++ b/src/BlockTypes/ProductImage.php
@@ -115,19 +115,20 @@ class ProductImage extends AbstractBlock {
 	/**
 	 * Render anchor.
 	 *
-	 * @param \WC_Product $product Product object.
-	 * @param array       $attributes Attributes.
+	 * @param \WC_Product $product       Product object.
+	 * @param string      $on_sale_badge Return value from $render_image.
+	 * @param string      $product_image Return value from $render_on_sale_badge.
+	 * @param array       $attributes    Attributes.
 	 * @return string
 	 */
-	private function render_anchor( $product, $attributes ) {
+	private function render_anchor( $product, $on_sale_badge, $product_image, $attributes ) {
 		$product_permalink = $product->get_permalink();
-
-		$border_radius = StyleAttributesUtils::get_border_radius_class_and_style( $attributes );
 
 		$pointer_events = false === $attributes['showProductLink'] ? 'pointer-events: none;' : '';
 
-		return sprintf( '<a href="%s" style="%s">', $product_permalink, $pointer_events, isset( $border_radius['style'] ) ? $border_radius['style'] : '' );
+		return sprintf( '<a href="%1$s" style="%4$s">%2$s %3$s</a>', $product_permalink, $on_sale_badge, $product_image, $pointer_events );
 	}
+
 
 
 	/**
@@ -185,19 +186,17 @@ class ProductImage extends AbstractBlock {
 		$product = wc_get_product( $post_id );
 
 		if ( $product ) {
+			$sale_badge = $this->render_on_sale_badge( $product, $parsed_attributes );
+			$prod_image = $this->render_image( $product );
+
 			return sprintf(
 				'
 			<div class="wc-block-components-product-image wc-block-grid__product-image" style="%s %s">
 				 	%s
-				 	%s
-					%s
-				</a>
 			</div>',
 				isset( $border_radius['style'] ) ? $border_radius['style'] : '',
 				isset( $margin['style'] ) ? $margin['style'] : '',
-				$this->render_anchor( $product, $parsed_attributes ),
-				$this->render_on_sale_badge( $product, $parsed_attributes ),
-				$this->render_image( $product )
+				$this->render_anchor( $product, $sale_badge, $prod_image, $parsed_attributes )
 			);
 
 		}

--- a/src/BlockTypes/ProductImage.php
+++ b/src/BlockTypes/ProductImage.php
@@ -126,7 +126,13 @@ class ProductImage extends AbstractBlock {
 
 		$pointer_events = false === $attributes['showProductLink'] ? 'pointer-events: none;' : '';
 
-		return sprintf( '<a href="%1$s" style="%4$s">%2$s %3$s</a>', $product_permalink, $on_sale_badge, $product_image, $pointer_events );
+		return sprintf(
+			'<a href="%1$s" style="%2$s">%3$s %4$s</a>',
+			$product_permalink,
+			$pointer_events,
+			$on_sale_badge,
+			$product_image
+		);
 	}
 
 
@@ -186,17 +192,18 @@ class ProductImage extends AbstractBlock {
 		$product = wc_get_product( $post_id );
 
 		if ( $product ) {
-			$sale_badge = $this->render_on_sale_badge( $product, $parsed_attributes );
-			$prod_image = $this->render_image( $product );
-
 			return sprintf(
-				'
-			<div class="wc-block-components-product-image wc-block-grid__product-image" style="%s %s">
-				 	%s
-			</div>',
+				'<div class="wc-block-components-product-image wc-block-grid__product-image" style="%1$s %2$s">
+					%3$s
+				</div>',
 				isset( $border_radius['style'] ) ? $border_radius['style'] : '',
 				isset( $margin['style'] ) ? $margin['style'] : '',
-				$this->render_anchor( $product, $sale_badge, $prod_image, $parsed_attributes )
+				$this->render_anchor(
+					$product,
+					$this->render_on_sale_badge( $product, $parsed_attributes ),
+					$this->render_image( $product ),
+					$parsed_attributes
+				)
 			);
 
 		}

--- a/src/BlockTypes/ProductImage.php
+++ b/src/BlockTypes/ProductImage.php
@@ -147,7 +147,7 @@ class ProductImage extends AbstractBlock {
 		$image_info = wp_get_attachment_image_src( get_post_thumbnail_id( $product->get_id() ), 'woocommerce_thumbnail' );
 
 		if ( ! isset( $image_info[0] ) ) {
-			return sprintf( '<img src="%s" alt="" width="500 height="500" />', woocommerce_placeholder_img_src( 'woocommerce_thumbnail' ) );
+			return sprintf( '<img src="%s" alt="" width="500 height="500" />', wc_placeholder_img_src( 'woocommerce_thumbnail' ) );
 		}
 
 		return sprintf(


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
While digging into the backend code for the Atomic blocks, I noticed that the main render method for the Product Image block outputs a closing `</a>` tag but the opening tag is rendered by a different method.

Initially this was confusing and I thought that the closing tag was an error.

This PR is just a minor change/suggestion to render the entire anchor (opening and closing tags) via the `render_anchor` method and pass the children of the anchor to that method as args.


<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Create a post/page and add the Product Query block.
2. Confirm everything continues to work as expected:
   - No JS related to the Product Image block is loaded (the block is rendered on the server).
   - The UI of the block is identical to on the editor side.
   - The settings are reflected correctly (eg: "show on sale badge" disabled -> no on sale badge should be visible).

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental
