### PR TITLE
Introduce Toggle between Shipping Options and Pickup Locations

### DIFF
--- a/assets/js/base/context/hooks/use-checkout-address.ts
+++ b/assets/js/base/context/hooks/use-checkout-address.ts
@@ -38,7 +38,7 @@ interface CheckoutAddress {
  */
 export const useCheckoutAddress = (): CheckoutAddress => {
 	const { needsShipping } = useShippingData();
-	const { useShippingAsBilling } = useSelect( ( select ) =>
+	const { useShippingAsBilling, prefersCollection } = useSelect( ( select ) =>
 		select( CHECKOUT_STORE_KEY ).getCheckoutState()
 	);
 	const { setUseShippingAsBilling } = useDispatch( CHECKOUT_STORE_KEY );
@@ -73,6 +73,8 @@ export const useCheckoutAddress = (): CheckoutAddress => {
 		[ setShippingAddress ]
 	);
 
+	console.log( prefersCollection );
+
 	return {
 		shippingAddress,
 		billingAddress,
@@ -84,7 +86,8 @@ export const useCheckoutAddress = (): CheckoutAddress => {
 		defaultAddressFields,
 		useShippingAsBilling,
 		setUseShippingAsBilling,
-		showShippingFields: needsShipping,
-		showBillingFields: ! needsShipping || ! useShippingAsBilling,
+		showShippingFields: needsShipping && ! prefersCollection,
+		showBillingFields:
+			! needsShipping || ! useShippingAsBilling || prefersCollection,
 	};
 };

--- a/assets/js/base/context/hooks/use-checkout-address.ts
+++ b/assets/js/base/context/hooks/use-checkout-address.ts
@@ -73,8 +73,6 @@ export const useCheckoutAddress = (): CheckoutAddress => {
 		[ setShippingAddress ]
 	);
 
-	console.log( prefersCollection );
-
 	return {
 		shippingAddress,
 		billingAddress,

--- a/assets/js/blocks/checkout/inner-blocks/checkout-collection-method/edit.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-collection-method/edit.tsx
@@ -20,6 +20,8 @@ import {
 import { useShippingData } from '@woocommerce/base-context/hooks';
 import { innerBlockAreas } from '@woocommerce/blocks-checkout';
 import type { CartShippingPackageShippingRate } from '@woocommerce/type-defs/cart';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
 
 /**
  * Internal dependencies
@@ -155,7 +157,13 @@ export const Edit = ( {
 	};
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
 } ): JSX.Element => {
-	const [ currentView, changeView ] = useState( 'shipping' );
+	const { setPrefersCollection } = useDispatch( CHECKOUT_STORE_KEY );
+	const { prefersCollection } = useSelect( ( select ) => {
+		const checkoutStore = select( CHECKOUT_STORE_KEY );
+		return {
+			prefersCollection: checkoutStore.prefersCollection(),
+		};
+	} );
 	const { showPrice, showIcon, className, localPickupText, shippingText } =
 		attributes;
 	const { shippingRates } = useShippingData();
@@ -165,6 +173,15 @@ export const Edit = ( {
 	const shippingStartingPrice = getShippingStartingPrice(
 		shippingRates[ 0 ]?.shipping_rates
 	);
+
+	const changeView = ( method: string ) => {
+		if ( method === 'pickup' ) {
+			setPrefersCollection( true );
+		} else {
+			setPrefersCollection( false );
+		}
+	};
+
 	return (
 		<FormStepBlock
 			attributes={ attributes }
@@ -215,10 +232,10 @@ export const Edit = ( {
 				className="wc-block-checkout__collection-method-container"
 				label="options"
 				onChange={ changeView }
-				checked={ currentView }
+				checked={ prefersCollection ? 'pickup' : 'shipping' }
 			>
 				<ShippingSelector
-					checked={ currentView }
+					checked={ prefersCollection ? 'pickup' : 'shipping' }
 					rate={ shippingStartingPrice }
 					showPrice={ showPrice }
 					showIcon={ showIcon }
@@ -226,7 +243,7 @@ export const Edit = ( {
 					toggleText={ shippingText }
 				/>
 				<LocalPickupSelector
-					checked={ currentView }
+					checked={ prefersCollection ? 'pickup' : 'shipping' }
 					rate={ localPickupStartingPrice }
 					showPrice={ showPrice }
 					showIcon={ showIcon }

--- a/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/edit.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/edit.tsx
@@ -3,6 +3,7 @@
  */
 import classnames from 'classnames';
 import { useBlockProps } from '@wordpress/block-editor';
+import { useCheckoutAddress } from '@woocommerce/base-context/hooks';
 import { innerBlockAreas } from '@woocommerce/blocks-checkout';
 
 /**
@@ -30,7 +31,7 @@ export const Edit = ( {
 		className: string;
 	};
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
-} ): JSX.Element => {
+} ): JSX.Element | null => {
 	const {
 		showCompanyField,
 		showApartmentField,
@@ -40,6 +41,12 @@ export const Edit = ( {
 	} = useCheckoutBlockContext();
 	const { addressFieldControls: Controls } =
 		useCheckoutBlockControlsContext();
+	const { showShippingFields } = useCheckoutAddress();
+
+	if ( ! showShippingFields ) {
+		return null;
+	}
+
 	return (
 		<FormStepBlock
 			setAttributes={ setAttributes }

--- a/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/edit.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/edit.tsx
@@ -8,6 +8,7 @@ import { PanelBody, ExternalLink } from '@wordpress/components';
 import { ADMIN_URL, getSetting } from '@woocommerce/settings';
 import ExternalLinkCard from '@woocommerce/editor-components/external-link-card';
 import { innerBlockAreas } from '@woocommerce/blocks-checkout';
+import { useCheckoutAddress } from '@woocommerce/base-context/hooks';
 import Noninteractive from '@woocommerce/base-components/noninteractive';
 
 /**
@@ -38,13 +39,19 @@ export const Edit = ( {
 		className: string;
 	};
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
-} ): JSX.Element => {
+} ): JSX.Element | null => {
 	const globalShippingMethods = getSetting(
 		'globalShippingMethods'
 	) as shippingAdminLink[];
 	const activeShippingZones = getSetting(
 		'activeShippingZones'
 	) as shippingAdminLink[];
+
+	const { showShippingFields } = useCheckoutAddress();
+
+	if ( ! showShippingFields ) {
+		return null;
+	}
 
 	return (
 		<FormStepBlock


### PR DESCRIPTION
Implements the toggle between Shipping and Collection in the editor and on the frontend.

Works by storing `prefersCollection` in the checkout store. The value of this is then used to determine visibility of shipping blocks.

Note this is targeting the add/shipping-method-block branch, not trunk.

Fixes #7163

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. Go to the editor and insert a checkout block, or edit the checkout page
2. Click "collection" in the Shipping Method Block
    - Confirm shipping address + options are removed from view
    - Confirm billing address is shown in view
3. Click "delivery" in the Shipping Method Block
    - Confirm shipping address + options are added to the view
    - Confirm billing address is removed from view

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental