### PR TITLE
Fix storybook build failing issues

### DIFF
--- a/assets/js/base/components/form-token-field/vendor.scss
+++ b/assets/js/base/components/form-token-field/vendor.scss
@@ -4,9 +4,9 @@
 // Tooltip must be under the same scope to work properly.
 .wc-blocks-components-form-token-field-wrapper {
 	/* stylelint-disable no-invalid-position-at-import-rule */
-	@import "@wordpress/base-styles/breakpoints";
-	@import "@wordpress/base-styles/mixins";
-	@import "wordpress-components/src/popover/style";
-	@import "wordpress-components/src/tooltip/style";
+	@import "node_modules/@wordpress/base-styles/breakpoints";
+	@import "node_modules/@wordpress/base-styles/mixins";
+	@import "node_modules/wordpress-components/src/popover/style";
+	@import "node_modules/wordpress-components/src/tooltip/style";
 	/* stylelint-enable no-invalid-position-at-import-rule */
 }

--- a/storybook/main.js
+++ b/storybook/main.js
@@ -14,6 +14,9 @@ module.exports = {
 		babelModeV7: true,
 		emotionAlias: false,
 	},
+	// webpackFinal field was added in following PR: https://github.com/woocommerce/woocommerce-blocks/pull/7514
+	// This fixes "storybook build issue" related to framer-motion library.
+	// Solution is from this commment: https://github.com/storybookjs/storybook/issues/16690#issuecomment-971579785
 	webpackFinal: async ( config ) => {
 		config.module.rules.push( {
 			test: /\.mjs$/,

--- a/storybook/main.js
+++ b/storybook/main.js
@@ -14,4 +14,12 @@ module.exports = {
 		babelModeV7: true,
 		emotionAlias: false,
 	},
+	webpackFinal: async ( config ) => {
+		config.module.rules.push( {
+			test: /\.mjs$/,
+			include: /node_modules/,
+			type: 'javascript/auto',
+		} );
+		return config;
+	},
 };


### PR DESCRIPTION
The storybook build was failing because of 2 issues:
### Issue 1
> Can't import the named export 'Fragment' from non EcmaScript module (only default export is available) 

Following is the error which was appearing in terminal logs:
```
ERROR in ./node_modules/@wordpress/block-editor/node_modules/framer-motion/dist/es/components/AnimatePresence/index.mjs 99:36-50
Can't import the named export 'Fragment' from non EcmaScript module (only default export is available)
 @ ./node_modules/@wordpress/block-editor/node_modules/framer-motion/dist/es/index.mjs
 @ ./node_modules/@wordpress/block-editor/node_modules/@wordpress/components/build-module/animation/index.js
 @ ./node_modules/@wordpress/block-editor/node_modules/@wordpress/components/build-module/index.js
 @ ./node_modules/@wordpress/block-editor/build-module/components/block-settings-menu/block-settings-menu-first-item.js
 @ ./node_modules/@wordpress/block-editor/build-module/components/index.js
 @ ./node_modules/@wordpress/block-editor/build-module/index.js
 @ ./assets/js/utils/global-style.js
 @ ./assets/js/utils/index.ts
 @ ./assets/js/editor-components/external-link-card/index.tsx
 @ ./assets/js/editor-components/external-link-card/stories/index.tsx
 @ ./assets/js sync ^\.(?:(?:^|\/|(?:(?:(?!(?:^|\/)\.).)*?)\/)stories\/(?!\.)(?=.)[^/]*?\.(js|jsx|ts|tsx))$
 @ ./generated-stories-entry.js
 @ multi ./node_modules/@storybook/core-client/dist/esm/globals/polyfills.js ./node_modules/@storybook/core-client/dist/esm/globals/globals.js (webpack)-hot-middleware/client.js?reload=true&quiet=false&noInfo=undefined ./storybook-init-framework-entry.js ./node_modules/@storybook/react/dist/esm/client/docs/config-generated-config-entry.js ./node_modules/@storybook/react/dist/esm/client/preview/config-generated-config-entry.js ./node_modules/@storybook/addon-docs/preview.js-generated-config-entry.js ./node_modules/@storybook/addon-actions/preview.js-generated-config-entry.js ./node_modules/@storybook/addon-backgrounds/preview.js-generated-config-entry.js ./node_modules/@storybook/addon-measure/preview.js-generated-config-entry.js ./node_modules/@storybook/addon-outline/preview.js-generated-config-entry.js ./node_modules/@storybook/addon-a11y/preview.js-generated-config-entry.js ./node_modules/@storybook/addon-links/preview.js-generated-config-entry.js ./storybook/preview.js-generated-config-entry.js ./generated-stories-entry.js
```

I used solution provided in following comment:
https://github.com/storybookjs/storybook/issues/16690#issuecomment-971579785

This issue comes from the framer-motion library.

### Issue 2
> SassError: Can't find stylesheet to import. 

To fix this issue, I have updated the path in import statements. 

**Before**
```
@import "@wordpress/base-styles/breakpoints";
@import "@wordpress/base-styles/mixins";
@import "wordpress-components/src/popover/style";
@import "wordpress-components/src/tooltip/style";
```
**After**
```
@import "node_modules/@wordpress/base-styles/breakpoints";
@import "node_modules/@wordpress/base-styles/mixins";
@import "node_modules/wordpress-components/src/popover/style";
@import "node_modules/wordpress-components/src/tooltip/style";
```

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #6987 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

- Run the following command: `npm run storybook`
- Above command should build storybook without any errors & you should be able to see the UI at: http://localhost:6006/

* [X] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix storybook build failing issue
