### PR TITLE
Import useEffect from @wordpress/element package

### DIFF
--- a/assets/js/atomic/blocks/product-elements/button/edit.js
+++ b/assets/js/atomic/blocks/product-elements/button/edit.js
@@ -3,7 +3,7 @@
  */
 import { Disabled } from '@wordpress/components';
 import { useBlockProps } from '@wordpress/block-editor';
-import { useEffect } from 'react';
+import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
This PR fixes the import of the `useEffect` function. Thanks, @dinhtungdu for catching this :) 



