### PR TITLE
Fix wrong keys being sent in `canMakePayment` and customer data showing in the Checkout block in the editor

### DIFF
--- a/assets/js/base/context/providers/cart-checkout/checkout-events/index.tsx
+++ b/assets/js/base/context/providers/cart-checkout/checkout-events/index.tsx
@@ -88,7 +88,7 @@ export const CheckoutEventsProvider = ( {
 		if ( ! isEditor && Object.keys( paymentMethods ).length === 0 ) {
 			return;
 		}
-		__internalInitializePaymentStore();
+		__internalUpdateAvailablePaymentMethods();
 	}, [ isEditor, paymentMethods, __internalInitializePaymentStore ] );
 
 	const checkoutActions = useDispatch( CHECKOUT_STORE_KEY );

--- a/assets/js/base/context/providers/cart-checkout/checkout-events/index.tsx
+++ b/assets/js/base/context/providers/cart-checkout/checkout-events/index.tsx
@@ -79,13 +79,13 @@ export const CheckoutEventsProvider = ( {
 	const paymentMethods = getPaymentMethods();
 
 	// Go into useState as once this is set it won't change.
-	const isEditor = useState( !! wpDataSelect( 'core/editor' ) );
+	const [ isEditor ] = useState( !! wpDataSelect( 'core/editor' ) );
 
 	const { __internalInitializePaymentStore } =
 		useDispatch( PAYMENT_STORE_KEY );
 
 	useEffect( () => {
-		if ( Object.keys( paymentMethods ).length === 0 && ! isEditor ) {
+		if ( ! isEditor && Object.keys( paymentMethods ).length === 0 ) {
 			return;
 		}
 		__internalInitializePaymentStore();

--- a/assets/js/base/context/providers/cart-checkout/checkout-events/index.tsx
+++ b/assets/js/base/context/providers/cart-checkout/checkout-events/index.tsx
@@ -10,15 +10,10 @@ import {
 	useMemo,
 	useEffect,
 	useCallback,
-	useState,
 } from '@wordpress/element';
 import { usePrevious } from '@woocommerce/base-hooks';
 import deprecated from '@wordpress/deprecated';
-import {
-	select as wpDataSelect,
-	useDispatch,
-	useSelect,
-} from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	CHECKOUT_STORE_KEY,
 	PAYMENT_STORE_KEY,
@@ -38,6 +33,7 @@ import {
 	getExpressPaymentMethods,
 	getPaymentMethods,
 } from '../../../../../blocks-registry/payment-methods/registry';
+import { useEditorContext } from '../../editor-context';
 
 type CheckoutEventsContextType = {
 	// Submits the checkout and begins processing.
@@ -81,9 +77,7 @@ export const CheckoutEventsProvider = ( {
 } ): JSX.Element => {
 	const paymentMethods = getPaymentMethods();
 	const expressPaymentMethods = getExpressPaymentMethods();
-
-	// Go into useState as once this is set it won't change.
-	const [ isEditor ] = useState( !! wpDataSelect( 'core/editor' ) );
+	const { isEditor } = useEditorContext();
 
 	const { __internalUpdateAvailablePaymentMethods } =
 		useDispatch( PAYMENT_STORE_KEY );

--- a/assets/js/blocks/cart-checkout-shared/payment-methods/test/payment-methods.js
+++ b/assets/js/blocks/cart-checkout-shared/payment-methods/test/payment-methods.js
@@ -81,7 +81,7 @@ const registerMockPaymentMethods = () => {
 			ariaLabel: name,
 		} );
 	} );
-	dispatch( PAYMENT_STORE_KEY ).__internalInitializePaymentStore();
+	dispatch( PAYMENT_STORE_KEY ).__internalUpdateAvailablePaymentMethods();
 };
 
 const resetMockPaymentMethods = () => {

--- a/assets/js/data/cart/index.ts
+++ b/assets/js/data/cart/index.ts
@@ -50,7 +50,7 @@ const unsubscribeInitializePaymentStore = registeredStore.subscribe(
 		if ( cartLoaded ) {
 			wpDataDispatch(
 				'wc/store/payment'
-			).__internalInitializePaymentStore();
+			).__internalUpdateAvailablePaymentMethods();
 			unsubscribeInitializePaymentStore();
 		}
 	}

--- a/assets/js/data/checkout/index.ts
+++ b/assets/js/data/checkout/index.ts
@@ -1,13 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	createReduxStore,
-	register,
-	subscribe,
-	select as wpDataSelect,
-	dispatch as wpDataDispatch,
-} from '@wordpress/data';
+import { createReduxStore, register } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -17,7 +11,6 @@ import * as selectors from './selectors';
 import * as actions from './actions';
 import reducer from './reducers';
 import { DispatchFromMap, SelectFromMap } from '../mapped-types';
-import { checkPaymentMethodsCanPay } from '../payment/check-payment-methods';
 
 export const config = {
 	reducer,
@@ -31,22 +24,6 @@ export const config = {
 
 const store = createReduxStore( STORE_KEY, config );
 register( store );
-
-const isEditor = !! wpDataSelect( 'core/editor' );
-
-// This is needed to ensure that the payment methods are displayed in the editor
-if ( isEditor ) {
-	const unsubscribeEditor = subscribe( async () => {
-		await checkPaymentMethodsCanPay();
-		await checkPaymentMethodsCanPay( true );
-	} );
-
-	const unsubscribeInitializePaymentStore = subscribe( async () => {
-		wpDataDispatch( 'wc/store/payment' ).__internalInitializePaymentStore();
-		unsubscribeEditor();
-		unsubscribeInitializePaymentStore();
-	} );
-}
 
 export const CHECKOUT_STORE_KEY = STORE_KEY;
 declare module '@wordpress/data' {

--- a/assets/js/data/payment/actions.ts
+++ b/assets/js/data/payment/actions.ts
@@ -158,13 +158,17 @@ export const __internalRemoveAvailableExpressPaymentMethod = (
 /**
  * The store is initialised once we have checked whether the payment methods registered can pay or not
  */
-export function __internalInitializePaymentStore() {
-	return async ( { dispatch } ) => {
+export function __internalUpdateAvailablePaymentMethods() {
+	return async ( { select, dispatch } ) => {
 		const expressRegistered = await checkPaymentMethodsCanPay( true );
 		const registered = await checkPaymentMethodsCanPay( false );
-		if ( registered && expressRegistered ) {
-			dispatch( __internalSetExpressPaymentMethodsInitialized( true ) );
+		const { paymentMethodsInitialized, expressPaymentMethodsInitialized } =
+			select;
+		if ( registered && paymentMethodsInitialized ) {
 			dispatch( __internalSetPaymentMethodsInitialized( true ) );
+		}
+		if ( expressRegistered && expressPaymentMethodsInitialized ) {
+			dispatch( __internalSetExpressPaymentMethodsInitialized( true ) );
 		}
 	};
 }

--- a/assets/js/data/payment/check-payment-methods.ts
+++ b/assets/js/data/payment/check-payment-methods.ts
@@ -7,7 +7,10 @@ import {
 } from '@woocommerce/type-defs/payments';
 import { CURRENT_USER_IS_ADMIN, getSetting } from '@woocommerce/settings';
 import { dispatch, select } from '@wordpress/data';
-import { deriveSelectedShippingRates } from '@woocommerce/base-utils';
+import {
+	deriveSelectedShippingRates,
+	emptyHiddenAddressFields,
+} from '@woocommerce/base-utils';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 
@@ -15,6 +18,7 @@ import {
 	getExpressPaymentMethods,
 	getPaymentMethods,
 } from '@woocommerce/blocks-registry';
+import { previewCart } from '@woocommerce/resource-previews';
 
 /**
  * Internal dependencies
@@ -22,6 +26,15 @@ import {
 import { STORE_KEY as CART_STORE_KEY } from '../cart/constants';
 import { STORE_KEY as PAYMENT_STORE_KEY } from './constants';
 import { noticeContexts } from '../../base/context/event-emit';
+import {
+	EMPTY_CART_ERRORS,
+	EMPTY_CART_ITEM_ERRORS,
+	EMPTY_EXTENSIONS,
+} from '../../data/constants';
+import {
+	defaultBillingAddress,
+	defaultShippingAddress,
+} from '../../base/context/providers/cart-checkout/customer/constants';
 
 export const checkPaymentMethodsCanPay = async ( express = false ) => {
 	const isEditor = !! select( 'core/editor' );
@@ -46,19 +59,93 @@ export const checkPaymentMethodsCanPay = async ( express = false ) => {
 	const noticeContext = express
 		? noticeContexts.EXPRESS_PAYMENTS
 		: noticeContexts.PAYMENTS;
-	const cart = select( CART_STORE_KEY ).getCartData();
-	const selectedShippingMethods = deriveSelectedShippingRates(
-		cart.shippingRates
-	);
-	const canPayArgument = {
-		cart,
-		cartTotals: cart.totals,
-		cartNeedsShipping: cart.needsShipping,
-		billingData: cart.billingAddress,
-		shippingAddress: cart.shippingAddress,
-		selectedShippingMethods,
-		paymentRequirements: cart.paymentRequirements,
-	};
+
+	let cartForCanPayArgument: Record< string, unknown > = {};
+	let canPayArgument: Record< string, unknown > = {};
+
+	if ( ! isEditor ) {
+		const store = select( CART_STORE_KEY );
+		const cart = store.getCartData();
+		const cartErrors = store.getCartErrors();
+		const cartTotals = store.getCartTotals();
+		const cartIsLoading = ! store.hasFinishedResolution( 'getCartData' );
+		const isLoadingRates = store.isCustomerDataUpdating();
+		const selectedShippingMethods = deriveSelectedShippingRates(
+			cart.shippingRates
+		);
+
+		cartForCanPayArgument = {
+			cartCoupons: cart.coupons,
+			cartItems: cart.items,
+			crossSellsProducts: cart.crossSells,
+			cartFees: cart.fees,
+			cartItemsCount: cart.itemsCount,
+			cartItemsWeight: cart.itemsWeight,
+			cartNeedsPayment: cart.needsPayment,
+			cartNeedsShipping: cart.needsShipping,
+			cartItemErrors: cart.errors,
+			cartTotals,
+			cartIsLoading,
+			cartErrors,
+			billingData: emptyHiddenAddressFields( cart.billingAddress ),
+			billingAddress: emptyHiddenAddressFields( cart.billingAddress ),
+			shippingAddress: emptyHiddenAddressFields( cart.shippingAddress ),
+			extensions: cart.extensions,
+			shippingRates: cart.shippingRates,
+			isLoadingRates,
+			cartHasCalculatedShipping: cart.hasCalculatedShipping,
+			paymentRequirements: cart.paymentRequirements,
+			receiveCart: dispatch( CART_STORE_KEY ).receiveCart,
+		};
+
+		canPayArgument = {
+			cart: cartForCanPayArgument,
+			cartTotals: cart.totals,
+			cartNeedsShipping: cart.needsShipping,
+			billingData: cart.billingAddress,
+			shippingAddress: cart.shippingAddress,
+			selectedShippingMethods,
+			paymentRequirements: cart.paymentRequirements,
+		};
+	} else {
+		cartForCanPayArgument = {
+			cartCoupons: previewCart.coupons,
+			cartItems: previewCart.items,
+			crossSellsProducts: previewCart.cross_sells,
+			cartFees: previewCart.fees,
+			cartItemsCount: previewCart.items_count,
+			cartItemsWeight: previewCart.items_weight,
+			cartNeedsPayment: previewCart.needs_payment,
+			cartNeedsShipping: previewCart.needs_shipping,
+			cartItemErrors: EMPTY_CART_ITEM_ERRORS,
+			cartTotals: previewCart.totals,
+			cartIsLoading: false,
+			cartErrors: EMPTY_CART_ERRORS,
+			billingData: defaultBillingAddress,
+			billingAddress: defaultBillingAddress,
+			shippingAddress: defaultShippingAddress,
+			extensions: EMPTY_EXTENSIONS,
+			shippingRates: previewCart.shipping_rates,
+			isLoadingRates: false,
+			cartHasCalculatedShipping: previewCart.has_calculated_shipping,
+			paymentRequirements: previewCart.paymentRequirements,
+			receiveCart:
+				typeof previewCart?.receiveCart === 'function'
+					? previewCart.receiveCart
+					: () => undefined,
+		};
+		canPayArgument = {
+			cart: cartForCanPayArgument,
+			cartTotals: cartForCanPayArgument.totals,
+			cartNeedsShipping: cartForCanPayArgument.needsShipping,
+			billingData: cartForCanPayArgument.billingAddress,
+			shippingAddress: cartForCanPayArgument.shippingAddress,
+			selectedShippingMethods: deriveSelectedShippingRates(
+				cartForCanPayArgument.shippingRates
+			),
+			paymentRequirements: cartForCanPayArgument.paymentRequirements,
+		};
+	}
 
 	let paymentMethodsOrder;
 	if ( express ) {

--- a/assets/js/data/payment/check-payment-methods.ts
+++ b/assets/js/data/payment/check-payment-methods.ts
@@ -103,6 +103,7 @@ export const checkPaymentMethodsCanPay = async ( express = false ) => {
 			cartTotals: cart.totals,
 			cartNeedsShipping: cart.needsShipping,
 			billingData: cart.billingAddress,
+			billingAddress: cart.billingAddress,
 			shippingAddress: cart.shippingAddress,
 			selectedShippingMethods,
 			paymentRequirements: cart.paymentRequirements,
@@ -139,6 +140,7 @@ export const checkPaymentMethodsCanPay = async ( express = false ) => {
 			cartTotals: cartForCanPayArgument.totals,
 			cartNeedsShipping: cartForCanPayArgument.needsShipping,
 			billingData: cartForCanPayArgument.billingAddress,
+			billingAddress: cartForCanPayArgument.billingAddress,
 			shippingAddress: cartForCanPayArgument.shippingAddress,
 			selectedShippingMethods: deriveSelectedShippingRates(
 				cartForCanPayArgument.shippingRates

--- a/assets/js/data/payment/test/selectors.js
+++ b/assets/js/data/payment/test/selectors.js
@@ -133,7 +133,7 @@ const registerMockPaymentMethods = ( savedCards = true ) => {
 	} );
 	wpDataFunctions
 		.dispatch( PAYMENT_STORE_KEY )
-		.__internalInitializePaymentStore();
+		.__internalUpdateAvailablePaymentMethods();
 };
 
 const resetMockPaymentMethods = () => {

--- a/assets/js/data/payment/test/selectors.js
+++ b/assets/js/data/payment/test/selectors.js
@@ -24,7 +24,6 @@ import {
 	CheckoutExpressPayment,
 	SavedPaymentMethodOptions,
 } from '../../../blocks/cart-checkout-shared/payment-methods';
-import { checkPaymentMethodsCanPay } from '../check-payment-methods';
 import { defaultCartState } from '../../cart/default-state';
 
 const originalSelect = jest.requireActual( '@wordpress/data' ).select;
@@ -132,8 +131,9 @@ const registerMockPaymentMethods = ( savedCards = true ) => {
 			},
 		} );
 	} );
-	checkPaymentMethodsCanPay();
-	checkPaymentMethodsCanPay( true );
+	wpDataFunctions
+		.dispatch( PAYMENT_STORE_KEY )
+		.__internalInitializePaymentStore();
 };
 
 const resetMockPaymentMethods = () => {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
Previously we used `useStoreCart` to get the cart which was sent in the arguments to `canMakePayment`, a method used by payment methods to determine whether they are suitable to process the current cart.

When converting to using data stores, we missed the slight difference in key names, so any payment methods relying on these would have broken. 

The reason we cannot use `useStoreCart` now is because this is a hook, and since the data stores exist outside of React, hooks cannot be used.

This PR copies the code from `useStoreCart` to ensure the cart is formatted correctly in the editor and front-end contexts.

This change caused the editor to stop displaying the payment methods. This was because previously we were calling `getCartData` and when that resolved, the cart in the data store was updated. This caused the payment methods to refresh, so it was only really working by fluke. To ensure the payment method data store is re-initialised when payment methods update, I have added a call to `__internalUpdateAvailablePaymentMethods` in the `CheckoutEventsContext` - this is a context that is mounted on both Cart and Checkout pages, and given the name,  a place for checkout events seems like a logical place to put code that happens when changing the `paymentMethods` object. Happy to take suggestions on other places though.

I also changed the name of the selector to initialize the payment store, this is an idea @alexflorisca had in #7413 which makes it easier to reason with the process of setting up the stores.

I am marking this as `type: blocker` as it is very important that this goes into the next release.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [x] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Ensure you can check out using Stripe. Please also try various other payment gateways.
2. If you can, please check out with an express payment method.
3. Open the Checkout block in the editor. Ensure your customer details are not there.
4. Upload this extension [extension-for-testing.zip](https://github.com/woocommerce/woocommerce-blocks/files/9828874/extension-for-testing.zip) to your site and activate it. Ensure you see a payment method called `some-extension-name payment method` on your checkout. (see the notes below for explanation of this testing step!)

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### 📔 Note
The extension used in step 4 of the testing registers a payment method and contains the following code in the `canMakePayment` argument:

```js
canMakePayment: (args) => {
			const requiredKeys = [
				'billingData',
				'billingAddress',
				'cart',
				'cartNeedsShipping',
				'cartTotals',
				'paymentRequirements',
				'selectedShippingMethods',
				'shippingAddress',
			];
			const argKeys = Object.keys(args);

			const requiredCartKeys = [
				'cartCoupons',
				'cartItems',
				'crossSellsProducts',
				'cartFees',
				'cartItemsCount',
				'cartItemsWeight',
				'cartNeedsPayment',
				'cartNeedsShipping',
				'cartItemErrors',
				'cartTotals',
				'cartIsLoading',
				'cartErrors',
				'billingData',
				'billingAddress',
				'shippingAddress',
				'extensions',
				'shippingRates',
				'isLoadingRates',
				'cartHasCalculatedShipping',
				'paymentRequirements',
				'receiveCart',
			];
			const cartKeys = Object.keys(args.cart);
			const requiredTotalsKeys = [
				'total_items',
				'total_items_tax',
				'total_fees',
				'total_fees_tax',
				'total_discount',
				'total_discount_tax',
				'total_shipping',
				'total_shipping_tax',
				'total_price',
				'total_tax',
				'tax_lines',
				'currency_code',
				'currency_symbol',
				'currency_minor_unit',
				'currency_decimal_separator',
				'currency_thousand_separator',
				'currency_prefix',
				'currency_suffix',
			];
			const totalsKeys = Object.keys(args.cartTotals);
			return (
				requiredKeys.every((key) => argKeys.includes(key)) &&
				requiredTotalsKeys.every((key) => totalsKeys.includes(key)) &&
				requiredCartKeys.every((key) => cartKeys.includes(key))
			);
		},
```

The test here is that all of the expected keys are on the argument passed to `canMakePayment`. Testing this on release 8.6.0 should still have this method show up, but it will not show on 8.7.0 where this bug is present.

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fixed an issue where the argument passed to `canMakePayment` contained the incorrect keys. Also fixed the current user's customer data appearing in the editor when editing the Checkout block.
