### PR TITLE
Fix error when trying to access the queried object when it's null

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -438,7 +438,7 @@ class BlockTemplatesController {
 				return;
 			}
 
-			if ( taxonomy_is_product_attribute( $queried_object->slug ) &&
+			if ( isset( $queried_object->slug ) && taxonomy_is_product_attribute( $queried_object->slug ) &&
 				! BlockTemplateUtils::theme_has_template( 'archive-product' ) &&
 				$this->block_template_is_available( 'archive-product' )
 			) {

--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -438,7 +438,7 @@ class BlockTemplatesController {
 				return;
 			}
 
-			if ( isset( $queried_object->slug ) && taxonomy_is_product_attribute( $queried_object->slug ) &&
+			if ( isset( $queried_object->taxonomy ) && taxonomy_is_product_attribute( $queried_object->taxonomy ) &&
 				! BlockTemplateUtils::theme_has_template( 'archive-product' ) &&
 				$this->block_template_is_available( 'archive-product' )
 			) {

--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -434,6 +434,9 @@ class BlockTemplatesController {
 			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
 		} else {
 			$queried_object = get_queried_object();
+			if ( is_null( $queried_object ) ) {
+				return;
+			}
 
 			if ( taxonomy_is_product_attribute( $queried_object->slug ) &&
 				! BlockTemplateUtils::theme_has_template( 'archive-product' ) &&

--- a/src/Templates/ProductAttributeTemplate.php
+++ b/src/Templates/ProductAttributeTemplate.php
@@ -31,7 +31,7 @@ class ProductAttributeTemplate {
 	 */
 	public function update_taxonomy_template_hierarchy( $templates ) {
 		$queried_object = get_queried_object();
-		if ( taxonomy_is_product_attribute( $queried_object->slug ) && wc_current_theme_is_fse_theme() ) {
+		if ( taxonomy_is_product_attribute( $queried_object->taxonomy ) && wc_current_theme_is_fse_theme() ) {
 			array_unshift( $templates, self::SLUG );
 		}
 


### PR DESCRIPTION
Fixed an error caused by trying to access the `slug` attribute on a null object.
Also changed `slug` by `taxonomy`, otherwise, the `taxonomy_is_product_attribute` would always return **false**.

### Testing

#### The error is no longer there
1. **On `trunk`**, go to the homepage of your site and see the ` Warning: Attempt to read property "slug" on null in /plugins/woocommerce-blocks/src/BlockTemplatesController.php on line 438` error
2. Checkout this branch, go again to the homepage and see that the error no longer shows up.

#### The archive product template loads
1. Make sure you have a block theme active (like Twenty Twenty-Three).
2. Navigate to Products > Attributes and edit an existing one or create a new one.
3. Click the Enable Archives option and save, go back.
4. Click Configure terms next to your attribute.
5. Hover over one of the terms and click the View link of one of the attributes.
6. Verify that the page is rendered with a header, a footer, and using a product grid.


* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
