### PR TITLE
Fix: Active Filters not working on for site templates

### DIFF
--- a/assets/js/blocks/active-filters/block.tsx
+++ b/assets/js/blocks/active-filters/block.tsx
@@ -154,7 +154,9 @@ const ActiveFiltersBlock = ( {
 			( ! productAttributes.length &&
 				! urlContainsAttributeFilter( STORE_ATTRIBUTES ) )
 		) {
-			setIsLoading( false );
+			if ( isLoading ) {
+				setIsLoading( false );
+			}
 			return null;
 		}
 

--- a/assets/js/blocks/active-filters/block.tsx
+++ b/assets/js/blocks/active-filters/block.tsx
@@ -76,6 +76,7 @@ const ActiveFiltersBlock = ( {
 	);
 	const [ minPrice, setMinPrice ] = useQueryStateByKey( 'min_price' );
 	const [ maxPrice, setMaxPrice ] = useQueryStateByKey( 'max_price' );
+
 	const [ productRatings, setProductRatings ] =
 		useQueryStateByKey( 'rating' );
 
@@ -168,7 +169,9 @@ const ActiveFiltersBlock = ( {
 			);
 
 			if ( ! attributeObject ) {
-				setIsLoading( false );
+				if ( isLoading ) {
+					setIsLoading( false );
+				}
 				return null;
 			}
 
@@ -187,6 +190,7 @@ const ActiveFiltersBlock = ( {
 		productAttributes,
 		componentHasMounted,
 		STORE_ATTRIBUTES,
+		isLoading,
 		blockAttributes.displayStyle,
 	] );
 

--- a/assets/js/blocks/active-filters/block.tsx
+++ b/assets/js/blocks/active-filters/block.tsx
@@ -76,6 +76,8 @@ const ActiveFiltersBlock = ( {
 	);
 	const [ minPrice, setMinPrice ] = useQueryStateByKey( 'min_price' );
 	const [ maxPrice, setMaxPrice ] = useQueryStateByKey( 'max_price' );
+	const [ productRatings, setProductRatings ] =
+		useQueryStateByKey( 'rating' );
 
 	const STOCK_STATUS_OPTIONS = getSetting( 'stockStatusOptions', [] );
 	const STORE_ATTRIBUTES = getSetting( 'attributes', [] );
@@ -187,9 +189,6 @@ const ActiveFiltersBlock = ( {
 		STORE_ATTRIBUTES,
 		blockAttributes.displayStyle,
 	] );
-
-	const [ productRatings, setProductRatings ] =
-		useQueryStateByKey( 'rating' );
 
 	/**
 	 * Parse the filter URL to set the active rating fitlers.


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #7345

This PR:
- fixes the infinite rerender issue for Active Filter Block when using with templates.
- moves the `useQueryStateByKey` call for the rating filter block next to other blocks.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->


### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Add Active Filters and Price/Stock filter to Appearance > Site Editor > Product Catalog
2. Go to frontend 
3. Filter your products
4. See no error in the console, see the filter work as expected.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->
