### PR TITLE
Make footer and header patterns available in pattern chooser

### DIFF
--- a/patterns/footer-large-dark.php
+++ b/patterns/footer-large-dark.php
@@ -3,6 +3,7 @@
  * Title: WooCommerce Large Footer | Dark
  * Slug: woocommerce-blocks/footer-large-dark
  * Categories: WooCommerce
+ * Block Types: core/template-part/footer
  */
 ?>
 

--- a/patterns/footer-large.php
+++ b/patterns/footer-large.php
@@ -3,6 +3,7 @@
  * Title: WooCommerce Large Footer
  * Slug: woocommerce-blocks/footer-large
  * Categories: WooCommerce
+ * Block Types: core/template-part/footer
  */
 ?>
 

--- a/patterns/footer-simple-dark.php
+++ b/patterns/footer-simple-dark.php
@@ -3,6 +3,7 @@
  * Title: WooCommerce Simple Footer | Dark
  * Slug: woocommerce-blocks/footer-simple-dark
  * Categories: WooCommerce
+ * Block Types: core/template-part/footer
  */
 ?>
 

--- a/patterns/footer-simple.php
+++ b/patterns/footer-simple.php
@@ -3,6 +3,7 @@
  * Title: WooCommerce Simple Footer
  * Slug: woocommerce-blocks/footer-simple
  * Categories: WooCommerce
+ * Block Types: core/template-part/footer
  */
 ?>
 

--- a/patterns/footer-with-2-menus-dark.php
+++ b/patterns/footer-with-2-menus-dark.php
@@ -3,6 +3,7 @@
  * Title: WooCommerce Footer with 2 menus | Dark
  * Slug: woocommerce-blocks/footer-with-2-menus-dark
  * Categories: WooCommerce
+ * Block Types: core/template-part/footer
  */
 ?>
 

--- a/patterns/footer-with-2-menus.php
+++ b/patterns/footer-with-2-menus.php
@@ -3,6 +3,7 @@
  * Title: WooCommerce Footer with 2 menus
  * Slug: woocommerce-blocks/footer-with-2-menus
  * Categories: WooCommerce
+ * Block Types: core/template-part/footer
  */
 ?>
 

--- a/patterns/header-essential-dark.php
+++ b/patterns/header-essential-dark.php
@@ -3,6 +3,7 @@
  * Title: WooCommerce Essential Header | Dark
  * Slug: woocommerce-blocks/header-essential-dark
  * Categories: WooCommerce
+ * Block Types: core/template-part/header
  */
 ?>
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"1rem","bottom":"1rem","right":"1rem","left":"1rem"},"blockGap":"1rem"},"elements":{"link":{"color":{"text":"var:preset|color|background"}}}},"backgroundColor":"black","textColor":"white","className":"has-background-color","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->

--- a/patterns/header-essential.php
+++ b/patterns/header-essential.php
@@ -3,6 +3,7 @@
  * Title: WooCommerce Essential Header
  * Slug: woocommerce-blocks/header-essential
  * Categories: WooCommerce
+ * Block Types: core/template-part/header
  */
 ?>
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"1rem","bottom":"1rem","right":"1rem","left":"1rem"},"blockGap":"1rem"}},"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->

--- a/patterns/header-large-dark.php
+++ b/patterns/header-large-dark.php
@@ -3,6 +3,7 @@
  * Title: WooCommerce Large Header | Dark
  * Slug: woocommerce-blocks/header-large-dark
  * Categories: WooCommerce
+ * Block Types: core/template-part/header
  */
 ?>
 <!-- wp:group {"align":"full","style":{"spacing":{"blockGap":"0px","padding":{"top":"1rem","right":"1rem","bottom":"1rem","left":"1rem"}},"elements":{"link":{"color":{"text":"var:preset|color|background"}}}},"backgroundColor":"black","textColor":"white","layout":{"type":"default"}} -->

--- a/patterns/header-large.php
+++ b/patterns/header-large.php
@@ -3,6 +3,7 @@
  * Title: WooCommerce Large Header
  * Slug: woocommerce-blocks/header-large
  * Categories: WooCommerce
+ * Block Types: core/template-part/header
  */
 ?>
 <!-- wp:group {"align":"full","style":{"spacing":{"blockGap":"0px","padding":{"top":"1rem","right":"1rem","bottom":"1rem","left":"1rem"}}},"layout":{"type":"default"}} -->

--- a/patterns/header-minimal-dark.php
+++ b/patterns/header-minimal-dark.php
@@ -3,6 +3,7 @@
  * Title: WooCommerce Minimal Header | Dark
  * Slug: woocommerce-blocks/minimal-header-dark
  * Categories: WooCommerce
+ * Block Types: core/template-part/header
  */
 ?>
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"2%","bottom":"16px","left":"2%","top":"16px"},"margin":{"top":"0px","bottom":"0px"}},"elements":{"link":{"color":{"text":"var:preset|color|background"}}}},"backgroundColor":"black","textColor":"white","className":"sticky-header","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->

--- a/patterns/header-minimal.php
+++ b/patterns/header-minimal.php
@@ -3,6 +3,7 @@
  * Title: WooCommerce Minimal Header
  * Slug: woocommerce-blocks/header-minimal
  * Categories: WooCommerce
+ * Block Types: core/template-part/header
  */
 ?>
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"right":"2%","bottom":"16px","left":"2%","top":"16px"},"margin":{"top":"0px","bottom":"0px"}}},"className":"sticky-header","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->


### PR DESCRIPTION
As described in https://github.com/woocommerce/woocommerce-blocks/issues/7518 the header and footer patterns were not available in the pattern chooser of header and footer, see the gif below:

![image](https://user-images.githubusercontent.com/20098064/202403075-3caa5f22-7813-4f23-9975-be31f9d9bf33.png)
_Gif copy-pasted from the original issue_

The fix was to register patterns as a template-parts by extending a comment block with:
- ```* Block Types: core/template-part/footer```
- ```* Block Types: core/template-part/header```


Fixes #7518

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

|  Case  | Before | After |
| ------ | ----- | ----- |
|     Header pattern chooser (phrase: woocommerce)   |     <img width="1438" alt="Screen Shot 2022-11-17 at 10 11 30 AM" src="https://user-images.githubusercontent.com/20098064/202404758-6bde1dd2-cb75-4416-86ea-2c53009b07e0.png">  |    <img width="1343" alt="Screen Shot 2022-11-17 at 10 10 07 AM" src="https://user-images.githubusercontent.com/20098064/202404891-9ec263c8-2096-49b4-913c-12b899f4d7df.png">.  |
|     Footer pattern chooser (phrase: woocommerce)   |     <img width="1299" alt="Screen Shot 2022-11-17 at 10 11 46 AM" src="https://user-images.githubusercontent.com/20098064/202404935-ffe0f888-5ae7-4200-9401-fa82c1b90f53.png">  |   <img width="1312" alt="Screen Shot 2022-11-17 at 10 10 40 AM" src="https://user-images.githubusercontent.com/20098064/202404997-be5b4f92-3863-4eb9-b16d-eb7aa807f5b8.png"> |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

###### Header patterns
1. Go to Site Editor. You can choose any template.
2. Choose Header Block
3. Use "Replace" option:
<img width="520" alt="Screen Shot 2022-11-17 at 10 17 31 AM" src="https://user-images.githubusercontent.com/20098064/202406218-f6a91109-c964-4da7-b60f-3d2c3ae76d44.png">
4. Type "woocommerce" in a search bar
**Expected**: There's 6 WooCommerce patterns available
5. Choose one of them
**Expected**: Pattern is applied correctly

###### Footer patterns
Repeat the above steps, but for Footer Block

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Make Footer and Header patterns available in pattern chooser
