### PR TITLE
Fix: use correct type specifier for rating HTML

### DIFF
--- a/assets/js/base/components/product-rating/index.tsx
+++ b/assets/js/base/components/product-rating/index.tsx
@@ -32,8 +32,8 @@ const Rating = ( {
 
 	const ratingHTML = {
 		__html: sprintf(
-			/* translators: %f is referring to the rating value */
-			__( 'Rated %f out of 5', 'woo-gutenberg-products-block' ),
+			/* translators: %s is the rating value wrapped in HTML strong tags. */
+			__( 'Rated %s out of 5', 'woo-gutenberg-products-block' ),
 			sprintf( '<strong class="rating">%f</strong>', rating )
 		),
 	};


### PR DESCRIPTION
We're using the `%f` in the `sprintf` of the `ratingHTML`, but we feed the `sprintf` with a string instead of float, which throws a TypeError. We need to use `%s` instead to keep the console happy.

<img width="583" alt="Screen Shot 2022-11-07 at 13 20 35" src="https://user-images.githubusercontent.com/5423135/200240470-954d06ab-6f6c-4595-aefe-c89f39d5ef2d.png">

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### Screenshot

<table>
<tr>
	<td> Before 
	<td> After
<tr>
	<td> <img width="355" alt="image" src="https://user-images.githubusercontent.com/5423135/200256161-350e005e-631e-4c11-97eb-6d15ca3c197e.png">
	<td> <img width="354" alt="image" src="https://user-images.githubusercontent.com/5423135/200256006-53bf27a9-bb83-43d0-832f-a1e6ba9c145f.png">

</table>

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Add the `Filter by Rating` block to a page.
2. Do not see the TypeError error above in the console log.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental