### PR TITLE
StoreAPI: Introduce `woocommerce_store_api_add_to_cart_data` as part of the `CartAddItem` route

### DIFF
--- a/src/StoreApi/Utilities/CartController.php
+++ b/src/StoreApi/Utilities/CartController.php
@@ -42,7 +42,7 @@ class CartController {
 	 * @throws RouteException Exception if invalid data is detected.
 	 *
 	 * @param array $request Add to cart request params.
-	 * @return string|Error
+	 * @return string
 	 */
 	public function add_to_cart( $request ) {
 		$cart    = $this->get_cart_instance();


### PR DESCRIPTION
Cart Items in WooCommerce core accept `id`, `variations`, `quantity`, and `cart_item_data` parameters. `cart_item_data` is used for supplemental data and is often utilised by extensions. Blocks does not make use of this field, and it's omitted from the API (the reasoning being there is no way to know in what format `cart_item_data` needs to be, and what it may or may not contain in advance).

In order to use `cart_item_data`, 3rd party code needs a hook to set it before the request is made to `CartController::add_to_cart`. For this I propose a new filter named `woocommerce_store_api_add_to_cart_data` which has access to all of the data sent in an API request.

There is a similar existing hook named `woocommerce_add_cart_item` but this does not have access to the store API request data, that's why a new hook is needed.

An example of usage would be someone making a request to the `/cart/add-item` endpoint with the following payload:

```json
{
	"id": 17,
	"quantity": 5,
	"custom-extension-data": "Hello there"
}
```

`custom-extension-data` is not a field the API accepts so it is ignored, however, by using the new `woocommerce_store_api_add_to_cart_data` hook we can retrieve its value and set `cart_item_data` as needed. E.g.

```php
add_filter( 'woocommerce_store_api_add_to_cart_data', function( $add_to_cart_data, \WP_REST_Request $request ) {
     $add_to_cart_data['cart_item_data']['custom'] = sanitize_text_field( $request['custom-extension-data'] );
     return $add_to_cart_data;
}, 10, 2 );
```

We should check this covers the needs of those who requested this in #6445.

Fixes #6445

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Testing

This filter is not utilised in the Blocks extension so there is nothing specific to test. 

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental

### Changelog

> Store API: Introduced `woocommerce_store_api_add_to_cart_data` hook.
