### PR TITLE
Block Checkout: Apply selected Local Pickup rate to entire order (all packages)

### DIFF
--- a/assets/js/base/components/cart-checkout/totals/shipping/shipping-via.tsx
+++ b/assets/js/base/components/cart-checkout/totals/shipping/shipping-via.tsx
@@ -11,7 +11,14 @@ export const ShippingVia = ( {
 } ): JSX.Element => {
 	return (
 		<div className="wc-block-components-totals-item__description wc-block-components-totals-shipping__via">
-			{ decodeEntities( selectedShippingRates.join( ', ' ) ) }
+			{ decodeEntities(
+				selectedShippingRates
+					.filter(
+						( item, index ) =>
+							selectedShippingRates.indexOf( item ) === index
+					)
+					.join( ', ' )
+			) }
 		</div>
 	);
 };

--- a/assets/js/base/components/radio-control/types.ts
+++ b/assets/js/base/components/radio-control/types.ts
@@ -27,7 +27,7 @@ interface RadioControlOptionContent {
 	label: string;
 	description?: string | ReactElement | undefined;
 	secondaryLabel?: string | ReactElement | undefined;
-	secondaryDescription?: string | undefined;
+	secondaryDescription?: string | ReactElement | undefined;
 }
 
 export interface RadioControlOption extends RadioControlOptionContent {

--- a/assets/js/base/context/hooks/shipping/use-select-shipping-rate.ts
+++ b/assets/js/base/context/hooks/shipping/use-select-shipping-rate.ts
@@ -30,7 +30,7 @@ export const useSelectShippingRate = (): SelectShippingRateType => {
 	} as {
 		selectShippingRate: (
 			newShippingRateId: string,
-			packageId: string | number
+			packageId?: string | number
 		) => Promise< unknown >;
 	};
 

--- a/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/block.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/block.tsx
@@ -13,47 +13,64 @@ import { getSetting } from '@woocommerce/settings';
 import { Icon, mapMarker } from '@wordpress/icons';
 import RadioControl from '@woocommerce/base-components/radio-control';
 import type { RadioControlOption } from '@woocommerce/base-components/radio-control/types';
+import { CartShippingPackageShippingRate } from '@woocommerce/types';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
 
-interface pickupLocation {
-	rate_id: string;
-	name: string;
-	address: string;
-	details: string;
-}
+const getPickupLocation = (
+	option: CartShippingPackageShippingRate
+): string => {
+	if ( option?.meta_data ) {
+		const match = option.meta_data.find(
+			( meta: MetaKeyValue ) => meta.key === 'pickup_location'
+		);
+		return match ? match.value : '';
+	}
+	return '';
+};
 
-interface pickupLocationRate extends pickupLocation {
-	price: number;
-	taxes: number;
-}
+const getPickupAddress = (
+	option: CartShippingPackageShippingRate
+): string => {
+	if ( option?.meta_data ) {
+		const match = option.meta_data.find(
+			( meta: MetaKeyValue ) => meta.key === 'pickup_address'
+		);
+		return match ? match.value : '';
+	}
+	return '';
+};
 
 const renderPickupLocation = (
-	option: pickupLocationRate
+	option: CartShippingPackageShippingRate
 ): RadioControlOption => {
 	const priceWithTaxes = getSetting( 'displayCartPricesIncludingTax', false )
 		? option.price + option.taxes
 		: option.price;
+	const location = getPickupLocation( option );
+	const address = getPickupAddress( option );
 	return {
 		value: option.rate_id,
-		label: decodeEntities( option.name ),
+		label: location
+			? decodeEntities( location )
+			: decodeEntities( option.name ),
 		secondaryLabel: (
 			<FormattedMonetaryAmount
 				currency={ getCurrencyFromPriceResponse( option ) }
 				value={ priceWithTaxes }
 			/>
 		),
-		description: decodeEntities( option.details ),
-		secondaryDescription: option.address ? (
+		description: decodeEntities( option.description ),
+		secondaryDescription: address ? (
 			<>
 				<Icon
 					icon={ mapMarker }
 					className="wc-block-editor-components-block-icon"
 				/>
-				{ decodeEntities( option.address ) }
+				{ decodeEntities( address ) }
 			</>
 		) : undefined,
 	};
@@ -72,30 +89,32 @@ const Block = (): JSX.Element | null => {
 		[ selectShippingRate, shippingRates ]
 	);
 
-	const pickupLocations = (
-		getSetting( 'localPickupLocations', [] ) as pickupLocation[]
-	 ).map( ( pickupLocation: pickupLocation ): pickupLocationRate => {
-		// Find the cost and taxes from the shipping rates response.
-		const pickupRate = shippingRates.reduce(
-			( acc, shippingRatePackage ) => {
-				const rate =
-					shippingRatePackage.shipping_rates.find(
-						( { rate_id: rateId } ) =>
-							rateId === pickupLocation.rate_id
-					) || null;
-				if ( rate ) {
-					acc.price = acc.price + parseInt( rate.price, 10 );
-					acc.taxes = acc.taxes + parseInt( rate.taxes, 10 );
-				}
-				return acc;
-			},
-			{ price: 0, taxes: 0 }
-		);
-		return {
-			...pickupLocation,
-			...pickupRate,
-		};
-	} );
+	// Get pickup locations from the first shipping package.
+	const pickupLocations = ( shippingRates[ 0 ]?.shipping_rates || [] )
+		.filter( ( { method_id: methodId } ) => methodId === 'pickup_location' )
+		// Combine prices by rate ID.
+		.map( ( pickupLocation ) => {
+			// Find the cost and taxes from the shipping rates response.
+			const pickupRate = shippingRates.reduce(
+				( acc, shippingRatePackage ) => {
+					const rate =
+						shippingRatePackage.shipping_rates.find(
+							( { rate_id: rateId } ) =>
+								rateId === pickupLocation.rate_id
+						) || null;
+					if ( rate ) {
+						acc.price = acc.price + parseInt( rate.price, 10 );
+						acc.taxes = acc.taxes + parseInt( rate.taxes, 10 );
+					}
+					return acc;
+				},
+				{ price: 0, taxes: 0 }
+			);
+			return {
+				...pickupLocation,
+				...pickupRate,
+			};
+		} );
 
 	// Update the selected option if there is no rate selected on mount.
 	useEffect( () => {

--- a/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/block.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/block.tsx
@@ -101,40 +101,15 @@ const Block = (): JSX.Element | null => {
 	const [ selectedOption, setSelectedOption ] = useState< string >( '' );
 	const onSelectRate = useCallback(
 		( rateId: string ) => {
-			shippingRates.forEach( ( { package_id: packageId } ) => {
-				selectShippingRate( rateId, packageId );
-			} );
+			selectShippingRate( rateId );
 		},
-		[ selectShippingRate, shippingRates ]
+		[ selectShippingRate ]
 	);
 
 	// Get pickup locations from the first shipping package.
 	const pickupLocations = ( shippingRates[ 0 ]?.shipping_rates || [] ).filter(
 		( { method_id: methodId } ) => methodId === 'pickup_location'
 	);
-	/* Combine prices by rate ID.
-		.map( ( pickupLocation ) => {
-			// Find the cost and taxes from the shipping rates response.
-			const pickupRate = shippingRates.reduce(
-				( acc, shippingRatePackage ) => {
-					const rate =
-						shippingRatePackage.shipping_rates.find(
-							( { rate_id: rateId } ) =>
-								rateId === pickupLocation.rate_id
-						) || null;
-					if ( rate ) {
-						acc.price = acc.price + parseInt( rate.price, 10 );
-						acc.taxes = acc.taxes + parseInt( rate.taxes, 10 );
-					}
-					return acc;
-				},
-				{ price: 0, taxes: 0 }
-			);
-			return {
-				...pickupLocation,
-				...pickupRate,
-			};
-		} );*/
 
 	// Update the selected option if there is no rate selected on mount.
 	useEffect( () => {

--- a/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/block.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/block.tsx
@@ -23,12 +23,14 @@ const LocalPickupSelector = ( {
 	showPrice,
 	showIcon,
 	toggleText,
+	multiple,
 }: {
 	checked: string;
 	rate: minMaxPrices;
 	showPrice: boolean;
 	showIcon: boolean;
 	toggleText: string;
+	multiple: boolean;
 } ) => {
 	return (
 		<Radio
@@ -52,7 +54,11 @@ const LocalPickupSelector = ( {
 				{ toggleText }
 			</span>
 			{ showPrice === true && (
-				<RatePrice minRate={ rate.min } maxRate={ rate.max } />
+				<RatePrice
+					multiple={ multiple }
+					minRate={ rate.min }
+					maxRate={ rate.max }
+				/>
 			) }
 		</Radio>
 	);
@@ -145,6 +151,7 @@ const Block = ( {
 				rate={ getLocalPickupPrices(
 					shippingRates[ 0 ]?.shipping_rates
 				) }
+				multiple={ shippingRates.length > 1 }
 				showPrice={ showPrice }
 				showIcon={ showIcon }
 				toggleText={ localPickupText }

--- a/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/shared/rate-price.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/shared/rate-price.tsx
@@ -12,9 +12,11 @@ import type { CartShippingPackageShippingRate } from '@woocommerce/type-defs/car
 export const RatePrice = ( {
 	minRate,
 	maxRate,
+	multiple = false,
 }: {
 	minRate: CartShippingPackageShippingRate | undefined;
 	maxRate: CartShippingPackageShippingRate | undefined;
+	multiple: boolean;
 } ) => {
 	if ( minRate === undefined || maxRate === undefined ) {
 		return null;
@@ -37,7 +39,7 @@ export const RatePrice = ( {
 
 	return (
 		<span className="wc-block-checkout__shipping-method-option-price">
-			{ minRatePrice === maxRatePrice
+			{ minRatePrice === maxRatePrice && ! multiple
 				? priceElement
 				: createInterpolateElement(
 						__( 'from <price />', 'woo-gutenberg-products-block' ),

--- a/assets/js/data/cart/actions.ts
+++ b/assets/js/data/cart/actions.ts
@@ -449,16 +449,9 @@ export function* changeCartItemQuantity(
 	yield itemIsPendingQuantity( cartItemKey, false );
 }
 
-/**
- * Selects a shipping rate.
- *
- * @param {string}          rateId      The id of the rate being selected.
- * @param {number | string} [packageId] The key of the packages that we will
- *                                      select within.
- */
 export function* selectShippingRate(
 	rateId: string,
-	packageId = 0
+	packageId: number | string | undefined
 ): Generator< unknown, boolean, { response: CartResponse } > {
 	try {
 		yield shippingRatesBeingSelected( true );

--- a/assets/js/types/type-defs/shipping.ts
+++ b/assets/js/types/type-defs/shipping.ts
@@ -16,7 +16,7 @@ export interface SelectShippingRateType {
 	// Returns a function that accepts a shipping rate ID and a package ID.
 	selectShippingRate: (
 		newShippingRateId: string,
-		packageId: string | number
+		packageId?: string | number
 	) => unknown;
 	// True when a rate is currently being selected and persisted to the server.
 	isSelectingRate: boolean;

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -233,24 +233,6 @@ class Checkout extends AbstractBlock {
 			),
 			true
 		);
-		$this->asset_data_registry->add(
-			'localPickupLocations',
-			function() {
-				$locations           = get_option( 'pickup_location_pickup_locations', [] );
-				$formatted_locations = [];
-
-				foreach ( $locations as $index => $location ) {
-					$formatted_locations[] = [
-						'rate_id' => 'pickup_location:' . $index,
-						'name'    => wp_kses_post( $location['name'] ),
-						'details' => wp_kses_post( $location['details'] ),
-						'address' => wc()->countries->get_formatted_address( $location['address'], ', ' ),
-					];
-				}
-				return $formatted_locations;
-			},
-			true
-		);
 		$this->asset_data_registry->add( 'checkoutShowLoginReminder', filter_var( get_option( 'woocommerce_enable_checkout_login_reminder' ), FILTER_VALIDATE_BOOLEAN ), true );
 		$this->asset_data_registry->add( 'displayCartPricesIncludingTax', 'incl' === get_option( 'woocommerce_tax_display_cart' ), true );
 		$this->asset_data_registry->add( 'displayItemizedTaxes', 'itemized' === get_option( 'woocommerce_tax_total_display' ), true );

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -233,6 +233,24 @@ class Checkout extends AbstractBlock {
 			),
 			true
 		);
+		$this->asset_data_registry->add(
+			'localPickupLocations',
+			function() {
+				$locations           = get_option( 'pickup_location_pickup_locations', [] );
+				$formatted_locations = [];
+
+				foreach ( $locations as $index => $location ) {
+					$formatted_locations[] = [
+						'rate_id' => 'pickup_location:' . $index,
+						'name'    => wp_kses_post( $location['name'] ),
+						'details' => wp_kses_post( $location['details'] ),
+						'address' => wc()->countries->get_formatted_address( $location['address'], ', ' ),
+					];
+				}
+				return $formatted_locations;
+			},
+			true
+		);
 		$this->asset_data_registry->add( 'checkoutShowLoginReminder', filter_var( get_option( 'woocommerce_enable_checkout_login_reminder' ), FILTER_VALIDATE_BOOLEAN ), true );
 		$this->asset_data_registry->add( 'displayCartPricesIncludingTax', 'incl' === get_option( 'woocommerce_tax_display_cart' ), true );
 		$this->asset_data_registry->add( 'displayItemizedTaxes', 'itemized' === get_option( 'woocommerce_tax_total_display' ), true );

--- a/src/Shipping/ShippingController.php
+++ b/src/Shipping/ShippingController.php
@@ -3,6 +3,7 @@ namespace Automattic\WooCommerce\Blocks\Shipping;
 
 use Automattic\WooCommerce\Blocks\Assets\Api as AssetApi;
 use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
+use Automattic\WooCommerce\Utilities\ArrayUtil;
 
 /**
  * ShippingController class.
@@ -73,10 +74,10 @@ class ShippingController {
 		}
 		add_action( 'rest_api_init', [ $this, 'register_settings' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'admin_scripts' ] );
-		add_action( 'woocommerce_load_shipping_methods', array( $this, 'register_shipping_methods' ) );
+		add_action( 'woocommerce_load_shipping_methods', array( $this, 'register_local_pickup' ) );
+		add_filter( 'woocommerce_local_pickup_methods', array( $this, 'register_local_pickup_method' ) );
+		add_filter( 'woocommerce_customer_taxable_address', array( $this, 'filter_taxable_address' ) );
 		add_filter( 'woocommerce_shipping_packages', array( $this, 'filter_shipping_packages' ) );
-		add_filter( 'woocommerce_local_pickup_methods', array( $this, 'filter_local_pickup_methods' ) );
-		add_filter( 'woocommerce_customer_taxable_address', array( $this, 'pickup_location_customer_tax_location' ) );
 	}
 
 	/**
@@ -177,60 +178,19 @@ class ShippingController {
 	}
 
 	/**
-	 * Registers the local pickup method for blocks.
+	 * Registers the Local Pickup shipping method used by the Checkout Block.
 	 */
-	public function register_shipping_methods() {
-		$pickup = new PickupLocation();
-		wc()->shipping->register_shipping_method( $pickup );
+	public function register_local_pickup() {
+		wc()->shipping->register_shipping_method( new PickupLocation() );
 	}
 
 	/**
-	 * For Local Pickup to work, all packages must support local pickup. This filters the option out if unavailable.
-	 *
-	 * @param array $packages Array of shipping packages.
-	 * @return array
-	 */
-	public function filter_shipping_packages( $packages ) {
-		$valid = true;
-
-		// Check that each package has a pickup_location method available.
-		foreach ( $packages as $package_id => $package ) {
-			foreach ( $package['rates'] as $rate_id => $rate ) {
-				$method_id = $rate->get_method_id();
-
-				if ( 'pickup_location' === $method_id ) {
-					continue 2;
-				}
-			}
-
-			$valid = false;
-		}
-
-		if ( $valid ) {
-			return $packages;
-		}
-
-		// Remove pickup location if invalid.
-		foreach ( $packages as $package_id => $package ) {
-			foreach ( $package['rates'] as $rate_id => $rate ) {
-				$method_id = $rate->get_method_id();
-
-				if ( 'pickup_location' === $method_id ) {
-					unset( $packages[ $package_id ]['rates'][ $rate_id ] );
-				}
-			}
-		}
-
-		return $packages;
-	}
-
-	/**
-	 * Declares the Pickup Location shipping method as being a Local Pickup method.
+	 * Declares the Pickup Location shipping method as a Local Pickup method for WooCommerce.
 	 *
 	 * @param array $methods Shipping method ids.
 	 * @return array
 	 */
-	public function filter_local_pickup_methods( $methods ) {
+	public function register_local_pickup_method( $methods ) {
 		$methods[] = 'pickup_location';
 		return $methods;
 	}
@@ -241,7 +201,7 @@ class ShippingController {
 	 * @param array $address Location args.
 	 * @return array
 	 */
-	public function pickup_location_customer_tax_location( $address ) {
+	public function filter_taxable_address( $address ) {
 		// We only need to select from the first package, since pickup_location only supports a single package.
 		$chosen_method          = current( WC()->session->get( 'chosen_shipping_methods', array() ) ) ?? '';
 		$chosen_method_id       = explode( ':', $chosen_method )[0];
@@ -250,8 +210,9 @@ class ShippingController {
 		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		if ( $chosen_method_id && true === apply_filters( 'woocommerce_apply_base_tax_for_local_pickup', true ) && 'pickup_location' === $chosen_method_id ) {
 			$pickup_locations = get_option( 'pickup_location_pickup_locations', [] );
+			$pickup_location  = $pickup_locations[ $chosen_method_instance ] ?? [];
 
-			if ( ! empty( $pickup_locations[ $chosen_method_instance ] ) && ! empty( $pickup_locations[ $chosen_method_instance ]['address']['country'] ) ) {
+			if ( isset( $pickup_location['address'], $pickup_location['address']['country'] ) && ! empty( $pickup_location['address']['country'] ) ) {
 				$address = array(
 					$pickup_locations[ $chosen_method_instance ]['address']['country'],
 					$pickup_locations[ $chosen_method_instance ]['address']['state'],
@@ -262,5 +223,44 @@ class ShippingController {
 		}
 
 		return $address;
+	}
+
+	/**
+	 * For Local Pickup to work during Block Checkout, all packages must support local pickup. This is because the entire
+	 * order must be picked up (so correct taxes are applied to the full order).
+	 *
+	 * If a shipping package does not support local pickup (e.g. if disabled by an extension), this filters the option
+	 * out for all packages. This will in turn disable the "pickup" toggle in Block Checkout.
+	 *
+	 * @param array $packages Array of shipping packages.
+	 * @return array
+	 */
+	public function filter_shipping_packages( $packages ) {
+		// Check all packages for an instance of the pickup_location shipping method.
+		$valid_packages = array_filter(
+			$packages,
+			function( $package ) {
+				$shipping_method_ids = ArrayUtil::select( $package['rates'] ?? [], 'get_method_id', ArrayUtil::SELECT_BY_OBJECT_METHOD );
+				return in_array( 'pickup_location', $shipping_method_ids, true );
+			}
+		);
+
+		// Remove pickup location from rates arrays.
+		if ( count( $valid_packages ) !== count( $packages ) ) {
+			$packages = array_map(
+				function( $package ) {
+					$package['rates'] = array_filter(
+						$package['rates'],
+						function( $rate ) {
+							return 'pickup_location' !== $rate->get_method_id();
+						}
+					);
+					return $package;
+				},
+				$packages
+			);
+		}
+
+		return $packages;
 	}
 }

--- a/src/Shipping/ShippingController.php
+++ b/src/Shipping/ShippingController.php
@@ -226,8 +226,8 @@ class ShippingController {
 	}
 
 	/**
-	 * For Local Pickup to work during Block Checkout, all packages must support local pickup. This is because the entire
-	 * order must be picked up (so correct taxes are applied to the full order).
+	 * Local Pickup requires all packages to support local pickup. This is because the entire order must be picked up
+	 * so that all packages get the same tax rates applied during checkout.
 	 *
 	 * If a shipping package does not support local pickup (e.g. if disabled by an extension), this filters the option
 	 * out for all packages. This will in turn disable the "pickup" toggle in Block Checkout.


### PR DESCRIPTION
Improves the logic for Local Pickup to simplify the customer-facing UI, and to prevent tax inconsistencies which could occur if multiple local pickup methods were chosen during checkout.

1. Checks that all Shipping Packages in the cart support Local Pickup — if a package does not, Local Pickup is removed and cannot be selected.

2. Allows only one Pickup Location for the order. During checkout, if multiple packages exist, rather than showing a radio select per package, a single radio select is shown and then the selection is applied to all packages in the cart. 

cc @senadir 

### Screenshots

![Screenshot 2022-10-26 at 12 02 15](https://user-images.githubusercontent.com/90977/198010751-d1f0c7af-80ba-4f4f-a630-8c8136a2f899.png)

I've also pushed a change to include the package count rather than combining costs. I've commented out the previous logic so we can revert if needed. This seems clearer:

![Screenshot 2022-10-26 at 12 31 27](https://user-images.githubusercontent.com/90977/198015683-7c649f84-317a-45f1-8b71-20d1c751f4bb.png)

#### User Facing Testing

1. Go to checkout. Confirm you can toggle on Local Pickup and checkout.
2. Install the Multiple Packages extension
3. Ensure you have products across several shipping classes, and add the items to the cart
4. In Multiple Packages extension settings, disable Local Pickup for one of your shipping classes.
5. Confirm (new) Local Pickup cannot be toggled on on the checkout.
6. Confirm (new) Local Pickup is not an available rate.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->