### PR TITLE
Remove duplicate shouldSavePaymentMethod selector

### DIFF
--- a/assets/js/base/context/providers/cart-checkout/checkout-processor.js
+++ b/assets/js/base/context/providers/cart-checkout/checkout-processor.js
@@ -86,7 +86,7 @@ const CheckoutProcessor = () => {
 			paymentMethodData: store.getPaymentMethodData(),
 			isExpressPaymentMethodActive: store.isExpressPaymentMethodActive(),
 			currentPaymentStatus: store.getCurrentStatus(),
-			shouldSavePayment: store.shouldSavePaymentMethod(),
+			shouldSavePayment: store.getShouldSavePaymentMethod(),
 		};
 	}, [] );
 

--- a/assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-card.js
+++ b/assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-card.js
@@ -30,7 +30,7 @@ const PaymentMethodCard = ( { children, showSaveOption } ) => {
 		const checkoutStore = select( CHECKOUT_STORE_KEY );
 		return {
 			shouldSavePaymentMethod:
-				paymentMethodStore.shouldSavePaymentMethod(),
+				paymentMethodStore.getShouldSavePaymentMethod(),
 			customerId: checkoutStore.getCustomerId(),
 		};
 	} );

--- a/assets/js/data/payment/selectors.ts
+++ b/assets/js/data/payment/selectors.ts
@@ -63,10 +63,6 @@ export const getActiveSavedPaymentMethods = (
 	);
 };
 
-export const shouldSavePaymentMethod = ( state: PaymentMethodDataState ) => {
-	return state.shouldSavePaymentMethod;
-};
-
 export const paymentMethodsInitialized = ( state: PaymentMethodDataState ) => {
 	return state.paymentMethodsInitialized;
 };


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
There are currently two selectors that do the same thing in the payment store. the `shouldSavePaymentMethod` is a copy of `getShouldSavePaymentMethod`. To keep consistent with the naming convention here of prefixing selectors with `get`, we are keeping `getShouldSavePaymentMethod` in favour of `shouldSavePaymentMethod`

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Go to the Checkout page
2. Checkout with a stripe card (4242 4242 4242 4242) and tick the `Save payment information to my account for future purchases.` box
3. Make sure the order was placed successfully
4. Add some more item to your cart and go to the checkout page again
5. Make sure you can see the card you saved under Payment Options

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental