### PR TITLE
Return 402 instead of 400 when checkout payment fails

### DIFF
--- a/src/StoreApi/Routes/V1/Checkout.php
+++ b/src/StoreApi/Routes/V1/Checkout.php
@@ -518,7 +518,7 @@ class Checkout extends AbstractCartRoute {
 				throw new RouteException( 'woocommerce_rest_checkout_invalid_payment_result', __( 'Invalid payment result received from payment method.', 'woo-gutenberg-products-block' ), 500 );
 			}
 		} catch ( \Exception $e ) {
-			throw new RouteException( 'woocommerce_rest_checkout_process_payment_error', $e->getMessage(), 424 );
+			throw new RouteException( 'woocommerce_rest_checkout_process_payment_error', $e->getMessage(), 402 );
 		}
 	}
 

--- a/src/StoreApi/Routes/V1/Checkout.php
+++ b/src/StoreApi/Routes/V1/Checkout.php
@@ -518,7 +518,7 @@ class Checkout extends AbstractCartRoute {
 				throw new RouteException( 'woocommerce_rest_checkout_invalid_payment_result', __( 'Invalid payment result received from payment method.', 'woo-gutenberg-products-block' ), 500 );
 			}
 		} catch ( \Exception $e ) {
-			throw new RouteException( 'woocommerce_rest_checkout_process_payment_error', $e->getMessage(), 400 );
+			throw new RouteException( 'woocommerce_rest_checkout_process_payment_error', $e->getMessage(), 424 );
 		}
 	}
 


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
I was investigating a bug and wondered if we should be setting a HTTP status of 400 whenever the payment fails during checkout. HTTP 400 means a bad request, so it doesn't seem appropriate here. The reason the StoreApi `/checkout` endpoint failed, is because the request to process the payment failed for some reason. 

This PR changes the status from 400 to 402 - Request Failed, to better show why the request failed.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> StoreApi `/checkout` endpoint now returns HTTP 402 instead of HTTP 400 when payment fails