### PR TITLE
Remove the experimental flag that's used to include thunks in wp.data

### DIFF
--- a/assets/js/data/checkout/index.ts
+++ b/assets/js/data/checkout/index.ts
@@ -16,10 +16,6 @@ export const config = {
 	reducer,
 	selectors,
 	actions,
-	// TODO: Gutenberg with Thunks was released in WP 6.0. Once 6.1 is released, remove the experimental flag here
-	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-	// @ts-ignore We pass this in case there is an older version of Gutenberg running.
-	__experimentalUseThunks: true,
 };
 
 const store = createReduxStore( STORE_KEY, config );

--- a/assets/js/data/payment/index.ts
+++ b/assets/js/data/payment/index.ts
@@ -20,10 +20,6 @@ export const config = {
 	actions,
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	controls: { ...dataControls, ...sharedControls } as any,
-	// TODO: Gutenberg with Thunks was released in WP 6.0. Once 6.1 is released, remove the experimental flag here
-	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-	// @ts-ignore We pass this in case there is an older version of Gutenberg running.
-	__experimentalUseThunks: true,
 };
 
 const store = createReduxStore( STORE_KEY, config );

--- a/assets/js/data/validation/index.ts
+++ b/assets/js/data/validation/index.ts
@@ -16,10 +16,6 @@ export const config = {
 	reducer,
 	selectors,
 	actions,
-	// TODO: Gutenberg with Thunks was released in WP 6.0. Once 6.1 is released, remove the experimental flag here
-	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-	// @ts-ignore We pass this in case there is an older version of Gutenberg running.
-	__experimentalUseThunks: true,
 };
 
 const store = createReduxStore( STORE_KEY, config );

--- a/assets/js/types/type-defs/product-response.ts
+++ b/assets/js/types/type-defs/product-response.ts
@@ -20,6 +20,7 @@ export interface ProductResponseItemBaseData {
 	value: string;
 	display?: string;
 	hidden?: boolean;
+	className?: string;
 }
 
 export type ProductResponseItemData = ProductResponseItemBaseData &

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -531,7 +531,7 @@
 <error line="164" column="25" severity="error" message="Property &apos;SET_PRISTINE&apos; does not exist on type &apos;{ readonly SET_IDLE: &quot;SET_IDLE&quot;; readonly SET_REDIRECT_URL: &quot;SET_REDIRECT_URL&quot;; readonly SET_COMPLETE: &quot;SET_CHECKOUT_COMPLETE&quot;; readonly SET_BEFORE_PROCESSING: &quot;SET_BEFORE_PROCESSING&quot;; ... 11 more ...; readonly SET_IS_CART: &quot;SET_IS_CART&quot;; }&apos;." source="TS2339" />
 </file>
 <file name="assets/js/data/checkout/index.ts">
-<error line="25" column="44" severity="error" message="Argument of type &apos;{ reducer: (state: CheckoutState | undefined, action: actions.CheckoutAction) =&gt; CheckoutState; selectors: typeof selectors; actions: typeof actions; __experimentalUseThunks: boolean; }&apos; is not assignable to parameter of type &apos;StoreConfig&lt;CheckoutState&gt;&apos;.
+<error line="21" column="44" severity="error" message="Argument of type &apos;{ reducer: (state: CheckoutState | undefined, action: actions.CheckoutAction) =&gt; CheckoutState; selectors: typeof selectors; actions: typeof actions; }&apos; is not assignable to parameter of type &apos;StoreConfig&lt;CheckoutState&gt;&apos;.
   Types of property &apos;actions&apos; are incompatible.
     Type &apos;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/data/checkout/actions&quot;)&apos; is not assignable to type &apos;{ [k: string]: (...args: readonly any[]) =&gt; AnyAction | Generator&lt;any, any, unknown&gt;; }&apos;.
       Property &apos;__internalProcessCheckoutResponse&apos; is incompatible with index signature.
@@ -584,7 +584,7 @@
 <error line="162" column="27" severity="error" message="Binding element &apos;dispatch&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
 </file>
 <file name="assets/js/data/payment/index.ts">
-<error line="29" column="44" severity="error" message="Argument of type &apos;{ reducer: Reducer&lt;PaymentMethodDataState, AnyAction&gt;; selectors: typeof selectors; actions: typeof actions; controls: any; __experimentalUseThunks: boolean; }&apos; is not assignable to parameter of type &apos;StoreConfig&lt;PaymentMethodDataState&gt;&apos;.
+<error line="25" column="44" severity="error" message="Argument of type &apos;{ reducer: Reducer&lt;PaymentMethodDataState, AnyAction&gt;; selectors: typeof selectors; actions: typeof actions; controls: any; }&apos; is not assignable to parameter of type &apos;StoreConfig&lt;PaymentMethodDataState&gt;&apos;.
   Types of property &apos;actions&apos; are incompatible.
     Type &apos;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/data/payment/actions&quot;)&apos; is not assignable to type &apos;{ [k: string]: (...args: readonly any[]) =&gt; AnyAction | Generator&lt;any, any, unknown&gt;; }&apos;.
       Property &apos;__internalUpdateAvailablePaymentMethods&apos; is incompatible with index signature.
@@ -1669,6 +1669,10 @@
   Types of property &apos;stepHeadingContent&apos; are incompatible.
     Type &apos;Element | undefined&apos; is not assignable to type &apos;Element&apos;.
       Type &apos;undefined&apos; is not assignable to type &apos;Element&apos;." source="TS2375" />
+</file>
+<file name="assets/js/base/components/cart-checkout/product-details/index.tsx">
+<error line="36" column="14" severity="error" message="Property &apos;className&apos; does not exist on type &apos;ProductResponseItemData&apos;.
+  Property &apos;className&apos; does not exist on type &apos;ProductResponseItemBaseData &amp; { key: string; name?: never; }&apos;." source="TS2339" />
 </file>
 <file name="assets/js/base/components/cart-checkout/product-summary/index.tsx">
 <error line="32" column="4" severity="error" message="Type &apos;{ className: string | undefined; source: string; maxLength: number; countType: WordCountType; }&apos; is not assignable to type &apos;SummaryProps&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1670,10 +1670,6 @@
     Type &apos;Element | undefined&apos; is not assignable to type &apos;Element&apos;.
       Type &apos;undefined&apos; is not assignable to type &apos;Element&apos;." source="TS2375" />
 </file>
-<file name="assets/js/base/components/cart-checkout/product-details/index.tsx">
-<error line="36" column="14" severity="error" message="Property &apos;className&apos; does not exist on type &apos;ProductResponseItemData&apos;.
-  Property &apos;className&apos; does not exist on type &apos;ProductResponseItemBaseData &amp; { key: string; name?: never; }&apos;." source="TS2339" />
-</file>
 <file name="assets/js/base/components/cart-checkout/product-summary/index.tsx">
 <error line="32" column="4" severity="error" message="Type &apos;{ className: string | undefined; source: string; maxLength: number; countType: WordCountType; }&apos; is not assignable to type &apos;SummaryProps&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
   Types of property &apos;className&apos; are incompatible.


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
Support for wp/data thunks was merged to WP Core in the 6.0 Release. Since we support latest 2 releases, and WP 6.1 has just launched, this removes the experimental flag that makes wp/data work with thunks.

Also fixes a ts error introduced in https://github.com/woocommerce/woocommerce-blocks/pull/7328

<!-- Reference any related issues or PRs here -->

Fixes #6610

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Testing

1. If you can place an order successfully with the Checkout Block without any errors, then it works. Try this on WP 6.0 and 6.1 

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

