### PR TITLE
Add a workflow for building nightly releases of the repo

### DIFF
--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -28,6 +28,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          # 80931450 is the release ID of this nightly release https://github.com/woocommerce/woocommerce-blocks/releases/tag/nightly
           upload_url: https://uploads.github.com/repos/${{ github.repository }}/releases/80943895/assets{?name,label}
           release_id: 80943895
           asset_path: woocommerce-gutenberg-products-block.zip

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -1,0 +1,46 @@
+name: Nightly builds
+on:
+  schedule:
+    - cron: '0 0 * * *' # Run at 12 AM UTC.
+  workflow_dispatch:
+jobs:
+  build:
+    name: Nightly builds
+    strategy:
+      fail-fast: false
+      matrix:
+        build: [trunk]
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ matrix.build }}
+
+      - name: Install Node Dependencies
+        run: npm ci --no-optional
+
+      - name: Build zip
+        run: bash bin/build-plugin-zip.sh -d
+
+      - name: Deploy nightly build
+        uses: WebFreak001/deploy-nightly@v1.1.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: https://uploads.github.com/repos/${{ github.repository }}/releases/80943895/assets{?name,label}
+          release_id: 80943895
+          asset_path: woocommerce-gutenberg-products-block.zip
+          asset_name: woocommerce-blocks-${{ matrix.build }}-nightly.zip
+          asset_content_type: application/zip
+          max_releases: 1
+  update:
+    name: Update nightly tag commit ref
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Update nightly tag
+        uses: richardsimko/github-tag-action@v1.0.5
+        with:
+          tag_name: nightly
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -28,7 +28,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          # 80931450 is the release ID of this nightly release https://github.com/woocommerce/woocommerce-blocks/releases/tag/nightly
+          # 80943895 is the release ID of this nightly release https://github.com/woocommerce/woocommerce-blocks/releases/tag/nightly
           upload_url: https://uploads.github.com/repos/${{ github.repository }}/releases/80943895/assets{?name,label}
           release_id: 80943895
           asset_path: woocommerce-gutenberg-products-block.zip

--- a/.github/workflows/wordpress-deploy.yml
+++ b/.github/workflows/wordpress-deploy.yml
@@ -1,7 +1,7 @@
 name: Deploy to WordPress.org
 on:
     release:
-        types: [published]
+        types: [released]
 jobs:
     tag:
         name: New Release


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR adds a GIthub workflow that will build nightly releases of the blocks repo, much like WooCommerce did in [this PR](https://github.com/woocommerce/woocommerce/pull/26315). The builds will be development builds for easy debugging and testing. It works by updating a [pre-release](https://github.com/woocommerce/woocommerce-blocks/releases/tag/nightly) I created via Github UI for this PR. 

This PR also changes the wordpress.org deploy action to run on the `released` event rather than `published` event for a github release. `published` is triggered even for pre-releases, `released` isn't.

<!-- Reference any related issues or PRs here -->

Fixes #6040 

### Testing

#### User Facing Testing

1. For this repository on GitHub (make sure you de-select `Copy the trunk branch only`
2. Create a pre-release with a tag called `nightly` in your forked repo (feel free to put any title or description).
3. Switch to the `add/nightly-releases` branch
5. Modify the [on](https://github.com/woocommerce/woocommerce-blocks/blob/add/nightly-releases/.github/workflows/nightly-builds.yml#L2-L5) section of the `nightly-builds.yml` file, to the following: 

```
on:
    push:
        branches:
            - add/nightly-releases
```

This is just for testing purposes so you don't have to wait until midnight to test!

6. Visit https://api.github.com/repos/<YOUR _USERNAME>/woocommerce-blocks/releases and get the id of the Nightly release you created in step 2
7. Replace the id on [these 2 lines](https://github.com/alexflorisca/woocommerce-blocks/blob/add/nightly-builds/.github/workflows/nightly-builds.yml#L35-L36).
8. Add a new file (can be anything) inside the `src/` folder
9. Add and push these changes to the `add/nightly-releases` branch of your forked repo
10. This should trigger the Nightly Build action and this should succeed.
11. After the action is done running, go to the Nightly release you created in step 2. Click to expand the Assets. Check timestamps match with when the action has finished running
12. Download and open the `woocommerce-blocks-trunk-nightly.zip`. Check the file you added in step 8 is there.
13. Approve this PR, wait until the next day after it has been merged, and check the Nightly Build action has run.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Added nightly build releases for testing purposes
