### PR TITLE
Product Query: Add order by “best selling” as a preset

### DIFF
--- a/assets/js/blocks/product-query/constants.ts
+++ b/assets/js/blocks/product-query/constants.ts
@@ -20,9 +20,13 @@ function objectOmit< T, K extends keyof T >( obj: T, key: K ) {
 
 export const QUERY_LOOP_ID = 'core/query';
 
-export const DEFAULT_CORE_ALLOWED_CONTROLS = [ 'order', 'taxQuery', 'search' ];
+export const DEFAULT_CORE_ALLOWED_CONTROLS = [ 'taxQuery', 'search' ];
 
-export const ALL_PRODUCT_QUERY_CONTROLS = [ 'onSale', 'stockStatus' ];
+export const ALL_PRODUCT_QUERY_CONTROLS = [
+	'presets',
+	'onSale',
+	'stockStatus',
+];
 
 export const DEFAULT_ALLOWED_CONTROLS = [
 	...DEFAULT_CORE_ALLOWED_CONTROLS,

--- a/assets/js/blocks/product-query/inspector-controls.tsx
+++ b/assets/js/blocks/product-query/inspector-controls.tsx
@@ -26,7 +26,7 @@ import {
 } from './types';
 import {
 	isWooQueryBlockVariation,
-	setCustomQueryAttribute,
+	setQueryAttribute,
 	useAllowedControls,
 } from './utils';
 import {
@@ -99,7 +99,7 @@ export const TOOLS_PANEL_CONTROLS = {
 					) }
 					checked={ query.__woocommerceOnSale || false }
 					onChange={ ( __woocommerceOnSale ) => {
-						setCustomQueryAttribute( props, {
+						setQueryAttribute( props, {
 							__woocommerceOnSale,
 						} );
 					} }
@@ -125,7 +125,7 @@ export const TOOLS_PANEL_CONTROLS = {
 							.map( getStockStatusIdByLabel )
 							.filter( Boolean ) as string[];
 
-						setCustomQueryAttribute( props, {
+						setQueryAttribute( props, {
 							__woocommerceStockStatus,
 						} );
 					} }
@@ -166,10 +166,7 @@ export const withProductQueryControls =
 							'woo-gutenberg-products-block'
 						) }
 						resetAll={ () => {
-							setCustomQueryAttribute(
-								props,
-								defaultWooQueryParams
-							);
+							setQueryAttribute( props, defaultWooQueryParams );
 						} }
 					>
 						{ Object.entries( TOOLS_PANEL_CONTROLS ).map(

--- a/assets/js/blocks/product-query/inspector-controls.tsx
+++ b/assets/js/blocks/product-query/inspector-controls.tsx
@@ -34,6 +34,7 @@ import {
 	QUERY_LOOP_ID,
 	STOCK_STATUS_OPTIONS,
 } from './constants';
+import { PopularPresets } from './inspector-controls/popular-presets';
 
 const NAMESPACED_CONTROLS = ALL_PRODUCT_QUERY_CONTROLS.map(
 	( id ) =>
@@ -82,7 +83,7 @@ function getStockStatusIdByLabel( statusLabel: FormTokenField.Value ) {
 	)?.[ 0 ];
 }
 
-export const INSPECTOR_CONTROLS = {
+export const TOOLS_PANEL_CONTROLS = {
 	onSale: ( props: ProductQueryBlock ) => {
 		const { query } = props.attributes;
 
@@ -154,12 +155,14 @@ export const withProductQueryControls =
 
 		return isWooQueryBlockVariation( props ) ? (
 			<>
-				<BlockEdit { ...props } />
 				<InspectorControls>
+					{ allowedControls?.includes( 'presets' ) && (
+						<PopularPresets { ...props } />
+					) }
 					<ToolsPanel
 						class="woocommerce-product-query-toolspanel"
 						label={ __(
-							'Product filters',
+							'Advanced Filters',
 							'woo-gutenberg-products-block'
 						) }
 						resetAll={ () => {
@@ -169,7 +172,7 @@ export const withProductQueryControls =
 							);
 						} }
 					>
-						{ Object.entries( INSPECTOR_CONTROLS ).map(
+						{ Object.entries( TOOLS_PANEL_CONTROLS ).map(
 							( [ key, Control ] ) =>
 								allowedControls?.includes( key ) ? (
 									<Control { ...props } />
@@ -177,6 +180,7 @@ export const withProductQueryControls =
 						) }
 					</ToolsPanel>
 				</InspectorControls>
+				<BlockEdit { ...props } />
 			</>
 		) : (
 			<BlockEdit { ...props } />

--- a/assets/js/blocks/product-query/inspector-controls/popular-presets.tsx
+++ b/assets/js/blocks/product-query/inspector-controls/popular-presets.tsx
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import { CustomSelectControl, PanelBody } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { ProductQueryBlock, ProductQueryBlockQuery } from '../types';
+import { setQueryAttribute } from '../utils';
+
+const PRESETS = [
+	{ key: 'date/desc', name: __( 'Newest', 'woo-gutenberg-products-block' ) },
+	{
+		key: 'popularity/desc',
+		name: __( 'Best Selling', 'woo-gutenberg-products-block' ),
+	},
+];
+
+export function PopularPresets( props: ProductQueryBlock ) {
+	const { query } = props.attributes;
+
+	return (
+		<PanelBody
+			className="woocommerce-product-query-panel__sort"
+			title={ __( 'Popular Filters', 'woo-gutenberg-products-block' ) }
+			initialOpen={ true }
+		>
+			<p>
+				{ __(
+					'Arrange products by popular pre-sets.',
+					'woo-gutenberg-products-block'
+				) }
+			</p>
+			<CustomSelectControl
+				hideLabelFromVision={ true }
+				label={ __(
+					'Choose among these pre-sets',
+					'woo-gutenberg-products-block'
+				) }
+				onChange={ ( option ) => {
+					if ( ! option.selectedItem?.key ) return;
+
+					const [ orderBy, order ] = option.selectedItem?.key?.split(
+						'/'
+					) as [
+						ProductQueryBlockQuery[ 'orderBy' ],
+						ProductQueryBlockQuery[ 'order' ]
+					];
+
+					setQueryAttribute( props, { order, orderBy } );
+				} }
+				options={ PRESETS }
+				value={ PRESETS.find(
+					( option ) =>
+						option.key === `${ query.orderBy }/${ query.order }`
+				) }
+			/>
+		</PanelBody>
+	);
+}

--- a/assets/js/blocks/product-query/types.ts
+++ b/assets/js/blocks/product-query/types.ts
@@ -10,6 +10,13 @@ import type { EditorBlock } from '@woocommerce/types';
 /* eslint-disable @typescript-eslint/naming-convention */
 export interface ProductQueryArguments {
 	/**
+	 * Available sorting options specific to the Product Query block
+	 *
+	 * Other sorting options may be possible, but we are restricting
+	 * the choice to those.
+	 */
+	orderBy: 'date' | 'popularity';
+	/**
 	 * Display only products on sale.
 	 *
 	 * Will generate the following `meta_query`:
@@ -52,7 +59,11 @@ export interface ProductQueryArguments {
 
 export type ProductQueryBlock = EditorBlock< QueryBlockAttributes >;
 
-export type ProductQueryBlockQuery = QueryBlockQuery & ProductQueryArguments;
+export type ProductQueryBlockQuery = Omit<
+	QueryBlockQuery,
+	keyof ProductQueryArguments
+> &
+	ProductQueryArguments;
 
 export interface QueryBlockAttributes {
 	allowedControls?: string[];
@@ -81,7 +92,7 @@ export interface QueryBlockQuery {
 }
 
 export interface ProductQueryContext {
-	query?: QueryBlockQuery & ProductQueryArguments;
+	query?: ProductQueryBlockQuery;
 	queryId?: number;
 }
 

--- a/assets/js/blocks/product-query/utils.tsx
+++ b/assets/js/blocks/product-query/utils.tsx
@@ -9,8 +9,8 @@ import { store as WP_BLOCKS_STORE } from '@wordpress/blocks';
  */
 import { QUERY_LOOP_ID } from './constants';
 import {
-	ProductQueryArguments,
 	ProductQueryBlock,
+	ProductQueryBlockQuery,
 	QueryVariation,
 } from './types';
 
@@ -40,14 +40,11 @@ export function isWooQueryBlockVariation( block: ProductQueryBlock ) {
 /**
  * Sets the new query arguments of a Product Query block
  *
- * Because we add a new set of deeply nested attributes to the query
- * block, this utility function makes it easier to change just the
- * options relating to our custom query, while keeping the code
- * clean.
+ * Shorthand for setting new nested query parameters.
  */
-export function setCustomQueryAttribute(
+export function setQueryAttribute(
 	block: ProductQueryBlock,
-	queryParams: Partial< ProductQueryArguments >
+	queryParams: Partial< ProductQueryBlockQuery >
 ) {
 	const { query } = block.attributes;
 

--- a/src/BlockTypes/ProductQuery.php
+++ b/src/BlockTypes/ProductQuery.php
@@ -3,6 +3,7 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
 // phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 // phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 
 /**
  * ProductQuery class.
@@ -21,6 +22,13 @@ class ProductQuery extends AbstractBlock {
 	 * @var array
 	 */
 	protected $parsed_block;
+
+	/**
+	 * Orderby options not natively supported by WordPress REST API
+	 *
+	 * @var array
+	 */
+	protected $custom_order_opts = array( 'popularity' );
 
 	/**
 	 * All the query args related to the filter by attributes block.
@@ -46,6 +54,7 @@ class ProductQuery extends AbstractBlock {
 			2
 		);
 		add_filter( 'rest_product_query', array( $this, 'update_rest_query' ), 10, 2 );
+		add_filter( 'rest_product_collection_params', array( $this, 'extend_rest_query_allowed_params' ), 10, 1 );
 	}
 
 	/**
@@ -94,8 +103,9 @@ class ProductQuery extends AbstractBlock {
 	 */
 	public function update_rest_query( $args, $request ) {
 		$on_sale_query = $request->get_param( '__woocommerceOnSale' ) !== 'true' ? array() : $this->get_on_sale_products_query();
+		$orderby_query = $this->get_custom_orderby_query( $request->get_param( 'orderby' ) );
 
-		return array_merge( $args, $on_sale_query );
+		return array_merge( $args, $on_sale_query, $orderby_query );
 	}
 
 	/**
@@ -124,6 +134,12 @@ class ProductQuery extends AbstractBlock {
 
 		$queries_by_attributes = $this->get_queries_by_attributes( $parsed_block );
 		$queries_by_filters    = $this->get_queries_by_applied_filters();
+		$orderby_query         = $this->get_custom_orderby_query( $query['orderby'] );
+
+		$base_query = array_merge(
+			$common_query_values,
+			$orderby_query
+		);
 
 		return array_reduce(
 			array_merge(
@@ -183,6 +199,20 @@ class ProductQuery extends AbstractBlock {
 	}
 
 	/**
+	 * Extends allowed `collection_params` for the REST API
+	 *
+	 * By itself, the REST API doesn't accept custom `orderby` values,
+	 * even if they are supported by a custom post type.
+	 *
+	 * @param array $params  A list of allowed `orderby` values.
+	 *
+	 * @return array
+	 */
+	private function extend_rest_query_params( $params ) {
+		return array_merge( $params, $this->custom_order_opts );
+	}
+
+	/**
 	 * Return a query for on sale products.
 	 *
 	 * @return array
@@ -190,6 +220,28 @@ class ProductQuery extends AbstractBlock {
 	private function get_on_sale_products_query() {
 		return array(
 			'post__in' => wc_get_product_ids_on_sale(),
+		);
+	}
+
+	/**
+	 * Return query params to support custom sort values
+	 *
+	 * @param string $orderby  Sort order option.
+	 *
+	 * @return array
+	 */
+	private function get_custom_orderby_query( $orderby ) {
+		if ( ! in_array( $orderby, $this->custom_order_opts, true ) ) {
+			return array( 'orderby' => $orderby );
+		}
+
+		$meta_keys = array(
+			'popularity' => 'total_sales',
+		);
+
+		return array(
+			'meta_key' => $meta_keys[ $orderby ],
+			'orderby'  => 'meta_value_num',
 		);
 	}
 

--- a/src/BlockTypes/ProductQuery.php
+++ b/src/BlockTypes/ProductQuery.php
@@ -209,7 +209,8 @@ class ProductQuery extends AbstractBlock {
 	 * @return array
 	 */
 	public function extend_rest_query_allowed_params( $params ) {
-		return array_merge( $params, $this->custom_order_opts );
+		$params['orderby']['enum'] = array_merge( $params['orderby']['enum'], $this->custom_order_opts );
+		return $params;
 	}
 
 	/**

--- a/src/BlockTypes/ProductQuery.php
+++ b/src/BlockTypes/ProductQuery.php
@@ -149,7 +149,7 @@ class ProductQuery extends AbstractBlock {
 			function( $acc, $query ) {
 				return $this->merge_queries( $acc, $query );
 			},
-			$common_query_values
+			$base_query
 		);
 	}
 
@@ -208,7 +208,7 @@ class ProductQuery extends AbstractBlock {
 	 *
 	 * @return array
 	 */
-	private function extend_rest_query_allowed_params( $params ) {
+	public function extend_rest_query_allowed_params( $params ) {
 		return array_merge( $params, $this->custom_order_opts );
 	}
 

--- a/src/BlockTypes/ProductQuery.php
+++ b/src/BlockTypes/ProductQuery.php
@@ -208,7 +208,7 @@ class ProductQuery extends AbstractBlock {
 	 *
 	 * @return array
 	 */
-	private function extend_rest_query_params( $params ) {
+	private function extend_rest_query_allowed_params( $params ) {
 		return array_merge( $params, $this->custom_order_opts );
 	}
 


### PR DESCRIPTION
This PR achieves the following:

* Adds a section in the inspector control called “Popular Presets”, which contains a dropdown with popular presets (see woocommerce/woocommerce-blocks#7621).
* Adds support for the first preset: “Best selling products”. By selecting this, users can sort products by total sales.
* Switches the order of the custom inspector controls and the default Query Loop inspector controls: our controls will be now on top as per the latest design spec (see pdnLyh-2By-p2).
* Restricts the allowed Query parameters to the sort orders we want to allow according to the latest design spec (disabling title and date).
* Removes the core “Order By” dropdown.
* Refactor `setCustomQueryAttribute` to `setQueryAttribute` because since a few iterations, our custom query attributes are not deeply nested anymore, and this function can be used for the normal query too.

In order to achieve back-end compatibility, since the Product Query block uses the WordPress API as opposed to the Store API, we needed to add compatibility for the custom `popularity` meta value as a valid value of the `orderby` parameter through a REST API filter. This shouldn't cause any side-effects, but it is important to know that we are meddling once more with the REST API itself (the other is to add compatibility for editor preview).

Fixes woocommerce/woocommerce-blocks#7324 
References woocommerce/woocommerce-blocks#7621

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [x] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<img width="273" alt="Screenshot 2022-11-15 at 19 28 26" src="https://user-images.githubusercontent.com/1847066/201997720-0d973e4d-9ca7-421e-9924-4937d1839600.png">


### Testing

#### User Facing Testing

> **Warning**
> Ensure you have at least one order of some of your products and your products have some sales associated with them.

1. Add a Product Query block.
2. Ensure the core Query Loop block inspector settings are now at the bottom of the inspector controls.
3. Ensure a new section called “Popular Filters” is there with a dropdown.
4. Ensure “Newest” is selected as default from the dropdown and products are shown in descending order of date published.
5. Change “Newest” to “Best selling”.
6. Ensure the new order is based on the total sales. For products with no sales, they should all come after, ordered by ID. See https://github.com/woocommerce/woocommerce/issues/42596 and https://wordpress.org/support/topic/sort-by-popularity-4. We are now just reproducing the old logic. Discussion on this is pending.
7. Ensure steps 4 and 6 work on the front-end.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental

### Changelog

> Product Query: add option to sort products by “Best selling”