### PR TITLE
Fix typo in 8.8.2 changelog

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -88,7 +88,7 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 - Make the Filter by Price block range color dependent of the theme color. [7525](https://github.com/woocommerce/woocommerce-blocks/pull/7525)
 - Filter by Price block: fix price slider visibility on dark themes. [7527](https://github.com/woocommerce/woocommerce-blocks/pull/7527)
 - Update the Mini Cart block drawer to honor the theme's background. [7510](https://github.com/woocommerce/woocommerce-blocks/pull/7510)
-- Add white background to Filter by Attribute block dropdown so text is legible in dark backgrounds. [7506](https://github.com/woocommerce/woocommerce-blocks/pull/750
+- Add white background to Filter by Attribute block dropdown so text is legible in dark backgrounds. [7506](https://github.com/woocommerce/woocommerce-blocks/pull/7506)
 
 = 8.8.1 - 2022-10-28 =
 


### PR DESCRIPTION
Link appeared broken when updating the plugin:

<img src="https://user-images.githubusercontent.com/3616980/199048554-74828320-948e-4604-adbf-08b3d5697970.png" alt="" width="486" />