### PR TITLE
Fix: Product Query: Update the Editor preview when custom attributes are changed

### DIFF
--- a/assets/js/blocks/product-query/inspector-controls.tsx
+++ b/assets/js/blocks/product-query/inspector-controls.tsx
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { InspectorControls } from '@wordpress/block-editor';
-import { ToggleControl } from '@wordpress/components';
+import { PanelBody, ToggleControl } from '@wordpress/components';
 import { addFilter } from '@wordpress/hooks';
 import { EditorBlock } from '@woocommerce/types';
 import { ElementType } from 'react';
@@ -41,12 +41,14 @@ export const withProductQueryControls =
 			<>
 				<BlockEdit { ...props } />
 				<InspectorControls>
-					{ Object.entries( INSPECTOR_CONTROLS ).map(
-						( [ key, Control ] ) =>
-							allowedControls?.includes( key ) ? (
-								<Control { ...props } />
-							) : null
-					) }
+					<PanelBody>
+						{ Object.entries( INSPECTOR_CONTROLS ).map(
+							( [ key, Control ] ) =>
+								allowedControls?.includes( key ) ? (
+									<Control { ...props } />
+								) : null
+						) }
+					</PanelBody>
 				</InspectorControls>
 			</>
 		) : (

--- a/src/BlockTypes/ProductQuery.php
+++ b/src/BlockTypes/ProductQuery.php
@@ -35,7 +35,7 @@ class ProductQuery extends AbstractBlock {
 			10,
 			2
 		);
-
+		add_filter( 'rest_product_query', array( $this, 'update_rest_query' ), 10, 2 );
 	}
 
 	/**
@@ -48,7 +48,6 @@ class ProductQuery extends AbstractBlock {
 		return isset( $parsed_block['attrs']['namespace'] )
 		&& substr( $parsed_block['attrs']['namespace'], 0, 11 ) === 'woocommerce';
 	}
-
 
 	/**
 	 * Update the query for the product query block.
@@ -74,6 +73,18 @@ class ProductQuery extends AbstractBlock {
 				1
 			);
 		}
+	}
+
+	/**
+	 * Update the query for the product query block in Editor.
+	 *
+	 * @param array           $args    Query args.
+	 * @param WP_REST_Request $request Request.
+	 */
+	public function update_rest_query( $args, $request ) {
+		$on_sale_query = $request->get_param( '__woocommerceOnSale' ) !== 'true' ? array() : $this->get_on_sale_products_query();
+
+		return array_merge( $args, $on_sale_query );
 	}
 
 	/**
@@ -121,7 +132,6 @@ class ProductQuery extends AbstractBlock {
 		);
 
 	}
-
 
 	/**
 	 * Return a query for on sale products.


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #6969 

This PR is a rework of #6975 by @gigitux.

This PR fixes the issue with the editor preview for the Product Query Block by modifying the query arguments for the REST requests. This also fixes the styling issue of the On Sale toggle control.

I decided to keep the `__woocommerceOnSale` instead of following the approach in #6975 because:
- The implementation is much simpler.
- We don't need many custom query arguments. Most product query variations can be created by adjusting the default query:
  - Best selling products: order by `popularity`.
  - Newest products: order by `date`.
  - Top rated products: order by `rating`.
  - Handpicked products: use posts from `post__in`.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

https://user-images.githubusercontent.com/5423135/195121442-125e72c6-10d6-4cc1-ab54-882cf89b9a9c.mov

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Add a Product Query block.
2. Click on “Show only products on sale”.
3. Notice that the block preview IS updated to show only products on sale.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Fix: Product Query: Update the Editor preview when custom attributes are changed