### PR TITLE
Prevent resetting default payment method if available payment method is still available

### DIFF
--- a/assets/js/data/payment/actions.ts
+++ b/assets/js/data/payment/actions.ts
@@ -111,11 +111,14 @@ export const __internalSetPaymentMethodData = (
 export const __internalSetAvailablePaymentMethods = (
 	paymentMethods: PaymentMethods
 ) => {
-	return async ( { dispatch } ) => {
+	return async ( { dispatch, select } ) => {
 		// If the currently selected method is not in this new list, then we need to select a new one, or select a default.
 
-		// TODO See if we can stop this being dispatched if the currently selected method is still available.
-		await setDefaultPaymentMethod( paymentMethods );
+		const activePaymentMethod = select.getActivePaymentMethod();
+
+		if ( ! ( activePaymentMethod in paymentMethods ) ) {
+			await setDefaultPaymentMethod( paymentMethods );
+		}
 		dispatch( {
 			type: ACTION_TYPES.SET_AVAILABLE_PAYMENT_METHODS,
 			paymentMethods,

--- a/assets/js/data/payment/actions.ts
+++ b/assets/js/data/payment/actions.ts
@@ -2,8 +2,8 @@
  * External dependencies
  */
 import {
-	PaymentMethods,
-	ExpressPaymentMethods,
+	PlainPaymentMethods,
+	PlainExpressPaymentMethods,
 } from '@woocommerce/type-defs/payments';
 
 /**
@@ -109,13 +109,11 @@ export const __internalSetPaymentMethodData = (
  * An available payment method is one that has been validated and can make a payment.
  */
 export const __internalSetAvailablePaymentMethods = (
-	paymentMethods: PaymentMethods
+	paymentMethods: PlainPaymentMethods
 ) => {
 	return async ( { dispatch, select } ) => {
 		// If the currently selected method is not in this new list, then we need to select a new one, or select a default.
-
 		const activePaymentMethod = select.getActivePaymentMethod();
-
 		if ( ! ( activePaymentMethod in paymentMethods ) ) {
 			await setDefaultPaymentMethod( paymentMethods );
 		}
@@ -131,7 +129,7 @@ export const __internalSetAvailablePaymentMethods = (
  * An available payment method is one that has been validated and can make a payment.
  */
 export const __internalSetAvailableExpressPaymentMethods = (
-	paymentMethods: ExpressPaymentMethods
+	paymentMethods: PlainExpressPaymentMethods
 ) => ( {
 	type: ACTION_TYPES.SET_AVAILABLE_EXPRESS_PAYMENT_METHODS,
 	paymentMethods,

--- a/assets/js/data/payment/default-state.ts
+++ b/assets/js/data/payment/default-state.ts
@@ -4,8 +4,8 @@
 import type { EmptyObjectType } from '@woocommerce/types';
 import { getSetting } from '@woocommerce/settings';
 import {
-	PaymentMethods,
-	ExpressPaymentMethods,
+	PlainPaymentMethods,
+	PlainExpressPaymentMethods,
 } from '@woocommerce/type-defs/payments';
 
 /**
@@ -29,8 +29,8 @@ export interface PaymentMethodDataState {
 	activePaymentMethod: string;
 	activeSavedToken: string;
 	// Avilable payment methods are payment methods which have been validated and can make payment
-	availablePaymentMethods: PaymentMethods;
-	availableExpressPaymentMethods: ExpressPaymentMethods;
+	availablePaymentMethods: PlainPaymentMethods;
+	availableExpressPaymentMethods: PlainExpressPaymentMethods;
 	savedPaymentMethods:
 		| Record< string, SavedPaymentMethod[] >
 		| EmptyObjectType;

--- a/assets/js/data/payment/set-default-payment-method.ts
+++ b/assets/js/data/payment/set-default-payment-method.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { select, dispatch } from '@wordpress/data';
-import { PaymentMethods } from '@woocommerce/type-defs/payments';
+import { PlainPaymentMethods } from '@woocommerce/type-defs/payments';
 
 /**
  * Internal dependencies
@@ -10,7 +10,7 @@ import { PaymentMethods } from '@woocommerce/type-defs/payments';
 import { STORE_KEY as PAYMENT_STORE_KEY } from './constants';
 
 export const setDefaultPaymentMethod = async (
-	paymentMethods: PaymentMethods
+	paymentMethods: PlainPaymentMethods
 ) => {
 	const paymentMethodKeys = Object.keys( paymentMethods );
 

--- a/assets/js/data/payment/test/actions.ts
+++ b/assets/js/data/payment/test/actions.ts
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import * as setDefaultPaymentMethodFunctions from '../set-default-payment-method';
-import { PAYMENT_METHOD_DATA_STORE_KEY } from '..';
+import { PAYMENT_STORE_KEY } from '..';
 import { PlainPaymentMethods } from '../../../types';
 
 const originalDispatch = jest.requireActual( '@wordpress/data' ).dispatch;
@@ -23,7 +23,7 @@ describe( 'payment data store actions', () => {
 
 	describe( 'setAvailablePaymentMethods', () => {
 		it( 'Does not call setDefaultPaymentGateway if the current method is still available', () => {
-			const actions = originalDispatch( PAYMENT_METHOD_DATA_STORE_KEY );
+			const actions = originalDispatch( PAYMENT_STORE_KEY );
 			actions.__internalSetActivePaymentMethod(
 				Object.keys( paymentMethods )[ 0 ]
 			);
@@ -34,7 +34,7 @@ describe( 'payment data store actions', () => {
 		} );
 
 		it( 'Resets the default gateway if the current method is no longer available', () => {
-			const actions = originalDispatch( PAYMENT_METHOD_DATA_STORE_KEY );
+			const actions = originalDispatch( PAYMENT_STORE_KEY );
 			actions.__internalSetActivePaymentMethod(
 				Object.keys( paymentMethods )[ 0 ]
 			);

--- a/assets/js/data/payment/test/actions.ts
+++ b/assets/js/data/payment/test/actions.ts
@@ -1,0 +1,49 @@
+/**
+ * Internal dependencies
+ */
+import * as setDefaultPaymentMethodFunctions from '../set-default-payment-method';
+import { PAYMENT_METHOD_DATA_STORE_KEY } from '..';
+import { PlainPaymentMethods } from '../../../types';
+
+const originalDispatch = jest.requireActual( '@wordpress/data' ).dispatch;
+
+jest.mock( '../set-default-payment-method', () => ( {
+	setDefaultPaymentMethod: jest.fn(),
+} ) );
+
+describe( 'payment data store actions', () => {
+	const paymentMethods: PlainPaymentMethods = {
+		'wc-payment-gateway-1': {
+			name: 'wc-payment-gateway-1',
+		},
+		'wc-payment-gateway-2': {
+			name: 'wc-payment-gateway-2',
+		},
+	};
+
+	describe( 'setAvailablePaymentMethods', () => {
+		it( 'Does not call setDefaultPaymentGateway if the current method is still available', () => {
+			const actions = originalDispatch( PAYMENT_METHOD_DATA_STORE_KEY );
+			actions.__internalSetActivePaymentMethod(
+				Object.keys( paymentMethods )[ 0 ]
+			);
+			actions.__internalSetAvailablePaymentMethods( paymentMethods );
+			expect(
+				setDefaultPaymentMethodFunctions.setDefaultPaymentMethod
+			).not.toBeCalled();
+		} );
+
+		it( 'Resets the default gateway if the current method is no longer available', () => {
+			const actions = originalDispatch( PAYMENT_METHOD_DATA_STORE_KEY );
+			actions.__internalSetActivePaymentMethod(
+				Object.keys( paymentMethods )[ 0 ]
+			);
+			actions.__internalSetAvailablePaymentMethods( [
+				paymentMethods[ Object.keys( paymentMethods )[ 0 ] ],
+			] );
+			expect(
+				setDefaultPaymentMethodFunctions.setDefaultPaymentMethod
+			).toBeCalled();
+		} );
+	} );
+} );

--- a/assets/js/data/payment/test/set-default-payment-method.ts
+++ b/assets/js/data/payment/test/set-default-payment-method.ts
@@ -8,7 +8,7 @@ import * as wpDataFunctions from '@wordpress/data';
  * Internal dependencies
  */
 import { setDefaultPaymentMethod } from '../set-default-payment-method';
-import { PaymentMethods } from '../../../types';
+import { PlainPaymentMethods } from '../../../types';
 import { PAYMENT_STORE_KEY } from '..';
 
 const originalSelect = jest.requireActual( '@wordpress/data' ).select;
@@ -19,7 +19,7 @@ describe( 'setDefaultPaymentMethod', () => {
 		jest.resetModules();
 	} );
 
-	const paymentMethods: PaymentMethods = {
+	const paymentMethods: PlainPaymentMethods = {
 		'wc-payment-gateway-1': {
 			name: 'wc-payment-gateway-1',
 		},

--- a/assets/js/data/payment/types.ts
+++ b/assets/js/data/payment/types.ts
@@ -1,7 +1,10 @@
 /**
  * External dependencies
  */
-import { PaymentMethods } from '@woocommerce/type-defs/payments';
+import {
+	PlainPaymentMethods,
+	PlainExpressPaymentMethods,
+} from '@woocommerce/type-defs/payments';
 import type {
 	EmptyObjectType,
 	ObjectType,
@@ -31,6 +34,19 @@ export interface SavedPaymentMethod {
 export type SavedPaymentMethods =
 	| Record< string, SavedPaymentMethod[] >
 	| EmptyObjectType;
+
+export interface PaymentMethodDispatchers {
+	setRegisteredPaymentMethods: (
+		paymentMethods: PlainPaymentMethods
+	) => void;
+	setRegisteredExpressPaymentMethods: (
+		paymentMethods: PlainExpressPaymentMethods
+	) => void;
+	setActivePaymentMethod: (
+		paymentMethod: string,
+		paymentMethodData?: ObjectType | EmptyObjectType
+	) => void;
+}
 
 export interface PaymentStatusDispatchers {
 	pristine: () => void;
@@ -69,7 +85,7 @@ export type PaymentMethodCurrentStatusType = {
 };
 
 export type PaymentMethodsDispatcherType = (
-	paymentMethods: PaymentMethods
+	paymentMethods: PlainPaymentMethods
 ) => undefined | void;
 
 /**

--- a/assets/js/types/type-defs/payments.ts
+++ b/assets/js/types/type-defs/payments.ts
@@ -91,6 +91,16 @@ export type PaymentMethods =
 	| Record< string, PaymentMethodConfigInstance >
 	| EmptyObjectType;
 
+/**
+ * Used to represent payment methods in a context where storing objects is not allowed, i.e. in data stores.
+ */
+export type PlainPaymentMethods = Record< string, { name: string } >;
+
+/**
+ * Used to represent payment methods in a context where storing objects is not allowed, i.e. in data stores.
+ */
+export type PlainExpressPaymentMethods = PlainPaymentMethods;
+
 export type ExpressPaymentMethods =
 	| Record< string, ExpressPaymentMethodConfigInstance >
 	| EmptyObjectType;


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
When the available payment methods change, the data store resets the default payment method. This PR makes it so that if the currently selected method is available, then it remains selected and the code to set the default payment method is not executed. This is a minor performance increase.

This PR also adds two types which better represent the `PaymentMethods` and `ExpressPaymentMethods` we store in the data store. It also includes unit tests to verify that the `setDefaultPaymentMethods` function is not being called unnecessarily.

This PR is based on the `update/rename-store-actions-internal` branch from #7266. cc @alexflorisca 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [ ] E2E tests

#### User Facing Testing

These instructions will not be included in the testing notes because it requires installing a test plugin, but we can test it amongst ourselves.

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Run `npx @wordpress/create-block -t @woocommerce/extend-cart-checkout-block some-extension-name`. This will install a plugin called `Some Extension Name`
2. Go to your plugins and activate it.
3. Ensure your store has Cash on Delivery as an available payment method along with some others.
4. Go to checkout and enter an address, do not use Denver as the City. Ensure Cash on Delivery is not selected.
5. Change the city to `Denver`. 
6. Ensure the currently selected payment method is still active.
7. Change the city back to something that is not `Denver`.
8. Select Cash on Delivery.
9. Change the city to `Denver`. 
10. Ensure Cash on Delivery disappears and that another default method is chosen (it should be the first available method).
11. Ensure checkout works successfully.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Skipping
