### PR TITLE
Add compatibility with HPOS (custom order tables) for WooCommerce

### DIFF
--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -15,7 +15,7 @@
  * @package WooCommerce\Blocks
  * @internal This file is only used when running as a feature plugin.
  */
-
+ 
 defined( 'ABSPATH' ) || exit;
 
 $minimum_wp_version = '6.0';
@@ -23,6 +23,14 @@ $minimum_wp_version = '6.0';
 if ( ! defined( 'WC_BLOCKS_IS_FEATURE_PLUGIN' ) ) {
 	define( 'WC_BLOCKS_IS_FEATURE_PLUGIN', true );
 }
+
+// Declare comaptibility with custom order tables for WooCommerce
+if ( class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) ) {
+    add_action('before_woocommerce_init', function() {
+        \Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility('custom_order_tables', __FILE__, true);
+    });
+}
+
 /**
  * Whether notices must be displayed in the current page (plugins and WooCommerce pages).
  *


### PR DESCRIPTION
This declares compatibility with the new custom order tables in WooCommerce. It's based on this P2 post (internal): pcShBQ-oY-p2


#### User Facing Testing

This is difficult to test until the custom order tables and the new WC ui for enabling/disabling plugins is finished. So for now, just 

1. Make sure the blocks plugin still loads!

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental