### PR TITLE
Fix: add missing export for Product Sale Badge

### DIFF
--- a/assets/js/atomic/blocks/product-elements/sale-badge/block.tsx
+++ b/assets/js/atomic/blocks/product-elements/sale-badge/block.tsx
@@ -25,7 +25,7 @@ import type { BlockAttributes } from './types';
 
 type Props = BlockAttributes & HTMLAttributes< HTMLDivElement >;
 
-const Block = ( props: Props ): JSX.Element | null => {
+export const Block = ( props: Props ): JSX.Element | null => {
 	const { className, align } = props;
 	const { parentClassName } = useInnerBlockLayoutContext();
 	const { product } = useProductDataContext();


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

This PR is a follow-up of #7094 which adds the export for `Block` in `assets/js/atomic/blocks/product-elements/sale-badge/block.tsx` back. `CartCrossSellsProduct` imports the `Block` component directly so we need to export it.

Question: should we refactor the `CartCrossSellsProduct` imports later to use only default exports?

Additional context: This is breaking the Cross-sell block of the Cart block and it [was caught](https://github.com/woocommerce/woocommerce-blocks/actions/runs/3375482325/jobs/5602154260) by our E2E tests.

<details>
<summary>Screenshots</summary>

![16673729645330 5216746803142194](https://user-images.githubusercontent.com/5423135/199432303-6e6a04f1-30e2-4339-9772-03cdd89fe9c0.png)


</details>

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental