### PR TITLE
[Experimental] Blockified prototype of the Single Product template

### DIFF
--- a/assets/js/atomic/blocks/product-elements/button/index.js
+++ b/assets/js/atomic/blocks/product-elements/button/index.js
@@ -20,11 +20,7 @@ const blockConfig = {
 	apiVersion: 2,
 	title,
 	description,
-	ancestor: [
-		'@woocommerce/all-products',
-		'@woocommerce/single-product',
-		'core/post-template',
-	],
+	ancestor: false,
 	usesContext: [ 'query', 'queryId', 'postId' ],
 	icon: { src: icon },
 	attributes,

--- a/assets/js/atomic/blocks/product-elements/image/index.js
+++ b/assets/js/atomic/blocks/product-elements/image/index.js
@@ -32,11 +32,7 @@ const blockConfig = {
 		'woo-gutenberg-products-block'
 	),
 	usesContext: [ 'query', 'queryId', 'postId' ],
-	parent: [
-		'@woocommerce/all-products',
-		'@woocommerce/single-product',
-		'core/post-template',
-	],
+	ancestor: false,
 	textdomain: 'woo-gutenberg-products-block',
 	attributes,
 	supports,

--- a/src/BlockTypes/ProductButton.php
+++ b/src/BlockTypes/ProductButton.php
@@ -75,7 +75,7 @@ class ProductButton extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		if ( ! empty( $content ) ) {
+		if ( ! empty( $content ) && ! is_product() ) {
 			parent::register_block_type_assets();
 			$this->register_chunk_translations( [ $this->block_name ] );
 			return $content;

--- a/src/BlockTypes/ProductImage.php
+++ b/src/BlockTypes/ProductImage.php
@@ -178,7 +178,7 @@ class ProductImage extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		if ( ! empty( $content ) ) {
+		if ( ! empty( $content ) && ! is_product() ) {
 			parent::register_block_type_assets();
 			$this->register_chunk_translations( [ $this->block_name ] );
 			return $content;


### PR DESCRIPTION
This is an experimental PR. With this PR, it is possible to add the `Product Image` block and `Add To Cart` block in the Single Product template. Both blocks work on the front-end side.

### Screenshots

https://user-images.githubusercontent.com/4463174/197823086-157427e9-5e2b-4e9f-b9db-50c8c786c038.mp4


#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

Check out this branch

1. Open the Site Editor.
2. Open the Single Product Template
3. Add the `Product Image` block and the `Add To Cart` block. ⚠️ The `Product Image` block shows an image placeholder, while the `Add To Cart` block shows only the loading skeleton.
4. Save.
5. On the frontend side, land on a product page.
6. Check that blocks work correctly.

