### PR TITLE
Filter by Rating: Add E2E tests

### DIFF
--- a/assets/js/base/components/product-rating/index.tsx
+++ b/assets/js/base/components/product-rating/index.tsx
@@ -50,7 +50,11 @@ const Rating = ( {
 					dangerouslySetInnerHTML={ ratingHTML }
 				/>
 			</div>
-			{ ratedProductsCount !== null ? `(${ ratedProductsCount })` : null }
+			{ ratedProductsCount !== null ? (
+				<span className={ 'wc-block-components-product-rating-count' }>
+					({ ratedProductsCount })
+				</span>
+			) : null }
 		</div>
 	);
 };

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -215,13 +215,13 @@
   No index signature with a parameter of type &apos;string&apos; was found on type &apos;Object&apos;." source="TS7053" />
 <error line="22" column="40" severity="error" message="Property &apos;defaults&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
 </file>
-<file name="assets/js/blocks-registry/payment-methods/payment-method-config.tsx">
-<error line="48" column="3" severity="error" message="Type &apos;string | undefined&apos; is not assignable to type &apos;string&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the type of the target.
-  Type &apos;undefined&apos; is not assignable to type &apos;string&apos;." source="TS2412" />
-</file>
 <file name="assets/js/filters/exclude-draft-status-from-analytics.js">
 <error line="10" column="33" severity="error" message="Parameter &apos;optionsGroup&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
 <error line="15" column="9" severity="error" message="Parameter &apos;option&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+</file>
+<file name="assets/js/blocks-registry/payment-methods/payment-method-config.tsx">
+<error line="48" column="3" severity="error" message="Type &apos;string | undefined&apos; is not assignable to type &apos;string&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the type of the target.
+  Type &apos;undefined&apos; is not assignable to type &apos;string&apos;." source="TS2412" />
 </file>
 <file name="assets/js/settings/blocks/feature-flags.ts">
 <error line="22" column="29" severity="error" message="No overload matches this call.
@@ -239,197 +239,6 @@
   Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{}&gt;): Block&lt;{}&gt; | undefined&apos;, gave the following error.
     Argument of type &apos;string | BlockConfiguration&lt;{}&gt;&apos; is not assignable to parameter of type &apos;string&apos;.
       Type &apos;BlockConfiguration&lt;{}&gt;&apos; is not assignable to type &apos;string&apos;." source="TS2769" />
-</file>
-<file name="assets/js/blocks-registry/block-components/register-block-component.js">
-<error line="42" column="2" severity="error" message="Type &apos;Function&apos; is not assignable to type &apos;RegisteredBlockComponent&apos;." source="TS2322" />
-<error line="53" column="7" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;Object&apos;.
-  No index signature with a parameter of type &apos;string&apos; was found on type &apos;Object&apos;." source="TS7053" />
-<error line="54" column="15" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;Object&apos;.
-  No index signature with a parameter of type &apos;string&apos; was found on type &apos;Object&apos;." source="TS7053" />
-<error line="58" column="4" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;Object&apos;.
-  No index signature with a parameter of type &apos;string&apos; was found on type &apos;Object&apos;." source="TS7053" />
-<error line="59" column="4" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;Object&apos;.
-  No index signature with a parameter of type &apos;string&apos; was found on type &apos;Object&apos;." source="TS7053" />
-<error line="78" column="28" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;Object&apos;.
-  No index signature with a parameter of type &apos;string&apos; was found on type &apos;Object&apos;." source="TS7053" />
-</file>
-<file name="packages/prices/utils/price.ts">
-<error line="52" column="8" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
-<error line="53" column="10" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
-<error line="54" column="21" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
-<error line="55" column="20" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
-<error line="56" column="13" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
-<error line="58" column="3" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
-<error line="59" column="3" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
-<error line="62" column="3" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
-<error line="63" column="3" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
-</file>
-<file name="packages/prices/utils/index.js">
-<error line="1" column="15" severity="error" message="File &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/packages/prices/utils/price.ts&apos; is not listed within the file list of project &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/tsconfig.json&apos;. Projects must list all files or use an &apos;include&apos; pattern." source="TS6307" />
-</file>
-<file name="packages/prices/index.js">
-<error line="1" column="15" severity="error" message="File &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/packages/prices/utils/index.js&apos; is not listed within the file list of project &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/tsconfig.json&apos;. Projects must list all files or use an &apos;include&apos; pattern." source="TS6307" />
-</file>
-<file name="assets/js/base/components/product-price/index.tsx">
-<error line="7" column="29" severity="error" message="File &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/packages/prices/index.js&apos; is not listed within the file list of project &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/tsconfig.json&apos;. Projects must list all files or use an &apos;include&apos; pattern.
-  The file is in the program because:
-    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/base/components/product-price/index.tsx&apos;
-    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/atomic/blocks/product-elements/price/block.js&apos;
-    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/base/context/hooks/payment-methods/use-payment-method-interface.ts&apos;
-    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/packages/checkout/components/totals/item/index.tsx&apos;
-    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/packages/checkout/components/totals/subtotal/index.tsx&apos;
-    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/packages/checkout/components/totals/taxes/index.tsx&apos;
-    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/packages/checkout/components/totals/fees/index.tsx&apos;
-    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/base/components/cart-checkout/order-summary/order-summary-item.tsx&apos;
-    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/base/components/cart-checkout/product-sale-badge/index.tsx&apos;
-    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/render-package-rate-option.tsx&apos;
-    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/shipping/index.tsx&apos;
-    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/active-filters/utils.tsx&apos;
-    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/cart/cart-line-items-table/cart-line-item-row.tsx&apos;
-    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-block/edit.tsx&apos;
-    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-subtotal/block.tsx&apos;
-    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-fee/block.tsx&apos;
-    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-discount/block.tsx&apos;
-    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-shipping/block.tsx&apos;
-    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-taxes/block.tsx&apos;
-    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-block/frontend.tsx&apos;
-    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-block/edit.tsx&apos;
-    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/block.tsx&apos;
-    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-subtotal/block.tsx&apos;
-    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-fee/block.tsx&apos;
-    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-discount/block.tsx&apos;
-    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-shipping/block.tsx&apos;
-    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-taxes/block.tsx&apos;
-    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-block/frontend.tsx&apos;
-    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/mini-cart/block.tsx&apos;
-    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-footer-block/block.tsx&apos;
-    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/mini-cart/edit.tsx&apos;
-    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/price-filter/block.tsx&apos;" source="TS6307" />
-<error line="285" column="5" severity="error" message="Type &apos;{ currency: Currency | Record&lt;string, never&gt;; price: string | number; priceClassName: string | undefined; priceStyle: CSSProperties | undefined; regularPrice: string | number; regularPriceClassName: string | undefined; regularPriceStyle: CSSProperties | undefined; }&apos; is not assignable to type &apos;SalePriceProps&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
-  Types of property &apos;regularPriceClassName&apos; are incompatible.
-    Type &apos;string | undefined&apos; is not assignable to type &apos;string&apos;.
-      Type &apos;undefined&apos; is not assignable to type &apos;string&apos;." source="TS2375" />
-<error line="297" column="5" severity="error" message="Type &apos;{ currency: Currency | Record&lt;string, never&gt;; maxPrice: string | number; minPrice: string | number; priceClassName: string | undefined; priceStyle: CSSProperties | undefined; }&apos; is not assignable to type &apos;PriceRangeProps&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
-  Types of property &apos;priceClassName&apos; are incompatible.
-    Type &apos;string | undefined&apos; is not assignable to type &apos;string&apos;.
-      Type &apos;undefined&apos; is not assignable to type &apos;string&apos;." source="TS2375" />
-<error line="307" column="5" severity="error" message="Type &apos;{ className: string; currency: Currency | Record&lt;string, never&gt;; value: string | number; style: CSSProperties | undefined; }&apos; is not assignable to type &apos;FormattedMonetaryAmountProps&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
-  Types of property &apos;style&apos; are incompatible.
-    Type &apos;CSSProperties | undefined&apos; is not assignable to type &apos;CSSProperties&apos;.
-      Type &apos;undefined&apos; is not assignable to type &apos;Properties&lt;string | number, string &amp; {}&gt;&apos;." source="TS2375" />
-</file>
-<file name="assets/js/shared/context/inner-block-layout-context.js">
-<error line="26" column="2" severity="error" message="Binding element &apos;children&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="33" column="37" severity="error" message="Property &apos;isLoading&apos; is missing in type &apos;{ parentName: string; parentClassName: string; }&apos; but required in type &apos;{ parentName: string; parentClassName: string; isLoading: boolean; }&apos;." source="TS2741" />
-</file>
-<file name="assets/js/shared/context/product-data-context.js">
-<error line="72" column="2" severity="error" message="Binding element &apos;children&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-</file>
-<file name="assets/js/shared/hocs/with-product-data-context.js">
-<error line="17" column="10" severity="error" message="Property &apos;productId&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="17" column="21" severity="error" message="Property &apos;OriginalComponent&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="22" column="17" severity="error" message="Property &apos;product&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="23" column="22" severity="error" message="Property &apos;product&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="26" column="13" severity="error" message="Property &apos;product&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="64" column="11" severity="error" message="Parameter &apos;props&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-</file>
-<file name="assets/js/base/utils/errors.js">
-<error line="26" column="14" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
-<error line="33" column="3" severity="error" message="Type &apos;string | undefined&apos; is not assignable to type &apos;string&apos;.
-  Type &apos;undefined&apos; is not assignable to type &apos;string&apos;." source="TS2322" />
-<error line="45" column="16" severity="error" message="Property &apos;data&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="45" column="33" severity="error" message="Property &apos;code&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="46" column="49" severity="error" message="Property &apos;data&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="52" column="19" severity="error" message="Property &apos;message&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="53" column="30" severity="error" message="Property &apos;message&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-</file>
-<file name="assets/js/base/utils/address.ts">
-<error line="89" column="46" severity="error" message="Argument of type &apos;string[]&apos; is not assignable to parameter of type &apos;(keyof AddressFields)[]&apos;.
-  Type &apos;string&apos; is not assignable to type &apos;keyof AddressFields&apos;." source="TS2345" />
-</file>
-<file name="assets/js/base/utils/shipping-rates.js">
-<error line="4" column="12" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
-<error line="13" column="12" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
-</file>
-<file name="assets/js/base/components/block-error-boundary/index.tsx">
-<error line="58" column="6" severity="error" message="Type &apos;{ showErrorBlock: boolean; errorMessage: string | null; header: string | undefined; imageUrl: string | undefined; text: ReactNode; errorMessagePrefix: string | undefined; button: ReactNode; }&apos; is not assignable to type &apos;BlockErrorProps&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
-  Types of property &apos;imageUrl&apos; are incompatible.
-    Type &apos;string | undefined&apos; is not assignable to type &apos;string&apos;.
-      Type &apos;undefined&apos; is not assignable to type &apos;string&apos;." source="TS2375" />
-<error line="58" column="6" severity="error" message="&apos;BlockError&apos; cannot be used as a JSX component.
-  Its return type &apos;ReactNode&apos; is not a valid JSX element.
-    Type &apos;undefined&apos; is not assignable to type &apos;Element | null&apos;." source="TS2786" />
-</file>
-<file name="assets/js/base/utils/render-frontend.tsx">
-<error line="60" column="4" severity="error" message="No overload matches this call.
-  Overload 1 of 2, &apos;(props: BlockErrorBoundaryProps | Readonly&lt;BlockErrorBoundaryProps&gt;): BlockErrorBoundary&apos;, gave the following error.
-    Property &apos;text&apos; is missing in type &apos;{ children: Element; }&apos; but required in type &apos;Readonly&lt;BlockErrorBoundaryProps&gt;&apos;.
-  Overload 2 of 2, &apos;(props: BlockErrorBoundaryProps, context: any): BlockErrorBoundary&apos;, gave the following error.
-    Property &apos;text&apos; is missing in type &apos;{ children: Element; }&apos; but required in type &apos;Readonly&lt;BlockErrorBoundaryProps&gt;&apos;." source="TS2769" />
-<error line="168" column="27" severity="error" message="Argument of type &apos;{ Block: BlockType&lt;TProps, TAttributes&gt; | null; containers: NodeListOf&lt;Element&gt;; getProps: GetPropsFn&lt;TProps, TAttributes&gt; | undefined; getErrorBoundaryProps: ((el: HTMLElement, i: number) =&gt; Record&lt;...&gt;) | undefined; }&apos; is not assignable to parameter of type &apos;RenderBlockInContainersParams&lt;TProps, TAttributes&gt;&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
-  Types of property &apos;getProps&apos; are incompatible.
-    Type &apos;GetPropsFn&lt;TProps, TAttributes&gt; | undefined&apos; is not assignable to type &apos;GetPropsFn&lt;TProps, TAttributes&gt;&apos;.
-      Type &apos;undefined&apos; is not assignable to type &apos;GetPropsFn&lt;TProps, TAttributes&gt;&apos;." source="TS2379" />
-<error line="199" column="27" severity="error" message="Argument of type &apos;{ Block: BlockType&lt;TProps, TAttributes&gt; | null; containers: NodeListOf&lt;Element&gt;; getProps: GetPropsFn&lt;TProps, TAttributes&gt; | undefined; getErrorBoundaryProps: ((el: HTMLElement, i: number) =&gt; Record&lt;...&gt;) | undefined; }&apos; is not assignable to parameter of type &apos;RenderBlockInContainersParams&lt;TProps, TAttributes&gt;&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
-  Types of property &apos;getProps&apos; are incompatible.
-    Type &apos;GetPropsFn&lt;TProps, TAttributes&gt; | undefined&apos; is not assignable to type &apos;GetPropsFn&lt;TProps, TAttributes&gt;&apos;.
-      Type &apos;undefined&apos; is not assignable to type &apos;GetPropsFn&lt;TProps, TAttributes&gt;&apos;." source="TS2379" />
-<error line="244" column="30" severity="error" message="Argument of type &apos;{ Block: BlockType&lt;TProps, TAttributes&gt; | null; getProps: GetPropsFn&lt;TProps, TAttributes&gt; | undefined; getErrorBoundaryProps: ((el: HTMLElement, i: number) =&gt; Record&lt;...&gt;) | undefined; selector: string; wrappers: NodeListOf&lt;...&gt;; }&apos; is not assignable to parameter of type &apos;RenderBlockOutsideWrappersParams&lt;TProps, TAttributes&gt;&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
-  Types of property &apos;getProps&apos; are incompatible.
-    Type &apos;GetPropsFn&lt;TProps, TAttributes&gt; | undefined&apos; is not assignable to type &apos;GetPropsFn&lt;TProps, TAttributes&gt;&apos;.
-      Type &apos;undefined&apos; is not assignable to type &apos;GetPropsFn&lt;TProps, TAttributes&gt;&apos;." source="TS2379" />
-</file>
-<file name="assets/js/base/utils/get-valid-block-attributes.js">
-<error line="5" column="12" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
-<error line="6" column="13" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
-<error line="9" column="8" severity="error" message="Variable &apos;attributes&apos; implicitly has type &apos;any[]&apos; in some locations where its type cannot be determined." source="TS7034" />
-<error line="12" column="30" severity="error" message="Element implicitly has an &apos;any&apos; type because index expression is not of type &apos;number&apos;." source="TS7015" />
-<error line="13" column="13" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;Object&apos;.
-  No index signature with a parameter of type &apos;string&apos; was found on type &apos;Object&apos;." source="TS7053" />
-<error line="15" column="6" severity="error" message="Variable &apos;attributes&apos; implicitly has an &apos;any[]&apos; type." source="TS7005" />
-<error line="15" column="18" severity="error" message="Element implicitly has an &apos;any&apos; type because index expression is not of type &apos;number&apos;." source="TS7015" />
-<error line="16" column="22" severity="error" message="Element implicitly has an &apos;any&apos; type because index expression is not of type &apos;number&apos;." source="TS7015" />
-<error line="17" column="22" severity="error" message="Element implicitly has an &apos;any&apos; type because index expression is not of type &apos;number&apos;." source="TS7015" />
-<error line="20" column="6" severity="error" message="Variable &apos;attributes&apos; implicitly has an &apos;any[]&apos; type." source="TS7005" />
-<error line="20" column="18" severity="error" message="Element implicitly has an &apos;any&apos; type because index expression is not of type &apos;number&apos;." source="TS7015" />
-<error line="20" column="51" severity="error" message="Element implicitly has an &apos;any&apos; type because index expression is not of type &apos;number&apos;." source="TS7015" />
-<error line="24" column="6" severity="error" message="Variable &apos;attributes&apos; implicitly has an &apos;any[]&apos; type." source="TS7005" />
-<error line="24" column="18" severity="error" message="Element implicitly has an &apos;any&apos; type because index expression is not of type &apos;number&apos;." source="TS7015" />
-<error line="24" column="53" severity="error" message="Element implicitly has an &apos;any&apos; type because index expression is not of type &apos;number&apos;." source="TS7015" />
-<error line="27" column="6" severity="error" message="Variable &apos;attributes&apos; implicitly has an &apos;any[]&apos; type." source="TS7005" />
-<error line="27" column="18" severity="error" message="Element implicitly has an &apos;any&apos; type because index expression is not of type &apos;number&apos;." source="TS7015" />
-<error line="27" column="41" severity="error" message="Element implicitly has an &apos;any&apos; type because index expression is not of type &apos;number&apos;." source="TS7015" />
-<error line="31" column="4" severity="error" message="Variable &apos;attributes&apos; implicitly has an &apos;any[]&apos; type." source="TS7005" />
-<error line="31" column="16" severity="error" message="Element implicitly has an &apos;any&apos; type because index expression is not of type &apos;number&apos;." source="TS7015" />
-<error line="31" column="24" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;Object&apos;.
-  No index signature with a parameter of type &apos;string&apos; was found on type &apos;Object&apos;." source="TS7053" />
-<error line="35" column="9" severity="error" message="Variable &apos;attributes&apos; implicitly has an &apos;any[]&apos; type." source="TS7005" />
-</file>
-<file name="assets/js/base/utils/product-data.js">
-<error line="8" column="17" severity="error" message="Property &apos;is_purchasable&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="30" column="42" severity="error" message="Property &apos;type&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-</file>
-<file name="assets/js/shared/hocs/with-filtered-attributes.js">
-<error line="12" column="27" severity="error" message="Parameter &apos;OriginalComponent&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="13" column="12" severity="error" message="Parameter &apos;ownProps&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-</file>
-<file name="assets/js/utils/global-style.js">
-<error line="5" column="10" severity="error" message="Module &apos;&quot;@wordpress/block-editor&quot;&apos; has no exported member &apos;__experimentalGetSpacingClassesAndStyles&apos;." source="TS2305" />
-</file>
-<file name="assets/js/hooks/style-attributes.ts">
-<error line="6" column="2" severity="error" message="Module &apos;&quot;@wordpress/block-editor&quot;&apos; has no exported member &apos;__experimentalUseColorProps&apos;." source="TS2305" />
-<error line="7" column="2" severity="error" message="Module &apos;&quot;@wordpress/block-editor&quot;&apos; has no exported member &apos;__experimentalGetSpacingClassesAndStyles&apos;." source="TS2305" />
-<error line="8" column="2" severity="error" message="Module &apos;&quot;@wordpress/block-editor&quot;&apos; has no exported member &apos;__experimentalUseBorderProps&apos;." source="TS2305" />
-</file>
-<file name="assets/js/atomic/blocks/product-elements/price/block.js">
-<error line="55" column="18" severity="error" message="Type &apos;string | undefined&apos; is not assignable to type &apos;&quot;center&quot; | &quot;left&quot; | &quot;right&quot; | undefined&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the type of the target." source="TS2412" />
-<error line="60" column="49" severity="error" message="Argument of type &apos;{ currency_code: string; currency_symbol: string; currency_minor_unit: number; currency_decimal_separator: string; currency_thousand_separator: string; currency_prefix: string; currency_suffix: string; price: string; regular_price: string; sale_price: string; price_range: null; }&apos; is not assignable to parameter of type &apos;CurrencyResponse | Record&lt;string, never&gt; | CartShippingPackageShippingRate | undefined&apos;.
-  Type &apos;{ currency_code: string; currency_symbol: string; currency_minor_unit: number; currency_decimal_separator: string; currency_thousand_separator: string; currency_prefix: string; currency_suffix: string; price: string; regular_price: string; sale_price: string; price_range: null; }&apos; is not assignable to type &apos;Record&lt;string, never&gt;&apos;.
-    Property &apos;currency_code&apos; is incompatible with index signature.
-      Type &apos;string&apos; is not assignable to type &apos;never&apos;." source="TS2345" />
-<error line="69" column="4" severity="error" message="Type &apos;string | undefined&apos; is not assignable to type &apos;&quot;center&quot; | &quot;left&quot; | &quot;right&quot; | undefined&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the type of the target." source="TS2412" />
-<error line="77" column="36" severity="error" message="Property &apos;min_amount&apos; does not exist on type &apos;never&apos;." source="TS2339" />
-<error line="78" column="36" severity="error" message="Property &apos;max_amount&apos; does not exist on type &apos;never&apos;." source="TS2339" />
 </file>
 <file name="assets/js/data/schema/selectors.js">
 <error line="19" column="12" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
@@ -463,9 +272,9 @@
 <error line="28" column="21" severity="error" message="Parameter &apos;route&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
 </file>
 <file name="assets/js/data/schema/index.js">
-<error line="17" column="2" severity="error" message="Type &apos;Reducer&lt;CombinedState&lt;{ routes: Object; }&gt;, AnyAction&gt;&apos; is not assignable to type &apos;Reducer&lt;&quot;wc/store/cart&quot;, AnyAction&gt;&apos;.
+<error line="17" column="2" severity="error" message="Type &apos;Reducer&lt;CombinedState&lt;{ routes: Object; }&gt;, AnyAction&gt;&apos; is not assignable to type &apos;Reducer&lt;&quot;core/editor&quot;, AnyAction&gt;&apos;.
   Types of parameters &apos;state&apos; and &apos;state&apos; are incompatible.
-    Type &apos;&quot;wc/store/cart&quot; | undefined&apos; is not assignable to type &apos;CombinedState&lt;{ routes: Object; }&gt; | undefined&apos;.
+    Type &apos;&quot;core/editor&quot; | undefined&apos; is not assignable to type &apos;CombinedState&lt;{ routes: Object; }&gt; | undefined&apos;.
       Type &apos;string&apos; is not assignable to type &apos;CombinedState&lt;{ routes: Object; }&gt;&apos;.
         Type &apos;string&apos; is not assignable to type &apos;{ routes: Object; }&apos;." source="TS2322" />
 <error line="18" column="2" severity="error" message="Type &apos;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/data/schema/actions&quot;)&apos; is not assignable to type &apos;{ [k: string]: (...args: readonly any[]) =&gt; AnyAction | Generator&lt;any, any, unknown&gt;; }&apos;.
@@ -553,8 +362,8 @@
       Types of parameters &apos;state&apos; and &apos;state&apos; are incompatible.
         Type &apos;Object&apos; is not assignable to type &apos;string&apos;." source="TS2322" />
 </file>
-<file name="assets/js/data/default-states.ts">
-<error line="72" column="4" severity="error" message="Type &apos;&quot;&quot;&apos; is not assignable to type &apos;CurrencyCode&apos;." source="TS2322" />
+<file name="assets/js/data/cart/default-state.ts">
+<error line="73" column="4" severity="error" message="Type &apos;&quot;&quot;&apos; is not assignable to type &apos;CurrencyCode&apos;." source="TS2322" />
 </file>
 <file name="assets/js/data/mapped-types.ts">
 <error line="29" column="28" severity="error" message="Type &apos;S[selector]&apos; does not satisfy the constraint &apos;Function&apos;.
@@ -631,8 +440,156 @@
 <error line="178" column="38" severity="error" message="Property &apos;isResolving&apos; does not exist on type &apos;Partial&lt;unknown&gt;&apos;." source="TS2339" />
 <error line="187" column="30" severity="error" message="Property &apos;isCartDataStale&apos; does not exist on type &apos;Partial&lt;unknown&gt;&apos;." source="TS2339" />
 </file>
+<file name="assets/js/base/utils/errors.js">
+<error line="26" column="14" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
+<error line="33" column="3" severity="error" message="Type &apos;string | undefined&apos; is not assignable to type &apos;string&apos;.
+  Type &apos;undefined&apos; is not assignable to type &apos;string&apos;." source="TS2322" />
+<error line="45" column="16" severity="error" message="Property &apos;data&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="45" column="33" severity="error" message="Property &apos;code&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="46" column="49" severity="error" message="Property &apos;data&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="52" column="19" severity="error" message="Property &apos;message&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="59" column="34" severity="error" message="Property &apos;message&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+</file>
+<file name="assets/js/base/utils/address.ts">
+<error line="92" column="46" severity="error" message="Argument of type &apos;string[]&apos; is not assignable to parameter of type &apos;(keyof AddressFields)[]&apos;.
+  Type &apos;string&apos; is not assignable to type &apos;keyof AddressFields&apos;." source="TS2345" />
+</file>
+<file name="assets/js/base/utils/shipping-rates.js">
+<error line="4" column="12" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
+<error line="13" column="12" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
+</file>
+<file name="assets/js/base/components/block-error-boundary/index.tsx">
+<error line="58" column="6" severity="error" message="Type &apos;{ showErrorBlock: boolean; errorMessage: string | null; header: string | undefined; imageUrl: string | undefined; text: ReactNode; errorMessagePrefix: string | undefined; button: ReactNode; }&apos; is not assignable to type &apos;BlockErrorProps&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+  Types of property &apos;imageUrl&apos; are incompatible.
+    Type &apos;string | undefined&apos; is not assignable to type &apos;string&apos;.
+      Type &apos;undefined&apos; is not assignable to type &apos;string&apos;." source="TS2375" />
+<error line="58" column="6" severity="error" message="&apos;BlockError&apos; cannot be used as a JSX component.
+  Its return type &apos;ReactNode&apos; is not a valid JSX element.
+    Type &apos;undefined&apos; is not assignable to type &apos;Element | null&apos;." source="TS2786" />
+</file>
+<file name="assets/js/base/utils/render-frontend.tsx">
+<error line="60" column="4" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(props: BlockErrorBoundaryProps | Readonly&lt;BlockErrorBoundaryProps&gt;): BlockErrorBoundary&apos;, gave the following error.
+    Property &apos;text&apos; is missing in type &apos;{ children: Element; }&apos; but required in type &apos;Readonly&lt;BlockErrorBoundaryProps&gt;&apos;.
+  Overload 2 of 2, &apos;(props: BlockErrorBoundaryProps, context: any): BlockErrorBoundary&apos;, gave the following error.
+    Property &apos;text&apos; is missing in type &apos;{ children: Element; }&apos; but required in type &apos;Readonly&lt;BlockErrorBoundaryProps&gt;&apos;." source="TS2769" />
+<error line="168" column="27" severity="error" message="Argument of type &apos;{ Block: BlockType&lt;TProps, TAttributes&gt; | null; containers: NodeListOf&lt;Element&gt;; getProps: GetPropsFn&lt;TProps, TAttributes&gt; | undefined; getErrorBoundaryProps: ((el: HTMLElement, i: number) =&gt; Record&lt;...&gt;) | undefined; }&apos; is not assignable to parameter of type &apos;RenderBlockInContainersParams&lt;TProps, TAttributes&gt;&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+  Types of property &apos;getProps&apos; are incompatible.
+    Type &apos;GetPropsFn&lt;TProps, TAttributes&gt; | undefined&apos; is not assignable to type &apos;GetPropsFn&lt;TProps, TAttributes&gt;&apos;.
+      Type &apos;undefined&apos; is not assignable to type &apos;GetPropsFn&lt;TProps, TAttributes&gt;&apos;." source="TS2379" />
+<error line="199" column="27" severity="error" message="Argument of type &apos;{ Block: BlockType&lt;TProps, TAttributes&gt; | null; containers: NodeListOf&lt;Element&gt;; getProps: GetPropsFn&lt;TProps, TAttributes&gt; | undefined; getErrorBoundaryProps: ((el: HTMLElement, i: number) =&gt; Record&lt;...&gt;) | undefined; }&apos; is not assignable to parameter of type &apos;RenderBlockInContainersParams&lt;TProps, TAttributes&gt;&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+  Types of property &apos;getProps&apos; are incompatible.
+    Type &apos;GetPropsFn&lt;TProps, TAttributes&gt; | undefined&apos; is not assignable to type &apos;GetPropsFn&lt;TProps, TAttributes&gt;&apos;.
+      Type &apos;undefined&apos; is not assignable to type &apos;GetPropsFn&lt;TProps, TAttributes&gt;&apos;." source="TS2379" />
+<error line="244" column="30" severity="error" message="Argument of type &apos;{ Block: BlockType&lt;TProps, TAttributes&gt; | null; getProps: GetPropsFn&lt;TProps, TAttributes&gt; | undefined; getErrorBoundaryProps: ((el: HTMLElement, i: number) =&gt; Record&lt;...&gt;) | undefined; selector: string; wrappers: NodeListOf&lt;...&gt;; }&apos; is not assignable to parameter of type &apos;RenderBlockOutsideWrappersParams&lt;TProps, TAttributes&gt;&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+  Types of property &apos;getProps&apos; are incompatible.
+    Type &apos;GetPropsFn&lt;TProps, TAttributes&gt; | undefined&apos; is not assignable to type &apos;GetPropsFn&lt;TProps, TAttributes&gt;&apos;.
+      Type &apos;undefined&apos; is not assignable to type &apos;GetPropsFn&lt;TProps, TAttributes&gt;&apos;." source="TS2379" />
+</file>
+<file name="assets/js/base/utils/get-valid-block-attributes.js">
+<error line="5" column="12" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
+<error line="6" column="13" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
+<error line="9" column="8" severity="error" message="Variable &apos;attributes&apos; implicitly has type &apos;any[]&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="12" column="30" severity="error" message="Element implicitly has an &apos;any&apos; type because index expression is not of type &apos;number&apos;." source="TS7015" />
+<error line="13" column="13" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;Object&apos;.
+  No index signature with a parameter of type &apos;string&apos; was found on type &apos;Object&apos;." source="TS7053" />
+<error line="15" column="6" severity="error" message="Variable &apos;attributes&apos; implicitly has an &apos;any[]&apos; type." source="TS7005" />
+<error line="15" column="18" severity="error" message="Element implicitly has an &apos;any&apos; type because index expression is not of type &apos;number&apos;." source="TS7015" />
+<error line="16" column="22" severity="error" message="Element implicitly has an &apos;any&apos; type because index expression is not of type &apos;number&apos;." source="TS7015" />
+<error line="17" column="22" severity="error" message="Element implicitly has an &apos;any&apos; type because index expression is not of type &apos;number&apos;." source="TS7015" />
+<error line="20" column="6" severity="error" message="Variable &apos;attributes&apos; implicitly has an &apos;any[]&apos; type." source="TS7005" />
+<error line="20" column="18" severity="error" message="Element implicitly has an &apos;any&apos; type because index expression is not of type &apos;number&apos;." source="TS7015" />
+<error line="20" column="51" severity="error" message="Element implicitly has an &apos;any&apos; type because index expression is not of type &apos;number&apos;." source="TS7015" />
+<error line="24" column="6" severity="error" message="Variable &apos;attributes&apos; implicitly has an &apos;any[]&apos; type." source="TS7005" />
+<error line="24" column="18" severity="error" message="Element implicitly has an &apos;any&apos; type because index expression is not of type &apos;number&apos;." source="TS7015" />
+<error line="24" column="53" severity="error" message="Element implicitly has an &apos;any&apos; type because index expression is not of type &apos;number&apos;." source="TS7015" />
+<error line="27" column="6" severity="error" message="Variable &apos;attributes&apos; implicitly has an &apos;any[]&apos; type." source="TS7005" />
+<error line="27" column="18" severity="error" message="Element implicitly has an &apos;any&apos; type because index expression is not of type &apos;number&apos;." source="TS7015" />
+<error line="27" column="41" severity="error" message="Element implicitly has an &apos;any&apos; type because index expression is not of type &apos;number&apos;." source="TS7015" />
+<error line="31" column="4" severity="error" message="Variable &apos;attributes&apos; implicitly has an &apos;any[]&apos; type." source="TS7005" />
+<error line="31" column="16" severity="error" message="Element implicitly has an &apos;any&apos; type because index expression is not of type &apos;number&apos;." source="TS7015" />
+<error line="31" column="24" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;Object&apos;.
+  No index signature with a parameter of type &apos;string&apos; was found on type &apos;Object&apos;." source="TS7053" />
+<error line="35" column="9" severity="error" message="Variable &apos;attributes&apos; implicitly has an &apos;any[]&apos; type." source="TS7005" />
+</file>
+<file name="assets/js/base/utils/product-data.js">
+<error line="8" column="17" severity="error" message="Property &apos;is_purchasable&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="30" column="42" severity="error" message="Property &apos;type&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+</file>
 <file name="assets/js/data/cart/controls.js">
 <error line="22" column="31" severity="error" message="Parameter &apos;preserveCartData&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+</file>
+<file name="assets/js/utils/notices.ts">
+<error line="12" column="52" severity="error" message="Property &apos;type&apos; does not exist on type &apos;Notice&apos;." source="TS2339" />
+</file>
+<file name="assets/js/data/checkout/thunks.ts">
+<error line="5" column="10" severity="error" message="Module &apos;&quot;@wordpress/notices&quot;&apos; has no exported member &apos;store&apos;." source="TS2305" />
+<error line="57" column="11" severity="error" message="Property &apos;createErrorNotice&apos; does not exist on type &apos;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__rich-text/store/actions&quot;)&apos;." source="TS2339" />
+<error line="92" column="12" severity="error" message="Property &apos;createErrorNotice&apos; does not exist on type &apos;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__rich-text/store/actions&quot;)&apos;." source="TS2339" />
+</file>
+<file name="assets/js/data/checkout/reducers.ts">
+<error line="164" column="25" severity="error" message="Property &apos;SET_PRISTINE&apos; does not exist on type &apos;{ readonly SET_IDLE: &quot;SET_IDLE&quot;; readonly SET_REDIRECT_URL: &quot;SET_REDIRECT_URL&quot;; readonly SET_COMPLETE: &quot;SET_CHECKOUT_COMPLETE&quot;; readonly SET_BEFORE_PROCESSING: &quot;SET_BEFORE_PROCESSING&quot;; ... 11 more ...; readonly SET_IS_CART: &quot;SET_IS_CART&quot;; }&apos;." source="TS2339" />
+</file>
+<file name="assets/js/data/checkout/index.ts">
+<error line="25" column="44" severity="error" message="Argument of type &apos;{ reducer: (state: CheckoutState | undefined, action: actions.CheckoutAction) =&gt; CheckoutState; selectors: typeof selectors; actions: typeof actions; __experimentalUseThunks: boolean; }&apos; is not assignable to parameter of type &apos;StoreConfig&lt;CheckoutState&gt;&apos;.
+  Types of property &apos;actions&apos; are incompatible.
+    Type &apos;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/data/checkout/actions&quot;)&apos; is not assignable to type &apos;{ [k: string]: (...args: readonly any[]) =&gt; AnyAction | Generator&lt;any, any, unknown&gt;; }&apos;.
+      Property &apos;__internalProcessCheckoutResponse&apos; is incompatible with index signature.
+        Type &apos;(response: CheckoutResponse) =&gt; ({ dispatch, }: { dispatch: DispatchFromMap&lt;typeof actions&gt;; }) =&gt; void&apos; is not assignable to type &apos;(...args: readonly any[]) =&gt; AnyAction | Generator&lt;any, any, unknown&gt;&apos;.
+          Type &apos;({ dispatch, }: { dispatch: DispatchFromMap&lt;typeof actions&gt;; }) =&gt; void&apos; is not assignable to type &apos;AnyAction | Generator&lt;any, any, unknown&gt;&apos;." source="TS2345" />
+</file>
+<file name="assets/js/previews/cart.ts">
+<error line="75" column="4" severity="error" message="Property &apos;price_range&apos; is missing in type &apos;{ currency_code: &quot;USD&quot;; currency_symbol: string; currency_minor_unit: number; currency_decimal_separator: string; currency_thousand_separator: string; currency_prefix: string; currency_suffix: string; price: string; regular_price: string; sale_price: string; raw_prices: { ...; }; }&apos; but required in type &apos;CartItemPrices&apos;." source="TS2741" />
+<error line="141" column="4" severity="error" message="Property &apos;price_range&apos; is missing in type &apos;{ currency_code: &quot;USD&quot;; currency_symbol: string; currency_minor_unit: number; currency_decimal_separator: string; currency_thousand_separator: string; currency_prefix: string; currency_suffix: string; price: string; regular_price: string; sale_price: string; raw_prices: { ...; }; }&apos; but required in type &apos;CartItemPrices&apos;." source="TS2741" />
+<error line="180" column="4" severity="error" message="Property &apos;price_range&apos; is missing in type &apos;{ currency_code: &quot;USD&quot;; currency_symbol: string; currency_minor_unit: number; currency_decimal_separator: string; currency_thousand_separator: string; currency_prefix: string; currency_suffix: string; price: string; regular_price: string; sale_price: string; raw_prices: { ...; }; }&apos; but required in type &apos;ProductResponseItemPrices&apos;." source="TS2741" />
+<error line="215" column="4" severity="error" message="Property &apos;price_range&apos; is missing in type &apos;{ currency_code: &quot;USD&quot;; currency_symbol: string; currency_minor_unit: number; currency_decimal_separator: string; currency_thousand_separator: string; currency_prefix: string; currency_suffix: string; price: string; regular_price: string; sale_price: string; raw_prices: { ...; }; }&apos; but required in type &apos;ProductResponseItemPrices&apos;." source="TS2741" />
+<error line="252" column="4" severity="error" message="Property &apos;price_range&apos; is missing in type &apos;{ currency_code: &quot;USD&quot;; currency_symbol: string; currency_minor_unit: number; currency_decimal_separator: string; currency_thousand_separator: string; currency_prefix: string; currency_suffix: string; price: string; regular_price: string; sale_price: string; raw_prices: { ...; }; }&apos; but required in type &apos;ProductResponseItemPrices&apos;." source="TS2741" />
+<error line="290" column="4" severity="error" message="Property &apos;price_range&apos; is missing in type &apos;{ currency_code: &quot;USD&quot;; currency_symbol: string; currency_minor_unit: number; currency_decimal_separator: string; currency_thousand_separator: string; currency_prefix: string; currency_suffix: string; price: string; regular_price: string; sale_price: string; raw_prices: { ...; }; }&apos; but required in type &apos;ProductResponseItemPrices&apos;." source="TS2741" />
+<error line="327" column="4" severity="error" message="Property &apos;price_range&apos; is missing in type &apos;{ currency_code: &quot;USD&quot;; currency_symbol: string; currency_minor_unit: number; currency_decimal_separator: string; currency_thousand_separator: string; currency_prefix: string; currency_suffix: string; price: string; regular_price: string; sale_price: string; raw_prices: { ...; }; }&apos; but required in type &apos;ProductResponseItemPrices&apos;." source="TS2741" />
+<error line="365" column="4" severity="error" message="Property &apos;price_range&apos; is missing in type &apos;{ currency_code: &quot;USD&quot;; currency_symbol: string; currency_minor_unit: number; currency_decimal_separator: string; currency_thousand_separator: string; currency_prefix: string; currency_suffix: string; price: string; regular_price: string; sale_price: string; raw_prices: { ...; }; }&apos; but required in type &apos;ProductResponseItemPrices&apos;." source="TS2741" />
+<error line="411" column="5" severity="error" message="Type &apos;{ currency_code: &quot;USD&quot;; currency_symbol: string; currency_minor_unit: number; currency_decimal_separator: string; currency_thousand_separator: string; currency_prefix: string; currency_suffix: string; total: string; total_tax: string; tax_lines: { ...; }[]; }&apos; is not assignable to type &apos;CartResponseFeeItemTotals&apos;.
+  Object literal may only specify known properties, and &apos;tax_lines&apos; does not exist in type &apos;CartResponseFeeItemTotals&apos;." source="TS2322" />
+</file>
+<file name="assets/js/data/payment/check-payment-methods.ts">
+<error line="15" column="10" severity="error" message="Module &apos;&quot;@wordpress/notices&quot;&apos; has no exported member &apos;store&apos;." source="TS2305" />
+<error line="132" column="37" severity="error" message="Property &apos;paymentRequirements&apos; does not exist on type &apos;CartResponse&apos;. Did you mean &apos;payment_requirements&apos;?" source="TS2551" />
+<error line="134" column="25" severity="error" message="Property &apos;receiveCart&apos; does not exist on type &apos;CartResponse&apos;." source="TS2339" />
+<error line="135" column="20" severity="error" message="Property &apos;receiveCart&apos; does not exist on type &apos;CartResponse&apos;." source="TS2339" />
+<error line="146" column="5" severity="error" message="Argument of type &apos;unknown&apos; is not assignable to parameter of type &apos;CartShippingRate[]&apos;." source="TS2345" />
+<error line="176" column="37" severity="error" message="Argument of type &apos;Record&lt;string, unknown&gt;&apos; is not assignable to parameter of type &apos;CanMakePaymentArgument&apos;.
+  Type &apos;Record&lt;string, unknown&gt;&apos; is missing the following properties from type &apos;CanMakePaymentArgument&apos;: cart, cartTotals, cartNeedsShipping, billingData, and 3 more." source="TS2345" />
+<error line="188" column="13" severity="error" message="Property &apos;createErrorNotice&apos; does not exist on type &apos;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__rich-text/store/actions&quot;)&apos;." source="TS2339" />
+</file>
+<file name="assets/js/data/payment/thunks.ts">
+<error line="4" column="10" severity="error" message="Module &apos;&quot;@wordpress/notices&quot;&apos; has no exported member &apos;store&apos;." source="TS2305" />
+<error line="22" column="13" severity="error" message="Binding element &apos;registry&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="74" column="23" severity="error" message="Property &apos;meta&apos; does not exist on type &apos;never&apos;." source="TS2339" />
+<error line="92" column="24" severity="error" message="Property &apos;message&apos; does not exist on type &apos;never&apos;." source="TS2339" />
+<error line="92" column="49" severity="error" message="Property &apos;message&apos; does not exist on type &apos;never&apos;." source="TS2339" />
+<error line="93" column="39" severity="error" message="Property &apos;message&apos; does not exist on type &apos;never&apos;." source="TS2339" />
+<error line="97" column="23" severity="error" message="Property &apos;messageContext&apos; does not exist on type &apos;never&apos;." source="TS2339" />
+<error line="103" column="21" severity="error" message="Property &apos;meta&apos; does not exist on type &apos;never&apos;." source="TS2339" />
+<error line="113" column="24" severity="error" message="Property &apos;message&apos; does not exist on type &apos;never&apos;." source="TS2339" />
+<error line="113" column="49" severity="error" message="Property &apos;message&apos; does not exist on type &apos;never&apos;." source="TS2339" />
+<error line="114" column="39" severity="error" message="Property &apos;message&apos; does not exist on type &apos;never&apos;." source="TS2339" />
+<error line="118" column="23" severity="error" message="Property &apos;messageContext&apos; does not exist on type &apos;never&apos;." source="TS2339" />
+<error line="124" column="41" severity="error" message="Property &apos;validationErrors&apos; does not exist on type &apos;never&apos;." source="TS2339" />
+</file>
+<file name="assets/js/data/payment/actions.ts">
+<error line="43" column="19" severity="error" message="Binding element &apos;select&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="43" column="27" severity="error" message="Binding element &apos;dispatch&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="114" column="19" severity="error" message="Binding element &apos;dispatch&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="114" column="29" severity="error" message="Binding element &apos;select&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="162" column="19" severity="error" message="Binding element &apos;select&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="162" column="27" severity="error" message="Binding element &apos;dispatch&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+</file>
+<file name="assets/js/data/payment/index.ts">
+<error line="29" column="44" severity="error" message="Argument of type &apos;{ reducer: Reducer&lt;PaymentMethodDataState, AnyAction&gt;; selectors: typeof selectors; actions: typeof actions; controls: any; __experimentalUseThunks: boolean; }&apos; is not assignable to parameter of type &apos;StoreConfig&lt;PaymentMethodDataState&gt;&apos;.
+  Types of property &apos;actions&apos; are incompatible.
+    Type &apos;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/data/payment/actions&quot;)&apos; is not assignable to type &apos;{ [k: string]: (...args: readonly any[]) =&gt; AnyAction | Generator&lt;any, any, unknown&gt;; }&apos;.
+      Property &apos;__internalUpdateAvailablePaymentMethods&apos; is incompatible with index signature.
+        Type &apos;() =&gt; ({ select, dispatch }: { select: any; dispatch: any; }) =&gt; Promise&lt;void&gt;&apos; is not assignable to type &apos;(...args: readonly any[]) =&gt; AnyAction | Generator&lt;any, any, unknown&gt;&apos;.
+          Type &apos;({ select, dispatch }: { select: any; dispatch: any; }) =&gt; Promise&lt;void&gt;&apos; is not assignable to type &apos;AnyAction | Generator&lt;any, any, unknown&gt;&apos;." source="TS2345" />
 </file>
 <file name="assets/js/data/query-state/utils.js">
 <error line="1" column="37" severity="error" message="Parameter &apos;state&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
@@ -651,55 +608,90 @@
       Type &apos;Object&apos; is not assignable to type &apos;AnyAction | Generator&lt;any, any, unknown&gt;&apos;.
         The &apos;Object&apos; type is assignable to very few other types. Did you mean to use the &apos;any&apos; type instead?" source="TS2322" />
 </file>
-<file name="assets/js/base/context/providers/editor-context.js">
-<error line="8" column="56" severity="error" message="Namespace &apos;&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/types/type-defs/contexts&quot;&apos; has no exported member &apos;EditorDataContext&apos;." source="TS2694" />
-<error line="9" column="52" severity="error" message="Namespace &apos;&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/types/type-defs/cart&quot;&apos; has no exported member &apos;CartData&apos;." source="TS2694" />
-<error line="59" column="12" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;any&apos; can&apos;t be used to index type &apos;Object&apos;." source="TS7053" />
+<file name="assets/js/types/type-defs/payment-method-interface.ts">
+<error line="20" column="53" severity="error" message="Cannot find module &apos;../../base/context/providers/cart-checkout/payment-events/types&apos; or its corresponding type declarations." source="TS2307" />
 </file>
-<file name="assets/js/base/context/hooks/cart/use-store-cart-event-listeners.ts">
-<error line="20" column="23" severity="error" message="Parameter &apos;e&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="23" column="24" severity="error" message="Property &apos;invalidateResolutionForStore&apos; does not exist on type &apos;DispatchFromMap&lt;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/data/cart/actions&quot;)&gt;&apos;." source="TS2339" />
-</file>
-<file name="assets/js/base/context/hooks/cart/use-store-cart.ts">
-<error line="73" column="2" severity="error" message="Type &apos;&quot;&quot;&apos; is not assignable to type &apos;CurrencyCode&apos;." source="TS2322" />
-<error line="144" column="3" severity="error" message="Argument of type &apos;(select: any, { dispatch }: { dispatch: any; }) =&gt; StoreCart | { cartCoupons: any; cartItems: any; cartFees: any; cartItemsCount: any; cartItemsWeight: any; cartNeedsPayment: any; cartNeedsShipping: any; ... 12 more ...; receiveCart: any; } | { ...; }&apos; is not assignable to parameter of type &apos;(s: { (key: string): SelectorMap; (key: &quot;core/rich-text&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__rich-text/store/selectors&quot;); (key: &quot;core/notices&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__no...&apos;." source="TS2345" />
-<error line="144" column="5" severity="error" message="Parameter &apos;select&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="144" column="15" severity="error" message="Binding element &apos;dispatch&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="223" column="44" severity="error" message="Argument of type &apos;Record&lt;string, unknown&gt;&apos; is not assignable to parameter of type &apos;CartResponseShippingAddress | CartResponseBillingAddress&apos;.
-  Type &apos;Record&lt;string, unknown&gt;&apos; is missing the following properties from type &apos;CartResponseBillingAddress&apos;: email, company, phone, address_1, and 7 more." source="TS2345" />
-<error line="224" column="47" severity="error" message="Argument of type &apos;Record&lt;string, unknown&gt;&apos; is not assignable to parameter of type &apos;CartResponseShippingAddress | CartResponseBillingAddress&apos;." source="TS2345" />
-<error line="225" column="48" severity="error" message="Argument of type &apos;Record&lt;string, unknown&gt;&apos; is not assignable to parameter of type &apos;CartResponseShippingAddress | CartResponseBillingAddress&apos;." source="TS2345" />
-<error line="241" column="3" severity="error" message="Type &apos;StoreCart&apos; is not assignable to type &apos;undefined&apos;." source="TS2322" />
-<error line="244" column="2" severity="error" message="Type &apos;undefined&apos; is not assignable to type &apos;StoreCart&apos;." source="TS2322" />
-</file>
-<file name="assets/js/base/context/providers/validation/context.js">
-<error line="14" column="57" severity="error" message="Namespace &apos;&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/types/type-defs/contexts&quot;&apos; has no exported member &apos;ValidationContext&apos;." source="TS2694" />
-<error line="20" column="25" severity="error" message="Parameter &apos;errors&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="21" column="26" severity="error" message="Parameter &apos;property&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="27" column="26" severity="error" message="Parameter &apos;errorId&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="58" column="19" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;any&apos; can&apos;t be used to index type &apos;{}&apos;." source="TS7053" />
-<error line="72" column="18" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;any&apos; can&apos;t be used to index type &apos;{}&apos;." source="TS7053" />
-<error line="102" column="13" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;Object&apos;.
+<file name="assets/js/blocks-registry/block-components/register-block-component.js">
+<error line="42" column="2" severity="error" message="Type &apos;Function&apos; is not assignable to type &apos;RegisteredBlockComponent&apos;." source="TS2322" />
+<error line="53" column="7" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;Object&apos;.
   No index signature with a parameter of type &apos;string&apos; was found on type &apos;Object&apos;." source="TS7053" />
-<error line="108" column="9" severity="error" message="Type &apos;Object&apos; has no matching index signature for type &apos;string&apos;." source="TS2537" />
-<error line="143" column="31" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;{}&apos;.
-  No index signature with a parameter of type &apos;string&apos; was found on type &apos;{}&apos;." source="TS7053" />
-<error line="169" column="8" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;any&apos; can&apos;t be used to index type &apos;{}&apos;." source="TS7053" />
-<error line="172" column="27" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;any&apos; can&apos;t be used to index type &apos;{}&apos;." source="TS7053" />
-<error line="220" column="11" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;{}&apos;.
-  No index signature with a parameter of type &apos;string&apos; was found on type &apos;{}&apos;." source="TS7053" />
-<error line="221" column="7" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;{}&apos;.
-  No index signature with a parameter of type &apos;string&apos; was found on type &apos;{}&apos;." source="TS7053" />
-<error line="222" column="11" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;{}&apos;.
-  No index signature with a parameter of type &apos;string&apos; was found on type &apos;{}&apos;." source="TS7053" />
-<error line="253" column="31" severity="error" message="Type &apos;{ getValidationError: (property: any) =&gt; any; setValidationErrors: (newErrors: any) =&gt; void; clearValidationError: (property: string) =&gt; void; clearAllValidationErrors: () =&gt; undefined; ... 4 more ...; getValidationErrorId: (errorId: any) =&gt; string; }&apos; is not assignable to type &apos;{ getValidationError: () =&gt; &quot;&quot;; setValidationErrors: (errors: any) =&gt; undefined; clearValidationError: (property: any) =&gt; undefined; clearAllValidationErrors: () =&gt; undefined; hideValidationError: () =&gt; undefined; showValidationError: () =&gt; undefined; showAllValidationErrors: () =&gt; undefined; hasValidationErrors: bo...&apos;.
-  The types returned by &apos;setValidationErrors(...)&apos; are incompatible between these types.
-    Type &apos;void&apos; is not assignable to type &apos;undefined&apos;." source="TS2322" />
+<error line="54" column="15" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;Object&apos;.
+  No index signature with a parameter of type &apos;string&apos; was found on type &apos;Object&apos;." source="TS7053" />
+<error line="58" column="4" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;Object&apos;.
+  No index signature with a parameter of type &apos;string&apos; was found on type &apos;Object&apos;." source="TS7053" />
+<error line="59" column="4" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;Object&apos;.
+  No index signature with a parameter of type &apos;string&apos; was found on type &apos;Object&apos;." source="TS7053" />
+<error line="78" column="28" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;Object&apos;.
+  No index signature with a parameter of type &apos;string&apos; was found on type &apos;Object&apos;." source="TS7053" />
 </file>
-<file name="assets/js/base/context/hooks/cart/use-store-cart-coupons.ts">
-<error line="36" column="3" severity="error" message="Argument of type &apos;(select: any, { dispatch }: { dispatch: any; }) =&gt; { applyCoupon: (couponCode: string) =&gt; void; removeCoupon: (couponCode: string) =&gt; void; isApplyingCoupon: any; isRemovingCoupon: any; }&apos; is not assignable to parameter of type &apos;(s: { (key: string): SelectorMap; (key: &quot;core/rich-text&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__rich-text/store/selectors&quot;); (key: &quot;core/notices&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__no...&apos;." source="TS2345" />
-<error line="36" column="5" severity="error" message="Parameter &apos;select&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="36" column="15" severity="error" message="Binding element &apos;dispatch&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<file name="packages/prices/utils/price.ts">
+<error line="52" column="8" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
+<error line="53" column="10" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
+<error line="54" column="21" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
+<error line="55" column="20" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
+<error line="56" column="13" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
+<error line="58" column="3" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
+<error line="59" column="3" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
+<error line="62" column="3" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
+<error line="63" column="3" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
+</file>
+<file name="packages/prices/utils/index.js">
+<error line="1" column="15" severity="error" message="File &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/packages/prices/utils/price.ts&apos; is not listed within the file list of project &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/tsconfig.json&apos;. Projects must list all files or use an &apos;include&apos; pattern." source="TS6307" />
+</file>
+<file name="packages/prices/index.js">
+<error line="1" column="15" severity="error" message="File &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/packages/prices/utils/index.js&apos; is not listed within the file list of project &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/tsconfig.json&apos;. Projects must list all files or use an &apos;include&apos; pattern." source="TS6307" />
+</file>
+<file name="assets/js/base/components/product-price/index.tsx">
+<error line="7" column="29" severity="error" message="File &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/packages/prices/index.js&apos; is not listed within the file list of project &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/tsconfig.json&apos;. Projects must list all files or use an &apos;include&apos; pattern.
+  The file is in the program because:
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/base/components/product-price/index.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/atomic/blocks/product-elements/price/block.js&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/base/context/hooks/payment-methods/use-payment-method-interface.ts&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/packages/checkout/components/totals/item/index.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/packages/checkout/components/totals/subtotal/index.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/packages/checkout/components/totals/taxes/index.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/packages/checkout/components/totals/fees/index.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/base/components/cart-checkout/order-summary/order-summary-item.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/base/components/cart-checkout/product-sale-badge/index.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/render-package-rate-option.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/shipping/index.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/active-filters/utils.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/cart/cart-line-items-table/cart-line-item-row.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-block/edit.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-subtotal/block.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-fee/block.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-discount/block.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-shipping/block.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-taxes/block.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-block/frontend.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-block/edit.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/block.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-subtotal/block.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-fee/block.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-discount/block.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-shipping/block.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-taxes/block.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-block/frontend.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/price-filter/block.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/mini-cart/block.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-footer-block/block.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/mini-cart/edit.tsx&apos;" source="TS6307" />
+<error line="285" column="5" severity="error" message="Type &apos;{ currency: Currency | Record&lt;string, never&gt;; price: string | number; priceClassName: string | undefined; priceStyle: CSSProperties | undefined; regularPrice: string | number; regularPriceClassName: string | undefined; regularPriceStyle: CSSProperties | undefined; }&apos; is not assignable to type &apos;SalePriceProps&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+  Types of property &apos;regularPriceClassName&apos; are incompatible.
+    Type &apos;string | undefined&apos; is not assignable to type &apos;string&apos;.
+      Type &apos;undefined&apos; is not assignable to type &apos;string&apos;." source="TS2375" />
+<error line="297" column="5" severity="error" message="Type &apos;{ currency: Currency | Record&lt;string, never&gt;; maxPrice: string | number; minPrice: string | number; priceClassName: string | undefined; priceStyle: CSSProperties | undefined; }&apos; is not assignable to type &apos;PriceRangeProps&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+  Types of property &apos;priceClassName&apos; are incompatible.
+    Type &apos;string | undefined&apos; is not assignable to type &apos;string&apos;.
+      Type &apos;undefined&apos; is not assignable to type &apos;string&apos;." source="TS2375" />
+<error line="307" column="5" severity="error" message="Type &apos;{ className: string; currency: Currency | Record&lt;string, never&gt;; value: string | number; style: CSSProperties | undefined; }&apos; is not assignable to type &apos;FormattedMonetaryAmountProps&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+  Types of property &apos;style&apos; are incompatible.
+    Type &apos;CSSProperties | undefined&apos; is not assignable to type &apos;CSSProperties&apos;.
+      Type &apos;undefined&apos; is not assignable to type &apos;Properties&lt;string | number, string &amp; {}&gt;&apos;." source="TS2375" />
+</file>
+<file name="assets/js/shared/context/inner-block-layout-context.js">
+<error line="26" column="2" severity="error" message="Binding element &apos;children&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="33" column="37" severity="error" message="Property &apos;isLoading&apos; is missing in type &apos;{ parentName: string; parentClassName: string; }&apos; but required in type &apos;{ parentName: string; parentClassName: string; isLoading: boolean; }&apos;." source="TS2741" />
 </file>
 <file name="assets/js/base/hooks/use-container-queries.ts">
 <error line="36" column="7" severity="error" message="Object is possibly &apos;null&apos;." source="TS2531" />
@@ -710,55 +702,83 @@
 <error line="26" column="13" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
 <error line="75" column="24" severity="error" message="Argument of type &apos;null&apos; is not assignable to parameter of type &apos;Element&apos;." source="TS2345" />
 </file>
-<file name="assets/js/base/context/providers/cart-checkout/payment-methods/use-payment-method-registration.ts">
-<error line="135" column="9" severity="error" message="Argument of type &apos;{ cart: StoreCart; cartTotals: CartResponseTotals; cartNeedsShipping: boolean; billingData: BillingAddress; billingAddress: BillingAddress; shippingAddress: EnteredAddress; selectedShippingMethods: Record&lt;...&gt;; paymentRequirements: string[]; }&apos; is not assignable to parameter of type &apos;CanMakePaymentArgument&apos;.
-  Types of property &apos;cart&apos; are incompatible.
-    Type &apos;StoreCart&apos; is missing the following properties from type &apos;Cart&apos;: coupons, items, itemsCount, itemsWeight, and 6 more." source="TS2345" />
+<file name="node_modules/@types/wordpress__block-editor/index.d.ts">
+<error line="21" column="14" severity="error" message="Cannot redeclare block-scoped variable &apos;store&apos;." source="TS2451" />
 </file>
-<file name="assets/js/base/context/providers/cart-checkout/payment-methods/use-payment-method-dispatchers.ts">
-<error line="91" column="23" severity="error" message="Argument of type &apos;{ paymentMethodData: ObjectType | EmptyObjectType | undefined; }&apos; is not assignable to parameter of type &apos;{ paymentMethodData?: Record&lt;string, unknown&gt;; }&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
-  Types of property &apos;paymentMethodData&apos; are incompatible.
-    Type &apos;ObjectType | EmptyObjectType | undefined&apos; is not assignable to type &apos;Record&lt;string, unknown&gt;&apos;.
-      Type &apos;undefined&apos; is not assignable to type &apos;Record&lt;string, unknown&gt;&apos;." source="TS2379" />
+<file name="assets/js/utils/global-style.js">
+<error line="5" column="10" severity="error" message="Module &apos;&quot;@wordpress/block-editor&quot;&apos; has no exported member &apos;__experimentalGetSpacingClassesAndStyles&apos;." source="TS2305" />
+</file>
+<file name="assets/js/utils/products.js">
+<error line="5" column="12" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
+<error line="20" column="12" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
+</file>
+<file name="assets/js/base/hooks/use-spacing-props.ts">
+<error line="5" column="10" severity="error" message="Module &apos;&quot;@wordpress/block-editor&quot;&apos; has no exported member &apos;__experimentalGetSpacingClassesAndStyles&apos;." source="TS2305" />
+</file>
+<file name="assets/js/base/hooks/use-color-props.ts">
+<error line="5" column="10" severity="error" message="Module &apos;&quot;@wordpress/block-editor&quot;&apos; has no exported member &apos;__experimentalUseColorProps&apos;." source="TS2305" />
+</file>
+<file name="assets/js/base/hooks/use-border-props.ts">
+<error line="5" column="10" severity="error" message="Module &apos;&quot;@wordpress/block-editor&quot;&apos; has no exported member &apos;__experimentalUseBorderProps&apos;." source="TS2305" />
+</file>
+<file name="assets/js/base/context/providers/editor-context.js">
+<error line="8" column="56" severity="error" message="Namespace &apos;&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/types/type-defs/contexts&quot;&apos; has no exported member &apos;EditorDataContext&apos;." source="TS2694" />
+<error line="9" column="52" severity="error" message="Namespace &apos;&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/types/type-defs/cart&quot;&apos; has no exported member &apos;CartData&apos;." source="TS2694" />
+<error line="59" column="12" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;any&apos; can&apos;t be used to index type &apos;Object&apos;." source="TS7053" />
+</file>
+<file name="assets/js/base/context/hooks/cart/use-store-cart-event-listeners.ts">
+<error line="20" column="23" severity="error" message="Parameter &apos;e&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="23" column="24" severity="error" message="Property &apos;invalidateResolutionForStore&apos; does not exist on type &apos;DispatchFromMap&lt;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/data/cart/actions&quot;)&gt;&apos;." source="TS2339" />
+</file>
+<file name="assets/js/base/context/hooks/cart/use-store-cart.ts">
+<error line="74" column="2" severity="error" message="Type &apos;&quot;&quot;&apos; is not assignable to type &apos;CurrencyCode&apos;." source="TS2322" />
+<error line="146" column="3" severity="error" message="Argument of type &apos;(select: any, { dispatch }: { dispatch: any; }) =&gt; StoreCart | { cartCoupons: any; cartItems: any; crossSellsProducts: any; cartFees: any; cartItemsCount: any; cartItemsWeight: any; cartNeedsPayment: any; ... 13 more ...; receiveCart: any; } | { ...; }&apos; is not assignable to parameter of type &apos;(s: { (storeNameOrDescriptor: string | StoreDescriptor): SelectorMap; (key: &quot;core/rich-text&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__rich-text/store/selectors&quot;); (key: &quot;core/notices&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-bloc...&apos;." source="TS2345" />
+<error line="146" column="5" severity="error" message="Parameter &apos;select&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="146" column="15" severity="error" message="Binding element &apos;dispatch&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="227" column="44" severity="error" message="Argument of type &apos;Record&lt;string, unknown&gt;&apos; is not assignable to parameter of type &apos;CartResponseShippingAddress | CartResponseBillingAddress&apos;.
+  Type &apos;Record&lt;string, unknown&gt;&apos; is missing the following properties from type &apos;CartResponseBillingAddress&apos;: email, company, phone, address_1, and 7 more." source="TS2345" />
+<error line="228" column="47" severity="error" message="Argument of type &apos;Record&lt;string, unknown&gt;&apos; is not assignable to parameter of type &apos;CartResponseShippingAddress | CartResponseBillingAddress&apos;." source="TS2345" />
+<error line="229" column="48" severity="error" message="Argument of type &apos;Record&lt;string, unknown&gt;&apos; is not assignable to parameter of type &apos;CartResponseShippingAddress | CartResponseBillingAddress&apos;." source="TS2345" />
+<error line="245" column="3" severity="error" message="Type &apos;StoreCart&apos; is not assignable to type &apos;undefined&apos;." source="TS2322" />
+<error line="248" column="2" severity="error" message="Type &apos;undefined&apos; is not assignable to type &apos;StoreCart&apos;." source="TS2322" />
+</file>
+<file name="assets/js/base/context/hooks/cart/use-store-cart-coupons.ts">
+<error line="41" column="3" severity="error" message="Type &apos;&quot;applyCoupon&quot; | &quot;removeCoupon&quot; | &quot;receiveApplyingCoupon&quot; | &quot;isApplyingCoupon&quot; | &quot;isRemovingCoupon&quot;&apos; does not satisfy the constraint &apos;keyof StoreCartCoupon&apos;.
+  Type &apos;&quot;receiveApplyingCoupon&quot;&apos; is not assignable to type &apos;keyof StoreCartCoupon&apos;." source="TS2344" />
+<error line="47" column="3" severity="error" message="Argument of type &apos;(select: any, { dispatch }: { dispatch: any; }) =&gt; { applyCoupon: any; removeCoupon: any; isApplyingCoupon: any; isRemovingCoupon: any; receiveApplyingCoupon: any; }&apos; is not assignable to parameter of type &apos;(s: { (storeNameOrDescriptor: string | StoreDescriptor): SelectorMap; (key: &quot;core/rich-text&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__rich-text/store/selectors&quot;); (key: &quot;core/notices&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-bloc...&apos;." source="TS2345" />
+<error line="47" column="5" severity="error" message="Parameter &apos;select&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="47" column="15" severity="error" message="Binding element &apos;dispatch&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="64" column="5" severity="error" message="Property &apos;then&apos; does not exist on type &apos;void&apos;." source="TS2339" />
+<error line="64" column="13" severity="error" message="Parameter &apos;result&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="84" column="14" severity="error" message="Parameter &apos;error&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="92" column="5" severity="error" message="Cannot find name &apos;receiveApplyingCoupon&apos;." source="TS2304" />
+<error line="98" column="5" severity="error" message="Property &apos;then&apos; does not exist on type &apos;void&apos;." source="TS2339" />
+<error line="98" column="13" severity="error" message="Parameter &apos;result&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="118" column="14" severity="error" message="Parameter &apos;error&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="124" column="5" severity="error" message="Cannot find name &apos;receiveApplyingCoupon&apos;." source="TS2304" />
+</file>
+<file name="assets/js/base/context/hooks/use-query-state.js">
+<error line="28" column="13" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
+<error line="131" column="5" severity="error" message="Argument of type &apos;Object | undefined&apos; is not assignable to parameter of type &apos;any[] | ComparableObject&apos;.
+  Type &apos;undefined&apos; is not assignable to type &apos;any[] | ComparableObject&apos;." source="TS2345" />
+</file>
+<file name="assets/js/base/context/hooks/collections/use-collection.ts">
+<error line="103" column="35" severity="error" message="Cannot find name &apos;T&apos;." source="TS2304" />
+</file>
+<file name="assets/js/base/context/hooks/collections/use-collection-data.ts">
+<error line="87" column="7" severity="error" message="Parameter &apos;attribute&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+</file>
+<file name="assets/js/base/context/hooks/shipping/use-shipping-data.ts">
+<error line="55" column="33" severity="error" message="Argument of type &apos;CartResponseShippingRate[]&apos; is not assignable to parameter of type &apos;CartShippingRate[]&apos;." source="TS2345" />
+<error line="68" column="3" severity="error" message="Type &apos;CartResponseShippingRate[]&apos; is not assignable to type &apos;CartShippingRate[]&apos;.
+  Type &apos;CartResponseShippingRate&apos; is not assignable to type &apos;CartShippingRate&apos;.
+    Types of property &apos;package_id&apos; are incompatible.
+      Type &apos;string | number&apos; is not assignable to type &apos;number&apos;.
+        Type &apos;string&apos; is not assignable to type &apos;number&apos;." source="TS2322" />
 </file>
 <file name="assets/js/base/context/hooks/use-checkout-notices.js">
 <error line="12" column="56" severity="error" message="Namespace &apos;&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/types/type-defs/contexts&quot;&apos; has no exported member &apos;StoreNoticeObject&apos;." source="TS2694" />
 <error line="13" column="53" severity="error" message="Namespace &apos;&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/types/type-defs/hooks&quot;&apos; has no exported member &apos;CheckoutNotices&apos;." source="TS2694" />
-</file>
-<file name="assets/js/utils/notices.ts">
-<error line="12" column="52" severity="error" message="Property &apos;type&apos; does not exist on type &apos;Notice&apos;." source="TS2339" />
-</file>
-<file name="assets/js/base/context/providers/cart-checkout/payment-methods/utils.ts">
-<error line="9" column="15" severity="error" message="Module &apos;&quot;./types&quot;&apos; declares &apos;PaymentMethods&apos; locally, but it is not exported." source="TS2459" />
-<error line="21" column="41" severity="error" message="No overload matches this call.
-  Overload 1 of 2, &apos;(o: {}): string[]&apos;, gave the following error.
-    Argument of type &apos;unknown&apos; is not assignable to parameter of type &apos;{}&apos;.
-  Overload 2 of 2, &apos;(o: object): string[]&apos;, gave the following error.
-    Argument of type &apos;unknown&apos; is not assignable to parameter of type &apos;object&apos;." source="TS2769" />
-<error line="27" column="19" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
-</file>
-<file name="assets/js/base/context/providers/cart-checkout/payment-methods/payment-method-data-context.tsx">
-<error line="99" column="3" severity="error" message="Argument of type &apos;(paymentMethods: PaymentMethods) =&gt; void&apos; is not assignable to parameter of type &apos;PaymentMethodsDispatcherType&apos;.
-  Type &apos;void&apos; is not assignable to type &apos;undefined&apos;." source="TS2345" />
-<error line="103" column="3" severity="error" message="Argument of type &apos;(paymentMethods: ExpressPaymentMethods) =&gt; void&apos; is not assignable to parameter of type &apos;PaymentMethodsDispatcherType&apos;.
-  Type &apos;void&apos; is not assignable to type &apos;undefined&apos;." source="TS2345" />
-<error line="198" column="59" severity="error" message="Property &apos;gateway&apos; does not exist on type &apos;PaymentMethodConfiguration&apos;." source="TS2339" />
-<error line="282" column="24" severity="error" message="Property &apos;meta&apos; does not exist on type &apos;never&apos;." source="TS2339" />
-<error line="283" column="24" severity="error" message="Property &apos;meta&apos; does not exist on type &apos;never&apos;." source="TS2339" />
-<error line="284" column="24" severity="error" message="Property &apos;meta&apos; does not exist on type &apos;never&apos;." source="TS2339" />
-<error line="288" column="21" severity="error" message="Property &apos;message&apos; does not exist on type &apos;never&apos;." source="TS2339" />
-<error line="289" column="21" severity="error" message="Property &apos;message&apos; does not exist on type &apos;never&apos;." source="TS2339" />
-<error line="291" column="37" severity="error" message="Property &apos;message&apos; does not exist on type &apos;never&apos;." source="TS2339" />
-<error line="295" column="24" severity="error" message="Property &apos;messageContext&apos; does not exist on type &apos;never&apos;." source="TS2339" />
-<error line="300" column="22" severity="error" message="Property &apos;message&apos; does not exist on type &apos;never&apos;." source="TS2339" />
-<error line="301" column="22" severity="error" message="Property &apos;meta&apos; does not exist on type &apos;never&apos;." source="TS2339" />
-<error line="302" column="22" severity="error" message="Property &apos;meta&apos; does not exist on type &apos;never&apos;." source="TS2339" />
-<error line="306" column="21" severity="error" message="Property &apos;message&apos; does not exist on type &apos;never&apos;." source="TS2339" />
-<error line="307" column="21" severity="error" message="Property &apos;message&apos; does not exist on type &apos;never&apos;." source="TS2339" />
-<error line="309" column="37" severity="error" message="Property &apos;message&apos; does not exist on type &apos;never&apos;." source="TS2339" />
-<error line="313" column="24" severity="error" message="Property &apos;messageContext&apos; does not exist on type &apos;never&apos;." source="TS2339" />
-<error line="317" column="46" severity="error" message="Property &apos;message&apos; does not exist on type &apos;never&apos;." source="TS2339" />
-<error line="318" column="42" severity="error" message="Property &apos;validationErrors&apos; does not exist on type &apos;never&apos;." source="TS2339" />
 </file>
 <file name="assets/js/base/context/providers/cart-checkout/shipping/constants.js">
 <error line="2" column="56" severity="error" message="Namespace &apos;&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/types/type-defs/contexts&quot;&apos; has no exported member &apos;ShippingErrorTypes&apos;." source="TS2694" />
@@ -777,270 +797,16 @@
 <error line="33" column="3" severity="error" message="Argument of type &apos;Function&apos; is not assignable to parameter of type &apos;Dispatch&lt;ActionType&gt;&apos;." source="TS2345" />
 </file>
 <file name="assets/js/base/context/providers/cart-checkout/shipping/index.js">
-<error line="31" column="56" severity="error" message="Namespace &apos;&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/types/type-defs/contexts&quot;&apos; has no exported member &apos;ShippingDataContext&apos;." source="TS2694" />
-<error line="65" column="42" severity="error" message="Property &apos;onSuccess&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="66" column="61" severity="error" message="Property &apos;onFail&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="68" column="42" severity="error" message="Property &apos;onSelectSuccess&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="70" column="42" severity="error" message="Property &apos;onSelectFail&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-</file>
-<file name="assets/js/base/context/providers/store-notices/context.js">
-<error line="13" column="21" severity="error" message="Parameter &apos;val&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="48" column="33" severity="error" message="Type &apos;{ setIsSuppressed: React.Dispatch&lt;React.SetStateAction&lt;boolean&gt;&gt;; isSuppressed: boolean; }&apos; is not assignable to type &apos;{ setIsSuppressed: (val: any) =&gt; undefined; isSuppressed: boolean; }&apos;.
-  The types returned by &apos;setIsSuppressed(...)&apos; are incompatible between these types.
-    Type &apos;void&apos; is not assignable to type &apos;undefined&apos;." source="TS2322" />
-</file>
-<file name="assets/js/base/context/providers/store-notices/components/store-notices-container.js">
-<error line="6" column="24" severity="error" message="Could not find a declaration file for module &apos;wordpress-components&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/wordpress-components/build/index.js&apos; implicitly has an &apos;any&apos; type.
-  If the &apos;@wordpress/components&apos; package actually exposes this module, consider sending a pull request to amend &apos;https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/wordpress__components&apos;" source="TS7016" />
-<error line="29" column="2" severity="error" message="Binding element &apos;className&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="31" column="2" severity="error" message="Binding element &apos;additionalNotices&apos; implicitly has an &apos;any[]&apos; type." source="TS7031" />
-<error line="43" column="33" severity="error" message="Property &apos;type&apos; does not exist on type &apos;Notice&apos;." source="TS2339" />
-</file>
-<file name="assets/js/base/context/providers/cart-checkout/checkout-processor.js">
-<error line="142" column="7" severity="error" message="Variable &apos;unsubscribeProcessing&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
-<error line="151" column="5" severity="error" message="Variable &apos;unsubscribeProcessing&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
-<error line="196" column="9" severity="error" message="Property &apos;shipping_address&apos; does not exist on type &apos;{ extensions: { [x: string]: extensionDataItem; }; payment_method: string | undefined; payment_data: { key: string; value: unknown; }[]; billing_address: BillingAddress; customer_note: string; create_account: boolean; } | { ...; }&apos;.
-  Property &apos;shipping_address&apos; does not exist on type &apos;{ extensions: { [x: string]: extensionDataItem; }; payment_method: string | undefined; payment_data: { key: string; value: unknown; }[]; billing_address: BillingAddress; customer_note: string; create_account: boolean; }&apos;." source="TS2339" />
-<error line="231" column="35" severity="error" message="Parameter &apos;response&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="241" column="10" severity="error" message="Parameter &apos;additionalError&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-</file>
-<file name="assets/js/base/context/providers/cart-checkout/checkout-provider.js">
-<error line="4" column="28" severity="error" message="Could not find a declaration file for module &apos;@wordpress/plugins&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@wordpress/plugins/build/index.js&apos; implicitly has an &apos;any&apos; type.
-  Try `npm i --save-dev @types/wordpress__plugins` if it exists or add a new declaration (.d.ts) file containing `declare module &apos;@wordpress/plugins&apos;;`" source="TS7016" />
-<error line="35" column="26" severity="error" message="Type &apos;string | undefined&apos; is not assignable to type &apos;string&apos;.
-  Type &apos;undefined&apos; is not assignable to type &apos;string&apos;." source="TS2322" />
-<error line="36" column="4" severity="error" message="Type &apos;Element&apos; is missing the following properties from type &apos;ReactChildren&apos;: map, forEach, count, only, toArray" source="TS2739" />
-<error line="43" column="8" severity="error" message="No overload matches this call.
-  Overload 1 of 2, &apos;(props: BlockErrorBoundaryProps | Readonly&lt;BlockErrorBoundaryProps&gt;): BlockErrorBoundary&apos;, gave the following error.
-    Type &apos;(() =&gt; null) | null&apos; is not assignable to type &apos;(props: RenderErrorProps) =&gt; ReactNode&apos;.
-      Type &apos;null&apos; is not assignable to type &apos;(props: RenderErrorProps) =&gt; ReactNode&apos;.
-  Overload 2 of 2, &apos;(props: BlockErrorBoundaryProps, context: any): BlockErrorBoundary&apos;, gave the following error.
-    Type &apos;(() =&gt; null) | null&apos; is not assignable to type &apos;(props: RenderErrorProps) =&gt; ReactNode&apos;.
-      Type &apos;null&apos; is not assignable to type &apos;(props: RenderErrorProps) =&gt; ReactNode&apos;." source="TS2769" />
-</file>
-<file name="assets/js/base/context/providers/cart-checkout/cart/index.js">
-<error line="20" column="4" severity="error" message="Type &apos;Object | undefined&apos; is not assignable to type &apos;Object&apos;.
-  Type &apos;undefined&apos; is not assignable to type &apos;Object&apos;." source="TS2322" />
-</file>
-<file name="assets/js/base/context/hooks/use-query-state.js">
-<error line="28" column="13" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
-<error line="131" column="5" severity="error" message="Argument of type &apos;Object | undefined&apos; is not assignable to parameter of type &apos;any[] | ComparableObject&apos;.
-  Type &apos;undefined&apos; is not assignable to type &apos;any[] | ComparableObject&apos;." source="TS2345" />
-</file>
-<file name="assets/js/base/context/hooks/collections/use-collection.ts">
-<error line="103" column="35" severity="error" message="Cannot find name &apos;T&apos;." source="TS2304" />
-</file>
-<file name="assets/js/base/context/hooks/collections/use-collection-data.ts">
-<error line="80" column="7" severity="error" message="Parameter &apos;attribute&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="32" column="56" severity="error" message="Namespace &apos;&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/types/type-defs/contexts&quot;&apos; has no exported member &apos;ShippingDataContext&apos;." source="TS2694" />
+<error line="67" column="42" severity="error" message="Property &apos;onSuccess&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="68" column="61" severity="error" message="Property &apos;onFail&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="70" column="42" severity="error" message="Property &apos;onSelectSuccess&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="72" column="42" severity="error" message="Property &apos;onSelectFail&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
 </file>
 <file name="assets/js/base/context/hooks/use-store-add-to-cart.ts">
 <error line="93" column="3" severity="error" message="Type &apos;(quantity?: number) =&gt; Promise&lt;void&gt;&apos; is not assignable to type &apos;(quantity?: number | undefined) =&gt; Promise&lt;boolean&gt;&apos;.
   Type &apos;Promise&lt;void&gt;&apos; is not assignable to type &apos;Promise&lt;boolean&gt;&apos;.
     Type &apos;void&apos; is not assignable to type &apos;boolean&apos;." source="TS2322" />
-</file>
-<file name="assets/js/base/context/hooks/use-checkout-submit.js">
-<error line="37" column="19" severity="error" message="Property &apos;placeOrderButtonLabel&apos; does not exist on type &apos;ExpressPaymentMethodConfigInstance&apos;." source="TS2339" />
-</file>
-<file name="assets/js/atomic/blocks/product-elements/image/block.js">
-<error line="137" column="19" severity="error" message="Binding element &apos;image&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="137" column="26" severity="error" message="Binding element &apos;onLoad&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="137" column="34" severity="error" message="Binding element &apos;loaded&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="137" column="42" severity="error" message="Binding element &apos;showFullSize&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="137" column="56" severity="error" message="Binding element &apos;fallbackAlt&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-</file>
-<file name="assets/js/atomic/blocks/product-elements/rating/block.js">
-<error line="99" column="28" severity="error" message="Parameter &apos;product&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="105" column="26" severity="error" message="Parameter &apos;product&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-</file>
-<file name="assets/js/atomic/blocks/product-elements/button/block.js">
-<error line="100" column="3" severity="error" message="Property &apos;id&apos; does not exist on type &apos;Object | undefined&apos;." source="TS2339" />
-<error line="101" column="3" severity="error" message="Property &apos;permalink&apos; does not exist on type &apos;Object | undefined&apos;." source="TS2339" />
-<error line="102" column="3" severity="error" message="Property &apos;add_to_cart&apos; does not exist on type &apos;Object | undefined&apos;." source="TS2339" />
-<error line="103" column="3" severity="error" message="Property &apos;has_options&apos; does not exist on type &apos;Object | undefined&apos;." source="TS2339" />
-<error line="104" column="3" severity="error" message="Property &apos;is_purchasable&apos; does not exist on type &apos;Object | undefined&apos;." source="TS2339" />
-<error line="105" column="3" severity="error" message="Property &apos;is_in_stock&apos; does not exist on type &apos;Object | undefined&apos;." source="TS2339" />
-<error line="110" column="3" severity="error" message="Expected 1 arguments, but got 2." source="TS2554" />
-<error line="167" column="5" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
-<error line="167" column="17" severity="error" message="Property &apos;className&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="168" column="5" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
-<error line="168" column="18" severity="error" message="Property &apos;className&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="175" column="8" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
-<error line="175" column="20" severity="error" message="Property &apos;style&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="176" column="8" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
-<error line="176" column="21" severity="error" message="Property &apos;style&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="177" column="8" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
-<error line="177" column="25" severity="error" message="Property &apos;style&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="178" column="8" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
-<error line="178" column="22" severity="error" message="Property &apos;style&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="212" column="5" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
-<error line="212" column="17" severity="error" message="Property &apos;className&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="213" column="5" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
-<error line="213" column="18" severity="error" message="Property &apos;className&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="216" column="8" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
-<error line="216" column="20" severity="error" message="Property &apos;style&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="217" column="8" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
-<error line="217" column="21" severity="error" message="Property &apos;style&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="218" column="8" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
-<error line="218" column="25" severity="error" message="Property &apos;style&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="219" column="8" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
-<error line="219" column="22" severity="error" message="Property &apos;style&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-</file>
-<file name="assets/js/base/components/summary/utils.js">
-<error line="4" column="23" severity="error" message="Could not find a declaration file for module &apos;@wordpress/wordcount&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@wordpress/wordcount/build/index.js&apos; implicitly has an &apos;any&apos; type.
-  Try `npm i --save-dev @types/wordpress__wordcount` if it exists or add a new declaration (.d.ts) file containing `declare module &apos;@wordpress/wordcount&apos;;`" source="TS7016" />
-</file>
-<file name="assets/js/atomic/blocks/product-elements/stock-indicator/block.js">
-<error line="72" column="24" severity="error" message="Parameter &apos;lowStock&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="80" column="21" severity="error" message="Parameter &apos;inStock&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="80" column="30" severity="error" message="Parameter &apos;isBackordered&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-</file>
-<file name="assets/js/base/context/providers/add-to-cart-form/form-state/actions.js">
-<error line="42" column="27" severity="error" message="Parameter &apos;data&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="50" column="17" severity="error" message="Parameter &apos;quantity&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="54" column="22" severity="error" message="Parameter &apos;data&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-</file>
-<file name="assets/js/base/context/providers/add-to-cart-form/form-state/reducer.js">
-<error line="46" column="11" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="55" column="11" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="64" column="24" severity="error" message="Property &apos;quantity&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="75" column="15" severity="error" message="Property &apos;requestParams&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="88" column="11" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="97" column="14" severity="error" message="Property &apos;hasError&apos; does not exist on type &apos;Object | { status: string; hasError: boolean; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; }&apos;.
-  Property &apos;hasError&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="103" column="11" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="113" column="11" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="121" column="21" severity="error" message="Property &apos;hasError&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="128" column="11" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="129" column="11" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="137" column="21" severity="error" message="Property &apos;hasError&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="149" column="3" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
-<error line="149" column="12" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object | { status: string; hasError: boolean; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
-  Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="151" column="3" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
-<error line="151" column="12" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object | { status: string; hasError: boolean; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
-  Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-</file>
-<file name="assets/js/base/context/providers/add-to-cart-form/form-state/event-emit.js">
-<error line="34" column="3" severity="error" message="Argument of type &apos;Function&apos; is not assignable to parameter of type &apos;Dispatch&lt;ActionType&gt;&apos;." source="TS2345" />
-<error line="38" column="3" severity="error" message="Argument of type &apos;Function&apos; is not assignable to parameter of type &apos;Dispatch&lt;ActionType&gt;&apos;." source="TS2345" />
-<error line="42" column="3" severity="error" message="Argument of type &apos;Function&apos; is not assignable to parameter of type &apos;Dispatch&lt;ActionType&gt;&apos;." source="TS2345" />
-</file>
-<file name="assets/js/base/context/providers/add-to-cart-form/form-state/index.js">
-<error line="38" column="56" severity="error" message="Namespace &apos;&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/types/type-defs/contexts&quot;&apos; has no exported member &apos;AddToCartFormContext&apos;." source="TS2694" />
-<error line="59" column="44" severity="error" message="Parameter &apos;callback&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="60" column="42" severity="error" message="Parameter &apos;callback&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="61" column="34" severity="error" message="Parameter &apos;callback&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="66" column="18" severity="error" message="Parameter &apos;quantity&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="67" column="18" severity="error" message="Parameter &apos;hasError&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="68" column="25" severity="error" message="Parameter &apos;response&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="69" column="23" severity="error" message="Parameter &apos;data&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="114" column="7" severity="error" message="Property &apos;onAddToCartAfterProcessingWithSuccess&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="117" column="7" severity="error" message="Property &apos;onAddToCartAfterProcessingWithError&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="120" column="7" severity="error" message="Property &apos;onAddToCartBeforeProcessing&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="130" column="36" severity="error" message="Argument of type &apos;{ type: string; }&apos; is not assignable to parameter of type &apos;{ quantity: number; type: string; data: Object; }&apos;.
-  Type &apos;{ type: string; }&apos; is missing the following properties from type &apos;{ quantity: number; type: string; data: Object; }&apos;: quantity, data" source="TS2345" />
-<error line="131" column="37" severity="error" message="Argument of type &apos;{ type: string; }&apos; is not assignable to parameter of type &apos;{ quantity: number; type: string; data: Object; }&apos;.
-  Type &apos;{ type: string; }&apos; is missing the following properties from type &apos;{ quantity: number; type: string; data: Object; }&apos;: quantity, data" source="TS2345" />
-<error line="133" column="20" severity="error" message="Argument of type &apos;{ type: string; quantity: any; }&apos; is not assignable to parameter of type &apos;{ quantity: number; type: string; data: Object; }&apos;.
-  Property &apos;data&apos; is missing in type &apos;{ type: string; quantity: any; }&apos; but required in type &apos;{ quantity: number; type: string; data: Object; }&apos;." source="TS2345" />
-<error line="135" column="20" severity="error" message="Argument of type &apos;{ type: string; }&apos; is not assignable to parameter of type &apos;{ quantity: number; type: string; data: Object; }&apos;.
-  Type &apos;{ type: string; }&apos; is missing the following properties from type &apos;{ quantity: number; type: string; data: Object; }&apos;: quantity, data" source="TS2345" />
-<error line="137" column="20" severity="error" message="Argument of type &apos;{ type: string; data: any; }&apos; is not assignable to parameter of type &apos;{ quantity: number; type: string; data: Object; }&apos;.
-  Property &apos;quantity&apos; is missing in type &apos;{ type: string; data: any; }&apos; but required in type &apos;{ quantity: number; type: string; data: Object; }&apos;." source="TS2345" />
-<error line="139" column="15" severity="error" message="Argument of type &apos;{ type: string; data: any; }&apos; is not assignable to parameter of type &apos;{ quantity: number; type: string; data: Object; }&apos;.
-  Property &apos;quantity&apos; is missing in type &apos;{ type: string; data: any; }&apos; but required in type &apos;{ quantity: number; type: string; data: Object; }&apos;." source="TS2345" />
-<error line="140" column="20" severity="error" message="Argument of type &apos;{ type: string; }&apos; is not assignable to parameter of type &apos;{ quantity: number; type: string; data: Object; }&apos;.
-  Type &apos;{ type: string; }&apos; is missing the following properties from type &apos;{ quantity: number; type: string; data: Object; }&apos;: quantity, data" source="TS2345" />
-<error line="150" column="18" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
-<error line="150" column="37" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
-  Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="152" column="6" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
-<error line="152" column="14" severity="error" message="Property &apos;id&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="152" column="44" severity="error" message="Argument of type &apos;Object | undefined&apos; is not assignable to parameter of type &apos;Object&apos;.
-  Type &apos;undefined&apos; is not assignable to type &apos;Object&apos;." source="TS2345" />
-<error line="155" column="14" severity="error" message="Argument of type &apos;{ type: string; }&apos; is not assignable to parameter of type &apos;{ quantity: number; type: string; data: Object; }&apos;.
-  Type &apos;{ type: string; }&apos; is missing the following properties from type &apos;{ quantity: number; type: string; data: Object; }&apos;: quantity, data" source="TS2345" />
-<error line="157" column="14" severity="error" message="Argument of type &apos;{ type: string; }&apos; is not assignable to parameter of type &apos;{ quantity: number; type: string; data: Object; }&apos;.
-  Type &apos;{ type: string; }&apos; is missing the following properties from type &apos;{ quantity: number; type: string; data: Object; }&apos;: quantity, data" source="TS2345" />
-<error line="159" column="7" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
-<error line="159" column="26" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
-  Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="165" column="18" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
-<error line="165" column="37" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
-  Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="189" column="16" severity="error" message="Argument of type &apos;{ type: string; }&apos; is not assignable to parameter of type &apos;{ quantity: number; type: string; data: Object; }&apos;." source="TS2345" />
-<error line="191" column="16" severity="error" message="Argument of type &apos;{ type: string; }&apos; is not assignable to parameter of type &apos;{ quantity: number; type: string; data: Object; }&apos;.
-  Type &apos;{ type: string; }&apos; is missing the following properties from type &apos;{ quantity: number; type: string; data: Object; }&apos;: quantity, data" source="TS2345" />
-<error line="196" column="3" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
-<error line="196" column="22" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
-  Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="201" column="12" severity="error" message="Property &apos;id&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="208" column="8" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
-<error line="208" column="27" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
-  Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="214" column="25" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
-<error line="214" column="44" severity="error" message="Property &apos;processingResponse&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
-  Property &apos;processingResponse&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="217" column="34" severity="error" message="Parameter &apos;observerResponses&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="219" column="34" severity="error" message="Parameter &apos;response&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="236" column="9" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
-<error line="236" column="28" severity="error" message="Property &apos;hasError&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
-  Property &apos;hasError&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="254" column="18" severity="error" message="Property &apos;id&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="258" column="16" severity="error" message="Argument of type &apos;{ type: string; }&apos; is not assignable to parameter of type &apos;{ quantity: number; type: string; data: Object; }&apos;." source="TS2345" />
-<error line="272" column="16" severity="error" message="Argument of type &apos;{ type: string; }&apos; is not assignable to parameter of type &apos;{ quantity: number; type: string; data: Object; }&apos;." source="TS2345" />
-<error line="274" column="16" severity="error" message="Argument of type &apos;{ type: string; }&apos; is not assignable to parameter of type &apos;{ quantity: number; type: string; data: Object; }&apos;." source="TS2345" />
-<error line="279" column="3" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
-<error line="279" column="22" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
-  Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="280" column="3" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
-<error line="280" column="22" severity="error" message="Property &apos;hasError&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
-  Property &apos;hasError&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="281" column="3" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
-<error line="281" column="22" severity="error" message="Property &apos;processingResponse&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
-  Property &apos;processingResponse&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="288" column="12" severity="error" message="Property &apos;id&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="291" column="61" severity="error" message="Argument of type &apos;Object | undefined&apos; is not assignable to parameter of type &apos;Object&apos;.
-  Type &apos;undefined&apos; is not assignable to type &apos;Object&apos;." source="TS2345" />
-<error line="298" column="16" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
-<error line="298" column="24" severity="error" message="Property &apos;type&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="299" column="47" severity="error" message="Argument of type &apos;Object | undefined&apos; is not assignable to parameter of type &apos;Object&apos;.
-  Type &apos;undefined&apos; is not assignable to type &apos;Object&apos;." source="TS2345" />
-<error line="300" column="22" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
-<error line="300" column="30" severity="error" message="Property &apos;has_options&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="304" column="4" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
-<error line="304" column="23" severity="error" message="Property &apos;quantity&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
-  Property &apos;quantity&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="304" column="44" severity="error" message="Property &apos;add_to_cart&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="305" column="25" severity="error" message="Property &apos;add_to_cart&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="306" column="25" severity="error" message="Property &apos;add_to_cart&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="307" column="24" severity="error" message="Property &apos;add_to_cart&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="308" column="18" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
-<error line="308" column="37" severity="error" message="Property &apos;requestParams&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
-  Property &apos;requestParams&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="309" column="11" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
-<error line="309" column="30" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
-  Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="310" column="15" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
-<error line="310" column="34" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
-  Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="311" column="17" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
-<error line="311" column="36" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
-  Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="313" column="4" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
-<error line="313" column="23" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
-  Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="315" column="4" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
-<error line="315" column="23" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
-  Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="316" column="13" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
-<error line="316" column="32" severity="error" message="Property &apos;hasError&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
-  Property &apos;hasError&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-</file>
-<file name="assets/js/base/context/providers/add-to-cart-form/form/submit/index.js">
-<error line="85" column="18" severity="error" message="Property &apos;setNonce&apos; does not exist on type &apos;typeof apiFetch&apos;." source="TS2339" />
-<error line="88" column="43" severity="error" message="Parameter &apos;response&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="125" column="35" severity="error" message="Parameter &apos;response&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
 </file>
 <file name="packages/checkout/components/totals/item/index.tsx">
 <error line="8" column="15" severity="error" message="Module &apos;&quot;@woocommerce/price-format&quot;&apos; has no exported member &apos;Currency&apos;." source="TS2305" />
@@ -1118,7 +884,8 @@
 <error line="23" column="2" severity="error" message="Binding element &apos;cart&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
 <error line="24" column="2" severity="error" message="Binding element &apos;components&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
 <error line="25" column="2" severity="error" message="Binding element &apos;context&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="27" column="20" severity="error" message="Variable &apos;useSlot&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="26" column="2" severity="error" message="Binding element &apos;shippingRates&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="28" column="20" severity="error" message="Variable &apos;useSlot&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
 </file>
 <file name="assets/js/base/components/button/index.tsx">
 <error line="4" column="36" severity="error" message="Could not find a declaration file for module &apos;wordpress-components&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/wordpress-components/build/index.js&apos; implicitly has an &apos;any&apos; type.
@@ -1142,6 +909,9 @@
 <file name="packages/checkout/utils/index.js">
 <error line="1" column="15" severity="error" message="File &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/packages/checkout/utils/validation/index.ts&apos; is not listed within the file list of project &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/tsconfig.json&apos;. Projects must list all files or use an &apos;include&apos; pattern." source="TS6307" />
 <error line="2" column="37" severity="error" message="File &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/packages/checkout/utils/extension-cart-update.ts&apos; is not listed within the file list of project &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/tsconfig.json&apos;. Projects must list all files or use an &apos;include&apos; pattern." source="TS6307" />
+</file>
+<file name="packages/checkout/filter-registry/index.ts">
+<error line="36" column="37" severity="error" message="Cannot find name &apos;T&apos;." source="TS2304" />
 </file>
 <file name="packages/checkout/blocks-registry/get-registered-blocks.ts">
 <error line="4" column="50" severity="error" message="File &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/packages/checkout/blocks-registry/types.ts&apos; is not listed within the file list of project &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/tsconfig.json&apos;. Projects must list all files or use an &apos;include&apos; pattern.
@@ -1176,11 +946,213 @@
 <error line="6" column="34" severity="error" message="Could not find a declaration file for module &apos;wordpress-components&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/wordpress-components/build/index.js&apos; implicitly has an &apos;any&apos; type.
   If the &apos;@wordpress/components&apos; package actually exposes this module, consider sending a pull request to amend &apos;https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/wordpress__components&apos;" source="TS7016" />
 </file>
+<file name="assets/js/base/context/providers/add-to-cart-form/form-state/actions.js">
+<error line="42" column="27" severity="error" message="Parameter &apos;data&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="50" column="17" severity="error" message="Parameter &apos;quantity&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="54" column="22" severity="error" message="Parameter &apos;data&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+</file>
+<file name="assets/js/base/context/providers/add-to-cart-form/form-state/reducer.js">
+<error line="46" column="11" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="55" column="11" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="64" column="24" severity="error" message="Property &apos;quantity&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="75" column="15" severity="error" message="Property &apos;requestParams&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="88" column="11" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="97" column="14" severity="error" message="Property &apos;hasError&apos; does not exist on type &apos;Object | { status: string; hasError: boolean; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; }&apos;.
+  Property &apos;hasError&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="103" column="11" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="113" column="11" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="121" column="21" severity="error" message="Property &apos;hasError&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="128" column="11" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="129" column="11" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="137" column="21" severity="error" message="Property &apos;hasError&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="149" column="3" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="149" column="12" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object | { status: string; hasError: boolean; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
+  Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="151" column="3" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="151" column="12" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object | { status: string; hasError: boolean; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
+  Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+</file>
+<file name="assets/js/base/context/providers/add-to-cart-form/form-state/event-emit.js">
+<error line="34" column="3" severity="error" message="Argument of type &apos;Function&apos; is not assignable to parameter of type &apos;Dispatch&lt;ActionType&gt;&apos;." source="TS2345" />
+<error line="38" column="3" severity="error" message="Argument of type &apos;Function&apos; is not assignable to parameter of type &apos;Dispatch&lt;ActionType&gt;&apos;." source="TS2345" />
+<error line="42" column="3" severity="error" message="Argument of type &apos;Function&apos; is not assignable to parameter of type &apos;Dispatch&lt;ActionType&gt;&apos;." source="TS2345" />
+</file>
+<file name="assets/js/base/context/providers/add-to-cart-form/form-state/index.js">
+<error line="39" column="56" severity="error" message="Namespace &apos;&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/types/type-defs/contexts&quot;&apos; has no exported member &apos;AddToCartFormContext&apos;." source="TS2694" />
+<error line="60" column="44" severity="error" message="Parameter &apos;callback&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="61" column="42" severity="error" message="Parameter &apos;callback&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="62" column="34" severity="error" message="Parameter &apos;callback&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="67" column="18" severity="error" message="Parameter &apos;quantity&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="68" column="18" severity="error" message="Parameter &apos;hasError&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="69" column="25" severity="error" message="Parameter &apos;response&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="70" column="23" severity="error" message="Parameter &apos;data&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="113" column="7" severity="error" message="Property &apos;onAddToCartAfterProcessingWithSuccess&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="116" column="7" severity="error" message="Property &apos;onAddToCartAfterProcessingWithError&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="119" column="7" severity="error" message="Property &apos;onAddToCartBeforeProcessing&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="129" column="36" severity="error" message="Argument of type &apos;{ type: string; }&apos; is not assignable to parameter of type &apos;{ quantity: number; type: string; data: Object; }&apos;.
+  Type &apos;{ type: string; }&apos; is missing the following properties from type &apos;{ quantity: number; type: string; data: Object; }&apos;: quantity, data" source="TS2345" />
+<error line="130" column="37" severity="error" message="Argument of type &apos;{ type: string; }&apos; is not assignable to parameter of type &apos;{ quantity: number; type: string; data: Object; }&apos;.
+  Type &apos;{ type: string; }&apos; is missing the following properties from type &apos;{ quantity: number; type: string; data: Object; }&apos;: quantity, data" source="TS2345" />
+<error line="132" column="20" severity="error" message="Argument of type &apos;{ type: string; quantity: any; }&apos; is not assignable to parameter of type &apos;{ quantity: number; type: string; data: Object; }&apos;.
+  Property &apos;data&apos; is missing in type &apos;{ type: string; quantity: any; }&apos; but required in type &apos;{ quantity: number; type: string; data: Object; }&apos;." source="TS2345" />
+<error line="134" column="20" severity="error" message="Argument of type &apos;{ type: string; }&apos; is not assignable to parameter of type &apos;{ quantity: number; type: string; data: Object; }&apos;.
+  Type &apos;{ type: string; }&apos; is missing the following properties from type &apos;{ quantity: number; type: string; data: Object; }&apos;: quantity, data" source="TS2345" />
+<error line="136" column="20" severity="error" message="Argument of type &apos;{ type: string; data: any; }&apos; is not assignable to parameter of type &apos;{ quantity: number; type: string; data: Object; }&apos;.
+  Property &apos;quantity&apos; is missing in type &apos;{ type: string; data: any; }&apos; but required in type &apos;{ quantity: number; type: string; data: Object; }&apos;." source="TS2345" />
+<error line="138" column="15" severity="error" message="Argument of type &apos;{ type: string; data: any; }&apos; is not assignable to parameter of type &apos;{ quantity: number; type: string; data: Object; }&apos;.
+  Property &apos;quantity&apos; is missing in type &apos;{ type: string; data: any; }&apos; but required in type &apos;{ quantity: number; type: string; data: Object; }&apos;." source="TS2345" />
+<error line="139" column="20" severity="error" message="Argument of type &apos;{ type: string; }&apos; is not assignable to parameter of type &apos;{ quantity: number; type: string; data: Object; }&apos;.
+  Type &apos;{ type: string; }&apos; is missing the following properties from type &apos;{ quantity: number; type: string; data: Object; }&apos;: quantity, data" source="TS2345" />
+<error line="149" column="18" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="149" column="37" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
+  Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="151" column="6" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="151" column="14" severity="error" message="Property &apos;id&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="151" column="44" severity="error" message="Argument of type &apos;Object | undefined&apos; is not assignable to parameter of type &apos;Object&apos;.
+  Type &apos;undefined&apos; is not assignable to type &apos;Object&apos;." source="TS2345" />
+<error line="154" column="14" severity="error" message="Argument of type &apos;{ type: string; }&apos; is not assignable to parameter of type &apos;{ quantity: number; type: string; data: Object; }&apos;.
+  Type &apos;{ type: string; }&apos; is missing the following properties from type &apos;{ quantity: number; type: string; data: Object; }&apos;: quantity, data" source="TS2345" />
+<error line="156" column="14" severity="error" message="Argument of type &apos;{ type: string; }&apos; is not assignable to parameter of type &apos;{ quantity: number; type: string; data: Object; }&apos;.
+  Type &apos;{ type: string; }&apos; is missing the following properties from type &apos;{ quantity: number; type: string; data: Object; }&apos;: quantity, data" source="TS2345" />
+<error line="158" column="7" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="158" column="26" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
+  Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="164" column="18" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="164" column="37" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
+  Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="188" column="16" severity="error" message="Argument of type &apos;{ type: string; }&apos; is not assignable to parameter of type &apos;{ quantity: number; type: string; data: Object; }&apos;." source="TS2345" />
+<error line="190" column="16" severity="error" message="Argument of type &apos;{ type: string; }&apos; is not assignable to parameter of type &apos;{ quantity: number; type: string; data: Object; }&apos;.
+  Type &apos;{ type: string; }&apos; is missing the following properties from type &apos;{ quantity: number; type: string; data: Object; }&apos;: quantity, data" source="TS2345" />
+<error line="195" column="3" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="195" column="22" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
+  Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="200" column="12" severity="error" message="Property &apos;id&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="207" column="8" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="207" column="27" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
+  Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="213" column="25" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="213" column="44" severity="error" message="Property &apos;processingResponse&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
+  Property &apos;processingResponse&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="216" column="34" severity="error" message="Parameter &apos;observerResponses&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="218" column="34" severity="error" message="Parameter &apos;response&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="235" column="9" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="235" column="28" severity="error" message="Property &apos;hasError&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
+  Property &apos;hasError&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="253" column="18" severity="error" message="Property &apos;id&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="257" column="16" severity="error" message="Argument of type &apos;{ type: string; }&apos; is not assignable to parameter of type &apos;{ quantity: number; type: string; data: Object; }&apos;." source="TS2345" />
+<error line="271" column="16" severity="error" message="Argument of type &apos;{ type: string; }&apos; is not assignable to parameter of type &apos;{ quantity: number; type: string; data: Object; }&apos;." source="TS2345" />
+<error line="273" column="16" severity="error" message="Argument of type &apos;{ type: string; }&apos; is not assignable to parameter of type &apos;{ quantity: number; type: string; data: Object; }&apos;." source="TS2345" />
+<error line="278" column="3" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="278" column="22" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
+  Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="279" column="3" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="279" column="22" severity="error" message="Property &apos;hasError&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
+  Property &apos;hasError&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="280" column="3" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="280" column="22" severity="error" message="Property &apos;processingResponse&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
+  Property &apos;processingResponse&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="284" column="12" severity="error" message="Property &apos;id&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="287" column="61" severity="error" message="Argument of type &apos;Object | undefined&apos; is not assignable to parameter of type &apos;Object&apos;.
+  Type &apos;undefined&apos; is not assignable to type &apos;Object&apos;." source="TS2345" />
+<error line="294" column="16" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="294" column="24" severity="error" message="Property &apos;type&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="295" column="47" severity="error" message="Argument of type &apos;Object | undefined&apos; is not assignable to parameter of type &apos;Object&apos;.
+  Type &apos;undefined&apos; is not assignable to type &apos;Object&apos;." source="TS2345" />
+<error line="296" column="22" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="296" column="30" severity="error" message="Property &apos;has_options&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="300" column="4" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="300" column="23" severity="error" message="Property &apos;quantity&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
+  Property &apos;quantity&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="300" column="44" severity="error" message="Property &apos;add_to_cart&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="301" column="25" severity="error" message="Property &apos;add_to_cart&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="302" column="25" severity="error" message="Property &apos;add_to_cart&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="303" column="24" severity="error" message="Property &apos;add_to_cart&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="304" column="18" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="304" column="37" severity="error" message="Property &apos;requestParams&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
+  Property &apos;requestParams&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="305" column="11" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="305" column="30" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
+  Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="306" column="15" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="306" column="34" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
+  Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="307" column="17" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="307" column="36" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
+  Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="309" column="4" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="309" column="23" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
+  Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="311" column="4" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="311" column="23" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
+  Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="312" column="13" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="312" column="32" severity="error" message="Property &apos;hasError&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
+  Property &apos;hasError&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+</file>
+<file name="assets/js/base/context/providers/add-to-cart-form/form/submit/index.js">
+<error line="88" column="18" severity="error" message="Property &apos;setNonce&apos; does not exist on type &apos;typeof apiFetch&apos;." source="TS2339" />
+<error line="91" column="43" severity="error" message="Parameter &apos;response&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="128" column="35" severity="error" message="Parameter &apos;response&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+</file>
+<file name="assets/js/base/context/providers/cart-checkout/checkout-processor.js">
+<error line="174" column="7" severity="error" message="Variable &apos;unsubscribeProcessing&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="183" column="5" severity="error" message="Variable &apos;unsubscribeProcessing&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="229" column="9" severity="error" message="Property &apos;shipping_address&apos; does not exist on type &apos;{ extensions: { [x: string]: Record&lt;string, unknown&gt;; }; payment_method: string | undefined; payment_data: { key: string; value: unknown; }[]; billing_address: BillingAddress; customer_note: string; create_account: boolean; } | { ...; }&apos;.
+  Property &apos;shipping_address&apos; does not exist on type &apos;{ extensions: { [x: string]: Record&lt;string, unknown&gt;; }; payment_method: string | undefined; payment_data: { key: string; value: unknown; }[]; billing_address: BillingAddress; customer_note: string; create_account: boolean; }&apos;." source="TS2339" />
+<error line="258" column="35" severity="error" message="Parameter &apos;response&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="268" column="9" severity="error" message="Argument of type &apos;{ id: string; context: string; __unstableHTML: boolean; }&apos; is not assignable to parameter of type &apos;Partial&lt;Options&gt;&apos;.
+  Object literal may only specify known properties, and &apos;__unstableHTML&apos; does not exist in type &apos;Partial&lt;Options&gt;&apos;." source="TS2345" />
+<error line="272" column="10" severity="error" message="Parameter &apos;additionalError&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="276" column="10" severity="error" message="Argument of type &apos;{ id: any; context: string; __unstableHTML: boolean; }&apos; is not assignable to parameter of type &apos;Partial&lt;Options&gt;&apos;.
+  Object literal may only specify known properties, and &apos;__unstableHTML&apos; does not exist in type &apos;Partial&lt;Options&gt;&apos;." source="TS2345" />
+<error line="299" column="8" severity="error" message="Argument of type &apos;{ id: string; context: string; __unstableHTML: boolean; }&apos; is not assignable to parameter of type &apos;Partial&lt;Options&gt;&apos;.
+  Object literal may only specify known properties, and &apos;__unstableHTML&apos; does not exist in type &apos;Partial&lt;Options&gt;&apos;." source="TS2345" />
+</file>
+<file name="assets/js/base/context/providers/cart-checkout/checkout-provider.js">
+<error line="4" column="28" severity="error" message="Could not find a declaration file for module &apos;@wordpress/plugins&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@wordpress/plugins/build/index.js&apos; implicitly has an &apos;any&apos; type.
+  Try `npm i --save-dev @types/wordpress__plugins` if it exists or add a new declaration (.d.ts) file containing `declare module &apos;@wordpress/plugins&apos;;`" source="TS7016" />
+<error line="30" column="27" severity="error" message="Type &apos;string | undefined&apos; is not assignable to type &apos;string&apos;.
+  Type &apos;undefined&apos; is not assignable to type &apos;string&apos;." source="TS2322" />
+<error line="31" column="4" severity="error" message="Type &apos;Element&apos; is missing the following properties from type &apos;ReactChildren&apos;: map, forEach, count, only, toArray" source="TS2739" />
+<error line="38" column="8" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(props: BlockErrorBoundaryProps | Readonly&lt;BlockErrorBoundaryProps&gt;): BlockErrorBoundary&apos;, gave the following error.
+    Type &apos;(() =&gt; null) | null&apos; is not assignable to type &apos;(props: RenderErrorProps) =&gt; ReactNode&apos;.
+      Type &apos;null&apos; is not assignable to type &apos;(props: RenderErrorProps) =&gt; ReactNode&apos;.
+  Overload 2 of 2, &apos;(props: BlockErrorBoundaryProps, context: any): BlockErrorBoundary&apos;, gave the following error.
+    Type &apos;(() =&gt; null) | null&apos; is not assignable to type &apos;(props: RenderErrorProps) =&gt; ReactNode&apos;.
+      Type &apos;null&apos; is not assignable to type &apos;(props: RenderErrorProps) =&gt; ReactNode&apos;." source="TS2769" />
+</file>
+<file name="assets/js/base/context/providers/cart-checkout/cart/index.js">
+<error line="20" column="4" severity="error" message="Type &apos;Object | undefined&apos; is not assignable to type &apos;Object&apos;.
+  Type &apos;undefined&apos; is not assignable to type &apos;Object&apos;." source="TS2322" />
+</file>
+<file name="assets/js/base/context/providers/store-notices/components/store-notices-container.js">
+<error line="6" column="24" severity="error" message="Could not find a declaration file for module &apos;wordpress-components&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/wordpress-components/build/index.js&apos; implicitly has an &apos;any&apos; type.
+  If the &apos;@wordpress/components&apos; package actually exposes this module, consider sending a pull request to amend &apos;https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/wordpress__components&apos;" source="TS7016" />
+<error line="30" column="2" severity="error" message="Binding element &apos;className&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="32" column="2" severity="error" message="Binding element &apos;additionalNotices&apos; implicitly has an &apos;any[]&apos; type." source="TS7031" />
+<error line="46" column="33" severity="error" message="Property &apos;type&apos; does not exist on type &apos;Notice&apos;." source="TS2339" />
+</file>
 <file name="assets/js/base/context/providers/store-snackbar-notices/components/snackbar-notices-container.js">
 <error line="5" column="30" severity="error" message="Could not find a declaration file for module &apos;wordpress-components&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/wordpress-components/build/index.js&apos; implicitly has an &apos;any&apos; type.
   If the &apos;@wordpress/components&apos; package actually exposes this module, consider sending a pull request to amend &apos;https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/wordpress__components&apos;" source="TS7016" />
+<error line="18" column="2" severity="error" message="Binding element &apos;className&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="36" column="24" severity="error" message="Property &apos;type&apos; does not exist on type &apos;Notice&apos;." source="TS2339" />
+<error line="42" column="6" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;{}&apos;.
+  No index signature with a parameter of type &apos;string&apos; was found on type &apos;{}&apos;." source="TS7053" />
+<error line="53" column="17" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;{}&apos;.
+  No index signature with a parameter of type &apos;string&apos; was found on type &apos;{}&apos;." source="TS7053" />
+</file>
+<file name="assets/js/base/context/providers/container-width-context.js">
+<error line="10" column="56" severity="error" message="Namespace &apos;&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/types/type-defs/contexts&quot;&apos; has no exported member &apos;ContainerWidthContext&apos;." source="TS2694" />
+</file>
+<file name="assets/js/base/context/providers/index.js">
+<error line="6" column="1" severity="error" message="Module &apos;./cart-checkout&apos; has already exported a member named &apos;React&apos;. Consider explicitly re-exporting to resolve the ambiguity." source="TS2308" />
+</file>
+<file name="assets/js/base/context/hooks/use-checkout-submit.js">
 <error line="7" column="51" severity="error" message="File &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/packages/checkout/index.js&apos; is not listed within the file list of project &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/tsconfig.json&apos;. Projects must list all files or use an &apos;include&apos; pattern.
   The file is in the program because:
+    Imported via &apos;@woocommerce/blocks-checkout&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/base/context/hooks/use-checkout-submit.js&apos;
     Imported via &apos;@woocommerce/blocks-checkout&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/base/context/providers/store-snackbar-notices/components/snackbar-notices-container.js&apos;
     Imported via &apos;@woocommerce/blocks-checkout&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/atomic/utils/render-parent-block.tsx&apos;
     Imported via &apos;@woocommerce/blocks-checkout&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/base/components/cart-checkout/order-summary/index.tsx&apos;
@@ -1191,12 +1163,13 @@
     Imported via &apos;@woocommerce/blocks-checkout&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/discount/index.tsx&apos;
     Imported via &apos;@woocommerce/blocks-checkout&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/footer-item/index.tsx&apos;
     Imported via &apos;@woocommerce/blocks-checkout&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/shipping/index.tsx&apos;
-    Imported via &apos;@woocommerce/blocks-checkout&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-card.js&apos;
+    Imported via &apos;@woocommerce/blocks-checkout&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/base/components/checkbox-list/index.tsx&apos;
     Imported via &apos;@woocommerce/blocks-checkout&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/cart/block.js&apos;
     Imported via &apos;@woocommerce/blocks-checkout&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/filled-cart-block/edit.tsx&apos;
     Imported via &apos;@woocommerce/blocks-checkout&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-items-block/edit.tsx&apos;
     Imported via &apos;@woocommerce/blocks-checkout&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/cart/cart-line-items-table/cart-line-item-row.tsx&apos;
     Imported via &apos;@woocommerce/blocks-checkout&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-totals-block/edit.tsx&apos;
+    Imported via &apos;@woocommerce/blocks-checkout&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-card.js&apos;
     Imported via &apos;@woocommerce/blocks-checkout&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/empty-cart-block/edit.tsx&apos;
     Imported via &apos;@woocommerce/blocks-checkout&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-block/edit.tsx&apos;
     Imported via &apos;@woocommerce/blocks-checkout&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-block/slotfills.tsx&apos;
@@ -1207,6 +1180,7 @@
     Imported via &apos;@woocommerce/blocks-checkout&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-coupon-form/block.tsx&apos;
     Imported via &apos;@woocommerce/blocks-checkout&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-taxes/block.tsx&apos;
     Imported via &apos;@woocommerce/blocks-checkout&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/register-components.ts&apos;
+    Imported via &apos;@woocommerce/blocks-checkout&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/cart/test/block.js&apos;
     Imported via &apos;@woocommerce/blocks-checkout&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/cart/test/slots.js&apos;
     Imported via &apos;@woocommerce/blocks-checkout&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/checkout/block.tsx&apos;
     Imported via &apos;@woocommerce/blocks-checkout&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/edit.tsx&apos;
@@ -1235,20 +1209,90 @@
     Imported via &apos;@woocommerce/blocks-checkout&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-footer-block/block.tsx&apos;
     Imported via &apos;@woocommerce/blocks-checkout&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/filled-mini-cart-contents-block/edit.tsx&apos;
     Imported via &apos;@woocommerce/blocks-checkout&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/mini-cart/test/block.js&apos;" source="TS6307" />
-<error line="18" column="2" severity="error" message="Binding element &apos;className&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="36" column="24" severity="error" message="Property &apos;type&apos; does not exist on type &apos;Notice&apos;." source="TS2339" />
-<error line="42" column="6" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;{}&apos;.
-  No index signature with a parameter of type &apos;string&apos; was found on type &apos;{}&apos;." source="TS7053" />
-<error line="53" column="17" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;{}&apos;.
-  No index signature with a parameter of type &apos;string&apos; was found on type &apos;{}&apos;." source="TS7053" />
 </file>
-<file name="assets/js/base/context/providers/container-width-context.js">
-<error line="10" column="56" severity="error" message="Namespace &apos;&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/types/type-defs/contexts&quot;&apos; has no exported member &apos;ContainerWidthContext&apos;." source="TS2694" />
+<file name="assets/js/base/context/hooks/use-checkout-extension-data.ts">
+<error line="12" column="15" severity="error" message="Module &apos;&quot;../../../data/checkout/types&quot;&apos; declares &apos;CheckoutState&apos; locally, but it is not exported." source="TS2459" />
 </file>
-<file name="assets/js/base/context/providers/index.js">
-<error line="4" column="1" severity="error" message="Module &apos;./cart-checkout&apos; has already exported a member named &apos;React&apos;. Consider explicitly re-exporting to resolve the ambiguity." source="TS2308" />
-<error line="6" column="1" severity="error" message="Module &apos;./cart-checkout&apos; has already exported a member named &apos;React&apos;. Consider explicitly re-exporting to resolve the ambiguity." source="TS2308" />
-<error line="7" column="1" severity="error" message="Module &apos;./cart-checkout&apos; has already exported a member named &apos;React&apos;. Consider explicitly re-exporting to resolve the ambiguity." source="TS2308" />
+<file name="assets/js/shared/hocs/with-product-data-context.js">
+<error line="16" column="10" severity="error" message="Property &apos;productId&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="16" column="21" severity="error" message="Property &apos;OriginalComponent&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="16" column="40" severity="error" message="Property &apos;postId&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="16" column="48" severity="error" message="Property &apos;product&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="18" column="20" severity="error" message="Property &apos;isDescendentOfQueryLoop&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="21" column="3" severity="error" message="Argument of type &apos;{ include: any; }&apos; is not assignable to parameter of type &apos;Query&apos;.
+  Object literal may only specify known properties, and &apos;include&apos; does not exist in type &apos;Query&apos;." source="TS2345" />
+<error line="54" column="11" severity="error" message="Parameter &apos;props&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+</file>
+<file name="assets/js/shared/hocs/with-filtered-attributes.js">
+<error line="12" column="27" severity="error" message="Parameter &apos;OriginalComponent&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="13" column="12" severity="error" message="Parameter &apos;ownProps&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+</file>
+<file name="assets/js/atomic/blocks/product-elements/price/block.js">
+<error line="52" column="18" severity="error" message="Type &apos;string | undefined&apos; is not assignable to type &apos;&quot;center&quot; | &quot;left&quot; | &quot;right&quot; | undefined&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the type of the target." source="TS2412" />
+<error line="57" column="49" severity="error" message="Argument of type &apos;{ currency_code: string; currency_symbol: string; currency_minor_unit: number; currency_decimal_separator: string; currency_thousand_separator: string; currency_prefix: string; currency_suffix: string; price: string; regular_price: string; sale_price: string; price_range: null; }&apos; is not assignable to parameter of type &apos;CurrencyResponse | Record&lt;string, never&gt; | CartShippingPackageShippingRate | undefined&apos;.
+  Type &apos;{ currency_code: string; currency_symbol: string; currency_minor_unit: number; currency_decimal_separator: string; currency_thousand_separator: string; currency_prefix: string; currency_suffix: string; price: string; regular_price: string; sale_price: string; price_range: null; }&apos; is not assignable to type &apos;Record&lt;string, never&gt;&apos;.
+    Property &apos;currency_code&apos; is incompatible with index signature.
+      Type &apos;string&apos; is not assignable to type &apos;never&apos;." source="TS2345" />
+<error line="66" column="4" severity="error" message="Type &apos;string | undefined&apos; is not assignable to type &apos;&quot;center&quot; | &quot;left&quot; | &quot;right&quot; | undefined&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the type of the target." source="TS2412" />
+<error line="74" column="36" severity="error" message="Property &apos;min_amount&apos; does not exist on type &apos;never&apos;." source="TS2339" />
+<error line="75" column="36" severity="error" message="Property &apos;max_amount&apos; does not exist on type &apos;never&apos;." source="TS2339" />
+</file>
+<file name="assets/js/atomic/blocks/product-elements/image/block.js">
+<error line="137" column="19" severity="error" message="Binding element &apos;image&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="137" column="26" severity="error" message="Binding element &apos;loaded&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="137" column="34" severity="error" message="Binding element &apos;showFullSize&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="137" column="48" severity="error" message="Binding element &apos;fallbackAlt&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+</file>
+<file name="assets/js/atomic/blocks/product-elements/rating/block.tsx">
+<error line="55" column="35" severity="error" message="Argument of type &apos;{ id: number; name: string; parent: number; type: string; variation: string; permalink: string; sku: string; short_description: string; description: string; on_sale: boolean; prices: { currency_code: string; ... 9 more ...; price_range: null; }; ... 14 more ...; add_to_cart: { ...; }; }&apos; is not assignable to parameter of type &apos;Omit&lt;ProductResponseItem, &quot;average_rating&quot;&gt; &amp; { average_rating: string; }&apos;.
+  Type &apos;{ id: number; name: string; parent: number; type: string; variation: string; permalink: string; sku: string; short_description: string; description: string; on_sale: boolean; prices: { currency_code: string; ... 9 more ...; price_range: null; }; ... 14 more ...; add_to_cart: { ...; }; }&apos; is not assignable to type &apos;Omit&lt;ProductResponseItem, &quot;average_rating&quot;&gt;&apos;.
+    Types of property &apos;prices&apos; are incompatible.
+      Property &apos;raw_prices&apos; is missing in type &apos;{ currency_code: string; currency_symbol: string; currency_minor_unit: number; currency_decimal_separator: string; currency_thousand_separator: string; currency_prefix: string; currency_suffix: string; price: string; regular_price: string; sale_price: string; price_range: null; }&apos; but required in type &apos;ProductResponseItemPrices&apos;." source="TS2345" />
+<error line="74" column="34" severity="error" message="Argument of type &apos;{ id: number; name: string; parent: number; type: string; variation: string; permalink: string; sku: string; short_description: string; description: string; on_sale: boolean; prices: { currency_code: string; ... 9 more ...; price_range: null; }; ... 14 more ...; add_to_cart: { ...; }; }&apos; is not assignable to parameter of type &apos;ProductResponseItem&apos;.
+  Types of property &apos;prices&apos; are incompatible.
+    Property &apos;raw_prices&apos; is missing in type &apos;{ currency_code: string; currency_symbol: string; currency_minor_unit: number; currency_decimal_separator: string; currency_thousand_separator: string; currency_prefix: string; currency_suffix: string; price: string; regular_price: string; sale_price: string; price_range: null; }&apos; but required in type &apos;ProductResponseItemPrices&apos;." source="TS2345" />
+</file>
+<file name="assets/js/atomic/blocks/product-elements/button/block.js">
+<error line="100" column="3" severity="error" message="Property &apos;id&apos; does not exist on type &apos;Object | undefined&apos;." source="TS2339" />
+<error line="101" column="3" severity="error" message="Property &apos;permalink&apos; does not exist on type &apos;Object | undefined&apos;." source="TS2339" />
+<error line="102" column="3" severity="error" message="Property &apos;add_to_cart&apos; does not exist on type &apos;Object | undefined&apos;." source="TS2339" />
+<error line="103" column="3" severity="error" message="Property &apos;has_options&apos; does not exist on type &apos;Object | undefined&apos;." source="TS2339" />
+<error line="104" column="3" severity="error" message="Property &apos;is_purchasable&apos; does not exist on type &apos;Object | undefined&apos;." source="TS2339" />
+<error line="105" column="3" severity="error" message="Property &apos;is_in_stock&apos; does not exist on type &apos;Object | undefined&apos;." source="TS2339" />
+<error line="110" column="3" severity="error" message="Expected 1 arguments, but got 2." source="TS2554" />
+<error line="168" column="5" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="168" column="17" severity="error" message="Property &apos;className&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="169" column="5" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="169" column="18" severity="error" message="Property &apos;className&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="176" column="8" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="176" column="20" severity="error" message="Property &apos;style&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="177" column="8" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="177" column="21" severity="error" message="Property &apos;style&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="178" column="8" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="178" column="25" severity="error" message="Property &apos;style&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="179" column="8" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="179" column="22" severity="error" message="Property &apos;style&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="214" column="5" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="214" column="17" severity="error" message="Property &apos;className&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="215" column="5" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="215" column="18" severity="error" message="Property &apos;className&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="218" column="8" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="218" column="20" severity="error" message="Property &apos;style&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="219" column="8" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="219" column="21" severity="error" message="Property &apos;style&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="220" column="8" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="220" column="25" severity="error" message="Property &apos;style&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="221" column="8" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="221" column="22" severity="error" message="Property &apos;style&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+</file>
+<file name="assets/js/base/components/summary/utils.js">
+<error line="4" column="23" severity="error" message="Could not find a declaration file for module &apos;@wordpress/wordcount&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@wordpress/wordcount/build/index.js&apos; implicitly has an &apos;any&apos; type.
+  Try `npm i --save-dev @types/wordpress__wordcount` if it exists or add a new declaration (.d.ts) file containing `declare module &apos;@wordpress/wordcount&apos;;`" source="TS7016" />
+</file>
+<file name="assets/js/atomic/blocks/product-elements/stock-indicator/block.js">
+<error line="69" column="24" severity="error" message="Parameter &apos;lowStock&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="77" column="21" severity="error" message="Parameter &apos;inStock&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="77" column="30" severity="error" message="Parameter &apos;isBackordered&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
 </file>
 <file name="assets/js/atomic/blocks/product-elements/add-to-cart/shared/add-to-cart-button.js">
 <error line="120" column="4" severity="error" message="Type &apos;{ children: string; className: string; href: string; onClick: () =&gt; any; rel: string; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; ButtonProps&apos;.
@@ -1309,6 +1353,10 @@
 </file>
 <file name="assets/js/atomic/blocks/product-elements/save.js">
 <error line="6" column="18" severity="error" message="Binding element &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+</file>
+<file name="assets/js/atomic/blocks/product-elements/shared/config.tsx">
+<error line="31" column="2" severity="error" message="Type &apos;{ category: string; keywords: string[]; icon: { src: Element; }; supports: { html: false; }; ancestor: string[]; save: ({ attributes }: { attributes: any; }) =&gt; Element | null; deprecated: { attributes: {}; save(): null; }[]; }&apos; is not assignable to type &apos;Omit&lt;BlockConfiguration&lt;{}&gt;, &quot;title&quot; | &quot;attributes&quot;&gt;&apos;.
+  Object literal may only specify known properties, and &apos;ancestor&apos; does not exist in type &apos;Omit&lt;BlockConfiguration&lt;{}&gt;, &quot;title&quot; | &quot;attributes&quot;&gt;&apos;." source="TS2322" />
 </file>
 <file name="assets/js/editor-components/heading-toolbar/heading-level-icon.js">
 <error line="6" column="45" severity="error" message="Binding element &apos;level&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
@@ -1406,65 +1454,90 @@
 <file name="assets/js/atomic/blocks/product-elements/shared/with-product-selector.js">
 <error line="23" column="51" severity="error" message="Parameter &apos;OriginalComponent&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
 <error line="24" column="11" severity="error" message="Parameter &apos;props&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="38" column="27" severity="error" message="Property &apos;icon&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="39" column="28" severity="error" message="Property &apos;label&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="42" column="25" severity="error" message="Property &apos;description&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="43" column="28" severity="error" message="Property &apos;description&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="48" column="9" severity="error" message="Type &apos;{ selected: any; showVariations: true; onChange: (value?: any[]) =&gt; void; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; { selected: number[]; } &amp; { children?: ReactNode; }&apos;.
+<error line="41" column="27" severity="error" message="Property &apos;icon&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="42" column="28" severity="error" message="Property &apos;label&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="45" column="25" severity="error" message="Property &apos;description&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="46" column="28" severity="error" message="Property &apos;description&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="51" column="9" severity="error" message="Type &apos;{ selected: any; showVariations: true; onChange: (value?: any[]) =&gt; void; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; { selected: number[]; } &amp; { children?: ReactNode; }&apos;.
   Property &apos;showVariations&apos; does not exist on type &apos;IntrinsicAttributes &amp; { selected: number[]; } &amp; { children?: ReactNode; }&apos;." source="TS2322" />
-<error line="49" column="22" severity="error" message="Parameter &apos;value&apos; implicitly has an &apos;any[]&apos; type." source="TS7006" />
+<error line="52" column="22" severity="error" message="Parameter &apos;value&apos; implicitly has an &apos;any[]&apos; type." source="TS7006" />
+</file>
+<file name="assets/js/atomic/blocks/product-elements/title/index.ts">
+<error line="46" column="5" severity="error" message="Type &apos;{ __experimentalSelector?: string; spacing?: Partial&lt;SpacingProps&gt; | { margin: true; __experimentalSkipSerialization: true; } | undefined; typography?: Partial&lt;TypographyProps&gt; | { ...; } | undefined; ... 10 more ...; lock?: boolean | undefined; }&apos; is not assignable to type &apos;BlockSupports&apos;.
+  Types of property &apos;color&apos; are incompatible.
+    Type &apos;Partial&lt;ColorProps&gt; | { text: true; background: true; link: false; gradients: true; __experimentalSkipSerialization: true; } | undefined&apos; is not assignable to type &apos;Partial&lt;ColorProps&gt; | undefined&apos;.
+      Type &apos;{ text: true; background: true; link: false; gradients: true; __experimentalSkipSerialization: true; }&apos; is not assignable to type &apos;Partial&lt;ColorProps&gt;&apos;.
+        Object literal may only specify known properties, and &apos;__experimentalSkipSerialization&apos; does not exist in type &apos;Partial&lt;ColorProps&gt;&apos;." source="TS2322" />
 </file>
 <file name="assets/js/atomic/blocks/product-elements/price/edit.js">
-<error line="19" column="23" severity="error" message="Binding element &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="19" column="35" severity="error" message="Binding element &apos;setAttributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="20" column="23" severity="error" message="Binding element &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="20" column="35" severity="error" message="Binding element &apos;setAttributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="20" column="50" severity="error" message="Binding element &apos;context&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
 </file>
 <file name="assets/js/atomic/blocks/product-elements/price/attributes.js">
-<error line="16" column="3" severity="error" message="Type &apos;{ textAlign: { type: string; }; productId: { type: string; default: number; }; }&apos; is not assignable to type &apos;{ productId: { type: string; default: number; }; }&apos;.
-  Object literal may only specify known properties, and &apos;textAlign&apos; does not exist in type &apos;{ productId: { type: string; default: number; }; }&apos;." source="TS2322" />
+<error line="20" column="3" severity="error" message="Type &apos;{ textAlign: { type: string; }; productId: { type: string; default: number; }; isDescendentOfQueryLoop: { type: string; default: boolean; }; }&apos; is not assignable to type &apos;{ productId: { type: string; default: number; }; isDescendentOfQueryLoop: { type: string; default: boolean; }; }&apos;.
+  Object literal may only specify known properties, and &apos;textAlign&apos; does not exist in type &apos;{ productId: { type: string; default: number; }; isDescendentOfQueryLoop: { type: string; default: boolean; }; }&apos;." source="TS2322" />
+</file>
+<file name="assets/js/atomic/blocks/product-elements/price/index.js">
+<error line="54" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{}&gt;, settings?: Partial&lt;BlockConfiguration&lt;{}&gt;&gt; | undefined): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{}&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{}&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{}&gt;): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ apiVersion: number; title: string; description: string; parent: string[]; ancestor: string[]; usesContext: string[]; icon: { src: JSX.Element; }; attributes: { productId: { type: string; default: number; }; isDescendentOfQueryLoop: { ...; }; }; ... 18 more ...; merge?: ((attributes: {}, attributesToMerge: {}) =&gt; P...&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{}&gt;&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+      Type &apos;{ apiVersion: number; title: string; description: string; parent: string[]; ancestor: string[]; usesContext: string[]; icon: { src: JSX.Element; }; attributes: { productId: { type: string; default: number; }; isDescendentOfQueryLoop: { ...; }; }; ... 18 more ...; merge?: ((attributes: {}, attributesToMerge: {}) =&gt; P...&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;{}&gt;, &quot;icon&quot;&gt;&gt;&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+        The types of &apos;supports.color&apos; are incompatible between these types.
+          Type &apos;Partial&lt;ColorProps&gt; | { text: boolean; background: boolean; link: boolean; __experimentalSkipSerialization: boolean; } | undefined&apos; is not assignable to type &apos;Partial&lt;ColorProps&gt; | undefined&apos;.
+            Type &apos;{ text: boolean; background: boolean; link: boolean; __experimentalSkipSerialization: boolean; }&apos; is not assignable to type &apos;Partial&lt;ColorProps&gt;&apos;.
+              Types of property &apos;text&apos; are incompatible.
+                Type &apos;boolean&apos; is not assignable to type &apos;string&apos;." source="TS2769" />
 </file>
 <file name="assets/js/atomic/blocks/product-elements/image/edit.js">
-<error line="13" column="2" severity="error" message="Module &apos;&quot;@wordpress/components&quot;&apos; has no exported member &apos;__experimentalToggleGroupControl&apos;." source="TS2305" />
-<error line="15" column="2" severity="error" message="Module &apos;&quot;@wordpress/components&quot;&apos; has no exported member &apos;__experimentalToggleGroupControlOption&apos;." source="TS2305" />
-<error line="25" column="18" severity="error" message="Binding element &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="25" column="30" severity="error" message="Binding element &apos;setAttributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="76" column="21" severity="error" message="Parameter &apos;value&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="127" column="20" severity="error" message="Parameter &apos;value&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="14" column="2" severity="error" message="Module &apos;&quot;@wordpress/components&quot;&apos; has no exported member &apos;__experimentalToggleGroupControl&apos;." source="TS2305" />
+<error line="16" column="2" severity="error" message="Module &apos;&quot;@wordpress/components&quot;&apos; has no exported member &apos;__experimentalToggleGroupControlOption&apos;." source="TS2305" />
+<error line="24" column="18" severity="error" message="Binding element &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="24" column="30" severity="error" message="Binding element &apos;setAttributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="24" column="45" severity="error" message="Binding element &apos;context&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="94" column="21" severity="error" message="Parameter &apos;value&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="146" column="21" severity="error" message="Parameter &apos;value&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
 </file>
 <file name="assets/js/atomic/blocks/product-elements/image/index.js">
-<error line="31" column="1" severity="error" message="No overload matches this call.
+<error line="46" column="1" severity="error" message="No overload matches this call.
   Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{}&gt;, settings?: Partial&lt;BlockConfiguration&lt;{}&gt;&gt; | undefined): Block&lt;{}&gt; | undefined&apos;, gave the following error.
     Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{}&gt;&apos;.
       Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{}&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
   Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{}&gt;): Block&lt;{}&gt; | undefined&apos;, gave the following error.
-    Argument of type &apos;{ apiVersion: number; title: string; description: string; icon: { src: JSX.Element; }; attributes: { showProductLink: { type: string; default: boolean; }; showSaleBadge: { type: string; default: boolean; }; saleBadgeAlign: { ...; }; imageSizing: { ...; }; productId: { ...; }; }; ... 20 more ...; merge?: ((attributes...&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{}&gt;&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
-      Types of property &apos;supports&apos; are incompatible.
-        Type &apos;{ __experimentalSelector?: string; spacing?: { margin: boolean; __experimentalSkipSerialization: boolean; }; __experimentalBorder?: { radius: boolean; __experimentalSkipSerialization: boolean; }; typography?: { ...; }; }&apos; has no properties in common with type &apos;BlockSupports&apos;." source="TS2769" />
+    Argument of type &apos;{ apiVersion: number; name: string; title: string; icon: { src: JSX.Element; }; keywords: string[]; description: string; usesContext: string[]; parent: string[]; textdomain: string; attributes: { showProductLink: { ...; }; ... 4 more ...; isDescendentOfQueryLoop: { ...; }; }; ... 15 more ...; merge?: ((attributes: {...&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{}&gt;&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+      Type &apos;{ apiVersion: number; name: string; title: string; icon: { src: JSX.Element; }; keywords: string[]; description: string; usesContext: string[]; parent: string[]; textdomain: string; attributes: { showProductLink: { ...; }; ... 4 more ...; isDescendentOfQueryLoop: { ...; }; }; ... 15 more ...; merge?: ((attributes: {...&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;{}&gt;, &quot;icon&quot;&gt;&gt;&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+        Types of property &apos;edit&apos; are incompatible.
+          Type &apos;({ attributes, setAttributes, context }: { attributes: any; setAttributes: any; context: any; }) =&gt; Element&apos; is not assignable to type &apos;ComponentType&lt;BlockEditProps&lt;{}&gt;&gt; | undefined&apos;.
+            Type &apos;({ attributes, setAttributes, context }: { attributes: any; setAttributes: any; context: any; }) =&gt; Element&apos; is not assignable to type &apos;FunctionComponent&lt;BlockEditProps&lt;{}&gt;&gt;&apos;.
+              Types of parameters &apos;__0&apos; and &apos;props&apos; are incompatible.
+                Property &apos;context&apos; is missing in type &apos;BlockEditProps&lt;{}&gt; &amp; { children?: ReactNode; }&apos; but required in type &apos;{ attributes: any; setAttributes: any; context: any; }&apos;." source="TS2769" />
 </file>
-<file name="assets/js/atomic/blocks/product-elements/rating/edit.js">
-<error line="14" column="18" severity="error" message="Binding element &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-</file>
-<file name="assets/js/atomic/blocks/product-elements/rating/index.js">
-<error line="31" column="1" severity="error" message="No overload matches this call.
-  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{}&gt;, settings?: Partial&lt;BlockConfiguration&lt;{}&gt;&gt; | undefined): Block&lt;{}&gt; | undefined&apos;, gave the following error.
-    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{}&gt;&apos;.
-      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{}&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
-  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{}&gt;): Block&lt;{}&gt; | undefined&apos;, gave the following error.
-    Argument of type &apos;{ apiVersion: number; title: string; description: string; icon: { src: JSX.Element; }; attributes: { productId: { type: string; default: number; }; }; supports: { __experimentalSelector?: string; spacing?: { ...; }; color?: { ...; }; typography?: { ...; }; }; ... 19 more ...; merge?: ((attributes: {}, attributesToMe...&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{}&gt;&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
-      Types of property &apos;supports&apos; are incompatible.
-        Type &apos;{ __experimentalSelector?: string; spacing?: { margin: boolean; __experimentalSkipSerialization: boolean; }; color?: { text: boolean; background: boolean; link: boolean; __experimentalSkipSerialization: boolean; }; typography?: { ...; }; }&apos; has no properties in common with type &apos;BlockSupports&apos;." source="TS2769" />
+<file name="assets/js/atomic/blocks/product-elements/rating/index.ts">
+<error line="32" column="2" severity="error" message="Type &apos;{ __experimentalSelector?: string; spacing?: { margin: boolean; __experimentalSkipSerialization: boolean; }; color?: { text: boolean; background: boolean; link: boolean; __experimentalSkipSerialization: boolean; }; typography?: { ...; }; }&apos; is not assignable to type &apos;BlockSupports&apos;.
+  The types of &apos;color.text&apos; are incompatible between these types.
+    Type &apos;boolean&apos; is not assignable to type &apos;string&apos;." source="TS2322" />
 </file>
 <file name="assets/js/atomic/blocks/product-elements/button/edit.js">
-<error line="15" column="18" severity="error" message="Binding element &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="13" column="18" severity="error" message="Binding element &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="13" column="30" severity="error" message="Binding element &apos;setAttributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="13" column="45" severity="error" message="Binding element &apos;context&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
 </file>
 <file name="assets/js/atomic/blocks/product-elements/button/index.js">
-<error line="31" column="1" severity="error" message="No overload matches this call.
+<error line="35" column="1" severity="error" message="No overload matches this call.
   Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{}&gt;, settings?: Partial&lt;BlockConfiguration&lt;{}&gt;&gt; | undefined): Block&lt;{}&gt; | undefined&apos;, gave the following error.
     Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{}&gt;&apos;.
       Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{}&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
   Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{}&gt;): Block&lt;{}&gt; | undefined&apos;, gave the following error.
-    Argument of type &apos;{ apiVersion: number; title: string; description: string; icon: { src: JSX.Element; }; attributes: { productId: { type: string; default: number; }; }; supports: { typography?: { fontSize: boolean; __experimentalFontWeight: boolean; __experimentalSkipSerialization: boolean; }; __experimentalSelector?: string; spacing...&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{}&gt;&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
-      Types of property &apos;supports&apos; are incompatible.
-        Type &apos;{ typography?: { fontSize: boolean; __experimentalFontWeight: boolean; __experimentalSkipSerialization: boolean; }; __experimentalSelector?: string; spacing?: { padding: boolean; __experimentalSkipSerialization: boolean; }; color?: { ...; }; __experimentalBorder?: { ...; }; }&apos; has no properties in common with type &apos;BlockSupports&apos;." source="TS2769" />
+    Argument of type &apos;{ apiVersion: number; title: string; description: string; ancestor: string[]; usesContext: string[]; icon: { src: JSX.Element; }; attributes: { productId: { type: string; default: number; }; isDescendentOfQueryLoop: { ...; }; }; ... 19 more ...; merge?: ((attributes: {}, attributesToMerge: {}) =&gt; Partial&lt;...&gt;) | und...&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{}&gt;&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+      Type &apos;{ apiVersion: number; title: string; description: string; ancestor: string[]; usesContext: string[]; icon: { src: JSX.Element; }; attributes: { productId: { type: string; default: number; }; isDescendentOfQueryLoop: { ...; }; }; ... 19 more ...; merge?: ((attributes: {}, attributesToMerge: {}) =&gt; Partial&lt;...&gt;) | und...&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;{}&gt;, &quot;icon&quot;&gt;&gt;&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+        Types of property &apos;edit&apos; are incompatible.
+          Type &apos;({ attributes, setAttributes, context }: { attributes: any; setAttributes: any; context: any; }) =&gt; Element&apos; is not assignable to type &apos;ComponentType&lt;BlockEditProps&lt;{}&gt;&gt; | undefined&apos;.
+            Type &apos;({ attributes, setAttributes, context }: { attributes: any; setAttributes: any; context: any; }) =&gt; Element&apos; is not assignable to type &apos;FunctionComponent&lt;BlockEditProps&lt;{}&gt;&gt;&apos;.
+              Types of parameters &apos;__0&apos; and &apos;props&apos; are incompatible.
+                Property &apos;context&apos; is missing in type &apos;BlockEditProps&lt;{}&gt; &amp; { children?: ReactNode; }&apos; but required in type &apos;{ attributes: any; setAttributes: any; context: any; }&apos;." source="TS2769" />
 </file>
 <file name="assets/js/atomic/blocks/product-elements/summary/edit.js">
 <error line="15" column="18" severity="error" message="Binding element &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
@@ -1476,20 +1549,18 @@
       Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{}&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
   Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{}&gt;): Block&lt;{}&gt; | undefined&apos;, gave the following error.
     Argument of type &apos;{ apiVersion: number; title: string; description: string; icon: { src: JSX.Element; }; attributes: { productId: { type: string; default: number; }; }; supports: { color?: { text: boolean; background: boolean; link: boolean; }; typography?: { ...; }; __experimentalSelector?: string; }; ... 19 more ...; merge?: ((attr...&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{}&gt;&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
-      Types of property &apos;supports&apos; are incompatible.
-        Type &apos;{ color?: { text: boolean; background: boolean; link: boolean; }; typography?: { fontSize: boolean; }; __experimentalSelector?: string; }&apos; has no properties in common with type &apos;BlockSupports&apos;." source="TS2769" />
-</file>
-<file name="assets/js/atomic/blocks/product-elements/sale-badge/edit.js">
-<error line="14" column="18" severity="error" message="Binding element &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+      Type &apos;{ apiVersion: number; title: string; description: string; icon: { src: JSX.Element; }; attributes: { productId: { type: string; default: number; }; }; supports: { color?: { text: boolean; background: boolean; link: boolean; }; typography?: { ...; }; __experimentalSelector?: string; }; ... 19 more ...; merge?: ((attr...&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;{}&gt;, &quot;icon&quot;&gt;&gt;&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+        The types of &apos;supports.color.text&apos; are incompatible between these types.
+          Type &apos;boolean&apos; is not assignable to type &apos;string&apos;." source="TS2769" />
 </file>
 <file name="assets/js/editor-components/edit-product-link/index.js">
 <error line="18" column="40" severity="error" message="Property &apos;productId&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
 </file>
-<file name="assets/js/atomic/blocks/product-elements/sku/edit.js">
-<error line="14" column="18" severity="error" message="Binding element &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-</file>
 <file name="assets/js/atomic/blocks/product-elements/category-list/index.ts">
-<error line="30" column="2" severity="error" message="Type &apos;{ color?: { text: true; link: true; background: false; __experimentalSkipSerialization: true; }; typography?: { fontSize: true; lineHeight: true; __experimentalFontStyle: true; __experimentalFontWeight: true; __experimentalSkipSerialization: true; }; __experimentalSelector?: string; }&apos; has no properties in common with type &apos;BlockSupports&apos;." source="TS2559" />
+<error line="36" column="5" severity="error" message="Type &apos;{ color?: { text: true; link: true; background: false; __experimentalSkipSerialization: true; }; typography?: { fontSize: true; lineHeight: true; __experimentalFontStyle: true; __experimentalFontWeight: true; __experimentalSkipSerialization: true; }; __experimentalSelector?: string; }&apos; is not assignable to type &apos;BlockSupports&apos;.
+  Types of property &apos;color&apos; are incompatible.
+    Type &apos;{ text: true; link: true; background: false; __experimentalSkipSerialization: true; }&apos; is not assignable to type &apos;Partial&lt;ColorProps&gt;&apos;.
+      Object literal may only specify known properties, and &apos;__experimentalSkipSerialization&apos; does not exist in type &apos;Partial&lt;ColorProps&gt;&apos;." source="TS2322" />
 <error line="49" column="2" severity="error" message="Type &apos;({ attributes }: Props) =&gt; JSX.Element&apos; is not assignable to type &apos;ComponentType&lt;BlockSaveProps&lt;{}&gt;&gt;&apos;.
   Type &apos;({ attributes }: Props) =&gt; JSX.Element&apos; is not assignable to type &apos;FunctionComponent&lt;BlockSaveProps&lt;{}&gt;&gt;&apos;.
     Types of parameters &apos;__0&apos; and &apos;props&apos; are incompatible.
@@ -1498,8 +1569,10 @@
           Type &apos;Readonly&lt;{}&gt;&apos; is not assignable to type &apos;Record&lt;string, unknown&gt; &amp; { className: string; }&apos;.
             Property &apos;className&apos; is missing in type &apos;Readonly&lt;{}&gt;&apos; but required in type &apos;{ className: string; }&apos;." source="TS2322" />
 </file>
-<file name="assets/js/atomic/blocks/product-elements/tag-list/edit.js">
-<error line="16" column="18" severity="error" message="Binding element &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<file name="assets/js/atomic/blocks/product-elements/tag-list/index.ts">
+<error line="28" column="2" severity="error" message="Type &apos;{ color?: { text: boolean; background: boolean; link: boolean; }; typography?: { fontSize: boolean; }; __experimentalSelector?: string; }&apos; is not assignable to type &apos;BlockSupports&apos;.
+  The types of &apos;color.text&apos; are incompatible between these types.
+    Type &apos;boolean&apos; is not assignable to type &apos;string&apos;." source="TS2322" />
 </file>
 <file name="assets/js/atomic/blocks/product-elements/stock-indicator/edit.js">
 <error line="15" column="18" severity="error" message="Binding element &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
@@ -1516,23 +1589,23 @@
 <error line="475" column="34" severity="error" message="Argument of type &apos;null&apos; is not assignable to parameter of type &apos;Object | undefined&apos;." source="TS2345" />
 </file>
 <file name="assets/js/atomic/blocks/product-elements/image/test/block.test.js">
-<error line="70" column="33" severity="error" message="Type &apos;{ name: string; id: number; fallbackAlt: string; permalink: string; images: { id: number; src: string; thumbnail: string; srcset: string; sizes: string; name: string; alt: string; }[]; }&apos; is not assignable to type &apos;null | undefined&apos;." source="TS2322" />
-<error line="87" column="12" severity="error" message="Object is possibly &apos;null&apos;." source="TS2531" />
-<error line="94" column="33" severity="error" message="Type &apos;{ name: string; id: number; fallbackAlt: string; permalink: string; images: never[]; }&apos; is not assignable to type &apos;null | undefined&apos;." source="TS2322" />
-<error line="105" column="12" severity="error" message="Object is possibly &apos;null&apos;." source="TS2531" />
-<error line="108" column="12" severity="error" message="Object is possibly &apos;null&apos;." source="TS2531" />
-<error line="117" column="33" severity="error" message="Type &apos;{ name: string; id: number; fallbackAlt: string; permalink: string; images: { id: number; src: string; thumbnail: string; srcset: string; sizes: string; name: string; alt: string; }[]; }&apos; is not assignable to type &apos;null | undefined&apos;." source="TS2322" />
-<error line="137" column="33" severity="error" message="Type &apos;{ name: string; id: number; fallbackAlt: string; permalink: string; images: never[]; }&apos; is not assignable to type &apos;null | undefined&apos;." source="TS2322" />
+<error line="65" column="6" severity="error" message="Property &apos;isLoading&apos; is missing in type &apos;{ children: Element; product: { name: string; id: number; fallbackAlt: string; permalink: string; images: { id: number; src: string; thumbnail: string; srcset: string; sizes: string; name: string; alt: string; }[]; }; }&apos; but required in type &apos;{ product: any; children: Object; isLoading: boolean; }&apos;." source="TS2741" />
+<error line="82" column="12" severity="error" message="Object is possibly &apos;null&apos;." source="TS2531" />
+<error line="89" column="6" severity="error" message="Property &apos;isLoading&apos; is missing in type &apos;{ children: Element; product: { name: string; id: number; fallbackAlt: string; permalink: string; images: never[]; }; }&apos; but required in type &apos;{ product: any; children: Object; isLoading: boolean; }&apos;." source="TS2741" />
+<error line="100" column="12" severity="error" message="Object is possibly &apos;null&apos;." source="TS2531" />
+<error line="103" column="12" severity="error" message="Object is possibly &apos;null&apos;." source="TS2531" />
+<error line="112" column="6" severity="error" message="Property &apos;isLoading&apos; is missing in type &apos;{ children: Element; product: { name: string; id: number; fallbackAlt: string; permalink: string; images: { id: number; src: string; thumbnail: string; srcset: string; sizes: string; name: string; alt: string; }[]; }; }&apos; but required in type &apos;{ product: any; children: Object; isLoading: boolean; }&apos;." source="TS2741" />
+<error line="132" column="6" severity="error" message="Property &apos;isLoading&apos; is missing in type &apos;{ children: Element; product: { name: string; id: number; fallbackAlt: string; permalink: string; images: never[]; }; }&apos; but required in type &apos;{ product: any; children: Object; isLoading: boolean; }&apos;." source="TS2741" />
 </file>
 <file name="assets/js/atomic/blocks/product-elements/title/test/block.test.js">
-<error line="22" column="33" severity="error" message="Type &apos;{ id: number; name: string; permalink: string; }&apos; is not assignable to type &apos;null | undefined&apos;." source="TS2322" />
-<error line="23" column="7" severity="error" message="Type &apos;{ showProductLink: false; }&apos; is missing the following properties from type &apos;Attributes&apos;: headingLevel, productId, align" source="TS2739" />
-<error line="37" column="33" severity="error" message="Type &apos;{ id: number; name: string; permalink: string; }&apos; is not assignable to type &apos;null | undefined&apos;." source="TS2322" />
-<error line="38" column="7" severity="error" message="Type &apos;{ showProductLink: true; }&apos; is missing the following properties from type &apos;Attributes&apos;: headingLevel, productId, align" source="TS2739" />
+<error line="22" column="6" severity="error" message="Property &apos;isLoading&apos; is missing in type &apos;{ children: Element; product: { id: number; name: string; permalink: string; }; }&apos; but required in type &apos;{ product: any; children: Object; isLoading: boolean; }&apos;." source="TS2741" />
+<error line="23" column="7" severity="error" message="Type &apos;{ showProductLink: false; }&apos; is missing the following properties from type &apos;Attributes&apos;: headingLevel, align" source="TS2739" />
+<error line="37" column="6" severity="error" message="Property &apos;isLoading&apos; is missing in type &apos;{ children: Element; product: { id: number; name: string; permalink: string; }; }&apos; but required in type &apos;{ product: any; children: Object; isLoading: boolean; }&apos;." source="TS2741" />
+<error line="38" column="7" severity="error" message="Type &apos;{ showProductLink: true; }&apos; is missing the following properties from type &apos;Attributes&apos;: headingLevel, align" source="TS2739" />
 <error line="45" column="12" severity="error" message="Object is possibly &apos;null&apos;." source="TS2531" />
 <error line="46" column="12" severity="error" message="Object is possibly &apos;null&apos;." source="TS2531" />
-<error line="51" column="33" severity="error" message="Type &apos;{ id: number; name: string; permalink: string; }&apos; is not assignable to type &apos;null | undefined&apos;." source="TS2322" />
-<error line="52" column="7" severity="error" message="Type &apos;{ showProductLink: true; linkTarget: string; }&apos; is missing the following properties from type &apos;Attributes&apos;: headingLevel, productId, align" source="TS2739" />
+<error line="51" column="6" severity="error" message="Property &apos;isLoading&apos; is missing in type &apos;{ children: Element; product: { id: number; name: string; permalink: string; }; }&apos; but required in type &apos;{ product: any; children: Object; isLoading: boolean; }&apos;." source="TS2741" />
+<error line="52" column="7" severity="error" message="Type &apos;{ showProductLink: true; linkTarget: string; }&apos; is missing the following properties from type &apos;Attributes&apos;: headingLevel, align" source="TS2739" />
 <error line="59" column="12" severity="error" message="Object is possibly &apos;null&apos;." source="TS2531" />
 <error line="60" column="12" severity="error" message="Object is possibly &apos;null&apos;." source="TS2531" />
 </file>
@@ -1541,14 +1614,10 @@
 <error line="11" column="14" severity="error" message="&apos;createBlocksFromTemplate&apos; implicitly has return type &apos;any&apos; because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions." source="TS7023" />
 <error line="13" column="9" severity="error" message="&apos;children&apos; implicitly has type &apos;any&apos; because it does not have a type annotation and is referenced directly or indirectly in its own initializer." source="TS7022" />
 </file>
-<file name="node_modules/html-react-parser/lib/dom-to-react.d.ts">
-<error line="4" column="10" severity="error" message="Module &apos;&quot;domhandler&quot;&apos; has no exported member &apos;DomElement&apos;. Did you mean to use &apos;import DomElement from &quot;domhandler&quot;&apos; instead?" source="TS2614" />
-</file>
-<file name="node_modules/html-dom-parser/lib/html-to-dom-server.d.ts">
-<error line="3" column="29" severity="error" message="Module &apos;&quot;domhandler&quot;&apos; has no exported member &apos;DomElement&apos;. Did you mean to use &apos;import DomElement from &quot;domhandler&quot;&apos; instead?" source="TS2614" />
-</file>
-<file name="node_modules/html-react-parser/index.d.ts">
-<error line="3" column="10" severity="error" message="Module &apos;&quot;htmlparser2&quot;&apos; has no exported member &apos;DomElement&apos;." source="TS2305" />
+<file name="assets/js/atomic/utils/render-parent-block.tsx">
+<error line="144" column="2" severity="error" message="Type &apos;(string | Element | null)[]&apos; is not assignable to type &apos;(Element | null)[]&apos;.
+  Type &apos;string | Element | null&apos; is not assignable to type &apos;Element | null&apos;.
+    Type &apos;string&apos; is not assignable to type &apos;Element&apos;." source="TS2322" />
 </file>
 <file name="assets/js/atomic/utils/render-standalone-blocks.js">
 <error line="17" column="22" severity="error" message="Parameter &apos;el&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
@@ -1569,20 +1638,15 @@
       Type &apos;undefined&apos; is not assignable to type &apos;string&apos;." source="TS2375" />
 </file>
 <file name="assets/js/base/components/text-input/validated-text-input.tsx">
-<error line="178" column="32" severity="error" message="Argument of type &apos;({ className, instanceId, id, ariaDescribedBy, errorId, focusOnMount, onChange, showError, errorMessage: passedErrorMessage, value, ...rest }: ValidatedTextInputProps) =&gt; JSX.Element&apos; is not assignable to parameter of type &apos;ComponentType&lt;{ instanceId: string | number; }&gt;&apos;.
-  Type &apos;({ className, instanceId, id, ariaDescribedBy, errorId, focusOnMount, onChange, showError, errorMessage: passedErrorMessage, value, ...rest }: ValidatedTextInputProps) =&gt; JSX.Element&apos; is not assignable to type &apos;FunctionComponent&lt;{ instanceId: string | number; }&gt;&apos;.
-    Types of parameters &apos;__0&apos; and &apos;props&apos; are incompatible.
-      Type &apos;PropsWithChildren&lt;{ instanceId: string | number; }&gt;&apos; is not assignable to type &apos;ValidatedTextInputProps&apos;.
-        Type &apos;PropsWithChildren&lt;{ instanceId: string | number; }&gt;&apos; is not assignable to type &apos;ValidatedTextInputPropsWithInstanceId &amp; { className?: string; ariaDescribedBy?: string; errorId?: string; focusOnMount?: boolean; showError?: boolean; errorMessage?: string; onChange: (newValue: string) =&gt; void; value: string; }&apos;.
-          Type &apos;PropsWithChildren&lt;{ instanceId: string | number; }&gt;&apos; is not assignable to type &apos;ValidatedTextInputPropsWithInstanceId&apos;.
-            Types of property &apos;instanceId&apos; are incompatible.
-              Type &apos;string | number&apos; is not assignable to type &apos;string&apos;.
-                Type &apos;number&apos; is not assignable to type &apos;string&apos;." source="TS2345" />
+<error line="136" column="4" severity="error" message="Type &apos;{ className: string; &quot;aria-invalid&quot;: boolean; id: string; onBlur: () =&gt; void; feedback: false | Element; ref: RefObject&lt;HTMLInputElement&gt;; onChange: (val: string) =&gt; void; ariaDescribedBy: string | undefined; value: string; }&apos; is not assignable to type &apos;TextInputProps&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+  Types of property &apos;ariaDescribedBy&apos; are incompatible.
+    Type &apos;string | undefined&apos; is not assignable to type &apos;string&apos;.
+      Type &apos;undefined&apos; is not assignable to type &apos;string&apos;." source="TS2375" />
 </file>
 <file name="assets/js/base/components/combobox/index.tsx">
 <error line="8" column="33" severity="error" message="Could not find a declaration file for module &apos;wordpress-components&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/wordpress-components/build/index.js&apos; implicitly has an &apos;any&apos; type.
   If the &apos;@wordpress/components&apos; package actually exposes this module, consider sending a pull request to amend &apos;https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/wordpress__components&apos;" source="TS7016" />
-<error line="152" column="32" severity="error" message="Argument of type &apos;({ id, className, label, onChange, options, value, required, errorMessage, errorId: incomingErrorId, instanceId, autoComplete, }: ComboboxProps) =&gt; JSX.Element&apos; is not assignable to parameter of type &apos;ComponentType&lt;{ instanceId: string | number; }&gt;&apos;.
+<error line="148" column="32" severity="error" message="Argument of type &apos;({ id, className, label, onChange, options, value, required, errorMessage, errorId: incomingErrorId, instanceId, autoComplete, }: ComboboxProps) =&gt; JSX.Element&apos; is not assignable to parameter of type &apos;ComponentType&lt;{ instanceId: string | number; }&gt;&apos;.
   Type &apos;({ id, className, label, onChange, options, value, required, errorMessage, errorId: incomingErrorId, instanceId, autoComplete, }: ComboboxProps) =&gt; JSX.Element&apos; is not assignable to type &apos;FunctionComponent&lt;{ instanceId: string | number; }&gt;&apos;.
     Types of parameters &apos;__0&apos; and &apos;props&apos; are incompatible.
       Type &apos;PropsWithChildren&lt;{ instanceId: string | number; }&gt;&apos; is missing the following properties from type &apos;ComboboxProps&apos;: errorId, id, label, onChange, and 2 more." source="TS2345" />
@@ -1594,8 +1658,8 @@
 <file name="assets/js/base/components/state-input/state-input.tsx">
 <error line="93" column="6" severity="error" message="Type &apos;{ className: string; id: string; label: string; onChange: (stateValue: string) =&gt; void; options: { value: string; label: string; }[]; value: string; errorMessage: string; required: boolean; autoComplete: string; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; Omit&lt;{ instanceId: string | number; }, &quot;instanceId&quot;&gt; &amp; { children?: ReactNode; }&apos;.
   Property &apos;className&apos; does not exist on type &apos;IntrinsicAttributes &amp; Omit&lt;{ instanceId: string | number; }, &quot;instanceId&quot;&gt; &amp; { children?: ReactNode; }&apos;." source="TS2322" />
-<error line="134" column="4" severity="error" message="Type &apos;{ className: string | undefined; id: string; label: string; onChange: (stateValue: string) =&gt; void; autoComplete: string; value: string; required: boolean; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; Omit&lt;{ instanceId: string | number; }, &quot;instanceId&quot;&gt; &amp; { children?: ReactNode; }&apos;.
-  Property &apos;className&apos; does not exist on type &apos;IntrinsicAttributes &amp; Omit&lt;{ instanceId: string | number; }, &quot;instanceId&quot;&gt; &amp; { children?: ReactNode; }&apos;." source="TS2322" />
+<error line="136" column="4" severity="error" message="Type &apos;{ className: string | undefined; id: string; label: string; onChange: (stateValue: string) =&gt; void; autoComplete: string; value: string; required: boolean; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; Omit&lt;ValidatedTextInputProps, &quot;instanceId&quot;&gt; &amp; { children?: ReactNode; }&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+  Property &apos;label&apos; does not exist on type &apos;IntrinsicAttributes &amp; Omit&lt;ValidatedTextInputProps, &quot;instanceId&quot;&gt; &amp; { children?: ReactNode; }&apos;." source="TS2375" />
 </file>
 <file name="assets/js/base/components/state-input/billing-state-input.tsx">
 <error line="13" column="21" severity="error" message="Type &apos;Record&lt;string, string&gt;&apos; is not assignable to type &apos;Record&lt;string, Record&lt;string, string&gt;&gt;&apos;.
@@ -1603,16 +1667,16 @@
     Type &apos;string&apos; is not assignable to type &apos;Record&lt;string, string&gt;&apos;." source="TS2322" />
 </file>
 <file name="assets/js/base/components/cart-checkout/address-form/address-form.tsx">
-<error line="156" column="8" severity="error" message="Type &apos;{ key: &quot;country&quot;; id: string; label: string; value: string; autoComplete: string; onChange: (newValue: string) =&gt; void; errorId: string | null; errorMessage: string | undefined; required: boolean; }&apos; is not assignable to type &apos;CountryInputProps&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+<error line="162" column="8" severity="error" message="Type &apos;{ key: &quot;country&quot;; id: string; label: string; value: string; autoComplete: string; onChange: (newValue: string) =&gt; void; errorId: string | null; errorMessage: string | undefined; required: boolean; }&apos; is not assignable to type &apos;CountryInputProps&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
   Types of property &apos;errorMessage&apos; are incompatible.
     Type &apos;string | undefined&apos; is not assignable to type &apos;string&apos;.
       Type &apos;undefined&apos; is not assignable to type &apos;string&apos;." source="TS2375" />
-<error line="190" column="8" severity="error" message="Type &apos;{ key: &quot;state&quot;; id: string; country: string; label: string; value: string; autoComplete: string; onChange: (newValue: string) =&gt; void; errorMessage: string | undefined; required: boolean; }&apos; is not assignable to type &apos;StateInputProps&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+<error line="196" column="8" severity="error" message="Type &apos;{ key: &quot;state&quot;; id: string; country: string; label: string; value: string; autoComplete: string; onChange: (newValue: string) =&gt; void; errorMessage: string | undefined; required: boolean; }&apos; is not assignable to type &apos;StateInputProps&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
   Types of property &apos;errorMessage&apos; are incompatible.
     Type &apos;string | undefined&apos; is not assignable to type &apos;string&apos;.
       Type &apos;undefined&apos; is not assignable to type &apos;string&apos;." source="TS2375" />
-<error line="216" column="7" severity="error" message="Type &apos;{ key: &quot;first_name&quot; | &quot;last_name&quot; | &quot;company&quot; | &quot;address_1&quot; | &quot;address_2&quot; | &quot;city&quot; | &quot;postcode&quot;; id: string; className: string; label: string; value: string; autoCapitalize: string | undefined; autoComplete: string; onChange: (newValue: string) =&gt; void; errorMessage: string | undefined; required: boolean; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; Omit&lt;{ instanceId: string | number; }, &quot;instanceId&quot;&gt; &amp; { children?: ReactNode; }&apos;.
-  Property &apos;id&apos; does not exist on type &apos;IntrinsicAttributes &amp; Omit&lt;{ instanceId: string | number; }, &quot;instanceId&quot;&gt; &amp; { children?: ReactNode; }&apos;." source="TS2322" />
+<error line="224" column="7" severity="error" message="Type &apos;{ key: &quot;first_name&quot; | &quot;last_name&quot; | &quot;company&quot; | &quot;address_1&quot; | &quot;address_2&quot; | &quot;city&quot; | &quot;postcode&quot;; id: string; className: string; label: string; value: string; autoCapitalize: string | undefined; autoComplete: string; onChange: (newValue: string) =&gt; void; errorMessage: string | undefined; required: boolean; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; Omit&lt;ValidatedTextInputProps, &quot;instanceId&quot;&gt; &amp; { children?: ReactNode; }&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+  Property &apos;label&apos; does not exist on type &apos;IntrinsicAttributes &amp; Omit&lt;ValidatedTextInputProps, &quot;instanceId&quot;&gt; &amp; { children?: ReactNode; }&apos;." source="TS2375" />
 </file>
 <file name="assets/js/base/components/cart-checkout/form-step/index.tsx">
 <error line="81" column="6" severity="error" message="Type &apos;{ title: string; stepHeadingContent: Element | undefined; }&apos; is not assignable to type &apos;StepHeadingProps&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
@@ -1630,24 +1694,13 @@
 <error line="7" column="15" severity="error" message="Module &apos;&quot;@woocommerce/price-format&quot;&apos; has no exported member &apos;Currency&apos;." source="TS2305" />
 </file>
 <file name="assets/js/base/components/cart-checkout/shipping-calculator/index.tsx">
-<error line="29" column="5" severity="error" message="Type &apos;Partial&lt;keyof EnteredAddress&gt;[]&apos; is not assignable to type &apos;Partial&lt;keyof AddressFields&gt;[]&apos;.
-  Type &apos;Partial&lt;keyof EnteredAddress&gt;&apos; is not assignable to type &apos;Partial&lt;keyof AddressFields&gt;&apos;.
+<error line="30" column="5" severity="error" message="Type &apos;Partial&lt;keyof ShippingAddress&gt;[]&apos; is not assignable to type &apos;Partial&lt;keyof AddressFields&gt;[]&apos;.
+  Type &apos;Partial&lt;keyof ShippingAddress&gt;&apos; is not assignable to type &apos;Partial&lt;keyof AddressFields&gt;&apos;.
     Type &apos;&quot;phone&quot;&apos; is not assignable to type &apos;Partial&lt;keyof AddressFields&gt;&apos;." source="TS2322" />
 </file>
-<file name="assets/js/base/components/cart-checkout/shipping-rates-control/index.tsx">
-<error line="62" column="6" severity="error" message="Type &apos;{ key: string | number; packageId: string | number; packageData: { name: string; destination: ResponseBaseAddress; items: ShippingRateItem[]; shipping_rates: CartResponseShippingPackageShippingRate[]; }; ... 4 more ...; renderOption: PackageRateRenderOption; }&apos; is not assignable to type &apos;PackageProps&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
-  Types of property &apos;collapse&apos; are incompatible.
-    Type &apos;boolean | undefined&apos; is not assignable to type &apos;boolean&apos;.
-      Type &apos;undefined&apos; is not assignable to type &apos;boolean&apos;." source="TS2375" />
-</file>
 <file name="assets/js/base/components/cart-checkout/totals/coupon/index.tsx">
-<error line="93" column="8" severity="error" message="Type &apos;{ id: string; errorId: string; className: string; label: string; value: string; ariaDescribedBy: any; onChange: (newCouponValue: any) =&gt; void; focusOnMount: boolean; showError: boolean; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; Omit&lt;{ instanceId: string | number; }, &quot;instanceId&quot;&gt; &amp; { children?: ReactNode; }&apos;.
-  Property &apos;id&apos; does not exist on type &apos;IntrinsicAttributes &amp; Omit&lt;{ instanceId: string | number; }, &quot;instanceId&quot;&gt; &amp; { children?: ReactNode; }&apos;." source="TS2322" />
-<error line="104" column="21" severity="error" message="Parameter &apos;newCouponValue&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="114" column="8" severity="error" message="Type &apos;(e: React.MouseEvent&lt;HTMLElement, &apos;click&apos;&gt;) =&gt; void&apos; is not assignable to type &apos;(e: MouseEvent&lt;HTMLButtonElement, MouseEvent&gt;) =&gt; void&apos;.
-  Types of parameters &apos;e&apos; and &apos;e&apos; are incompatible.
-    Type &apos;MouseEvent&lt;HTMLButtonElement, MouseEvent&gt;&apos; is not assignable to type &apos;MouseEvent&lt;HTMLElement, &quot;click&quot;&gt;&apos;.
-      Type &apos;MouseEvent&apos; is not assignable to type &apos;&quot;click&quot;&apos;." source="TS2322" />
+<error line="102" column="8" severity="error" message="Type &apos;{ id: string; errorId: string; className: string; label: string; value: string; ariaDescribedBy: string | undefined; onChange: (newCouponValue: string) =&gt; void; focusOnMount: true; showError: false; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; Omit&lt;ValidatedTextInputProps, &quot;instanceId&quot;&gt; &amp; { children?: ReactNode; }&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+  Property &apos;label&apos; does not exist on type &apos;IntrinsicAttributes &amp; Omit&lt;ValidatedTextInputProps, &quot;instanceId&quot;&gt; &amp; { children?: ReactNode; }&apos;." source="TS2375" />
 </file>
 <file name="assets/js/base/components/chip/chip.tsx">
 <error line="66" column="4" severity="error" message="Type &apos;{ children: (false | {} | Element | null)[]; className: string; }&apos; is not assignable to type &apos;IntrinsicAttributes&apos;.
@@ -1678,8 +1731,8 @@
 <error line="15" column="22" severity="error" message="Binding element &apos;children&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
 <error line="83" column="33" severity="error" message="Binding element &apos;type&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
 <error line="92" column="5" severity="error" message="Type &apos;string[]&apos; is not assignable to type &apos;(keyof AddressFields)[]&apos;." source="TS2322" />
-<error line="102" column="37" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;EnteredAddress&apos;.
-  No index signature with a parameter of type &apos;string&apos; was found on type &apos;EnteredAddress&apos;." source="TS7053" />
+<error line="102" column="37" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;ShippingAddress&apos;.
+  No index signature with a parameter of type &apos;string&apos; was found on type &apos;ShippingAddress&apos;." source="TS7053" />
 <error line="116" column="17" severity="error" message="Argument of type &apos;{ country: string; countryKey: string; city: string; state: string; postcode: string; }&apos; is not assignable to parameter of type &apos;{ country?: null | undefined; city?: null | undefined; state?: null | undefined; postcode?: null | undefined; }&apos;.
   Types of property &apos;country&apos; are incompatible.
     Type &apos;string&apos; is not assignable to type &apos;null | undefined&apos;." source="TS2345" />
@@ -1705,12 +1758,6 @@
 <error line="162" column="17" severity="error" message="Argument of type &apos;{ country: string; countryKey: string; city: string; state: string; postcode: string; }&apos; is not assignable to parameter of type &apos;{ country?: null | undefined; city?: null | undefined; state?: null | undefined; postcode?: null | undefined; }&apos;." source="TS2345" />
 <error line="163" column="19" severity="error" message="Type &apos;string&apos; is not assignable to type &apos;null | undefined&apos;." source="TS2322" />
 <error line="164" column="48" severity="error" message="Property &apos;value&apos; does not exist on type &apos;HTMLElement&apos;." source="TS2339" />
-</file>
-<file name="assets/js/previews/cart.ts">
-<error line="75" column="4" severity="error" message="Property &apos;price_range&apos; is missing in type &apos;{ currency_code: &quot;USD&quot;; currency_symbol: string; currency_minor_unit: number; currency_decimal_separator: string; currency_thousand_separator: string; currency_prefix: string; currency_suffix: string; price: string; regular_price: string; sale_price: string; raw_prices: { ...; }; }&apos; but required in type &apos;CartItemPrices&apos;." source="TS2741" />
-<error line="141" column="4" severity="error" message="Property &apos;price_range&apos; is missing in type &apos;{ currency_code: &quot;USD&quot;; currency_symbol: string; currency_minor_unit: number; currency_decimal_separator: string; currency_thousand_separator: string; currency_prefix: string; currency_suffix: string; price: string; regular_price: string; sale_price: string; raw_prices: { ...; }; }&apos; but required in type &apos;CartItemPrices&apos;." source="TS2741" />
-<error line="189" column="5" severity="error" message="Type &apos;{ currency_code: &quot;USD&quot;; currency_symbol: string; currency_minor_unit: number; currency_decimal_separator: string; currency_thousand_separator: string; currency_prefix: string; currency_suffix: string; total: string; total_tax: string; tax_lines: { ...; }[]; }&apos; is not assignable to type &apos;CartResponseFeeItemTotals&apos;.
-  Object literal may only specify known properties, and &apos;tax_lines&apos; does not exist in type &apos;CartResponseFeeItemTotals&apos;." source="TS2322" />
 </file>
 <file name="assets/js/base/components/cart-checkout/product-details/test/index.js">
 <error line="19" column="20" severity="error" message="Type &apos;({ name: string; value: string; display?: never; } | { name: string; value: string; display: string; } | { value: string; name?: never; display?: never; })[]&apos; is not assignable to type &apos;ProductResponseItemData[]&apos;.
@@ -1745,54 +1792,9 @@
     Types of property &apos;currency_code&apos; are incompatible.
       Type &apos;string&apos; is not assignable to type &apos;CurrencyCode&apos;." source="TS2322" />
 </file>
-<file name="assets/js/base/components/dropdown-selector/input.js">
-<error line="2" column="2" severity="error" message="Binding element &apos;checked&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="3" column="2" severity="error" message="Binding element &apos;getInputProps&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="4" column="2" severity="error" message="Binding element &apos;inputRef&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="5" column="2" severity="error" message="Binding element &apos;isDisabled&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="6" column="2" severity="error" message="Binding element &apos;onFocus&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="7" column="2" severity="error" message="Binding element &apos;onRemoveItem&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="8" column="2" severity="error" message="Binding element &apos;placeholder&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="9" column="2" severity="error" message="Binding element &apos;tabIndex&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="10" column="2" severity="error" message="Binding element &apos;value&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="20" column="16" severity="error" message="Parameter &apos;e&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-</file>
-<file name="assets/js/base/components/dropdown-selector/input-wrapper.js">
-<error line="1" column="42" severity="error" message="Binding element &apos;children&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="1" column="52" severity="error" message="Binding element &apos;onClick&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-</file>
-<file name="assets/js/base/components/dropdown-selector/menu.js">
-<error line="8" column="2" severity="error" message="Binding element &apos;checked&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="9" column="2" severity="error" message="Binding element &apos;getItemProps&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="10" column="2" severity="error" message="Binding element &apos;getMenuProps&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="11" column="2" severity="error" message="Binding element &apos;highlightedIndex&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="12" column="2" severity="error" message="Binding element &apos;options&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="21" column="21" severity="error" message="Parameter &apos;option&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="21" column="29" severity="error" message="Parameter &apos;index&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-</file>
-<file name="assets/js/base/components/dropdown-selector/selected-chip.js">
-<error line="7" column="42" severity="error" message="Binding element &apos;onRemoveItem&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="7" column="56" severity="error" message="Binding element &apos;option&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-</file>
-<file name="assets/js/base/components/dropdown-selector/selected-value.js">
-<error line="8" column="43" severity="error" message="Binding element &apos;onClick&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="8" column="52" severity="error" message="Binding element &apos;onRemoveItem&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="8" column="66" severity="error" message="Binding element &apos;option&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="12" column="3" severity="error" message="Object is possibly &apos;null&apos;." source="TS2531" />
-</file>
-<file name="assets/js/base/components/dropdown-selector/index.js">
-<error line="27" column="12" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
-<error line="33" column="12" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
-<error line="123" column="7" severity="error" message="Type &apos;{ children: (Element | (Element | null)[])[]; isOpen: boolean; onClick: () =&gt; any; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; { children: any; onClick: any; }&apos;.
-  Property &apos;isOpen&apos; does not exist on type &apos;IntrinsicAttributes &amp; { children: any; onClick: any; }&apos;." source="TS2322" />
-<error line="124" column="23" severity="error" message="Object is possibly &apos;null&apos;." source="TS2531" />
-<error line="135" column="31" severity="error" message="Parameter &apos;val&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="136" column="19" severity="error" message="Expected 0 arguments, but got 1." source="TS2554" />
-<error line="137" column="9" severity="error" message="Object is possibly &apos;null&apos;." source="TS2531" />
-<error line="149" column="26" severity="error" message="Object is possibly &apos;null&apos;." source="TS2531" />
-<error line="161" column="25" severity="error" message="Parameter &apos;val&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="162" column="19" severity="error" message="Expected 0 arguments, but got 1." source="TS2554" />
-<error line="163" column="9" severity="error" message="Object is possibly &apos;null&apos;." source="TS2531" />
+<file name="assets/js/base/components/form-token-field/index.tsx">
+<error line="4" column="52" severity="error" message="Could not find a declaration file for module &apos;wordpress-components&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/wordpress-components/build/index.js&apos; implicitly has an &apos;any&apos; type.
+  If the &apos;@wordpress/components&apos; package actually exposes this module, consider sending a pull request to amend &apos;https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/wordpress__components&apos;" source="TS7016" />
 </file>
 <file name="assets/js/base/components/label/test/index.js">
 <error line="45" column="7" severity="error" message="Type &apos;{ className: string; &apos;data-foo&apos;: string; }&apos; is not assignable to type &apos;HTMLProps&lt;HTMLElement&gt;&apos;.
@@ -1810,68 +1812,72 @@
 <error line="53" column="17" severity="error" message="Argument of type &apos;number | null | undefined&apos; is not assignable to parameter of type &apos;number | undefined&apos;." source="TS2345" />
 </file>
 <file name="assets/js/base/components/price-slider/index.tsx">
-<error line="105" column="20" severity="error" message="Argument of type &apos;number | null | undefined&apos; is not assignable to parameter of type &apos;number&apos;.
+<error line="127" column="20" severity="error" message="Argument of type &apos;number | null | undefined&apos; is not assignable to parameter of type &apos;number&apos;.
   Type &apos;undefined&apos; is not assignable to type &apos;number&apos;." source="TS2345" />
-<error line="105" column="49" severity="error" message="Argument of type &apos;number | null | undefined&apos; is not assignable to parameter of type &apos;number&apos;.
+<error line="127" column="49" severity="error" message="Argument of type &apos;number | null | undefined&apos; is not assignable to parameter of type &apos;number&apos;.
   Type &apos;undefined&apos; is not assignable to type &apos;number&apos;." source="TS2345" />
-<error line="113" column="16" severity="error" message="Argument of type &apos;number | null&apos; is not assignable to parameter of type &apos;number&apos;.
+<error line="135" column="16" severity="error" message="Argument of type &apos;number | null&apos; is not assignable to parameter of type &apos;number&apos;.
   Type &apos;null&apos; is not assignable to type &apos;number&apos;." source="TS2345" />
-<error line="114" column="16" severity="error" message="Argument of type &apos;number | null&apos; is not assignable to parameter of type &apos;number&apos;.
+<error line="136" column="16" severity="error" message="Argument of type &apos;number | null&apos; is not assignable to parameter of type &apos;number&apos;.
   Type &apos;null&apos; is not assignable to type &apos;number&apos;." source="TS2345" />
-<error line="126" column="10" severity="error" message="Object is possibly &apos;null&apos;." source="TS2531" />
-<error line="126" column="21" severity="error" message="Object is possibly &apos;null&apos; or &apos;undefined&apos;." source="TS2533" />
-<error line="127" column="9" severity="error" message="Object is possibly &apos;null&apos; or &apos;undefined&apos;." source="TS2533" />
-<error line="127" column="25" severity="error" message="Object is possibly &apos;null&apos; or &apos;undefined&apos;." source="TS2533" />
-<error line="132" column="10" severity="error" message="Object is possibly &apos;null&apos;." source="TS2531" />
-<error line="132" column="21" severity="error" message="Object is possibly &apos;null&apos; or &apos;undefined&apos;." source="TS2533" />
-<error line="133" column="9" severity="error" message="Object is possibly &apos;null&apos; or &apos;undefined&apos;." source="TS2533" />
-<error line="133" column="25" severity="error" message="Object is possibly &apos;null&apos; or &apos;undefined&apos;." source="TS2533" />
-<error line="171" column="41" severity="error" message="Object is possibly &apos;null&apos; or &apos;undefined&apos;." source="TS2533" />
-<error line="172" column="41" severity="error" message="Object is possibly &apos;null&apos; or &apos;undefined&apos;." source="TS2533" />
-<error line="201" column="10" severity="error" message="Type &apos;[number, number | null] | [number | null, number]&apos; is not assignable to type &apos;[number, number]&apos;.
+<error line="148" column="10" severity="error" message="Object is possibly &apos;null&apos;." source="TS2531" />
+<error line="148" column="21" severity="error" message="Object is possibly &apos;null&apos; or &apos;undefined&apos;." source="TS2533" />
+<error line="149" column="9" severity="error" message="Object is possibly &apos;null&apos; or &apos;undefined&apos;." source="TS2533" />
+<error line="149" column="25" severity="error" message="Object is possibly &apos;null&apos; or &apos;undefined&apos;." source="TS2533" />
+<error line="154" column="10" severity="error" message="Object is possibly &apos;null&apos;." source="TS2531" />
+<error line="154" column="21" severity="error" message="Object is possibly &apos;null&apos; or &apos;undefined&apos;." source="TS2533" />
+<error line="155" column="9" severity="error" message="Object is possibly &apos;null&apos; or &apos;undefined&apos;." source="TS2533" />
+<error line="155" column="25" severity="error" message="Object is possibly &apos;null&apos; or &apos;undefined&apos;." source="TS2533" />
+<error line="193" column="41" severity="error" message="Object is possibly &apos;null&apos; or &apos;undefined&apos;." source="TS2533" />
+<error line="194" column="41" severity="error" message="Object is possibly &apos;null&apos; or &apos;undefined&apos;." source="TS2533" />
+<error line="223" column="10" severity="error" message="Type &apos;[number, number | null] | [number | null, number]&apos; is not assignable to type &apos;[number, number]&apos;.
   Type &apos;[number, number | null]&apos; is not assignable to type &apos;[number, number]&apos;.
     Type at position 1 in source is not compatible with type at position 1 in target.
       Type &apos;number | null&apos; is not assignable to type &apos;number&apos;.
         Type &apos;null&apos; is not assignable to type &apos;number&apos;." source="TS2322" />
-<error line="251" column="9" severity="error" message="Object is possibly &apos;null&apos;." source="TS2531" />
-<error line="251" column="26" severity="error" message="Object is possibly &apos;null&apos;." source="TS2531" />
-<error line="253" column="11" severity="error" message="Type &apos;number | null&apos; is not assignable to type &apos;number&apos;.
+<error line="273" column="9" severity="error" message="Object is possibly &apos;null&apos;." source="TS2531" />
+<error line="273" column="26" severity="error" message="Object is possibly &apos;null&apos;." source="TS2531" />
+<error line="275" column="11" severity="error" message="Type &apos;number | null&apos; is not assignable to type &apos;number&apos;.
   Type &apos;null&apos; is not assignable to type &apos;number&apos;." source="TS2322" />
-<error line="260" column="16" severity="error" message="Argument of type &apos;number&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2345" />
-<error line="261" column="16" severity="error" message="Argument of type &apos;number&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2345" />
-<error line="266" column="7" severity="error" message="Type &apos;number | null&apos; is not assignable to type &apos;number&apos;.
+<error line="282" column="16" severity="error" message="Argument of type &apos;number&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2345" />
+<error line="283" column="16" severity="error" message="Argument of type &apos;number&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2345" />
+<error line="288" column="7" severity="error" message="Type &apos;number | null&apos; is not assignable to type &apos;number&apos;.
   Type &apos;null&apos; is not assignable to type &apos;number&apos;." source="TS2322" />
-<error line="266" column="22" severity="error" message="Type &apos;number | null&apos; is not assignable to type &apos;number&apos;.
+<error line="288" column="22" severity="error" message="Type &apos;number | null&apos; is not assignable to type &apos;number&apos;.
   Type &apos;null&apos; is not assignable to type &apos;number&apos;." source="TS2322" />
-<error line="298" column="3" severity="error" message="Object is possibly &apos;null&apos;." source="TS2531" />
-<error line="301" column="3" severity="error" message="Object is possibly &apos;null&apos;." source="TS2531" />
-<error line="309" column="5" severity="error" message="Type &apos;(event: React.MouseEvent&lt;HTMLDivElement&gt;) =&gt; void&apos; is not assignable to type &apos;FocusEventHandler&lt;HTMLDivElement&gt;&apos;.
+<error line="323" column="3" severity="error" message="Object is possibly &apos;null&apos;." source="TS2531" />
+<error line="326" column="3" severity="error" message="Object is possibly &apos;null&apos;." source="TS2531" />
+<error line="339" column="4" severity="error" message="Type &apos;(event: React.MouseEvent&lt;HTMLDivElement&gt;) =&gt; void&apos; is not assignable to type &apos;FocusEventHandler&lt;HTMLDivElement&gt;&apos;.
   Types of parameters &apos;event&apos; and &apos;event&apos; are incompatible.
     Type &apos;FocusEvent&lt;HTMLDivElement, Element&gt;&apos; is missing the following properties from type &apos;MouseEvent&lt;HTMLDivElement, MouseEvent&gt;&apos;: altKey, button, buttons, clientX, and 13 more." source="TS2322" />
-<error line="325" column="8" severity="error" message="Type &apos;number | null | undefined&apos; is not assignable to type &apos;string | number | readonly string[] | undefined&apos;.
+<error line="355" column="7" severity="error" message="Type &apos;number | null | undefined&apos; is not assignable to type &apos;string | number | readonly string[] | undefined&apos;.
   Type &apos;null&apos; is not assignable to type &apos;string | number | readonly string[] | undefined&apos;." source="TS2322" />
-<error line="332" column="8" severity="error" message="Type &apos;number | null | undefined&apos; is not assignable to type &apos;string | number | undefined&apos;.
+<error line="362" column="7" severity="error" message="Type &apos;number | null | undefined&apos; is not assignable to type &apos;string | number | undefined&apos;.
   Type &apos;null&apos; is not assignable to type &apos;string | number | undefined&apos;." source="TS2322" />
-<error line="333" column="8" severity="error" message="Type &apos;number | null | undefined&apos; is not assignable to type &apos;string | number | undefined&apos;." source="TS2322" />
-<error line="346" column="8" severity="error" message="Type &apos;number | null | undefined&apos; is not assignable to type &apos;string | number | readonly string[] | undefined&apos;." source="TS2322" />
-<error line="353" column="8" severity="error" message="Type &apos;number | null | undefined&apos; is not assignable to type &apos;string | number | undefined&apos;." source="TS2322" />
-<error line="354" column="8" severity="error" message="Type &apos;number | null | undefined&apos; is not assignable to type &apos;string | number | undefined&apos;." source="TS2322" />
-<error line="375" column="9" severity="error" message="Type &apos;number | null | undefined&apos; is not assignable to type &apos;number&apos;.
+<error line="363" column="7" severity="error" message="Type &apos;number | null | undefined&apos; is not assignable to type &apos;string | number | undefined&apos;." source="TS2322" />
+<error line="376" column="7" severity="error" message="Type &apos;number | null | undefined&apos; is not assignable to type &apos;string | number | readonly string[] | undefined&apos;." source="TS2322" />
+<error line="383" column="7" severity="error" message="Type &apos;number | null | undefined&apos; is not assignable to type &apos;string | number | undefined&apos;." source="TS2322" />
+<error line="384" column="7" severity="error" message="Type &apos;number | null | undefined&apos; is not assignable to type &apos;string | number | undefined&apos;." source="TS2322" />
+<error line="411" column="9" severity="error" message="Type &apos;number | null | undefined&apos; is not assignable to type &apos;number&apos;.
   Type &apos;undefined&apos; is not assignable to type &apos;number&apos;." source="TS2322" />
-<error line="377" column="9" severity="error" message="Type &apos;number | null&apos; is not assignable to type &apos;number&apos;.
+<error line="413" column="9" severity="error" message="Type &apos;number | null&apos; is not assignable to type &apos;number&apos;.
   Type &apos;null&apos; is not assignable to type &apos;number&apos;." source="TS2322" />
-<error line="387" column="8" severity="error" message="Type &apos;number | null&apos; is not assignable to type &apos;string | number&apos;.
+<error line="423" column="8" severity="error" message="Type &apos;number | null&apos; is not assignable to type &apos;string | number&apos;.
   Type &apos;null&apos; is not assignable to type &apos;string | number&apos;." source="TS2322" />
-<error line="398" column="9" severity="error" message="Type &apos;number | null | undefined&apos; is not assignable to type &apos;number&apos;.
+<error line="440" column="9" severity="error" message="Type &apos;number | null | undefined&apos; is not assignable to type &apos;number&apos;.
   Type &apos;undefined&apos; is not assignable to type &apos;number&apos;." source="TS2322" />
-<error line="409" column="8" severity="error" message="Type &apos;number | null&apos; is not assignable to type &apos;string | number&apos;." source="TS2322" />
-<error line="422" column="9" severity="error" message="Type &apos;number | null&apos; is not assignable to type &apos;string | number&apos;." source="TS2322" />
-<error line="427" column="9" severity="error" message="Type &apos;number | null&apos; is not assignable to type &apos;string | number&apos;." source="TS2322" />
+<error line="451" column="8" severity="error" message="Type &apos;number | null&apos; is not assignable to type &apos;string | number&apos;." source="TS2322" />
+<error line="466" column="8" severity="error" message="Type &apos;number | null&apos; is not assignable to type &apos;string | number&apos;." source="TS2322" />
+<error line="470" column="8" severity="error" message="Type &apos;number | null&apos; is not assignable to type &apos;string | number&apos;." source="TS2322" />
+<error line="482" column="11" severity="error" message="Type &apos;number | null | undefined&apos; is not assignable to type &apos;number&apos;.
+  Type &apos;undefined&apos; is not assignable to type &apos;number&apos;." source="TS2322" />
+<error line="483" column="11" severity="error" message="Type &apos;number | null | undefined&apos; is not assignable to type &apos;number&apos;.
+  Type &apos;undefined&apos; is not assignable to type &apos;number&apos;." source="TS2322" />
 </file>
 <file name="assets/js/base/components/product-list/product-list.tsx">
-<error line="244" column="14" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
-<error line="246" column="8" severity="error" message="Type &apos;unknown&apos; is not assignable to type &apos;Partial&lt;ProductResponseItem&gt;&apos;." source="TS2322" />
-<error line="262" column="33" severity="error" message="Argument of type &apos;({ attributes, currentPage, onPageChange, onSortChange, sortValue, scrollToTop, }: ProductListProps) =&gt; JSX.Element&apos; is not assignable to parameter of type &apos;FunctionComponent&lt;Record&lt;string, unknown&gt;&gt;&apos;.
+<error line="255" column="14" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
+<error line="257" column="8" severity="error" message="Type &apos;unknown&apos; is not assignable to type &apos;Partial&lt;ProductResponseItem&gt;&apos;." source="TS2322" />
+<error line="273" column="33" severity="error" message="Argument of type &apos;({ attributes, currentPage, onPageChange, onSortChange, sortValue, scrollToTop, }: ProductListProps) =&gt; JSX.Element&apos; is not assignable to parameter of type &apos;FunctionComponent&lt;Record&lt;string, unknown&gt;&gt;&apos;.
   Types of parameters &apos;__0&apos; and &apos;props&apos; are incompatible.
     Type &apos;PropsWithChildren&lt;Record&lt;string, unknown&gt;&gt;&apos; is missing the following properties from type &apos;ProductListProps&apos;: attributes, currentPage, onPageChange, onSortChange, and 2 more." source="TS2345" />
 </file>
@@ -1991,49 +1997,50 @@
 <error line="114" column="26" severity="error" message="Property &apos;toHaveErrored&apos; does not exist on type &apos;Matchers&lt;void, Console&gt;&apos;." source="TS2339" />
 </file>
 <file name="assets/js/base/context/hooks/cart/test/use-store-cart-item-quantity.js">
-<error line="25" column="17" severity="error" message="Parameter &apos;a&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="29" column="6" severity="error" message="Variable &apos;registry&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
-<error line="29" column="16" severity="error" message="Variable &apos;renderer&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
-<error line="31" column="33" severity="error" message="Parameter &apos;Component&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="32" column="29" severity="error" message="Variable &apos;registry&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
-<error line="37" column="29" severity="error" message="Parameter &apos;options&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="39" column="11" severity="error" message="Type &apos;{ isPendingDelete: boolean; quantity: number; setItemQuantity: Dispatch&lt;SetStateAction&lt;number&gt;&gt;; removeItem: () =&gt; Promise&lt;boolean&gt;; cartItemQuantityErrors: CartResponseErrorItem[]; }&apos; has no properties in common with type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLDivElement&gt;, HTMLDivElement&gt;&apos;." source="TS2559" />
-<error line="42" column="6" severity="error" message="Variable &apos;mockRemoveItemFromCart&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
-<error line="43" column="6" severity="error" message="Variable &apos;mockChangeCartItemQuantity&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
-<error line="44" column="25" severity="error" message="Binding element &apos;isPendingDelete&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="44" column="42" severity="error" message="Binding element &apos;isPendingQuantity&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="51" column="3" severity="error" message="Variable &apos;registry&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
-<error line="74" column="3" severity="error" message="Variable &apos;mockRemoveItemFromCart&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
-<error line="75" column="3" severity="error" message="Variable &apos;mockChangeCartItemQuantity&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
-<error line="81" column="34" severity="error" message="Property &apos;mockReturnValue&apos; does not exist on type &apos;(options?: { shouldSelect: boolean; }) =&gt; StoreCart&apos;." source="TS2339" />
-<error line="99" column="5" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
-<error line="108" column="5" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
-<error line="125" column="27" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
-<error line="131" column="12" severity="error" message="Variable &apos;mockRemoveItemFromCart&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
-<error line="146" column="32" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
-<error line="152" column="12" severity="error" message="Variable &apos;mockChangeCartItemQuantity&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
-<error line="164" column="33" severity="error" message="Property &apos;mockReturnValue&apos; does not exist on type &apos;(options?: { shouldSelect: boolean; }) =&gt; StoreCart&apos;." source="TS2339" />
-<error line="180" column="4" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
-<error line="190" column="33" severity="error" message="Property &apos;mockReturnValue&apos; does not exist on type &apos;(options?: { shouldSelect: boolean; }) =&gt; StoreCart&apos;." source="TS2339" />
-<error line="205" column="31" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="27" column="17" severity="error" message="Parameter &apos;a&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="31" column="6" severity="error" message="Variable &apos;registry&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="31" column="16" severity="error" message="Variable &apos;renderer&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="33" column="33" severity="error" message="Parameter &apos;Component&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="34" column="29" severity="error" message="Variable &apos;registry&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="39" column="29" severity="error" message="Parameter &apos;options&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="41" column="11" severity="error" message="Type &apos;{ isPendingDelete: boolean; quantity: number; setItemQuantity: Dispatch&lt;SetStateAction&lt;number&gt;&gt;; removeItem: () =&gt; Promise&lt;boolean&gt;; cartItemQuantityErrors: CartResponseErrorItem[]; }&apos; has no properties in common with type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLDivElement&gt;, HTMLDivElement&gt;&apos;." source="TS2559" />
+<error line="44" column="6" severity="error" message="Variable &apos;mockRemoveItemFromCart&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="45" column="6" severity="error" message="Variable &apos;mockChangeCartItemQuantity&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="46" column="25" severity="error" message="Binding element &apos;isPendingDelete&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="46" column="42" severity="error" message="Binding element &apos;isPendingQuantity&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="55" column="3" severity="error" message="Variable &apos;registry&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="72" column="3" severity="error" message="Variable &apos;registry&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="81" column="3" severity="error" message="Variable &apos;mockRemoveItemFromCart&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="82" column="3" severity="error" message="Variable &apos;mockChangeCartItemQuantity&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="88" column="34" severity="error" message="Property &apos;mockReturnValue&apos; does not exist on type &apos;(options?: { shouldSelect: boolean; }) =&gt; StoreCart&apos;." source="TS2339" />
+<error line="106" column="5" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="115" column="5" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="132" column="27" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="138" column="12" severity="error" message="Variable &apos;mockRemoveItemFromCart&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="153" column="32" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="159" column="12" severity="error" message="Variable &apos;mockChangeCartItemQuantity&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="171" column="33" severity="error" message="Property &apos;mockReturnValue&apos; does not exist on type &apos;(options?: { shouldSelect: boolean; }) =&gt; StoreCart&apos;." source="TS2339" />
+<error line="187" column="4" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="197" column="33" severity="error" message="Property &apos;mockReturnValue&apos; does not exist on type &apos;(options?: { shouldSelect: boolean; }) =&gt; StoreCart&apos;." source="TS2339" />
+<error line="212" column="31" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
 </file>
 <file name="assets/js/base/context/hooks/cart/test/use-store-cart.js">
 <error line="26" column="6" severity="error" message="Variable &apos;registry&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
 <error line="26" column="16" severity="error" message="Variable &apos;renderer&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
-<error line="111" column="8" severity="error" message="Variable &apos;mockCartErrors&apos; implicitly has type &apos;any[]&apos; in some locations where its type cannot be determined." source="TS7034" />
-<error line="122" column="15" severity="error" message="Variable &apos;mockCartErrors&apos; implicitly has an &apos;any[]&apos; type." source="TS7005" />
-<error line="135" column="33" severity="error" message="Parameter &apos;Component&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="136" column="29" severity="error" message="Variable &apos;registry&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
-<error line="141" column="29" severity="error" message="Parameter &apos;options&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="143" column="15" severity="error" message="Type &apos;{ cartCoupons: CartResponseCoupons; cartItems: CartItem[]; cartFees: CartResponseFeeItem[]; cartItemsCount: number; cartItemsWeight: number; ... 12 more ...; paymentRequirements: string[]; }&apos; is not assignable to type &apos;number&apos;." source="TS2322" />
-<error line="150" column="47" severity="error" message="Variable &apos;mockCartErrors&apos; implicitly has an &apos;any[]&apos; type." source="TS7005" />
-<error line="158" column="3" severity="error" message="Variable &apos;registry&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
-<error line="171" column="20" severity="error" message="Property &apos;mockReset&apos; does not exist on type &apos;() =&gt; any&apos;." source="TS2339" />
-<error line="176" column="21" severity="error" message="Property &apos;mockReturnValue&apos; does not exist on type &apos;() =&gt; any&apos;." source="TS2339" />
-<error line="193" column="5" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
-<error line="212" column="5" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
-<error line="221" column="21" severity="error" message="Property &apos;mockReturnValue&apos; does not exist on type &apos;() =&gt; any&apos;." source="TS2339" />
-<error line="242" column="5" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="112" column="8" severity="error" message="Variable &apos;mockCartErrors&apos; implicitly has type &apos;any[]&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="123" column="15" severity="error" message="Variable &apos;mockCartErrors&apos; implicitly has an &apos;any[]&apos; type." source="TS7005" />
+<error line="136" column="33" severity="error" message="Parameter &apos;Component&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="137" column="29" severity="error" message="Variable &apos;registry&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="142" column="29" severity="error" message="Parameter &apos;options&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="144" column="15" severity="error" message="Type &apos;{ cartCoupons: CartResponseCoupons; cartItems: CartItem[]; crossSellsProducts: ProductResponseItem[]; cartFees: CartResponseFeeItem[]; ... 14 more ...; paymentRequirements: string[]; }&apos; is not assignable to type &apos;number&apos;." source="TS2322" />
+<error line="151" column="47" severity="error" message="Variable &apos;mockCartErrors&apos; implicitly has an &apos;any[]&apos; type." source="TS7005" />
+<error line="159" column="3" severity="error" message="Variable &apos;registry&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="172" column="20" severity="error" message="Property &apos;mockReset&apos; does not exist on type &apos;() =&gt; any&apos;." source="TS2339" />
+<error line="177" column="21" severity="error" message="Property &apos;mockReturnValue&apos; does not exist on type &apos;() =&gt; any&apos;." source="TS2339" />
+<error line="194" column="5" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="213" column="5" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="222" column="21" severity="error" message="Property &apos;mockReturnValue&apos; does not exist on type &apos;() =&gt; any&apos;." source="TS2339" />
+<error line="243" column="5" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
 </file>
 <file name="assets/js/base/context/hooks/collections/test/use-collection.js">
 <error line="20" column="15" severity="error" message="Parameter &apos;props&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
@@ -2087,11 +2094,11 @@
 <error line="57" column="30" severity="error" message="Argument of type &apos;{ total_items: string; total_items_tax: string; total_fees: string; total_fees_tax: string; total_discount: string; total_discount_tax: string; total_shipping: string; total_shipping_tax: string; total_tax: string; }&apos; is not assignable to parameter of type &apos;CartResponseTotals&apos;." source="TS2345" />
 </file>
 <file name="assets/js/base/context/hooks/test/use-checkout-submit.js">
-<error line="31" column="6" severity="error" message="Variable &apos;registry&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
-<error line="31" column="16" severity="error" message="Variable &apos;renderer&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
-<error line="33" column="33" severity="error" message="Parameter &apos;Component&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="34" column="29" severity="error" message="Variable &apos;registry&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
-<error line="59" column="24" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="33" column="6" severity="error" message="Variable &apos;registry&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="33" column="16" severity="error" message="Variable &apos;renderer&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="35" column="33" severity="error" message="Parameter &apos;Component&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="36" column="29" severity="error" message="Variable &apos;registry&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="64" column="24" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
 </file>
 <file name="assets/js/base/context/hooks/test/use-query-state.js">
 <error line="23" column="6" severity="error" message="Variable &apos;registry&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
@@ -2138,47 +2145,6 @@
 <error line="97" column="5" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
 <error line="103" column="57" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
 <error line="106" column="4" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
-</file>
-<file name="assets/js/blocks/cart-checkout-shared/payment-methods/no-payment-methods/index.js">
-<error line="5" column="45" severity="error" message="Could not find a declaration file for module &apos;wordpress-components&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/wordpress-components/build/index.js&apos; implicitly has an &apos;any&apos; type.
-  If the &apos;@wordpress/components&apos; package actually exposes this module, consider sending a pull request to amend &apos;https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/wordpress__components&apos;" source="TS7016" />
-</file>
-<file name="assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-error-boundary.js">
-<error line="14" column="35" severity="error" message="Parameter &apos;error&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-</file>
-<file name="assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-options.js">
-<error line="45" column="26" severity="error" message="Property &apos;label&apos; does not exist on type &apos;PaymentMethodConfigInstance | ExpressPaymentMethodConfigInstance&apos;." source="TS2339" />
-<error line="57" column="24" severity="error" message="Type &apos;boolean | undefined&apos; is not assignable to type &apos;boolean&apos;." source="TS2322" />
-<error line="58" column="22" severity="error" message="No overload matches this call.
-  The last overload gave the following error.
-    Argument of type &apos;ReactNode&apos; is not assignable to parameter of type &apos;ReactElement&lt;any, string | JSXElementConstructor&lt;any&gt;&gt;&apos;.
-      Type &apos;undefined&apos; is not assignable to type &apos;ReactElement&lt;any, string | JSXElementConstructor&lt;any&gt;&gt;&apos;." source="TS2769" />
-</file>
-<file name="assets/js/blocks/cart-checkout-shared/payment-methods/saved-payment-method-options.js">
-<error line="17" column="56" severity="error" message="Namespace &apos;&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/types/type-defs/contexts&quot;&apos; has no exported member &apos;CustomerPaymentMethod&apos;." source="TS2694" />
-<error line="18" column="56" severity="error" message="Namespace &apos;&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/types/type-defs/contexts&quot;&apos; has no exported member &apos;PaymentStatusDispatch&apos;." source="TS2694" />
-<error line="83" column="24" severity="error" message="Property &apos;map&apos; does not exist on type &apos;CustomerPaymentMethod&apos;." source="TS2339" />
-<error line="83" column="31" severity="error" message="Parameter &apos;paymentMethod&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="92" column="19" severity="error" message="Parameter &apos;token&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="126" column="42" severity="error" message="Property &apos;savedTokenComponent&apos; does not exist on type &apos;PaymentMethodConfigInstance | ExpressPaymentMethodConfigInstance&apos;.
-  Property &apos;savedTokenComponent&apos; does not exist on type &apos;ExpressPaymentMethodConfigInstance&apos;." source="TS2339" />
-<error line="128" column="45" severity="error" message="Property &apos;savedTokenComponent&apos; does not exist on type &apos;PaymentMethodConfigInstance | ExpressPaymentMethodConfigInstance&apos;.
-  Property &apos;savedTokenComponent&apos; does not exist on type &apos;ExpressPaymentMethodConfigInstance&apos;." source="TS2339" />
-<error line="135" column="5" severity="error" message="Property &apos;onChange&apos; is missing in type &apos;{ id: string; selected: string; options: any[]; }&apos; but required in type &apos;RadioControlProps&apos;." source="TS2741" />
-</file>
-<file name="assets/js/blocks/cart-checkout-shared/payment-methods/payment-methods.js">
-<error line="44" column="7" severity="error" message="Type &apos;string[]&apos; is not assignable to type &apos;string&apos;." source="TS2322" />
-</file>
-<file name="assets/js/base/context/providers/cart-checkout/payment-methods/test/payment-method-data-context.js">
-<error line="36" column="17" severity="error" message="Parameter &apos;setting&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="36" column="26" severity="error" message="Rest parameter &apos;rest&apos; implicitly has an &apos;any[]&apos; type." source="TS7019" />
-<error line="140" column="25" severity="error" message="Property &apos;invalidateResolutionForStore&apos; does not exist on type &apos;DispatchFromMap&lt;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/data/cart/actions&quot;)&gt;&apos;." source="TS2339" />
-<error line="141" column="38" severity="error" message="Argument of type &apos;Cart&apos; is not assignable to parameter of type &apos;CartResponse&apos;.
-  Type &apos;Cart&apos; is missing the following properties from type &apos;CartResponse&apos;: shipping_rates, shipping_address, billing_address, items_count, and 5 more." source="TS2345" />
-<error line="219" column="25" severity="error" message="Property &apos;invalidateResolutionForStore&apos; does not exist on type &apos;DispatchFromMap&lt;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/data/cart/actions&quot;)&gt;&apos;." source="TS2339" />
-<error line="220" column="38" severity="error" message="Argument of type &apos;Cart&apos; is not assignable to parameter of type &apos;CartResponse&apos;." source="TS2345" />
-<error line="238" column="33" severity="error" message="Type &apos;{ onChange: () =&gt; undefined; }&apos; is not assignable to type &apos;IntrinsicAttributes&apos;.
-  Property &apos;onChange&apos; does not exist on type &apos;IntrinsicAttributes&apos;." source="TS2322" />
 </file>
 <file name="assets/js/blocks/reviews/utils.js">
 <error line="8" column="30" severity="error" message="Parameter &apos;sortValue&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
@@ -2262,9 +2228,9 @@
 <error line="69" column="5" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
 <error line="71" column="20" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
 </file>
-<file name="assets/js/utils/products.js">
-<error line="5" column="12" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
-<error line="20" column="12" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
+<file name="assets/js/blocks/active-filters/block.tsx">
+<error line="158" column="35" severity="error" message="Argument of type &apos;unknown&apos; is not assignable to parameter of type &apos;StoreAttributes[]&apos;." source="TS2345" />
+<error line="166" column="35" severity="error" message="Parameter &apos;attribute&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
 </file>
 <file name="assets/js/editor-components/block-title/index.js">
 <error line="15" column="2" severity="error" message="Binding element &apos;className&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
@@ -2275,69 +2241,79 @@
 <error line="23" column="4" severity="error" message="Type &apos;{ children: Element[]; className: any; }&apos; is not assignable to type &apos;IntrinsicAttributes&apos;.
   Property &apos;children&apos; does not exist on type &apos;IntrinsicAttributes&apos;." source="TS2322" />
 </file>
+<file name="assets/js/blocks/filter-wrapper/upgrade.tsx">
+<error line="28" column="12" severity="error" message="Property &apos;getBlockParentsByBlockName&apos; does not exist on type &apos;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__block-editor/store/selectors&quot;)&apos;." source="TS2339" />
+</file>
 <file name="assets/js/blocks/active-filters/edit.tsx">
-<error line="14" column="2" severity="error" message="Module &apos;&quot;@wordpress/components&quot;&apos; has no exported member &apos;__experimentalToggleGroupControl&apos;." source="TS2305" />
-<error line="16" column="2" severity="error" message="Module &apos;&quot;@wordpress/components&quot;&apos; has no exported member &apos;__experimentalToggleGroupControlOption&apos;." source="TS2305" />
+<error line="13" column="2" severity="error" message="Module &apos;&quot;@wordpress/components&quot;&apos; has no exported member &apos;__experimentalToggleGroupControl&apos;." source="TS2305" />
+<error line="15" column="2" severity="error" message="Module &apos;&quot;@wordpress/components&quot;&apos; has no exported member &apos;__experimentalToggleGroupControlOption&apos;." source="TS2305" />
 </file>
 <file name="assets/js/blocks/active-filters/index.tsx">
-<error line="19" column="20" severity="error" message="No overload matches this call.
+<error line="18" column="20" severity="error" message="No overload matches this call.
   Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;Attributes&gt;, settings?: Partial&lt;BlockConfiguration&lt;Attributes&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
-    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { html: boolean; multiple: boolean; color: { text: boolean; background: boolean; }; }; attributes: { ...; }; textdomain: string; apiVersion: number; $schema: string; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;Attributes&gt;&apos;.
-      Type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { html: boolean; multiple: boolean; color: { text: boolean; background: boolean; }; }; attributes: { ...; }; textdomain: string; apiVersion: number; $schema: string; }&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;Attributes&gt;, &quot;icon&quot;&gt;&gt;&apos;.
+    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { html: boolean; multiple: boolean; inserter: boolean; color: { text: boolean; background: boolean; }; lock: boolean; }; attributes: { ...; }; textdomain: string; apiVersion: number; $schema: string; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;Attributes&gt;&apos;.
+      Type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { html: boolean; multiple: boolean; inserter: boolean; color: { text: boolean; background: boolean; }; lock: boolean; }; attributes: { ...; }; textdomain: string; apiVersion: number; $schema: string; }&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;Attributes&gt;, &quot;icon&quot;&gt;&gt;&apos;.
         Types of property &apos;attributes&apos; are incompatible.
           Property &apos;heading&apos; is missing in type &apos;{ displayStyle: { type: string; default: string; }; headingLevel: { type: string; default: number; }; }&apos; but required in type &apos;{ readonly heading: BlockAttribute&lt;string&gt;; readonly headingLevel: BlockAttribute&lt;number&gt;; readonly displayStyle: BlockAttribute&lt;string&gt;; readonly className?: BlockAttribute&lt;...&gt;; }&apos;.
   Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;Attributes&gt;): Block&lt;Attributes&gt; | undefined&apos;, gave the following error.
-    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { html: boolean; multiple: boolean; color: { text: boolean; background: boolean; }; }; attributes: { ...; }; textdomain: string; apiVersion: number; $schema: string; }&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2769" />
-<error line="43" column="18" severity="error" message="Property &apos;idBase&apos; does not exist on type &apos;Attributes&apos;." source="TS2339" />
-<error line="43" column="26" severity="error" message="Property &apos;instance&apos; does not exist on type &apos;Attributes&apos;." source="TS2339" />
-<error line="46" column="20" severity="error" message="Property &apos;instance&apos; does not exist on type &apos;Attributes&apos;." source="TS2339" />
+    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { html: boolean; multiple: boolean; inserter: boolean; color: { text: boolean; background: boolean; }; lock: boolean; }; attributes: { ...; }; textdomain: string; apiVersion: number; $schema: string; }&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2769" />
+</file>
+<file name="assets/js/blocks/attribute-filter/checkbox-filter.tsx">
+<error line="36" column="4" severity="error" message="Type &apos;{ className: string; options: DisplayOption[] | undefined; checked: string[] | undefined; onChange: (value: string) =&gt; void; isLoading: false; isDisabled: false; }&apos; is not assignable to type &apos;CheckboxListProps&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+  Types of property &apos;checked&apos; are incompatible.
+    Type &apos;string[] | undefined&apos; is not assignable to type &apos;string[]&apos;.
+      Type &apos;undefined&apos; is not assignable to type &apos;string[]&apos;." source="TS2375" />
 </file>
 <file name="assets/js/blocks/attribute-filter/block.tsx">
-<error line="20" column="24" severity="error" message="Could not find a declaration file for module &apos;wordpress-components&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/wordpress-components/build/index.js&apos; implicitly has an &apos;any&apos; type.
+<error line="22" column="24" severity="error" message="Could not find a declaration file for module &apos;wordpress-components&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/wordpress-components/build/index.js&apos; implicitly has an &apos;any&apos; type.
   If the &apos;@wordpress/components&apos; package actually exposes this module, consider sending a pull request to amend &apos;https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/wordpress__components&apos;" source="TS7016" />
-<error line="584" column="7" severity="error" message="Type &apos;(checkedValue: any) =&gt; void&apos; is not assignable to type &apos;() =&gt; any&apos;." source="TS2322" />
 </file>
 <file name="assets/js/blocks/attribute-filter/edit.tsx">
-<error line="29" column="2" severity="error" message="Module &apos;&quot;@wordpress/components&quot;&apos; has no exported member &apos;__experimentalToggleGroupControl&apos;." source="TS2305" />
-<error line="31" column="2" severity="error" message="Module &apos;&quot;@wordpress/components&quot;&apos; has no exported member &apos;__experimentalToggleGroupControlOption&apos;." source="TS2305" />
-<error line="155" column="5" severity="error" message="Type &apos;{ id: number; name: string; }[]&apos; is not assignable to type &apos;SearchListItemsType&apos;.
+<error line="28" column="2" severity="error" message="Module &apos;&quot;@wordpress/components&quot;&apos; has no exported member &apos;__experimentalToggleGroupControl&apos;." source="TS2305" />
+<error line="30" column="2" severity="error" message="Module &apos;&quot;@wordpress/components&quot;&apos; has no exported member &apos;__experimentalToggleGroupControlOption&apos;." source="TS2305" />
+<error line="153" column="5" severity="error" message="Type &apos;{ id: number; name: string; }[]&apos; is not assignable to type &apos;SearchListItemsType&apos;.
   Type &apos;{ id: number; name: string; }[]&apos; is not assignable to type &apos;SearchListItemType[]&apos;.
     Type &apos;{ id: number; name: string; }&apos; is missing the following properties from type &apos;SearchListItemType&apos;: value, parent, count, children, breadcrumbs" source="TS2322" />
-<error line="156" column="5" severity="error" message="Type &apos;{ id: number; name: string; }[]&apos; is not assignable to type &apos;SearchListItemsType&apos;." source="TS2322" />
+<error line="154" column="5" severity="error" message="Type &apos;{ id: number; name: string; }[]&apos; is not assignable to type &apos;SearchListItemsType&apos;." source="TS2322" />
 </file>
 <file name="assets/js/blocks/attribute-filter/index.tsx">
-<error line="19" column="20" severity="error" message="No overload matches this call.
+<error line="18" column="20" severity="error" message="No overload matches this call.
   Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;BlockAttributes&gt;, settings?: Partial&lt;BlockConfiguration&lt;BlockAttributes&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
-    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { html: boolean; color: { text: boolean; background: boolean; }; }; example: { attributes: { ...; }; }; attributes: { ...; }; textdomain: string; apiVersion: number; $schema: string; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;BlockAttributes&gt;&apos;.
-      Type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { html: boolean; color: { text: boolean; background: boolean; }; }; example: { attributes: { ...; }; }; attributes: { ...; }; textdomain: string; apiVersion: number; $schema: string; }&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;BlockAttributes&gt;, &quot;icon&quot;&gt;&gt;&apos;.
+    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { html: boolean; color: { text: boolean; background: boolean; }; inserter: boolean; lock: boolean; }; ... 4 more ...; $schema: string; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;BlockAttributes&gt;&apos;.
+      Type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { html: boolean; color: { text: boolean; background: boolean; }; inserter: boolean; lock: boolean; }; ... 4 more ...; $schema: string; }&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;BlockAttributes&gt;, &quot;icon&quot;&gt;&gt;&apos;.
         Types of property &apos;attributes&apos; are incompatible.
           Property &apos;heading&apos; is missing in type &apos;{ className: { type: string; default: string; }; attributeId: { type: string; default: number; }; showCounts: { type: string; default: boolean; }; queryType: { type: string; default: string; }; headingLevel: { ...; }; displayStyle: { ...; }; showFilterButton: { ...; }; selectType: { ...; }; isPreview: { ...; }; }&apos; but required in type &apos;{ readonly className?: BlockAttribute&lt;string | undefined&gt;; readonly attributeId: BlockAttribute&lt;number&gt;; readonly showCounts: BlockAttribute&lt;boolean&gt;; ... 6 more ...; readonly isPreview?: BlockAttribute&lt;...&gt;; }&apos;.
   Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;BlockAttributes&gt;): Block&lt;BlockAttributes&gt; | undefined&apos;, gave the following error.
-    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { html: boolean; color: { text: boolean; background: boolean; }; }; example: { attributes: { ...; }; }; attributes: { ...; }; textdomain: string; apiVersion: number; $schema: string; }&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2769" />
-<error line="53" column="18" severity="error" message="Property &apos;idBase&apos; does not exist on type &apos;BlockAttributes&apos;." source="TS2339" />
-<error line="53" column="26" severity="error" message="Property &apos;instance&apos; does not exist on type &apos;BlockAttributes&apos;." source="TS2339" />
-<error line="55" column="20" severity="error" message="Property &apos;instance&apos; does not exist on type &apos;BlockAttributes&apos;." source="TS2339" />
+    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { html: boolean; color: { text: boolean; background: boolean; }; inserter: boolean; lock: boolean; }; ... 4 more ...; $schema: string; }&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2769" />
+</file>
+<file name="assets/js/blocks/attribute-filter/test/block.tsx">
+<error line="19" column="33" severity="error" message="Cannot find name &apos;SetWindowUrlParams&apos;." source="TS2304" />
+<error line="154" column="26" severity="error" message="Property &apos;toBeDisabled&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="162" column="30" severity="error" message="Property &apos;toBeDisabled&apos; does not exist on type &apos;Matchers&lt;void, HTMLElement&gt;&apos;." source="TS2339" />
+<error line="168" column="28" severity="error" message="Expected 1 arguments, but got 0." source="TS2554" />
+<error line="170" column="26" severity="error" message="Property &apos;toBeDisabled&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="175" column="5" severity="error" message="Expected 1 arguments, but got 0." source="TS2554" />
+<error line="178" column="30" severity="error" message="Property &apos;toBeDisabled&apos; does not exist on type &apos;Matchers&lt;void, HTMLElement&gt;&apos;." source="TS2339" />
+<error line="185" column="30" severity="error" message="Property &apos;toBeDisabled&apos; does not exist on type &apos;Matchers&lt;void, HTMLElement&gt;&apos;." source="TS2339" />
+<error line="188" column="26" severity="error" message="Property &apos;toBeDisabled&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
 </file>
 <file name="assets/js/blocks/cart/block.js">
-<error line="20" column="8" severity="error" message="Cannot find module &apos;@woocommerce/base-context/providers&apos; or its corresponding type declarations." source="TS2307" />
-<error line="29" column="55" severity="error" message="Expected 0 arguments, but got 1." source="TS2554" />
-<error line="31" column="18" severity="error" message="Binding element &apos;children&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="33" column="10" severity="error" message="Property &apos;hasDarkControls&apos; does not exist on type &apos;{}&apos;." source="TS2339" />
-<error line="50" column="27" severity="error" message="Binding element &apos;scrollToTop&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="75" column="19" severity="error" message="Binding element &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="75" column="31" severity="error" message="Binding element &apos;children&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="75" column="41" severity="error" message="Binding element &apos;scrollToTop&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="87" column="3" severity="error" message="No overload matches this call.
+<error line="16" column="30" severity="error" message="Cannot find module &apos;@woocommerce/base-context/providers&apos; or its corresponding type declarations." source="TS2307" />
+<error line="25" column="55" severity="error" message="Expected 0 arguments, but got 1." source="TS2554" />
+<error line="27" column="18" severity="error" message="Binding element &apos;children&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="29" column="10" severity="error" message="Property &apos;hasDarkControls&apos; does not exist on type &apos;{}&apos;." source="TS2339" />
+<error line="44" column="27" severity="error" message="Binding element &apos;scrollToTop&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="69" column="19" severity="error" message="Binding element &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="69" column="31" severity="error" message="Binding element &apos;children&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="69" column="41" severity="error" message="Binding element &apos;scrollToTop&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="84" column="3" severity="error" message="No overload matches this call.
   Overload 1 of 2, &apos;(props: BlockErrorBoundaryProps | Readonly&lt;BlockErrorBoundaryProps&gt;): BlockErrorBoundary&apos;, gave the following error.
     Type &apos;unknown&apos; is not assignable to type &apos;boolean&apos;.
   Overload 2 of 2, &apos;(props: BlockErrorBoundaryProps, context: any): BlockErrorBoundary&apos;, gave the following error.
     Type &apos;unknown&apos; is not assignable to type &apos;boolean&apos;." source="TS2769" />
-<error line="101" column="33" severity="error" message="Argument of type &apos;({ attributes, children, scrollToTop }: { attributes: any; children: any; scrollToTop: any; }) =&gt; Element&apos; is not assignable to parameter of type &apos;FunctionComponent&lt;Record&lt;string, unknown&gt;&gt;&apos;.
+<error line="96" column="33" severity="error" message="Argument of type &apos;({ attributes, children, scrollToTop }: { attributes: any; children: any; scrollToTop: any; }) =&gt; Element&apos; is not assignable to parameter of type &apos;FunctionComponent&lt;Record&lt;string, unknown&gt;&gt;&apos;.
   Types of parameters &apos;__0&apos; and &apos;props&apos; are incompatible.
     Type &apos;PropsWithChildren&lt;Record&lt;string, unknown&gt;&gt;&apos; is missing the following properties from type &apos;{ attributes: any; children: any; scrollToTop: any; }&apos;: attributes, scrollToTop" source="TS2345" />
-</file>
-<file name="assets/js/editor-components/compatibility-notices/woo-image.js">
-<error line="1" column="20" severity="error" message="Parameter &apos;props&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
 </file>
 <file name="assets/js/blocks/cart-checkout-shared/hacks.ts">
 <error line="58" column="44" severity="error" message="Property &apos;getSelectedBlock&apos; does not exist on type &apos;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__rich-text/store/selectors&quot;)&apos;." source="TS2339" />
@@ -2362,69 +2338,263 @@
 <error line="32" column="20" severity="error" message="Property &apos;getSelectedBlockClientId&apos; does not exist on type &apos;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__rich-text/store/selectors&quot;)&apos;." source="TS2339" />
 <error line="32" column="46" severity="error" message="Property &apos;getBlockParentsByBlockName&apos; does not exist on type &apos;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__rich-text/store/selectors&quot;)&apos;." source="TS2339" />
 </file>
+<file name="assets/js/editor-components/default-notice/index.tsx">
+<error line="52" column="6" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
+<error line="128" column="4" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(props: Props, context?: any): ReactElement&lt;any, any&gt; | Component&lt;Props, any, any&gt; | null&apos;, gave the following error.
+    Type &apos;{ children: string | Element; className: string; status: &quot;warning&quot; | &quot;success&quot;; onRemove: () =&gt; void; spokenMessage: string; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; Props&apos;.
+      Property &apos;spokenMessage&apos; does not exist on type &apos;IntrinsicAttributes &amp; Props&apos;.
+  Overload 2 of 2, &apos;(props: PropsWithChildren&lt;Props&gt;, context?: any): ReactElement&lt;any, any&gt; | Component&lt;Props, any, any&gt; | null&apos;, gave the following error.
+    Type &apos;{ children: string | Element; className: string; status: &quot;warning&quot; | &quot;success&quot;; onRemove: () =&gt; void; spokenMessage: string; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; Props &amp; { children?: ReactNode; }&apos;.
+      Property &apos;spokenMessage&apos; does not exist on type &apos;IntrinsicAttributes &amp; Props &amp; { children?: ReactNode; }&apos;." source="TS2769" />
+</file>
+<file name="assets/js/editor-components/feedback-prompt/index.js">
+<error line="67" column="3" severity="error" message="&apos;FeedbackPrompt&apos; cannot be used as a JSX component.
+  Its return type &apos;false | Element&apos; is not a valid JSX element.
+    Type &apos;boolean&apos; is not assignable to type &apos;Element&apos;." source="TS2786" />
+<error line="77" column="3" severity="error" message="&apos;FeedbackPrompt&apos; cannot be used as a JSX component.
+  Its return type &apos;false | Element&apos; is not a valid JSX element." source="TS2786" />
+</file>
+<file name="assets/js/blocks/cart-checkout-shared/sidebar-notices/index.tsx">
+<error line="28" column="6" severity="error" message="Cannot redeclare block-scoped variable &apos;store&apos;." source="TS2451" />
+<error line="32" column="21" severity="error" message="Parameter &apos;props&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="49" column="13" severity="error" message="Property &apos;getBlockParentsByBlockName&apos; does not exist on type &apos;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__rich-text/store/selectors&quot;)&apos;." source="TS2339" />
+<error line="49" column="41" severity="error" message="Property &apos;getBlockName&apos; does not exist on type &apos;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__rich-text/store/selectors&quot;)&apos;." source="TS2339" />
+</file>
 <file name="assets/js/blocks/cart/inner-blocks/filled-cart-block/index.tsx">
-<error line="14" column="33" severity="error" message="Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: string[]; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; lock: boolean; }; attributes: { ...; }; parent: string[]; textdomain: string; apiVersion: number; }&apos; is not assignable to parameter of type &apos;string | BlockConfiguration&lt;{}&gt;&apos;.
-  Type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: string[]; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; lock: boolean; }; attributes: { ...; }; parent: string[]; textdomain: string; apiVersion: number; }&apos; is not assignable to type &apos;BlockConfiguration&lt;{}&gt;&apos;.
-    Type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: string[]; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; lock: boolean; }; attributes: { ...; }; parent: string[]; textdomain: string; apiVersion: number; }&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;{}&gt;, &quot;icon&quot;&gt;&gt;&apos;.
-      The types of &apos;supports.align&apos; are incompatible between these types.
-        Type &apos;string[]&apos; is not assignable to type &apos;boolean | readonly BlockAlignment[] | undefined&apos;.
-          Type &apos;string[]&apos; is not assignable to type &apos;readonly BlockAlignment[]&apos;.
-            Type &apos;string&apos; is not assignable to type &apos;BlockAlignment&apos;." source="TS2345" />
+<error line="13" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{}&gt;, settings?: Partial&lt;BlockConfiguration&lt;{}&gt;&gt; | undefined): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{}&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{}&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{}&gt;): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: ({ clientId }: { clientId: string; }) =&gt; JSX.Element; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{}&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: ({ clientId }: { clientId: string; }) =&gt; Element; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{}&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
+</file>
+<file name="assets/js/blocks/cart/inner-blocks/cart-items-block/index.tsx">
+<error line="12" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{}&gt;, settings?: Partial&lt;BlockConfiguration&lt;{}&gt;&gt; | undefined): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{}&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{}&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{}&gt;): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: ({ clientId }: Props) =&gt; JSX.Element; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{}&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: ({ clientId }: Props) =&gt; Element; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{}&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
 </file>
 <file name="assets/js/blocks/cart/cart-line-items-table/cart-line-item-row.tsx">
 <error line="24" column="2" severity="error" message="Module &apos;&quot;@woocommerce/price-format&quot;&apos; has no exported member &apos;Currency&apos;." source="TS2305" />
 <error line="50" column="34" severity="error" message="Parameter &apos;value&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="208" column="5" severity="error" message="Type &apos;number | null&apos; is not assignable to type &apos;number | undefined&apos;.
+<error line="215" column="5" severity="error" message="Type &apos;number | null&apos; is not assignable to type &apos;number | undefined&apos;.
   Type &apos;null&apos; is not assignable to type &apos;number | undefined&apos;." source="TS2322" />
+</file>
+<file name="assets/js/blocks/cart/inner-blocks/cart-line-items-block/index.tsx">
+<error line="12" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ className: string; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ className: string; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ className: string; }&gt;): Block&lt;{ className: string; }&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: ({ attributes, }: { attributes: { className: string; }; }) =&gt; JSX.Element; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: ({ attributes, }: { attributes: { className: string; }; }) =&gt; Element; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
+</file>
+<file name="assets/js/blocks/cart/inner-blocks/cart-cross-sells-block/index.tsx">
+<error line="13" column="20" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{}&gt;, settings?: Partial&lt;BlockConfiguration&lt;{}&gt;&gt; | undefined): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: boolean; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; }; parent: string[]; textdomain: string; apiVersion: number; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{}&gt;&apos;.
+      Property &apos;attributes&apos; is missing in type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: boolean; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; }; parent: string[]; textdomain: string; apiVersion: number; }&apos; but required in type &apos;Pick&lt;Block&lt;{}&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{}&gt;): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: boolean; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; }; parent: string[]; textdomain: string; apiVersion: number; }&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2769" />
+</file>
+<file name="assets/js/blocks/cart/cart-cross-sells-product-list/cart-cross-sells-product.tsx">
+<error line="51" column="8" severity="error" message="Type &apos;{}&apos; is missing the following properties from type &apos;BlockAttributes&apos;: productId, align" source="TS2739" />
+</file>
+<file name="assets/js/blocks/cart/inner-blocks/cart-cross-sells-products/index.tsx">
+<error line="13" column="20" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ className?: string; columns: number; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ className?: string; columns: number; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: boolean; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; lock: boolean; }; attributes: { ...; }; parent: string[]; textdomain: string; apiVersion: number; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className?: string; columns: number; }&gt;&apos;.
+      Type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: boolean; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; lock: boolean; }; attributes: { ...; }; parent: string[]; textdomain: string; apiVersion: number; }&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;{ className?: string; columns: number; }&gt;, &quot;icon&quot;&gt;&gt;&apos;.
+        The types of &apos;attributes.columns&apos; are incompatible between these types.
+          Type &apos;{ type: string; default: number; }&apos; is not assignable to type &apos;BlockAttribute&lt;number&gt;&apos;.
+            Type &apos;{ type: string; default: number; }&apos; is missing the following properties from type &apos;Query&lt;number&gt;&apos;: source, selector, query
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ className?: string; columns: number; }&gt;): Block&lt;{ className?: string; columns: number; }&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: boolean; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; lock: boolean; }; attributes: { ...; }; parent: string[]; textdomain: string; apiVersion: number; }&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2769" />
+</file>
+<file name="assets/js/blocks/cart/inner-blocks/cart-totals-block/index.tsx">
+<error line="12" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{}&gt;, settings?: Partial&lt;BlockConfiguration&lt;{}&gt;&gt; | undefined): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{}&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{}&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{}&gt;): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: ({ clientId }: { clientId: string; }) =&gt; JSX.Element; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{}&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: ({ clientId }: { clientId: string; }) =&gt; Element; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{}&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
+</file>
+<file name="assets/js/blocks/cart-checkout-shared/payment-methods/no-payment-methods/index.js">
+<error line="5" column="45" severity="error" message="Could not find a declaration file for module &apos;wordpress-components&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/wordpress-components/build/index.js&apos; implicitly has an &apos;any&apos; type.
+  If the &apos;@wordpress/components&apos; package actually exposes this module, consider sending a pull request to amend &apos;https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/wordpress__components&apos;" source="TS7016" />
+</file>
+<file name="assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-error-boundary.js">
+<error line="9" column="10" severity="error" message="Module &apos;&quot;@woocommerce/base-context/hooks&quot;&apos; has no exported member &apos;noticeContexts&apos;." source="TS2305" />
+<error line="14" column="35" severity="error" message="Parameter &apos;error&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+</file>
+<file name="assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-options.js">
+<error line="60" column="22" severity="error" message="No overload matches this call.
+  The last overload gave the following error.
+    Argument of type &apos;number | boolean | {} | ReactElement&lt;any, string | JSXElementConstructor&lt;any&gt;&gt; | Iterable&lt;ReactNode&gt; | ReactPortal | null | undefined&apos; is not assignable to parameter of type &apos;ReactElement&lt;any, string | JSXElementConstructor&lt;any&gt;&gt;&apos;.
+      Type &apos;undefined&apos; is not assignable to type &apos;ReactElement&lt;any, string | JSXElementConstructor&lt;any&gt;&gt;&apos;." source="TS2769" />
+<error line="65" column="24" severity="error" message="Type &apos;boolean | undefined&apos; is not assignable to type &apos;boolean&apos;." source="TS2322" />
+<error line="66" column="22" severity="error" message="No overload matches this call.
+  The last overload gave the following error.
+    Argument of type &apos;ReactNode&apos; is not assignable to parameter of type &apos;ReactElement&lt;any, string | JSXElementConstructor&lt;any&gt;&gt;&apos;.
+      Type &apos;undefined&apos; is not assignable to type &apos;ReactElement&lt;any, string | JSXElementConstructor&lt;any&gt;&gt;&apos;." source="TS2769" />
+</file>
+<file name="assets/js/blocks/cart-checkout-shared/payment-methods/saved-payment-method-options.js">
+<error line="17" column="56" severity="error" message="Namespace &apos;&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/types/type-defs/contexts&quot;&apos; has no exported member &apos;CustomerPaymentMethod&apos;." source="TS2694" />
+<error line="18" column="56" severity="error" message="Namespace &apos;&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/types/type-defs/contexts&quot;&apos; has no exported member &apos;PaymentStatusDispatch&apos;." source="TS2694" />
+<error line="89" column="19" severity="error" message="Parameter &apos;token&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="126" column="6" severity="error" message="No overload matches this call.
+  The last overload gave the following error.
+    Argument of type &apos;ReactNode&apos; is not assignable to parameter of type &apos;ReactElement&lt;any, string | JSXElementConstructor&lt;any&gt;&gt;&apos;." source="TS2769" />
+</file>
+<file name="assets/js/blocks/cart-checkout-shared/payment-methods/payment-methods.js">
+<error line="50" column="7" severity="error" message="Type &apos;string[]&apos; is not assignable to type &apos;string&apos;." source="TS2322" />
 </file>
 <file name="assets/js/blocks/cart/inner-blocks/cart-express-payment-block/edit.tsx">
 <error line="6" column="37" severity="error" message="Could not find a declaration file for module &apos;wordpress-components&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/wordpress-components/build/index.js&apos; implicitly has an &apos;any&apos; type.
   If the &apos;@wordpress/components&apos; package actually exposes this module, consider sending a pull request to amend &apos;https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/wordpress__components&apos;" source="TS7016" />
 </file>
+<file name="assets/js/blocks/cart/inner-blocks/cart-express-payment-block/index.tsx">
+<error line="12" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ className: string; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ className: string; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ className: string; }&gt;): Block&lt;{ className: string; }&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: ({ attributes, }: { attributes: { className: string; }; }) =&gt; JSX.Element | null; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: ({ attributes, }: { attributes: { className: string; }; }) =&gt; Element | null; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
+</file>
 <file name="assets/js/editor-components/page-selector/index.js">
 <error line="12" column="26" severity="error" message="Binding element &apos;setPageId&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
 <error line="12" column="37" severity="error" message="Binding element &apos;pageId&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
 <error line="12" column="45" severity="error" message="Binding element &apos;labels&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="33" column="10" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
-<error line="33" column="23" severity="error" message="Parameter &apos;page&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="35" column="35" severity="error" message="Argument of type &apos;unknown&apos; is not assignable to parameter of type &apos;any[]&apos;." source="TS2345" />
+<error line="31" column="8" severity="error" message="Type &apos;number&apos; is not assignable to type &apos;string&apos;." source="TS2322" />
+<error line="33" column="7" severity="error" message="Type &apos;{ label: string; value: number; }&apos; is not assignable to type &apos;Option&apos;.
+  Types of property &apos;value&apos; are incompatible.
+    Type &apos;number&apos; is not assignable to type &apos;string&apos;." source="TS2322" />
+<error line="35" column="29" severity="error" message="Argument of type &apos;Record&lt;string, any&gt;&apos; is not assignable to parameter of type &apos;{ title: { raw: string; }; slug: string; }&apos;.
+  Type &apos;Record&lt;string, any&gt;&apos; is missing the following properties from type &apos;{ title: { raw: string; }; slug: string; }&apos;: title, slug" source="TS2345" />
 </file>
 <file name="assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/block.tsx">
-<error line="59" column="4" severity="error" message="Type &apos;{ children: string; className: string; href: unknown; disabled: boolean; onClick: () =&gt; void; showSpinner: boolean; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; ButtonProps&apos;.
+<error line="62" column="4" severity="error" message="Type &apos;{ children: string; className: string; href: unknown; disabled: boolean; onClick: () =&gt; void; showSpinner: boolean; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; ButtonProps&apos;.
   Property &apos;href&apos; does not exist on type &apos;IntrinsicAttributes &amp; ButtonProps&apos;." source="TS2322" />
 </file>
 <file name="assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/edit.tsx">
 <error line="47" column="21" severity="error" message="Parameter &apos;id&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
 </file>
+<file name="assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/index.tsx">
+<error line="13" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ checkoutPageId: number; className: string; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ checkoutPageId: number; className: string; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ checkoutPageId: number; className: string; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ checkoutPageId: number; className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ checkoutPageId: number; className: string; }&gt;): Block&lt;{ checkoutPageId: number; className: string; }&gt; | undefined&apos;, gave the following error.
+    Property &apos;className&apos; is missing in type &apos;{ checkoutPageId: { type: string; default: number; }; lock: { type: string; default: { move: boolean; remove: boolean; }; }; }&apos; but required in type &apos;{ readonly checkoutPageId: BlockAttribute&lt;number&gt;; readonly className: BlockAttribute&lt;string&gt;; }&apos;." source="TS2769" />
+</file>
 <file name="assets/js/blocks/cart/inner-blocks/empty-cart-block/index.tsx">
-<error line="14" column="33" severity="error" message="Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: string[]; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; lock: boolean; }; attributes: { ...; }; parent: string[]; textdomain: string; apiVersion: number; }&apos; is not assignable to parameter of type &apos;string | BlockConfiguration&lt;{}&gt;&apos;.
-  Type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: string[]; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; lock: boolean; }; attributes: { ...; }; parent: string[]; textdomain: string; apiVersion: number; }&apos; is not assignable to type &apos;BlockConfiguration&lt;{}&gt;&apos;.
-    Type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: string[]; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; lock: boolean; }; attributes: { ...; }; parent: string[]; textdomain: string; apiVersion: number; }&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;{}&gt;, &quot;icon&quot;&gt;&gt;&apos;.
-      The types of &apos;supports.align&apos; are incompatible between these types.
-        Type &apos;string[]&apos; is not assignable to type &apos;boolean | readonly BlockAlignment[] | undefined&apos;." source="TS2345" />
+<error line="13" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{}&gt;, settings?: Partial&lt;BlockConfiguration&lt;{}&gt;&gt; | undefined): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{}&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{}&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{}&gt;): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: ({ clientId }: { clientId: string; }) =&gt; JSX.Element; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{}&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: ({ clientId }: { clientId: string; }) =&gt; Element; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{}&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
 </file>
 <file name="assets/js/blocks/cart/inner-blocks/cart-accepted-payment-methods-block/block.tsx">
 <error line="14" column="40" severity="error" message="Argument of type &apos;EmptyObjectType | Record&lt;string, PaymentMethodConfigInstance&gt; | Record&lt;string, ExpressPaymentMethodConfigInstance&gt;&apos; is not assignable to parameter of type &apos;PaymentMethods&apos;.
   Type &apos;Record&lt;string, ExpressPaymentMethodConfigInstance&gt;&apos; is not assignable to type &apos;PaymentMethods&apos;." source="TS2345" />
 </file>
 <file name="assets/js/blocks/cart/inner-blocks/cart-accepted-payment-methods-block/index.tsx">
-<error line="13" column="33" severity="error" message="Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: boolean; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; }; parent: string[]; textdomain: string; apiVersion: number; }&apos; is not assignable to parameter of type &apos;string | BlockConfiguration&lt;{}&gt;&apos;.
-  Type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: boolean; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; }; parent: string[]; textdomain: string; apiVersion: number; }&apos; is not assignable to type &apos;BlockConfiguration&lt;{}&gt;&apos;.
-    Property &apos;attributes&apos; is missing in type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: boolean; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; }; parent: string[]; textdomain: string; apiVersion: number; }&apos; but required in type &apos;Pick&lt;Block&lt;{}&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;." source="TS2345" />
+<error line="12" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ className: string; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ className: string; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ className: string; }&gt;): Block&lt;{ className: string; }&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: ({ attributes, }: { attributes: { className: string; }; }) =&gt; JSX.Element; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: ({ attributes, }: { attributes: { className: string; }; }) =&gt; Element; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
+</file>
+<file name="assets/js/blocks/cart/inner-blocks/cart-order-summary-block/index.tsx">
+<error line="13" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{}&gt;, settings?: Partial&lt;BlockConfiguration&lt;{}&gt;&gt; | undefined): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{}&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{}&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{}&gt;): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: ({ clientId }: { clientId: string; }) =&gt; JSX.Element; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{}&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: ({ clientId }: { clientId: string; }) =&gt; Element; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{}&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
+</file>
+<file name="assets/js/blocks/cart/inner-blocks/cart-order-summary-subtotal/index.tsx">
+<error line="13" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ className: string; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ className: string; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ className: string; }&gt;): Block&lt;{ className: string; }&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: ({ attributes, }: { attributes: { className: string; }; setAttributes: (attributes: Record&lt;string, unknown&gt;) =&gt; void; }) =&gt; JSX.Element; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: ({ attributes, }: { attributes: { className: string; }; setAttributes: (attributes: Record&lt;string, unknown&gt;) =&gt; void; }) =&gt; Element; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
+</file>
+<file name="assets/js/blocks/cart/inner-blocks/cart-order-summary-fee/index.tsx">
+<error line="13" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ className: string; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ className: string; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ className: string; }&gt;): Block&lt;{ className: string; }&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: ({ attributes, }: { attributes: { className: string; }; setAttributes: (attributes: Record&lt;string, unknown&gt;) =&gt; void; }) =&gt; JSX.Element; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: ({ attributes, }: { attributes: { className: string; }; setAttributes: (attributes: Record&lt;string, unknown&gt;) =&gt; void; }) =&gt; Element; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
+</file>
+<file name="assets/js/blocks/cart/inner-blocks/cart-order-summary-discount/index.tsx">
+<error line="13" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ className: string; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ className: string; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ className: string; }&gt;): Block&lt;{ className: string; }&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: ({ attributes, }: { attributes: { className: string; }; setAttributes: (attributes: Record&lt;string, unknown&gt;) =&gt; void; }) =&gt; JSX.Element; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: ({ attributes, }: { attributes: { className: string; }; setAttributes: (attributes: Record&lt;string, unknown&gt;) =&gt; void; }) =&gt; Element; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
+</file>
+<file name="assets/js/blocks/cart/inner-blocks/cart-order-summary-shipping/index.tsx">
+<error line="14" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ isShippingCalculatorEnabled: boolean; className: string; lock: { move: boolean; remove: boolean; }; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ isShippingCalculatorEnabled: boolean; className: string; lock: { ...; }; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ isShippingCalculatorEnabled: boolean; className: string; lock: { move: boolean; remove: boolean; }; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ isShippingCalculatorEnabled: boolean; className: string; lock: { move: boolean; remove: boolean; }; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ isShippingCalculatorEnabled: boolean; className: string; lock: { move: boolean; remove: boolean; }; }&gt;): Block&lt;{ isShippingCalculatorEnabled: boolean; className: string; lock: { ...; }; }&gt; | undefined&apos;, gave the following error.
+    Property &apos;className&apos; is missing in type &apos;{ isShippingCalculatorEnabled: { type: string; default: unknown; }; lock: { type: string; default: { move: boolean; remove: boolean; }; }; }&apos; but required in type &apos;{ readonly isShippingCalculatorEnabled: BlockAttribute&lt;boolean&gt;; readonly className: BlockAttribute&lt;string&gt;; readonly lock: BlockAttribute&lt;{ move: boolean; remove: boolean; }&gt;; }&apos;." source="TS2769" />
+</file>
+<file name="assets/js/blocks/cart/inner-blocks/cart-order-summary-coupon-form/index.tsx">
+<error line="12" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ className: string; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ className: string; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ className: string; }&gt;): Block&lt;{ className: string; }&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: ({ attributes, }: { attributes: { className: string; }; setAttributes: (attributes: Record&lt;string, unknown&gt;) =&gt; void; }) =&gt; JSX.Element; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: ({ attributes, }: { attributes: { className: string; }; setAttributes: (attributes: Record&lt;string, unknown&gt;) =&gt; void; }) =&gt; Element; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
+</file>
+<file name="assets/js/blocks/cart/inner-blocks/cart-order-summary-taxes/index.tsx">
+<error line="14" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ className: string; showRateAfterTaxName: boolean; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ className: string; showRateAfterTaxName: boolean; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; showRateAfterTaxName: boolean; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ className: string; showRateAfterTaxName: boolean; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ className: string; showRateAfterTaxName: boolean; }&gt;): Block&lt;{ className: string; showRateAfterTaxName: boolean; }&gt; | undefined&apos;, gave the following error.
+    Property &apos;className&apos; is missing in type &apos;{ showRateAfterTaxName: { type: string; default: unknown; }; lock: { type: string; default: { remove: boolean; move: boolean; }; }; }&apos; but required in type &apos;{ readonly className: BlockAttribute&lt;string&gt;; readonly showRateAfterTaxName: BlockAttribute&lt;boolean&gt;; }&apos;." source="TS2769" />
+</file>
+<file name="assets/js/blocks/cart/inner-blocks/cart-order-summary-heading/index.tsx">
+<error line="13" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ content: string; className: string; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ content: string; className: string; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ content: string; className: string; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ content: string; className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ content: string; className: string; }&gt;): Block&lt;{ content: string; className: string; }&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: ({ attributes, setAttributes, }: { attributes: { content: string; className: string; }; setAttributes: (attributes: Record&lt;string, unknown&gt;) =&gt; void; }) =&gt; JSX.Element; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ content: string; className: string; }&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: ({ attributes, setAttributes, }: { attributes: { content: string; className: string; }; setAttributes: (attributes: Record&lt;string, unknown&gt;) =&gt; void; }) =&gt; Element; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{ content: string; className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
 </file>
 <file name="assets/js/blocks/cart/edit.js">
-<error line="64" column="27" severity="error" message="Binding element &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="64" column="39" severity="error" message="Binding element &apos;setAttributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="118" column="25" severity="error" message="Binding element &apos;className&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="118" column="36" severity="error" message="Binding element &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="118" column="48" severity="error" message="Binding element &apos;setAttributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="118" column="63" severity="error" message="Binding element &apos;clientId&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="136" column="3" severity="error" message="Type &apos;{}[][]&apos; is not assignable to type &apos;TemplateArray&apos;.
+<error line="56" column="25" severity="error" message="Binding element &apos;className&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="56" column="36" severity="error" message="Binding element &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="56" column="48" severity="error" message="Binding element &apos;setAttributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="56" column="63" severity="error" message="Binding element &apos;clientId&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="74" column="3" severity="error" message="Type &apos;{}[][]&apos; is not assignable to type &apos;TemplateArray&apos;.
   Type &apos;{}[]&apos; is not assignable to type &apos;Template&apos;.
     Target requires 1 element(s) but source may have fewer." source="TS2322" />
-<error line="163" column="21" severity="error" message="Type &apos;{ children: Element; __experimentalShareWithChildBlocks: true; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; Props&apos;.
-  Property &apos;__experimentalShareWithChildBlocks&apos; does not exist on type &apos;IntrinsicAttributes &amp; Props&apos;." source="TS2322" />
-<error line="174" column="9" severity="error" message="Type &apos;{}[][]&apos; is not assignable to type &apos;readonly Template[]&apos;." source="TS2322" />
+<error line="113" column="9" severity="error" message="Type &apos;{}[][]&apos; is not assignable to type &apos;readonly Template[]&apos;." source="TS2322" />
 </file>
 <file name="assets/js/blocks/cart/inner-blocks/cart-items-block/frontend.tsx">
 <error line="15" column="4" severity="error" message="Type &apos;{ children: Element; className: string; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; RefAttributes&lt;any&gt;&apos;.
@@ -2435,17 +2605,18 @@
   Property &apos;children&apos; does not exist on type &apos;IntrinsicAttributes &amp; RefAttributes&lt;any&gt;&apos;." source="TS2322" />
 </file>
 <file name="assets/js/blocks/cart/inner-blocks/register-components.ts">
-<error line="18" column="2" severity="error" message="Type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: string[]; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; lock: boolean; }; attributes: { ...; }; parent: string[]; textdomain: string; apiVersion: number; }&apos; is not assignable to type &apos;CheckoutBlockOptionsMetadata&apos;.
+<error line="18" column="2" severity="error" message="Type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: string[]; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; lock: boolean; }; ... 4 more ...; apiVersion: number; }&apos; is not assignable to type &apos;CheckoutBlockOptionsMetadata&apos;.
   The types of &apos;supports.align&apos; are incompatible between these types.
     Type &apos;string[]&apos; is not assignable to type &apos;boolean | readonly BlockAlignment[] | undefined&apos;.
-      Type &apos;string[]&apos; is not assignable to type &apos;readonly BlockAlignment[]&apos;." source="TS2322" />
+      Type &apos;string[]&apos; is not assignable to type &apos;readonly BlockAlignment[]&apos;.
+        Type &apos;string&apos; is not assignable to type &apos;BlockAlignment&apos;." source="TS2322" />
 <error line="19" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ children, className, }: { children: Element | Element[]; className: string; }) =&gt; Element | null&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
   Type &apos;LazyExoticComponent&lt;({ children, className, }: { children: Element | Element[]; className: string; }) =&gt; Element | null&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos;.
     Type &apos;LazyExoticComponent&lt;({ children, className, }: { children: Element | Element[]; className: string; }) =&gt; Element | null&gt;&apos; is not assignable to type &apos;ExoticComponent&lt;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&gt;&apos;.
       Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
         Type &apos;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos; is not assignable to type &apos;{ children: Element | Element[]; className: string; }&apos;.
           Property &apos;className&apos; is missing in type &apos;{ children?: ReactNode; }&apos; but required in type &apos;{ children: Element | Element[]; className: string; }&apos;." source="TS2322" />
-<error line="29" column="2" severity="error" message="Type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: string[]; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; lock: boolean; }; attributes: { ...; }; parent: string[]; textdomain: string; apiVersion: number; }&apos; is not assignable to type &apos;CheckoutBlockOptionsMetadata&apos;.
+<error line="29" column="2" severity="error" message="Type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: string[]; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; lock: boolean; }; ... 4 more ...; apiVersion: number; }&apos; is not assignable to type &apos;CheckoutBlockOptionsMetadata&apos;.
   The types of &apos;supports.align&apos; are incompatible between these types.
     Type &apos;string[]&apos; is not assignable to type &apos;boolean | readonly BlockAlignment[] | undefined&apos;." source="TS2322" />
 <error line="30" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ children, className, }: { children: Element; className: string; }) =&gt; Element | null&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
@@ -2466,28 +2637,42 @@
       Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
         Type &apos;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos; is not assignable to type &apos;{ className: string; }&apos;.
           Property &apos;className&apos; is missing in type &apos;{ children?: ReactNode; }&apos; but required in type &apos;{ className: string; }&apos;." source="TS2322" />
-<error line="63" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ children, className, }: { children: Element | Element[]; className?: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
+<error line="63" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ children, className, }: Props) =&gt; Element | null&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
+  Type &apos;LazyExoticComponent&lt;({ children, className, }: Props) =&gt; Element | null&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos;.
+    Type &apos;LazyExoticComponent&lt;({ children, className, }: Props) =&gt; Element | null&gt;&apos; is not assignable to type &apos;ExoticComponent&lt;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&gt;&apos;.
+      Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
+        Type &apos;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos; is not assignable to type &apos;Props&apos;.
+          Type &apos;{ children?: ReactNode; }&apos; is not assignable to type &apos;Props&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+            Types of property &apos;children&apos; are incompatible.
+              Type &apos;ReactNode&apos; is not assignable to type &apos;Element | Element[]&apos;.
+                Type &apos;undefined&apos; is not assignable to type &apos;Element | Element[]&apos;." source="TS2322" />
+<error line="74" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ className, columns }: BlockProps) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
+  Type &apos;LazyExoticComponent&lt;({ className, columns }: BlockProps) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos;.
+    Type &apos;LazyExoticComponent&lt;({ className, columns }: BlockProps) =&gt; Element&gt;&apos; is not assignable to type &apos;ExoticComponent&lt;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&gt;&apos;.
+      Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
+        Type &apos;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos; is not assignable to type &apos;BlockProps&apos;.
+          Property &apos;columns&apos; is missing in type &apos;{ children?: ReactNode; }&apos; but required in type &apos;BlockProps&apos;." source="TS2322" />
+<error line="85" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ children, className, }: { children: Element | Element[]; className?: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
   Type &apos;LazyExoticComponent&lt;({ children, className, }: { children: Element | Element[]; className?: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos;.
     Type &apos;LazyExoticComponent&lt;({ children, className, }: { children: Element | Element[]; className?: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;ExoticComponent&lt;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&gt;&apos;.
       Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
         Type &apos;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos; is not assignable to type &apos;{ children: Element | Element[]; className?: string; }&apos;.
           Type &apos;{ children?: ReactNode; }&apos; is not assignable to type &apos;{ children: Element | Element[]; className?: string; }&apos;.
             Types of property &apos;children&apos; are incompatible.
-              Type &apos;ReactNode&apos; is not assignable to type &apos;Element | Element[]&apos;.
-                Type &apos;undefined&apos; is not assignable to type &apos;Element | Element[]&apos;." source="TS2322" />
-<error line="74" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ className }: { className: string; }) =&gt; Element | null&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
+              Type &apos;ReactNode&apos; is not assignable to type &apos;Element | Element[]&apos;." source="TS2322" />
+<error line="96" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ className }: { className: string; }) =&gt; Element | null&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
   Type &apos;LazyExoticComponent&lt;({ className }: { className: string; }) =&gt; Element | null&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos;.
     Type &apos;LazyExoticComponent&lt;({ className }: { className: string; }) =&gt; Element | null&gt;&apos; is not assignable to type &apos;ExoticComponent&lt;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&gt;&apos;.
       Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
         Type &apos;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos; is not assignable to type &apos;{ className: string; }&apos;.
           Property &apos;className&apos; is missing in type &apos;{ children?: ReactNode; }&apos; but required in type &apos;{ className: string; }&apos;." source="TS2322" />
-<error line="96" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ className }: { className: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
+<error line="118" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ className }: { className: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
   Type &apos;LazyExoticComponent&lt;({ className }: { className: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos;.
     Type &apos;LazyExoticComponent&lt;({ className }: { className: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;ExoticComponent&lt;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&gt;&apos;.
       Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
         Type &apos;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos; is not assignable to type &apos;{ className: string; }&apos;.
           Property &apos;className&apos; is missing in type &apos;{ children?: ReactNode; }&apos; but required in type &apos;{ className: string; }&apos;." source="TS2322" />
-<error line="107" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ children, className, }: { children?: Element | Element[]; className?: string; }) =&gt; Element | null&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
+<error line="129" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ children, className, }: { children?: Element | Element[]; className?: string; }) =&gt; Element | null&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
   Type &apos;LazyExoticComponent&lt;({ children, className, }: { children?: Element | Element[]; className?: string; }) =&gt; Element | null&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos;.
     Type &apos;LazyExoticComponent&lt;({ children, className, }: { children?: Element | Element[]; className?: string; }) =&gt; Element | null&gt;&apos; is not assignable to type &apos;ExoticComponent&lt;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&gt;&apos;.
       Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
@@ -2495,25 +2680,25 @@
           Type &apos;{ children?: ReactNode; }&apos; is not assignable to type &apos;{ children?: Element | Element[]; className?: string; }&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
             Types of property &apos;children&apos; are incompatible.
               Type &apos;ReactNode&apos; is not assignable to type &apos;Element | Element[]&apos;." source="TS2322" />
-<error line="129" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ className }: { className?: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
+<error line="151" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ className }: { className?: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
   Type &apos;LazyExoticComponent&lt;({ className }: { className?: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos;.
     Type &apos;LazyExoticComponent&lt;({ className }: { className?: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;ExoticComponent&lt;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&gt;&apos;.
       Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
         Type &apos;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos; is not assignable to type &apos;{ className?: string; }&apos;.
           Type &apos;{ children?: ReactNode; }&apos; has no properties in common with type &apos;{ className?: string; }&apos;." source="TS2322" />
-<error line="140" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ className }: { className: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
+<error line="162" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ className }: { className: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
   Type &apos;LazyExoticComponent&lt;({ className }: { className: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos;.
     Type &apos;LazyExoticComponent&lt;({ className }: { className: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;ExoticComponent&lt;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&gt;&apos;.
       Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
         Type &apos;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos; is not assignable to type &apos;{ className: string; }&apos;.
           Property &apos;className&apos; is missing in type &apos;{ children?: ReactNode; }&apos; but required in type &apos;{ className: string; }&apos;." source="TS2322" />
-<error line="151" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ className }: { className: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
+<error line="173" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ className }: { className: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
   Type &apos;LazyExoticComponent&lt;({ className }: { className: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos;.
     Type &apos;LazyExoticComponent&lt;({ className }: { className: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;ExoticComponent&lt;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&gt;&apos;.
       Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
         Type &apos;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos; is not assignable to type &apos;{ className: string; }&apos;.
           Property &apos;className&apos; is missing in type &apos;{ children?: ReactNode; }&apos; but required in type &apos;{ className: string; }&apos;." source="TS2322" />
-<error line="162" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ className }: { className: string; }) =&gt; Element | null&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
+<error line="184" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ className }: { className: string; }) =&gt; Element | null&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
   Type &apos;LazyExoticComponent&lt;({ className }: { className: string; }) =&gt; Element | null&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos;.
     Type &apos;LazyExoticComponent&lt;({ className }: { className: string; }) =&gt; Element | null&gt;&apos; is not assignable to type &apos;ExoticComponent&lt;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&gt;&apos;.
       Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
@@ -2525,41 +2710,61 @@
 <error line="27" column="21" severity="error" message="Binding element &apos;children&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
 </file>
 <file name="assets/js/blocks/cart/index.js">
-<error line="53" column="14" severity="error" message="Binding element &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="65" column="15" severity="error" message="Parameter &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="65" column="27" severity="error" message="Parameter &apos;innerBlocks&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="105" column="18" severity="error" message="Parameter &apos;_&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="105" column="21" severity="error" message="Parameter &apos;innerBlocks&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="107" column="8" severity="error" message="Parameter &apos;block&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="51" column="14" severity="error" message="Binding element &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="63" column="15" severity="error" message="Parameter &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="63" column="27" severity="error" message="Parameter &apos;innerBlocks&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="103" column="18" severity="error" message="Parameter &apos;_&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="103" column="21" severity="error" message="Parameter &apos;innerBlocks&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="105" column="8" severity="error" message="Parameter &apos;block&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="112" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;any&gt;, settings?: Partial&lt;BlockConfiguration&lt;any&gt;&gt; | undefined): Block&lt;any&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;any&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;any&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;any&gt;): Block&lt;any&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ title: string; icon: { src: Element; }; category: string; keywords: string[]; description: string; supports: { align: string[]; html: boolean; multiple: boolean; }; example: { attributes: { isPreview: boolean; }; }; attributes: { ...; }; edit: ({ className, attributes, setAttributes, clientId }: { ...; }) =&gt; Eleme...&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;any&gt;&apos;.
+      Type &apos;{ title: string; icon: { src: Element; }; category: string; keywords: string[]; description: string; supports: { align: string[]; html: boolean; multiple: boolean; }; example: { attributes: { isPreview: boolean; }; }; attributes: { ...; }; edit: ({ className, attributes, setAttributes, clientId }: { ...; }) =&gt; Eleme...&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;any&gt;, &quot;icon&quot;&gt;&gt;&apos;.
+        Types of property &apos;attributes&apos; are incompatible.
+          Type &apos;{ isPreview: { type: string; default: boolean; save: boolean; }; hasDarkControls: { type: string; default: any; }; isShippingCalculatorEnabled: { type: string; default: any; }; checkoutPageId: { type: string; default: number; }; showRateAfterTaxName: { ...; }; align: { ...; }; }&apos; is not assignable to type &apos;{ readonly [x: string]: BlockAttribute&lt;any&gt;; }&apos;.
+            Property &apos;isPreview&apos; is incompatible with index signature.
+              Type &apos;{ type: string; default: boolean; save: boolean; }&apos; is not assignable to type &apos;BlockAttribute&lt;any&gt;&apos;.
+                Type &apos;{ type: string; default: boolean; save: boolean; }&apos; is missing the following properties from type &apos;Query&lt;any&gt;&apos;: source, selector, query" source="TS2769" />
+</file>
+<file name="node_modules/@jest/test-result/build/index.d.ts">
+<error line="11" column="14" severity="error" message="Module &apos;&quot;jest-haste-map&quot;&apos; has no exported member &apos;IHasteFS&apos;. Did you mean to use &apos;import IHasteFS from &quot;jest-haste-map&quot;&apos; instead?" source="TS2614" />
 </file>
 <file name="assets/js/blocks/cart/test/block.js">
-<error line="47" column="5" severity="error" message="Property &apos;className&apos; is missing in type &apos;{ children: Element[]; }&apos; but required in type &apos;{ children: Element | Element[]; className: string; }&apos;." source="TS2741" />
-<error line="48" column="6" severity="error" message="Property &apos;className&apos; is missing in type &apos;{ children: Element; }&apos; but required in type &apos;{ children: Element; className: string; }&apos;." source="TS2741" />
-<error line="49" column="7" severity="error" message="Property &apos;className&apos; is missing in type &apos;{}&apos; but required in type &apos;{ className: string; }&apos;." source="TS2741" />
-<error line="64" column="7" severity="error" message="Property &apos;className&apos; is missing in type &apos;{}&apos; but required in type &apos;{ className: string; }&apos;." source="TS2741" />
-<error line="65" column="7" severity="error" message="Property &apos;className&apos; is missing in type &apos;{ checkoutPageId: number; }&apos; but required in type &apos;{ checkoutPageId: number; className: string; }&apos;." source="TS2741" />
+<error line="49" column="5" severity="error" message="Property &apos;className&apos; is missing in type &apos;{ children: Element[]; }&apos; but required in type &apos;{ children: Element | Element[]; className: string; }&apos;." source="TS2741" />
+<error line="50" column="6" severity="error" message="Property &apos;className&apos; is missing in type &apos;{ children: Element; }&apos; but required in type &apos;{ children: Element; className: string; }&apos;." source="TS2741" />
+<error line="51" column="7" severity="error" message="Property &apos;className&apos; is missing in type &apos;{}&apos; but required in type &apos;{ className: string; }&apos;." source="TS2741" />
 <error line="66" column="7" severity="error" message="Property &apos;className&apos; is missing in type &apos;{}&apos; but required in type &apos;{ className: string; }&apos;." source="TS2741" />
-<error line="69" column="5" severity="error" message="Property &apos;className&apos; is missing in type &apos;{ children: Element; }&apos; but required in type &apos;{ children: Element; className: string; }&apos;." source="TS2741" />
-<error line="86" column="25" severity="error" message="Property &apos;invalidateResolutionForStore&apos; does not exist on type &apos;DispatchFromMap&lt;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/data/cart/actions&quot;)&gt;&apos;." source="TS2339" />
-<error line="87" column="38" severity="error" message="Argument of type &apos;Cart&apos; is not assignable to parameter of type &apos;CartResponse&apos;." source="TS2345" />
-<error line="101" column="5" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
-<error line="113" column="40" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
-<error line="120" column="48" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
-<error line="127" column="45" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
-<error line="138" column="46" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
-<error line="149" column="5" severity="error" message="Type &apos;{ showRateAfterTaxName: true; }&apos; is missing the following properties from type &apos;{ showRateAfterTaxName: boolean; isShippingCalculatorEnabled: boolean; checkoutPageId: number; }&apos;: isShippingCalculatorEnabled, checkoutPageId" source="TS2739" />
-<error line="155" column="50" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
-<error line="172" column="47" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
-<error line="177" column="27" severity="error" message="No overload matches this call.
+<error line="67" column="7" severity="error" message="Property &apos;className&apos; is missing in type &apos;{ checkoutPageId: number; }&apos; but required in type &apos;{ checkoutPageId: number; className: string; }&apos;." source="TS2741" />
+<error line="68" column="7" severity="error" message="Property &apos;className&apos; is missing in type &apos;{}&apos; but required in type &apos;{ className: string; }&apos;." source="TS2741" />
+<error line="71" column="5" severity="error" message="Property &apos;className&apos; is missing in type &apos;{ children: Element; }&apos; but required in type &apos;{ children: Element; className: string; }&apos;." source="TS2741" />
+<error line="88" column="25" severity="error" message="Property &apos;invalidateResolutionForStore&apos; does not exist on type &apos;DispatchFromMap&lt;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/data/cart/actions&quot;)&gt;&apos;." source="TS2339" />
+<error line="89" column="38" severity="error" message="Argument of type &apos;Cart&apos; is not assignable to parameter of type &apos;CartResponse&apos;.
+  Type &apos;Cart&apos; is missing the following properties from type &apos;CartResponse&apos;: shipping_rates, shipping_address, billing_address, items_count, and 6 more." source="TS2345" />
+<error line="103" column="5" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="115" column="40" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="122" column="48" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="129" column="45" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="140" column="46" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="151" column="5" severity="error" message="Type &apos;{ showRateAfterTaxName: true; }&apos; is missing the following properties from type &apos;{ showRateAfterTaxName: boolean; isShippingCalculatorEnabled: boolean; checkoutPageId: number; }&apos;: isShippingCalculatorEnabled, checkoutPageId" source="TS2739" />
+<error line="157" column="50" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="174" column="47" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="179" column="27" severity="error" message="No overload matches this call.
   Overload 1 of 2, &apos;(fn: MockResponseInitFunction): FetchMock&apos;, gave the following error.
     Argument of type &apos;(req: Request) =&gt; Promise&lt;string&gt; | undefined&apos; is not assignable to parameter of type &apos;MockResponseInitFunction&apos;.
       Type &apos;Promise&lt;string&gt; | undefined&apos; is not assignable to type &apos;Promise&lt;string | MockResponseInit&gt;&apos;.
         Type &apos;undefined&apos; is not assignable to type &apos;Promise&lt;string | MockResponseInit&gt;&apos;.
   Overload 2 of 2, &apos;(response: string, responseInit?: MockParams | undefined): FetchMock&apos;, gave the following error.
     Argument of type &apos;(req: Request) =&gt; Promise&lt;string&gt; | undefined&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2769" />
-<error line="204" column="48" severity="error" message="Property &apos;toHaveTextContent&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
-<error line="225" column="25" severity="error" message="Property &apos;value&apos; does not exist on type &apos;HTMLElement&apos;." source="TS2339" />
-<error line="231" column="25" severity="error" message="Property &apos;value&apos; does not exist on type &apos;HTMLElement&apos;." source="TS2339" />
+<error line="206" column="48" severity="error" message="Property &apos;toHaveTextContent&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="227" column="25" severity="error" message="Property &apos;value&apos; does not exist on type &apos;HTMLElement&apos;." source="TS2339" />
+<error line="233" column="25" severity="error" message="Property &apos;value&apos; does not exist on type &apos;HTMLElement&apos;." source="TS2339" />
+<error line="244" column="4" severity="error" message="Type &apos;&lt;T&gt;(value: T, extensions: Record&lt;string, unknown&gt;, { cartItem }: CheckoutFilterArguments | undefined) =&gt; boolean&apos; is not assignable to type &apos;CheckoutFilterFunction&apos;.
+  Type &apos;boolean&apos; is not assignable to type &apos;T&apos;.
+    &apos;T&apos; could be instantiated with an arbitrary type which could be unrelated to &apos;boolean&apos;." source="TS2322" />
+<error line="244" column="47" severity="error" message="Property &apos;cartItem&apos; does not exist on type &apos;CheckoutFilterArguments | undefined&apos;." source="TS2339" />
 </file>
 <file name="assets/js/blocks/cart/test/slots.js">
 <error line="11" column="32" severity="error" message="Could not find a declaration file for module &apos;@wordpress/plugins&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@wordpress/plugins/build/index.js&apos; implicitly has an &apos;any&apos; type.
@@ -2578,10 +2783,11 @@
 <error line="82" column="5" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
 </file>
 <file name="assets/js/blocks/cart-checkout-shared/payment-methods/test/payment-methods.js">
-<error line="24" column="57" severity="error" message="Binding element &apos;onChange&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="36" column="7" severity="error" message="Binding element &apos;onChange&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="81" column="24" severity="error" message="Property &apos;invalidateResolutionForStore&apos; does not exist on type &apos;DispatchFromMap&lt;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/data/cart/actions&quot;)&gt;&apos;." source="TS2339" />
-<error line="82" column="37" severity="error" message="Argument of type &apos;Cart&apos; is not assignable to parameter of type &apos;CartResponse&apos;." source="TS2345" />
+<error line="22" column="57" severity="error" message="Binding element &apos;onChange&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="34" column="7" severity="error" message="Binding element &apos;onChange&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="50" column="8" severity="error" message="This condition will always return &apos;false&apos; since the types &apos;&quot;core/editor&quot;&apos; and &apos;&quot;wc/store/payment&quot;&apos; have no overlap." source="TS2367" />
+<error line="104" column="5" severity="error" message="Property &apos;invalidateResolutionForStore&apos; does not exist on type &apos;DispatchFromMap&lt;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/data/cart/actions&quot;)&gt;&apos;." source="TS2339" />
+<error line="107" column="18" severity="error" message="Argument of type &apos;Cart&apos; is not assignable to parameter of type &apos;CartResponse&apos;." source="TS2345" />
 </file>
 <file name="assets/js/blocks/checkout/checkout-order-error/index.js">
 <error line="80" column="46" severity="error" message="Property &apos;code&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
@@ -2593,25 +2799,50 @@
 <error line="15" column="68" severity="error" message="Expected 0 arguments, but got 1." source="TS2554" />
 </file>
 <file name="assets/js/blocks/checkout/block.tsx">
-<error line="15" column="39" severity="error" message="Cannot find module &apos;@woocommerce/base-context/providers&apos; or its corresponding type declarations." source="TS2307" />
-<error line="88" column="4" severity="error" message="Type &apos;{ allowCreateAccount: boolean; showCompanyField: boolean; requireCompanyField: boolean; showApartmentField: boolean; showPhoneField: boolean; requirePhoneField: boolean; }&apos; is missing the following properties from type &apos;CheckoutBlockContextProps&apos;: showOrderNotes, showPolicyLinks, showReturnToCart, cartPageId, showRateAfterTaxName" source="TS2739" />
-<error line="165" column="4" severity="error" message="No overload matches this call.
+<error line="12" column="39" severity="error" message="Cannot find module &apos;@woocommerce/base-context/providers&apos; or its corresponding type declarations." source="TS2307" />
+<error line="95" column="4" severity="error" message="Type &apos;{ allowCreateAccount: boolean; showCompanyField: boolean; requireCompanyField: boolean; showApartmentField: boolean; showPhoneField: boolean; requirePhoneField: boolean; }&apos; is missing the following properties from type &apos;CheckoutBlockContextProps&apos;: showOrderNotes, showPolicyLinks, showReturnToCart, cartPageId, showRateAfterTaxName" source="TS2739" />
+<error line="184" column="4" severity="error" message="No overload matches this call.
   Overload 1 of 2, &apos;(props: BlockErrorBoundaryProps | Readonly&lt;BlockErrorBoundaryProps&gt;): BlockErrorBoundary&apos;, gave the following error.
     Type &apos;unknown&apos; is not assignable to type &apos;boolean&apos;.
   Overload 2 of 2, &apos;(props: BlockErrorBoundaryProps, context: any): BlockErrorBoundary&apos;, gave the following error.
     Type &apos;unknown&apos; is not assignable to type &apos;boolean&apos;." source="TS2769" />
-<error line="168" column="5" severity="error" message="This JSX tag&apos;s &apos;children&apos; prop expects a single child of type &apos;Element&apos;, but multiple children were provided." source="TS2746" />
-<error line="193" column="33" severity="error" message="Argument of type &apos;({ attributes, children, scrollToTop, }: { attributes: Attributes; children: React.ReactChildren; scrollToTop: (props: Record&lt;string, unknown&gt;) =&gt; void; }) =&gt; JSX.Element&apos; is not assignable to parameter of type &apos;FunctionComponent&lt;Record&lt;string, unknown&gt;&gt;&apos;.
+<error line="207" column="33" severity="error" message="Argument of type &apos;({ attributes, children, scrollToTop, }: { attributes: Attributes; children: React.ReactChildren; scrollToTop: (props: Record&lt;string, unknown&gt;) =&gt; void; }) =&gt; JSX.Element&apos; is not assignable to parameter of type &apos;FunctionComponent&lt;Record&lt;string, unknown&gt;&gt;&apos;.
   Types of parameters &apos;__0&apos; and &apos;props&apos; are incompatible.
     Type &apos;PropsWithChildren&lt;Record&lt;string, unknown&gt;&gt;&apos; is missing the following properties from type &apos;{ attributes: Attributes; children: ReactChildren; scrollToTop: (props: Record&lt;string, unknown&gt;) =&gt; void; }&apos;: attributes, scrollToTop" source="TS2345" />
+</file>
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-fields-block/index.tsx">
+<error line="12" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ className?: string; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ className?: string; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className?: string; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ className?: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ className?: string; }&gt;): Block&lt;{ className?: string; }&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: ({ clientId, attributes, }: { clientId: string; attributes: { className?: string; }; }) =&gt; JSX.Element; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className?: string; }&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: ({ clientId, attributes, }: { clientId: string; attributes: { className?: string; }; }) =&gt; Element; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{ className?: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
+</file>
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-totals-block/index.tsx">
+<error line="12" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ className?: string; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ className?: string; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className?: string; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ className?: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ className?: string; }&gt;): Block&lt;{ className?: string; }&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: ({ clientId, attributes, }: { clientId: string; attributes: { className?: string; }; }) =&gt; JSX.Element; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className?: string; }&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: ({ clientId, attributes, }: { clientId: string; attributes: { className?: string; }; }) =&gt; Element; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{ className?: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
 </file>
 <file name="assets/js/blocks/checkout/form-step/additional-fields.tsx">
 <error line="21" column="19" severity="error" message="Argument of type &apos;{ clientId: string; registeredBlocks: string[]; }&apos; is not assignable to parameter of type &apos;{ clientId: string; registeredBlocks: string[]; defaultTemplate: TemplateArray; }&apos;.
   Property &apos;defaultTemplate&apos; is missing in type &apos;{ clientId: string; registeredBlocks: string[]; }&apos; but required in type &apos;{ clientId: string; registeredBlocks: string[]; defaultTemplate: TemplateArray; }&apos;." source="TS2345" />
 </file>
 <file name="assets/js/blocks/checkout/phone-number/index.tsx">
-<error line="23" column="4" severity="error" message="Type &apos;{ id: string; type: string; autoComplete: string; required: boolean; label: string; value: string; onChange: (value: string) =&gt; void; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; Omit&lt;{ instanceId: string | number; }, &quot;instanceId&quot;&gt; &amp; { children?: ReactNode; }&apos;.
-  Property &apos;id&apos; does not exist on type &apos;IntrinsicAttributes &amp; Omit&lt;{ instanceId: string | number; }, &quot;instanceId&quot;&gt; &amp; { children?: ReactNode; }&apos;." source="TS2322" />
+<error line="24" column="4" severity="error" message="Type &apos;{ id: string; type: string; autoComplete: string; required: boolean; label: string; value: string; onChange: (value: string) =&gt; void; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; Omit&lt;ValidatedTextInputProps, &quot;instanceId&quot;&gt; &amp; { children?: ReactNode; }&apos;.
+  Property &apos;type&apos; does not exist on type &apos;IntrinsicAttributes &amp; Omit&lt;ValidatedTextInputProps, &quot;instanceId&quot;&gt; &amp; { children?: ReactNode; }&apos;." source="TS2322" />
+</file>
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/index.tsx">
+<error line="13" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt;): Block&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt; | undefined&apos;, gave the following error.
+    Type &apos;{ className: { type: string; default: string; }; lock: { type: string; default: { move: boolean; remove: boolean; }; }; }&apos; is missing the following properties from type &apos;{ readonly title: BlockAttribute&lt;string&gt;; readonly description: BlockAttribute&lt;string&gt;; readonly showStepNumber: BlockAttribute&lt;boolean&gt;; readonly className: BlockAttribute&lt;...&gt;; }&apos;: title, description, showStepNumber" source="TS2769" />
 </file>
 <file name="assets/js/blocks/checkout/inner-blocks/checkout-terms-block/edit.tsx">
 <error line="62" column="8" severity="error" message="Property &apos;onChange&apos; is missing in type &apos;{ id: string; checked: false; }&apos; but required in type &apos;CheckboxControlProps&apos;." source="TS2741" />
@@ -2625,10 +2856,34 @@
   Overload 2 of 2, &apos;(props: PropsWithChildren&lt;Props&gt;, context?: any): ReactElement&lt;any, any&gt; | Component&lt;Props, any, any&gt; | null&apos;, gave the following error.
     Type &apos;{ className: string; label: Element; onClick: () =&gt; Window | null; }[]&apos; is not assignable to type &apos;readonly Action[]&apos;." source="TS2769" />
 </file>
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-terms-block/index.tsx">
+<error line="11" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ text: string; checkbox: boolean; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ text: string; checkbox: boolean; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ text: string; checkbox: boolean; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ text: string; checkbox: boolean; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ text: string; checkbox: boolean; }&gt;): Block&lt;{ text: string; checkbox: boolean; }&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: ({ attributes: { checkbox, text }, setAttributes, }: { attributes: { text: string; checkbox: boolean; }; setAttributes: (attributes: Record&lt;string, unknown&gt;) =&gt; void; }) =&gt; JSX.Element; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ text: string; checkbox: boolean; }&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: ({ attributes: { checkbox, text }, setAttributes, }: { attributes: { text: string; checkbox: boolean; }; setAttributes: (attributes: Record&lt;string, unknown&gt;) =&gt; void; }) =&gt; Element; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{ text: string; checkbox: boolean; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
+</file>
 <file name="assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/block.tsx">
-<error line="28" column="26" severity="error" message="Parameter &apos;value&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="51" column="5" severity="error" message="Type &apos;{ id: string; type: string; label: string; value: string; autoComplete: string; onChange: (value: any) =&gt; void; required: boolean; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; Omit&lt;{ instanceId: string | number; }, &quot;instanceId&quot;&gt; &amp; { children?: ReactNode; }&apos;.
-  Property &apos;id&apos; does not exist on type &apos;IntrinsicAttributes &amp; Omit&lt;{ instanceId: string | number; }, &quot;instanceId&quot;&gt; &amp; { children?: ReactNode; }&apos;." source="TS2322" />
+<error line="56" column="5" severity="error" message="Type &apos;{ id: string; type: string; label: string; value: string; autoComplete: string; onChange: (value: string) =&gt; void; required: boolean; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; Omit&lt;ValidatedTextInputProps, &quot;instanceId&quot;&gt; &amp; { children?: ReactNode; }&apos;.
+  Property &apos;type&apos; does not exist on type &apos;IntrinsicAttributes &amp; Omit&lt;ValidatedTextInputProps, &quot;instanceId&quot;&gt; &amp; { children?: ReactNode; }&apos;." source="TS2322" />
+</file>
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/index.tsx">
+<error line="13" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt;): Block&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt; | undefined&apos;, gave the following error.
+    Type &apos;{ className: { type: string; default: string; }; lock: { type: string; default: { remove: boolean; move: boolean; }; }; }&apos; is missing the following properties from type &apos;{ readonly title: BlockAttribute&lt;string&gt;; readonly description: BlockAttribute&lt;string&gt;; readonly showStepNumber: BlockAttribute&lt;boolean&gt;; readonly className: BlockAttribute&lt;...&gt;; }&apos;: title, description, showStepNumber" source="TS2769" />
+</file>
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/index.tsx">
+<error line="13" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt;): Block&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt; | undefined&apos;, gave the following error.
+    Type &apos;{ className: { type: string; default: string; }; lock: { type: string; default: { move: boolean; remove: boolean; }; }; }&apos; is missing the following properties from type &apos;{ readonly title: BlockAttribute&lt;string&gt;; readonly description: BlockAttribute&lt;string&gt;; readonly showStepNumber: BlockAttribute&lt;boolean&gt;; readonly className: BlockAttribute&lt;...&gt;; }&apos;: title, description, showStepNumber" source="TS2769" />
 </file>
 <file name="assets/js/blocks/checkout/inner-blocks/checkout-actions-block/block.tsx">
 <error line="30" column="6" severity="error" message="Type &apos;{ link: string | undefined; }&apos; is not assignable to type &apos;ReturnToCartButtonProps&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
@@ -2636,13 +2891,57 @@
     Type &apos;string | undefined&apos; is not assignable to type &apos;string&apos;.
       Type &apos;undefined&apos; is not assignable to type &apos;string&apos;." source="TS2375" />
 </file>
-<file name="assets/js/blocks/checkout/order-notes/index.tsx">
-<error line="36" column="5" severity="error" message="Type &apos;{ disabled: boolean; label: string; checked: boolean; onChange: (isChecked: boolean) =&gt; void; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; CheckboxControlProps&apos;.
-  Property &apos;disabled&apos; does not exist on type &apos;IntrinsicAttributes &amp; CheckboxControlProps&apos;." source="TS2322" />
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-actions-block/index.tsx">
+<error line="13" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ showReturnToCart: boolean; cartPageId: number; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ showReturnToCart: boolean; cartPageId: number; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ showReturnToCart: boolean; cartPageId: number; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ showReturnToCart: boolean; cartPageId: number; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ showReturnToCart: boolean; cartPageId: number; }&gt;): Block&lt;{ showReturnToCart: boolean; cartPageId: number; }&gt; | undefined&apos;, gave the following error.
+    Type &apos;{ cartPageId: { type: string; default: number; }; showReturnToCart: { type: string; default: boolean; }; className: { type: string; default: string; }; lock: { type: string; default: { move: boolean; remove: boolean; }; }; }&apos; is not assignable to type &apos;{ readonly showReturnToCart: BlockAttribute&lt;boolean&gt;; readonly cartPageId: BlockAttribute&lt;number&gt;; }&apos;.
+      Types of property &apos;showReturnToCart&apos; are incompatible.
+        Type &apos;{ type: string; default: boolean; }&apos; is not assignable to type &apos;BlockAttribute&lt;boolean&gt;&apos;.
+          Type &apos;{ type: string; default: boolean; }&apos; is missing the following properties from type &apos;Query&lt;boolean&gt;&apos;: source, selector, query" source="TS2769" />
+</file>
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-order-note-block/index.tsx">
+<error line="12" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{}&gt;, settings?: Partial&lt;BlockConfiguration&lt;{}&gt;&gt; | undefined): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{}&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{}&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{}&gt;): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: () =&gt; JSX.Element; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{}&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: () =&gt; Element; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{}&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
+</file>
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-order-summary-block/index.tsx">
+<error line="14" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ className: unknown; lock: unknown; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ className: unknown; lock: unknown; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: unknown; lock: unknown; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ className: unknown; lock: unknown; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ className: unknown; lock: unknown; }&gt;): Block&lt;{ className: unknown; lock: unknown; }&gt; | undefined&apos;, gave the following error.
+    Type &apos;{ className: { type: string; default: string; }; lock: { type: string; default: { move: boolean; remove: boolean; }; }; }&apos; is not assignable to type &apos;{ readonly className: BlockAttribute&lt;unknown&gt;; readonly lock: BlockAttribute&lt;unknown&gt;; }&apos;.
+      Types of property &apos;className&apos; are incompatible.
+        Type &apos;{ type: string; default: string; }&apos; is not assignable to type &apos;BlockAttribute&lt;unknown&gt;&apos;.
+          Type &apos;{ type: string; default: string; }&apos; is missing the following properties from type &apos;Query&lt;unknown&gt;&apos;: source, selector, query" source="TS2769" />
+</file>
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-payment-block/index.tsx">
+<error line="13" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt;): Block&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt; | undefined&apos;, gave the following error.
+    Type &apos;{ className: { type: string; default: string; }; lock: { type: string; default: { move: boolean; remove: boolean; }; }; }&apos; is missing the following properties from type &apos;{ readonly title: BlockAttribute&lt;string&gt;; readonly description: BlockAttribute&lt;string&gt;; readonly showStepNumber: BlockAttribute&lt;boolean&gt;; readonly className: BlockAttribute&lt;...&gt;; }&apos;: title, description, showStepNumber" source="TS2769" />
 </file>
 <file name="assets/js/blocks/checkout/inner-blocks/checkout-express-payment-block/edit.tsx">
 <error line="6" column="37" severity="error" message="Could not find a declaration file for module &apos;wordpress-components&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/wordpress-components/build/index.js&apos; implicitly has an &apos;any&apos; type.
   If the &apos;@wordpress/components&apos; package actually exposes this module, consider sending a pull request to amend &apos;https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/wordpress__components&apos;" source="TS7016" />
+</file>
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-express-payment-block/index.tsx">
+<error line="12" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ className?: string; lock: { move: boolean; remove: boolean; }; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ className?: string; lock: { move: boolean; remove: boolean; }; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className?: string; lock: { move: boolean; remove: boolean; }; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ className?: string; lock: { move: boolean; remove: boolean; }; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ className?: string; lock: { move: boolean; remove: boolean; }; }&gt;): Block&lt;{ className?: string; lock: { move: boolean; remove: boolean; }; }&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: ({ attributes, }: { attributes: { className?: string; lock: { move: boolean; remove: boolean; }; }; }) =&gt; JSX.Element | null; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className?: string; lock: { move: boolean; remove: boolean; }; }&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: ({ attributes, }: { attributes: { className?: string; lock: { move: boolean; remove: boolean; }; }; }) =&gt; Element | null; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{ className?: string; lock: { move: boolean; remove: boolean; }; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
 </file>
 <file name="assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/no-shipping-placeholder/index.js">
 <error line="5" column="37" severity="error" message="Could not find a declaration file for module &apos;wordpress-components&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/wordpress-components/build/index.js&apos; implicitly has an &apos;any&apos; type.
@@ -2652,17 +2951,82 @@
 <error line="12" column="24" severity="error" message="Could not find a declaration file for module &apos;wordpress-components&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/wordpress-components/build/index.js&apos; implicitly has an &apos;any&apos; type.
   If the &apos;@wordpress/components&apos; package actually exposes this module, consider sending a pull request to amend &apos;https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/wordpress__components&apos;" source="TS7016" />
 </file>
-<file name="assets/js/blocks/checkout/edit.tsx">
-<error line="144" column="3" severity="error" message="Type &apos;boolean&apos; is not assignable to type &apos;undefined&apos;." source="TS2322" />
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/index.tsx">
+<error line="13" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ title: string; description: string; showStepNumber: boolean; allowCreateAccount: boolean; className: string; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ title: string; description: string; showStepNumber: boolean; allowCreateAccount: boolean; className: string; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ title: string; description: string; showStepNumber: boolean; allowCreateAccount: boolean; className: string; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ title: string; description: string; showStepNumber: boolean; allowCreateAccount: boolean; className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ title: string; description: string; showStepNumber: boolean; allowCreateAccount: boolean; className: string; }&gt;): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Type &apos;{ allowCreateAccount: { type: string; default: boolean; }; className: { type: string; default: string; }; lock: { type: string; default: { move: boolean; remove: boolean; }; }; }&apos; is missing the following properties from type &apos;{ readonly title: BlockAttribute&lt;string&gt;; readonly description: BlockAttribute&lt;string&gt;; readonly showStepNumber: BlockAttribute&lt;boolean&gt;; readonly allowCreateAccount: BlockAttribute&lt;...&gt;; readonly className: BlockAttribute&lt;...&gt;; }&apos;: title, description, showStepNumber" source="TS2769" />
+</file>
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-order-summary-subtotal/index.tsx">
+<error line="13" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ className: string; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ className: string; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ className: string; }&gt;): Block&lt;{ className: string; }&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: ({ attributes, }: { attributes: { className: string; }; setAttributes: (attributes: Record&lt;string, unknown&gt;) =&gt; void; }) =&gt; JSX.Element; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: ({ attributes, }: { attributes: { className: string; }; setAttributes: (attributes: Record&lt;string, unknown&gt;) =&gt; void; }) =&gt; Element; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
+</file>
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-order-summary-fee/index.tsx">
+<error line="13" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ className: string; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ className: string; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ className: string; }&gt;): Block&lt;{ className: string; }&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: ({ attributes, }: { attributes: { className: string; }; setAttributes: (attributes: Record&lt;string, unknown&gt;) =&gt; void; }) =&gt; JSX.Element; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: ({ attributes, }: { attributes: { className: string; }; setAttributes: (attributes: Record&lt;string, unknown&gt;) =&gt; void; }) =&gt; Element; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
+</file>
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-order-summary-discount/index.tsx">
+<error line="13" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ className: string; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ className: string; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ className: string; }&gt;): Block&lt;{ className: string; }&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: ({ attributes, }: { attributes: { className: string; }; setAttributes: (attributes: Record&lt;string, unknown&gt;) =&gt; void; }) =&gt; JSX.Element; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: ({ attributes, }: { attributes: { className: string; }; setAttributes: (attributes: Record&lt;string, unknown&gt;) =&gt; void; }) =&gt; Element; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
+</file>
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-order-summary-shipping/index.tsx">
+<error line="13" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ className: string; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ className: string; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ className: string; }&gt;): Block&lt;{ className: string; }&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: ({ attributes, }: { attributes: { className: string; }; }) =&gt; JSX.Element; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: ({ attributes, }: { attributes: { className: string; }; }) =&gt; Element; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
+</file>
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-order-summary-coupon-form/index.tsx">
+<error line="12" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ className: string; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ className: string; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ className: string; }&gt;): Block&lt;{ className: string; }&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: ({ attributes, }: { attributes: { className: string; }; setAttributes: (attributes: Record&lt;string, unknown&gt;) =&gt; void; }) =&gt; JSX.Element; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: ({ attributes, }: { attributes: { className: string; }; setAttributes: (attributes: Record&lt;string, unknown&gt;) =&gt; void; }) =&gt; Element; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
+</file>
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-order-summary-taxes/index.tsx">
+<error line="14" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ className: string; showRateAfterTaxName: boolean; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ className: string; showRateAfterTaxName: boolean; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; showRateAfterTaxName: boolean; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ className: string; showRateAfterTaxName: boolean; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ className: string; showRateAfterTaxName: boolean; }&gt;): Block&lt;{ className: string; showRateAfterTaxName: boolean; }&gt; | undefined&apos;, gave the following error.
+    Property &apos;className&apos; is missing in type &apos;{ showRateAfterTaxName: { type: string; default: unknown; }; lock: { type: string; default: { remove: boolean; move: boolean; }; }; }&apos; but required in type &apos;{ readonly className: BlockAttribute&lt;string&gt;; readonly showRateAfterTaxName: BlockAttribute&lt;boolean&gt;; }&apos;." source="TS2769" />
+</file>
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-order-summary-cart-items/index.tsx">
+<error line="13" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ className: string; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ className: string; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ className: string; }&gt;): Block&lt;{ className: string; }&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: ({ attributes, }: { attributes: { className: string; }; setAttributes: (attributes: Record&lt;string, unknown&gt;) =&gt; void; }) =&gt; JSX.Element; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: ({ attributes, }: { attributes: { className: string; }; setAttributes: (attributes: Record&lt;string, unknown&gt;) =&gt; void; }) =&gt; Element; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
 </file>
 <file name="assets/js/blocks/checkout/inner-blocks/checkout-fields-block/frontend.tsx">
 <error line="20" column="4" severity="error" message="Type &apos;{ children: Element; className: string; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; RefAttributes&lt;any&gt;&apos;.
   Property &apos;children&apos; does not exist on type &apos;IntrinsicAttributes &amp; RefAttributes&lt;any&gt;&apos;." source="TS2322" />
 </file>
 <file name="assets/js/blocks/checkout/inner-blocks/checkout-terms-block/frontend.tsx">
-<error line="86" column="7" severity="error" message="Type &apos;string | boolean&apos; is not assignable to type &apos;boolean&apos;.
-  Type &apos;string&apos; is not assignable to type &apos;boolean&apos;." source="TS2322" />
-<error line="89" column="7" severity="error" message="Type &apos;Element&apos; is not assignable to type &apos;ReactChildren&apos;." source="TS2322" />
+<error line="93" column="7" severity="error" message="Type &apos;Element&apos; is not assignable to type &apos;ReactChildren&apos;." source="TS2322" />
 </file>
 <file name="assets/js/blocks/checkout/inner-blocks/checkout-totals-block/frontend.tsx">
 <error line="20" column="4" severity="error" message="Type &apos;{ children: Element; className: string; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; RefAttributes&lt;any&gt;&apos;.
@@ -2690,14 +3054,14 @@
       Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
         Type &apos;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos; is not assignable to type &apos;{ className?: string; }&apos;.
           Type &apos;{ children?: ReactNode; }&apos; has no properties in common with type &apos;{ className?: string; }&apos;." source="TS2322" />
-<error line="100" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;ComponentType&lt;Omit&lt;{ text: string; checkbox: boolean; instanceId: string; validation: ValidationData; className?: string; }, &quot;instanceId&quot;&gt;&gt;&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
-  Type &apos;LazyExoticComponent&lt;ComponentType&lt;Omit&lt;{ text: string; checkbox: boolean; instanceId: string; validation: ValidationData; className?: string; }, &quot;instanceId&quot;&gt;&gt;&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos;.
-    Type &apos;LazyExoticComponent&lt;ComponentType&lt;Omit&lt;{ text: string; checkbox: boolean; instanceId: string; validation: ValidationData; className?: string; }, &quot;instanceId&quot;&gt;&gt;&gt;&apos; is not assignable to type &apos;ExoticComponent&lt;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&gt;&apos;.
+<error line="100" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;ComponentType&lt;Omit&lt;{ text: string; checkbox: boolean; instanceId: string; className?: string; }, &quot;instanceId&quot;&gt;&gt;&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
+  Type &apos;LazyExoticComponent&lt;ComponentType&lt;Omit&lt;{ text: string; checkbox: boolean; instanceId: string; className?: string; }, &quot;instanceId&quot;&gt;&gt;&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos;.
+    Type &apos;LazyExoticComponent&lt;ComponentType&lt;Omit&lt;{ text: string; checkbox: boolean; instanceId: string; className?: string; }, &quot;instanceId&quot;&gt;&gt;&gt;&apos; is not assignable to type &apos;ExoticComponent&lt;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&gt;&apos;.
       Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
-        Type &apos;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos; is not assignable to type &apos;(Omit&lt;{ text: string; checkbox: boolean; instanceId: string; validation: ValidationData; className?: string; }, &quot;instanceId&quot;&gt; &amp; RefAttributes&lt;Component&lt;Omit&lt;{ text: string; checkbox: boolean; instanceId: string; validation: ValidationData; className?: string; }, &quot;instanceId&quot;&gt;, any, any&gt;&gt;) | (Omit&lt;...&gt; &amp; { ...; })&apos;.
-          Type &apos;{ children?: ReactNode; }&apos; is not assignable to type &apos;(Omit&lt;{ text: string; checkbox: boolean; instanceId: string; validation: ValidationData; className?: string; }, &quot;instanceId&quot;&gt; &amp; RefAttributes&lt;Component&lt;Omit&lt;{ text: string; checkbox: boolean; instanceId: string; validation: ValidationData; className?: string; }, &quot;instanceId&quot;&gt;, any, any&gt;&gt;) | (Omit&lt;...&gt; &amp; { ...; })&apos;.
-            Type &apos;{ children?: ReactNode; }&apos; is not assignable to type &apos;Omit&lt;{ text: string; checkbox: boolean; instanceId: string; validation: ValidationData; className?: string; }, &quot;instanceId&quot;&gt; &amp; { children?: ReactNode; }&apos;.
-              Type &apos;{ children?: ReactNode; }&apos; is missing the following properties from type &apos;Omit&lt;{ text: string; checkbox: boolean; instanceId: string; validation: ValidationData; className?: string; }, &quot;instanceId&quot;&gt;&apos;: checkbox, text, validation" source="TS2322" />
+        Type &apos;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos; is not assignable to type &apos;(Omit&lt;{ text: string; checkbox: boolean; instanceId: string; className?: string; }, &quot;instanceId&quot;&gt; &amp; RefAttributes&lt;Component&lt;Omit&lt;{ text: string; checkbox: boolean; instanceId: string; className?: string; }, &quot;instanceId&quot;&gt;, any, any&gt;&gt;) | (Omit&lt;...&gt; &amp; { ...; })&apos;.
+          Type &apos;{ children?: ReactNode; }&apos; is not assignable to type &apos;(Omit&lt;{ text: string; checkbox: boolean; instanceId: string; className?: string; }, &quot;instanceId&quot;&gt; &amp; RefAttributes&lt;Component&lt;Omit&lt;{ text: string; checkbox: boolean; instanceId: string; className?: string; }, &quot;instanceId&quot;&gt;, any, any&gt;&gt;) | (Omit&lt;...&gt; &amp; { ...; })&apos;.
+            Type &apos;{ children?: ReactNode; }&apos; is not assignable to type &apos;Omit&lt;{ text: string; checkbox: boolean; instanceId: string; className?: string; }, &quot;instanceId&quot;&gt; &amp; { children?: ReactNode; }&apos;.
+              Type &apos;{ children?: ReactNode; }&apos; is missing the following properties from type &apos;Omit&lt;{ text: string; checkbox: boolean; instanceId: string; className?: string; }, &quot;instanceId&quot;&gt;&apos;: checkbox, text" source="TS2322" />
 <error line="120" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ children, className, }: { children: Element; className?: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
   Type &apos;LazyExoticComponent&lt;({ children, className, }: { children: Element; className?: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos;.
     Type &apos;LazyExoticComponent&lt;({ children, className, }: { children: Element; className?: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;ExoticComponent&lt;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&gt;&apos;.
@@ -2758,11 +3122,14 @@
       Type &apos;undefined&apos; is not assignable to type &apos;ReactElement&lt;any, any&gt; | null&apos;." source="TS2322" />
 </file>
 <file name="assets/js/blocks/checkout/index.tsx">
-<error line="143" column="33" severity="error" message="Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { align: string[]; html: boolean; multiple: boolean; }; attributes: { isPreview: { type: string; default: boolean; save: boolean; }; ... 5 more ...; requirePhoneField: { ...; }; }; textdomain: string;...&apos; is not assignable to parameter of type &apos;string | BlockConfiguration&lt;{}&gt;&apos;.
-  Type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { align: string[]; html: boolean; multiple: boolean; }; attributes: { isPreview: { type: string; default: boolean; save: boolean; }; ... 5 more ...; requirePhoneField: { ...; }; }; textdomain: string;...&apos; is not assignable to type &apos;BlockConfiguration&lt;{}&gt;&apos;.
-    Type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { align: string[]; html: boolean; multiple: boolean; }; attributes: { isPreview: { type: string; default: boolean; save: boolean; }; ... 5 more ...; requirePhoneField: { ...; }; }; textdomain: string;...&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;{}&gt;, &quot;icon&quot;&gt;&gt;&apos;.
-      The types of &apos;supports.align&apos; are incompatible between these types.
-        Type &apos;string[]&apos; is not assignable to type &apos;boolean | readonly BlockAlignment[] | undefined&apos;." source="TS2345" />
+<error line="142" column="20" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;BlockInstance&lt;Record&lt;string, any&gt;&gt;[] | { showOrderNotes: boolean; showPolicyLinks: boolean; showReturnToCart: boolean; cartPageId: number; }&gt;, settings?: Partial&lt;...&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { align: string[]; html: boolean; multiple: boolean; }; attributes: { isPreview: { type: string; default: boolean; save: boolean; }; ... 5 more ...; requirePhoneField: { ...; }; }; textdomain: string;...&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;BlockInstance&lt;Record&lt;string, any&gt;&gt;[] | { showOrderNotes: boolean; showPolicyLinks: boolean; showReturnToCart: boolean; cartPageId: number; }&gt;&apos;.
+      Type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { align: string[]; html: boolean; multiple: boolean; }; attributes: { isPreview: { type: string; default: boolean; save: boolean; }; ... 5 more ...; requirePhoneField: { ...; }; }; textdomain: string;...&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;BlockInstance&lt;Record&lt;string, any&gt;&gt;[] | { showOrderNotes: boolean; showPolicyLinks: boolean; showReturnToCart: boolean; cartPageId: number; }&gt;, &quot;icon&quot;&gt;&gt;&apos;.
+        Types of property &apos;attributes&apos; are incompatible.
+          Type &apos;{ isPreview: { type: string; default: boolean; save: boolean; }; showCompanyField: { type: string; default: boolean; }; requireCompanyField: { type: string; default: boolean; }; allowCreateAccount: { ...; }; showApartmentField: { ...; }; showPhoneField: { ...; }; requirePhoneField: { ...; }; }&apos; is not assignable to type &apos;readonly BlockAttribute&lt;BlockInstance&lt;Record&lt;string, any&gt;&gt;&gt;[] | { readonly showOrderNotes: BlockAttribute&lt;boolean&gt;; readonly showPolicyLinks: BlockAttribute&lt;...&gt;; readonly showReturnToCart: BlockAttribute&lt;...&gt;; readonly cartPageId: BlockAttribute&lt;...&gt;; }&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;BlockInstance&lt;Record&lt;string, any&gt;&gt;[] | { showOrderNotes: boolean; showPolicyLinks: boolean; showReturnToCart: boolean; cartPageId: number; }&gt;): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { align: string[]; html: boolean; multiple: boolean; }; attributes: { isPreview: { type: string; default: boolean; save: boolean; }; ... 5 more ...; requirePhoneField: { ...; }; }; textdomain: string;...&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2769" />
 </file>
 <file name="tests/utils/find-by-text.ts">
 <error line="12" column="21" severity="error" message="Parameter &apos;_node&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
@@ -2809,11 +3176,14 @@
 <error line="106" column="9" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;Matchers&lt;void, HTMLElement | null&gt;&apos;." source="TS2339" />
 </file>
 <file name="assets/js/blocks/checkout/inner-blocks/checkout-terms-block/test/frontend.js">
-<error line="48" column="22" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
-<error line="65" column="26" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;Matchers&lt;void, HTMLElement | null&gt;&apos;." source="TS2339" />
+<error line="43" column="22" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="59" column="26" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;Matchers&lt;void, HTMLElement | null&gt;&apos;." source="TS2339" />
 </file>
 <file name="assets/js/blocks/classic-template/index.tsx">
-<error line="191" column="6" severity="error" message="Type &apos;{ attributes: { template: string; align: string; }; setAttributes: (attrs: Partial&lt;Attributes&gt;) =&gt; void; clientId: string; }&apos; is missing the following properties from type &apos;BlockEditProps&lt;Attributes&gt;&apos;: className, isSelected" source="TS2739" />
+<error line="196" column="6" severity="error" message="Type &apos;{ attributes: { template: string; align: string; }; setAttributes: (attrs: Partial&lt;Attributes&gt;) =&gt; void; clientId: string; }&apos; is missing the following properties from type &apos;BlockEditProps&lt;Attributes&gt;&apos;: className, isSelected" source="TS2739" />
+</file>
+<file name="assets/js/blocks/classic-template/test/utils.ts">
+<error line="15" column="2" severity="error" message="An object literal cannot have multiple properties with the same name." source="TS1117" />
 </file>
 <file name="assets/js/blocks/featured-items/block-controls.tsx">
 <error line="9" column="2" severity="error" message="Module &apos;&quot;@wordpress/block-editor&quot;&apos; has no exported member &apos;MediaReplaceFlow&apos;." source="TS2305" />
@@ -2830,6 +3200,22 @@
 <error line="12" column="2" severity="error" message="Module &apos;&quot;@wordpress/block-editor&quot;&apos; has no exported member &apos;__experimentalUseGradient&apos;." source="TS2305" />
 <error line="19" column="2" severity="error" message="Module &apos;&quot;@wordpress/components&quot;&apos; has no exported member &apos;__experimentalToggleGroupControl&apos;." source="TS2305" />
 <error line="20" column="2" severity="error" message="Module &apos;&quot;@wordpress/components&quot;&apos; has no exported member &apos;__experimentalToggleGroupControlOption&apos;." source="TS2305" />
+</file>
+<file name="assets/js/blocks/featured-items/register.tsx">
+<error line="74" column="43" severity="error" message="Property &apos;background&apos; does not exist on type &apos;never&apos;." source="TS2339" />
+<error line="75" column="37" severity="error" message="Property &apos;text&apos; does not exist on type &apos;never&apos;." source="TS2339" />
+<error line="78" column="33" severity="error" message="Property &apos;__experimentalDuotone&apos; does not exist on type &apos;never&apos;." source="TS2339" />
+<error line="115" column="2" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{}&gt;, settings?: Partial&lt;BlockConfiguration&lt;{}&gt;&gt; | undefined): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ style?: string; script?: string; title?: string; name?: string; version?: string; description?: string | undefined; category?: string; edit: React.ComponentType&lt;BlockEditProps&lt;{}&gt;&gt; | ((props: {}) =&gt; JSX.Element) | undefined; ... 17 more ...; icon?: BlockIcon | undefined; }&apos; is not assignable to parameter of type &apos;Partial&lt;BlockConfiguration&lt;{}&gt;&gt;&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+      Types of property &apos;supports&apos; are incompatible.
+        Type &apos;BlockSupports | { __experimentalBorder?: { color: boolean; radius: boolean; width: boolean; __experimentalSkipSerialization?: boolean; }; color: { __experimentalDuotone?: any; background: any; text: any; }; ... 11 more ...; typography?: Partial&lt;...&gt; | undefined; } | undefined&apos; is not assignable to type &apos;BlockSupports | undefined&apos;.
+          Type &apos;{ __experimentalBorder?: { color: boolean; radius: boolean; width: boolean; __experimentalSkipSerialization?: boolean; }; color: { __experimentalDuotone?: any; background: any; text: any; }; spacing: { ...; }; ... 10 more ...; typography?: Partial&lt;...&gt; | undefined; }&apos; is not assignable to type &apos;BlockSupports&apos;.
+            The types of &apos;spacing.padding&apos; are incompatible between these types.
+              Type &apos;((boolean | CSSDirection[] | undefined) &amp; (boolean | CSSDirections[])) | undefined&apos; is not assignable to type &apos;boolean | CSSDirection[]&apos;.
+                Type &apos;undefined&apos; is not assignable to type &apos;boolean | CSSDirection[]&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{}&gt;): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;Partial&lt;Omit&lt;Block&lt;{}&gt;, &quot;icon&quot;&gt;&gt; &amp; Pick&lt;Block&lt;{}&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt; &amp; { icon?: BlockIcon | undefined; } &amp; ExtendedBlockSupports&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2769" />
 </file>
 <file name="assets/js/editor-components/product-category-control/index.js">
 <error line="45" column="23" severity="error" message="Parameter &apos;args&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
@@ -2853,16 +3239,47 @@
   Type &apos;undefined&apos; is not assignable to type &apos;number&apos;." source="TS2322" />
 </file>
 <file name="assets/js/blocks/featured-items/featured-category/index.tsx">
-<error line="17" column="27" severity="error" message="Argument of type &apos;{ name: string; version: string; title: string; category: string; keywords: string[]; description: string; supports: { align: string[]; html: boolean; color: { background: boolean; text: boolean; __experimentalDuotone: string; }; spacing: { ...; }; __experimentalBorder: { ...; }; }; attributes: { ...; }; textdomain:...&apos; is not assignable to parameter of type &apos;Partial&lt;Omit&lt;Block&lt;{}&gt;, &quot;icon&quot;&gt;&gt; &amp; Pick&lt;Block&lt;{}&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt; &amp; { icon?: BlockIcon | undefined; } &amp; ExtendedBlockSupports&apos;.
-  Type &apos;{ name: string; version: string; title: string; category: string; keywords: string[]; description: string; supports: { align: string[]; html: boolean; color: { background: boolean; text: boolean; __experimentalDuotone: string; }; spacing: { ...; }; __experimentalBorder: { ...; }; }; attributes: { ...; }; textdomain:...&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;{}&gt;, &quot;icon&quot;&gt;&gt;&apos;.
+<error line="17" column="27" severity="error" message="Argument of type &apos;{ name: string; version: string; title: string; category: string; keywords: string[]; description: string; supports: { align: string[]; html: boolean; color: { background: boolean; text: boolean; }; spacing: { ...; }; __experimentalBorder: { ...; }; }; attributes: { ...; }; textdomain: string; apiVersion: number; $s...&apos; is not assignable to parameter of type &apos;Partial&lt;Omit&lt;Block&lt;{}&gt;, &quot;icon&quot;&gt;&gt; &amp; Pick&lt;Block&lt;{}&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt; &amp; { icon?: BlockIcon | undefined; } &amp; ExtendedBlockSupports&apos;.
+  Type &apos;{ name: string; version: string; title: string; category: string; keywords: string[]; description: string; supports: { align: string[]; html: boolean; color: { background: boolean; text: boolean; }; spacing: { ...; }; __experimentalBorder: { ...; }; }; attributes: { ...; }; textdomain: string; apiVersion: number; $s...&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;{}&gt;, &quot;icon&quot;&gt;&gt;&apos;.
+    The types of &apos;supports.align&apos; are incompatible between these types.
+      Type &apos;string[]&apos; is not assignable to type &apos;boolean | readonly BlockAlignment[] | undefined&apos;.
+        Type &apos;string[]&apos; is not assignable to type &apos;readonly BlockAlignment[]&apos;." source="TS2345" />
+</file>
+<file name="assets/js/blocks/featured-items/featured-product/index.tsx">
+<error line="16" column="27" severity="error" message="Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { align: string[]; html: boolean; color: { background: boolean; text: boolean; }; spacing: { ...; }; __experimentalBorder: { ...; }; multiple: boolean; }; attributes: { ...; }; textdomain: string; api...&apos; is not assignable to parameter of type &apos;Partial&lt;Omit&lt;Block&lt;{}&gt;, &quot;icon&quot;&gt;&gt; &amp; Pick&lt;Block&lt;{}&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt; &amp; { icon?: BlockIcon | undefined; } &amp; ExtendedBlockSupports&apos;.
+  Type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { align: string[]; html: boolean; color: { background: boolean; text: boolean; }; spacing: { ...; }; __experimentalBorder: { ...; }; multiple: boolean; }; attributes: { ...; }; textdomain: string; api...&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;{}&gt;, &quot;icon&quot;&gt;&gt;&apos;.
     The types of &apos;supports.align&apos; are incompatible between these types.
       Type &apos;string[]&apos; is not assignable to type &apos;boolean | readonly BlockAlignment[] | undefined&apos;." source="TS2345" />
 </file>
-<file name="assets/js/blocks/featured-items/featured-product/index.tsx">
-<error line="16" column="27" severity="error" message="Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { align: string[]; html: boolean; color: { background: boolean; text: boolean; __experimentalDuotone: string; }; spacing: { ...; }; __experimentalBorder: { ...; }; multiple: boolean; }; attributes: { ...&apos; is not assignable to parameter of type &apos;Partial&lt;Omit&lt;Block&lt;{}&gt;, &quot;icon&quot;&gt;&gt; &amp; Pick&lt;Block&lt;{}&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt; &amp; { icon?: BlockIcon | undefined; } &amp; ExtendedBlockSupports&apos;.
-  Type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { align: string[]; html: boolean; color: { background: boolean; text: boolean; __experimentalDuotone: string; }; spacing: { ...; }; __experimentalBorder: { ...; }; multiple: boolean; }; attributes: { ...&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;{}&gt;, &quot;icon&quot;&gt;&gt;&apos;.
-    The types of &apos;supports.align&apos; are incompatible between these types.
-      Type &apos;string[]&apos; is not assignable to type &apos;boolean | readonly BlockAlignment[] | undefined&apos;." source="TS2345" />
+<file name="assets/js/blocks/filter-wrapper/frontend.ts">
+<error line="15" column="2" severity="error" message="Type &apos;({ children }: Props) =&gt; JSX.Element&apos; is not assignable to type &apos;FunctionComponent&lt;{}&gt;&apos;.
+  Types of parameters &apos;__0&apos; and &apos;props&apos; are incompatible.
+    Type &apos;{ children?: ReactNode; }&apos; is not assignable to type &apos;Props&apos;.
+      Types of property &apos;children&apos; are incompatible.
+        Type &apos;ReactNode&apos; is not assignable to type &apos;Element[]&apos;.
+          Type &apos;undefined&apos; is not assignable to type &apos;Element[]&apos;." source="TS2322" />
+</file>
+<file name="assets/js/blocks/filter-wrapper/index.tsx">
+<error line="8" column="25" severity="error" message="Module &apos;&quot;@wordpress/block-editor&quot;&apos; has no exported member &apos;useInnerBlocksProps&apos;." source="TS2305" />
+<error line="47" column="34" severity="error" message="Parameter &apos;instance&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="112" column="20" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;Attributes&gt;, settings?: Partial&lt;BlockConfiguration&lt;Attributes&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; version: string; title: string; category: string; keywords: string[]; attributes: { filterType: { type: string; }; heading: { type: string; }; }; textdomain: string; apiVersion: number; $schema: string; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;Attributes&gt;&apos;.
+      Type &apos;{ name: string; version: string; title: string; category: string; keywords: string[]; attributes: { filterType: { type: string; }; heading: { type: string; }; }; textdomain: string; apiVersion: number; $schema: string; }&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;Attributes&gt;, &quot;icon&quot;&gt;&gt;&apos;.
+        The types of &apos;attributes.heading&apos; are incompatible between these types.
+          Type &apos;{ type: string; }&apos; is not assignable to type &apos;BlockAttribute&lt;string&gt;&apos;.
+            Type &apos;{ type: string; }&apos; is missing the following properties from type &apos;Query&lt;string&gt;&apos;: source, selector, query
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;Attributes&gt;): Block&lt;Attributes&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; version: string; title: string; category: string; keywords: string[]; attributes: { filterType: { type: string; }; heading: { type: string; }; }; textdomain: string; apiVersion: number; $schema: string; }&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2769" />
+<error line="136" column="16" severity="error" message="Parameter &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="160" column="16" severity="error" message="Parameter &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="185" column="16" severity="error" message="Parameter &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="210" column="16" severity="error" message="Parameter &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="236" column="17" severity="error" message="Parameter &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="262" column="18" severity="error" message="Property &apos;idBase&apos; does not exist on type &apos;Attributes&apos;." source="TS2339" />
+<error line="262" column="26" severity="error" message="Property &apos;instance&apos; does not exist on type &apos;Attributes&apos;." source="TS2339" />
+<error line="264" column="20" severity="error" message="Property &apos;idBase&apos; does not exist on type &apos;Attributes&apos;." source="TS2339" />
+<error line="264" column="28" severity="error" message="Property &apos;instance&apos; does not exist on type &apos;Attributes&apos;." source="TS2339" />
 </file>
 <file name="assets/js/blocks/handpicked-products/block.tsx">
 <error line="4" column="30" severity="error" message="Could not find a declaration file for module &apos;@wordpress/server-side-render&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@wordpress/server-side-render/build/index.js&apos; implicitly has an &apos;any&apos; type.
@@ -2960,16 +3377,16 @@
           Property &apos;className&apos; is missing in type &apos;{ children?: ReactNode; }&apos; but required in type &apos;MiniCartShoppingButtonBlockProps&apos;." source="TS2322" />
 </file>
 <file name="assets/js/blocks/mini-cart/block.tsx">
-<error line="101" column="6" severity="error" message="Type &apos;({ children, }: MiniCartContentsBlockProps) =&gt; JSX.Element&apos; is not assignable to type &apos;FunctionComponent&lt;{}&gt;&apos;.
+<error line="106" column="6" severity="error" message="Type &apos;({ children, }: MiniCartContentsBlockProps) =&gt; JSX.Element&apos; is not assignable to type &apos;FunctionComponent&lt;{}&gt;&apos;.
   Types of parameters &apos;__0&apos; and &apos;props&apos; are incompatible.
     Type &apos;{ children?: ReactNode; }&apos; is not assignable to type &apos;MiniCartContentsBlockProps&apos;.
       Types of property &apos;children&apos; are incompatible.
         Type &apos;ReactNode&apos; is not assignable to type &apos;Element | Element[]&apos;." source="TS2322" />
 </file>
 <file name="assets/js/blocks/mini-cart/component-frontend.tsx">
-<error line="30" column="3" severity="error" message="Type &apos;({ isInitiallyOpen, colorClassNames, style, contents, addToCartBehaviour, }: Props) =&gt; JSX.Element&apos; is not assignable to type &apos;BlockType&lt;Record&lt;string, unknown&gt;, Record&lt;string, unknown&gt;&gt;&apos;.
-  Types of parameters &apos;__0&apos; and &apos;props&apos; are incompatible.
-    Type &apos;BlockProps&lt;Record&lt;string, unknown&gt;, Record&lt;string, unknown&gt;&gt;&apos; is missing the following properties from type &apos;Props&apos;: contents, addToCartBehaviour" source="TS2322" />
+<error line="30" column="3" severity="error" message="Type &apos;(attributes: Props) =&gt; JSX.Element&apos; is not assignable to type &apos;BlockType&lt;Record&lt;string, unknown&gt;, Record&lt;string, unknown&gt;&gt;&apos;.
+  Types of parameters &apos;attributes&apos; and &apos;props&apos; are incompatible.
+    Type &apos;BlockProps&lt;Record&lt;string, unknown&gt;, Record&lt;string, unknown&gt;&gt;&apos; is missing the following properties from type &apos;Props&apos;: contents, addToCartBehaviour, hasHiddenPrice" source="TS2322" />
 </file>
 <file name="assets/js/blocks/mini-cart/frontend.ts">
 <error line="5" column="27" severity="error" message="Cannot find module &apos;@woocommerce/base-utils/preload-script&apos; or its corresponding type declarations." source="TS2307" />
@@ -2977,14 +3394,18 @@
 <error line="7" column="46" severity="error" message="Cannot find module &apos;@woocommerce/base-utils/legacy-events&apos; or its corresponding type declarations." source="TS2307" />
 </file>
 <file name="assets/js/blocks/mini-cart/index.tsx">
-<error line="36" column="3" severity="error" message="Type &apos;{ html: false; multiple: false; color: true; typography: { __experimentalFontFamily?: true; fontSize: true; }; }&apos; is not assignable to type &apos;BlockSupports&apos;.
-  Object literal may only specify known properties, and &apos;color&apos; does not exist in type &apos;BlockSupports&apos;." source="TS2322" />
-<error line="61" column="2" severity="error" message="Type &apos;({ attributes, setAttributes }: Props) =&gt; ReactElement&apos; is not assignable to type &apos;ComponentType&lt;BlockEditProps&lt;{}&gt;&gt; | undefined&apos;.
+<error line="36" column="3" severity="error" message="Type &apos;true&apos; has no properties in common with type &apos;Partial&lt;ColorProps&gt;&apos;." source="TS2559" />
+<error line="66" column="2" severity="error" message="Type &apos;({ attributes, setAttributes }: Props) =&gt; ReactElement&apos; is not assignable to type &apos;ComponentType&lt;BlockEditProps&lt;{}&gt;&gt; | undefined&apos;.
   Type &apos;({ attributes, setAttributes }: Props) =&gt; ReactElement&apos; is not assignable to type &apos;FunctionComponent&lt;BlockEditProps&lt;{}&gt;&gt;&apos;.
     Types of parameters &apos;__0&apos; and &apos;props&apos; are incompatible.
       Type &apos;PropsWithChildren&lt;BlockEditProps&lt;{}&gt;&gt;&apos; is not assignable to type &apos;Props&apos;.
         Types of property &apos;attributes&apos; are incompatible.
-          Property &apos;addToCartBehaviour&apos; is missing in type &apos;Readonly&lt;{}&gt;&apos; but required in type &apos;Attributes&apos;." source="TS2322" />
+          Type &apos;Readonly&lt;{}&gt;&apos; is missing the following properties from type &apos;Attributes&apos;: addToCartBehaviour, hasHiddenPrice" source="TS2322" />
+</file>
+<file name="assets/js/blocks/mini-cart/mini-cart-contents/edit.tsx">
+<error line="104" column="11" severity="error" message="Property &apos;selectorText&apos; does not exist on type &apos;CSSRule&apos;." source="TS2339" />
+<error line="105" column="11" severity="error" message="Property &apos;style&apos; does not exist on type &apos;CSSRule&apos;." source="TS2339" />
+<error line="110" column="35" severity="error" message="Property &apos;style&apos; does not exist on type &apos;CSSRule&apos;." source="TS2339" />
 </file>
 <file name="assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/empty-mini-cart-contents-block/index.tsx">
 <error line="14" column="20" severity="error" message="No overload matches this call.
@@ -3033,9 +3454,6 @@
   Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{}&gt;): Block&lt;{}&gt; | undefined&apos;, gave the following error.
     Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: boolean; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; lock: boolean; }; attributes: { ...; }; parent: string[]; textdomain: string; apiVersion: number; }&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2769" />
 </file>
-<file name="assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-products-table-block/edit.tsx">
-<error line="18" column="6" severity="error" message="Property &apos;className&apos; is missing in type &apos;{}&apos; but required in type &apos;MiniCartContentsBlockProps&apos;." source="TS2741" />
-</file>
 <file name="assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-products-table-block/index.tsx">
 <error line="13" column="20" severity="error" message="No overload matches this call.
   Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ lock: unknown; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ lock: unknown; }&gt;&gt; | undefined): Block&lt;{ lock: unknown; }&gt; | undefined&apos;, gave the following error.
@@ -3072,33 +3490,28 @@
   Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{}&gt;): Block&lt;{}&gt; | undefined&apos;, gave the following error.
     Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: boolean; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; }; attributes: { ...; }; parent: string[]; textdomain: string; apiVersion: number; }&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2769" />
 </file>
-<file name="assets/js/blocks/mini-cart/mini-cart-contents/index.tsx">
-<error line="40" column="3" severity="error" message="Type &apos;{ align: false; html: false; multiple: false; reusable: false; inserter: false; color: { link: true; }; lock: false; }&apos; is not assignable to type &apos;BlockSupports&apos;.
-  Object literal may only specify known properties, and &apos;color&apos; does not exist in type &apos;BlockSupports&apos;." source="TS2322" />
-</file>
 <file name="assets/js/blocks/mini-cart/test/block.js">
-<error line="24" column="25" severity="error" message="Parameter &apos;props&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="58" column="25" severity="error" message="Property &apos;invalidateResolutionForStore&apos; does not exist on type &apos;DispatchFromMap&lt;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/data/cart/actions&quot;)&gt;&apos;." source="TS2339" />
-<error line="59" column="38" severity="error" message="Argument of type &apos;Cart&apos; is not assignable to parameter of type &apos;CartResponse&apos;." source="TS2345" />
-<error line="102" column="6" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
-<error line="124" column="6" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="25" column="25" severity="error" message="Parameter &apos;props&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="59" column="25" severity="error" message="Property &apos;invalidateResolutionForStore&apos; does not exist on type &apos;DispatchFromMap&lt;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/data/cart/actions&quot;)&gt;&apos;." source="TS2339" />
+<error line="60" column="38" severity="error" message="Argument of type &apos;Cart&apos; is not assignable to parameter of type &apos;CartResponse&apos;." source="TS2345" />
+<error line="103" column="6" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="125" column="6" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="135" column="42" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="147" column="52" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;Matchers&lt;void, HTMLElement | null&gt;&apos;." source="TS2339" />
 </file>
 <file name="assets/js/blocks/price-filter/edit.tsx">
-<error line="19" column="2" severity="error" message="Module &apos;&quot;@wordpress/components&quot;&apos; has no exported member &apos;__experimentalToggleGroupControl&apos;." source="TS2305" />
-<error line="21" column="2" severity="error" message="Module &apos;&quot;@wordpress/components&quot;&apos; has no exported member &apos;__experimentalToggleGroupControlOption&apos;." source="TS2305" />
+<error line="18" column="2" severity="error" message="Module &apos;&quot;@wordpress/components&quot;&apos; has no exported member &apos;__experimentalToggleGroupControl&apos;." source="TS2305" />
+<error line="20" column="2" severity="error" message="Module &apos;&quot;@wordpress/components&quot;&apos; has no exported member &apos;__experimentalToggleGroupControlOption&apos;." source="TS2305" />
 </file>
 <file name="assets/js/blocks/price-filter/index.tsx">
-<error line="18" column="20" severity="error" message="No overload matches this call.
+<error line="16" column="20" severity="error" message="No overload matches this call.
   Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;Attributes&gt;, settings?: Partial&lt;BlockConfiguration&lt;Attributes&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
-    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { html: boolean; multiple: boolean; color: { text: boolean; background: boolean; }; }; ... 4 more ...; $schema: string; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;Attributes&gt;&apos;.
-      Type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { html: boolean; multiple: boolean; color: { text: boolean; background: boolean; }; }; ... 4 more ...; $schema: string; }&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;Attributes&gt;, &quot;icon&quot;&gt;&gt;&apos;.
+    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { html: boolean; multiple: boolean; color: { text: boolean; background: boolean; }; inserter: boolean; lock: boolean; }; ... 4 more ...; $schema: string; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;Attributes&gt;&apos;.
+      Type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { html: boolean; multiple: boolean; color: { text: boolean; background: boolean; }; inserter: boolean; lock: boolean; }; ... 4 more ...; $schema: string; }&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;Attributes&gt;, &quot;icon&quot;&gt;&gt;&apos;.
         Types of property &apos;attributes&apos; are incompatible.
-          Property &apos;heading&apos; is missing in type &apos;{ className: { type: string; default: string; }; showInputFields: { type: string; default: boolean; }; showFilterButton: { type: string; default: boolean; }; headingLevel: { type: string; default: number; }; }&apos; but required in type &apos;{ readonly showFilterButton: BlockAttribute&lt;boolean&gt;; readonly showInputFields: BlockAttribute&lt;boolean&gt;; readonly heading: BlockAttribute&lt;string&gt;; readonly headingLevel: BlockAttribute&lt;...&gt;; readonly className?: BlockAttribute&lt;...&gt;; }&apos;.
+          Property &apos;heading&apos; is missing in type &apos;{ className: { type: string; default: string; }; showInputFields: { type: string; default: boolean; }; inlineInput: { type: string; default: boolean; }; showFilterButton: { type: string; default: boolean; }; headingLevel: { ...; }; }&apos; but required in type &apos;{ readonly showFilterButton: BlockAttribute&lt;boolean&gt;; readonly showInputFields: BlockAttribute&lt;boolean&gt;; readonly inlineInput: BlockAttribute&lt;boolean&gt;; readonly heading: BlockAttribute&lt;...&gt;; readonly headingLevel: BlockAttribute&lt;...&gt;; readonly className?: BlockAttribute&lt;...&gt;; }&apos;.
   Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;Attributes&gt;): Block&lt;Attributes&gt; | undefined&apos;, gave the following error.
-    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { html: boolean; multiple: boolean; color: { text: boolean; background: boolean; }; }; ... 4 more ...; $schema: string; }&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2769" />
-<error line="52" column="18" severity="error" message="Property &apos;idBase&apos; does not exist on type &apos;Attributes&apos;." source="TS2339" />
-<error line="52" column="26" severity="error" message="Property &apos;instance&apos; does not exist on type &apos;Attributes&apos;." source="TS2339" />
-<error line="54" column="20" severity="error" message="Property &apos;instance&apos; does not exist on type &apos;Attributes&apos;." source="TS2339" />
+    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { html: boolean; multiple: boolean; color: { text: boolean; background: boolean; }; inserter: boolean; lock: boolean; }; ... 4 more ...; $schema: string; }&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2769" />
 </file>
 <file name="assets/js/blocks/price-filter/test/use-price-constraints.js">
 <error line="16" column="28" severity="error" message="Binding element &apos;price&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
@@ -3138,19 +3551,32 @@
 <error line="46" column="53" severity="error" message="Property &apos;isHierarchical&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
 <error line="64" column="20" severity="error" message="Parameter &apos;value&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
 </file>
-<file name="assets/js/blocks/product-categories/index.js">
-<error line="16" column="1" severity="error" message="No overload matches this call.
+<file name="assets/js/blocks/product-categories/edit.tsx">
+<error line="17" column="5" severity="error" message="Type &apos;unknown&apos; is not assignable to type &apos;IntrinsicAttributes &amp; Pick&lt;{ attributes: Object; setAttributes: (arg0: any) =&gt; any; name: string; }, &quot;name&quot; | &quot;attributes&quot; | &quot;setAttributes&quot;&gt; &amp; Pick&lt;...&gt; &amp; Pick&lt;...&gt;&apos;.
+  Type &apos;unknown&apos; is not assignable to type &apos;IntrinsicAttributes&apos;." source="TS2322" />
+<error line="17" column="16" severity="error" message="Spread types may only be created from object types." source="TS2698" />
+</file>
+<file name="assets/js/blocks/product-categories/index.tsx">
+<error line="15" column="20" severity="error" message="No overload matches this call.
   Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ align: unknown; hasCount: unknown; hasImage: unknown; hasEmpty: unknown; isDropdown: unknown; isHierarchical: unknown; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ align: unknown; hasCount: unknown; hasImage: unknown; hasEmpty: unknown; isDropdown: unknown; isHierarchical: unknown; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
-    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ align: unknown; hasCount: unknown; hasImage: unknown; hasEmpty: unknown; isDropdown: unknown; isHierarchical: unknown; }&gt;&apos;.
-      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ align: unknown; hasCount: unknown; hasImage: unknown; hasEmpty: unknown; isDropdown: unknown; isHierarchical: unknown; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
-  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ align: unknown; hasCount: unknown; hasImage: unknown; hasEmpty: unknown; isDropdown: unknown; isHierarchical: unknown; }&gt;): Block&lt;{ align: unknown; hasCount: unknown; hasImage: unknown; hasEmpty: unknown; isDropdown: unknown; isHierarchical: unknown; }&gt; | undefined&apos;, gave the following error.
-    Type &apos;(attributes: Record&lt;string, any&gt;) =&gt; Record&lt;string, any&gt;&apos; is not assignable to type &apos;(attributes: Record&lt;string, any&gt;, innerBlocks: BlockInstance&lt;{ [k: string]: any; }&gt;[]) =&gt; { align: unknown; hasCount: unknown; hasImage: unknown; hasEmpty: unknown; isDropdown: unknown; isHierarchical: unknown; } | [...]&apos;.
-      Type &apos;Record&lt;string, any&gt;&apos; is not assignable to type &apos;{ align: unknown; hasCount: unknown; hasImage: unknown; hasEmpty: unknown; isDropdown: unknown; isHierarchical: unknown; } | [{ align: unknown; hasCount: unknown; hasImage: unknown; hasEmpty: unknown; isDropdown: unknown; isHierarchical: unknown; }, BlockInstance&lt;{ [k: string]: any; }&gt;[]]&apos;.
-        Type &apos;Record&lt;string, any&gt;&apos; is not assignable to type &apos;[{ align: unknown; hasCount: unknown; hasImage: unknown; hasEmpty: unknown; isDropdown: unknown; isHierarchical: unknown; }, BlockInstance&lt;{ [k: string]: any; }&gt;[]]&apos;." source="TS2769" />
-<error line="108" column="18" severity="error" message="Property &apos;idBase&apos; does not exist on type &apos;{ align: unknown; hasCount: unknown; hasImage: unknown; hasEmpty: unknown; isDropdown: unknown; isHierarchical: unknown; }&apos;." source="TS2339" />
-<error line="108" column="26" severity="error" message="Property &apos;instance&apos; does not exist on type &apos;{ align: unknown; hasCount: unknown; hasImage: unknown; hasEmpty: unknown; isDropdown: unknown; isHierarchical: unknown; }&apos;." source="TS2339" />
-<error line="111" column="20" severity="error" message="Property &apos;instance&apos; does not exist on type &apos;{ align: unknown; hasCount: unknown; hasImage: unknown; hasEmpty: unknown; isDropdown: unknown; isHierarchical: unknown; }&apos;." source="TS2339" />
-<error line="206" column="11" severity="error" message="Type &apos;{ constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; }&apos; is missing the following properties from type &apos;Pick&lt;{ attributes: Object; setAttributes: (arg0: any) =&gt; any; name: string; }, &quot;name&quot; | &quot;attributes&quot; | &quot;setAttributes&quot;&gt;&apos;: name, attributes, setAttributes" source="TS2739" />
+    Argument of type &apos;{ name: string; title: string; category: string; description: string; keywords: string[]; supports: { align: string[]; html: boolean; color: { background: boolean; link: boolean; }; typography: { fontSize: boolean; lineHeight: boolean; }; }; ... 4 more ...; $schema: string; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ align: unknown; hasCount: unknown; hasImage: unknown; hasEmpty: unknown; isDropdown: unknown; isHierarchical: unknown; }&gt;&apos;.
+      Type &apos;{ name: string; title: string; category: string; description: string; keywords: string[]; supports: { align: string[]; html: boolean; color: { background: boolean; link: boolean; }; typography: { fontSize: boolean; lineHeight: boolean; }; }; ... 4 more ...; $schema: string; }&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;{ align: unknown; hasCount: unknown; hasImage: unknown; hasEmpty: unknown; isDropdown: unknown; isHierarchical: unknown; }&gt;, &quot;icon&quot;&gt;&gt;&apos;.
+        The types of &apos;attributes[&quot;align&quot;]&apos; are incompatible between these types.
+          Type &apos;{ type: string; }&apos; is not assignable to type &apos;BlockAttribute&lt;unknown&gt;&apos;.
+            Type &apos;{ type: string; }&apos; is missing the following properties from type &apos;Query&lt;unknown&gt;&apos;: source, selector, query
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{}&gt;): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; title: string; category: string; description: string; keywords: string[]; supports: { align: string[]; html: boolean; color: { background: boolean; link: boolean; }; typography: { fontSize: boolean; lineHeight: boolean; }; }; ... 4 more ...; $schema: string; }&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2769" />
+<error line="30" column="18" severity="error" message="Property &apos;idBase&apos; does not exist on type &apos;{ align: unknown; hasCount: unknown; hasImage: unknown; hasEmpty: unknown; isDropdown: unknown; isHierarchical: unknown; }&apos;." source="TS2339" />
+<error line="30" column="26" severity="error" message="Property &apos;instance&apos; does not exist on type &apos;{ align: unknown; hasCount: unknown; hasImage: unknown; hasEmpty: unknown; isDropdown: unknown; isHierarchical: unknown; }&apos;." source="TS2339" />
+<error line="33" column="20" severity="error" message="Property &apos;instance&apos; does not exist on type &apos;{ align: unknown; hasCount: unknown; hasImage: unknown; hasEmpty: unknown; isDropdown: unknown; isHierarchical: unknown; }&apos;." source="TS2339" />
+<error line="85" column="6" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;&quot;data-has-count&quot;&apos; can&apos;t be used to index type &apos;{}&apos;.
+  Property &apos;data-has-count&apos; does not exist on type &apos;{}&apos;." source="TS7053" />
+<error line="88" column="6" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;&quot;data-has-empty&quot;&apos; can&apos;t be used to index type &apos;{}&apos;.
+  Property &apos;data-has-empty&apos; does not exist on type &apos;{}&apos;." source="TS7053" />
+<error line="91" column="6" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;&quot;data-is-dropdown&quot;&apos; can&apos;t be used to index type &apos;{}&apos;.
+  Property &apos;data-is-dropdown&apos; does not exist on type &apos;{}&apos;." source="TS7053" />
+<error line="94" column="6" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;&quot;data-is-hierarchical&quot;&apos; can&apos;t be used to index type &apos;{}&apos;.
+  Property &apos;data-is-hierarchical&apos; does not exist on type &apos;{}&apos;." source="TS7053" />
 </file>
 <file name="assets/js/blocks/product-category/block.tsx">
 <error line="5" column="30" severity="error" message="Could not find a declaration file for module &apos;@wordpress/server-side-render&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@wordpress/server-side-render/build/index.js&apos; implicitly has an &apos;any&apos; type.
@@ -3203,28 +3629,45 @@
       Types of property &apos;columns&apos; are incompatible.
         Type &apos;{ type: string; default: any; }&apos; is not assignable to type &apos;BlockAttribute&lt;unknown&gt;&apos;." source="TS2769" />
 </file>
+<file name="assets/js/blocks/product-query/constants.ts">
+<error line="71" column="4" severity="error" message="Type &apos;[string]&apos; is not assignable to type &apos;InnerBlockTemplate&apos;.
+  Source has 1 element(s) but target requires 3." source="TS2322" />
+<error line="82" column="2" severity="error" message="Type &apos;[string]&apos; is not assignable to type &apos;InnerBlockTemplate&apos;." source="TS2322" />
+<error line="83" column="2" severity="error" message="Type &apos;[string]&apos; is not assignable to type &apos;InnerBlockTemplate&apos;." source="TS2322" />
+</file>
+<file name="assets/js/blocks/product-query/utils.tsx">
+<error line="5" column="10" severity="error" message="Module &apos;&quot;@wordpress/blocks&quot;&apos; has no exported member &apos;store&apos;." source="TS2305" />
+<error line="74" column="30" severity="error" message="Property &apos;getActiveBlockVariation&apos; does not exist on type &apos;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__rich-text/store/selectors&quot;)&apos;." source="TS2339" />
+</file>
+<file name="assets/js/blocks/product-query/inspector-controls.tsx">
+<error line="14" column="2" severity="error" message="Module &apos;&quot;@wordpress/components&quot;&apos; has no exported member &apos;__experimentalToolsPanel&apos;." source="TS2305" />
+<error line="16" column="2" severity="error" message="Module &apos;&quot;@wordpress/components&quot;&apos; has no exported member &apos;__experimentalToolsPanelItem&apos;." source="TS2305" />
+<error line="51" column="6" severity="error" message="Property &apos;getBlockVariations&apos; does not exist on type &apos;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__blocks/store/selectors&quot;)&apos;." source="TS2339" />
+<error line="118" column="6" severity="error" message="Type &apos;{ label: string; onChange: (statusLabels: readonly Value[]) =&gt; void; suggestions: string[]; validateInput: (value: string) =&gt; boolean; value: string[]; __experimentalExpandOnFocus: boolean; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; Props &amp; { children?: ReactNode; }&apos;.
+  Property &apos;label&apos; does not exist on type &apos;IntrinsicAttributes &amp; Props &amp; { children?: ReactNode; }&apos;." source="TS2322" />
+</file>
 <file name="assets/js/blocks/product-search/block.js">
 <error line="38" column="37" severity="error" message="Type &apos;unknown&apos; is not assignable to type &apos;string | undefined&apos;." source="TS2322" />
 <error line="61" column="7" severity="error" message="Type &apos;{ children: Element; type: &quot;submit&quot;; className: string; label: string; }&apos; is not assignable to type &apos;DetailedHTMLProps&lt;ButtonHTMLAttributes&lt;HTMLButtonElement&gt;, HTMLButtonElement&gt;&apos;.
   Property &apos;label&apos; does not exist on type &apos;DetailedHTMLProps&lt;ButtonHTMLAttributes&lt;HTMLButtonElement&gt;, HTMLButtonElement&gt;&apos;." source="TS2322" />
 </file>
 <file name="assets/js/blocks/product-search/edit.js">
-<error line="120" column="7" severity="error" message="Type &apos;string&apos; is not assignable to type &apos;number&apos;." source="TS2322" />
-<error line="160" column="32" severity="error" message="Argument of type &apos;{ ({ attributes: { label, placeholder, formId, className, hasLabel, align }, instanceId, setAttributes, }: {    attributes: {        label: string;        placeholder: string;        formId: string;        className: string;        hasLabel: boolean;        align: string;    };    instanceId: string;    setAttribute...&apos; is not assignable to parameter of type &apos;ComponentType&lt;{ attributes: { label: string; placeholder: string; formId: string; className: string; hasLabel: boolean; align: string; }; instanceId: string; setAttributes: (arg0: any) =&gt; any; }&gt;&apos;.
+<error line="109" column="7" severity="error" message="Type &apos;string&apos; is not assignable to type &apos;number&apos;." source="TS2322" />
+<error line="149" column="32" severity="error" message="Argument of type &apos;{ ({ attributes: { label, placeholder, formId, className, hasLabel, align }, instanceId, setAttributes, }: {    attributes: {        label: string;        placeholder: string;        formId: string;        className: string;        hasLabel: boolean;        align: string;    };    instanceId: string;    setAttribute...&apos; is not assignable to parameter of type &apos;ComponentType&lt;{ attributes: { label: string; placeholder: string; formId: string; className: string; hasLabel: boolean; align: string; }; instanceId: string; setAttributes: (arg0: any) =&gt; any; }&gt;&apos;.
   Type &apos;{ ({ attributes: { label, placeholder, formId, className, hasLabel, align }, instanceId, setAttributes, }: {    attributes: {        label: string;        placeholder: string;        formId: string;        className: string;        hasLabel: boolean;        align: string;    };    instanceId: string;    setAttribute...&apos; is not assignable to type &apos;FunctionComponent&lt;{ attributes: { label: string; placeholder: string; formId: string; className: string; hasLabel: boolean; align: string; }; instanceId: string; setAttributes: (arg0: any) =&gt; any; }&gt;&apos;.
     The types of &apos;propTypes.attributes&apos; are incompatible between these types.
       Type &apos;Validator&lt;object&gt;&apos; is not assignable to type &apos;Validator&lt;{ label: string; placeholder: string; formId: string; className: string; hasLabel: boolean; align: string; }&gt;&apos;.
         Type &apos;{}&apos; is missing the following properties from type &apos;{ label: string; placeholder: string; formId: string; className: string; hasLabel: boolean; align: string; }&apos;: label, placeholder, formId, className, and 2 more." source="TS2345" />
 </file>
-<file name="assets/js/blocks/product-search/index.js">
-<error line="49" column="20" severity="error" message="No overload matches this call.
+<file name="assets/js/blocks/product-search/index.tsx">
+<error line="118" column="20" severity="error" message="No overload matches this call.
   Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ hasLabel: unknown; label: unknown; placeholder: unknown; formId: unknown; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ hasLabel: unknown; label: unknown; placeholder: unknown; formId: unknown; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
     Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ hasLabel: unknown; label: unknown; placeholder: unknown; formId: unknown; }&gt;&apos;.
       Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ hasLabel: unknown; label: unknown; placeholder: unknown; formId: unknown; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;." source="TS2769" />
-<error line="80" column="18" severity="error" message="Property &apos;idBase&apos; does not exist on type &apos;{ hasLabel: unknown; label: unknown; placeholder: unknown; formId: unknown; }&apos;." source="TS2339" />
-<error line="80" column="26" severity="error" message="Property &apos;instance&apos; does not exist on type &apos;{ hasLabel: unknown; label: unknown; placeholder: unknown; formId: unknown; }&apos;." source="TS2339" />
-<error line="82" column="20" severity="error" message="Property &apos;instance&apos; does not exist on type &apos;{ hasLabel: unknown; label: unknown; placeholder: unknown; formId: unknown; }&apos;." source="TS2339" />
-<error line="98" column="8" severity="error" message="Type &apos;{ attributes: Readonly&lt;Record&lt;string, any&gt;&gt;; children?: ReactNode; }&apos; is not assignable to type &apos;Pick&lt;{ attributes: { label: string; placeholder: string; formId: string; className: string; hasLabel: boolean; align: string; }; }, &quot;attributes&quot;&gt;&apos;.
+<error line="150" column="18" severity="error" message="Property &apos;idBase&apos; does not exist on type &apos;{ hasLabel: unknown; label: unknown; placeholder: unknown; formId: unknown; }&apos;." source="TS2339" />
+<error line="150" column="26" severity="error" message="Property &apos;instance&apos; does not exist on type &apos;{ hasLabel: unknown; label: unknown; placeholder: unknown; formId: unknown; }&apos;." source="TS2339" />
+<error line="152" column="20" severity="error" message="Property &apos;instance&apos; does not exist on type &apos;{ hasLabel: unknown; label: unknown; placeholder: unknown; formId: unknown; }&apos;." source="TS2339" />
+<error line="167" column="8" severity="error" message="Type &apos;{ attributes: Readonly&lt;Record&lt;string, any&gt;&gt;; children?: ReactNode; }&apos; is not assignable to type &apos;Pick&lt;{ attributes: { label: string; placeholder: string; formId: string; className: string; hasLabel: boolean; align: string; }; }, &quot;attributes&quot;&gt;&apos;.
   Types of property &apos;attributes&apos; are incompatible.
     Type &apos;Readonly&lt;Record&lt;string, any&gt;&gt;&apos; is missing the following properties from type &apos;{ label: string; placeholder: string; formId: string; className: string; hasLabel: boolean; align: string; }&apos;: label, placeholder, formId, className, and 2 more." source="TS2322" />
 </file>
@@ -3304,8 +3747,11 @@
 <error line="6" column="52" severity="error" message="Parameter &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
 </file>
 <file name="assets/js/blocks/products/all-products/block.js">
-<error line="48" column="6" severity="error" message="Type &apos;{ attributes: any; urlParameterSuffix: any; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; Pick&lt;ProductListContainerProps, &quot;attributes&quot;&gt; &amp; Pick&lt;InferProps&lt;{ attributes: Validator&lt;object&gt;; hideOutOfStockItems: Requireable&lt;...&gt;; }&gt;, &quot;hideOutOfStockItems&quot;&gt; &amp; Pick&lt;...&gt;&apos;.
+<error line="43" column="6" severity="error" message="Type &apos;{ attributes: any; urlParameterSuffix: any; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; Pick&lt;ProductListContainerProps, &quot;attributes&quot;&gt; &amp; Pick&lt;InferProps&lt;{ attributes: Validator&lt;object&gt;; hideOutOfStockItems: Requireable&lt;...&gt;; }&gt;, &quot;hideOutOfStockItems&quot;&gt; &amp; Pick&lt;...&gt;&apos;.
   Property &apos;urlParameterSuffix&apos; does not exist on type &apos;IntrinsicAttributes &amp; Pick&lt;ProductListContainerProps, &quot;attributes&quot;&gt; &amp; Pick&lt;InferProps&lt;{ attributes: Validator&lt;object&gt;; hideOutOfStockItems: Requireable&lt;...&gt;; }&gt;, &quot;hideOutOfStockItems&quot;&gt; &amp; Pick&lt;...&gt;&apos;." source="TS2322" />
+</file>
+<file name="assets/js/blocks/products/all-products/deprecated.js">
+<error line="18" column="10" severity="error" message="Binding element &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
 </file>
 <file name="assets/js/blocks/products/all-products/edit.js">
 <error line="183" column="10" severity="error" message="Variable &apos;newBlocks&apos; implicitly has type &apos;any[]&apos; in some locations where its type cannot be determined." source="TS7034" />
@@ -3313,29 +3759,34 @@
   Type &apos;{ imageSizing: string; }&apos; is not assignable to type &apos;string&apos;." source="TS2345" />
 <error line="188" column="40" severity="error" message="Variable &apos;newBlocks&apos; implicitly has an &apos;any[]&apos; type." source="TS7005" />
 <error line="199" column="20" severity="error" message="Property &apos;renderAppender&apos; does not exist on type &apos;{ template: any; templateLock: boolean; allowedBlocks: string[]; }&apos;." source="TS2339" />
-<error line="223" column="11" severity="error" message="Type &apos;{ id: number; name: string; variation: string; permalink: string; sku: string; short_description: string; description: string; price: string; price_html: string; images: { id: number; src: string; thumbnail: string; name: string; alt: string; srcset: string; sizes: string; }[]; ... 8 more ...; on_sale: boolean; }&apos; is not assignable to type &apos;null | undefined&apos;." source="TS2322" />
+<error line="222" column="11" severity="error" message="Property &apos;isLoading&apos; is missing in type &apos;{ children: Element; product: { id: number; name: string; variation: string; permalink: string; sku: string; short_description: string; description: string; price: string; price_html: string; ... 9 more ...; on_sale: boolean; }; }&apos; but required in type &apos;{ product: any; children: Object; isLoading: boolean; }&apos;." source="TS2741" />
 <error line="225" column="12" severity="error" message="Type &apos;{ template: any; templateLock: boolean; allowedBlocks: string[]; }&apos; is not assignable to type &apos;Props&apos;.
   Types of property &apos;templateLock&apos; are incompatible.
     Type &apos;boolean&apos; is not assignable to type &apos;EditorTemplateLock | undefined&apos;." source="TS2322" />
 </file>
 <file name="assets/js/blocks/products/all-products/frontend.js">
-<error line="19" column="25" severity="error" message="Type &apos;{ children: Element; context: string; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; Pick&lt;{ children: Element; }, &quot;children&quot;&gt; &amp; Pick&lt;InferProps&lt;{ children: Requireable&lt;ReactNodeLike&gt;; }&gt;, never&gt; &amp; Pick&lt;...&gt;&apos;.
-  Property &apos;context&apos; does not exist on type &apos;IntrinsicAttributes &amp; Pick&lt;{ children: Element; }, &quot;children&quot;&gt; &amp; Pick&lt;InferProps&lt;{ children: Requireable&lt;ReactNodeLike&gt;; }&gt;, never&gt; &amp; Pick&lt;...&gt;&apos;." source="TS2322" />
-<error line="25" column="20" severity="error" message="Parameter &apos;el&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="20" column="20" severity="error" message="Parameter &apos;el&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+</file>
+<file name="assets/js/blocks/products/all-products/save.js">
+<error line="11" column="33" severity="error" message="Binding element &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="16" column="4" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;{}&apos;.
+  No index signature with a parameter of type &apos;string&apos; was found on type &apos;{}&apos;." source="TS7053" />
 </file>
 <file name="assets/js/blocks/products/all-products/index.js">
-<error line="54" column="10" severity="error" message="Binding element &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="59" column="5" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;{}&apos;.
-  No index signature with a parameter of type &apos;string&apos; was found on type &apos;{}&apos;." source="TS7053" />
-<error line="81" column="1" severity="error" message="No overload matches this call.
-  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ columns: unknown; rows: unknown; alignButtons: unknown; contentVisibility: unknown; orderby: unknown; layoutConfig: unknown; isPreview: unknown; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ columns: unknown; rows: unknown; alignButtons: unknown; contentVisibility: unknown; orderby: unknown; layoutConfig: unknown; isPreview: unknown; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
-    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ columns: unknown; rows: unknown; alignButtons: unknown; contentVisibility: unknown; orderby: unknown; layoutConfig: unknown; isPreview: unknown; }&gt;&apos;.
-      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ columns: unknown; rows: unknown; alignButtons: unknown; contentVisibility: unknown; orderby: unknown; layoutConfig: unknown; isPreview: unknown; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
-  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ columns: unknown; rows: unknown; alignButtons: unknown; contentVisibility: unknown; orderby: unknown; layoutConfig: unknown; isPreview: unknown; }&gt;): Block&lt;{ columns: unknown; rows: unknown; ... 4 more ...; isPreview: unknown; }&gt; | undefined&apos;, gave the following error.
-    Type &apos;{ columns: { type: string; }; rows: { type: string; }; alignButtons: { type: string; }; contentVisibility: { type: string; }; orderby: { type: string; }; layoutConfig: { type: string; }; isPreview: { type: string; default: boolean; }; } &amp; { ...; }&apos; is not assignable to type &apos;{ readonly [x: string]: BlockAttribute&lt;any&gt;; }&apos;.
-      Property &apos;columns&apos; is incompatible with index signature.
-        Type &apos;{ type: string; }&apos; is not assignable to type &apos;BlockAttribute&lt;any&gt;&apos;.
-          Type &apos;{ type: string; }&apos; is missing the following properties from type &apos;Query&lt;any&gt;&apos;: source, selector, query" source="TS2769" />
+<error line="36" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{}&gt;, settings?: Partial&lt;BlockConfiguration&lt;{}&gt;&gt; | undefined): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{}&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{}&gt;): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: any; save: ({ attributes }: { attributes: any; }) =&gt; JSX.Element; deprecated: { attributes: { columns: { type: string; }; rows: { type: string; }; alignButtons: { type: string; }; contentVisibility: { ...; }; orderby: { ...; }; layoutConfig: { ...; }; isPreview: { ...; }; } &amp; { ....&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{}&gt;&apos;.
+      Type &apos;{ icon: { src: JSX.Element; }; edit: any; save: ({ attributes }: { attributes: any; }) =&gt; JSX.Element; deprecated: { attributes: { columns: { type: string; }; rows: { type: string; }; alignButtons: { type: string; }; contentVisibility: { ...; }; orderby: { ...; }; layoutConfig: { ...; }; isPreview: { ...; }; } &amp; { ....&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;{}&gt;, &quot;icon&quot;&gt;&gt;&apos;.
+        Types of property &apos;deprecated&apos; are incompatible.
+          Type &apos;{ attributes: { columns: { type: string; }; rows: { type: string; }; alignButtons: { type: string; }; contentVisibility: { type: string; }; orderby: { type: string; }; layoutConfig: { type: string; }; isPreview: { ...; }; } &amp; { ...; }; save({ attributes }: { ...; }): Element; }[]&apos; is not assignable to type &apos;readonly BlockDeprecation&lt;{}, Record&lt;string, any&gt;&gt;[]&apos;.
+            Type &apos;{ attributes: { columns: { type: string; }; rows: { type: string; }; alignButtons: { type: string; }; contentVisibility: { type: string; }; orderby: { type: string; }; layoutConfig: { type: string; }; isPreview: { ...; }; } &amp; { ...; }; save({ attributes }: { ...; }): Element; }&apos; is not assignable to type &apos;BlockDeprecation&lt;{}, Record&lt;string, any&gt;&gt;&apos;.
+              Types of property &apos;attributes&apos; are incompatible.
+                Type &apos;{ columns: { type: string; }; rows: { type: string; }; alignButtons: { type: string; }; contentVisibility: { type: string; }; orderby: { type: string; }; layoutConfig: { type: string; }; isPreview: { type: string; default: boolean; }; } &amp; { ...; }&apos; is not assignable to type &apos;{ readonly [x: string]: BlockAttribute&lt;any&gt;; }&apos;.
+                  Property &apos;&quot;columns&quot;&apos; is incompatible with index signature.
+                    Type &apos;{ type: string; }&apos; is not assignable to type &apos;BlockAttribute&lt;any&gt;&apos;.
+                      Type &apos;{ type: string; }&apos; is missing the following properties from type &apos;Query&lt;any&gt;&apos;: source, selector, query" source="TS2769" />
 </file>
 <file name="assets/js/blocks/products-by-attribute/block.tsx">
 <error line="4" column="30" severity="error" message="Could not find a declaration file for module &apos;@wordpress/server-side-render&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@wordpress/server-side-render/build/index.js&apos; implicitly has an &apos;any&apos; type.
@@ -3382,6 +3833,17 @@
             Type &apos;{ type: string; default: number; }&apos; is missing the following properties from type &apos;Query&lt;unknown&gt;&apos;: source, selector, query
   Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ columns: unknown; rows: unknown; stockStatus: unknown; attributes: unknown; attrOperator: unknown; contentVisibility: unknown; orderby: unknown; alignButtons: unknown; isPreview: unknown; }&gt;): Block&lt;...&gt; | undefined&apos;, gave the following error.
     Argument of type &apos;{ name: string; title: string; category: string; keywords: string[]; description: string; supports: { align: string[]; html: boolean; }; attributes: { attributes: { type: string; default: never[]; }; attrOperator: { ...; }; ... 6 more ...; stockStatus: { ...; }; }; textdomain: string; apiVersion: number; $schema: st...&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2769" />
+</file>
+<file name="assets/js/blocks/rating-filter/index.tsx">
+<error line="18" column="21" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;Attributes&gt;, settings?: Partial&lt;BlockConfiguration&lt;Attributes&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { html: boolean; multiple: boolean; color: { __experimentalDefaultControls: { text: boolean; }; }; inserter: boolean; lock: boolean; }; ... 4 more ...; $schema: string; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;Attributes&gt;&apos;.
+      Type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { html: boolean; multiple: boolean; color: { __experimentalDefaultControls: { text: boolean; }; }; inserter: boolean; lock: boolean; }; ... 4 more ...; $schema: string; }&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;Attributes&gt;, &quot;icon&quot;&gt;&gt;&apos;.
+        The types of &apos;attributes.className&apos; are incompatible between these types.
+          Type &apos;{ type: string; default: string; }&apos; is not assignable to type &apos;BlockAttribute&lt;string | undefined&gt;&apos;.
+            Type &apos;{ type: string; default: string; }&apos; is missing the following properties from type &apos;Query&lt;string | undefined&gt;&apos;: source, selector, query
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;Attributes&gt;): Block&lt;Attributes&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { html: boolean; multiple: boolean; color: { __experimentalDefaultControls: { text: boolean; }; }; inserter: boolean; lock: boolean; }; ... 4 more ...; $schema: string; }&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2769" />
 </file>
 <file name="assets/js/blocks/reviews/edit-utils.js">
 <error line="15" column="2" severity="error" message="Module &apos;&quot;@wordpress/components&quot;&apos; has no exported member &apos;__experimentalToggleGroupControl&apos;." source="TS2305" />
@@ -3447,10 +3909,14 @@
 <error line="163" column="26" severity="error" message="Type &apos;() =&gt; JSX.Element&apos; is not assignable to type &apos;ReactElementLike&apos;." source="TS2322" />
 </file>
 <file name="assets/js/blocks/reviews/reviews-by-category/index.js">
-<error line="19" column="20" severity="error" message="No overload matches this call.
+<error line="19" column="1" severity="error" message="No overload matches this call.
   Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ categoryIds: unknown; showProductName: unknown; editMode: unknown; imageType: unknown; orderby: unknown; reviewsOnLoadMore: unknown; reviewsOnPageLoad: unknown; showLoadMore: unknown; showOrderby: unknown; showReviewDate: unknown; showReviewerName: unknown; showReviewImage: unknown; showReviewRating: unknown; showReviewContent: unknown; previewReviews: unknown; }&gt;, settings?: Partial&lt;...&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
     Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ categoryIds: unknown; showProductName: unknown; editMode: unknown; imageType: unknown; orderby: unknown; reviewsOnLoadMore: unknown; reviewsOnPageLoad: unknown; showLoadMore: unknown; showOrderby: unknown; showReviewDate: unknown; showReviewerName: unknown; showReviewImage: unknown; showReviewRa...&apos;.
-      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ categoryIds: unknown; showProductName: unknown; editMode: unknown; imageType: unknown; orderby: unknown; reviewsOnLoadMore: unknown; reviewsOnPageLoad: unknown; showLoadMore: unknown; showOrderby: unknown; showReviewDate: unknown; showReviewerName: unknown; showReviewImage: unknown; showReviewRating: un...&apos;." source="TS2769" />
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ categoryIds: unknown; showProductName: unknown; editMode: unknown; imageType: unknown; orderby: unknown; reviewsOnLoadMore: unknown; reviewsOnPageLoad: unknown; showLoadMore: unknown; showOrderby: unknown; showReviewDate: unknown; showReviewerName: unknown; showReviewImage: unknown; showReviewRating: un...&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ categoryIds: unknown; showProductName: unknown; editMode: unknown; imageType: unknown; orderby: unknown; reviewsOnLoadMore: unknown; reviewsOnPageLoad: unknown; showLoadMore: unknown; showOrderby: unknown; showReviewDate: unknown; showReviewerName: unknown; showReviewImage: unknown; showReviewRating: unknown; showReviewContent: unknown; previewReviews: unknown; }&gt;): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Type &apos;{ categoryIds: { type: &quot;array&quot;; default: never[]; }; showProductName: { type: &quot;boolean&quot;; default: true; }; editMode: { type: string; default: boolean; }; imageType: { type: string; default: string; }; orderby: { ...; }; ... 9 more ...; previewReviews: { ...; }; }&apos; is not assignable to type &apos;{ readonly categoryIds: BlockAttribute&lt;unknown&gt;; readonly showProductName: BlockAttribute&lt;unknown&gt;; readonly editMode: BlockAttribute&lt;unknown&gt;; readonly imageType: BlockAttribute&lt;...&gt;; ... 10 more ...; readonly previewReviews: BlockAttribute&lt;...&gt;; }&apos;.
+      Types of property &apos;editMode&apos; are incompatible.
+        Type &apos;{ type: string; default: boolean; }&apos; is not assignable to type &apos;BlockAttribute&lt;unknown&gt;&apos;." source="TS2769" />
 <error line="77" column="11" severity="error" message="Type &apos;{ constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; }&apos; is missing the following properties from type &apos;Omit&lt;{ attributes: Object; debouncedSpeak: (arg0: any) =&gt; any; setAttributes: (arg0: any) =&gt; any; }, &quot;speak&quot; | &quot;debouncedSpeak&quot;&gt;&apos;: attributes, setAttributes" source="TS2739" />
 </file>
 <file name="assets/js/blocks/reviews/reviews-by-product/no-reviews-placeholder.js">
@@ -3475,16 +3941,18 @@
   Type &apos;ComponentClass&lt;{ error: any; getProduct: any; isLoading: any; product: any; }, any&gt;&apos; is missing the following properties from type &apos;ReactElementLike&apos;: type, props, key" source="TS2322" />
 </file>
 <file name="assets/js/blocks/reviews/reviews-by-product/index.js">
-<error line="19" column="20" severity="error" message="No overload matches this call.
+<error line="19" column="1" severity="error" message="No overload matches this call.
   Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ productId: unknown; editMode: unknown; imageType: unknown; orderby: unknown; reviewsOnLoadMore: unknown; reviewsOnPageLoad: unknown; showLoadMore: unknown; showOrderby: unknown; showReviewDate: unknown; showReviewerName: unknown; showReviewImage: unknown; showReviewRating: unknown; showReviewContent: unknown; previewReviews: unknown; }&gt;, settings?: Partial&lt;...&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
     Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ productId: unknown; editMode: unknown; imageType: unknown; orderby: unknown; reviewsOnLoadMore: unknown; reviewsOnPageLoad: unknown; showLoadMore: unknown; showOrderby: unknown; showReviewDate: unknown; showReviewerName: unknown; showReviewImage: unknown; showReviewRating: unknown; showReviewCon...&apos;.
-      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ productId: unknown; editMode: unknown; imageType: unknown; orderby: unknown; reviewsOnLoadMore: unknown; reviewsOnPageLoad: unknown; showLoadMore: unknown; showOrderby: unknown; showReviewDate: unknown; showReviewerName: unknown; showReviewImage: unknown; showReviewRating: unknown; showReviewContent: un...&apos;." source="TS2769" />
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ productId: unknown; editMode: unknown; imageType: unknown; orderby: unknown; reviewsOnLoadMore: unknown; reviewsOnPageLoad: unknown; showLoadMore: unknown; showOrderby: unknown; showReviewDate: unknown; showReviewerName: unknown; showReviewImage: unknown; showReviewRating: unknown; showReviewContent: un...&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ productId: unknown; editMode: unknown; imageType: unknown; orderby: unknown; reviewsOnLoadMore: unknown; reviewsOnPageLoad: unknown; showLoadMore: unknown; showOrderby: unknown; showReviewDate: unknown; showReviewerName: unknown; showReviewImage: unknown; showReviewRating: unknown; showReviewContent: unknown; previewReviews: unknown; }&gt;): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Type &apos;{ productId: { type: &quot;number&quot;; }; editMode: { type: string; default: boolean; }; imageType: { type: string; default: string; }; orderby: { type: string; default: string; }; reviewsOnLoadMore: { type: string; default: number; }; ... 8 more ...; previewReviews: { ...; }; }&apos; is not assignable to type &apos;{ readonly productId: BlockAttribute&lt;unknown&gt;; readonly editMode: BlockAttribute&lt;unknown&gt;; readonly imageType: BlockAttribute&lt;unknown&gt;; readonly orderby: BlockAttribute&lt;unknown&gt;; ... 9 more ...; readonly previewReviews: BlockAttribute&lt;...&gt;; }&apos;.
+      Types of property &apos;editMode&apos; are incompatible.
+        Type &apos;{ type: string; default: boolean; }&apos; is not assignable to type &apos;BlockAttribute&lt;unknown&gt;&apos;." source="TS2769" />
 <error line="68" column="11" severity="error" message="Type &apos;{ constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; }&apos; is missing the following properties from type &apos;Omit&lt;{ attributes: Object; debouncedSpeak: (arg0: any) =&gt; any; setAttributes: (arg0: any) =&gt; any; }, &quot;speak&quot; | &quot;debouncedSpeak&quot;&gt;&apos;: attributes, setAttributes" source="TS2739" />
 </file>
 <file name="assets/js/blocks/single-product/block.js">
-<error line="34" column="64" severity="error" message="Property &apos;id&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
-<error line="49" column="5" severity="error" message="Type &apos;Object&apos; is not assignable to type &apos;null | undefined&apos;.
-  The &apos;Object&apos; type is assignable to very few other types. Did you mean to use the &apos;any&apos; type instead?" source="TS2322" />
+<error line="31" column="64" severity="error" message="Property &apos;id&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
 </file>
 <file name="assets/js/blocks/single-product/frontend.js">
 <error line="18" column="20" severity="error" message="Parameter &apos;el&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
@@ -3503,8 +3971,6 @@
 <error line="17" column="16" severity="error" message="Parameter &apos;value&apos; implicitly has an &apos;any[]&apos; type." source="TS7006" />
 </file>
 <file name="assets/js/blocks/single-product/edit/layout-editor.js">
-<error line="51" column="5" severity="error" message="Type &apos;Object&apos; is not assignable to type &apos;null | undefined&apos;.
-  The &apos;Object&apos; type is assignable to very few other types. Did you mean to use the &apos;any&apos; type instead?" source="TS2322" />
 <error line="78" column="7" severity="error" message="Type &apos;{}[][]&apos; is not assignable to type &apos;readonly Template[]&apos;.
   Type &apos;{}[]&apos; is not assignable to type &apos;Template&apos;.
     Target requires 1 element(s) but source may have fewer." source="TS2322" />
@@ -3525,14 +3991,14 @@
 <error line="7" column="18" severity="error" message="Binding element &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
 </file>
 <file name="assets/js/blocks/stock-filter/index.tsx">
-<error line="18" column="20" severity="error" message="No overload matches this call.
+<error line="17" column="20" severity="error" message="No overload matches this call.
   Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;Attributes&gt;, settings?: Partial&lt;BlockConfiguration&lt;Attributes&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
-    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { html: boolean; multiple: boolean; }; example: { attributes: { isPreview: boolean; }; }; attributes: { ...; }; textdomain: string; apiVersion: number; $schema: string; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;Attributes&gt;&apos;.
-      Type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { html: boolean; multiple: boolean; }; example: { attributes: { isPreview: boolean; }; }; attributes: { ...; }; textdomain: string; apiVersion: number; $schema: string; }&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;Attributes&gt;, &quot;icon&quot;&gt;&gt;&apos;.
+    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { html: boolean; multiple: boolean; color: { link: boolean; __experimentalDefaultControls: { ...; }; }; inserter: boolean; lock: boolean; }; ... 4 more ...; $schema: string; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;Attributes&gt;&apos;.
+      Type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { html: boolean; multiple: boolean; color: { link: boolean; __experimentalDefaultControls: { ...; }; }; inserter: boolean; lock: boolean; }; ... 4 more ...; $schema: string; }&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;Attributes&gt;, &quot;icon&quot;&gt;&gt;&apos;.
         Types of property &apos;attributes&apos; are incompatible.
           Property &apos;heading&apos; is missing in type &apos;{ className: { type: string; default: string; }; headingLevel: { type: string; default: number; }; showCounts: { type: string; default: boolean; }; showFilterButton: { type: string; default: boolean; }; isPreview: { ...; }; }&apos; but required in type &apos;{ readonly className?: BlockAttribute&lt;string | undefined&gt;; readonly heading: BlockAttribute&lt;string&gt;; readonly headingLevel: BlockAttribute&lt;number&gt;; readonly showCounts: BlockAttribute&lt;...&gt;; readonly showFilterButton: BlockAttribute&lt;...&gt;; readonly isPreview?: BlockAttribute&lt;...&gt;; }&apos;.
   Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;Attributes&gt;): Block&lt;Attributes&gt; | undefined&apos;, gave the following error.
-    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { html: boolean; multiple: boolean; }; example: { attributes: { isPreview: boolean; }; }; attributes: { ...; }; textdomain: string; apiVersion: number; $schema: string; }&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2769" />
+    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { html: boolean; multiple: boolean; color: { link: boolean; __experimentalDefaultControls: { ...; }; }; inserter: boolean; lock: boolean; }; ... 4 more ...; $schema: string; }&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2769" />
 </file>
 <file name="assets/js/blocks/stock-filter/test/block.js">
 <error line="46" column="28" severity="error" message="Parameter &apos;props&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
@@ -3544,15 +4010,18 @@
 <error line="73" column="22" severity="error" message="Property &apos;toHaveWarned&apos; does not exist on type &apos;JestMatchers&lt;Console&gt;&apos;." source="TS2339" />
 </file>
 <file name="assets/js/blocks-registry/payment-methods/test/payment-method-config-helper.ts">
-<error line="123" column="7" severity="error" message="Argument of type &apos;{ cartTotals: { total_items: string; total_items_tax: string; total_fees: string; total_fees_tax: string; total_discount: string; total_discount_tax: string; total_shipping: string; total_shipping_tax: string; ... 9 more ...; currency_suffix: string; }; ... 4 more ...; paymentRequirements: string[]; }&apos; is not assignable to parameter of type &apos;CanMakePaymentArgument&apos;.
-  Property &apos;cart&apos; is missing in type &apos;{ cartTotals: { total_items: string; total_items_tax: string; total_fees: string; total_fees_tax: string; total_discount: string; total_discount_tax: string; total_shipping: string; total_shipping_tax: string; ... 9 more ...; currency_suffix: string; }; ... 4 more ...; paymentRequirements: string[]; }&apos; but required in type &apos;CanMakePaymentArgument&apos;." source="TS2345" />
-<error line="144" column="7" severity="error" message="Argument of type &apos;{ cartTotals: { total_items: string; total_items_tax: string; total_fees: string; total_fees_tax: string; total_discount: string; total_discount_tax: string; total_shipping: string; total_shipping_tax: string; ... 9 more ...; currency_suffix: string; }; ... 4 more ...; paymentRequirements: string[]; }&apos; is not assignable to parameter of type &apos;CanMakePaymentArgument&apos;." source="TS2345" />
-<error line="161" column="8" severity="error" message="Argument of type &apos;{ cartTotals: { total_items: string; total_items_tax: string; total_fees: string; total_fees_tax: string; total_discount: string; total_discount_tax: string; total_shipping: string; total_shipping_tax: string; ... 9 more ...; currency_suffix: string; }; ... 4 more ...; paymentRequirements: string[]; }&apos; is not assignable to parameter of type &apos;CanMakePaymentArgument&apos;." source="TS2345" />
-<error line="171" column="7" severity="error" message="Argument of type &apos;{ cartTotals: { total_items: string; total_items_tax: string; total_fees: string; total_fees_tax: string; total_discount: string; total_discount_tax: string; total_shipping: string; total_shipping_tax: string; ... 9 more ...; currency_suffix: string; }; ... 4 more ...; paymentRequirements: string[]; }&apos; is not assignable to parameter of type &apos;CanMakePaymentArgument&apos;." source="TS2345" />
-<error line="180" column="7" severity="error" message="Argument of type &apos;{ cartTotals: { total_items: string; total_items_tax: string; total_fees: string; total_fees_tax: string; total_discount: string; total_discount_tax: string; total_shipping: string; total_shipping_tax: string; ... 9 more ...; currency_suffix: string; }; ... 4 more ...; paymentRequirements: string[]; }&apos; is not assignable to parameter of type &apos;CanMakePaymentArgument&apos;." source="TS2345" />
-<error line="189" column="7" severity="error" message="Argument of type &apos;{ cartTotals: { total_items: string; total_items_tax: string; total_fees: string; total_fees_tax: string; total_discount: string; total_discount_tax: string; total_shipping: string; total_shipping_tax: string; ... 9 more ...; currency_suffix: string; }; ... 4 more ...; paymentRequirements: string[]; }&apos; is not assignable to parameter of type &apos;CanMakePaymentArgument&apos;." source="TS2345" />
-<error line="200" column="7" severity="error" message="Argument of type &apos;{ cartTotals: { total_items: string; total_items_tax: string; total_fees: string; total_fees_tax: string; total_discount: string; total_discount_tax: string; total_shipping: string; total_shipping_tax: string; ... 9 more ...; currency_suffix: string; }; ... 4 more ...; paymentRequirements: string[]; }&apos; is not assignable to parameter of type &apos;CanMakePaymentArgument&apos;." source="TS2345" />
-<error line="201" column="22" severity="error" message="Property &apos;toHaveErrored&apos; does not exist on type &apos;JestMatchers&lt;Console&gt;&apos;." source="TS2339" />
+<error line="84" column="28" severity="error" message="Property &apos;billingAddress&apos; does not exist on type &apos;CanMakePaymentArgument&apos;." source="TS2339" />
+<error line="126" column="7" severity="error" message="Argument of type &apos;{ cartTotals: { total_items: string; total_items_tax: string; total_fees: string; total_fees_tax: string; total_discount: string; total_discount_tax: string; total_shipping: string; total_shipping_tax: string; ... 9 more ...; currency_suffix: string; }; ... 4 more ...; paymentRequirements: string[]; }&apos; is not assignable to parameter of type &apos;CanMakePaymentArgument&apos;.
+  Type &apos;{ cartTotals: { total_items: string; total_items_tax: string; total_fees: string; total_fees_tax: string; total_discount: string; total_discount_tax: string; total_shipping: string; total_shipping_tax: string; ... 9 more ...; currency_suffix: string; }; ... 4 more ...; paymentRequirements: string[]; }&apos; is missing the following properties from type &apos;CanMakePaymentArgument&apos;: cart, billingData" source="TS2345" />
+<error line="147" column="7" severity="error" message="Argument of type &apos;{ cartTotals: { total_items: string; total_items_tax: string; total_fees: string; total_fees_tax: string; total_discount: string; total_discount_tax: string; total_shipping: string; total_shipping_tax: string; ... 9 more ...; currency_suffix: string; }; ... 4 more ...; paymentRequirements: string[]; }&apos; is not assignable to parameter of type &apos;CanMakePaymentArgument&apos;." source="TS2345" />
+<error line="164" column="8" severity="error" message="Argument of type &apos;{ cartTotals: { total_items: string; total_items_tax: string; total_fees: string; total_fees_tax: string; total_discount: string; total_discount_tax: string; total_shipping: string; total_shipping_tax: string; ... 9 more ...; currency_suffix: string; }; ... 4 more ...; paymentRequirements: string[]; }&apos; is not assignable to parameter of type &apos;CanMakePaymentArgument&apos;." source="TS2345" />
+<error line="174" column="7" severity="error" message="Argument of type &apos;{ cartTotals: { total_items: string; total_items_tax: string; total_fees: string; total_fees_tax: string; total_discount: string; total_discount_tax: string; total_shipping: string; total_shipping_tax: string; ... 9 more ...; currency_suffix: string; }; ... 4 more ...; paymentRequirements: string[]; }&apos; is not assignable to parameter of type &apos;CanMakePaymentArgument&apos;." source="TS2345" />
+<error line="183" column="7" severity="error" message="Argument of type &apos;{ cartTotals: { total_items: string; total_items_tax: string; total_fees: string; total_fees_tax: string; total_discount: string; total_discount_tax: string; total_shipping: string; total_shipping_tax: string; ... 9 more ...; currency_suffix: string; }; ... 4 more ...; paymentRequirements: string[]; }&apos; is not assignable to parameter of type &apos;CanMakePaymentArgument&apos;." source="TS2345" />
+<error line="192" column="7" severity="error" message="Argument of type &apos;{ cartTotals: { total_items: string; total_items_tax: string; total_fees: string; total_fees_tax: string; total_discount: string; total_discount_tax: string; total_shipping: string; total_shipping_tax: string; ... 9 more ...; currency_suffix: string; }; ... 4 more ...; paymentRequirements: string[]; }&apos; is not assignable to parameter of type &apos;CanMakePaymentArgument&apos;." source="TS2345" />
+<error line="203" column="7" severity="error" message="Argument of type &apos;{ cartTotals: { total_items: string; total_items_tax: string; total_fees: string; total_fees_tax: string; total_discount: string; total_discount_tax: string; total_shipping: string; total_shipping_tax: string; ... 9 more ...; currency_suffix: string; }; ... 4 more ...; paymentRequirements: string[]; }&apos; is not assignable to parameter of type &apos;CanMakePaymentArgument&apos;." source="TS2345" />
+<error line="204" column="22" severity="error" message="Property &apos;toHaveErrored&apos; does not exist on type &apos;JestMatchers&lt;Console&gt;&apos;." source="TS2339" />
+<error line="214" column="7" severity="error" message="Argument of type &apos;{ cartTotals: { total_items: string; total_items_tax: string; total_fees: string; total_fees_tax: string; total_discount: string; total_discount_tax: string; total_shipping: string; total_shipping_tax: string; ... 9 more ...; currency_suffix: string; }; ... 4 more ...; paymentRequirements: string[]; }&apos; is not assignable to parameter of type &apos;CanMakePaymentArgument&apos;." source="TS2345" />
+<error line="215" column="26" severity="error" message="Property &apos;toHaveErrored&apos; does not exist on type &apos;Matchers&lt;void, Console&gt;&apos;." source="TS2339" />
 </file>
 <file name="assets/js/blocks-registry/payment-methods/test/registry.ts">
 <error line="21" column="25" severity="error" message="Property &apos;toHaveErrored&apos; does not exist on type &apos;Matchers&lt;void, Console&gt;&apos;." source="TS2339" />
@@ -3633,6 +4102,27 @@
 <error line="106" column="11" severity="error" message="Expected 4-6 arguments, but got 3." source="TS2554" />
 <error line="112" column="25" severity="error" message="Argument of type &apos;{ &apos;wc/blocks&apos;: { products: { &apos;[]&apos;: { &apos;?someQuery=2&apos;: { items: string[]; headers: { get: (key: any) =&gt; any; has: (key: any) =&gt; boolean; }; }; }; }; &apos;products/attributes&apos;: { &apos;[10]&apos;: { &apos;?someQuery=2&apos;: { items: string[]; headers: { get: (key: any) =&gt; any; has: (key: any) =&gt; boolean; }; }; }; }; &apos;products/attributes/term...&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2345" />
 </file>
+<file name="assets/js/data/payment/test/reducers.js">
+<error line="4" column="24" severity="error" message="Could not find a declaration file for module &apos;deep-freeze&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/deep-freeze/index.js&apos; implicitly has an &apos;any&apos; type.
+  Try `npm i --save-dev @types/deep-freeze` if it exists or add a new declaration (.d.ts) file containing `declare module &apos;deep-freeze&apos;;`" source="TS7016" />
+</file>
+<file name="assets/js/data/payment/test/selectors.js">
+<error line="32" column="7" severity="error" message="This condition will always return &apos;false&apos; since the types &apos;&quot;core/editor&quot;&apos; and &apos;&quot;wc/store/cart&quot;&apos; have no overlap." source="TS2367" />
+<error line="54" column="17" severity="error" message="Parameter &apos;setting&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="54" column="26" severity="error" message="Rest parameter &apos;rest&apos; implicitly has an &apos;any[]&apos; type." source="TS7019" />
+<error line="161" column="41" severity="error" message="Property &apos;invalidateResolutionForStore&apos; does not exist on type &apos;DispatchFromMap&lt;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/data/cart/actions&quot;)&gt;&apos;." source="TS2339" />
+<error line="164" column="19" severity="error" message="Argument of type &apos;Cart&apos; is not assignable to parameter of type &apos;CartResponse&apos;." source="TS2345" />
+<error line="243" column="41" severity="error" message="Property &apos;invalidateResolutionForStore&apos; does not exist on type &apos;DispatchFromMap&lt;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/data/cart/actions&quot;)&gt;&apos;." source="TS2339" />
+<error line="246" column="19" severity="error" message="Argument of type &apos;Cart&apos; is not assignable to parameter of type &apos;CartResponse&apos;." source="TS2345" />
+<error line="270" column="33" severity="error" message="Type &apos;{ onChange: () =&gt; undefined; }&apos; is not assignable to type &apos;IntrinsicAttributes&apos;.
+  Property &apos;onChange&apos; does not exist on type &apos;IntrinsicAttributes&apos;." source="TS2322" />
+</file>
+<file name="assets/js/data/payment/test/set-default-payment-method.ts">
+<error line="35" column="10" severity="error" message="This condition will always return &apos;false&apos; since the types &apos;&quot;core/editor&quot;&apos; and &apos;&quot;wc/store/payment&quot;&apos; have no overlap." source="TS2367" />
+<error line="60" column="10" severity="error" message="This condition will always return &apos;false&apos; since the types &apos;&quot;core/editor&quot;&apos; and &apos;&quot;wc/store/payment&quot;&apos; have no overlap." source="TS2367" />
+<error line="79" column="10" severity="error" message="This condition will always return &apos;false&apos; since the types &apos;&quot;core/editor&quot;&apos; and &apos;&quot;wc/store/payment&quot;&apos; have no overlap." source="TS2367" />
+<error line="123" column="10" severity="error" message="This condition will always return &apos;false&apos; since the types &apos;&quot;core/editor&quot;&apos; and &apos;&quot;wc/store/payment&quot;&apos; have no overlap." source="TS2367" />
+</file>
 <file name="assets/js/data/query-state/test/reducers.js">
 <error line="4" column="24" severity="error" message="Could not find a declaration file for module &apos;deep-freeze&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/deep-freeze/index.js&apos; implicitly has an &apos;any&apos; type.
   Try `npm i --save-dev @types/deep-freeze` if it exists or add a new declaration (.d.ts) file containing `declare module &apos;deep-freeze&apos;;`" source="TS7016" />
@@ -3692,24 +4182,28 @@
     Type &apos;{ id: number; name: string; parent: number; }&apos; is missing the following properties from type &apos;SearchListItemType&apos;: value, count, children, breadcrumbs" source="TS2345" />
 </file>
 <file name="assets/js/editor-components/search-list-control/test/index.js">
-<error line="35" column="5" severity="error" message="Type &apos;{ id: number; name: string; }[]&apos; is not assignable to type &apos;SearchListItemsType&apos;.
+<error line="40" column="5" severity="error" message="Type &apos;{ id: number; name: string; }[]&apos; is not assignable to type &apos;SearchListItemsType&apos;.
   Type &apos;{ id: number; name: string; }[]&apos; is not assignable to type &apos;SearchListItemType[]&apos;.
     Type &apos;{ id: number; name: string; }&apos; is missing the following properties from type &apos;SearchListItemType&apos;: value, parent, count, children, breadcrumbs" source="TS2322" />
-<error line="48" column="5" severity="error" message="Type &apos;{ id: number; name: string; }[]&apos; is not assignable to type &apos;SearchListItemsType&apos;." source="TS2322" />
-<error line="60" column="5" severity="error" message="Type &apos;{ id: number; name: string; }[]&apos; is not assignable to type &apos;SearchListItemsType&apos;." source="TS2322" />
-<error line="61" column="18" severity="error" message="Type &apos;{ id: number; name: string; }&apos; is not assignable to type &apos;SearchListItemType&apos;." source="TS2322" />
-<error line="72" column="5" severity="error" message="Type &apos;{ id: number; name: string; }[]&apos; is not assignable to type &apos;SearchListItemsType&apos;." source="TS2322" />
-<error line="73" column="18" severity="error" message="Type &apos;{ id: number; name: string; }&apos; is not assignable to type &apos;SearchListItemType&apos;." source="TS2322" />
-<error line="73" column="29" severity="error" message="Type &apos;{ id: number; name: string; }&apos; is not assignable to type &apos;SearchListItemType&apos;." source="TS2322" />
-<error line="83" column="5" severity="error" message="Type &apos;{ instanceId: number; list: []; selected: []; onChange: (...args: any[]) =&gt; void; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; SearchListControlProps&apos;.
+<error line="53" column="5" severity="error" message="Type &apos;{ id: number; name: string; }[]&apos; is not assignable to type &apos;SearchListItemsType&apos;." source="TS2322" />
+<error line="65" column="5" severity="error" message="Type &apos;{ id: number; name: string; }[]&apos; is not assignable to type &apos;SearchListItemsType&apos;." source="TS2322" />
+<error line="66" column="18" severity="error" message="Type &apos;{ id: number; name: string; }&apos; is not assignable to type &apos;SearchListItemType&apos;." source="TS2322" />
+<error line="77" column="5" severity="error" message="Type &apos;{ id: number; name: string; }[]&apos; is not assignable to type &apos;SearchListItemsType&apos;." source="TS2322" />
+<error line="78" column="18" severity="error" message="Type &apos;{ id: number; name: string; }&apos; is not assignable to type &apos;SearchListItemType&apos;." source="TS2322" />
+<error line="78" column="29" severity="error" message="Type &apos;{ id: number; name: string; }&apos; is not assignable to type &apos;SearchListItemType&apos;." source="TS2322" />
+<error line="88" column="5" severity="error" message="Type &apos;{ instanceId: number; list: []; selected: []; onChange: (...args: any[]) =&gt; void; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; SearchListControlProps&apos;.
   Property &apos;instanceId&apos; does not exist on type &apos;IntrinsicAttributes &amp; SearchListControlProps&apos;." source="TS2322" />
-<error line="96" column="5" severity="error" message="Type &apos;{ id: number; name: string; }[]&apos; is not assignable to type &apos;SearchListItemsType&apos;." source="TS2322" />
-<error line="110" column="5" severity="error" message="Type &apos;{ id: number; name: string; }[]&apos; is not assignable to type &apos;SearchListItemsType&apos;." source="TS2322" />
-<error line="124" column="5" severity="error" message="Type &apos;{ id: number; name: string; }[]&apos; is not assignable to type &apos;SearchListItemsType&apos;." source="TS2322" />
-<error line="139" column="5" severity="error" message="Type &apos;{ id: number; name: string; }[]&apos; is not assignable to type &apos;SearchListItemsType&apos;." source="TS2322" />
-<error line="149" column="26" severity="error" message="Binding element &apos;item&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="155" column="5" severity="error" message="Type &apos;{ id: number; name: string; }[]&apos; is not assignable to type &apos;SearchListItemsType&apos;." source="TS2322" />
-<error line="168" column="5" severity="error" message="Type &apos;{ id: number; name: string; parent: number; }[]&apos; is not assignable to type &apos;SearchListItemsType&apos;.
+<error line="101" column="5" severity="error" message="Type &apos;{ id: number; name: string; }[]&apos; is not assignable to type &apos;SearchListItemsType&apos;." source="TS2322" />
+<error line="115" column="5" severity="error" message="Type &apos;{ id: number; name: string; }[]&apos; is not assignable to type &apos;SearchListItemsType&apos;." source="TS2322" />
+<error line="123" column="4" severity="error" message="Argument of type &apos;Element | null&apos; is not assignable to parameter of type &apos;Document | Node | Element | Window&apos;.
+  Type &apos;null&apos; is not assignable to type &apos;Document | Node | Element | Window&apos;." source="TS2345" />
+<error line="143" column="5" severity="error" message="Type &apos;{ id: number; name: string; }[]&apos; is not assignable to type &apos;SearchListItemsType&apos;." source="TS2322" />
+<error line="151" column="4" severity="error" message="Argument of type &apos;Element | null&apos; is not assignable to parameter of type &apos;Document | Node | Element | Window&apos;." source="TS2345" />
+<error line="166" column="5" severity="error" message="Type &apos;{ id: number; name: string; }[]&apos; is not assignable to type &apos;SearchListItemsType&apos;." source="TS2322" />
+<error line="181" column="5" severity="error" message="Type &apos;{ id: number; name: string; }[]&apos; is not assignable to type &apos;SearchListItemsType&apos;." source="TS2322" />
+<error line="191" column="26" severity="error" message="Binding element &apos;item&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="197" column="5" severity="error" message="Type &apos;{ id: number; name: string; }[]&apos; is not assignable to type &apos;SearchListItemsType&apos;." source="TS2322" />
+<error line="210" column="5" severity="error" message="Type &apos;{ id: number; name: string; parent: number; }[]&apos; is not assignable to type &apos;SearchListItemsType&apos;.
   Type &apos;{ id: number; name: string; parent: number; }[]&apos; is not assignable to type &apos;SearchListItemType[]&apos;.
     Type &apos;{ id: number; name: string; parent: number; }&apos; is missing the following properties from type &apos;SearchListItemType&apos;: value, count, children, breadcrumbs" source="TS2322" />
 </file>
@@ -3888,14 +4382,14 @@
               Type &apos;Record&lt;string, unknown&gt;&apos; is not assignable to type &apos;boolean&apos;." source="TS2345" />
 </file>
 <file name="assets/js/utils/test/notices.js">
-<error line="19" column="11" severity="error" message="Property &apos;mockReturnValue&apos; does not exist on type &apos;{ (key: string): SelectorMap; (key: &quot;core/rich-text&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__rich-text/store/selectors&quot;); (key: &quot;core/notices&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__notice...&apos;." source="TS2339" />
-<error line="46" column="11" severity="error" message="Property &apos;mockReturnValue&apos; does not exist on type &apos;{ (key: string): SelectorMap; (key: &quot;core/rich-text&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__rich-text/store/selectors&quot;); (key: &quot;core/notices&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__notice...&apos;." source="TS2339" />
-<error line="55" column="11" severity="error" message="Property &apos;mockReturnValue&apos; does not exist on type &apos;{ (key: string): SelectorMap; (key: &quot;core/rich-text&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__rich-text/store/selectors&quot;); (key: &quot;core/notices&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__notice...&apos;." source="TS2339" />
-<error line="94" column="13" severity="error" message="Property &apos;mockReturnValue&apos; does not exist on type &apos;{ (key: string): DispatcherMap; (key: &quot;core/rich-text&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__rich-text/store/actions&quot;); (key: &quot;core/notices&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__notice...&apos;." source="TS2339" />
+<error line="19" column="11" severity="error" message="Property &apos;mockReturnValue&apos; does not exist on type &apos;{ (storeNameOrDescriptor: string | StoreDescriptor): SelectorMap; (key: &quot;core/rich-text&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__rich-text/store/selectors&quot;); (key: &quot;core/notices&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/n...&apos;." source="TS2339" />
+<error line="46" column="11" severity="error" message="Property &apos;mockReturnValue&apos; does not exist on type &apos;{ (storeNameOrDescriptor: string | StoreDescriptor): SelectorMap; (key: &quot;core/rich-text&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__rich-text/store/selectors&quot;); (key: &quot;core/notices&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/n...&apos;." source="TS2339" />
+<error line="55" column="11" severity="error" message="Property &apos;mockReturnValue&apos; does not exist on type &apos;{ (storeNameOrDescriptor: string | StoreDescriptor): SelectorMap; (key: &quot;core/rich-text&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__rich-text/store/selectors&quot;); (key: &quot;core/notices&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/n...&apos;." source="TS2339" />
+<error line="94" column="13" severity="error" message="Property &apos;mockReturnValue&apos; does not exist on type &apos;{ (storeNameOrDescriptor: string | StoreDescriptor): DispatcherMap; (key: &quot;core/rich-text&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__rich-text/store/actions&quot;); (key: &quot;core/notices&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/n...&apos;." source="TS2339" />
 <error line="98" column="12" severity="error" message="Expected 1 arguments, but got 0." source="TS2554" />
 <error line="103" column="12" severity="error" message="Expected 1 arguments, but got 0." source="TS2554" />
-<error line="111" column="11" severity="error" message="Property &apos;mockReturnValue&apos; does not exist on type &apos;{ (key: string): SelectorMap; (key: &quot;core/rich-text&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__rich-text/store/selectors&quot;); (key: &quot;core/notices&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__notice...&apos;." source="TS2339" />
-<error line="115" column="13" severity="error" message="Property &apos;mockReturnValue&apos; does not exist on type &apos;{ (key: string): DispatcherMap; (key: &quot;core/rich-text&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__rich-text/store/actions&quot;); (key: &quot;core/notices&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__notice...&apos;." source="TS2339" />
+<error line="111" column="11" severity="error" message="Property &apos;mockReturnValue&apos; does not exist on type &apos;{ (storeNameOrDescriptor: string | StoreDescriptor): SelectorMap; (key: &quot;core/rich-text&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__rich-text/store/selectors&quot;); (key: &quot;core/notices&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/n...&apos;." source="TS2339" />
+<error line="115" column="13" severity="error" message="Property &apos;mockReturnValue&apos; does not exist on type &apos;{ (storeNameOrDescriptor: string | StoreDescriptor): DispatcherMap; (key: &quot;core/rich-text&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__rich-text/store/actions&quot;); (key: &quot;core/notices&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/n...&apos;." source="TS2339" />
 <error line="119" column="12" severity="error" message="Expected 1 arguments, but got 0." source="TS2554" />
 </file>
 <file name="assets/js/utils/test/products.js">
@@ -3907,6 +4401,9 @@
 <error line="62" column="43" severity="error" message="Argument of type &apos;{}&apos; is not assignable to parameter of type &apos;{ images: any[]; }&apos;.
   Property &apos;images&apos; is missing in type &apos;{}&apos; but required in type &apos;{ images: any[]; }&apos;." source="TS2345" />
 <error line="68" column="45" severity="error" message="Type &apos;null&apos; is not assignable to type &apos;any[]&apos;." source="TS2322" />
+</file>
+<file name="storybook/main.js">
+<error line="20" column="24" severity="error" message="Parameter &apos;config&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
 </file>
 <file name="storybook/__mocks__/woocommerce-block-settings.js">
 <error line="1" column="15" severity="error" message="An import path cannot end with a &apos;.ts&apos; extension. Consider importing &apos;../../assets/js/settings/blocks/index.js&apos; instead." source="TS2691" />

--- a/tests/e2e/specs/backend/rating-filter.test.js
+++ b/tests/e2e/specs/backend/rating-filter.test.js
@@ -1,0 +1,68 @@
+/**
+ * External dependencies
+ */
+import {
+	switchUserToAdmin,
+	openDocumentSettingsSidebar,
+} from '@wordpress/e2e-test-utils';
+import { visitBlockPage } from '@woocommerce/blocks-test-utils';
+
+/**
+ * Internal dependencies
+ */
+
+const block = {
+	name: 'Filter by Rating',
+	slug: 'woocommerce/rating-filter',
+	class: '.wc-block-rating-filter',
+};
+
+describe( `${ block.name } Block`, () => {
+	beforeAll( async () => {
+		await switchUserToAdmin();
+		await visitBlockPage( `${ block.name } Block` );
+	} );
+
+	it( 'renders without crashing', async () => {
+		await expect( page ).toRenderBlock( block );
+	} );
+
+	describe( 'attributes', () => {
+		beforeEach( async () => {
+			await openDocumentSettingsSidebar();
+			await page.click( block.class );
+		} );
+
+		it( 'product count can be toggled', async () => {
+			await expect( page ).toMatchElement(
+				'.wc-block-components-product-rating-count'
+			);
+			await expect( page ).toClick( 'label', {
+				text: 'Display product count',
+			} );
+			await expect( page ).not.toMatchElement(
+				'.wc-block-components-product-rating-count'
+			);
+			// reset
+			await expect( page ).toClick( 'label', {
+				text: 'Display product count',
+			} );
+		} );
+
+		it( 'filter button can be toggled', async () => {
+			await expect( page ).not.toMatchElement(
+				'button.wc-block-filter-submit-button.wc-block-rating-filter__button'
+			);
+			await expect( page ).toClick( 'label', {
+				text: "Show 'Apply filters' button",
+			} );
+			await expect( page ).toMatchElement(
+				'button.wc-block-filter-submit-button.wc-block-rating-filter__button'
+			);
+			// reset
+			await expect( page ).toClick( 'label', {
+				text: "Show 'Apply filters' button",
+			} );
+		} );
+	} );
+} );

--- a/tests/e2e/specs/shopper/filter-products-by-rating.test.ts
+++ b/tests/e2e/specs/shopper/filter-products-by-rating.test.ts
@@ -1,0 +1,204 @@
+/**
+ * External dependencies
+ */
+import {
+	createNewPost,
+	deleteAllTemplates,
+	insertBlock,
+	switchUserToAdmin,
+	publishPost,
+} from '@wordpress/e2e-test-utils';
+import { selectBlockByName } from '@woocommerce/blocks-test-utils';
+
+/**
+ * Internal dependencies
+ */
+import {
+	BASE_URL,
+	goToTemplateEditor,
+	openBlockEditorSettings,
+	saveTemplate,
+	useTheme,
+	waitForAllProductsBlockLoaded,
+	waitForCanvas,
+} from '../../utils';
+
+const block = {
+	name: 'Filter by Rating',
+	slug: 'woocommerce/rating-filter',
+	class: '.wc-block-rating-filter',
+	selectors: {
+		editor: {
+			filterButtonToggle:
+				'//label[text()="Show \'Apply filters\' button"]',
+		},
+		frontend: {
+			productsList: '.wc-block-grid__products > li',
+			classicProductsList: '.products.columns-3 > li',
+			fiveStarInput: ".wc-block-rating-filter label[for='5'] input",
+			submitButton: '.wc-block-components-filter-submit-button',
+		},
+	},
+	urlSearchParamWhenFilterIsApplied: '?rating_filter=5',
+};
+
+const FIVE_STAR_PRODUCTS_AMOUNT = 5;
+
+const { selectors } = block;
+
+const goToShopPage = () =>
+	page.goto( BASE_URL + '/shop', {
+		waitUntil: 'networkidle0',
+	} );
+
+describe( `${ block.name } Block`, () => {
+	describe( 'with All Products Block', () => {
+		let link = '';
+		beforeAll( async () => {
+			await switchUserToAdmin();
+			await createNewPost( {
+				postType: 'post',
+				title: block.name,
+			} );
+
+			await insertBlock( block.name );
+			await insertBlock( 'All Products' );
+			await publishPost();
+
+			link = await page.evaluate( () =>
+				wp.data.select( 'core/editor' ).getPermalink()
+			);
+			await page.goto( link );
+		} );
+
+		it( 'should render', async () => {
+			await expect( page ).toMatchElement( block.class );
+		} );
+
+		it( 'should show only products that match the filter', async () => {
+			const isRefreshed = jest.fn( () => void 0 );
+			page.on( 'load', isRefreshed );
+			await waitForAllProductsBlockLoaded();
+			await page.waitForSelector( selectors.frontend.fiveStarInput );
+			await page.click( selectors.frontend.fiveStarInput );
+			await waitForAllProductsBlockLoaded();
+			const products = await page.$$( selectors.frontend.productsList );
+			expect( isRefreshed ).not.toBeCalled();
+			expect( products ).toHaveLength( FIVE_STAR_PRODUCTS_AMOUNT );
+		} );
+	} );
+
+	describe( 'with PHP classic template ', () => {
+		const productCatalogTemplateId =
+			'woocommerce/woocommerce//archive-product';
+
+		useTheme( 'emptytheme' );
+		beforeAll( async () => {
+			await deleteAllTemplates( 'wp_template' );
+			await deleteAllTemplates( 'wp_template_part' );
+			await goToTemplateEditor( {
+				postId: productCatalogTemplateId,
+			} );
+			await insertBlock( block.name );
+			await saveTemplate();
+			await goToShopPage();
+		} );
+
+		beforeEach( async () => {
+			await goToShopPage();
+		} );
+
+		afterAll( async () => {
+			await deleteAllTemplates( 'wp_template' );
+			await deleteAllTemplates( 'wp_template_part' );
+		} );
+
+		it( 'should render', async () => {
+			await expect( page ).toMatchElement( block.class );
+		} );
+
+		it( 'should show only products that match the filter', async () => {
+			const isRefreshed = jest.fn( () => void 0 );
+			page.on( 'load', isRefreshed );
+
+			await page.waitForSelector( block.class + '.is-loading', {
+				hidden: true,
+			} );
+
+			expect( isRefreshed ).not.toBeCalled();
+
+			await page.waitForSelector( selectors.frontend.fiveStarInput );
+
+			await Promise.all( [
+				page.waitForNavigation(),
+				page.click( selectors.frontend.fiveStarInput ),
+			] );
+
+			const products = await page.$$(
+				selectors.frontend.classicProductsList
+			);
+			const pageURL = page.url();
+			const parsedURL = new URL( pageURL );
+
+			expect( isRefreshed ).toBeCalledTimes( 1 );
+			expect( products ).toHaveLength( FIVE_STAR_PRODUCTS_AMOUNT );
+			expect( parsedURL.search ).toEqual(
+				block.urlSearchParamWhenFilterIsApplied
+			);
+		} );
+
+		it( 'should refresh the page only if the user click on button', async () => {
+			await goToTemplateEditor( {
+				postId: productCatalogTemplateId,
+			} );
+
+			await waitForCanvas();
+			await selectBlockByName( block.slug );
+			await openBlockEditorSettings( { isFSEEditor: true } );
+			await page.waitForXPath(
+				block.selectors.editor.filterButtonToggle
+			);
+
+			const [ filterButtonToggle ] = await page.$x(
+				selectors.editor.filterButtonToggle
+			);
+			await filterButtonToggle.click();
+			await saveTemplate();
+			await goToShopPage();
+
+			const isRefreshed = jest.fn( () => void 0 );
+			page.on( 'load', isRefreshed );
+
+			await page.waitForSelector( block.class + '.is-loading', {
+				hidden: true,
+			} );
+
+			expect( isRefreshed ).not.toBeCalled();
+
+			await page.waitForSelector( selectors.frontend.fiveStarInput );
+			await page.click( selectors.frontend.fiveStarInput );
+			await Promise.all( [
+				page.waitForNavigation( {
+					waitUntil: 'networkidle0',
+				} ),
+				page.click( selectors.frontend.submitButton ),
+			] );
+
+			const pageURL = page.url();
+			const parsedURL = new URL( pageURL );
+
+			await page.waitForSelector(
+				selectors.frontend.classicProductsList
+			);
+			const products = await page.$$(
+				selectors.frontend.classicProductsList
+			);
+
+			expect( isRefreshed ).toBeCalledTimes( 1 );
+			expect( products ).toHaveLength( FIVE_STAR_PRODUCTS_AMOUNT );
+			expect( parsedURL.search ).toEqual(
+				block.urlSearchParamWhenFilterIsApplied
+			);
+		} );
+	} );
+} );


### PR DESCRIPTION
This PR adds E2E tests for the **Filter by Rating** filter block.

Closes #7185

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests

#### Testing
1. Run `npm run wp-env start`
2. Run: 
- `npm run test:e2e tests/e2e/specs/backend/rating-filter.test.js`
- `npm run test:e2e tests/e2e/specs/shopper/filter-products-by-rating.test.ts`
3. Make sure they pass without errors

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
