### PR TITLE
Check that the callback for filtering payment methods is available and is a function before trying to run it

### DIFF
--- a/assets/js/blocks-registry/payment-methods/payment-method-config-helper.ts
+++ b/assets/js/blocks-registry/payment-methods/payment-method-config-helper.ts
@@ -50,7 +50,10 @@ export const canMakePaymentWithExtensions =
 
 			Object.entries( extensionsCallbacks ).forEach(
 				( [ namespace, callbacks ] ) => {
-					if ( ! ( paymentMethodName in callbacks ) ) {
+					if (
+						! ( paymentMethodName in callbacks ) ||
+						typeof callbacks[ paymentMethodName ] !== 'function'
+					) {
 						return;
 					}
 					namespacedCallbacks[ namespace ] =

--- a/assets/js/blocks-registry/payment-methods/payment-method-config-helper.ts
+++ b/assets/js/blocks-registry/payment-methods/payment-method-config-helper.ts
@@ -50,6 +50,9 @@ export const canMakePaymentWithExtensions =
 
 			Object.entries( extensionsCallbacks ).forEach(
 				( [ namespace, callbacks ] ) => {
+					if ( ! ( paymentMethodName in callbacks ) ) {
+						return;
+					}
 					namespacedCallbacks[ namespace ] =
 						callbacks[ paymentMethodName ];
 				}

--- a/assets/js/blocks-registry/payment-methods/test/payment-method-config-helper.ts
+++ b/assets/js/blocks-registry/payment-methods/test/payment-method-config-helper.ts
@@ -88,6 +88,9 @@ describe( 'payment-method-config-helper', () => {
 				woopay: trueCallback,
 				// testpay: one callback errors, one returns true
 				testpay: throwsCallback,
+				// Used to check that only valid callbacks run in each namespace. It is not present in
+				// 'other-woocommerce-marketplace-extension'.
+				blocks_pay: trueCallback,
 			}
 		);
 		registerPaymentMethodExtensionCallbacks(
@@ -201,6 +204,15 @@ describe( 'payment-method-config-helper', () => {
 			expect( console ).toHaveErrored();
 			expect( throwsCallback ).toHaveBeenCalledTimes( 1 );
 			expect( trueCallback ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'Does not error when a callback for a payment method is in one namespace but not another', () => {
+			helpers.canMakePaymentWithExtensions(
+				() => true,
+				canMakePaymentExtensionsCallbacks,
+				'blocks_pay'
+			)( canMakePaymentArgument );
+			expect( console ).not.toHaveErrored();
 		} );
 	} );
 } );


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
When [registering callbacks to filter payment methods](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/third-party-developers/extensibility/checkout-payment-methods/filtering-payment-methods.md) we have checks in place to ensure that (at the time of registration) the callbacks provided are functions. When deciding which payment methods to run callbacks for, we [only check that _any_ namespace has registered a callback](https://github.com/woocommerce/woocommerce-blocks/blob/3f82dbeff92c7ce80e0f8be5db2a7e8ba092cf47/assets/js/blocks-registry/payment-methods/payment-method-config-helper.ts#L99) for that method.

For example, consider the following list of registered payment method callbacks:

```
{
    "some-extension-name": {
          cod: args => {…},
          bacs: args => {…},
    },
    "woocommerce-conditional-shipping-and-payments": {
          bacs: args => {…},
          cheque:  args => {…},
          cod: args => {…},
          paypal: args => {…},
          stripe: args => {…},
     }
}
```

When we check whether any callbacks are registered for `paypal`, [because we use `.some`](https://github.com/woocommerce/woocommerce-blocks/blob/3f82dbeff92c7ce80e0f8be5db2a7e8ba092cf47/assets/js/blocks-registry/payment-methods/payment-method-config-helper.ts#L99) (which is the correct way to do it) we find out that they are, so the code in `canMakePaymentWithExtensions` will run and try to execute the callback for the payment method in each namespace **without checking whether the callback exists and is a function**.

This PR adds a check to ensure the callback we are trying to execute exists and is a function.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Install and activate [some-extension-name.zip](https://github.com/woocommerce/woocommerce-blocks/files/9764404/some-extension-name.zip) and [WooCommerce Conditional Shipping and Payments](https://woocommerce.com/products/conditional-shipping-and-payments/).
2. Activate the Cash on Delivery payment method.
3. Go to the Cart block and view the JS console. Ensure you don't see any errors such as `Error when executing callback for cheque in some-extension-name TypeError: namespacedCallbacks[namespace] is not a function`.
4. Go to the Checkout block and check that no similar errors appear.
5. Change your city to `Denver` and ensure the Cash on Delivery method is not available.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fixed an issue where JavaScript errors would occur when more than one extension tried to filter specific payment methods in the Cart and Checkout blocks.
 