### PR TITLE
Store API: Replace `wc()->api->get_endpoint_data` usage in `/cart/extensions`

### DIFF
--- a/src/StoreApi/Schemas/V1/CartExtensionsSchema.php
+++ b/src/StoreApi/Schemas/V1/CartExtensionsSchema.php
@@ -2,6 +2,9 @@
 namespace Automattic\WooCommerce\StoreApi\Schemas\V1;
 
 use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
+use Automattic\WooCommerce\StoreApi\SchemaController;
+use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
+use Automattic\WooCommerce\StoreApi\Utilities\CartController;
 
 /**
  * Class CartExtensionsSchema
@@ -20,6 +23,24 @@ class CartExtensionsSchema extends AbstractSchema {
 	 * @var string
 	 */
 	const IDENTIFIER = 'cart-extensions';
+
+	/**
+	 * Cart schema instance.
+	 *
+	 * @var CartSchema
+	 */
+	public $cart_schema;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param ExtendSchema     $extend Rest Extending instance.
+	 * @param SchemaController $controller Schema Controller instance.
+	 */
+	public function __construct( ExtendSchema $extend, SchemaController $controller ) {
+		parent::__construct( $extend, $controller );
+		$this->cart_schema = $this->controller->get( CartSchema::IDENTIFIER );
+	}
 
 	/**
 	 * Cart extensions schema properties.
@@ -51,6 +72,10 @@ class CartExtensionsSchema extends AbstractSchema {
 		if ( is_callable( $callback ) ) {
 			$callback( $request['data'] );
 		}
-		return rest_ensure_response( wc()->api->get_endpoint_data( '/wc/store/v1/cart' ) );
+
+		$controller = new CartController();
+		$cart       = $controller->get_cart_instance();
+
+		return rest_ensure_response( $this->cart_schema->get_item_response( $cart ) );
 	}
 }

--- a/src/StoreApi/Schemas/V1/CartSchema.php
+++ b/src/StoreApi/Schemas/V1/CartSchema.php
@@ -5,8 +5,6 @@ use Automattic\WooCommerce\StoreApi\SchemaController;
 use Automattic\WooCommerce\StoreApi\Utilities\CartController;
 use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
 use WC_Tax;
-use WP_Error;
-
 
 /**
  * CartSchema class.


### PR DESCRIPTION
`wc()->api->get_endpoint_data` encodes and decodes to and from JSON before returning the response data. JSON is not aware of Objects and Arrays, so object data is lost and converted to an array. This threw off developers using `rest_request_after_callbacks`. 

Ideally, types would be checked there before use, since they are filtering data of unknown type from data that could be filtered by any other consumer, but we can mitigate the issue by providing the response from the Cart Schema class instead.

Fixes #7275

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. With items in the cart, make a request to `https://store.local/wp-json/wc/store/v1/cart/extensions` and confirm the response is valid.
2. You can try the following code:

```
add_filter( 'rest_request_after_callbacks', 'filter_cart_item_data', 10, 3 );

function filter_cart_item_data( $response, $server, $request ) {
	if ( is_wp_error( $response ) ) {
		return $response;
	}

	if ( strpos( $request->get_route(), 'wc/store' ) === false ) {
		return $response;
	}

	$data = $response->get_data();

	if ( empty( $data[ 'items' ] ) ) {
		return $response;
	}

	foreach ( $data[ 'items' ] as &$item_data ) {
		var_dump( is_object( $item_data['quantity_limits'] ) );
	}

	return $response;
}
```

Before the patch, you'll see 2 results when making the request; one true (from the call to get_endpoint_data), one false (from the cart extension data response).

After the patch, you'll just see 1 result (true).

There is also a code-based test case under https://github.com/woocommerce/woocommerce-blocks/issues/7275

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Store API: Replaced `wc()->api->get_endpoint_data` usage in `/cart/extensions` to fix inconsistencies via filter hooks.
