### PR TITLE
Refactor useCheckoutAddress hook to enable "Use same address for billing" option in Editor

### DIFF
--- a/assets/js/base/context/hooks/use-checkout-address.ts
+++ b/assets/js/base/context/hooks/use-checkout-address.ts
@@ -90,8 +90,7 @@ export const useCheckoutAddress = (): CheckoutAddress => {
 		useShippingAsBilling,
 		setUseShippingAsBilling: __internalSetUseShippingAsBilling,
 		showShippingFields: ! forcedBillingAddress && needsShipping,
-		showBillingFields:
-			forcedBillingAddress || ! needsShipping || ! useShippingAsBilling,
+		showBillingFields: ! needsShipping || ! useShippingAsBilling,
 		forcedBillingAddress,
 	};
 };

--- a/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/frontend.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/frontend.tsx
@@ -38,9 +38,9 @@ const FrontendBlock = ( {
 		showCompanyField,
 		showPhoneField,
 	} = useCheckoutBlockContext();
-	const { showBillingFields } = useCheckoutAddress();
+	const { showBillingFields, forcedBillingAddress } = useCheckoutAddress();
 
-	if ( ! showBillingFields ) {
+	if ( ! showBillingFields && ! forcedBillingAddress ) {
 		return null;
 	}
 


### PR DESCRIPTION
With the changes introduced in #7268, the option `Use same address for billing` option in the Editor for Checkout block stopped working because of the [new condition added for showBillingFields](https://github.com/woocommerce/woocommerce-blocks/pull/7268/files#diff-7c87e5add79aa1f5a205aff4c27d637c57d2dfffea5f703cc1584884c904a73fR94) in useCheckoutAddress hook.


### Changes in the PR
1. Rolled back the previous condition for `showBillingFields` in the useCheckoutAddress hook. 
2. Edited the conditions to display the billing address form on frontend when `forcedBillingAddress` is true.



### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. Go to `wp-admin/admin.php?page=wc-settings&tab=shipping&section=options` page.
2. Enable the `Force shipping to the customer billing address` option and save the changes.
3. Go to Checkout block Editor, and confirm `Use same address for billing` toggle is working as expected.
4. Go to the Checkout block front-end, and confirm shipping address form is not visible.
5. Change the billing address, confirm the shipping address in the order summary gets changed, and shipping methods are updated. 


* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental



### Changelog

> Refactor useCheckoutAddress hook to enable "Use same address for billing" option in Editor
