### PR TITLE
TRY: Show payment compatibility in Checkout block

### DIFF
--- a/assets/js/blocks/checkout/inner-blocks/checkout-payment-block/edit.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-payment-block/edit.tsx
@@ -72,6 +72,10 @@ export const Edit = ( {
 									href={ `${ ADMIN_URL }admin.php?page=wc-settings&tab=checkout&section=${ method.id }` }
 									title={ method.title }
 									description={ method.description }
+									notice={
+										method.title === 'PayPal' &&
+										'This payment method is not compatible yet.'
+									}
 								/>
 							);
 						} ) }

--- a/assets/js/editor-components/external-link-card/editor.scss
+++ b/assets/js/editor-components/external-link-card/editor.scss
@@ -23,6 +23,14 @@
 		@include font-size(small);
 		margin-top: 0.5em;
 	}
+	.wc-block-editor-components-external-link-card__notice {
+		background-color: #f4a2a2;
+		border-left: 4px solid #cc1818;
+		display: block;
+		@include font-size(small);
+		margin-top: 0.5em;
+		padding: 8px 12px;
+	}
 	.wc-block-editor-components-external-link-card__icon {
 		flex: 0 0 24px;
 		margin: 0;

--- a/assets/js/editor-components/external-link-card/index.tsx
+++ b/assets/js/editor-components/external-link-card/index.tsx
@@ -15,6 +15,7 @@ export interface ExternalLinkCardProps {
 	href: string;
 	title: string;
 	description?: string;
+	notice?: string;
 }
 
 /**
@@ -25,6 +26,7 @@ const ExternalLinkCard = ( {
 	href,
 	title,
 	description,
+	notice,
 }: ExternalLinkCardProps ): JSX.Element => {
 	return (
 		<a
@@ -44,6 +46,11 @@ const ExternalLinkCard = ( {
 							__html: sanitizeHTML( description ),
 						} }
 					></span>
+				) }
+				{ notice && (
+					<span className="wc-block-editor-components-external-link-card__notice">
+						{ notice }
+					</span>
 				) }
 			</span>
 			<VisuallyHidden as="span">


### PR DESCRIPTION
# ⚠️ DO NOT MERGE THIS PR ⚠️

Currently, not every payment extension is compatible with WooCommerce Blocks. This PR is a try to see how compatibility messages could appear within the Checkout block.

## Thoughts

When selecting the `Payment options` in the Checkout block, we're showing activated payment methods in the sidebar. The output is defined in https://github.com/woocommerce/woocommerce-blocks/blob/446fade219c3f31058947d7560a203f834446dd4/assets/js/blocks/checkout/inner-blocks/checkout-payment-block/edit.tsx#L68-L77

We could add the prop `notice` to the [`<ExternalLinkCard>`](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/assets/js/editor-components/external-link-card/index.tsx) component. If we detect that a payment method is incompatible with WooCommerce Blocks, we could then show the incompatibility message using this prop. 

**Detecting if a payment method is incompatible is not part of this test.**

## Screenshot

![compatibility-in-checkout-block](https://user-images.githubusercontent.com/3323310/194807175-256a0b47-d104-49bd-b186-e273f4c412b5.png)
