### PR TITLE
Improve the performance of checking payment methods

### DIFF
--- a/assets/js/data/cart/index.ts
+++ b/assets/js/data/cart/index.ts
@@ -1,11 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	dispatch as wpDataDispatch,
-	registerStore,
-	select as wpDataSelect,
-} from '@wordpress/data';
+import { registerStore } from '@wordpress/data';
 import { controls as dataControls } from '@wordpress/data-controls';
 
 /**
@@ -20,7 +16,7 @@ import { controls as sharedControls } from '../shared-controls';
 import { controls } from './controls';
 import type { SelectFromMap, DispatchFromMap } from '../mapped-types';
 import { pushChanges } from './push-changes';
-import { checkPaymentMethodsCanPay } from '../payment/check-payment-methods';
+import { updatePaymentMethods } from './update-payment-methods';
 
 const registeredStore = registerStore< State >( STORE_KEY, {
 	reducer,
@@ -32,29 +28,7 @@ const registeredStore = registerStore< State >( STORE_KEY, {
 } );
 
 registeredStore.subscribe( pushChanges );
-registeredStore.subscribe( async () => {
-	const isInitialized =
-		wpDataSelect( STORE_KEY ).hasFinishedResolution( 'getCartData' );
-
-	if ( ! isInitialized ) {
-		return;
-	}
-	await checkPaymentMethodsCanPay();
-	await checkPaymentMethodsCanPay( true );
-} );
-
-const unsubscribeInitializePaymentStore = registeredStore.subscribe(
-	async () => {
-		const cartLoaded =
-			wpDataSelect( STORE_KEY ).hasFinishedResolution( 'getCartTotals' );
-		if ( cartLoaded ) {
-			wpDataDispatch(
-				'wc/store/payment'
-			).__internalUpdateAvailablePaymentMethods();
-			unsubscribeInitializePaymentStore();
-		}
-	}
-);
+registeredStore.subscribe( updatePaymentMethods );
 
 export const CART_STORE_KEY = STORE_KEY;
 

--- a/assets/js/data/cart/update-payment-methods.ts
+++ b/assets/js/data/cart/update-payment-methods.ts
@@ -1,10 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	dispatch as wpDataDispatch,
-	select as wpDataSelect,
-} from '@wordpress/data';
+import { dispatch, select } from '@wordpress/data';
 import { debounce } from 'lodash';
 
 /**
@@ -15,13 +12,13 @@ import { STORE_KEY } from './constants';
 
 export const updatePaymentMethods = debounce( async () => {
 	const isInitialized =
-		wpDataSelect( STORE_KEY ).hasFinishedResolution( 'getCartData' );
+		select( STORE_KEY ).hasFinishedResolution( 'getCartData' );
 
 	if ( ! isInitialized ) {
 		return;
 	}
 
-	await wpDataDispatch(
+	await dispatch(
 		PAYMENT_STORE_KEY
 	).__internalUpdateAvailablePaymentMethods();
 }, 1000 );

--- a/assets/js/data/cart/update-payment-methods.ts
+++ b/assets/js/data/cart/update-payment-methods.ts
@@ -7,7 +7,7 @@ import { debounce } from 'lodash';
 /**
  * Internal dependencies
  */
-import { PAYMENT_STORE_KEY } from '../payment';
+import { STORE_KEY as PAYMENT_STORE_KEY } from '../payment/constants';
 import { STORE_KEY } from './constants';
 
 export const updatePaymentMethods = debounce( async () => {

--- a/assets/js/data/cart/update-payment-methods.ts
+++ b/assets/js/data/cart/update-payment-methods.ts
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+import {
+	dispatch as wpDataDispatch,
+	select as wpDataSelect,
+} from '@wordpress/data';
+import { debounce } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import { PAYMENT_STORE_KEY } from '../payment';
+import { STORE_KEY } from './constants';
+
+export const updatePaymentMethods = debounce( async () => {
+	const isInitialized =
+		wpDataSelect( STORE_KEY ).hasFinishedResolution( 'getCartData' );
+
+	if ( ! isInitialized ) {
+		return;
+	}
+
+	await wpDataDispatch(
+		PAYMENT_STORE_KEY
+	).__internalUpdateAvailablePaymentMethods();
+}, 1000 );

--- a/assets/js/data/payment/actions.ts
+++ b/assets/js/data/payment/actions.ts
@@ -164,10 +164,10 @@ export function __internalUpdateAvailablePaymentMethods() {
 		const registered = await checkPaymentMethodsCanPay( false );
 		const { paymentMethodsInitialized, expressPaymentMethodsInitialized } =
 			select;
-		if ( registered && paymentMethodsInitialized ) {
+		if ( registered && ! paymentMethodsInitialized() ) {
 			dispatch( __internalSetPaymentMethodsInitialized( true ) );
 		}
-		if ( expressRegistered && expressPaymentMethodsInitialized ) {
+		if ( expressRegistered && ! expressPaymentMethodsInitialized() ) {
 			dispatch( __internalSetExpressPaymentMethodsInitialized( true ) );
 		}
 	};


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR aims to improve performance of the C & C blocks by reducing the number of times we check that each payment method can pay. After the data store migration, we call `checkPaymentMethodsCanPay` for each change to the cart store. This is a function that does a lot of heavy processing (calls the `canPay` method for each payment method registered on the store). It was being run 4 times for standard payment methods, and 4 for express payment methods just on loading the cart page. 

I've done 2 things here:

1. I've debounced the function that runs on each cart store change, similar to the [pushChanges](https://github.com/woocommerce/woocommerce-blocks/blob/fix/too-many-calls-too-check-payment-methods-can-pay/assets/js/data/cart/push-changes.ts#L127) function.
2. I've refactored and renamed the `__internalInitializePaymentStore` function to `__internalUpdateAvailablePaymentMethods` to better reflect what it's doing. It now checks if the payment methods have been initialised and only calls the action to initialize them if they haven't. This allows us to call this function from a `.subscribe()` function without worrying that the `__internalSetPaymentMethodsInitialized` and `__internalSetExpressPaymentMethodsInitialized` will be called multiple times.

<!-- Reference any related issues or PRs here -->

Fixes #7031

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. @opr You know what to do. Try and break it :)

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

This should speed things up slightly on the front-end
