### PR TITLE
Support editing collection method titles in editor.

### DIFF
--- a/assets/js/blocks/checkout/inner-blocks/checkout-collection-method/attributes.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-collection-method/attributes.tsx
@@ -28,6 +28,14 @@ export default {
 		type: 'boolean',
 		default: true,
 	},
+	localPickupText: {
+		type: 'string',
+		default: __( 'Local Pickup', 'woo-gutenberg-products-block' ),
+	},
+	shippingText: {
+		type: 'string',
+		default: __( 'Delivery', 'woo-gutenberg-products-block' ),
+	},
 	lock: {
 		type: 'object',
 		default: {

--- a/assets/js/blocks/checkout/inner-blocks/checkout-collection-method/edit.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-collection-method/edit.tsx
@@ -4,9 +4,20 @@
 import classnames from 'classnames';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import {
+	__experimentalRadio as Radio,
+	__experimentalRadioGroup as RadioGroup,
+} from 'wordpress-components';
+import { Icon, store, shipping } from '@wordpress/icons';
+import {
+	InspectorControls,
+	useBlockProps,
+	RichText,
+} from '@wordpress/block-editor';
+import { useShippingData } from '@woocommerce/base-context/hooks';
 import { PanelBody, ToggleControl } from '@wordpress/components';
 import { innerBlockAreas } from '@woocommerce/blocks-checkout';
+import type { CartShippingPackageShippingRate } from '@woocommerce/type-defs/cart';
 
 /**
  * Internal dependencies
@@ -16,7 +27,110 @@ import {
 	AdditionalFields,
 	AdditionalFieldsContent,
 } from '../../form-step';
-import Block from './block';
+import {
+	RatePrice,
+	getLocalPickupStartingPrice,
+	getShippingStartingPrice,
+} from './shared';
+import './style.scss';
+
+const LocalPickupSelector = ( {
+	checked,
+	rate,
+	showPrice,
+	showIcon,
+	toggleText,
+	setAttributes,
+}: {
+	checked: string;
+	rate: CartShippingPackageShippingRate;
+	showPrice: boolean;
+	showIcon: boolean;
+	toggleText: string;
+	setAttributes: ( attributes: Record< string, unknown > ) => void;
+} ) => {
+	return (
+		<Radio
+			value="pickup"
+			className={ classnames( 'wc-block-checkout__collection-item', {
+				'wc-block-checkout__collection-item--selected':
+					checked === 'pickup',
+			} ) }
+		>
+			{ showIcon === true && (
+				<Icon
+					icon={ store }
+					size={ 28 }
+					className="wc-block-checkout__collection-item-icon"
+				/>
+			) }
+			<RichText
+				value={ toggleText }
+				tagName="span"
+				className="wc-block-checkout__collection-item-title"
+				onChange={ ( value ) =>
+					setAttributes( { localPickupText: value } )
+				}
+			/>
+			{ showPrice === true && <RatePrice rate={ rate } /> }
+		</Radio>
+	);
+};
+
+const ShippingSelector = ( {
+	checked,
+	rate,
+	showPrice,
+	showIcon,
+	toggleText,
+	setAttributes,
+}: {
+	checked: string;
+	rate: CartShippingPackageShippingRate;
+	showPrice: boolean;
+	showIcon: boolean;
+	toggleText: string;
+	setAttributes: ( attributes: Record< string, unknown > ) => void;
+} ) => {
+	const Price =
+		rate === undefined ? (
+			<span className="wc-block-checkout__collection-item-price">
+				{ __(
+					'calculated with an address',
+					'woo-gutenberg-products-block'
+				) }
+			</span>
+		) : (
+			<RatePrice rate={ rate } />
+		);
+
+	return (
+		<Radio
+			value="shipping"
+			className={ classnames( 'wc-block-checkout__collection-item', {
+				'wc-block-checkout__collection-item--selected':
+					checked === 'shipping',
+			} ) }
+		>
+			{ showIcon === true && (
+				<Icon
+					icon={ shipping }
+					size={ 28 }
+					className="wc-block-checkout__collection-item-icon"
+				/>
+			) }
+			<RichText
+				value={ toggleText }
+				tagName="span"
+				className="wc-block-checkout__collection-item-title"
+				onChange={ ( value ) =>
+					setAttributes( { shippingText: value } )
+				}
+			/>
+			{ showPrice === true && Price }
+		</Radio>
+	);
+};
 
 export const Edit = ( {
 	attributes,
@@ -27,6 +141,8 @@ export const Edit = ( {
 		description: string;
 		showStepNumber: boolean;
 		allowCreateAccount: boolean;
+		localPickupText: string;
+		shippingText: string;
 		showPrice: boolean;
 		showIcon: boolean;
 		className: string;
@@ -34,13 +150,22 @@ export const Edit = ( {
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
 } ): JSX.Element => {
 	const [ currentView, changeView ] = useState( 'shipping' );
+	const { showPrice, showIcon, className, localPickupText, shippingText } =
+		attributes;
+	const { shippingRates } = useShippingData();
+	const localPickupStartingPrice = getLocalPickupStartingPrice(
+		shippingRates[ 0 ]?.shipping_rates
+	);
+	const shippingStartingPrice = getShippingStartingPrice(
+		shippingRates[ 0 ]?.shipping_rates
+	);
 	return (
 		<FormStepBlock
 			attributes={ attributes }
 			setAttributes={ setAttributes }
 			className={ classnames(
 				'wc-block-checkout__collection-method',
-				attributes?.className
+				className
 			) }
 		>
 			<InspectorControls>
@@ -58,10 +183,10 @@ export const Edit = ( {
 							'Show icon',
 							'woo-gutenberg-products-block'
 						) }
-						checked={ attributes.showIcon }
+						checked={ showIcon }
 						onChange={ () =>
 							setAttributes( {
-								showIcon: ! attributes.showIcon,
+								showIcon: ! showIcon,
 							} )
 						}
 					/>
@@ -70,21 +195,39 @@ export const Edit = ( {
 							'Show costs',
 							'woo-gutenberg-products-block'
 						) }
-						checked={ attributes.showPrice }
+						checked={ showPrice }
 						onChange={ () =>
 							setAttributes( {
-								showPrice: ! attributes.showPrice,
+								showPrice: ! showPrice,
 							} )
 						}
 					/>
 				</PanelBody>
 			</InspectorControls>
-			<Block
-				checked={ currentView }
+			<RadioGroup
+				id="collection-method"
+				className="wc-block-checkout__collection-method-container"
+				label="options"
 				onChange={ changeView }
-				showPrice={ attributes.showPrice }
-				showIcon={ attributes.showIcon }
-			/>
+				checked={ currentView }
+			>
+				<ShippingSelector
+					checked={ currentView }
+					rate={ shippingStartingPrice }
+					showPrice={ showPrice }
+					showIcon={ showIcon }
+					setAttributes={ setAttributes }
+					toggleText={ shippingText }
+				/>
+				<LocalPickupSelector
+					checked={ currentView }
+					rate={ localPickupStartingPrice }
+					showPrice={ showPrice }
+					showIcon={ showIcon }
+					setAttributes={ setAttributes }
+					toggleText={ localPickupText }
+				/>
+			</RadioGroup>
 			<AdditionalFields block={ innerBlockAreas.COLLECTION_METHOD } />
 		</FormStepBlock>
 	);

--- a/assets/js/blocks/checkout/inner-blocks/checkout-collection-method/edit.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-collection-method/edit.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @wordpress/no-unsafe-wp-apis */
 /**
  * External dependencies
  */
@@ -5,9 +6,11 @@ import classnames from 'classnames';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import {
+	PanelBody,
+	ToggleControl,
 	__experimentalRadio as Radio,
 	__experimentalRadioGroup as RadioGroup,
-} from 'wordpress-components';
+} from '@wordpress/components';
 import { Icon, store, shipping } from '@wordpress/icons';
 import {
 	InspectorControls,
@@ -15,7 +18,6 @@ import {
 	RichText,
 } from '@wordpress/block-editor';
 import { useShippingData } from '@woocommerce/base-context/hooks';
-import { PanelBody, ToggleControl } from '@wordpress/components';
 import { innerBlockAreas } from '@woocommerce/blocks-checkout';
 import type { CartShippingPackageShippingRate } from '@woocommerce/type-defs/cart';
 
@@ -71,6 +73,8 @@ const LocalPickupSelector = ( {
 				onChange={ ( value ) =>
 					setAttributes( { localPickupText: value } )
 				}
+				__unstableDisableFormats
+				preserveWhiteSpace
 			/>
 			{ showPrice === true && <RatePrice rate={ rate } /> }
 		</Radio>
@@ -126,6 +130,8 @@ const ShippingSelector = ( {
 				onChange={ ( value ) =>
 					setAttributes( { shippingText: value } )
 				}
+				__unstableDisableFormats
+				preserveWhiteSpace
 			/>
 			{ showPrice === true && Price }
 		</Radio>

--- a/assets/js/blocks/checkout/inner-blocks/checkout-collection-method/frontend.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-collection-method/frontend.tsx
@@ -20,6 +20,8 @@ const FrontendBlock = ( {
 	className,
 	showPrice,
 	showIcon,
+	shippingText,
+	localPickupText,
 }: {
 	title: string;
 	description: string;
@@ -28,6 +30,8 @@ const FrontendBlock = ( {
 	className?: string;
 	showPrice: boolean;
 	showIcon: boolean;
+	shippingText: string;
+	localPickupText: string;
 } ) => {
 	const { checkoutIsProcessing, prefersCollection } = useSelect(
 		( select ) => {
@@ -64,6 +68,8 @@ const FrontendBlock = ( {
 				onChange={ onChange }
 				showPrice={ showPrice }
 				showIcon={ showIcon }
+				localPickupText={ localPickupText }
+				shippingText={ shippingText }
 			/>
 			{ children }
 		</FormStep>

--- a/assets/js/blocks/checkout/inner-blocks/checkout-collection-method/shared/helpers.ts
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-collection-method/shared/helpers.ts
@@ -1,0 +1,68 @@
+/**
+ * External dependencies
+ */
+import type { CartShippingPackageShippingRate } from '@woocommerce/type-defs/cart';
+
+/**
+ * Returns the cheapest rate that isn't a local pickup.
+ *
+ * @param {Array|undefined} shippingRates Array of shipping Rate.
+ *
+ * @return {Object|undefined} cheapest rate.
+ */
+export function getShippingStartingPrice(
+	shippingRates: CartShippingPackageShippingRate[]
+): CartShippingPackageShippingRate | undefined {
+	if ( shippingRates ) {
+		return shippingRates.reduce(
+			(
+				lowestRate: CartShippingPackageShippingRate | undefined,
+				currentRate: CartShippingPackageShippingRate
+			) => {
+				if ( currentRate.method_id === 'local_pickup' ) {
+					return lowestRate;
+				}
+				if (
+					lowestRate === undefined ||
+					currentRate.price < lowestRate.price
+				) {
+					return currentRate;
+				}
+				return lowestRate;
+			},
+			undefined
+		);
+	}
+}
+
+/**
+ * Returns the cheapest rate that is a local pickup.
+ *
+ * @param {Array|undefined} shippingRates Array of shipping Rate.
+ *
+ * @return {Object|undefined} cheapest rate.
+ */
+export function getLocalPickupStartingPrice(
+	shippingRates: CartShippingPackageShippingRate[]
+): CartShippingPackageShippingRate | undefined {
+	if ( shippingRates ) {
+		return shippingRates.reduce(
+			(
+				lowestRate: CartShippingPackageShippingRate | undefined,
+				currentRate: CartShippingPackageShippingRate
+			) => {
+				if ( currentRate.method_id !== 'local_pickup' ) {
+					return lowestRate;
+				}
+				if (
+					lowestRate === undefined ||
+					currentRate.price < lowestRate.price
+				) {
+					return currentRate;
+				}
+				return lowestRate;
+			},
+			undefined
+		);
+	}
+}

--- a/assets/js/blocks/checkout/inner-blocks/checkout-collection-method/shared/index.js
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-collection-method/shared/index.js
@@ -1,0 +1,2 @@
+export { RatePrice } from './rate-price';
+export * from './helpers';

--- a/assets/js/blocks/checkout/inner-blocks/checkout-collection-method/shared/rate-price.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-collection-method/shared/rate-price.tsx
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { getSetting } from '@woocommerce/settings';
+import { createInterpolateElement } from '@wordpress/element';
+import { getCurrencyFromPriceResponse } from '@woocommerce/price-format';
+import FormattedMonetaryAmount from '@woocommerce/base-components/formatted-monetary-amount';
+import type { CartShippingPackageShippingRate } from '@woocommerce/type-defs/cart';
+
+export const RatePrice = ( {
+	rate,
+}: {
+	rate: CartShippingPackageShippingRate;
+} ) => {
+	const ratePrice = getSetting( 'displayCartPricesIncludingTax', false )
+		? parseInt( rate.price, 10 ) + parseInt( rate.taxes, 10 )
+		: parseInt( rate.price, 10 );
+	return (
+		<span className="wc-block-checkout__collection-item-price">
+			{ ratePrice === 0
+				? __( 'free', 'woo-gutenberg-products-block' )
+				: createInterpolateElement(
+						__( 'from <price />', 'woo-gutenberg-products-block' ),
+						{
+							price: (
+								<FormattedMonetaryAmount
+									currency={ getCurrencyFromPriceResponse(
+										rate
+									) }
+									value={ ratePrice }
+								/>
+							),
+						}
+				  ) }
+		</span>
+	);
+};


### PR DESCRIPTION
This PR adds text editing for the collection method in the editor. This would allow merchant to edit the titles "Local pickup" and "Delivery".

### Screenshots
<img width="550" alt="image" src="https://user-images.githubusercontent.com/6165348/193821718-a34cbc8d-c0cf-4804-abd5-5cad22329b8c.png">
<img width="752" alt="image" src="https://user-images.githubusercontent.com/6165348/193822607-4b994887-1d0b-424f-a900-bca00f5fad24.png">

#### User Facing Testing

1. In the editor, modify the text.
2. Make sure your result persist on frontend.

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental
