### PR TITLE
Fix failing filter test

### DIFF
--- a/packages/checkout/filter-registry/test/index.js
+++ b/packages/checkout/filter-registry/test/index.js
@@ -66,15 +66,17 @@ describe( 'Checkout registry', () => {
 			.mockImplementation( () => {} );
 
 		const error = new Error( 'test error' );
+		// We use this new filter name here to avoid return the cached value for the filter
+		const filterNameThatThrows = 'throw';
 		const value = 'Hello World';
-		__experimentalRegisterCheckoutFilters( filterName, {
-			[ filterName ]: () => {
+		__experimentalRegisterCheckoutFilters( filterNameThatThrows, {
+			[ filterNameThatThrows ]: () => {
 				throw error;
 			},
 		} );
 		const { result: newValue } = renderHook( () =>
 			__experimentalApplyCheckoutFilter( {
-				filterName,
+				filterName: filterNameThatThrows,
 				defaultValue: value,
 			} )
 		);


### PR DESCRIPTION
There is a failing unit test on trunk introduced in #7154 

The test failes because `cachedValues` was changed from a ref (that was updated every render), to a global (which is not). Because in that test file, we run the `__experimentalApplyCheckoutFilter` multiple times, in different tests, the function actually returns the cached value after the second time it runs, instead of the new value we want (in the case of the  failing test, we want to throw an error).

This PR uses a new filter name for the failing test to bypass the caching mechanism.