### PR TITLE
Update Express Payment Block text

### DIFF
--- a/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment/checkout-express-payment.js
+++ b/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment/checkout-express-payment.js
@@ -103,12 +103,6 @@ const CheckoutExpressPayment = () => {
 						<StoreNoticesContainer
 							context={ noticeContexts.EXPRESS_PAYMENTS }
 						/>
-						<p>
-							{ __(
-								'In a hurry? Use one of our express checkout options:',
-								'woo-gutenberg-products-block'
-							) }
-						</p>
 						<ExpressPaymentMethods />
 					</div>
 				</div>

--- a/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment/style.scss
+++ b/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment/style.scss
@@ -75,7 +75,7 @@ $border-radius: 5px;
 
 	.wc-block-components-express-payment__content {
 		@include with-translucent-border(0 $border-width $border-width);
-		padding: em($gap-large) #{$gap-large - $border-width};
+		padding: #{$gap-large - $border-radius} $gap-large $gap-large;
 
 		&::after {
 			border-radius: 0 0 $border-radius $border-radius;
@@ -92,17 +92,18 @@ $border-radius: 5px;
 			width: 50%;
 		}
 
-		> li:only-child {
-			display: block;
-			width: 100%;
-		}
-
 		> li:nth-child(even) {
 			padding-left: $gap-smaller;
 		}
 
 		> li:nth-child(odd) {
 			padding-right: $gap-smaller;
+		}
+
+		> li:only-child {
+			display: block;
+			width: 100%;
+			padding: 0;
 		}
 	}
 }


### PR DESCRIPTION
Removes the unnecessary "In a hurry" text from the express payment block, and fixes button spacing so the button is centred vertically.

Fixes #7314

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|![Screenshot 2022-10-24 at 16 07 27](https://user-images.githubusercontent.com/90977/197563608-2387bade-debf-4624-909b-bd2ccf986a46.png)|![Screenshot 2022-10-24 at 16 20 05](https://user-images.githubusercontent.com/90977/197563620-975b7eb1-cef0-4c7b-b715-c0d8832d7968.png)|

### Testing

#### User Facing Testing

1. Install the "WooCommerce Stripe" extension
2. Go to the checkout page in chrome.
3. When express payments load, check that the "google pay" button is centered and the "in a hurry" text is no longer shown.

### Changelog

> Improve the appearance of the Express Payment Block.
