### PR TITLE
Replace additional instance of wp_is_block_theme() with wc_current_theme_is_fse_theme()

### DIFF
--- a/src/BlockTypes/ProductImage.php
+++ b/src/BlockTypes/ProductImage.php
@@ -165,7 +165,7 @@ class ProductImage extends AbstractBlock {
 	 *                           not in the post content on editor load.
 	 */
 	protected function enqueue_data( array $attributes = [] ) {
-		$this->asset_data_registry->add( 'is_block_theme_enabled', wp_is_block_theme(), false );
+		$this->asset_data_registry->add( 'is_block_theme_enabled', wc_current_theme_is_fse_theme(), false );
 	}
 
 


### PR DESCRIPTION
Replace the last instance of `wp_is_block_theme()` with `wc_current_theme_is_fse_theme()` to avoid Fatal error in WP <= 5.8.

Related issue: https://github.com/woocommerce/woocommerce-blocks/pull/6590

<img width="853" alt="Screenshot 2022-10-27 at 09 51 39" src="https://user-images.githubusercontent.com/16900754/198223496-d6155740-07bf-467d-94ce-3da86a8996e1.png">

### Testing

#### User Facing Testing

**Test there are no regressions:**

0. In WP 6.1.
1. Enable a classic theme (ie: Storefront).
2. Create a post or page and add the _Products (Beta)_ block.
3. Select the Product Image block.
4. Verify it has the _Image sizing_ option.
<img src="https://user-images.githubusercontent.com/3616980/209947659-63273553-f230-4038-b98c-c726e414a02a.png" alt="Screenshot showing the Product Image block options with the Image sizing option available" width="278" />
5. Now, enable a block theme (ie: Twenty Twenty-Three) and reload the page in the editor.
6. Verify the Product Image block doesn't have a _Image sizing_ option.
<img src="https://user-images.githubusercontent.com/3616980/209947679-4e8f0a28-9f9c-4809-8789-78814f292483.png" alt="Screenshot showing the Product Image block options without the Image sizing option available" width="278" />

**Test the fatal is fixed:**

0. In WP 5.8.
1. Create a post or page.
2. Verify there is no fatal error and you can create the post or page and publish it.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix fatal error in WordPress 5.8 when creating a post or page.
