### PR TITLE
Fix E2E errors with debounced `updatePaymentMethods` function

### DIFF
--- a/assets/js/data/cart/index.ts
+++ b/assets/js/data/cart/index.ts
@@ -16,10 +16,7 @@ import { controls as sharedControls } from '../shared-controls';
 import { controls } from './controls';
 import type { SelectFromMap, DispatchFromMap } from '../mapped-types';
 import { pushChanges } from './push-changes';
-import {
-	updatePaymentMethods,
-	debouncedUpdatePaymentMethods,
-} from './update-payment-methods';
+import { debouncedUpdatePaymentMethods } from './update-payment-methods';
 
 const registeredStore = registerStore< State >( STORE_KEY, {
 	reducer,
@@ -31,20 +28,7 @@ const registeredStore = registerStore< State >( STORE_KEY, {
 } );
 
 registeredStore.subscribe( pushChanges );
-
-// First we will run the updatePaymentMethods function without any debounce to ensure payment methods are ready as soon
-// as the cart is loaded. After that, we will unsubscribe this function and instead run the
-// debouncedUpdatePaymentMethods function on subsequent cart updates.
-const unsubscribeUpdatePaymentMethods = registeredStore.subscribe( async () => {
-	const didActionDispatch = await updatePaymentMethods();
-	if ( didActionDispatch ) {
-		// The function we're currently in will unsubscribe itself. When we reach this line, this will be the last time
-		// this function is called.
-		unsubscribeUpdatePaymentMethods();
-		// Resubscribe, but with the debounced version of updatePaymentMethods.
-		registeredStore.subscribe( debouncedUpdatePaymentMethods );
-	}
-} );
+registeredStore.subscribe( debouncedUpdatePaymentMethods );
 
 export const CART_STORE_KEY = STORE_KEY;
 

--- a/assets/js/data/cart/index.ts
+++ b/assets/js/data/cart/index.ts
@@ -16,7 +16,10 @@ import { controls as sharedControls } from '../shared-controls';
 import { controls } from './controls';
 import type { SelectFromMap, DispatchFromMap } from '../mapped-types';
 import { pushChanges } from './push-changes';
-import { debouncedUpdatePaymentMethods } from './update-payment-methods';
+import {
+	updatePaymentMethods,
+	debouncedUpdatePaymentMethods,
+} from './update-payment-methods';
 
 const registeredStore = registerStore< State >( STORE_KEY, {
 	reducer,
@@ -28,7 +31,20 @@ const registeredStore = registerStore< State >( STORE_KEY, {
 } );
 
 registeredStore.subscribe( pushChanges );
-registeredStore.subscribe( debouncedUpdatePaymentMethods );
+
+// First we will run the updatePaymentMethods function without any debounce to ensure payment methods are ready as soon
+// as the cart is loaded. After that, we will unsubscribe this function and instead run the
+// debouncedUpdatePaymentMethods function on subsequent cart updates.
+const unsubscribeUpdatePaymentMethods = registeredStore.subscribe( async () => {
+	const didActionDispatch = await updatePaymentMethods();
+	if ( didActionDispatch ) {
+		// The function we're currently in will unsubscribe itself. When we reach this line, this will be the last time
+		// this function is called.
+		unsubscribeUpdatePaymentMethods();
+		// Resubscribe, but with the debounced version of updatePaymentMethods.
+		registeredStore.subscribe( debouncedUpdatePaymentMethods );
+	}
+} );
 
 export const CART_STORE_KEY = STORE_KEY;
 

--- a/assets/js/data/cart/index.ts
+++ b/assets/js/data/cart/index.ts
@@ -32,12 +32,16 @@ const registeredStore = registerStore< State >( STORE_KEY, {
 
 registeredStore.subscribe( pushChanges );
 
-// First we will run the updatePaymentMethods function without a debounce to ensure payment methods are ready.
+// First we will run the updatePaymentMethods function without any debounce to ensure payment methods are ready as soon
+// as the cart is loaded. After that, we will unsubscribe this function and instead run the
+// debouncedUpdatePaymentMethods function on subsequent cart updates.
 const unsubscribeUpdatePaymentMethods = registeredStore.subscribe( async () => {
 	const didActionDispatch = await updatePaymentMethods();
 	if ( didActionDispatch ) {
+		// The function we're currently in will unsubscribe itself. When we reach this line, this will be the last time
+		// this function is called.
 		unsubscribeUpdatePaymentMethods();
-		// Resubscribe, but with the debounced version of updatePaymentMethods
+		// Resubscribe, but with the debounced version of updatePaymentMethods.
 		registeredStore.subscribe( debouncedUpdatePaymentMethods );
 	}
 } );

--- a/assets/js/data/cart/update-payment-methods.ts
+++ b/assets/js/data/cart/update-payment-methods.ts
@@ -31,6 +31,5 @@ export const updatePaymentMethods = async () => {
 // each payment method's canMakePayment function on every single change.
 export const debouncedUpdatePaymentMethods = debounce(
 	updatePaymentMethods,
-	1000,
-	{ leading: true, trailing: false }
+	1000
 );

--- a/assets/js/data/cart/update-payment-methods.ts
+++ b/assets/js/data/cart/update-payment-methods.ts
@@ -10,6 +10,11 @@ import { debounce } from 'lodash';
 import { STORE_KEY as PAYMENT_STORE_KEY } from '../payment/constants';
 import { STORE_KEY } from './constants';
 
+/**
+ * This function is used to update payment methods when the cart changes, or on first load.
+ *
+ * @return {boolean} True if the __internalUpdateAvailablePaymentMethods action was dispatched, false if not.
+ */
 export const updatePaymentMethods = async () => {
 	const isInitialized =
 		select( STORE_KEY ).hasFinishedResolution( 'getCartData' );
@@ -21,6 +26,9 @@ export const updatePaymentMethods = async () => {
 	).__internalUpdateAvailablePaymentMethods();
 	return true;
 };
+
+// We debounce this because it's possible for multiple cart updates to happen in quick succession, we don't want to run
+// each payment method's canMakePayment function on every single change.
 export const debouncedUpdatePaymentMethods = debounce(
 	updatePaymentMethods,
 	1000

--- a/assets/js/data/cart/update-payment-methods.ts
+++ b/assets/js/data/cart/update-payment-methods.ts
@@ -31,5 +31,6 @@ export const updatePaymentMethods = async () => {
 // each payment method's canMakePayment function on every single change.
 export const debouncedUpdatePaymentMethods = debounce(
 	updatePaymentMethods,
-	1000
+	1000,
+	{ leading: true, trailing: false }
 );

--- a/assets/js/data/cart/update-payment-methods.ts
+++ b/assets/js/data/cart/update-payment-methods.ts
@@ -23,5 +23,5 @@ export const updatePaymentMethods = async () => {
 };
 export const debouncedUpdatePaymentMethods = debounce(
 	updatePaymentMethods,
-	500
+	1000
 );

--- a/assets/js/data/cart/update-payment-methods.ts
+++ b/assets/js/data/cart/update-payment-methods.ts
@@ -10,15 +10,18 @@ import { debounce } from 'lodash';
 import { STORE_KEY as PAYMENT_STORE_KEY } from '../payment/constants';
 import { STORE_KEY } from './constants';
 
-export const updatePaymentMethods = debounce( async () => {
+export const updatePaymentMethods = async () => {
 	const isInitialized =
 		select( STORE_KEY ).hasFinishedResolution( 'getCartData' );
-
 	if ( ! isInitialized ) {
-		return;
+		return false;
 	}
-
 	await dispatch(
 		PAYMENT_STORE_KEY
 	).__internalUpdateAvailablePaymentMethods();
-}, 1000 );
+	return true;
+};
+export const debouncedUpdatePaymentMethods = debounce(
+	updatePaymentMethods,
+	500
+);


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR will improve on the changes made in #7413. We found there were issues with the E2E tests because the payment methods weren't ready immediately.

To fix this I added a non-debounced version of `updatePaymentMethods`. This will subscribe to the `wc/store/cart` store and run on _every_ update until the totals are loaded (at this point we know the Cart has been loaded into the data store successfully).

After the non-debounced version of this function has successfully run and dispatched the `__internalUpdateAvailablePaymentMethods` action, we can then unsubscribe it and re-subscribe with the debounced version.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests

#### User Facing Testing

N/A

#### Developer testing

1. Wait for E2E tests to pass.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Skipping
