### PR TITLE
Add filter for block types

### DIFF
--- a/src/BlockTypesController.php
+++ b/src/BlockTypesController.php
@@ -250,7 +250,7 @@ final class BlockTypesController {
 			);
 		}
 
-		return $block_types;
+		return apply_filters( 'woocommerce_blocks_block_types', $block_types );
 	}
 
 }


### PR DESCRIPTION
A filter to make it possible to adjust list of blocks to load. This is needed for performance reasons, as loading the blocks takes quite some time.