### PR TITLE
Add `CartEventsContext` to dispatch events in the Cart block

### DIFF
--- a/assets/js/base/components/quantity-selector/index.tsx
+++ b/assets/js/base/components/quantity-selector/index.tsx
@@ -82,13 +82,17 @@ const QuantitySelector = ( {
 }: QuantitySelectorProps ): JSX.Element => {
 	const errorId = `wc-block-components-quantity-selector-error-${ instanceId }`;
 
-	const hasValidationErrors = useSelect( ( select ) => {
-		return !! select( VALIDATION_STORE_KEY ).getValidationError( errorId );
+	const { hasValidationError, validationError } = useSelect( ( select ) => {
+		const store = select( VALIDATION_STORE_KEY );
+		return {
+			hasValidationError: !! store.getValidationError( errorId ),
+			validationError: store.getValidationError( errorId ),
+		};
 	} );
 
 	const classes = classNames(
 		'wc-block-components-quantity-selector',
-		hasValidationErrors ? 'has-error' : '',
+		hasValidationError ? 'has-error' : '',
 		className
 	);
 
@@ -266,16 +270,19 @@ const QuantitySelector = ( {
 				return;
 			}
 			const isValid = inputRef.current.checkValidity();
-			if ( ! isValid ) {
+
+			if ( ! isValid || hasValidationError ) {
 				inputRef.current.focus();
 				return {
 					type: 'error',
-					message: inputRef.current.validationMessage,
+					message:
+						inputRef.current.validationMessage ||
+						validationError?.message,
 				};
 			}
 			return true;
 		} );
-	}, [ onProceedToCheckout ] );
+	}, [ errorId, hasValidationError, onProceedToCheckout, validationError ] );
 
 	return (
 		<div>
@@ -364,7 +371,7 @@ const QuantitySelector = ( {
 					&#65291;
 				</button>
 			</div>
-			{ hasValidationErrors && ! strictLimits && (
+			{ hasValidationError && ! strictLimits && (
 				<div>
 					<ValidationInputError propertyName={ errorId } />
 				</div>

--- a/assets/js/base/components/quantity-selector/index.tsx
+++ b/assets/js/base/components/quantity-selector/index.tsx
@@ -133,7 +133,7 @@ const QuantitySelector = ( {
 				onChange( value );
 			}
 		},
-		[ hasMaximum, maximum, minimum, onChange, step ]
+		[ hasMaximum, maximum, minimum, onChange, step, strictLimits ]
 	);
 
 	/*

--- a/assets/js/base/context/providers/cart-checkout/cart-events/event-emit.ts
+++ b/assets/js/base/context/providers/cart-checkout/cart-events/event-emit.ts
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import { useMemo } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import {
+	emitterCallback,
+	reducer,
+	emitEvent,
+	emitEventWithAbort,
+	ActionType,
+} from '../../../event-emit';
+
+// These events are emitted when the Cart status is BEFORE_PROCESSING and AFTER_PROCESSING
+// to enable third parties to hook into the cart process
+const EVENTS = {
+	PROCEED_TO_CHECKOUT: 'cart_proceed_to_checkout',
+};
+
+type EventEmittersType = Record< string, ReturnType< typeof emitterCallback > >;
+
+/**
+ * Receives a reducer dispatcher and returns an object with the
+ * various event emitters for the payment processing events.
+ *
+ * Calling the event registration function with the callback will register it
+ * for the event emitter and will return a dispatcher for removing the
+ * registered callback (useful for implementation in `useEffect`).
+ *
+ * @param {Function} observerDispatch The emitter reducer dispatcher.
+ * @return {Object} An object with the various payment event emitter registration functions
+ */
+const useEventEmitters = (
+	observerDispatch: React.Dispatch< ActionType >
+): EventEmittersType => {
+	const eventEmitters = useMemo(
+		() => ( {
+			onProceedToCheckout: emitterCallback(
+				EVENTS.PROCEED_TO_CHECKOUT,
+				observerDispatch
+			),
+		} ),
+		[ observerDispatch ]
+	);
+	return eventEmitters;
+};
+
+export { EVENTS, useEventEmitters, reducer, emitEvent, emitEventWithAbort };

--- a/assets/js/base/context/providers/cart-checkout/cart-events/index.tsx
+++ b/assets/js/base/context/providers/cart-checkout/cart-events/index.tsx
@@ -47,7 +47,7 @@ export const useCartEventsContext = () => {
 export const CartEventsProvider = ( {
 	children,
 }: {
-	children: React.ReactChildren;
+	children: React.ReactNode;
 } ): JSX.Element => {
 	const [ observers, observerDispatch ] = useReducer( emitReducer, {} );
 	const currentObservers = useRef( observers );

--- a/assets/js/base/context/providers/cart-checkout/cart-events/index.tsx
+++ b/assets/js/base/context/providers/cart-checkout/cart-events/index.tsx
@@ -1,0 +1,78 @@
+/**
+ * External dependencies
+ */
+
+import {
+	createContext,
+	useContext,
+	useReducer,
+	useRef,
+	useEffect,
+} from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import {
+	useEventEmitters,
+	reducer as emitReducer,
+	emitEventWithAbort,
+	EVENTS,
+} from './event-emit';
+import type { emitterCallback } from '../../../event-emit';
+
+type CartEventsContextType = {
+	// Used to register a callback that will fire when the cart has been processed and has an error.
+	onProceedToCheckout: ReturnType< typeof emitterCallback >;
+	// Used to register a callback that will fire when the cart has been processed and has an error.
+	dispatchOnProceedToCheckout: () => Promise< unknown[] >;
+};
+
+const CartEventsContext = createContext< CartEventsContextType >( {
+	onProceedToCheckout: () => () => void null,
+	dispatchOnProceedToCheckout: () => new Promise( () => void null ),
+} );
+
+export const useCartEventsContext = () => {
+	return useContext( CartEventsContext );
+};
+
+/**
+ * Checkout Events provider
+ * Emit Checkout events and provide access to Checkout event handlers
+ *
+ * @param {Object} props          Incoming props for the provider.
+ * @param {Object} props.children The children being wrapped.
+ */
+export const CartEventsProvider = ( {
+	children,
+}: {
+	children: React.ReactChildren;
+} ): JSX.Element => {
+	const [ observers, observerDispatch ] = useReducer( emitReducer, {} );
+	const currentObservers = useRef( observers );
+	const { onProceedToCheckout } = useEventEmitters( observerDispatch );
+
+	// set observers on ref so it's always current.
+	useEffect( () => {
+		currentObservers.current = observers;
+	}, [ observers ] );
+
+	const dispatchOnProceedToCheckout = async () => {
+		return await emitEventWithAbort(
+			currentObservers.current,
+			EVENTS.PROCEED_TO_CHECKOUT,
+			null
+		);
+	};
+
+	const cartEvents = {
+		onProceedToCheckout,
+		dispatchOnProceedToCheckout,
+	};
+	return (
+		<CartEventsContext.Provider value={ cartEvents }>
+			{ children }
+		</CartEventsContext.Provider>
+	);
+};

--- a/assets/js/base/context/providers/cart-checkout/cart-events/test/index.tsx
+++ b/assets/js/base/context/providers/cart-checkout/cart-events/test/index.tsx
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import { useCartEventsContext } from '@woocommerce/base-context';
+import { useEffect } from '@wordpress/element';
+import { render, screen, waitFor } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { CartEventsProvider } from '../index';
+import Block from '../../../../../../blocks/cart/inner-blocks/proceed-to-checkout-block/block';
+
+describe( 'CartEventsProvider', () => {
+	it( 'allows observers to unsubscribe', async () => {
+		const mockObserver = jest.fn();
+		const MockObserverComponent = () => {
+			const { onProceedToCheckout } = useCartEventsContext();
+			useEffect( () => {
+				const unsubscribe = onProceedToCheckout( () => {
+					mockObserver();
+					unsubscribe();
+				} );
+			}, [ onProceedToCheckout ] );
+			return <div>Mock observer</div>;
+		};
+
+		render(
+			<CartEventsProvider>
+				<div>
+					<MockObserverComponent />
+					<Block checkoutPageId={ 0 } className="test-block" />
+				</div>
+			</CartEventsProvider>
+		);
+		expect( screen.getByText( 'Mock observer' ) ).toBeInTheDocument();
+		const button = screen.getByText( 'Proceed to Checkout' );
+		// Click twice. The observer should unsubscribe after the first click.
+		button.click();
+		button.click();
+		await waitFor( () => {
+			expect( mockObserver ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+} );

--- a/assets/js/base/context/providers/cart-checkout/index.js
+++ b/assets/js/base/context/providers/cart-checkout/index.js
@@ -2,6 +2,7 @@ export * from './payment-events';
 export * from './shipping';
 export * from './customer';
 export * from './checkout-events';
+export * from './cart-events';
 export * from './cart';
 export * from './checkout-processor';
 export * from './checkout-provider';

--- a/assets/js/blocks/cart/block.js
+++ b/assets/js/blocks/cart/block.js
@@ -13,7 +13,10 @@ import { CURRENT_USER_IS_ADMIN } from '@woocommerce/settings';
 import BlockErrorBoundary from '@woocommerce/base-components/block-error-boundary';
 import { translateJQueryEventToNative } from '@woocommerce/base-utils';
 import withScrollToTop from '@woocommerce/base-hocs/with-scroll-to-top';
-import { CartProvider } from '@woocommerce/base-context/providers';
+import {
+	CartProvider,
+	CartEventsProvider,
+} from '@woocommerce/base-context/providers';
 import { SlotFillProvider } from '@woocommerce/blocks-checkout';
 
 /**
@@ -87,8 +90,10 @@ const Block = ( { attributes, children, scrollToTop } ) => (
 		<StoreNoticesContainer context="wc/cart" />
 		<SlotFillProvider>
 			<CartProvider>
-				<Cart attributes={ attributes }>{ children }</Cart>
-				<ScrollOnError scrollToTop={ scrollToTop } />
+				<CartEventsProvider>
+					<Cart attributes={ attributes }>{ children }</Cart>
+					<ScrollOnError scrollToTop={ scrollToTop } />
+				</CartEventsProvider>
 			</CartProvider>
 		</SlotFillProvider>
 	</BlockErrorBoundary>

--- a/assets/js/blocks/cart/cart-line-items-table/cart-line-item-row.tsx
+++ b/assets/js/blocks/cart/cart-line-items-table/cart-line-item-row.tsx
@@ -99,186 +99,202 @@ const CartLineItemRow: ForwardRefExoticComponent<
 					price: '0',
 					regular_price: '0',
 					sale_price: '0',
+					price_range: null,
+					raw_prices: {
+						precision: 6,
+						price: '0',
+						regular_price: '0',
+						sale_price: '0',
+					},
 				},
-			},
-			totals = {
-				currency_code: 'USD',
-				currency_minor_unit: 2,
-				currency_symbol: '$',
-				currency_prefix: '$',
-				currency_suffix: '',
-				currency_decimal_separator: '.',
-				currency_thousand_separator: ',',
-				line_subtotal: '0',
-				line_subtotal_tax: '0',
-			},
-			extensions,
-		} = lineItem;
+				totals = {
+					currency_code: 'USD',
+					currency_minor_unit: 2,
+					currency_symbol: '$',
+					currency_prefix: '$',
+					currency_suffix: '',
+					currency_decimal_separator: '.',
+					currency_thousand_separator: ',',
+					line_subtotal: '0',
+					line_subtotal_tax: '0',
+				},
+				extensions,
+			} = lineItem;
 
-		const { quantity, setItemQuantity, removeItem, isPendingDelete } =
-			useStoreCartItemQuantity( lineItem );
-		const { dispatchStoreEvent } = useStoreEvents();
+			const { quantity, setItemQuantity, removeItem, isPendingDelete } =
+				useStoreCartItemQuantity( lineItem );
+			const { dispatchStoreEvent } = useStoreEvents();
 
-		// Prepare props to pass to the __experimentalApplyCheckoutFilter filter.
-		// We need to pluck out receiveCart.
-		// eslint-disable-next-line no-unused-vars
-		const { receiveCart, ...cart } = useStoreCart();
-		const arg = useMemo(
-			() => ( {
-				context: 'cart',
-				cartItem: lineItem,
-				cart,
-			} ),
-			[ lineItem, cart ]
-		);
-		const priceCurrency = getCurrencyFromPriceResponse( prices );
-		const name = __experimentalApplyCheckoutFilter( {
-			filterName: 'itemName',
-			defaultValue: initialName,
-			extensions,
-			arg,
-		} );
+			// Prepare props to pass to the __experimentalApplyCheckoutFilter filter.
+			// We need to pluck out receiveCart.
+			// eslint-disable-next-line no-unused-vars
+			const { receiveCart, ...cart } = useStoreCart();
+			const arg = useMemo(
+				() => ( {
+					context: 'cart',
+					cartItem: lineItem,
+					cart,
+				} ),
+				[ lineItem, cart ]
+			);
+			const priceCurrency = getCurrencyFromPriceResponse( prices );
+			const name = __experimentalApplyCheckoutFilter( {
+				filterName: 'itemName',
+				defaultValue: initialName,
+				extensions,
+				arg,
+			} );
 
-		const regularAmountSingle = Dinero( {
-			amount: parseInt( prices.raw_prices.regular_price, 10 ),
-			precision: prices.raw_prices.precision,
-		} );
-		const purchaseAmountSingle = Dinero( {
-			amount: parseInt( prices.raw_prices.price, 10 ),
-			precision: prices.raw_prices.precision,
-		} );
-		const saleAmountSingle =
-			regularAmountSingle.subtract( purchaseAmountSingle );
-		const saleAmount = saleAmountSingle.multiply( quantity );
-		const totalsCurrency = getCurrencyFromPriceResponse( totals );
-		let lineSubtotal = parseInt( totals.line_subtotal, 10 );
-		if ( getSetting( 'displayCartPricesIncludingTax', false ) ) {
-			lineSubtotal += parseInt( totals.line_subtotal_tax, 10 );
-		}
-		const subtotalPrice = Dinero( {
-			amount: lineSubtotal,
-			precision: totalsCurrency.minorUnit,
-		} );
+			const regularAmountSingle = Dinero( {
+				amount: parseInt( prices.raw_prices.regular_price, 10 ),
+				precision: prices.raw_prices.precision,
+			} );
+			const purchaseAmountSingle = Dinero( {
+				amount: parseInt( prices.raw_prices.price, 10 ),
+				precision: prices.raw_prices.precision,
+			} );
+			const saleAmountSingle =
+				regularAmountSingle.subtract( purchaseAmountSingle );
+			const saleAmount = saleAmountSingle.multiply( quantity );
+			const totalsCurrency = getCurrencyFromPriceResponse( totals );
+			let lineSubtotal = parseInt( totals.line_subtotal, 10 );
+			if ( getSetting( 'displayCartPricesIncludingTax', false ) ) {
+				lineSubtotal += parseInt( totals.line_subtotal_tax, 10 );
+			}
+			const subtotalPrice = Dinero( {
+				amount: lineSubtotal,
+				precision: totalsCurrency.minorUnit,
+			} );
 
-		const firstImage = images.length ? images[ 0 ] : {};
-		const isProductHiddenFromCatalog =
-			catalogVisibility === 'hidden' || catalogVisibility === 'search';
+			const firstImage = images.length ? images[ 0 ] : {};
+			const isProductHiddenFromCatalog =
+				catalogVisibility === 'hidden' ||
+				catalogVisibility === 'search';
 
-		const cartItemClassNameFilter = __experimentalApplyCheckoutFilter( {
-			filterName: 'cartItemClass',
-			defaultValue: '',
-			extensions,
-			arg,
-		} );
+			const cartItemClassNameFilter = __experimentalApplyCheckoutFilter( {
+				filterName: 'cartItemClass',
+				defaultValue: '',
+				extensions,
+				arg,
+			} );
 
-		// Allow extensions to filter how the price is displayed. Ie: prepending or appending some values.
-		const productPriceFormat = __experimentalApplyCheckoutFilter( {
-			filterName: 'cartItemPrice',
-			defaultValue: '<price/>',
-			extensions,
-			arg,
-			validation: productPriceValidation,
-		} );
+			// Allow extensions to filter how the price is displayed. Ie: prepending or appending some values.
+			const productPriceFormat = __experimentalApplyCheckoutFilter( {
+				filterName: 'cartItemPrice',
+				defaultValue: '<price/>',
+				extensions,
+				arg,
+				validation: productPriceValidation,
+			} );
 
-		const subtotalPriceFormat = __experimentalApplyCheckoutFilter( {
-			filterName: 'subtotalPriceFormat',
-			defaultValue: '<price/>',
-			extensions,
-			arg,
-			validation: productPriceValidation,
-		} );
+			const subtotalPriceFormat = __experimentalApplyCheckoutFilter( {
+				filterName: 'subtotalPriceFormat',
+				defaultValue: '<price/>',
+				extensions,
+				arg,
+				validation: productPriceValidation,
+			} );
 
-		const saleBadgePriceFormat = __experimentalApplyCheckoutFilter( {
-			filterName: 'saleBadgePriceFormat',
-			defaultValue: '<price/>',
-			extensions,
-			arg,
-			validation: productPriceValidation,
-		} );
+			const saleBadgePriceFormat = __experimentalApplyCheckoutFilter( {
+				filterName: 'saleBadgePriceFormat',
+				defaultValue: '<price/>',
+				extensions,
+				arg,
+				validation: productPriceValidation,
+			} );
 
-		const showRemoveItemLink = __experimentalApplyCheckoutFilter( {
-			filterName: 'showRemoveItemLink',
-			defaultValue: true,
-			extensions,
-			arg,
-		} );
+			const showRemoveItemLink = __experimentalApplyCheckoutFilter( {
+				filterName: 'showRemoveItemLink',
+				defaultValue: true,
+				extensions,
+				arg,
+			} );
 
-		return (
-			<tr
-				className={ classnames(
-					'wc-block-cart-items__row',
-					cartItemClassNameFilter,
-					{
-						'is-disabled': isPendingDelete,
-					}
-				) }
-				ref={ ref }
-				tabIndex={ tabIndex }
-			>
-				{ /* If the image has no alt text, this link is unnecessary and can be hidden. */ }
-				<td
-					className="wc-block-cart-item__image"
-					aria-hidden={
-						! objectHasProp( firstImage, 'alt' ) || ! firstImage.alt
-					}
+			return (
+				<tr
+					className={ classnames(
+						'wc-block-cart-items__row',
+						cartItemClassNameFilter,
+						{
+							'is-disabled': isPendingDelete,
+						}
+					) }
+					ref={ ref }
+					tabIndex={ tabIndex }
 				>
-					{ /* We don't need to make it focusable, because product name has the same link. */ }
-					{ isProductHiddenFromCatalog ? (
-						<ProductImage
-							image={ firstImage }
-							fallbackAlt={ name }
-						/>
-					) : (
-						<a href={ permalink } tabIndex={ -1 }>
+					{ /* If the image has no alt text, this link is unnecessary and can be hidden. */ }
+					<td
+						className="wc-block-cart-item__image"
+						aria-hidden={
+							! objectHasProp( firstImage, 'alt' ) ||
+							! firstImage.alt
+						}
+					>
+						{ /* We don't need to make it focusable, because product name has the same link. */ }
+						{ isProductHiddenFromCatalog ? (
 							<ProductImage
 								image={ firstImage }
 								fallbackAlt={ name }
 							/>
-						</a>
-					) }
-				</td>
-				<td className="wc-block-cart-item__product">
-					<div className="wc-block-cart-item__wrap">
-						<ProductName
-							disabled={
-								isPendingDelete || isProductHiddenFromCatalog
-							}
-							name={ name }
-							permalink={ permalink }
-						/>
-						{ showBackorderBadge ? (
-							<ProductBackorderBadge />
 						) : (
-							!! lowStockRemaining && (
-								<ProductLowStockBadge
-									lowStockRemaining={ lowStockRemaining }
+							<a href={ permalink } tabIndex={ -1 }>
+								<ProductImage
+									image={ firstImage }
+									fallbackAlt={ name }
 								/>
-							)
+							</a>
 						) }
-
-						<div className="wc-block-cart-item__prices">
-							<ProductPrice
-								currency={ priceCurrency }
-								regularPrice={ getAmountFromRawPrice(
-									regularAmountSingle,
-									priceCurrency
-								) }
-								price={ getAmountFromRawPrice(
-									purchaseAmountSingle,
-									priceCurrency
-								) }
-								format={ subtotalPriceFormat }
+					</td>
+					<td className="wc-block-cart-item__product">
+						<div className="wc-block-cart-item__wrap">
+							<ProductName
+								disabled={
+									isPendingDelete ||
+									isProductHiddenFromCatalog
+								}
+								name={ name }
+								permalink={ permalink }
 							/>
-						</div>
-
-						<ProductSaleBadge
-							currency={ priceCurrency }
-							saleAmount={ getAmountFromRawPrice(
-								saleAmountSingle,
-								priceCurrency
+							{ showBackorderBadge ? (
+								<ProductBackorderBadge />
+							) : (
+								!! lowStockRemaining && (
+									<ProductLowStockBadge
+										lowStockRemaining={ lowStockRemaining }
+									/>
+								)
 							) }
-							format={ saleBadgePriceFormat }
-						/>
+
+							<div className="wc-block-cart-item__prices">
+								<ProductPrice
+									currency={ priceCurrency }
+									regularPrice={ getAmountFromRawPrice(
+										regularAmountSingle,
+										priceCurrency
+									) }
+									price={ getAmountFromRawPrice(
+										purchaseAmountSingle,
+										priceCurrency
+									) }
+									format={ subtotalPriceFormat }
+								/>
+							</div>
+
+							<ProductSaleBadge
+								currency={ priceCurrency }
+								saleAmount={ getAmountFromRawPrice(
+									saleAmountSingle,
+									priceCurrency
+								) }
+								format={ saleBadgePriceFormat }
+							/>
+
+							<ProductMetadata
+								shortDescription={ shortDescription }
+								fullDescription={ fullDescription }
+								itemData={ itemData }
+								variation={ variation }
+							/>
 
 						<ProductMetadata
 							shortDescription={ shortDescription }
@@ -300,47 +316,51 @@ const CartLineItemRow: ForwardRefExoticComponent<
 										onChange={ ( newQuantity ) => {
 											setItemQuantity( newQuantity );
 											dispatchStoreEvent(
-												'cart-set-item-quantity',
+												'cart-remove-item',
 												{
 													product: lineItem,
-													quantity: newQuantity,
+													quantity,
 												}
 											);
+											speak(
+												sprintf(
+													/* translators: %s refers to the item name in the cart. */
+													__(
+														'%s has been removed from your cart.',
+														'woo-gutenberg-products-block'
+													),
+													name
+												)
+											);
 										} }
-										itemName={ name }
-									/>
+										disabled={ isPendingDelete }
+									>
+										{ __(
+											'Remove item',
+											'woo-gutenberg-products-block'
+										) }
+									</button>
 								) }
-							{ showRemoveItemLink && (
-								<button
-									className="wc-block-cart-item__remove-link"
-									onClick={ () => {
-										onRemove();
-										removeItem();
-										dispatchStoreEvent(
-											'cart-remove-item',
-											{
-												product: lineItem,
-												quantity,
-											}
-										);
-										speak(
-											sprintf(
-												/* translators: %s refers to the item name in the cart. */
-												__(
-													'%s has been removed from your cart.',
-													'woo-gutenberg-products-block'
-												),
-												name
-											)
-										);
-									} }
-									disabled={ isPendingDelete }
-								>
-									{ __(
-										'Remove item',
-										'woo-gutenberg-products-block'
+							</div>
+						</div>
+					</td>
+					<td className="wc-block-cart-item__total">
+						<div className="wc-block-cart-item__total-price-and-sale-badge-wrapper">
+							<ProductPrice
+								currency={ totalsCurrency }
+								format={ productPriceFormat }
+								price={ subtotalPrice.getAmount() }
+							/>
+
+							{ quantity > 1 && (
+								<ProductSaleBadge
+									currency={ priceCurrency }
+									saleAmount={ getAmountFromRawPrice(
+										saleAmount,
+										priceCurrency
 									) }
-								</button>
+									format={ saleBadgePriceFormat }
+								/>
 							) }
 						</div>
 					</div>

--- a/assets/js/blocks/cart/cart-line-items-table/cart-line-item-row.tsx
+++ b/assets/js/blocks/cart/cart-line-items-table/cart-line-item-row.tsx
@@ -99,202 +99,186 @@ const CartLineItemRow: ForwardRefExoticComponent<
 					price: '0',
 					regular_price: '0',
 					sale_price: '0',
-					price_range: null,
-					raw_prices: {
-						precision: 6,
-						price: '0',
-						regular_price: '0',
-						sale_price: '0',
-					},
 				},
-				totals = {
-					currency_code: 'USD',
-					currency_minor_unit: 2,
-					currency_symbol: '$',
-					currency_prefix: '$',
-					currency_suffix: '',
-					currency_decimal_separator: '.',
-					currency_thousand_separator: ',',
-					line_subtotal: '0',
-					line_subtotal_tax: '0',
-				},
-				extensions,
-			} = lineItem;
+			},
+			totals = {
+				currency_code: 'USD',
+				currency_minor_unit: 2,
+				currency_symbol: '$',
+				currency_prefix: '$',
+				currency_suffix: '',
+				currency_decimal_separator: '.',
+				currency_thousand_separator: ',',
+				line_subtotal: '0',
+				line_subtotal_tax: '0',
+			},
+			extensions,
+		} = lineItem;
 
-			const { quantity, setItemQuantity, removeItem, isPendingDelete } =
-				useStoreCartItemQuantity( lineItem );
-			const { dispatchStoreEvent } = useStoreEvents();
+		const { quantity, setItemQuantity, removeItem, isPendingDelete } =
+			useStoreCartItemQuantity( lineItem );
+		const { dispatchStoreEvent } = useStoreEvents();
 
-			// Prepare props to pass to the __experimentalApplyCheckoutFilter filter.
-			// We need to pluck out receiveCart.
-			// eslint-disable-next-line no-unused-vars
-			const { receiveCart, ...cart } = useStoreCart();
-			const arg = useMemo(
-				() => ( {
-					context: 'cart',
-					cartItem: lineItem,
-					cart,
-				} ),
-				[ lineItem, cart ]
-			);
-			const priceCurrency = getCurrencyFromPriceResponse( prices );
-			const name = __experimentalApplyCheckoutFilter( {
-				filterName: 'itemName',
-				defaultValue: initialName,
-				extensions,
-				arg,
-			} );
+		// Prepare props to pass to the __experimentalApplyCheckoutFilter filter.
+		// We need to pluck out receiveCart.
+		// eslint-disable-next-line no-unused-vars
+		const { receiveCart, ...cart } = useStoreCart();
+		const arg = useMemo(
+			() => ( {
+				context: 'cart',
+				cartItem: lineItem,
+				cart,
+			} ),
+			[ lineItem, cart ]
+		);
+		const priceCurrency = getCurrencyFromPriceResponse( prices );
+		const name = __experimentalApplyCheckoutFilter( {
+			filterName: 'itemName',
+			defaultValue: initialName,
+			extensions,
+			arg,
+		} );
 
-			const regularAmountSingle = Dinero( {
-				amount: parseInt( prices.raw_prices.regular_price, 10 ),
-				precision: prices.raw_prices.precision,
-			} );
-			const purchaseAmountSingle = Dinero( {
-				amount: parseInt( prices.raw_prices.price, 10 ),
-				precision: prices.raw_prices.precision,
-			} );
-			const saleAmountSingle =
-				regularAmountSingle.subtract( purchaseAmountSingle );
-			const saleAmount = saleAmountSingle.multiply( quantity );
-			const totalsCurrency = getCurrencyFromPriceResponse( totals );
-			let lineSubtotal = parseInt( totals.line_subtotal, 10 );
-			if ( getSetting( 'displayCartPricesIncludingTax', false ) ) {
-				lineSubtotal += parseInt( totals.line_subtotal_tax, 10 );
-			}
-			const subtotalPrice = Dinero( {
-				amount: lineSubtotal,
-				precision: totalsCurrency.minorUnit,
-			} );
+		const regularAmountSingle = Dinero( {
+			amount: parseInt( prices.raw_prices.regular_price, 10 ),
+			precision: prices.raw_prices.precision,
+		} );
+		const purchaseAmountSingle = Dinero( {
+			amount: parseInt( prices.raw_prices.price, 10 ),
+			precision: prices.raw_prices.precision,
+		} );
+		const saleAmountSingle =
+			regularAmountSingle.subtract( purchaseAmountSingle );
+		const saleAmount = saleAmountSingle.multiply( quantity );
+		const totalsCurrency = getCurrencyFromPriceResponse( totals );
+		let lineSubtotal = parseInt( totals.line_subtotal, 10 );
+		if ( getSetting( 'displayCartPricesIncludingTax', false ) ) {
+			lineSubtotal += parseInt( totals.line_subtotal_tax, 10 );
+		}
+		const subtotalPrice = Dinero( {
+			amount: lineSubtotal,
+			precision: totalsCurrency.minorUnit,
+		} );
 
-			const firstImage = images.length ? images[ 0 ] : {};
-			const isProductHiddenFromCatalog =
-				catalogVisibility === 'hidden' ||
-				catalogVisibility === 'search';
+		const firstImage = images.length ? images[ 0 ] : {};
+		const isProductHiddenFromCatalog =
+			catalogVisibility === 'hidden' || catalogVisibility === 'search';
 
-			const cartItemClassNameFilter = __experimentalApplyCheckoutFilter( {
-				filterName: 'cartItemClass',
-				defaultValue: '',
-				extensions,
-				arg,
-			} );
+		const cartItemClassNameFilter = __experimentalApplyCheckoutFilter( {
+			filterName: 'cartItemClass',
+			defaultValue: '',
+			extensions,
+			arg,
+		} );
 
-			// Allow extensions to filter how the price is displayed. Ie: prepending or appending some values.
-			const productPriceFormat = __experimentalApplyCheckoutFilter( {
-				filterName: 'cartItemPrice',
-				defaultValue: '<price/>',
-				extensions,
-				arg,
-				validation: productPriceValidation,
-			} );
+		// Allow extensions to filter how the price is displayed. Ie: prepending or appending some values.
+		const productPriceFormat = __experimentalApplyCheckoutFilter( {
+			filterName: 'cartItemPrice',
+			defaultValue: '<price/>',
+			extensions,
+			arg,
+			validation: productPriceValidation,
+		} );
 
-			const subtotalPriceFormat = __experimentalApplyCheckoutFilter( {
-				filterName: 'subtotalPriceFormat',
-				defaultValue: '<price/>',
-				extensions,
-				arg,
-				validation: productPriceValidation,
-			} );
+		const subtotalPriceFormat = __experimentalApplyCheckoutFilter( {
+			filterName: 'subtotalPriceFormat',
+			defaultValue: '<price/>',
+			extensions,
+			arg,
+			validation: productPriceValidation,
+		} );
 
-			const saleBadgePriceFormat = __experimentalApplyCheckoutFilter( {
-				filterName: 'saleBadgePriceFormat',
-				defaultValue: '<price/>',
-				extensions,
-				arg,
-				validation: productPriceValidation,
-			} );
+		const saleBadgePriceFormat = __experimentalApplyCheckoutFilter( {
+			filterName: 'saleBadgePriceFormat',
+			defaultValue: '<price/>',
+			extensions,
+			arg,
+			validation: productPriceValidation,
+		} );
 
-			const showRemoveItemLink = __experimentalApplyCheckoutFilter( {
-				filterName: 'showRemoveItemLink',
-				defaultValue: true,
-				extensions,
-				arg,
-			} );
+		const showRemoveItemLink = __experimentalApplyCheckoutFilter( {
+			filterName: 'showRemoveItemLink',
+			defaultValue: true,
+			extensions,
+			arg,
+		} );
 
-			return (
-				<tr
-					className={ classnames(
-						'wc-block-cart-items__row',
-						cartItemClassNameFilter,
-						{
-							'is-disabled': isPendingDelete,
-						}
-					) }
-					ref={ ref }
-					tabIndex={ tabIndex }
+		return (
+			<tr
+				className={ classnames(
+					'wc-block-cart-items__row',
+					cartItemClassNameFilter,
+					{
+						'is-disabled': isPendingDelete,
+					}
+				) }
+				ref={ ref }
+				tabIndex={ tabIndex }
+			>
+				{ /* If the image has no alt text, this link is unnecessary and can be hidden. */ }
+				<td
+					className="wc-block-cart-item__image"
+					aria-hidden={
+						! objectHasProp( firstImage, 'alt' ) || ! firstImage.alt
+					}
 				>
-					{ /* If the image has no alt text, this link is unnecessary and can be hidden. */ }
-					<td
-						className="wc-block-cart-item__image"
-						aria-hidden={
-							! objectHasProp( firstImage, 'alt' ) ||
-							! firstImage.alt
-						}
-					>
-						{ /* We don't need to make it focusable, because product name has the same link. */ }
-						{ isProductHiddenFromCatalog ? (
+					{ /* We don't need to make it focusable, because product name has the same link. */ }
+					{ isProductHiddenFromCatalog ? (
+						<ProductImage
+							image={ firstImage }
+							fallbackAlt={ name }
+						/>
+					) : (
+						<a href={ permalink } tabIndex={ -1 }>
 							<ProductImage
 								image={ firstImage }
 								fallbackAlt={ name }
 							/>
+						</a>
+					) }
+				</td>
+				<td className="wc-block-cart-item__product">
+					<div className="wc-block-cart-item__wrap">
+						<ProductName
+							disabled={
+								isPendingDelete || isProductHiddenFromCatalog
+							}
+							name={ name }
+							permalink={ permalink }
+						/>
+						{ showBackorderBadge ? (
+							<ProductBackorderBadge />
 						) : (
-							<a href={ permalink } tabIndex={ -1 }>
-								<ProductImage
-									image={ firstImage }
-									fallbackAlt={ name }
+							!! lowStockRemaining && (
+								<ProductLowStockBadge
+									lowStockRemaining={ lowStockRemaining }
 								/>
-							</a>
+							)
 						) }
-					</td>
-					<td className="wc-block-cart-item__product">
-						<div className="wc-block-cart-item__wrap">
-							<ProductName
-								disabled={
-									isPendingDelete ||
-									isProductHiddenFromCatalog
-								}
-								name={ name }
-								permalink={ permalink }
-							/>
-							{ showBackorderBadge ? (
-								<ProductBackorderBadge />
-							) : (
-								!! lowStockRemaining && (
-									<ProductLowStockBadge
-										lowStockRemaining={ lowStockRemaining }
-									/>
-								)
-							) }
 
-							<div className="wc-block-cart-item__prices">
-								<ProductPrice
-									currency={ priceCurrency }
-									regularPrice={ getAmountFromRawPrice(
-										regularAmountSingle,
-										priceCurrency
-									) }
-									price={ getAmountFromRawPrice(
-										purchaseAmountSingle,
-										priceCurrency
-									) }
-									format={ subtotalPriceFormat }
-								/>
-							</div>
-
-							<ProductSaleBadge
+						<div className="wc-block-cart-item__prices">
+							<ProductPrice
 								currency={ priceCurrency }
-								saleAmount={ getAmountFromRawPrice(
-									saleAmountSingle,
+								regularPrice={ getAmountFromRawPrice(
+									regularAmountSingle,
 									priceCurrency
 								) }
-								format={ saleBadgePriceFormat }
+								price={ getAmountFromRawPrice(
+									purchaseAmountSingle,
+									priceCurrency
+								) }
+								format={ subtotalPriceFormat }
 							/>
+						</div>
 
-							<ProductMetadata
-								shortDescription={ shortDescription }
-								fullDescription={ fullDescription }
-								itemData={ itemData }
-								variation={ variation }
-							/>
+						<ProductSaleBadge
+							currency={ priceCurrency }
+							saleAmount={ getAmountFromRawPrice(
+								saleAmountSingle,
+								priceCurrency
+							) }
+							format={ saleBadgePriceFormat }
+						/>
 
 						<ProductMetadata
 							shortDescription={ shortDescription }
@@ -316,51 +300,47 @@ const CartLineItemRow: ForwardRefExoticComponent<
 										onChange={ ( newQuantity ) => {
 											setItemQuantity( newQuantity );
 											dispatchStoreEvent(
-												'cart-remove-item',
+												'cart-set-item-quantity',
 												{
 													product: lineItem,
-													quantity,
+													quantity: newQuantity,
 												}
 											);
-											speak(
-												sprintf(
-													/* translators: %s refers to the item name in the cart. */
-													__(
-														'%s has been removed from your cart.',
-														'woo-gutenberg-products-block'
-													),
-													name
-												)
-											);
 										} }
-										disabled={ isPendingDelete }
-									>
-										{ __(
-											'Remove item',
-											'woo-gutenberg-products-block'
-										) }
-									</button>
+										itemName={ name }
+									/>
 								) }
-							</div>
-						</div>
-					</td>
-					<td className="wc-block-cart-item__total">
-						<div className="wc-block-cart-item__total-price-and-sale-badge-wrapper">
-							<ProductPrice
-								currency={ totalsCurrency }
-								format={ productPriceFormat }
-								price={ subtotalPrice.getAmount() }
-							/>
-
-							{ quantity > 1 && (
-								<ProductSaleBadge
-									currency={ priceCurrency }
-									saleAmount={ getAmountFromRawPrice(
-										saleAmount,
-										priceCurrency
+							{ showRemoveItemLink && (
+								<button
+									className="wc-block-cart-item__remove-link"
+									onClick={ () => {
+										onRemove();
+										removeItem();
+										dispatchStoreEvent(
+											'cart-remove-item',
+											{
+												product: lineItem,
+												quantity,
+											}
+										);
+										speak(
+											sprintf(
+												/* translators: %s refers to the item name in the cart. */
+												__(
+													'%s has been removed from your cart.',
+													'woo-gutenberg-products-block'
+												),
+												name
+											)
+										);
+									} }
+									disabled={ isPendingDelete }
+								>
+									{ __(
+										'Remove item',
+										'woo-gutenberg-products-block'
 									) }
-									format={ saleBadgePriceFormat }
-								/>
+								</button>
 							) }
 						</div>
 					</div>

--- a/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/block.tsx
+++ b/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/block.tsx
@@ -15,6 +15,7 @@ import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
  * Internal dependencies
  */
 import './style.scss';
+import { useCartEventsContext } from '../../../../base/context/providers/cart-checkout/cart-events';
 
 /**
  * Checkout button rendered in the full cart page.
@@ -62,7 +63,17 @@ const Block = ( {
 				className="wc-block-cart__submit-button"
 				href={ link || CHECKOUT_URL }
 				disabled={ isCalculating }
-				onClick={ () => setShowSpinner( true ) }
+				onClick={ ( e ) => {
+					dispatchOnProceedToCheckout().then(
+						( observerResponses ) => {
+							if ( observerResponses.some( isErrorResponse ) ) {
+								e.preventDefault();
+								return;
+							}
+							setShowSpinner( true );
+						}
+					);
+				} }
 				showSpinner={ showSpinner }
 			>
 				{ __( 'Proceed to Checkout', 'woo-gutenberg-products-block' ) }

--- a/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/block.tsx
+++ b/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/block.tsx
@@ -10,6 +10,7 @@ import { usePositionRelativeToViewport } from '@woocommerce/base-hooks';
 import { getSetting } from '@woocommerce/settings';
 import { useSelect } from '@wordpress/data';
 import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
+import { isErrorResponse } from '@woocommerce/base-context';
 
 /**
  * Internal dependencies
@@ -56,6 +57,8 @@ const Block = ( {
 			global.removeEventListener( 'pageshow', hideSpinner );
 		};
 	}, [] );
+
+	const { dispatchOnProceedToCheckout } = useCartEventsContext();
 
 	const submitContainerContents = (
 		<div>

--- a/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/test/block.tsx
+++ b/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/test/block.tsx
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import { useCartEventsContext } from '@woocommerce/base-context';
+import { useEffect } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import Block from '../block';
+import { CartEventsProvider } from '../../../../../base/context/providers';
+
+describe( 'ProceedToCheckoutBlock', () => {
+	it( 'dispatches the onProceedToCheckout event when the button is clicked', async () => {
+		const mockObserver = jest.fn();
+		const MockObserverComponent = () => {
+			const { onProceedToCheckout } = useCartEventsContext();
+			useEffect( () => {
+				return onProceedToCheckout( mockObserver );
+			}, [ onProceedToCheckout ] );
+			return <div>Mock observer</div>;
+		};
+
+		render(
+			<CartEventsProvider>
+				<div>
+					<MockObserverComponent />
+					<Block checkoutPageId={ 0 } className="test-block" />
+				</div>
+			</CartEventsProvider>
+		);
+		expect( screen.getByText( 'Mock observer' ) ).toBeInTheDocument();
+		const button = screen.getByText( 'Proceed to Checkout' );
+		button.click();
+		await waitFor( () => {
+			expect( mockObserver ).toHaveBeenCalled();
+		} );
+	} );
+} );

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1956,6 +1956,13 @@
 <error line="103" column="57" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
 <error line="106" column="4" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
 </file>
+<file name="assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/block.tsx">
+<error line="67" column="5" severity="error" message="Type &apos;{ children: string; className: string; href: unknown; disabled: boolean; onClick: (e: MouseEvent&lt;HTMLButtonElement, MouseEvent&gt;) =&gt; void; showSpinner: boolean; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; ButtonProps&apos;.
+  Property &apos;href&apos; does not exist on type &apos;IntrinsicAttributes &amp; ButtonProps&apos;." source="TS2322" />
+</file>
+<file name="assets/js/base/context/providers/cart-checkout/cart-events/test/index.tsx">
+<error line="36" column="49" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+</file>
 <file name="assets/js/blocks/reviews/utils.js">
 <error line="8" column="30" severity="error" message="Parameter &apos;sortValue&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
 <error line="32" column="29" severity="error" message="Parameter &apos;args&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
@@ -2108,19 +2115,19 @@
 <error line="188" column="26" severity="error" message="Property &apos;toBeDisabled&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
 </file>
 <file name="assets/js/blocks/cart/block.js">
-<error line="25" column="55" severity="error" message="Expected 0 arguments, but got 1." source="TS2554" />
-<error line="27" column="18" severity="error" message="Binding element &apos;children&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="29" column="10" severity="error" message="Property &apos;hasDarkControls&apos; does not exist on type &apos;{}&apos;." source="TS2339" />
-<error line="44" column="27" severity="error" message="Binding element &apos;scrollToTop&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="69" column="19" severity="error" message="Binding element &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="69" column="31" severity="error" message="Binding element &apos;children&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="69" column="41" severity="error" message="Binding element &apos;scrollToTop&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
-<error line="84" column="3" severity="error" message="No overload matches this call.
+<error line="28" column="55" severity="error" message="Expected 0 arguments, but got 1." source="TS2554" />
+<error line="30" column="18" severity="error" message="Binding element &apos;children&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="32" column="10" severity="error" message="Property &apos;hasDarkControls&apos; does not exist on type &apos;{}&apos;." source="TS2339" />
+<error line="47" column="27" severity="error" message="Binding element &apos;scrollToTop&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="72" column="19" severity="error" message="Binding element &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="72" column="31" severity="error" message="Binding element &apos;children&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="72" column="41" severity="error" message="Binding element &apos;scrollToTop&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="87" column="3" severity="error" message="No overload matches this call.
   Overload 1 of 2, &apos;(props: BlockErrorBoundaryProps | Readonly&lt;BlockErrorBoundaryProps&gt;): BlockErrorBoundary&apos;, gave the following error.
     Type &apos;unknown&apos; is not assignable to type &apos;boolean&apos;.
   Overload 2 of 2, &apos;(props: BlockErrorBoundaryProps, context: any): BlockErrorBoundary&apos;, gave the following error.
     Type &apos;unknown&apos; is not assignable to type &apos;boolean&apos;." source="TS2769" />
-<error line="96" column="33" severity="error" message="Argument of type &apos;({ attributes, children, scrollToTop }: { attributes: any; children: any; scrollToTop: any; }) =&gt; Element&apos; is not assignable to parameter of type &apos;FunctionComponent&lt;Record&lt;string, unknown&gt;&gt;&apos;.
+<error line="101" column="33" severity="error" message="Argument of type &apos;({ attributes, children, scrollToTop }: { attributes: any; children: any; scrollToTop: any; }) =&gt; Element&apos; is not assignable to parameter of type &apos;FunctionComponent&lt;Record&lt;string, unknown&gt;&gt;&apos;.
   Types of parameters &apos;__0&apos; and &apos;props&apos; are incompatible.
     Type &apos;PropsWithChildren&lt;Record&lt;string, unknown&gt;&gt;&apos; is missing the following properties from type &apos;{ attributes: any; children: any; scrollToTop: any; }&apos;: attributes, scrollToTop" source="TS2345" />
 </file>
@@ -2281,10 +2288,6 @@
     Type &apos;number&apos; is not assignable to type &apos;string&apos;." source="TS2322" />
 <error line="35" column="29" severity="error" message="Argument of type &apos;Record&lt;string, any&gt;&apos; is not assignable to parameter of type &apos;{ title: { raw: string; }; slug: string; }&apos;.
   Type &apos;Record&lt;string, any&gt;&apos; is missing the following properties from type &apos;{ title: { raw: string; }; slug: string; }&apos;: title, slug" source="TS2345" />
-</file>
-<file name="assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/block.tsx">
-<error line="63" column="5" severity="error" message="Type &apos;{ children: string; className: string; href: unknown; disabled: boolean; onClick: () =&gt; void; showSpinner: boolean; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; ButtonProps&apos;.
-  Property &apos;href&apos; does not exist on type &apos;IntrinsicAttributes &amp; ButtonProps&apos;." source="TS2322" />
 </file>
 <file name="assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/edit.tsx">
 <error line="47" column="21" severity="error" message="Parameter &apos;id&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
@@ -2534,6 +2537,9 @@
             Property &apos;isPreview&apos; is incompatible with index signature.
               Type &apos;{ type: string; default: boolean; save: boolean; }&apos; is not assignable to type &apos;BlockAttribute&lt;any&gt;&apos;.
                 Type &apos;{ type: string; default: boolean; save: boolean; }&apos; is missing the following properties from type &apos;Query&lt;any&gt;&apos;: source, selector, query" source="TS2769" />
+</file>
+<file name="assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/test/block.tsx">
+<error line="33" column="49" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
 </file>
 <file name="node_modules/@jest/test-result/build/index.d.ts">
 <error line="11" column="14" severity="error" message="Module &apos;&quot;jest-haste-map&quot;&apos; has no exported member &apos;IHasteFS&apos;. Did you mean to use &apos;import IHasteFS from &quot;jest-haste-map&quot;&apos; instead?" source="TS2614" />


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR adds a new context called `CartEventsContext` it currently has two functions as its value: `onProceedToCheckout` and `dispatchOnProceedToCheckout`

It uses the same pattern as the `CheckoutEventsContext` however I opted to create this new context to keep the concerns separated.

In this PR, we also call `dispatchOnProceedToCheckout` when the proceed to checkout button is clicked, and if any observers throw an error, or return an object with a type of error causing the process to stop and the user will not proceed to checkout.

The `QuantitySelector` component subscribes to this event, and if the quantity does not satisfy the validation criteria then it focuses the input, returns the error object and stops the cart -> checkout flow.

Two tests are also included in this PR, one to check the event is dispatched and correctly handled by observers when pressing the button, and one to check unsubscribing from observers works correctly.

This PR is based on `remove/auto-quantity-update` (https://github.com/woocommerce/woocommerce-blocks/pull/7606).

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

https://www.loom.com/share/5445f3a871204aa7a6b89fbed6800889

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Install [WooCommerce Min/Max Quantities](https://woocommerce.com/products/minmax-quantities/)
2. Set up some items (please test with more than one) with minimum and maximum quantities. Add these items to your cart.
3. Go to the Cart block, edit the quantities so they violate the min/max rules you set. You should see an error.
4. Try to proceed to checkout. 
5. Ensure the **first** invalid input is focused.
6. Fix the first error and try again.
7. Ensure the next invalid input is focused.
8. Fix all errors and ensure you can proceed to checkout.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Prevent shoppers from proceeding to checkout if the cart has invalid items.
