### PR TITLE
Prevent resource hinting when cart/checkout blocks are not in use

### DIFF
--- a/src/AssetsController.php
+++ b/src/AssetsController.php
@@ -97,39 +97,72 @@ final class AssetsController {
 			return $urls;
 		}
 
-		$resources         = [];
-		$is_block_cart     = has_block( 'woocommerce/cart' );
-		$is_block_checkout = has_block( 'woocommerce/checkout' );
-
 		if ( 'prefetch' === $relation_type ) {
-			if ( ! $is_block_cart ) {
-				$resources = array_merge( $resources, $this->get_block_asset_resource_hints( 'cart-frontend' ) );
-			}
-
-			if ( ! $is_block_checkout ) {
-				$resources = array_merge( $resources, $this->get_block_asset_resource_hints( 'checkout-frontend' ) );
-			}
-
 			$urls = array_merge(
 				$urls,
-				array_map(
-					function( $src ) {
-						return array(
-							'href' => $src,
-							'as'   => 'script',
-						);
-					},
-					array_unique( array_filter( $resources ) )
-				)
+				$this->get_prefetch_resource_hints()
 			);
 		}
 
-		if ( 'prerender' === $relation_type && $is_block_cart ) {
-			$checkout_page_id  = wc_get_page_id( 'checkout' );
-			$checkout_page_url = $checkout_page_id ? get_permalink( $checkout_page_id ) : '';
-			if ( $checkout_page_url ) {
-				$urls[] = $checkout_page_url;
-			}
+		if ( 'prerender' === $relation_type ) {
+			$urls = array_merge(
+				$urls,
+				$this->get_prerender_resource_hints()
+			);
+		}
+
+		return $urls;
+	}
+
+	/**
+	 * Get resource hints during prefetch requests.
+	 *
+	 * @return array Array of URLs.
+	 */
+	private function get_prefetch_resource_hints() {
+		$urls = [];
+
+		// Core page IDs.
+		$cart_page_id     = wc_get_page_id( 'cart' );
+		$checkout_page_id = wc_get_page_id( 'checkout' );
+
+		// Checks a specific page (by ID) to see if it contains the named block.
+		$has_block_cart     = $cart_page_id && has_block( 'woocommerce/cart', $cart_page_id );
+		$has_block_checkout = $checkout_page_id && has_block( 'woocommerce/checkout', $checkout_page_id );
+
+		// Checks the current page to see if it contains the named block.
+		$is_block_cart     = has_block( 'woocommerce/cart' );
+		$is_block_checkout = has_block( 'woocommerce/checkout' );
+
+		if ( $has_block_cart && ! $is_block_cart ) {
+			$urls = array_merge( $urls, $this->get_block_asset_resource_hints( 'cart-frontend' ) );
+		}
+
+		if ( $has_block_checkout && ! $is_block_checkout ) {
+			$urls = array_merge( $urls, $this->get_block_asset_resource_hints( 'checkout-frontend' ) );
+		}
+
+		return $urls;
+	}
+
+	/**
+	 * Get resource hints during prerender requests.
+	 *
+	 * @return array Array of URLs.
+	 */
+	private function get_prerender_resource_hints() {
+		$urls          = [];
+		$is_block_cart = has_block( 'woocommerce/cart' );
+
+		if ( ! $is_block_cart ) {
+			return $urls;
+		}
+
+		$checkout_page_id  = wc_get_page_id( 'checkout' );
+		$checkout_page_url = $checkout_page_id ? get_permalink( $checkout_page_id ) : '';
+
+		if ( $checkout_page_url ) {
+			$urls[] = $checkout_page_url;
 		}
 
 		return $urls;
@@ -148,7 +181,19 @@ final class AssetsController {
 		$script_data = $this->api->get_script_data(
 			$this->api->get_block_asset_build_path( $filename )
 		);
-		return array_merge( [ add_query_arg( 'ver', $script_data['version'], $script_data['src'] ) ], $this->get_script_dependency_src_array( $script_data['dependencies'] ) );
+		$resources   = array_merge(
+			[ add_query_arg( 'ver', $script_data['version'], $script_data['src'] ) ],
+			$this->get_script_dependency_src_array( $script_data['dependencies'] )
+		);
+		return array_map(
+			function( $src ) {
+				return array(
+					'href' => $src,
+					'as'   => 'script',
+				);
+			},
+			array_unique( array_filter( $resources ) )
+		);
 	}
 
 	/**

--- a/src/AssetsController.php
+++ b/src/AssetsController.php
@@ -86,7 +86,7 @@ final class AssetsController {
 	 * @return array URLs to print for resource hints.
 	 */
 	public function add_resource_hints( $urls, $relation_type ) {
-		if ( ! in_array( $relation_type, [ 'prefetch', 'prerender' ], true ) ) {
+		if ( ! in_array( $relation_type, [ 'prefetch', 'prerender' ], true ) || is_admin() ) {
 			return $urls;
 		}
 


### PR DESCRIPTION
There are 2 fixes in this PR;

1. Prevents resource hints being rendered in WP Admin (https://github.com/woocommerce/woocommerce-blocks/issues/7215)
2. Prevents resource hints being rendered if the Cart and Checkout Blocks are not being used on the Cart and Checkout pages (going by the ID stored to Woo Core settings) (https://github.com/woocommerce/woocommerce-blocks/issues/7216)

Fixes #7215
Fixes #7216

### Testing

#### User Facing Testing

As a reminder, resource hinting looks like this:

![Screenshot 2022-10-11 at 13 46 14](https://user-images.githubusercontent.com/90977/195094513-5354a41e-4cce-4467-86bb-f84bbc32bf00.png)

1. Ensure Cart and Checkout Blocks are used on your main Cart and Checkout pages
3. Go to the homepage. View page source and see the resource hints for cart/checkout block scripts.
4. Go to WP Admin. View page source and check no resource hints are shown for cart/checkout block scripts.
5. Go to the cart page. Check that there is a "prerender" hint for the checkout page.
6. Remove the cart and checkout blocks and repeat. No resource hints should be shown.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Prevent resource hinting when cart/checkout blocks are not in use.
