### PR TITLE
Run the Monitor TypeScript job on trunk branch

### DIFF
--- a/.github/workflows/typescript-monitoring.yml
+++ b/.github/workflows/typescript-monitoring.yml
@@ -1,5 +1,8 @@
 name: Monitor TypeScript errors
-on: pull_request
+on:
+    push:
+        branches: [trunk]
+    pull_request:
 
 jobs:
     check-typescript-errors-with-trunk:


### PR DESCRIPTION
This PR is necessary for running the Monitor TypeScript errors on the trunk branch
