### PR TITLE
Product Query: rename allowControls to allowedControls

### DIFF
--- a/assets/js/blocks/product-query/constants.ts
+++ b/assets/js/blocks/product-query/constants.ts
@@ -18,7 +18,7 @@ export const DEFAULT_ALLOWED_CONTROLS = [
 ];
 
 export const QUERY_DEFAULT_ATTRIBUTES: QueryBlockAttributes = {
-	allowControls: DEFAULT_ALLOWED_CONTROLS,
+	allowedControls: DEFAULT_ALLOWED_CONTROLS,
 	displayLayout: {
 		type: 'flex',
 		columns: 3,

--- a/assets/js/blocks/product-query/types.ts
+++ b/assets/js/blocks/product-query/types.ts
@@ -50,7 +50,7 @@ export interface ProductQueryAttributes {
 }
 
 export interface QueryBlockAttributes {
-	allowControls?: string[];
+	allowedControls?: string[];
 	displayLayout?: {
 		type: 'flex' | 'list';
 		columns?: number;

--- a/assets/js/blocks/product-query/utils.tsx
+++ b/assets/js/blocks/product-query/utils.tsx
@@ -73,7 +73,7 @@ export function useAllowedControls(
 			select( WP_BLOCKS_STORE ).getActiveBlockVariation(
 				'core/query',
 				attributes
-			)?.allowControls,
+			)?.allowedControls,
 
 		[ attributes ]
 	);

--- a/assets/js/blocks/product-query/variations/product-query.tsx
+++ b/assets/js/blocks/product-query/variations/product-query.tsx
@@ -40,7 +40,7 @@ if ( isExperimentalBuild() ) {
 		// https://github.com/WordPress/gutenberg/pull/43632
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore
-		allowControls: DEFAULT_ALLOWED_CONTROLS,
+		allowedControls: DEFAULT_ALLOWED_CONTROLS,
 		innerBlocks: INNER_BLOCKS_TEMPLATE,
 		scope: [ 'block', 'inserter' ],
 	} );

--- a/assets/js/blocks/product-query/variations/products-on-sale.tsx
+++ b/assets/js/blocks/product-query/variations/products-on-sale.tsx
@@ -46,7 +46,7 @@ if ( isExperimentalBuild() ) {
 		// https://github.com/WordPress/gutenberg/pull/43632
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore
-		allowControls: ArrayXOR(
+		allowedControls: ArrayXOR(
 			DEFAULT_CORE_ALLOWED_CONTROLS,
 			DISABLED_INSPECTOR_CONTROLS
 		),


### PR DESCRIPTION
This PR renames the `allowControls` key to `allowedControls`. This is necessary because the name of the key is changed in Gutenberg https://github.com/WordPress/gutenberg/pull/44523.

### Testing

1. Be sure that you have GB installed (or WP 6.1)
2. Create a post and add the Product Query.
3. Be sure that you don't have errors on the editor side.
4. Save the post.
5. Check the front-end side. Be sure that you don't have errors.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental
