### PR TITLE
Store API: Add missing documentation for reviews, categories, and tags

### DIFF
--- a/docs/third-party-developers/extensibility/rest-api/available-endpoints-to-extend.md
+++ b/docs/third-party-developers/extensibility/rest-api/available-endpoints-to-extend.md
@@ -2,24 +2,26 @@
 
 ## Table of Contents <!-- omit in toc -->
 
--   [`wc/store/checkout`](#wcstorecheckout)
-    -   [Passed Parameters](#passed-parameters)
-    -   [Key](#key)
--   [`wc/store/cart`](#wcstorecart)
-    -   [Passed Parameters](#passed-parameters-1)
-    -   [Key](#key-1)
--   [`wc/store/cart/items`](#wcstorecartitems)
-    -   [Passed Parameters](#passed-parameters-2)
-    -   [Key](#key-2)
--   [`wc/store/products`](#wcstoreproducts)
-    -   [Passed Parameters](#passed-parameters-3)
-    -   [Key](#key-3)
+- [`wc/store/checkout`](#wcstorecheckout)
+  - [Passed Parameters](#passed-parameters)
+  - [Key](#key)
+- [`wc/store/cart`](#wcstorecart)
+  - [Passed Parameters](#passed-parameters-1)
+  - [Key](#key-1)
+- [`wc/store/cart/items`](#wcstorecartitems)
+  - [Passed Parameters](#passed-parameters-2)
+  - [Key](#key-2)
+- [`wc/store/products`](#wcstoreproducts)
+  - [Passed Parameters](#passed-parameters-3)
+  - [Key](#key-3)
 
-To see how to add your data to Store API using ExtendSchema, [check this document](./extend-rest-api-add-data.md). This is a list of available endpoints that you can extend. If you want to add a new endpoint, [check this document](./extend-rest-api-new-endpoint.md).
+To see how to add your data to Store API using ExtendSchema, [check this document](./extend-rest-api-add-data.md). If you want to add a new endpoint, [check this document](./extend-rest-api-new-endpoint.md).
+
+This is a list of available endpoints that you can extend. For other endpoints, [see here](./../../../../src/StoreApi/README.md).
 
 ## `wc/store/checkout`
 
-The cartcheckout endpoint is extensible via ExtendSchema. The data is available via the `extensions` key in the response.
+The checkout endpoint is extensible via ExtendSchema. The data is available via the `extensions` key in the response.
 
 ### Passed Parameters
 

--- a/src/StoreApi/README.md
+++ b/src/StoreApi/README.md
@@ -73,6 +73,9 @@ Available resources in the Store API are listed below, with links to more detail
 | [`Product Attributes`](docs/product-attributes.md)           | `GET`                          | [`/wc/store/v1/products/attributes`](docs/product-attributes.md#list-product-attributes)      |
 |                                                              | `GET`                          | [`/wc/store/v1/products/attributes/:id`](docs/product-attributes.md#single-product-attribute) |
 | [`Product Attribute Terms`](docs/product-attribute-terms.md) | `GET`                          | [`/wc/store/v1/products/attributes/:id/terms`](docs/product-attribute-terms.md)               |
+| [`Product Categories`](docs/product-categories.md)           | `GET`                          | [`/wc/store/v1/products/categories`](docs/product-attribute-terms.md)                         |
+| [`Product Reviews`](docs/product-reviews.md)                 | `GET`                          | [`/wc/store/v1/products/reviews`](docs/product-attribute-terms.md)                            |
+| [`Product Tags`](docs/product-tags.md)                       | `GET`                          | [`/wc/store/v1/products/tags`](docs/product-attribute-terms.md)                               |
 
 ## Pagination
 
@@ -164,4 +167,3 @@ If the data is sensitive (for example, a core setting that should be private), o
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-blocks/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./src/StoreApi/README.md)
 
 <!-- /FEEDBACK -->
-

--- a/src/StoreApi/docs/product-categories.md
+++ b/src/StoreApi/docs/product-categories.md
@@ -1,0 +1,97 @@
+# Product Categories API <!-- omit in toc -->
+
+## Table of Contents <!-- omit in toc -->
+
+- [List Product Categories](#list-product-categories)
+- [Single Product Category](#single-product-category)
+
+## List Product Categories
+
+```http
+GET /products/categories
+```
+
+There are no parameters required for this endpoint.
+
+```sh
+curl "https://example-store.com/wp-json/wc/store/v1/products/categories"
+```
+
+Example response:
+
+```json
+[
+	{
+		"id": 16,
+		"name": "Clothing",
+		"slug": "clothing",
+		"description": "This is the clothing category.",
+		"parent": 0,
+		"count": 11,
+		"image": {
+			"id": 55,
+			"src": "https://store.local/wp-content/uploads/2021/11/t-shirt-with-logo-1.jpg",
+			"thumbnail": "https://store.local/wp-content/uploads/2021/11/t-shirt-with-logo-1-324x324.jpg",
+			"srcset": "https://store.local/wp-content/uploads/2021/11/t-shirt-with-logo-1.jpg 800w, https://store.local/wp-content/uploads/2021/11/t-shirt-with-logo-1-324x324.jpg 324w, https://store.local/wp-content/uploads/2021/11/t-shirt-with-logo-1-100x100.jpg 100w, https://store.local/wp-content/uploads/2021/11/t-shirt-with-logo-1-416x416.jpg 416w, https://store.local/wp-content/uploads/2021/11/t-shirt-with-logo-1-300x300.jpg 300w, https://store.local/wp-content/uploads/2021/11/t-shirt-with-logo-1-150x150.jpg 150w, https://store.local/wp-content/uploads/2021/11/t-shirt-with-logo-1-768x768.jpg 768w",
+			"sizes": "(max-width: 800px) 100vw, 800px",
+			"name": "t-shirt-with-logo-1.jpg",
+			"alt": ""
+		},
+		"review_count": 2,
+		"permalink": "https://store.local/product-category/clothing/"
+	},
+	{
+		"id": 21,
+		"name": "Decor",
+		"slug": "decor",
+		"description": "",
+		"parent": 0,
+		"count": 1,
+		"image": null,
+		"review_count": 1,
+		"permalink": "https://store.local/product-category/decor/"
+	}
+]
+```
+
+## Single Product Category
+
+Get a single category.
+
+```http
+GET /products/categories/:id
+```
+
+| Category | Type    | Required | Description                         |
+| :------- | :------ | :------: | :---------------------------------- |
+| `id`     | integer |   Yes    | The ID of the category to retrieve. |
+
+```sh
+curl "https://example-store.com/wp-json/wc/store/v1/products/categories/1"
+```
+
+**Example response:**
+
+```json
+{
+	"id": 1,
+	"name": "Decor",
+	"slug": "decor",
+	"description": "",
+	"parent": 0,
+	"count": 1,
+	"image": null,
+	"review_count": 1,
+	"permalink": "https://store.local/product-category/decor/"
+}
+```
+
+<!-- FEEDBACK -->
+
+---
+
+[We're hiring!](https://woocommerce.com/careers/) Come work with us!
+
+🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-blocks/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./src/StoreApi/docs/product-categories.md)
+
+<!-- /FEEDBACK -->

--- a/src/StoreApi/docs/product-reviews.md
+++ b/src/StoreApi/docs/product-reviews.md
@@ -1,0 +1,74 @@
+# Product Reviews API <!-- omit in toc -->
+
+## Table of Contents <!-- omit in toc -->
+
+- [List Product Reviews](#list-product-reviews)
+
+## List Product Reviews
+
+This endpoint returns product reviews (comments) and can also show results from either specific products or specific categories.
+
+```http
+GET /products/reviews
+GET /products/reviews?category_id=1,2,3
+GET /products/reviews?product_id=1,2,3
+GET /products/reviews?orderby=rating&order=desc
+```
+
+| Attribute     | Type    | Required | Description                                                                                         |
+| :------------ | :------ | :------: | :-------------------------------------------------------------------------------------------------- |
+| `page`        | integer |    no    | Current page of the collection.                                                                     |
+| `per_page`    | integer |    no    | Maximum number of items to be returned in result set. Defaults to no limit if left blank.           |
+| `offset`      | integer |    no    | Offset the result set by a specific number of items.                                                |
+| `order`       | string  |    no    | Order sort attribute ascending or descending. Allowed values: `asc`, `desc`                         |
+| `orderby`     | string  |    no    | Sort collection by object attribute. Allowed values : `date`, `date_gmt`, `id`, `rating`, `product` |
+| `category_id` | string  |    no    | Limit result set to reviews from specific category IDs.                                             |
+| `product_id`  | string  |    no    | Limit result set to reviews from specific product IDs.                                              |
+
+```sh
+curl "https://example-store.com/wp-json/wc/store/v1/products/collection-data?calculate_price_range=true&calculate_attribute_counts=pa_size,pa_color&calculate_rating_counts=true"
+```
+
+**Example response:**
+
+```json
+[
+	{
+		"id": 83,
+		"date_created": "2022-01-12T15:42:14",
+		"formatted_date_created": "January 12, 2022",
+		"date_created_gmt": "2022-01-12T15:42:14",
+		"product_id": 33,
+		"product_name": "Beanie with Logo",
+		"product_permalink": "https://store.local/product/beanie-with-logo/",
+		"product_image": {
+			"id": 56,
+			"src": "https://store.local/wp-content/uploads/2021/11/beanie-with-logo-1.jpg",
+			"thumbnail": "https://store.local/wp-content/uploads/2021/11/beanie-with-logo-1-324x324.jpg",
+			"srcset": "https://store.local/wp-content/uploads/2021/11/beanie-with-logo-1.jpg 800w, https://store.local/wp-content/uploads/2021/11/beanie-with-logo-1-324x324.jpg 324w, https://store.local/wp-content/uploads/2021/11/beanie-with-logo-1-100x100.jpg 100w, https://store.local/wp-content/uploads/2021/11/beanie-with-logo-1-416x416.jpg 416w, https://store.local/wp-content/uploads/2021/11/beanie-with-logo-1-300x300.jpg 300w, https://store.local/wp-content/uploads/2021/11/beanie-with-logo-1-150x150.jpg 150w, https://store.local/wp-content/uploads/2021/11/beanie-with-logo-1-768x768.jpg 768w",
+			"sizes": "(max-width: 800px) 100vw, 800px",
+			"name": "beanie-with-logo-1.jpg",
+			"alt": ""
+		},
+		"reviewer": "reviewer-name",
+		"review": "<p>This is a fantastic product.</p>\n",
+		"rating": 5,
+		"verified": true,
+		"reviewer_avatar_urls": {
+			"24": "https://secure.gravatar.com/avatar/12345?s=24&d=mm&r=g",
+			"48": "https://secure.gravatar.com/avatar/12345?s=48&d=mm&r=g",
+			"96": "https://secure.gravatar.com/avatar/12345?s=96&d=mm&r=g"
+		}
+	}
+]
+```
+
+<!-- FEEDBACK -->
+
+---
+
+[We're hiring!](https://woocommerce.com/careers/) Come work with us!
+
+🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-blocks/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./src/StoreApi/docs/product-collection-data.md)
+
+<!-- /FEEDBACK -->

--- a/src/StoreApi/docs/product-tags.md
+++ b/src/StoreApi/docs/product-tags.md
@@ -1,0 +1,50 @@
+# Product Tags API <!-- omit in toc -->
+
+## Table of Contents <!-- omit in toc -->
+
+- [List Product Tags](#list-product-tags)
+
+## List Product Tags
+
+```http
+GET /products/tags
+```
+
+There are no parameters required for this endpoint.
+
+```sh
+curl "https://example-store.com/wp-json/wc/store/v1/products/tags"
+```
+
+Example response:
+
+```json
+[
+	{
+		"id": 1,
+		"name": "Test Tag",
+		"slug": "test-tag",
+		"description": "",
+		"parent": 0,
+		"count": 1
+	},
+	{
+		"id": 2,
+		"name": "Another Tag",
+		"slug": "another-tag",
+		"description": "",
+		"parent": 0,
+		"count": 1
+	}
+]
+```
+
+<!-- FEEDBACK -->
+
+---
+
+[We're hiring!](https://woocommerce.com/careers/) Come work with us!
+
+🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-blocks/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./src/StoreApi/docs/product-tags.md)
+
+<!-- /FEEDBACK -->


### PR DESCRIPTION
Adds missing documentation for product routes, and updates the indexes.

Fixes #6251

### Testing

Review the docs:

- https://github.com/woocommerce/woocommerce-blocks/blob/9f646cae87c6a97b65798d9007d25e9a631fa5f1/src/StoreApi/docs/product-categories.md
- https://github.com/woocommerce/woocommerce-blocks/blob/9f646cae87c6a97b65798d9007d25e9a631fa5f1/src/StoreApi/docs/product-tags.md
- https://github.com/woocommerce/woocommerce-blocks/blob/9f646cae87c6a97b65798d9007d25e9a631fa5f1/src/StoreApi/docs/product-reviews.md

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->
