### PR TITLE
Update Filter by Stock block name in readme.txt

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -29,7 +29,7 @@ Use this plugin if you want access to the bleeding edge of available blocks for 
 - **Filter by Attribute**
 - **Filter by Price**
 - **Filter by Rating**
-- **Filter Products by Stock**
+- **Filter by Stock**
 - **Hand-picked Products**
 - **Mini Cart**
 - **Newest Products**


### PR DESCRIPTION
In #6883 we renamed "Filter Products by Stock" to "Filter by Stock", but didn't make the change in the block list in `readme.txt`. This PR fixes that updating the Filter by Stock block name in `readme.txt`.