### PR TITLE
Update HPOS compatibility snippet

### DIFF
--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -25,14 +25,14 @@ if ( ! defined( 'WC_BLOCKS_IS_FEATURE_PLUGIN' ) ) {
 }
 
 // Declare compatibility with custom order tables for WooCommerce.
-if ( class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) ) {
-	add_action(
-		'before_woocommerce_init',
-		function () {
+add_action(
+	'before_woocommerce_init',
+	function () {
+		if ( class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) ) {
 			\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
 		}
-	);
-}
+	}
+);
 
 /**
  * Whether notices must be displayed in the current page (plugins and WooCommerce pages).


### PR DESCRIPTION
Update the HPOS compatibility snippet based on this point: pcShBQ-oY-p2#comment-1031

### User Facing Tests
1. Refer to [High Performance Order Storage Upgrade Recipe Book](https://github.com/woocommerce/woocommerce/wiki/High-Performance-Order-Storage-Upgrade-Recipe-Book) on how to enable HPOS
2. Ensure no incompatibility warnings are displayed regarding the Blocks plugin

* [ ] Do not include in the Testing Notes

### Changelog

> Fixed a problem where Custom Order Tables compatibility declaration could fail due to the unpredictable plugin order load.