### PR TITLE
Prevent infinite loop when initialising the payments data store in the editor.

### DIFF
--- a/assets/js/data/checkout/index.ts
+++ b/assets/js/data/checkout/index.ts
@@ -36,14 +36,14 @@ const isEditor = !! wpDataSelect( 'core/editor' );
 
 // This is needed to ensure that the payment methods are displayed in the editor
 if ( isEditor ) {
-	subscribe( async () => {
+	const unsubscribeEditor = subscribe( async () => {
 		await checkPaymentMethodsCanPay();
 		await checkPaymentMethodsCanPay( true );
 	} );
 
 	const unsubscribeInitializePaymentStore = subscribe( async () => {
-		wpDataDispatch( 'wc/store/payment' ).__internalInitializePaymentStore();
-
+		wpDataDispatch( 'wc/store/payment-methods' ).initializePaymentStore();
+		unsubscribeEditor();
 		unsubscribeInitializePaymentStore();
 	} );
 }

--- a/assets/js/data/checkout/index.ts
+++ b/assets/js/data/checkout/index.ts
@@ -42,7 +42,7 @@ if ( isEditor ) {
 	} );
 
 	const unsubscribeInitializePaymentStore = subscribe( async () => {
-		wpDataDispatch( 'wc/store/payment-methods' ).initializePaymentStore();
+		wpDataDispatch( 'wc/store/payment' ).__internalInitializePaymentStore();
 		unsubscribeEditor();
 		unsubscribeInitializePaymentStore();
 	} );


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR will ensure that the subscription to the `wc/store/payment-methods` which was implemented to correctly display payment methods in the Checkout block in the editor is unsubscribed once the store is initialised.

Previously, this was never unsubscribed so we saw errors like `RangeError: Maximum call stack size exceeded` as `checkPaymentMethodsCanPay` was executed every time the store changed.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Open the editor on any page/create a new page.
2. View the console and ensure no errors about `RangeError: Maximum call stack size exceeded` or similar appear.
3. Add the Checkout Block, ensure the editor works and the block is displayed correctly
4. Make a new page and add the Cart block, ensure the editor works and the block is displayed correctly.
5. Do a test order using the Cart and Checkout blocks.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Fixed an error where adding new pages would cause an infinite loop and large amounts of memory use in redux.
