### PR TITLE
change any to or below the express payment method on cart

### DIFF
--- a/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment/cart-express-payment.js
+++ b/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment/cart-express-payment.js
@@ -79,7 +79,7 @@ const CartExpressPayment = () => {
 			</LoadingMask>
 			<div className="wc-block-components-express-payment-continue-rule wc-block-components-express-payment-continue-rule--cart">
 				{ /* translators: Shown in the Cart block between the express payment methods and the Proceed to Checkout button */ }
-				{ __( 'Any', 'woo-gutenberg-products-block' ) }
+				{ __( 'Or', 'woo-gutenberg-products-block' ) }
 			</div>
 		</>
 	);


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
The label that gets displayed between the express payment method and the proceed to checkout button on the cart was changed to `any` in #7045 by accident I presume. This PR changes it back to `or`

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Go to the cart block and make sure an express payment method is loaded
2. You should see ---- OR ------ between the express payment button and the proceed to checkout button

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental