### PR TITLE
Add tests to ensure argument passed to `canMakePayment` is correct

### DIFF
--- a/assets/js/data/payment/test/check-payment-methods.tsx
+++ b/assets/js/data/payment/test/check-payment-methods.tsx
@@ -1,0 +1,159 @@
+/**
+ * External dependencies
+ */
+import * as wpDataFunctions from '@wordpress/data';
+import { PAYMENT_STORE_KEY } from '@woocommerce/block-data';
+import {
+	registerPaymentMethod,
+	registerExpressPaymentMethod,
+	__experimentalDeRegisterPaymentMethod,
+	__experimentalDeRegisterExpressPaymentMethod,
+} from '@woocommerce/blocks-registry';
+
+/**
+ * Internal dependencies
+ */
+import { checkPaymentMethodsCanPay } from '../check-payment-methods';
+
+const requiredKeyCheck = ( args ) => {
+	const requiredKeys = [
+		'billingData',
+		'billingAddress',
+		'cart',
+		'cartNeedsShipping',
+		'cartTotals',
+		'paymentRequirements',
+		'selectedShippingMethods',
+		'shippingAddress',
+	];
+	const argKeys = Object.keys( args );
+
+	const requiredCartKeys = [
+		'cartCoupons',
+		'cartItems',
+		'crossSellsProducts',
+		'cartFees',
+		'cartItemsCount',
+		'cartItemsWeight',
+		'cartNeedsPayment',
+		'cartNeedsShipping',
+		'cartItemErrors',
+		'cartTotals',
+		'cartIsLoading',
+		'cartErrors',
+		'billingData',
+		'billingAddress',
+		'shippingAddress',
+		'extensions',
+		'shippingRates',
+		'isLoadingRates',
+		'cartHasCalculatedShipping',
+		'paymentRequirements',
+		'receiveCart',
+	];
+	const cartKeys = Object.keys( args.cart );
+	const requiredTotalsKeys = [
+		'total_items',
+		'total_items_tax',
+		'total_fees',
+		'total_fees_tax',
+		'total_discount',
+		'total_discount_tax',
+		'total_shipping',
+		'total_shipping_tax',
+		'total_price',
+		'total_tax',
+		'tax_lines',
+		'currency_code',
+		'currency_symbol',
+		'currency_minor_unit',
+		'currency_decimal_separator',
+		'currency_thousand_separator',
+		'currency_prefix',
+		'currency_suffix',
+	];
+	const totalsKeys = Object.keys( args.cartTotals );
+	return (
+		requiredKeys.every( ( key ) => argKeys.includes( key ) ) &&
+		requiredTotalsKeys.every( ( key ) => totalsKeys.includes( key ) ) &&
+		requiredCartKeys.every( ( key ) => cartKeys.includes( key ) )
+	);
+};
+
+const mockedCanMakePayment = jest.fn().mockImplementation( requiredKeyCheck );
+const mockedExpressCanMakePayment = jest
+	.fn()
+	.mockImplementation( requiredKeyCheck );
+
+const registerMockPaymentMethods = ( savedCards = true ) => {
+	[ 'credit-card' ].forEach( ( name ) => {
+		registerPaymentMethod( {
+			name,
+			label: name,
+			content: <div>A payment method</div>,
+			edit: <div>A payment method</div>,
+			icons: null,
+			canMakePayment: mockedCanMakePayment,
+			supports: {
+				showSavedCards: savedCards,
+				showSaveOption: true,
+				features: [ 'products' ],
+			},
+			ariaLabel: name,
+		} );
+	} );
+	[ 'express-payment' ].forEach( ( name ) => {
+		const Content = ( {
+			onClose = () => void null,
+			onClick = () => void null,
+		} ) => {
+			return (
+				<>
+					<button onClick={ onClick }>
+						{ name + ' express payment method' }
+					</button>
+					<button onClick={ onClose }>
+						{ name + ' express payment method close' }
+					</button>
+				</>
+			);
+		};
+		registerExpressPaymentMethod( {
+			name,
+			content: <Content />,
+			edit: <div>An express payment method</div>,
+			canMakePayment: mockedExpressCanMakePayment,
+			paymentMethodId: name,
+			supports: {
+				features: [ 'products' ],
+			},
+		} );
+	} );
+	wpDataFunctions
+		.dispatch( PAYMENT_STORE_KEY )
+		.__internalUpdateAvailablePaymentMethods();
+};
+
+const resetMockPaymentMethods = () => {
+	[ 'cheque', 'bacs', 'credit-card' ].forEach( ( name ) => {
+		__experimentalDeRegisterPaymentMethod( name );
+	} );
+	[ 'express-payment' ].forEach( ( name ) => {
+		__experimentalDeRegisterExpressPaymentMethod( name );
+	} );
+};
+
+describe( 'checkPaymentMethods', () => {
+	beforeEach( registerMockPaymentMethods );
+	afterEach( resetMockPaymentMethods );
+
+	it( `Sends correct arguments to regular payment methods' canMakePayment functions`, async () => {
+		await checkPaymentMethodsCanPay();
+		expect( mockedCanMakePayment ).toHaveReturnedWith( true );
+	} );
+
+	it( `Sends correct arguments to express payment methods' canMakePayment functions`, async () => {
+		await checkPaymentMethodsCanPay( true );
+		expect( mockedExpressCanMakePayment ).toHaveReturnedWith( true );
+	} );
+} );

--- a/assets/js/data/payment/test/check-payment-methods.tsx
+++ b/assets/js/data/payment/test/check-payment-methods.tsx
@@ -9,13 +9,14 @@ import {
 	__experimentalDeRegisterPaymentMethod,
 	__experimentalDeRegisterExpressPaymentMethod,
 } from '@woocommerce/blocks-registry';
+import { CanMakePaymentArgument } from '@woocommerce/type-defs/payments';
 
 /**
  * Internal dependencies
  */
-import { checkPaymentMethodsCanPay } from '../check-payment-methods';
+import { checkPaymentMethodsCanPay } from '../utils/check-payment-methods';
 
-const requiredKeyCheck = ( args ) => {
+const requiredKeyCheck = ( args: CanMakePaymentArgument ) => {
 	const requiredKeys = [
 		'billingData',
 		'billingAddress',

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -3847,6 +3847,9 @@
 <error line="106" column="11" severity="error" message="Expected 4-6 arguments, but got 3." source="TS2554" />
 <error line="112" column="25" severity="error" message="Argument of type &apos;{ &apos;wc/blocks&apos;: { products: { &apos;[]&apos;: { &apos;?someQuery=2&apos;: { items: string[]; headers: { get: (key: any) =&gt; any; has: (key: any) =&gt; boolean; }; }; }; }; &apos;products/attributes&apos;: { &apos;[10]&apos;: { &apos;?someQuery=2&apos;: { items: string[]; headers: { get: (key: any) =&gt; any; has: (key: any) =&gt; boolean; }; }; }; }; &apos;products/attributes/term...&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2345" />
 </file>
+<file name="assets/js/data/payment/test/check-payment-methods.tsx">
+<error line="18" column="28" severity="error" message="Parameter &apos;args&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+</file>
 <file name="assets/js/data/payment/test/reducers.js">
 <error line="4" column="24" severity="error" message="Could not find a declaration file for module &apos;deep-freeze&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/deep-freeze/index.js&apos; implicitly has an &apos;any&apos; type.
   Try `npm i --save-dev @types/deep-freeze` if it exists or add a new declaration (.d.ts) file containing `declare module &apos;deep-freeze&apos;;`" source="TS7016" />

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -3847,10 +3847,6 @@
 <error line="106" column="11" severity="error" message="Expected 4-6 arguments, but got 3." source="TS2554" />
 <error line="112" column="25" severity="error" message="Argument of type &apos;{ &apos;wc/blocks&apos;: { products: { &apos;[]&apos;: { &apos;?someQuery=2&apos;: { items: string[]; headers: { get: (key: any) =&gt; any; has: (key: any) =&gt; boolean; }; }; }; }; &apos;products/attributes&apos;: { &apos;[10]&apos;: { &apos;?someQuery=2&apos;: { items: string[]; headers: { get: (key: any) =&gt; any; has: (key: any) =&gt; boolean; }; }; }; }; &apos;products/attributes/term...&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2345" />
 </file>
-<file name="assets/js/data/payment/test/check-payment-methods.tsx">
-<error line="16" column="43" severity="error" message="Cannot find module &apos;../check-payment-methods&apos; or its corresponding type declarations." source="TS2307" />
-<error line="18" column="28" severity="error" message="Parameter &apos;args&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-</file>
 <file name="assets/js/data/payment/test/reducers.js">
 <error line="4" column="24" severity="error" message="Could not find a declaration file for module &apos;deep-freeze&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/deep-freeze/index.js&apos; implicitly has an &apos;any&apos; type.
   Try `npm i --save-dev @types/deep-freeze` if it exists or add a new declaration (.d.ts) file containing `declare module &apos;deep-freeze&apos;;`" source="TS7016" />

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -3848,6 +3848,7 @@
 <error line="112" column="25" severity="error" message="Argument of type &apos;{ &apos;wc/blocks&apos;: { products: { &apos;[]&apos;: { &apos;?someQuery=2&apos;: { items: string[]; headers: { get: (key: any) =&gt; any; has: (key: any) =&gt; boolean; }; }; }; }; &apos;products/attributes&apos;: { &apos;[10]&apos;: { &apos;?someQuery=2&apos;: { items: string[]; headers: { get: (key: any) =&gt; any; has: (key: any) =&gt; boolean; }; }; }; }; &apos;products/attributes/term...&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2345" />
 </file>
 <file name="assets/js/data/payment/test/check-payment-methods.tsx">
+<error line="16" column="43" severity="error" message="Cannot find module &apos;../check-payment-methods&apos; or its corresponding type declarations." source="TS2307" />
 <error line="18" column="28" severity="error" message="Parameter &apos;args&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
 </file>
 <file name="assets/js/data/payment/test/reducers.js">


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR adds a couple of unit tests to ensure the argument passed to payment methods' `canMakePayment` function are correct.

### Testing

#### Automated Tests
* [x] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [ ] E2E tests

### Dev testing notes

1. Run the unit tests, ensure they pass.
2. Go to https://github.com/woocommerce/woocommerce-blocks/blob/c75cf0fe998789fff38c0e58b99e8bc5adef5a04/assets/js/data/payment/check-payment-methods.ts#L77-L99 in your editor and modify the object so any of the items are removed (comment them out).
3. Ensure unit tests fail.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Skipping
