### PR TITLE
Use TT3 theme background for the Mini Cart background color

### DIFF
--- a/assets/js/blocks/mini-cart/mini-cart-contents/editor.scss
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/editor.scss
@@ -3,6 +3,8 @@
 	/* We need to override the margin top here to simulate the layout of
 	the mini cart contents on the front end. */
 	margin: 0 auto !important;
+	/* Set correct background color for Twenty Twenty Three */
+	background-color: var(--wp--preset--color--base, #fff);
 
 	.wp-block-woocommerce-empty-mini-cart-contents-block[hidden],
 	.wp-block-woocommerce-filled-mini-cart-contents-block[hidden] {

--- a/assets/js/blocks/mini-cart/style.scss
+++ b/assets/js/blocks/mini-cart/style.scss
@@ -190,3 +190,7 @@ h2.wc-block-mini-cart__title {
 		}
 	}
 }
+
+.theme-twentytwentythree .wp-block-woocommerce-mini-cart-contents {
+	background-color: var(--wp--preset--color--base);
+}


### PR DESCRIPTION
Fixes #7501.

I'm not a big fan of this solution because we need to add custom CSS for TT3. I guess ideally there would be a way to semantically access the `body` background color in order to be able to use it in order elements. But I couldn't find a way to achieve that. :disappointed: 

### Screenshots

| Before | After |
| ------ | ----- |
| ![imatge](https://user-images.githubusercontent.com/3616980/198244560-1f19a559-7e84-4f36-a21f-dcb58d5ad276.png) | ![imatge](https://user-images.githubusercontent.com/3616980/198263946-d9375e35-f424-445e-9841-30867f41ccb5.png) |
| ![imatge](https://user-images.githubusercontent.com/3616980/198264153-b7f0c965-9d0c-481a-9d16-8bce9db74fd3.png) | ![imatge](https://user-images.githubusercontent.com/3616980/198264041-7743257e-c4a5-434a-8dcf-d7f92af93524.png) |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. Download and activate [TT3](https://github.com/WordPress/twentytwentythree) select the Pilgrimage style variation (see screenshot below).
2. Add the Mini Cart block to a post or page.
3. In the frontend, click on the Mini Cart button to open the drawer.
4. Verify the background is dark and text can be read properly.
5. Back in the editor, select the Mini Cart block and press on `Edit Mini Cart template part` in the sidebar. That will open the template editor.
6. Verify text is legible there as well:
![imatge](https://user-images.githubusercontent.com/3616980/198266198-9a607821-cb5b-47e5-90ec-b0cd64ca34e3.png)
7. Try with all other TT3 theme variations and verify text can be properly read in all of them.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Update Mini Cart block drawer to honor Twenty Twenty Three theme background.
