### PR TITLE
Add white background to Filter by Attribute block dropdown so text is legible in dark backgrounds

### DIFF
--- a/assets/js/base/components/form-token-field/style.scss
+++ b/assets/js/base/components/form-token-field/style.scss
@@ -16,8 +16,10 @@
 	}
 
 	.components-form-token-field__input-container {
+		background-color: #fff;
 		border-radius: 0;
 		box-shadow: none;
+		color: #000;
 		position: relative;
 
 		input[type="text"].components-form-token-field__input {
@@ -64,6 +66,7 @@
 			margin-right: 0;
 			position: relative;
 			width: 100%;
+			z-index: 1;
 		}
 
 		.components-form-token-field__remove-token.components-button,


### PR DESCRIPTION
Fixes #7499.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
| ![imatge](https://user-images.githubusercontent.com/3616980/198288809-7f575c00-72f1-41e7-8a19-1cf2c9e2b3b7.png) | ![imatge](https://user-images.githubusercontent.com/3616980/198288636-225716da-6a6d-4db2-ad03-5dd404ea61d7.png) |
| ![imatge](https://user-images.githubusercontent.com/3616980/198288969-c5619a4b-a16f-4d39-815d-a6ebd336cc40.png) | ![imatge](https://user-images.githubusercontent.com/3616980/198289132-6066cb6d-03c6-4f5b-a791-69da2e1db95c.png) |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. Download and activate [TT3](https://github.com/WordPress/twentytwentythree).
2. Add the All Products block with the Filter by Attribute block next to it in a post or page.
2. Visit the post or page and interact with the Filter by Attribute block.
3. Verify the background of the input has white background, so text is legible.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Add white background to Filter by Attribute block dropdown so text is legible in dark backgrounds
