### PR TITLE
Display correct block template when filtering by attribute

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -426,17 +426,21 @@ class BlockTemplatesController {
 			$this->block_template_is_available( 'taxonomy-product_tag' )
 		) {
 			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
-		} elseif ( taxonomy_is_product_attribute( get_query_var( 'taxonomy' ) ) &&
-			! BlockTemplateUtils::theme_has_template( 'archive-product' ) &&
-			$this->block_template_is_available( 'archive-product' )
-		) {
-			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
 		} elseif (
 			( is_post_type_archive( 'product' ) || is_page( wc_get_page_id( 'shop' ) ) ) &&
 			! BlockTemplateUtils::theme_has_template( 'archive-product' ) &&
 			$this->block_template_is_available( 'archive-product' )
 		) {
 			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
+		} else {
+			$queried_object = get_queried_object();
+
+			if ( taxonomy_is_product_attribute( $queried_object->slug ) &&
+				! BlockTemplateUtils::theme_has_template( 'archive-product' ) &&
+				$this->block_template_is_available( 'archive-product' )
+			) {
+				add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
+			}
 		}
 	}
 

--- a/src/Templates/ProductAttributeTemplate.php
+++ b/src/Templates/ProductAttributeTemplate.php
@@ -30,7 +30,8 @@ class ProductAttributeTemplate {
 	 * @param array $templates Templates that match the product attributes taxonomy.
 	 */
 	public function update_taxonomy_template_hierarchy( $templates ) {
-		if ( taxonomy_is_product_attribute( get_query_var( 'taxonomy' ) ) && wc_current_theme_is_fse_theme() ) {
+		$queried_object = get_queried_object();
+		if ( taxonomy_is_product_attribute( $queried_object->slug ) && wc_current_theme_is_fse_theme() ) {
 			array_unshift( $templates, self::SLUG );
 		}
 


### PR DESCRIPTION
Fixes #7604.

I'm not completely sure what was going with this issue, but it looks like when an attribute filter was enabled, `get_query_var( 'taxonomy' )` was returning that attribute, causing the Products by Attribute template logic to fire. I refactored that code to check for `get_queried_object()` instead, that value doesn't change when an attribute filter is enabled.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

##### Test that #7604 has been fixed
1. Make sure you have a block theme active (like Twenty Twenty-Three).
2. Add the “Filter by Attribute” block to the “Products by Category” template (in Appearance > Site Editor).
3. Go to the front-end for a category (ie: `/product-category/clothing/`).
4. Select a filter.
5. Verify the query params are added to the URL and the URL stays correct.
6. Verify the loaded template is also correct (instead of rendering the “Product Catalog” template).

##### Test that there are no regressions with #6776

1. Make sure you have a block theme active (like Twenty Twenty-Three).
2. Navigate to `Products` > `Attributes` and edit an existing one or create a new one.
3. Click the `Enable Archives` option and save, go back.
4. Click `Configure terms` next to your attribute.
5. Hover over one of the terms and click the `View` link of one of the attributes.
6. Verify that the page is rendered with a header, a footer, and using a product grid.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Display correct block template when filtering by attribute
