### PR TITLE
Use theme's body background color as the mini cart contents default background color

### DIFF
--- a/assets/js/blocks/mini-cart/frontend.ts
+++ b/assets/js/blocks/mini-cart/frontend.ts
@@ -153,10 +153,16 @@ window.addEventListener( 'load', () => {
 		}
 	} );
 
-	const head = document.head || document.getElementsByTagName( 'head' )[ 0 ];
+	/**
+	 * Get the background color of the body then set it as the background color
+	 * of the Mini Cart Contents block. We use :where here to make customized
+	 * background color alway have higher priority.
+	 *
+	 * We only set the background color, instead of the whole background. As
+	 * we only provide the option to customize the background color.
+	 */
 	const style = document.createElement( 'style' );
-	const body = document.body || document.getElementsByTagName( 'body' )[ 0 ];
-	const backgroundColor = getComputedStyle( body ).backgroundColor;
+	const backgroundColor = getComputedStyle( document.body ).backgroundColor;
 
 	style.appendChild(
 		document.createTextNode(
@@ -165,5 +171,6 @@ window.addEventListener( 'load', () => {
 			}`
 		)
 	);
-	head.appendChild( style );
+
+	document.head.appendChild( style );
 } );

--- a/assets/js/blocks/mini-cart/frontend.ts
+++ b/assets/js/blocks/mini-cart/frontend.ts
@@ -152,4 +152,18 @@ window.addEventListener( 'load', () => {
 			);
 		}
 	} );
+
+	const head = document.head || document.getElementsByTagName( 'head' )[ 0 ];
+	const style = document.createElement( 'style' );
+	const body = document.body || document.getElementsByTagName( 'body' )[ 0 ];
+	const backgroundColor = getComputedStyle( body ).backgroundColor;
+
+	head.appendChild( style );
+	style.appendChild(
+		document.createTextNode(
+			`:where(.wp-block-woocommerce-mini-cart-contents) {
+				background-color: ${ backgroundColor };
+			}`
+		)
+	);
 } );

--- a/assets/js/blocks/mini-cart/frontend.ts
+++ b/assets/js/blocks/mini-cart/frontend.ts
@@ -158,7 +158,6 @@ window.addEventListener( 'load', () => {
 	const body = document.body || document.getElementsByTagName( 'body' )[ 0 ];
 	const backgroundColor = getComputedStyle( body ).backgroundColor;
 
-	head.appendChild( style );
 	style.appendChild(
 		document.createTextNode(
 			`:where(.wp-block-woocommerce-mini-cart-contents) {
@@ -166,4 +165,5 @@ window.addEventListener( 'load', () => {
 			}`
 		)
 	);
+	head.appendChild( style );
 } );

--- a/assets/js/blocks/mini-cart/mini-cart-contents/edit.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/edit.tsx
@@ -91,27 +91,40 @@ const Edit = ( { clientId }: Props ): ReactElement => {
 		const canvas =
 			canvasEl.contentDocument || canvasEl.contentWindow?.document;
 
-		if (
-			! canvas ||
-			canvas.getElementById( 'wc-block-mini-cart-editor-style' )
-		) {
+		if ( ! canvas ) {
 			return;
 		}
 
-		const body = canvas.querySelector( '.editor-styles-wrapper' );
+		const styles = Array.from( canvas.querySelectorAll( 'style' ) ).find(
+			( style ) =>
+				/\.editor-styles-wrapper(\s*)\{[^\}]*background-color[^\}]*\}/.test(
+					style.innerHTML
+				)
+		);
 
-		if ( ! body ) {
+		if ( ! styles ) {
 			return;
 		}
 
-		const backgroundColor = getComputedStyle( body ).backgroundColor;
+		const editorStylesWrapper = Array.from(
+			styles.sheet?.cssRules || []
+		).find(
+			( rule ) =>
+				rule.selectorText === '.editor-styles-wrapper' &&
+				rule.style.backgroundColor
+		);
+
+		if ( ! editorStylesWrapper ) {
+			return;
+		}
+
+		const backgroundColor = editorStylesWrapper.style.backgroundColor;
 
 		if ( ! backgroundColor ) {
 			return;
 		}
 
 		const style = document.createElement( 'style' );
-		style.id = 'wc-block-mini-cart-editor-style';
 		style.appendChild(
 			document.createTextNode(
 				`:where(.wp-block-woocommerce-mini-cart-contents) {
@@ -119,6 +132,12 @@ const Edit = ( { clientId }: Props ): ReactElement => {
 			}`
 			)
 		);
+
+		const body = canvas.querySelector( '.editor-styles-wrapper' );
+
+		if ( ! body ) {
+			return;
+		}
 
 		body.appendChild( style );
 	}, [] );

--- a/assets/js/blocks/mini-cart/mini-cart-contents/edit.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/edit.tsx
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import type { ReactElement } from 'react';
+import { ReactElement } from 'react';
 import {
 	useBlockProps,
 	InnerBlocks,
@@ -13,6 +13,7 @@ import { filledCart, removeCart } from '@woocommerce/icons';
 import { Icon } from '@wordpress/icons';
 import { EditorProvider } from '@woocommerce/base-context';
 import type { TemplateArray } from '@wordpress/blocks';
+import { useEffect, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -45,6 +46,7 @@ interface Props {
 }
 
 const Edit = ( { clientId }: Props ): ReactElement => {
+	const [ backgroundColor, setBackgroundColor ] = useState( '' );
 	const blockProps = useBlockProps( {
 		/**
 		 * This is a workaround for the Site Editor to calculate the
@@ -73,6 +75,21 @@ const Edit = ( { clientId }: Props ): ReactElement => {
 		defaultTemplate,
 	} );
 
+	useEffect( () => {
+		if ( backgroundColor ) return;
+		const canvasEl = document.querySelector(
+			'.edit-site-visual-editor__editor-canvas'
+		);
+		const canvas =
+			canvasEl?.contentDocument || canvasEl?.contentWindow.document;
+		if ( ! canvas ) {
+			return;
+		}
+		const body = canvas.querySelector( '.editor-styles-wrapper' );
+		const themeBackgroundColor = getComputedStyle( body ).backgroundColor;
+		setBackgroundColor( themeBackgroundColor );
+	}, [ backgroundColor ] );
+
 	return (
 		<div { ...blockProps }>
 			<EditorProvider currentView={ currentView }>
@@ -84,6 +101,11 @@ const Edit = ( { clientId }: Props ): ReactElement => {
 				/>
 			</EditorProvider>
 			<MiniCartInnerBlocksStyle style={ blockProps.style } />
+			<style>
+				{ `:where(.wp-block-woocommerce-mini-cart-contents) {
+				background-color: ${ backgroundColor };
+			}` }
+			</style>
 		</div>
 	);
 };

--- a/assets/js/blocks/mini-cart/mini-cart-contents/edit.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/edit.tsx
@@ -83,47 +83,31 @@ const Edit = ( { clientId }: Props ): ReactElement => {
 		const canvasEl = document.querySelector(
 			'.edit-site-visual-editor__editor-canvas'
 		);
-
 		if ( ! ( canvasEl instanceof HTMLIFrameElement ) ) {
 			return;
 		}
-
 		const canvas =
 			canvasEl.contentDocument || canvasEl.contentWindow?.document;
-
 		if ( ! canvas ) {
 			return;
 		}
-
-		const styles = Array.from( canvas.querySelectorAll( 'style' ) ).find(
-			( style ) =>
-				/\.editor-styles-wrapper(\s*)\{[^\}]*background-color[^\}]*\}/.test(
-					style.innerHTML
-				)
-		);
-
-		if ( ! styles ) {
+		const styles = canvas.querySelectorAll( 'style' );
+		const [ cssRule ] = Array.from( styles )
+			.map( ( style ) => Array.from( style.sheet?.cssRules || [] ) )
+			.flatMap( ( style ) => style )
+			.filter( Boolean )
+			.filter(
+				( rule ) =>
+					rule.selectorText === '.editor-styles-wrapper' &&
+					rule.style.backgroundColor
+			);
+		if ( ! cssRule ) {
 			return;
 		}
-
-		const editorStylesWrapper = Array.from(
-			styles.sheet?.cssRules || []
-		).find(
-			( rule ) =>
-				rule.selectorText === '.editor-styles-wrapper' &&
-				rule.style.backgroundColor
-		);
-
-		if ( ! editorStylesWrapper ) {
-			return;
-		}
-
-		const backgroundColor = editorStylesWrapper.style.backgroundColor;
-
+		const backgroundColor = cssRule.style.backgroundColor;
 		if ( ! backgroundColor ) {
 			return;
 		}
-
 		const style = document.createElement( 'style' );
 		style.appendChild(
 			document.createTextNode(
@@ -132,13 +116,10 @@ const Edit = ( { clientId }: Props ): ReactElement => {
 			}`
 			)
 		);
-
 		const body = canvas.querySelector( '.editor-styles-wrapper' );
-
 		if ( ! body ) {
 			return;
 		}
-
 		body.appendChild( style );
 	}, [] );
 

--- a/assets/js/blocks/mini-cart/mini-cart-contents/edit.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/edit.tsx
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { ReactElement } from 'react';
+import type { ReactElement } from 'react';
 import {
 	useBlockProps,
 	InnerBlocks,

--- a/assets/js/blocks/mini-cart/mini-cart-contents/edit.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/edit.tsx
@@ -91,6 +91,9 @@ const Edit = ( { clientId }: Props ): ReactElement => {
 		if ( ! canvas ) {
 			return;
 		}
+		if ( canvas.getElementById( 'mini-cart-contents-background-color' ) ) {
+			return;
+		}
 		const styles = canvas.querySelectorAll( 'style' );
 		const [ cssRule ] = Array.from( styles )
 			.map( ( style ) => Array.from( style.sheet?.cssRules || [] ) )
@@ -109,6 +112,7 @@ const Edit = ( { clientId }: Props ): ReactElement => {
 			return;
 		}
 		const style = document.createElement( 'style' );
+		style.id = 'mini-cart-contents-background-color';
 		style.appendChild(
 			document.createTextNode(
 				`:where(.wp-block-woocommerce-mini-cart-contents) {

--- a/assets/js/blocks/mini-cart/style.scss
+++ b/assets/js/blocks/mini-cart/style.scss
@@ -64,11 +64,13 @@
 }
 
 .wp-block-woocommerce-mini-cart-contents {
-	background: #fff;
 	box-sizing: border-box;
 	height: 100vh;
 	padding: 0;
 	justify-content: center;
+}
+:where(.wp-block-woocommerce-mini-cart-contents) {
+	background: #fff;
 }
 
 .wp-block-woocommerce-empty-mini-cart-contents-block,


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #7501 

This PR introduces an alternative approach to https://github.com/woocommerce/woocommerce-blocks/pull/7503. Instead of fixing the mini cart contents background per theme basis, we get the background color of the body element and use it as the default background color:
- On the front end, we get the background color of the body element using `getComputedStyle`.
- In the Site Editor, we parse the editor style and get the original value of the background color of the `.editor-styles-wrapper` element. By doing so, the Mini Cart Contents background works when users change the preset style.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Screenshots

https://user-images.githubusercontent.com/5423135/198499307-a8249428-98db-4d00-9fc4-23f77c9ee9e6.mov

| Before | After |
| ------ | ----- |
| ![imatge](https://user-images.githubusercontent.com/3616980/198244560-1f19a559-7e84-4f36-a21f-dcb58d5ad276.png) | ![imatge](https://user-images.githubusercontent.com/3616980/198263946-d9375e35-f424-445e-9841-30867f41ccb5.png) |
| ![imatge](https://user-images.githubusercontent.com/3616980/198264153-b7f0c965-9d0c-481a-9d16-8bce9db74fd3.png) | ![imatge](https://user-images.githubusercontent.com/3616980/198264041-7743257e-c4a5-434a-8dcf-d7f92af93524.png) |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Download and activate [TT3](https://github.com/WordPress/twentytwentythree) select the Pilgrimage style variation (see screenshot below).
2. Add the Mini Cart block to a post or page.
3. In the frontend, click on the Mini Cart button to open the drawer.
4. Verify the background is dark and text can be read properly.
5. Back in the editor, select the Mini Cart block and press on `Edit Mini Cart template part` in the sidebar. That will open the template editor.
6. Verify text is legible there as well:
![imatge](https://user-images.githubusercontent.com/3616980/198266198-9a607821-cb5b-47e5-90ec-b0cd64ca34e3.png)
7. Try with all other TT3 theme variations and verify text can be properly read in all of them.
8. Repeat all steps above with TT2.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Update the Mini Cart block drawer to honor the theme's background.