### PR TITLE
Remove old cart notices before showing new ones

### DIFF
--- a/assets/js/blocks/cart/inner-blocks/filled-cart-block/frontend.tsx
+++ b/assets/js/blocks/cart/inner-blocks/filled-cart-block/frontend.tsx
@@ -6,7 +6,7 @@ import { SidebarLayout } from '@woocommerce/base-components/sidebar-layout';
 import { useStoreCart } from '@woocommerce/base-context/hooks';
 import { useEffect } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -22,10 +22,25 @@ const FrontendBlock = ( {
 } ): JSX.Element | null => {
 	const { cartItems, cartIsLoading, cartItemErrors } = useStoreCart();
 	const { hasDarkControls } = useCartBlockContext();
-	const { createErrorNotice } = useDispatch( 'core/notices' );
+	const { createErrorNotice, removeNotice } = useDispatch( 'core/notices' );
 
-	// Ensures any cart errors listed in the API response get shown.
+	const currentlyDisplayedErrorNoticeCodes = useSelect( ( select ) => {
+		return select( 'core/notices' )
+			.getNotices( 'wc/cart' )
+			.filter(
+				( notice ) =>
+					notice.status === 'error' && notice.type === 'default'
+			)
+			.map( ( notice ) => notice.id );
+	} );
+
 	useEffect( () => {
+		// Clear errors out of the store before adding the new ones from the response.
+		currentlyDisplayedErrorNoticeCodes.forEach( ( id ) => {
+			removeNotice( id, 'wc/cart' );
+		} );
+
+		// Ensures any cart errors listed in the API response get shown.
 		cartItemErrors.forEach( ( error ) => {
 			createErrorNotice( decodeEntities( error.message ), {
 				isDismissible: true,

--- a/assets/js/blocks/cart/inner-blocks/filled-cart-block/frontend.tsx
+++ b/assets/js/blocks/cart/inner-blocks/filled-cart-block/frontend.tsx
@@ -24,6 +24,10 @@ const FrontendBlock = ( {
 	const { hasDarkControls } = useCartBlockContext();
 	const { createErrorNotice, removeNotice } = useDispatch( 'core/notices' );
 
+	/*
+	 * The code for removing old notices is also present in the filled-mini-cart-contents-block/frontend.tsx file and
+	 * will take care of removing outdated errors in the Mini Cart block.
+	 */
 	const currentlyDisplayedErrorNoticeCodes = useSelect( ( select ) => {
 		return select( 'core/notices' )
 			.getNotices( 'wc/cart' )

--- a/assets/js/blocks/cart/inner-blocks/filled-cart-block/frontend.tsx
+++ b/assets/js/blocks/cart/inner-blocks/filled-cart-block/frontend.tsx
@@ -48,7 +48,12 @@ const FrontendBlock = ( {
 				context: 'wc/cart',
 			} );
 		} );
-	}, [ createErrorNotice, cartItemErrors ] );
+	}, [
+		createErrorNotice,
+		cartItemErrors,
+		currentlyDisplayedErrorNoticeCodes,
+		removeNotice,
+	] );
 
 	if ( cartIsLoading || cartItems.length >= 1 ) {
 		return (

--- a/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/filled-mini-cart-contents-block/frontend.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/filled-mini-cart-contents-block/frontend.tsx
@@ -4,7 +4,7 @@
 import { StoreNoticesContainer } from '@woocommerce/blocks-checkout';
 import { useStoreCart } from '@woocommerce/base-context/hooks';
 
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 
@@ -19,10 +19,29 @@ const FilledMiniCartContentsBlock = ( {
 }: FilledMiniCartContentsBlockProps ): JSX.Element | null => {
 	const { cartItems, cartItemErrors } = useStoreCart();
 
-	const { createErrorNotice } = useDispatch( 'core/notices' );
+	const { createErrorNotice, removeNotice } = useDispatch( 'core/notices' );
+
+	/*
+	 * The code for removing old notices is also present in the filled-cart-block/frontend.tsx file and will take care
+	 * of removing outdated errors in the Cart block.
+	 */
+	const currentlyDisplayedErrorNoticeCodes = useSelect( ( select ) => {
+		return select( 'core/notices' )
+			.getNotices( 'wc/cart' )
+			.filter(
+				( notice ) =>
+					notice.status === 'error' && notice.type === 'default'
+			)
+			.map( ( notice ) => notice.id );
+	} );
 
 	// Ensures any cart errors listed in the API response get shown.
 	useEffect( () => {
+		// Clear errors out of the store before adding the new ones from the response.
+		currentlyDisplayedErrorNoticeCodes.forEach( ( id ) => {
+			removeNotice( id, 'wc/cart' );
+		} );
+
 		cartItemErrors.forEach( ( error ) => {
 			createErrorNotice( decodeEntities( error.message ), {
 				isDismissible: false,
@@ -30,7 +49,12 @@ const FilledMiniCartContentsBlock = ( {
 				context: 'wc/cart',
 			} );
 		} );
-	}, [ createErrorNotice, cartItemErrors ] );
+	}, [
+		createErrorNotice,
+		cartItemErrors,
+		currentlyDisplayedErrorNoticeCodes,
+		removeNotice,
+	] );
 
 	if ( cartItems.length === 0 ) {
 		return null;

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -2337,6 +2337,9 @@
     Target requires 1 element(s) but source may have fewer." source="TS2322" />
 <error line="113" column="9" severity="error" message="Type &apos;{}[][]&apos; is not assignable to type &apos;readonly Template[]&apos;." source="TS2322" />
 </file>
+<file name="assets/js/blocks/cart/inner-blocks/filled-cart-block/frontend.tsx">
+<error line="32" column="42" severity="error" message="Property &apos;type&apos; does not exist on type &apos;Notice&apos;." source="TS2339" />
+</file>
 <file name="assets/js/blocks/cart/inner-blocks/cart-items-block/frontend.tsx">
 <error line="15" column="4" severity="error" message="Type &apos;{ children: Element; className: string; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; RefAttributes&lt;any&gt;&apos;.
   Property &apos;children&apos; does not exist on type &apos;IntrinsicAttributes &amp; RefAttributes&lt;any&gt;&apos;." source="TS2322" />


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR will change the `Filled Cart Block` so that it will clear out previous errors before showing new ones. This is because in #5838 we noticed that even though old errors had been fixed and were no longer present in the API response, they were not removed from the UI.

<!-- Reference any related issues or PRs here -->

Fixes #5838
### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. Add two items to your cart, item A and item B.
2. Go to the Cart block, and ensure you see no errors.
3. Open a new tab, and edit product A. Set it to be out of stock.
4. **Without reloading the page** return to the Cart block, and increase the quantity of any product. Ensure an error appears.
5. Edit product A again, and set it to be in stock.
6. **Without reloading the page** return to the Cart block, and increase the quantity of any product. Ensure the previous error is removed.
7. In separate tabs, edit product A **and** B. Set them both to be out of stock.
8. **Without reloading the page** return to the Cart block, and increase the quantity of any product. Ensure an error appears showing **both** products are out of stock.
9. Edit **only one** product, set it back to in stock.
10. **Without reloading the page** return to the Cart block, and increase the quantity of any product. Ensure the error stays, but that it only shows that one of the products is out of stock.
11. Add the Mini Cart block to a page and repeat the above steps using the Mini Cart instead.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->
This will have a very slight, pretty much negligible, negative performance impact after receiving the cart from the API. This change will cause the Cart block to dispatch _n_ actions to the `core/notices` store, where _n_ is the number of notices currently displayed every time the cart updates. I am noting this anyway just so it's on the record, despite it being negligible.

### Changelog

> Fixed an issue where error notices that had been fixed would not be correctly removed from the Cart block.
