### PR TITLE
Fix menus on 'large', 'simple' and 'with 2 menus' footers

### DIFF
--- a/patterns/footer-large.php
+++ b/patterns/footer-large.php
@@ -34,7 +34,6 @@
 
 <!-- wp:column {"verticalAlignment":"top","width":"20%","style":{"spacing":{"blockGap":"16px"}}} -->
 <div class="wp-block-column is-vertically-aligned-top" style="flex-basis:20%"><!-- wp:navigation {"layout":{"type":"flex","orientation":"vertical"}} -->
-<!-- wp:page-list /-->
 <!-- /wp:navigation --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->

--- a/patterns/footer-simple.php
+++ b/patterns/footer-simple.php
@@ -11,7 +11,6 @@
 <div class="wp-block-columns"><!-- wp:column {"width":"50%"} -->
 <div class="wp-block-column" style="flex-basis:50%"><!-- wp:group {"style":{"spacing":{"blockGap":"32px"}},"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"center"}} -->
 <div class="wp-block-group"><!-- wp:navigation -->
-<!-- wp:page-list /-->
 <!-- /wp:navigation --></div>
 <!-- /wp:group --></div>
 <!-- /wp:column -->

--- a/patterns/footer-with-2-menus.php
+++ b/patterns/footer-with-2-menus.php
@@ -14,11 +14,9 @@
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"8px"}},"layout":{"type":"flex","orientation":"vertical","flexWrap":"nowrap"}} -->
 <div class="wp-block-group"><!-- wp:navigation -->
-<!-- wp:page-list /-->
 <!-- /wp:navigation -->
 
 <!-- wp:navigation -->
-<!-- wp:page-list /-->
 <!-- /wp:navigation --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group --></div>


### PR DESCRIPTION
The goal of this PR is to fix the menus on `large`, `footer simple` and `footer with 2 menus` patterns to make them look like the same as in the dark patterns.
### Testing

1. In a new page add the "WooCommerce Footer with 2 menus" normal and dark versions.
2. Add also the "WooCommerce Simple Footer" normal and dark versions.
3. Check they menus look the same.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental