### PR TITLE
Improvements to the 'Update user-facing documentation as needed' step in the release checklist

### DIFF
--- a/.github/patch-initial-checklist.md
+++ b/.github/patch-initial-checklist.md
@@ -102,7 +102,3 @@ You only need to post public release announcements and update relevant public fa
   - Ensure the release notes are included in the post verbatim.
   - Don't forget to use category `WooCommerce Blocks Release Notes` for the post.
 * [ ] Announce the release internally (`#woo-announcements` slack).
-* [ ] Update user-facing documentation as needed. When the plugin is released, ensure user-facing documentation is kept up to date with new blocks and compatibility information.
-  - Update minimum supported versions (WordPress, WooCommerce Core) and other requirements where necessary, including:
-    - [WCCOM product page](https://woocommerce.com/products/woocommerce-gutenberg-products-block/)
-    - [WooCommerce blocks main documentation page](https://docs.woocommerce.com/document/woocommerce-blocks/)

--- a/.github/release-initial-checklist.md
+++ b/.github/release-initial-checklist.md
@@ -132,4 +132,4 @@ This only needs to be done if this release is the last release of the feature pl
   - Ensure any major improvements or changes are documented.
 - [ ] Update minimum supported versions (WordPress, WooCommerce Core) and other requirements where necessary, including:
   - [WCCOM product page](https://woocommerce.com/products/woocommerce-gutenberg-products-block/)
-  - [WooCommerce blocks main documentation page](https://docs.woocommerce.com/document/woocommerce-blocks/)
+  - [WooCommerce Blocks main documentation page](https://docs.woocommerce.com/document/woocommerce-blocks/)

--- a/.github/release-initial-checklist.md
+++ b/.github/release-initial-checklist.md
@@ -130,6 +130,6 @@ This only needs to be done if this release is the last release of the feature pl
 * [ ] Update user-facing documentation as needed. When the plugin is released, ensure user-facing documentation is kept up to date with new blocks and compatibility information. The dev team should update documents in collaboration with support team and WooCommerce docs guild. In particular, please review and update as needed:
   - Are there any new blocks in this release? Ensure they have adequate user documentation.
   - Ensure any major improvements or changes are documented.
-  - Update minimum supported versions (WordPress, WooCommerce Core) and other requirements where necessary, including:
-    - [WCCOM product page](https://woocommerce.com/products/woocommerce-gutenberg-products-block/)
-    - [WooCommerce blocks main documentation page](https://docs.woocommerce.com/document/woocommerce-blocks/)
+- [ ] Update minimum supported versions (WordPress, WooCommerce Core) and other requirements where necessary, including:
+  - [WCCOM product page](https://woocommerce.com/products/woocommerce-gutenberg-products-block/)
+  - [WooCommerce blocks main documentation page](https://docs.woocommerce.com/document/woocommerce-blocks/)


### PR DESCRIPTION
This PR makes two changes:

* Removes the _Update user-facing documentation as needed_ step from the patch release checklist. This step shouldn't be necessary in patch releases because we should only be fixing bugs, not introducing or changing features.
* Makes the _Update user-facing documentation as needed_ step a top-level step in the minor release checklist. This is to ensure it's more difficult to skip when doing releases.

### Testing

#### User Facing Testing

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->
