### PR TITLE
Product button: Fix 'In cart' button localization.

### DIFF
--- a/src/BlockTypes/AllProducts.php
+++ b/src/BlockTypes/AllProducts.php
@@ -39,4 +39,12 @@ class AllProducts extends AbstractBlock {
 	protected function hydrate_from_api() {
 		$this->asset_data_registry->hydrate_api_request( '/wc/store/v1/cart' );
 	}
+
+	/**
+	 * It is necessary to register and enqueue assets during the render phase because we want to load assets only if the block has the content.
+	 */
+	protected function register_block_type_assets() {
+		parent::register_block_type_assets();
+		$this->register_chunk_translations( [ $this->block_name ] );
+	}
 }

--- a/src/BlockTypes/ProductButton.php
+++ b/src/BlockTypes/ProductButton.php
@@ -53,10 +53,11 @@ class ProductButton extends AbstractBlock {
 	}
 
 	/**
-	 * It is necessary to register and enqueues assets during the render phase because we want to load assets only if the block has the content.
+	 * It is necessary to register and enqueue assets during the render phase because we want to load assets only if the block has the content.
 	 */
 	protected function register_block_type_assets() {
-		return null;
+		parent::register_block_type_assets();
+		$this->register_chunk_translations( [ $this->block_name ] );
 	}
 
 	/**
@@ -67,7 +68,7 @@ class ProductButton extends AbstractBlock {
 	}
 
 	/**
-	 * Include and render the block
+	 * Include and render the block.
 	 *
 	 * @param array    $attributes Block attributes. Default empty array.
 	 * @param string   $content    Block content. Default empty string.


### PR DESCRIPTION
Fixes the issue with the "x in cart" text not translating within the **All products** block.

Fixes #7494.

Co-authored-by: Niels Lange <info@nielslange.de>

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
| ![Produkty_–_ratings-2](https://user-images.githubusercontent.com/905781/198283708-47290219-09c1-45df-b39c-a3bb50b08a0e.jpg)|![Produkty_–_ratings](https://user-images.githubusercontent.com/905781/198283735-d076ec6b-74ea-4fd1-86fd-15ce8e07e74f.jpg)|

### Testing
1. Add an instance of the **All Products** Block to the page.
2. Use a plugin like Loco Translate to translate the text of `%d in cart` within the WooCommerce core plugin language files.
3. Visit the All Products Block page and add a product to the cart.
4. Verify the string is being translated.

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing
Same as the above.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental


### Changelog

> Product button: Fix 'In cart' button localization.
