### PR TITLE
Add temporary workaround to fix inserting Cart block in WordPress.com

### DIFF
--- a/assets/js/blocks/cart-checkout-shared/use-forced-layout.ts
+++ b/assets/js/blocks/cart-checkout-shared/use-forced-layout.ts
@@ -67,7 +67,8 @@ export const useForcedLayout = ( {
 			insertBlock( newBlock, position, clientId, false );
 			setForcedBlocksInserted( forcedBlocksInserted + 1 );
 		},
-		[ clientId, insertBlock, forcedBlocksInserted ]
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[ clientId, forcedBlocksInserted ]
 	);
 
 	const lockedBlockTypes = useMemo(
@@ -144,11 +145,6 @@ export const useForcedLayout = ( {
 					break;
 			}
 		} );
-	}, [
-		clientId,
-		innerBlocks,
-		lockedBlockTypes,
-		replaceInnerBlocks,
-		appendBlock,
-	] );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ clientId, innerBlocks, lockedBlockTypes, appendBlock ] );
 };

--- a/assets/js/blocks/cart-checkout-shared/use-forced-layout.ts
+++ b/assets/js/blocks/cart-checkout-shared/use-forced-layout.ts
@@ -67,6 +67,7 @@ export const useForcedLayout = ( {
 			insertBlock( newBlock, position, clientId, false );
 			setForcedBlocksInserted( forcedBlocksInserted + 1 );
 		},
+		// We need to skip insertBlock here due to a cache issue in wordpress.com that causes an inifinite loop, see https://github.com/Automattic/wp-calypso/issues/66092 for an expanded doc.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 		[ clientId, forcedBlocksInserted ]
 	);
@@ -145,6 +146,7 @@ export const useForcedLayout = ( {
 					break;
 			}
 		} );
+		// We need to skip replaceInnerBlocks here due to a cache issue in wordpress.com that causes an inifinite loop, see https://github.com/Automattic/wp-calypso/issues/66092 for an expanded doc.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ clientId, innerBlocks, lockedBlockTypes, appendBlock ] );
 };

--- a/assets/js/blocks/cart-checkout-shared/use-forced-layout.ts
+++ b/assets/js/blocks/cart-checkout-shared/use-forced-layout.ts
@@ -146,7 +146,10 @@ export const useForcedLayout = ( {
 					break;
 			}
 		} );
-		// We need to skip replaceInnerBlocks here due to a cache issue in wordpress.com that causes an inifinite loop, see https://github.com/Automattic/wp-calypso/issues/66092 for an expanded doc.
+		/*
+		We need to skip replaceInnerBlocks here due to a cache issue in wordpress.com that causes an inifinite loop, see https://github.com/Automattic/wp-calypso/issues/66092 for an expanded doc.
+		 @todo Add replaceInnerBlocks and insertBlock after fixing https://github.com/Automattic/wp-calypso/issues/66092
+		*/
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ clientId, innerBlocks, lockedBlockTypes, appendBlock ] );
 };


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This is a temporary workaround to https://github.com/woocommerce/woocommerce-blocks/issues/5866

The source of the issue is https://github.com/Automattic/wp-calypso/issues/66092 and it causes dependencies to change a lot, until we implement a proper memoization system there, Cart on wordpress.com is broken.

`insertBlocks` and `replaceInnerBlocks` are stable function and we don't need to rerun actions if they change, because they won't. This change, while against React rules, is still safe.
<!-- Reference any related issues or PRs here -->

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/5866

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Get a zip of this plugin (from below) and upload it to a wordpress.com website.
2. Go to the editor and try to insert Cart, it should work.
3. Make sure no block is missing.

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix a problem that causes an infinite loop when inserting Cart block in wordpress.com
