### PR TITLE
Prevent `useForcedLayout` breaking in WP 6.1

### DIFF
--- a/assets/js/blocks/cart-checkout-shared/use-forced-layout.ts
+++ b/assets/js/blocks/cart-checkout-shared/use-forced-layout.ts
@@ -6,7 +6,6 @@ import {
 	useRef,
 	useCallback,
 	useMemo,
-	useState,
 } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
@@ -42,8 +41,6 @@ export const useForcedLayout = ( {
 } ): void => {
 	const currentRegisteredBlocks = useRef( registeredBlocks );
 	const currentDefaultTemplate = useRef( defaultTemplate );
-	const [ forcedBlocksInserted, setForcedBlocksInserted ] =
-		useState< number >( 0 );
 
 	const { insertBlock, replaceInnerBlocks } =
 		useDispatch( 'core/block-editor' );
@@ -58,18 +55,17 @@ export const useForcedLayout = ( {
 				),
 			};
 		},
-		[ clientId, currentRegisteredBlocks.current, forcedBlocksInserted ]
+		[ clientId, currentRegisteredBlocks.current ]
 	);
 
 	const appendBlock = useCallback(
 		( block, position ) => {
 			const newBlock = createBlock( block.name );
 			insertBlock( newBlock, position, clientId, false );
-			setForcedBlocksInserted( forcedBlocksInserted + 1 );
 		},
 		// We need to skip insertBlock here due to a cache issue in wordpress.com that causes an inifinite loop, see https://github.com/Automattic/wp-calypso/issues/66092 for an expanded doc.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-		[ clientId, forcedBlocksInserted ]
+		[ clientId ]
 	);
 
 	const lockedBlockTypes = useMemo(


### PR DESCRIPTION
This reverts commit 1564de216dadf8dd7d7ef7eba70dd10ba1e0fc91.

In WordPress 6.1 we noticed an issue where any extension adding inner blocks to the Cart or Checkout block will cause the parent block to break.

We think there is a race condition introduced by [this change in Gutenberg](https://github.com/WordPress/gutenberg/pull/43958) which causes  our function `useForcedLayout` to run continually. 

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes https://github.com/woocommerce/woocommerce/issues/35249

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/5656702/197206701-3e904809-0980-44ec-9d04-dca9620822a9.png) | <img width="803" alt="image" src="https://user-images.githubusercontent.com/5656702/197206908-f6abc34b-a8a7-4600-bf3b-9eae6b4083c0.png"> |
| <img width="527" alt="image" src="https://user-images.githubusercontent.com/5656702/197208720-1a0e75a8-4aad-4643-a2cb-dde0fa2ab2ef.png"> | <img width="525" alt="image" src="https://user-images.githubusercontent.com/5656702/197207536-3cf231d9-092e-4eb3-a318-175207b1438f.png"> |


### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Install latest Gutenberg plugin or WordPress 6.1.
2. Install WooCommerce Gift Cards, or grab this plugin: [extension-for-testing.zip](https://github.com/woocommerce/woocommerce-blocks/files/9839394/extension-for-testing.1.zip)
3. Add a new page. Add the Checkout block. Ensure the `Contact information` section loads, and ensure you do not see any errors where blocks should appear, both on the editor and the published checkout page.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Compatibility fix for Cart and Checkout inner blocks for WordPress 6.1.
