### PR TITLE
Product Query - Add To Cart block is visible in the inserter

### DIFF
--- a/assets/js/atomic/blocks/product-elements/button/index.js
+++ b/assets/js/atomic/blocks/product-elements/button/index.js
@@ -20,7 +20,6 @@ const blockConfig = {
 	apiVersion: 2,
 	title,
 	description,
-	parent: [ 'core/group' ],
 	ancestor: [
 		'@woocommerce/all-products',
 		'@woocommerce/single-product',

--- a/assets/js/atomic/blocks/product-elements/shared/config.tsx
+++ b/assets/js/atomic/blocks/product-elements/shared/config.tsx
@@ -28,7 +28,7 @@ const sharedConfig: Omit< BlockConfiguration, 'attributes' | 'title' > = {
 	supports: {
 		html: false,
 	},
-	ancestors: [ '@woocommerce/all-products', '@woocommerce/single-product' ],
+	ancestor: [ '@woocommerce/all-products', '@woocommerce/single-product' ],
 	save,
 	deprecated: [
 		{

--- a/assets/js/atomic/blocks/product-elements/shared/config.tsx
+++ b/assets/js/atomic/blocks/product-elements/shared/config.tsx
@@ -28,7 +28,7 @@ const sharedConfig: Omit< BlockConfiguration, 'attributes' | 'title' > = {
 	supports: {
 		html: false,
 	},
-	parent: [ '@woocommerce/all-products', '@woocommerce/single-product' ],
+	ancestors: [ '@woocommerce/all-products', '@woocommerce/single-product' ],
 	save,
 	deprecated: [
 		{


### PR DESCRIPTION
Before this PR, it was impossible to add the `Add To Cart` block as a child of the `Post Template` block via the inserter.


With this PR, I updated the shared configuration between all the atomic blocks. I converted the `parent` option to the `ancestors` option. In this way, the atomic blocks can be wrapped in `columns`, `rows` blocks.


#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Add the `Product Query` block in a post/page.
2. Be sure that it is possible to add the `Add To Cart` block as a child of `Post Template`.
3. Be sure that it isn't possible to add the `Add To Cart` block as the main block.


https://user-images.githubusercontent.com/4463174/195563799-593e4827-98d0-4b1c-9b4b-efb4bad53ad8.mp4


* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental
