### PR TITLE
Fix performance issue with the sidebar notices

### DIFF
--- a/assets/js/blocks/cart-checkout-shared/sidebar-notices/index.tsx
+++ b/assets/js/blocks/cart-checkout-shared/sidebar-notices/index.tsx
@@ -30,6 +30,13 @@ declare module '@wordpress/block-editor' {
 
 const withSidebarNotices = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
+		const { name: blockName, isSelected: isBlockSelected } = props;
+
+		// Show sidebar notices only when a WooCommerce block is selected.
+		if ( ! blockName.startsWith( 'woocommerce/' ) || ! isBlockSelected ) {
+			return <BlockEdit { ...props } />;
+		}
+
 		const addressFieldOrAccountBlocks = [
 			'woocommerce/checkout-shipping-address-block',
 			'woocommerce/checkout-billing-address-block',


### PR DESCRIPTION
Every time the `editor.BlockEdit` hook is fired, we run the `withSidebarNotices` HOC. The issue is that this hook is triggered on page editor scroll, hovering over blocks, loading block previews, and so on, which might create substantial performance issues.

To fix this, we want the `withSidebarNotices` HOC to run only when a Woo Block is selected!

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes p1664536525271509-slack-C02UBB1EPEF

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

I didn't notice any performance issues while testing with the available blocks. To test this, we can simply use a `console.log` to check when and how many times our function is called:

1. Add a `console.log` in [this line](https://github.com/woocommerce/woocommerce-blocks/blob/700b9c44471ecacd9a22bf360b04869ef403e644/assets/js/blocks/cart-checkout-shared/sidebar-notices/index.tsx#L39).
2. Create a new page and open the Chrome dev tools (console).
3. Open the `Block Inserter`, and hover over some blocks. A preview of the blocks should be displayed.
4. Check that your `console.log` message doesn't show in dev tools.
5. Add the Cart or Checkout blocks.
6. Select any block or inner block. Your message should only be displayed once on the console.
7. Open the inspector. You should see that all of the sidebar notices are displayed.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Fix performance issue with the sidebar notices