### PR TITLE
Add Product Query Support for Atomic SKU Block

### DIFF
--- a/assets/js/atomic/blocks/product-elements/sku/attributes.ts
+++ b/assets/js/atomic/blocks/product-elements/sku/attributes.ts
@@ -3,6 +3,10 @@ export const blockAttributes: Record< string, Record< string, unknown > > = {
 		type: 'number',
 		default: 0,
 	},
+	isDescendentOfQueryLoop: {
+		type: 'boolean',
+		default: false,
+	},
 };
 
 export default blockAttributes;

--- a/assets/js/atomic/blocks/product-elements/sku/block.tsx
+++ b/assets/js/atomic/blocks/product-elements/sku/block.tsx
@@ -14,9 +14,9 @@ import type { HTMLAttributes } from 'react';
  * Internal dependencies
  */
 import './style.scss';
-import type { BlockAttributes } from './types';
+import type { Attributes } from './types';
 
-type Props = BlockAttributes & HTMLAttributes< HTMLDivElement >;
+type Props = Attributes & HTMLAttributes< HTMLDivElement >;
 
 const Block = ( props: Props ): JSX.Element | null => {
 	const { className } = props;

--- a/assets/js/atomic/blocks/product-elements/sku/edit.tsx
+++ b/assets/js/atomic/blocks/product-elements/sku/edit.tsx
@@ -2,7 +2,10 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import type { BlockEditProps } from '@wordpress/blocks';
 import EditProductLink from '@woocommerce/editor-components/edit-product-link';
+import { ProductQueryContext as Context } from '@woocommerce/blocks/product-query/types';
+import { useEffect } from 'react';
 
 /**
  * Internal dependencies
@@ -10,17 +13,28 @@ import EditProductLink from '@woocommerce/editor-components/edit-product-link';
 import Block from './block';
 import withProductSelector from '../shared/with-product-selector';
 import { BLOCK_TITLE, BLOCK_ICON } from './constants';
-import type { BlockAttributes } from './types';
+import type { Attributes } from './types';
 
-interface Props {
-	attributes: BlockAttributes;
-}
+const Edit = ( {
+	attributes,
+	setAttributes,
+	context,
+}: BlockEditProps< Attributes > & { context: Context } ): JSX.Element => {
+	const blockAttrs = {
+		...attributes,
+		...context,
+	};
+	const isDescendentOfQueryLoop = Number.isFinite( context.queryId );
 
-const Edit = ( { attributes }: Props ): JSX.Element => {
+	useEffect(
+		() => setAttributes( { isDescendentOfQueryLoop } ),
+		[ setAttributes, isDescendentOfQueryLoop ]
+	);
+
 	return (
 		<>
 			<EditProductLink />
-			<Block { ...attributes } />
+			<Block { ...blockAttrs } />
 		</>
 	);
 };

--- a/assets/js/atomic/blocks/product-elements/sku/index.ts
+++ b/assets/js/atomic/blocks/product-elements/sku/index.ts
@@ -22,6 +22,12 @@ const blockConfig: BlockConfiguration = {
 	title,
 	description,
 	icon: { src: icon },
+	usesContext: [ 'query', 'queryId', 'postId' ],
+	parent: [
+		'@woocommerce/all-products',
+		'@woocommerce/single-product',
+		'core/post-template',
+	],
 	attributes,
 	edit,
 };

--- a/assets/js/atomic/blocks/product-elements/sku/index.ts
+++ b/assets/js/atomic/blocks/product-elements/sku/index.ts
@@ -17,7 +17,6 @@ import {
 } from './constants';
 
 const blockConfig: BlockConfiguration = {
-	...sharedConfig,
 	apiVersion: 2,
 	title,
 	description,

--- a/assets/js/atomic/blocks/product-elements/sku/index.ts
+++ b/assets/js/atomic/blocks/product-elements/sku/index.ts
@@ -23,7 +23,7 @@ const blockConfig: BlockConfiguration = {
 	description,
 	icon: { src: icon },
 	usesContext: [ 'query', 'queryId', 'postId' ],
-	parent: [
+	ancestor: [
 		'@woocommerce/all-products',
 		'@woocommerce/single-product',
 		'core/post-template',

--- a/assets/js/atomic/blocks/product-elements/sku/types.ts
+++ b/assets/js/atomic/blocks/product-elements/sku/types.ts
@@ -1,3 +1,4 @@
-export interface BlockAttributes {
-	className: string;
+export interface Attributes {
+	productId: number;
+	isDescendentOfQueryLoop: boolean;
 }

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1172,9 +1172,6 @@
 <error line="4" column="23" severity="error" message="Could not find a declaration file for module &apos;@wordpress/wordcount&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@wordpress/wordcount/build/index.js&apos; implicitly has an &apos;any&apos; type.
   Try `npm i --save-dev @types/wordpress__wordcount` if it exists or add a new declaration (.d.ts) file containing `declare module &apos;@wordpress/wordcount&apos;;`" source="TS7016" />
 </file>
-<file name="assets/js/atomic/blocks/product-elements/sku/block.tsx">
-<error line="17" column="15" severity="error" message="Module &apos;&quot;./types&quot;&apos; has no exported member &apos;BlockAttributes&apos;." source="TS2305" />
-</file>
 <file name="assets/js/atomic/blocks/product-elements/stock-indicator/block.js">
 <error line="69" column="24" severity="error" message="Parameter &apos;lowStock&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
 <error line="77" column="21" severity="error" message="Parameter &apos;inStock&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
@@ -1429,8 +1426,8 @@
 <error line="18" column="40" severity="error" message="Property &apos;productId&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
 </file>
 <file name="assets/js/atomic/blocks/product-elements/sku/index.ts">
-<error line="26" column="2" severity="error" message="Type &apos;{ apiVersion: number; title: string; description: string; icon: { src: JSX.Element; }; usesContext: string[]; ancestor: string[]; attributes: Record&lt;string, Record&lt;string, unknown&gt;&gt;; ... 19 more ...; merge?: ((attributes: {}, attributesToMerge: {}) =&gt; Partial&lt;...&gt;) | undefined; }&apos; is not assignable to type &apos;BlockConfiguration&lt;{}&gt;&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
-  Object literal may only specify known properties, and &apos;ancestor&apos; does not exist in type &apos;BlockConfiguration&lt;{}&gt;&apos;." source="TS2375" />
+<error line="25" column="2" severity="error" message="Type &apos;{ apiVersion: number; title: string; description: string; icon: { src: JSX.Element; }; usesContext: string[]; ancestor: string[]; attributes: Record&lt;string, Record&lt;string, unknown&gt;&gt;; edit: (props: any) =&gt; JSX.Element; }&apos; is not assignable to type &apos;BlockConfiguration&lt;{}&gt;&apos;.
+  Object literal may only specify known properties, and &apos;ancestor&apos; does not exist in type &apos;BlockConfiguration&lt;{}&gt;&apos;." source="TS2322" />
 </file>
 <file name="assets/js/atomic/blocks/product-elements/category-list/index.ts">
 <error line="36" column="5" severity="error" message="Type &apos;{ color?: { text: true; link: true; background: false; __experimentalSkipSerialization: true; }; typography?: { fontSize: true; lineHeight: true; __experimentalFontStyle: true; __experimentalFontWeight: true; __experimentalSkipSerialization: true; }; __experimentalSelector?: string; }&apos; is not assignable to type &apos;BlockSupports&apos;.

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1172,6 +1172,9 @@
 <error line="4" column="23" severity="error" message="Could not find a declaration file for module &apos;@wordpress/wordcount&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@wordpress/wordcount/build/index.js&apos; implicitly has an &apos;any&apos; type.
   Try `npm i --save-dev @types/wordpress__wordcount` if it exists or add a new declaration (.d.ts) file containing `declare module &apos;@wordpress/wordcount&apos;;`" source="TS7016" />
 </file>
+<file name="assets/js/atomic/blocks/product-elements/sku/block.tsx">
+<error line="17" column="15" severity="error" message="Module &apos;&quot;./types&quot;&apos; has no exported member &apos;BlockAttributes&apos;." source="TS2305" />
+</file>
 <file name="assets/js/atomic/blocks/product-elements/stock-indicator/block.js">
 <error line="69" column="24" severity="error" message="Parameter &apos;lowStock&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
 <error line="77" column="21" severity="error" message="Parameter &apos;inStock&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
@@ -1424,6 +1427,10 @@
 </file>
 <file name="assets/js/editor-components/edit-product-link/index.js">
 <error line="18" column="40" severity="error" message="Property &apos;productId&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+</file>
+<file name="assets/js/atomic/blocks/product-elements/sku/index.ts">
+<error line="26" column="2" severity="error" message="Type &apos;{ apiVersion: number; title: string; description: string; icon: { src: JSX.Element; }; usesContext: string[]; ancestor: string[]; attributes: Record&lt;string, Record&lt;string, unknown&gt;&gt;; ... 19 more ...; merge?: ((attributes: {}, attributesToMerge: {}) =&gt; Partial&lt;...&gt;) | undefined; }&apos; is not assignable to type &apos;BlockConfiguration&lt;{}&gt;&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+  Object literal may only specify known properties, and &apos;ancestor&apos; does not exist in type &apos;BlockConfiguration&lt;{}&gt;&apos;." source="TS2375" />
 </file>
 <file name="assets/js/atomic/blocks/product-elements/category-list/index.ts">
 <error line="36" column="5" severity="error" message="Type &apos;{ color?: { text: true; link: true; background: false; __experimentalSkipSerialization: true; }; typography?: { fontSize: true; lineHeight: true; __experimentalFontStyle: true; __experimentalFontWeight: true; __experimentalSkipSerialization: true; }; __experimentalSelector?: string; }&apos; is not assignable to type &apos;BlockSupports&apos;.

--- a/src/BlockTypes/ProductSKU.php
+++ b/src/BlockTypes/ProductSKU.php
@@ -57,7 +57,7 @@ class ProductSKU extends AbstractBlock {
 
 		if ( $product ) {
 			return sprintf(
-				'<div class="wc-block-components-product-rating wc-block-grid__product-rating">
+				'<div class="wc-block-components-product-sku wc-block-grid__product-sku">
 					SKU:
 					<strong>%s</strong>
 				</div>',

--- a/src/BlockTypes/ProductSKU.php
+++ b/src/BlockTypes/ProductSKU.php
@@ -21,12 +21,48 @@ class ProductSKU extends AbstractBlock {
 	protected $api_version = '2';
 
 	/**
-	 * Register script and style assets for the block type before it is registered.
+	 * Overwrite parent method to prevent script registration.
 	 *
-	 * This registers the scripts; it does not enqueue them.
+	 * It is necessary to register and enqueues assets during the render
+	 * phase because we want to load assets only if the block has the content.
 	 */
 	protected function register_block_type_assets() {
-		parent::register_block_type_assets();
-		$this->register_chunk_translations( [ $this->block_name ] );
+		return null;
+	}
+
+	/**
+	 * Register the context.
+	 */
+	protected function get_block_type_uses_context() {
+		return [ 'query', 'queryId', 'postId' ];
+	}
+
+	/**
+	 * Include and render the block.
+	 *
+	 * @param array    $attributes Block attributes. Default empty array.
+	 * @param string   $content    Block content. Default empty string.
+	 * @param WP_Block $block      Block instance.
+	 * @return string Rendered block type output.
+	 */
+	protected function render( $attributes, $content, $block ) {
+		if ( ! empty( $content ) ) {
+			parent::register_block_type_assets();
+			$this->register_chunk_translations( [ $this->block_name ] );
+			return $content;
+		}
+
+		$post_id = $block->context['postId'];
+		$product = wc_get_product( $post_id );
+
+		if ( $product ) {
+			return sprintf(
+				'<div class="wc-block-components-product-rating wc-block-grid__product-rating">
+					SKU:
+					<strong>%s</strong>
+				</div>',
+				$product->get_sku()
+			);
+		}
 	}
 }


### PR DESCRIPTION
Adds Product Query support for the atomic SKU block.

On the client side, when the SKU Block is used within the Product Query block, the markup will be rendered on the server side - no javascript related to the SKU block will be loaded.

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #7332 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->


### Testing

1. Checkout this branch and run `npm start` (need to run the `start` command to catch the experimental flags).
1. Be sure that you have the latest version of the Gutenberg feature plugin installed and activated.
1. Add the `woocommerce/product-sku` block to the Product Query `INNER_BLOCKS_TEMPLATE` in `assets/js/blocks/product-query/constants.ts` under line 54 (**only for testing, remove afterwards**).
1. Create a post/page and add the Product Query block.
1. Save it.
1. Open the frontend side and confirm that:
    - No JS related to the Product SKU block is loaded (search in your network tab for `product-sku-frontend.js`).
    - The UI of the block is identical to on the editor side.
    - That the settings are reflected correctly (eg: custom style).
1. Back in the editor confirm that the Product SKU block can be added as a child of the Product query block via the inserter (inside **Product Query > Post Template** use **Insert Before/After** one of the existing children blocks).
1. For comparison, switch to trunk and add the All Products block to confirm that the aforementioned `product-sku-frontend.js` _is_ loaded.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental
