### PR TITLE
Add product query support for Sale badge block

### DIFF
--- a/assets/js/atomic/blocks/product-elements/sale-badge/attributes.ts
+++ b/assets/js/atomic/blocks/product-elements/sale-badge/attributes.ts
@@ -3,6 +3,10 @@ export const blockAttributes: Record< string, Record< string, unknown > > = {
 		type: 'number',
 		default: 0,
 	},
+	isDescendentOfQueryLoop: {
+		type: 'boolean',
+		default: false,
+	},
 };
 
 export default blockAttributes;

--- a/assets/js/atomic/blocks/product-elements/sale-badge/edit.tsx
+++ b/assets/js/atomic/blocks/product-elements/sale-badge/edit.tsx
@@ -2,6 +2,9 @@
  * External dependencies
  */
 import { useBlockProps } from '@wordpress/block-editor';
+import type { BlockEditProps } from '@wordpress/blocks';
+import { ProductQueryContext as Context } from '@woocommerce/blocks/product-query/types';
+import { useEffect } from 'react';
 
 /**
  * Internal dependencies
@@ -15,15 +18,27 @@ import {
 } from './constants';
 import type { BlockAttributes } from './types';
 
-interface Props {
-	attributes: BlockAttributes;
-}
-
-const Edit = ( { attributes }: Props ): JSX.Element => {
+const Edit = ( {
+	attributes,
+	setAttributes,
+	context,
+}: BlockEditProps< BlockAttributes > & { context: Context } ): JSX.Element => {
 	const blockProps = useBlockProps();
+
+	const blockAttrs = {
+		...attributes,
+		...context,
+	};
+	const isDescendentOfQueryLoop = Number.isFinite( context.queryId );
+
+	useEffect(
+		() => setAttributes( { isDescendentOfQueryLoop } ),
+		[ setAttributes, isDescendentOfQueryLoop ]
+	);
+
 	return (
 		<div { ...blockProps }>
-			<Block { ...attributes } />
+			<Block { ...blockAttrs } />
 		</div>
 	);
 };

--- a/assets/js/atomic/blocks/product-elements/sale-badge/index.ts
+++ b/assets/js/atomic/blocks/product-elements/sale-badge/index.ts
@@ -15,7 +15,6 @@ import {
 	BLOCK_ICON as icon,
 	BLOCK_DESCRIPTION as description,
 } from './constants';
-import { Save } from './save';
 import { supports } from './support';
 
 const blockConfig: BlockConfiguration = {
@@ -27,7 +26,12 @@ const blockConfig: BlockConfiguration = {
 	supports,
 	attributes,
 	edit,
-	save: Save,
+	usesContext: [ 'query', 'queryId', 'postId' ],
+	ancestor: [
+		'@woocommerce/all-products',
+		'@woocommerce/single-product',
+		'core/post-template',
+	],
 };
 
 registerBlockType( 'woocommerce/product-sale-badge', { ...blockConfig } );

--- a/assets/js/atomic/blocks/product-elements/sale-badge/types.ts
+++ b/assets/js/atomic/blocks/product-elements/sale-badge/types.ts
@@ -1,4 +1,5 @@
 export interface BlockAttributes {
 	productId: number;
 	align: 'left' | 'center' | 'right';
+	isDescendentOfQueryLoop: boolean;
 }

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -1,0 +1,4215 @@
+<?xml version="1.0" encoding="utf-8"?>
+<checkstyle version="4.3">
+<file name="assets/js/global.d.ts">
+<error line="2" column="13" severity="error" message="Cannot redeclare block-scoped variable &apos;__webpack_public_path__&apos;." source="TS2451" />
+</file>
+<file name="node_modules/@types/react/index.d.ts">
+<error line="3077" column="19" severity="error" message="Interface &apos;ElementClass&apos; cannot simultaneously extend types &apos;Component&lt;any, {}, any&gt;&apos; and &apos;Component&lt;any, {}, any&gt;&apos;.
+  Named property &apos;props&apos; of types &apos;Component&lt;any, {}, any&gt;&apos; and &apos;Component&lt;any, {}, any&gt;&apos; are not identical." source="TS2320" />
+<error line="3085" column="14" severity="error" message="Duplicate identifier &apos;LibraryManagedAttributes&apos;." source="TS2300" />
+</file>
+<file name="assets/js/icons/library/woo.tsx">
+<error line="6" column="23" severity="error" message="Binding element &apos;className&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="6" column="34" severity="error" message="Binding element &apos;height&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="6" column="42" severity="error" message="Binding element &apos;width&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="29" column="14" severity="error" message="Type &apos;{}&apos; is missing the following properties from type &apos;{ [x: string]: any; className: any; height: any; width: any; }&apos;: className, height, width" source="TS2739" />
+</file>
+<file name="node_modules/@wordpress/element/node_modules/@types/react/index.d.ts">
+<error line="3086" column="14" severity="error" message="Duplicate identifier &apos;LibraryManagedAttributes&apos;." source="TS2300" />
+<error line="3099" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;a&apos; must be of type &apos;DetailedHTMLProps&lt;AnchorHTMLAttributes&lt;HTMLAnchorElement&gt;, HTMLAnchorElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;AnchorHTMLAttributes&lt;HTMLAnchorElement&gt;, HTMLAnchorElement&gt;&apos;." source="TS2717" />
+<error line="3100" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;abbr&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3101" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;address&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3102" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;area&apos; must be of type &apos;DetailedHTMLProps&lt;AreaHTMLAttributes&lt;HTMLAreaElement&gt;, HTMLAreaElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;AreaHTMLAttributes&lt;HTMLAreaElement&gt;, HTMLAreaElement&gt;&apos;." source="TS2717" />
+<error line="3103" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;article&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3104" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;aside&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3105" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;audio&apos; must be of type &apos;DetailedHTMLProps&lt;AudioHTMLAttributes&lt;HTMLAudioElement&gt;, HTMLAudioElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;AudioHTMLAttributes&lt;HTMLAudioElement&gt;, HTMLAudioElement&gt;&apos;." source="TS2717" />
+<error line="3106" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;b&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3107" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;base&apos; must be of type &apos;DetailedHTMLProps&lt;BaseHTMLAttributes&lt;HTMLBaseElement&gt;, HTMLBaseElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;BaseHTMLAttributes&lt;HTMLBaseElement&gt;, HTMLBaseElement&gt;&apos;." source="TS2717" />
+<error line="3108" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;bdi&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3109" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;bdo&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3110" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;big&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3111" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;blockquote&apos; must be of type &apos;DetailedHTMLProps&lt;BlockquoteHTMLAttributes&lt;HTMLQuoteElement&gt;, HTMLQuoteElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;BlockquoteHTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3112" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;body&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLBodyElement&gt;, HTMLBodyElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLBodyElement&gt;, HTMLBodyElement&gt;&apos;." source="TS2717" />
+<error line="3113" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;br&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLBRElement&gt;, HTMLBRElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLBRElement&gt;, HTMLBRElement&gt;&apos;." source="TS2717" />
+<error line="3114" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;button&apos; must be of type &apos;DetailedHTMLProps&lt;ButtonHTMLAttributes&lt;HTMLButtonElement&gt;, HTMLButtonElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;ButtonHTMLAttributes&lt;HTMLButtonElement&gt;, HTMLButtonElement&gt;&apos;." source="TS2717" />
+<error line="3115" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;canvas&apos; must be of type &apos;DetailedHTMLProps&lt;CanvasHTMLAttributes&lt;HTMLCanvasElement&gt;, HTMLCanvasElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;CanvasHTMLAttributes&lt;HTMLCanvasElement&gt;, HTMLCanvasElement&gt;&apos;." source="TS2717" />
+<error line="3116" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;caption&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3117" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;cite&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3118" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;code&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3119" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;col&apos; must be of type &apos;DetailedHTMLProps&lt;ColHTMLAttributes&lt;HTMLTableColElement&gt;, HTMLTableColElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;ColHTMLAttributes&lt;HTMLTableColElement&gt;, HTMLTableColElement&gt;&apos;." source="TS2717" />
+<error line="3120" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;colgroup&apos; must be of type &apos;DetailedHTMLProps&lt;ColgroupHTMLAttributes&lt;HTMLTableColElement&gt;, HTMLTableColElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;ColgroupHTMLAttributes&lt;HTMLTableColElement&gt;, HTMLTableColElement&gt;&apos;." source="TS2717" />
+<error line="3121" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;data&apos; must be of type &apos;DetailedHTMLProps&lt;DataHTMLAttributes&lt;HTMLDataElement&gt;, HTMLDataElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;DataHTMLAttributes&lt;HTMLDataElement&gt;, HTMLDataElement&gt;&apos;." source="TS2717" />
+<error line="3122" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;datalist&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLDataListElement&gt;, HTMLDataListElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLDataListElement&gt;, HTMLDataListElement&gt;&apos;." source="TS2717" />
+<error line="3123" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;dd&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3124" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;del&apos; must be of type &apos;DetailedHTMLProps&lt;DelHTMLAttributes&lt;HTMLModElement&gt;, HTMLModElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;DelHTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3125" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;details&apos; must be of type &apos;DetailedHTMLProps&lt;DetailsHTMLAttributes&lt;HTMLDetailsElement&gt;, HTMLDetailsElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;DetailsHTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3126" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;dfn&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3127" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;dialog&apos; must be of type &apos;DetailedHTMLProps&lt;DialogHTMLAttributes&lt;HTMLDialogElement&gt;, HTMLDialogElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;DialogHTMLAttributes&lt;HTMLDialogElement&gt;, HTMLDialogElement&gt;&apos;." source="TS2717" />
+<error line="3128" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;div&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLDivElement&gt;, HTMLDivElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLDivElement&gt;, HTMLDivElement&gt;&apos;." source="TS2717" />
+<error line="3129" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;dl&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLDListElement&gt;, HTMLDListElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLDListElement&gt;, HTMLDListElement&gt;&apos;." source="TS2717" />
+<error line="3130" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;dt&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3131" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;em&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3132" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;embed&apos; must be of type &apos;DetailedHTMLProps&lt;EmbedHTMLAttributes&lt;HTMLEmbedElement&gt;, HTMLEmbedElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;EmbedHTMLAttributes&lt;HTMLEmbedElement&gt;, HTMLEmbedElement&gt;&apos;." source="TS2717" />
+<error line="3133" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;fieldset&apos; must be of type &apos;DetailedHTMLProps&lt;FieldsetHTMLAttributes&lt;HTMLFieldSetElement&gt;, HTMLFieldSetElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;FieldsetHTMLAttributes&lt;HTMLFieldSetElement&gt;, HTMLFieldSetElement&gt;&apos;." source="TS2717" />
+<error line="3134" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;figcaption&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3135" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;figure&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3136" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;footer&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3137" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;form&apos; must be of type &apos;DetailedHTMLProps&lt;FormHTMLAttributes&lt;HTMLFormElement&gt;, HTMLFormElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;FormHTMLAttributes&lt;HTMLFormElement&gt;, HTMLFormElement&gt;&apos;." source="TS2717" />
+<error line="3138" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;h1&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLHeadingElement&gt;, HTMLHeadingElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLHeadingElement&gt;, HTMLHeadingElement&gt;&apos;." source="TS2717" />
+<error line="3139" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;h2&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLHeadingElement&gt;, HTMLHeadingElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLHeadingElement&gt;, HTMLHeadingElement&gt;&apos;." source="TS2717" />
+<error line="3140" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;h3&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLHeadingElement&gt;, HTMLHeadingElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLHeadingElement&gt;, HTMLHeadingElement&gt;&apos;." source="TS2717" />
+<error line="3141" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;h4&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLHeadingElement&gt;, HTMLHeadingElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLHeadingElement&gt;, HTMLHeadingElement&gt;&apos;." source="TS2717" />
+<error line="3142" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;h5&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLHeadingElement&gt;, HTMLHeadingElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLHeadingElement&gt;, HTMLHeadingElement&gt;&apos;." source="TS2717" />
+<error line="3143" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;h6&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLHeadingElement&gt;, HTMLHeadingElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLHeadingElement&gt;, HTMLHeadingElement&gt;&apos;." source="TS2717" />
+<error line="3144" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;head&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLHeadElement&gt;, HTMLHeadElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLHeadElement&gt;, HTMLHeadElement&gt;&apos;." source="TS2717" />
+<error line="3145" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;header&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3146" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;hgroup&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3147" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;hr&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLHRElement&gt;, HTMLHRElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLHRElement&gt;, HTMLHRElement&gt;&apos;." source="TS2717" />
+<error line="3148" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;html&apos; must be of type &apos;DetailedHTMLProps&lt;HtmlHTMLAttributes&lt;HTMLHtmlElement&gt;, HTMLHtmlElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HtmlHTMLAttributes&lt;HTMLHtmlElement&gt;, HTMLHtmlElement&gt;&apos;." source="TS2717" />
+<error line="3149" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;i&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3150" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;iframe&apos; must be of type &apos;DetailedHTMLProps&lt;IframeHTMLAttributes&lt;HTMLIFrameElement&gt;, HTMLIFrameElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;IframeHTMLAttributes&lt;HTMLIFrameElement&gt;, HTMLIFrameElement&gt;&apos;." source="TS2717" />
+<error line="3151" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;img&apos; must be of type &apos;DetailedHTMLProps&lt;ImgHTMLAttributes&lt;HTMLImageElement&gt;, HTMLImageElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;ImgHTMLAttributes&lt;HTMLImageElement&gt;, HTMLImageElement&gt;&apos;." source="TS2717" />
+<error line="3152" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;input&apos; must be of type &apos;DetailedHTMLProps&lt;InputHTMLAttributes&lt;HTMLInputElement&gt;, HTMLInputElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;InputHTMLAttributes&lt;HTMLInputElement&gt;, HTMLInputElement&gt;&apos;." source="TS2717" />
+<error line="3153" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;ins&apos; must be of type &apos;DetailedHTMLProps&lt;InsHTMLAttributes&lt;HTMLModElement&gt;, HTMLModElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;InsHTMLAttributes&lt;HTMLModElement&gt;, HTMLModElement&gt;&apos;." source="TS2717" />
+<error line="3154" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;kbd&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3155" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;keygen&apos; must be of type &apos;DetailedHTMLProps&lt;KeygenHTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;KeygenHTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3156" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;label&apos; must be of type &apos;DetailedHTMLProps&lt;LabelHTMLAttributes&lt;HTMLLabelElement&gt;, HTMLLabelElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;LabelHTMLAttributes&lt;HTMLLabelElement&gt;, HTMLLabelElement&gt;&apos;." source="TS2717" />
+<error line="3157" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;legend&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLLegendElement&gt;, HTMLLegendElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLLegendElement&gt;, HTMLLegendElement&gt;&apos;." source="TS2717" />
+<error line="3158" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;li&apos; must be of type &apos;DetailedHTMLProps&lt;LiHTMLAttributes&lt;HTMLLIElement&gt;, HTMLLIElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;LiHTMLAttributes&lt;HTMLLIElement&gt;, HTMLLIElement&gt;&apos;." source="TS2717" />
+<error line="3159" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;link&apos; must be of type &apos;DetailedHTMLProps&lt;LinkHTMLAttributes&lt;HTMLLinkElement&gt;, HTMLLinkElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;LinkHTMLAttributes&lt;HTMLLinkElement&gt;, HTMLLinkElement&gt;&apos;." source="TS2717" />
+<error line="3160" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;main&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3161" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;map&apos; must be of type &apos;DetailedHTMLProps&lt;MapHTMLAttributes&lt;HTMLMapElement&gt;, HTMLMapElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;MapHTMLAttributes&lt;HTMLMapElement&gt;, HTMLMapElement&gt;&apos;." source="TS2717" />
+<error line="3162" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;mark&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3163" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;menu&apos; must be of type &apos;DetailedHTMLProps&lt;MenuHTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;MenuHTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3164" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;menuitem&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3165" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;meta&apos; must be of type &apos;DetailedHTMLProps&lt;MetaHTMLAttributes&lt;HTMLMetaElement&gt;, HTMLMetaElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;MetaHTMLAttributes&lt;HTMLMetaElement&gt;, HTMLMetaElement&gt;&apos;." source="TS2717" />
+<error line="3166" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;meter&apos; must be of type &apos;DetailedHTMLProps&lt;MeterHTMLAttributes&lt;HTMLMeterElement&gt;, HTMLMeterElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;MeterHTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3167" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;nav&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3168" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;noindex&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3169" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;noscript&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3170" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;object&apos; must be of type &apos;DetailedHTMLProps&lt;ObjectHTMLAttributes&lt;HTMLObjectElement&gt;, HTMLObjectElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;ObjectHTMLAttributes&lt;HTMLObjectElement&gt;, HTMLObjectElement&gt;&apos;." source="TS2717" />
+<error line="3171" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;ol&apos; must be of type &apos;DetailedHTMLProps&lt;OlHTMLAttributes&lt;HTMLOListElement&gt;, HTMLOListElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;OlHTMLAttributes&lt;HTMLOListElement&gt;, HTMLOListElement&gt;&apos;." source="TS2717" />
+<error line="3172" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;optgroup&apos; must be of type &apos;DetailedHTMLProps&lt;OptgroupHTMLAttributes&lt;HTMLOptGroupElement&gt;, HTMLOptGroupElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;OptgroupHTMLAttributes&lt;HTMLOptGroupElement&gt;, HTMLOptGroupElement&gt;&apos;." source="TS2717" />
+<error line="3173" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;option&apos; must be of type &apos;DetailedHTMLProps&lt;OptionHTMLAttributes&lt;HTMLOptionElement&gt;, HTMLOptionElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;OptionHTMLAttributes&lt;HTMLOptionElement&gt;, HTMLOptionElement&gt;&apos;." source="TS2717" />
+<error line="3174" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;output&apos; must be of type &apos;DetailedHTMLProps&lt;OutputHTMLAttributes&lt;HTMLOutputElement&gt;, HTMLOutputElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;OutputHTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3175" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;p&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLParagraphElement&gt;, HTMLParagraphElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLParagraphElement&gt;, HTMLParagraphElement&gt;&apos;." source="TS2717" />
+<error line="3176" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;param&apos; must be of type &apos;DetailedHTMLProps&lt;ParamHTMLAttributes&lt;HTMLParamElement&gt;, HTMLParamElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;ParamHTMLAttributes&lt;HTMLParamElement&gt;, HTMLParamElement&gt;&apos;." source="TS2717" />
+<error line="3177" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;picture&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3178" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;pre&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLPreElement&gt;, HTMLPreElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLPreElement&gt;, HTMLPreElement&gt;&apos;." source="TS2717" />
+<error line="3179" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;progress&apos; must be of type &apos;DetailedHTMLProps&lt;ProgressHTMLAttributes&lt;HTMLProgressElement&gt;, HTMLProgressElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;ProgressHTMLAttributes&lt;HTMLProgressElement&gt;, HTMLProgressElement&gt;&apos;." source="TS2717" />
+<error line="3180" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;q&apos; must be of type &apos;DetailedHTMLProps&lt;QuoteHTMLAttributes&lt;HTMLQuoteElement&gt;, HTMLQuoteElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;QuoteHTMLAttributes&lt;HTMLQuoteElement&gt;, HTMLQuoteElement&gt;&apos;." source="TS2717" />
+<error line="3181" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;rp&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3182" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;rt&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3183" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;ruby&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3184" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;s&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3185" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;samp&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3186" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;slot&apos; must be of type &apos;DetailedHTMLProps&lt;SlotHTMLAttributes&lt;HTMLSlotElement&gt;, HTMLSlotElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;SlotHTMLAttributes&lt;HTMLSlotElement&gt;, HTMLSlotElement&gt;&apos;." source="TS2717" />
+<error line="3187" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;script&apos; must be of type &apos;DetailedHTMLProps&lt;ScriptHTMLAttributes&lt;HTMLScriptElement&gt;, HTMLScriptElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;ScriptHTMLAttributes&lt;HTMLScriptElement&gt;, HTMLScriptElement&gt;&apos;." source="TS2717" />
+<error line="3188" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;section&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3189" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;select&apos; must be of type &apos;DetailedHTMLProps&lt;SelectHTMLAttributes&lt;HTMLSelectElement&gt;, HTMLSelectElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;SelectHTMLAttributes&lt;HTMLSelectElement&gt;, HTMLSelectElement&gt;&apos;." source="TS2717" />
+<error line="3190" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;small&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3191" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;source&apos; must be of type &apos;DetailedHTMLProps&lt;SourceHTMLAttributes&lt;HTMLSourceElement&gt;, HTMLSourceElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;SourceHTMLAttributes&lt;HTMLSourceElement&gt;, HTMLSourceElement&gt;&apos;." source="TS2717" />
+<error line="3192" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;span&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLSpanElement&gt;, HTMLSpanElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLSpanElement&gt;, HTMLSpanElement&gt;&apos;." source="TS2717" />
+<error line="3193" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;strong&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3194" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;style&apos; must be of type &apos;DetailedHTMLProps&lt;StyleHTMLAttributes&lt;HTMLStyleElement&gt;, HTMLStyleElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;StyleHTMLAttributes&lt;HTMLStyleElement&gt;, HTMLStyleElement&gt;&apos;." source="TS2717" />
+<error line="3195" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;sub&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3196" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;summary&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3197" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;sup&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3198" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;table&apos; must be of type &apos;DetailedHTMLProps&lt;TableHTMLAttributes&lt;HTMLTableElement&gt;, HTMLTableElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;TableHTMLAttributes&lt;HTMLTableElement&gt;, HTMLTableElement&gt;&apos;." source="TS2717" />
+<error line="3199" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;template&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLTemplateElement&gt;, HTMLTemplateElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLTemplateElement&gt;, HTMLTemplateElement&gt;&apos;." source="TS2717" />
+<error line="3200" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;tbody&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLTableSectionElement&gt;, HTMLTableSectionElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLTableSectionElement&gt;, HTMLTableSectionElement&gt;&apos;." source="TS2717" />
+<error line="3201" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;td&apos; must be of type &apos;DetailedHTMLProps&lt;TdHTMLAttributes&lt;HTMLTableDataCellElement&gt;, HTMLTableDataCellElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;TdHTMLAttributes&lt;HTMLTableDataCellElement&gt;, HTMLTableDataCellElement&gt;&apos;." source="TS2717" />
+<error line="3202" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;textarea&apos; must be of type &apos;DetailedHTMLProps&lt;TextareaHTMLAttributes&lt;HTMLTextAreaElement&gt;, HTMLTextAreaElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;TextareaHTMLAttributes&lt;HTMLTextAreaElement&gt;, HTMLTextAreaElement&gt;&apos;." source="TS2717" />
+<error line="3203" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;tfoot&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLTableSectionElement&gt;, HTMLTableSectionElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLTableSectionElement&gt;, HTMLTableSectionElement&gt;&apos;." source="TS2717" />
+<error line="3204" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;th&apos; must be of type &apos;DetailedHTMLProps&lt;ThHTMLAttributes&lt;HTMLTableHeaderCellElement&gt;, HTMLTableHeaderCellElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;ThHTMLAttributes&lt;HTMLTableHeaderCellElement&gt;, HTMLTableHeaderCellElement&gt;&apos;." source="TS2717" />
+<error line="3205" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;thead&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLTableSectionElement&gt;, HTMLTableSectionElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLTableSectionElement&gt;, HTMLTableSectionElement&gt;&apos;." source="TS2717" />
+<error line="3206" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;time&apos; must be of type &apos;DetailedHTMLProps&lt;TimeHTMLAttributes&lt;HTMLTimeElement&gt;, HTMLTimeElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;TimeHTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3207" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;title&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLTitleElement&gt;, HTMLTitleElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLTitleElement&gt;, HTMLTitleElement&gt;&apos;." source="TS2717" />
+<error line="3208" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;tr&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLTableRowElement&gt;, HTMLTableRowElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLTableRowElement&gt;, HTMLTableRowElement&gt;&apos;." source="TS2717" />
+<error line="3209" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;track&apos; must be of type &apos;DetailedHTMLProps&lt;TrackHTMLAttributes&lt;HTMLTrackElement&gt;, HTMLTrackElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;TrackHTMLAttributes&lt;HTMLTrackElement&gt;, HTMLTrackElement&gt;&apos;." source="TS2717" />
+<error line="3210" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;u&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3211" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;ul&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLUListElement&gt;, HTMLUListElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLUListElement&gt;, HTMLUListElement&gt;&apos;." source="TS2717" />
+<error line="3212" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;&quot;var&quot;&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3213" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;video&apos; must be of type &apos;DetailedHTMLProps&lt;VideoHTMLAttributes&lt;HTMLVideoElement&gt;, HTMLVideoElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;VideoHTMLAttributes&lt;HTMLVideoElement&gt;, HTMLVideoElement&gt;&apos;." source="TS2717" />
+<error line="3214" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;wbr&apos; must be of type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLElement&gt;, HTMLElement&gt;&apos;." source="TS2717" />
+<error line="3215" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;webview&apos; must be of type &apos;DetailedHTMLProps&lt;WebViewHTMLAttributes&lt;HTMLWebViewElement&gt;, HTMLWebViewElement&gt;&apos;, but here has type &apos;DetailedHTMLProps&lt;WebViewHTMLAttributes&lt;HTMLWebViewElement&gt;, HTMLWebViewElement&gt;&apos;." source="TS2717" />
+<error line="3218" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;svg&apos; must be of type &apos;SVGProps&lt;SVGSVGElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGSVGElement&gt;&apos;." source="TS2717" />
+<error line="3220" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;animate&apos; must be of type &apos;SVGProps&lt;SVGElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGElement&gt;&apos;." source="TS2717" />
+<error line="3221" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;animateMotion&apos; must be of type &apos;SVGProps&lt;SVGElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGElement&gt;&apos;." source="TS2717" />
+<error line="3222" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;animateTransform&apos; must be of type &apos;SVGProps&lt;SVGElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGElement&gt;&apos;." source="TS2717" />
+<error line="3223" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;circle&apos; must be of type &apos;SVGProps&lt;SVGCircleElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGCircleElement&gt;&apos;." source="TS2717" />
+<error line="3224" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;clipPath&apos; must be of type &apos;SVGProps&lt;SVGClipPathElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGClipPathElement&gt;&apos;." source="TS2717" />
+<error line="3225" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;defs&apos; must be of type &apos;SVGProps&lt;SVGDefsElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGDefsElement&gt;&apos;." source="TS2717" />
+<error line="3226" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;desc&apos; must be of type &apos;SVGProps&lt;SVGDescElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGDescElement&gt;&apos;." source="TS2717" />
+<error line="3227" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;ellipse&apos; must be of type &apos;SVGProps&lt;SVGEllipseElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGEllipseElement&gt;&apos;." source="TS2717" />
+<error line="3228" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;feBlend&apos; must be of type &apos;SVGProps&lt;SVGFEBlendElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGFEBlendElement&gt;&apos;." source="TS2717" />
+<error line="3229" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;feColorMatrix&apos; must be of type &apos;SVGProps&lt;SVGFEColorMatrixElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGFEColorMatrixElement&gt;&apos;." source="TS2717" />
+<error line="3230" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;feComponentTransfer&apos; must be of type &apos;SVGProps&lt;SVGFEComponentTransferElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGFEComponentTransferElement&gt;&apos;." source="TS2717" />
+<error line="3231" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;feComposite&apos; must be of type &apos;SVGProps&lt;SVGFECompositeElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGFECompositeElement&gt;&apos;." source="TS2717" />
+<error line="3232" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;feConvolveMatrix&apos; must be of type &apos;SVGProps&lt;SVGFEConvolveMatrixElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGFEConvolveMatrixElement&gt;&apos;." source="TS2717" />
+<error line="3233" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;feDiffuseLighting&apos; must be of type &apos;SVGProps&lt;SVGFEDiffuseLightingElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGFEDiffuseLightingElement&gt;&apos;." source="TS2717" />
+<error line="3234" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;feDisplacementMap&apos; must be of type &apos;SVGProps&lt;SVGFEDisplacementMapElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGFEDisplacementMapElement&gt;&apos;." source="TS2717" />
+<error line="3235" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;feDistantLight&apos; must be of type &apos;SVGProps&lt;SVGFEDistantLightElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGFEDistantLightElement&gt;&apos;." source="TS2717" />
+<error line="3236" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;feDropShadow&apos; must be of type &apos;SVGProps&lt;SVGFEDropShadowElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGFEDropShadowElement&gt;&apos;." source="TS2717" />
+<error line="3237" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;feFlood&apos; must be of type &apos;SVGProps&lt;SVGFEFloodElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGFEFloodElement&gt;&apos;." source="TS2717" />
+<error line="3238" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;feFuncA&apos; must be of type &apos;SVGProps&lt;SVGFEFuncAElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGFEFuncAElement&gt;&apos;." source="TS2717" />
+<error line="3239" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;feFuncB&apos; must be of type &apos;SVGProps&lt;SVGFEFuncBElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGFEFuncBElement&gt;&apos;." source="TS2717" />
+<error line="3240" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;feFuncG&apos; must be of type &apos;SVGProps&lt;SVGFEFuncGElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGFEFuncGElement&gt;&apos;." source="TS2717" />
+<error line="3241" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;feFuncR&apos; must be of type &apos;SVGProps&lt;SVGFEFuncRElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGFEFuncRElement&gt;&apos;." source="TS2717" />
+<error line="3242" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;feGaussianBlur&apos; must be of type &apos;SVGProps&lt;SVGFEGaussianBlurElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGFEGaussianBlurElement&gt;&apos;." source="TS2717" />
+<error line="3243" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;feImage&apos; must be of type &apos;SVGProps&lt;SVGFEImageElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGFEImageElement&gt;&apos;." source="TS2717" />
+<error line="3244" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;feMerge&apos; must be of type &apos;SVGProps&lt;SVGFEMergeElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGFEMergeElement&gt;&apos;." source="TS2717" />
+<error line="3245" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;feMergeNode&apos; must be of type &apos;SVGProps&lt;SVGFEMergeNodeElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGFEMergeNodeElement&gt;&apos;." source="TS2717" />
+<error line="3246" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;feMorphology&apos; must be of type &apos;SVGProps&lt;SVGFEMorphologyElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGFEMorphologyElement&gt;&apos;." source="TS2717" />
+<error line="3247" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;feOffset&apos; must be of type &apos;SVGProps&lt;SVGFEOffsetElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGFEOffsetElement&gt;&apos;." source="TS2717" />
+<error line="3248" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;fePointLight&apos; must be of type &apos;SVGProps&lt;SVGFEPointLightElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGFEPointLightElement&gt;&apos;." source="TS2717" />
+<error line="3249" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;feSpecularLighting&apos; must be of type &apos;SVGProps&lt;SVGFESpecularLightingElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGFESpecularLightingElement&gt;&apos;." source="TS2717" />
+<error line="3250" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;feSpotLight&apos; must be of type &apos;SVGProps&lt;SVGFESpotLightElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGFESpotLightElement&gt;&apos;." source="TS2717" />
+<error line="3251" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;feTile&apos; must be of type &apos;SVGProps&lt;SVGFETileElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGFETileElement&gt;&apos;." source="TS2717" />
+<error line="3252" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;feTurbulence&apos; must be of type &apos;SVGProps&lt;SVGFETurbulenceElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGFETurbulenceElement&gt;&apos;." source="TS2717" />
+<error line="3253" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;filter&apos; must be of type &apos;SVGProps&lt;SVGFilterElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGFilterElement&gt;&apos;." source="TS2717" />
+<error line="3254" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;foreignObject&apos; must be of type &apos;SVGProps&lt;SVGForeignObjectElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGForeignObjectElement&gt;&apos;." source="TS2717" />
+<error line="3255" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;g&apos; must be of type &apos;SVGProps&lt;SVGGElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGGElement&gt;&apos;." source="TS2717" />
+<error line="3256" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;image&apos; must be of type &apos;SVGProps&lt;SVGImageElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGImageElement&gt;&apos;." source="TS2717" />
+<error line="3257" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;line&apos; must be of type &apos;SVGProps&lt;SVGLineElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGLineElement&gt;&apos;." source="TS2717" />
+<error line="3258" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;linearGradient&apos; must be of type &apos;SVGProps&lt;SVGLinearGradientElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGLinearGradientElement&gt;&apos;." source="TS2717" />
+<error line="3259" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;marker&apos; must be of type &apos;SVGProps&lt;SVGMarkerElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGMarkerElement&gt;&apos;." source="TS2717" />
+<error line="3260" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;mask&apos; must be of type &apos;SVGProps&lt;SVGMaskElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGMaskElement&gt;&apos;." source="TS2717" />
+<error line="3261" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;metadata&apos; must be of type &apos;SVGProps&lt;SVGMetadataElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGMetadataElement&gt;&apos;." source="TS2717" />
+<error line="3262" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;mpath&apos; must be of type &apos;SVGProps&lt;SVGElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGElement&gt;&apos;." source="TS2717" />
+<error line="3263" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;path&apos; must be of type &apos;SVGProps&lt;SVGPathElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGPathElement&gt;&apos;." source="TS2717" />
+<error line="3264" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;pattern&apos; must be of type &apos;SVGProps&lt;SVGPatternElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGPatternElement&gt;&apos;." source="TS2717" />
+<error line="3265" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;polygon&apos; must be of type &apos;SVGProps&lt;SVGPolygonElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGPolygonElement&gt;&apos;." source="TS2717" />
+<error line="3266" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;polyline&apos; must be of type &apos;SVGProps&lt;SVGPolylineElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGPolylineElement&gt;&apos;." source="TS2717" />
+<error line="3267" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;radialGradient&apos; must be of type &apos;SVGProps&lt;SVGRadialGradientElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGRadialGradientElement&gt;&apos;." source="TS2717" />
+<error line="3268" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;rect&apos; must be of type &apos;SVGProps&lt;SVGRectElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGRectElement&gt;&apos;." source="TS2717" />
+<error line="3269" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;stop&apos; must be of type &apos;SVGProps&lt;SVGStopElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGStopElement&gt;&apos;." source="TS2717" />
+<error line="3270" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;switch&apos; must be of type &apos;SVGProps&lt;SVGSwitchElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGSwitchElement&gt;&apos;." source="TS2717" />
+<error line="3271" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;symbol&apos; must be of type &apos;SVGProps&lt;SVGSymbolElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGSymbolElement&gt;&apos;." source="TS2717" />
+<error line="3272" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;text&apos; must be of type &apos;SVGProps&lt;SVGTextElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGTextElement&gt;&apos;." source="TS2717" />
+<error line="3273" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;textPath&apos; must be of type &apos;SVGProps&lt;SVGTextPathElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGTextPathElement&gt;&apos;." source="TS2717" />
+<error line="3274" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;tspan&apos; must be of type &apos;SVGProps&lt;SVGTSpanElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGTSpanElement&gt;&apos;." source="TS2717" />
+<error line="3275" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;use&apos; must be of type &apos;SVGProps&lt;SVGUseElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGUseElement&gt;&apos;." source="TS2717" />
+<error line="3276" column="13" severity="error" message="Subsequent property declarations must have the same type.  Property &apos;view&apos; must be of type &apos;SVGProps&lt;SVGViewElement&gt;&apos;, but here has type &apos;SVGProps&lt;SVGViewElement&gt;&apos;." source="TS2717" />
+</file>
+<file name="assets/js/filters/block-list-block.js">
+<error line="43" column="13" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="44" column="13" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="44" column="23" severity="error" message="Property &apos;defaults&apos; does not exist on type &apos;Block&lt;Record&lt;string, any&gt;&gt;&apos;." source="TS2339" />
+<error line="50" column="19" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="53" column="15" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="53" column="25" severity="error" message="Property &apos;defaults&apos; does not exist on type &apos;Block&lt;Record&lt;string, any&gt;&gt;&apos;." source="TS2339" />
+<error line="55" column="28" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="55" column="38" severity="error" message="Property &apos;defaults&apos; does not exist on type &apos;Block&lt;Record&lt;string, any&gt;&gt;&apos;." source="TS2339" />
+<error line="65" column="7" severity="error" message="Type &apos;{ attributes: any; children?: ReactNode; }&apos; is not assignable to type &apos;InnerProps&apos;.
+  &apos;{ attributes: any; children?: ReactNode; }&apos; is assignable to the constraint of type &apos;InnerProps&apos;, but &apos;InnerProps&apos; could be instantiated with a different subtype of constraint &apos;{}&apos;." source="TS2322" />
+</file>
+<file name="assets/js/filters/get-block-attributes.js">
+<error line="15" column="17" severity="error" message="Property &apos;name&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="16" column="26" severity="error" message="Property &apos;attributes&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="18" column="12" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;Object&apos;.
+  No index signature with a parameter of type &apos;string&apos; was found on type &apos;Object&apos;." source="TS7053" />
+<error line="19" column="22" severity="error" message="Property &apos;defaults&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="20" column="22" severity="error" message="Property &apos;defaults&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="22" column="5" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;Object&apos;.
+  No index signature with a parameter of type &apos;string&apos; was found on type &apos;Object&apos;." source="TS7053" />
+<error line="22" column="40" severity="error" message="Property &apos;defaults&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+</file>
+<file name="assets/js/filters/exclude-draft-status-from-analytics.js">
+<error line="10" column="33" severity="error" message="Parameter &apos;optionsGroup&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="15" column="9" severity="error" message="Parameter &apos;option&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+</file>
+<file name="assets/js/blocks-registry/payment-methods/payment-method-config.tsx">
+<error line="48" column="3" severity="error" message="Type &apos;string | undefined&apos; is not assignable to type &apos;string&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the type of the target.
+  Type &apos;undefined&apos; is not assignable to type &apos;string&apos;." source="TS2412" />
+</file>
+<file name="assets/js/settings/blocks/feature-flags.ts">
+<error line="22" column="29" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{}&gt;, settings?: Partial&lt;BlockConfiguration&lt;{}&gt;&gt; | undefined): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string | BlockConfiguration&lt;{}&gt;&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{}&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;BlockConfiguration&lt;{}&gt;&apos;.
+        Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{}&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{}&gt;): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string | BlockConfiguration&lt;{}&gt;&apos; is not assignable to parameter of type &apos;string&apos;.
+      Type &apos;BlockConfiguration&lt;{}&gt;&apos; is not assignable to type &apos;string&apos;." source="TS2769" />
+<error line="36" column="29" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{}&gt;, settings?: Partial&lt;BlockConfiguration&lt;{}&gt;&gt; | undefined): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string | BlockConfiguration&lt;{}&gt;&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{}&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;BlockConfiguration&lt;{}&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{}&gt;): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string | BlockConfiguration&lt;{}&gt;&apos; is not assignable to parameter of type &apos;string&apos;.
+      Type &apos;BlockConfiguration&lt;{}&gt;&apos; is not assignable to type &apos;string&apos;." source="TS2769" />
+</file>
+<file name="packages/prices/utils/price.ts">
+<error line="52" column="8" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
+<error line="53" column="10" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
+<error line="54" column="21" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
+<error line="55" column="20" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
+<error line="56" column="13" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
+<error line="58" column="3" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
+<error line="59" column="3" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
+<error line="62" column="3" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
+<error line="63" column="3" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
+</file>
+<file name="packages/prices/utils/index.js">
+<error line="1" column="15" severity="error" message="File &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/packages/prices/utils/price.ts&apos; is not listed within the file list of project &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/tsconfig.json&apos;. Projects must list all files or use an &apos;include&apos; pattern." source="TS6307" />
+</file>
+<file name="packages/prices/index.js">
+<error line="1" column="15" severity="error" message="File &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/packages/prices/utils/index.js&apos; is not listed within the file list of project &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/tsconfig.json&apos;. Projects must list all files or use an &apos;include&apos; pattern." source="TS6307" />
+</file>
+<file name="packages/checkout/components/totals/item/index.tsx">
+<error line="8" column="15" severity="error" message="Module &apos;&quot;@woocommerce/price-format&quot;&apos; has no exported member &apos;Currency&apos;." source="TS2305" />
+<error line="8" column="31" severity="error" message="File &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/packages/prices/index.js&apos; is not listed within the file list of project &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/tsconfig.json&apos;. Projects must list all files or use an &apos;include&apos; pattern.
+  The file is in the program because:
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/packages/checkout/components/totals/item/index.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/packages/checkout/components/totals/subtotal/index.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/packages/checkout/components/totals/taxes/index.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/packages/checkout/components/totals/fees/index.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/base/components/product-price/index.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/atomic/blocks/product-elements/price/block.js&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/base/context/hooks/payment-methods/use-payment-method-interface.ts&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/base/components/cart-checkout/order-summary/order-summary-item.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/base/components/cart-checkout/product-sale-badge/index.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/base/components/cart-checkout/shipping-rates-control-package/render-package-rate-option.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/base/components/cart-checkout/totals/shipping/index.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/active-filters/utils.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/cart/cart-line-items-table/cart-line-item-row.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-block/edit.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-subtotal/block.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-fee/block.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-discount/block.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-shipping/block.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-taxes/block.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/cart/inner-blocks/cart-order-summary-block/frontend.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-block/edit.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/block.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-subtotal/block.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-fee/block.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-discount/block.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-shipping/block.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-taxes/block.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-block/frontend.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/price-filter/block.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/mini-cart/block.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-footer-block/block.tsx&apos;
+    Imported via &apos;@woocommerce/price-format&apos; from file &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/blocks/mini-cart/edit.tsx&apos;" source="TS6307" />
+</file>
+<file name="packages/checkout/components/totals/subtotal/index.tsx">
+<error line="5" column="15" severity="error" message="Module &apos;&quot;@woocommerce/price-format&quot;&apos; has no exported member &apos;Currency&apos;." source="TS2305" />
+<error line="35" column="4" severity="error" message="Type &apos;{ className: string | undefined; currency: Currency; label: string; value: number; }&apos; is not assignable to type &apos;TotalsItemProps&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+  Types of property &apos;className&apos; are incompatible.
+    Type &apos;string | undefined&apos; is not assignable to type &apos;string&apos;.
+      Type &apos;undefined&apos; is not assignable to type &apos;string&apos;." source="TS2375" />
+</file>
+<file name="packages/checkout/components/totals/taxes/index.tsx">
+<error line="7" column="15" severity="error" message="Module &apos;&quot;@woocommerce/price-format&quot;&apos; has no exported member &apos;Currency&apos;." source="TS2305" />
+</file>
+<file name="packages/checkout/components/totals/fees/index.tsx">
+<error line="7" column="15" severity="error" message="Module &apos;&quot;@woocommerce/price-format&quot;&apos; has no exported member &apos;Currency&apos;." source="TS2305" />
+</file>
+<file name="packages/checkout/components/error-boundary/index.js">
+<error line="9" column="35" severity="error" message="Parameter &apos;error&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+</file>
+<file name="packages/checkout/slot/index.js">
+<error line="11" column="8" severity="error" message="Could not find a declaration file for module &apos;wordpress-components&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/wordpress-components/build/index.js&apos; implicitly has an &apos;any&apos; type.
+  If the &apos;@wordpress/components&apos; package actually exposes this module, consider sending a pull request to amend &apos;https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/wordpress__components&apos;" source="TS7016" />
+<error line="42" column="12" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
+<error line="83" column="13" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
+<error line="87" column="8" severity="error" message="Parameter &apos;fillProps&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+</file>
+<file name="packages/checkout/components/order-meta/index.js">
+<error line="9" column="41" severity="error" message="Variable &apos;useSlot&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="14" column="9" severity="error" message="Property &apos;Fill&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="14" column="38" severity="error" message="Property &apos;Slot&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="17" column="18" severity="error" message="Binding element &apos;className&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="17" column="29" severity="error" message="Binding element &apos;extensions&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="17" column="41" severity="error" message="Binding element &apos;cart&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="17" column="47" severity="error" message="Binding element &apos;context&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="18" column="20" severity="error" message="Variable &apos;useSlot&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+</file>
+<file name="packages/checkout/components/discounts-meta/index.js">
+<error line="9" column="41" severity="error" message="Variable &apos;useSlot&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="14" column="9" severity="error" message="Property &apos;Fill&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="14" column="42" severity="error" message="Property &apos;Slot&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="17" column="18" severity="error" message="Binding element &apos;className&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="17" column="29" severity="error" message="Binding element &apos;extensions&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="17" column="41" severity="error" message="Binding element &apos;cart&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="17" column="47" severity="error" message="Binding element &apos;context&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="18" column="20" severity="error" message="Variable &apos;useSlot&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+</file>
+<file name="packages/checkout/components/order-shipping-packages/index.js">
+<error line="9" column="26" severity="error" message="Variable &apos;useSlot&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="13" column="2" severity="error" message="Property &apos;Fill&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="14" column="2" severity="error" message="Property &apos;Slot&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="18" column="2" severity="error" message="Binding element &apos;className&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="19" column="2" severity="error" message="Binding element &apos;collapsible&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="20" column="2" severity="error" message="Binding element &apos;noResultsMessage&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="21" column="2" severity="error" message="Binding element &apos;renderOption&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="22" column="2" severity="error" message="Binding element &apos;extensions&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="23" column="2" severity="error" message="Binding element &apos;cart&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="24" column="2" severity="error" message="Binding element &apos;components&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="25" column="2" severity="error" message="Binding element &apos;context&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="26" column="2" severity="error" message="Binding element &apos;shippingRates&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="28" column="20" severity="error" message="Variable &apos;useSlot&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+</file>
+<file name="assets/js/base/components/button/index.tsx">
+<error line="4" column="36" severity="error" message="Could not find a declaration file for module &apos;wordpress-components&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/wordpress-components/build/index.js&apos; implicitly has an &apos;any&apos; type.
+  If the &apos;@wordpress/components&apos; package actually exposes this module, consider sending a pull request to amend &apos;https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/wordpress__components&apos;" source="TS7016" />
+</file>
+<file name="assets/js/data/schema/selectors.js">
+<error line="19" column="12" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
+<error line="106" column="7" severity="error" message="Variable &apos;namespaceRoutes&apos; implicitly has type &apos;any[]&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="109" column="8" severity="error" message="Variable &apos;namespaceRoutes&apos; implicitly has an &apos;any[]&apos; type." source="TS7005" />
+<error line="113" column="10" severity="error" message="Variable &apos;namespaceRoutes&apos; implicitly has an &apos;any[]&apos; type." source="TS7005" />
+<error line="122" column="12" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
+<error line="130" column="27" severity="error" message="Property &apos;find&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="130" column="39" severity="error" message="Binding element &apos;idNames&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="151" column="12" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
+<error line="152" column="12" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
+</file>
+<file name="assets/js/data/schema/resolvers.js">
+<error line="5" column="10" severity="error" message="Module &apos;&quot;@wordpress/data&quot;&apos; has no exported member &apos;controls&apos;." source="TS2305" />
+<error line="33" column="24" severity="error" message="&apos;yield&apos; expression implicitly results in an &apos;any&apos; type because its containing generator lacks a return-type annotation." source="TS7057" />
+</file>
+<file name="assets/js/data/schema/utils.js">
+<error line="31" column="13" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
+<error line="52" column="12" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
+</file>
+<file name="assets/js/data/utils/has-in-state.js">
+<error line="10" column="12" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
+</file>
+<file name="assets/js/data/utils/update-state.js">
+<error line="10" column="12" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
+</file>
+<file name="assets/js/data/schema/reducers.js">
+<error line="26" column="10" severity="error" message="Property &apos;type&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="26" column="16" severity="error" message="Property &apos;routes&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="26" column="24" severity="error" message="Property &apos;namespace&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="28" column="21" severity="error" message="Parameter &apos;route&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+</file>
+<file name="assets/js/data/schema/index.js">
+<error line="17" column="2" severity="error" message="Type &apos;Reducer&lt;CombinedState&lt;{ routes: Object; }&gt;, AnyAction&gt;&apos; is not assignable to type &apos;Reducer&lt;&quot;core/editor&quot;, AnyAction&gt;&apos;.
+  Types of parameters &apos;state&apos; and &apos;state&apos; are incompatible.
+    Type &apos;&quot;core/editor&quot; | undefined&apos; is not assignable to type &apos;CombinedState&lt;{ routes: Object; }&gt; | undefined&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;CombinedState&lt;{ routes: Object; }&gt;&apos;.
+        Type &apos;string&apos; is not assignable to type &apos;{ routes: Object; }&apos;." source="TS2322" />
+<error line="18" column="2" severity="error" message="Type &apos;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/data/schema/actions&quot;)&apos; is not assignable to type &apos;{ [k: string]: (...args: readonly any[]) =&gt; AnyAction | Generator&lt;any, any, unknown&gt;; }&apos;.
+  Property &apos;receiveRoutes&apos; is incompatible with index signature.
+    Type &apos;(routes: Object, namespace?: string) =&gt; Object&apos; is not assignable to type &apos;(...args: readonly any[]) =&gt; AnyAction | Generator&lt;any, any, unknown&gt;&apos;.
+      Type &apos;Object&apos; is not assignable to type &apos;AnyAction | Generator&lt;any, any, unknown&gt;&apos;.
+        The &apos;Object&apos; type is assignable to very few other types. Did you mean to use the &apos;any&apos; type instead?
+          The &apos;Object&apos; type is assignable to very few other types. Did you mean to use the &apos;any&apos; type instead?
+            Property &apos;type&apos; is missing in type &apos;Object&apos; but required in type &apos;AnyAction&apos;." source="TS2322" />
+</file>
+<file name="assets/js/data/collections/constants.js">
+<error line="2" column="14" severity="error" message="Variable &apos;DEFAULT_EMPTY_ARRAY&apos; implicitly has an &apos;any[]&apos; type." source="TS7005" />
+</file>
+<file name="assets/js/data/collections/selectors.js">
+<error line="13" column="2" severity="error" message="Binding element &apos;state&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="14" column="2" severity="error" message="Binding element &apos;namespace&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="15" column="2" severity="error" message="Binding element &apos;resourceName&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="16" column="2" severity="error" message="Binding element &apos;query&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="17" column="2" severity="error" message="Binding element &apos;ids&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="31" column="2" severity="error" message="Parameter &apos;state&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="32" column="2" severity="error" message="Parameter &apos;namespace&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="33" column="2" severity="error" message="Parameter &apos;resourceName&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="55" column="12" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
+<error line="58" column="13" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
+<error line="64" column="2" severity="error" message="Type &apos;null&apos; is not assignable to type &apos;Object | undefined&apos;." source="TS2322" />
+<error line="71" column="2" severity="error" message="Parameter &apos;state&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="72" column="2" severity="error" message="Parameter &apos;namespace&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="73" column="2" severity="error" message="Parameter &apos;resourceName&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="84" column="3" severity="error" message="Type &apos;null&apos; is not assignable to type &apos;any[] | undefined&apos;." source="TS2322" />
+<error line="104" column="12" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
+<error line="117" column="2" severity="error" message="Type &apos;null&apos; is not assignable to type &apos;Object | undefined&apos;." source="TS2322" />
+<error line="124" column="3" severity="error" message="Argument of type &apos;Object&apos; is not assignable to parameter of type &apos;null | undefined&apos;.
+  The &apos;Object&apos; type is assignable to very few other types. Did you mean to use the &apos;any&apos; type instead?" source="TS2345" />
+<error line="143" column="15" severity="error" message="Property &apos;lastModified&apos; does not exist on type &apos;string&apos;." source="TS2339" />
+</file>
+<file name="assets/js/data/collections/actions.js">
+<error line="8" column="8" severity="error" message="This expression is not constructable.
+  Type &apos;never&apos; has no construct signatures." source="TS2351" />
+<error line="20" column="12" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
+<error line="31" column="5" severity="error" message="&apos;}&apos; expected." source="TS1005" />
+<error line="46" column="26" severity="error" message="Type &apos;null&apos; is not assignable to type &apos;Headers&apos;." source="TS2322" />
+<error line="60" column="2" severity="error" message="Parameter &apos;namespace&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="61" column="2" severity="error" message="Parameter &apos;resourceName&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="62" column="2" severity="error" message="Parameter &apos;queryString&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="63" column="2" severity="error" message="Parameter &apos;ids&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="64" column="2" severity="error" message="Parameter &apos;error&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="80" column="38" severity="error" message="Parameter &apos;timestamp&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+</file>
+<file name="assets/js/data/shared-controls.ts">
+<error line="139" column="7" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
+<error line="141" column="17" severity="error" message="Parameter &apos;response&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="144" column="19" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
+<error line="146" column="26" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
+</file>
+<file name="assets/js/data/collections/resolvers.js">
+<error line="4" column="10" severity="error" message="Module &apos;&quot;@wordpress/data&quot;&apos; has no exported member &apos;controls&apos;." source="TS2305" />
+<error line="21" column="23" severity="error" message="&apos;yield&apos; expression implicitly results in an &apos;any&apos; type because its containing generator lacks a return-type annotation." source="TS7057" />
+<error line="40" column="12" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
+<error line="43" column="16" severity="error" message="&apos;yield&apos; expression implicitly results in an &apos;any&apos; type because its containing generator lacks a return-type annotation." source="TS7057" />
+<error line="93" column="12" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
+</file>
+<file name="assets/js/data/collections/reducers.js">
+<error line="18" column="14" severity="error" message="Property &apos;type&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="19" column="15" severity="error" message="Property &apos;timestamp&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="19" column="35" severity="error" message="Property &apos;lastModified&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="24" column="25" severity="error" message="Property &apos;timestamp&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="29" column="14" severity="error" message="Property &apos;type&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="33" column="10" severity="error" message="Property &apos;type&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="33" column="16" severity="error" message="Property &apos;namespace&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="33" column="27" severity="error" message="Property &apos;resourceName&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="33" column="41" severity="error" message="Property &apos;queryString&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="33" column="54" severity="error" message="Property &apos;response&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="35" column="21" severity="error" message="Property &apos;ids&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="35" column="50" severity="error" message="Property &apos;ids&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+</file>
+<file name="assets/js/data/collections/index.js">
+<error line="20" column="2" severity="error" message="Type &apos;{ API_FETCH_WITH_HEADERS: ({ options, }: { readonly type: &quot;API_FETCH_WITH_HEADERS&quot;; readonly options: APIFetchOptions; }) =&gt; Promise&lt;unknown&gt;; API_FETCH: (action: AnyAction) =&gt; Promise&lt;...&gt;; DISPATCH: (action: AnyAction) =&gt; void; SELECT: (action: AnyAction) =&gt; any; }&apos; is not assignable to type &apos;{ [k: string]: (action: AnyAction) =&gt; any; }&apos;.
+  Property &apos;API_FETCH_WITH_HEADERS&apos; is incompatible with index signature.
+    Type &apos;({ options, }: ReturnType&lt;typeof apiFetchWithHeaders&gt;) =&gt; Promise&lt;unknown&gt;&apos; is not assignable to type &apos;(action: AnyAction) =&gt; any&apos;.
+      Types of parameters &apos;__0&apos; and &apos;action&apos; are incompatible.
+        Property &apos;options&apos; is missing in type &apos;AnyAction&apos; but required in type &apos;{ readonly type: &quot;API_FETCH_WITH_HEADERS&quot;; readonly options: APIFetchOptions; }&apos;." source="TS2322" />
+<error line="21" column="2" severity="error" message="Type &apos;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/data/collections/selectors&quot;)&apos; is not assignable to type &apos;{ [k: string]: (state: Object, ...args: readonly any[]) =&gt; any; }&apos;.
+  Property &apos;getCollectionHeader&apos; is incompatible with index signature.
+    Type &apos;(state: string, header: string, namespace: string, resourceName: string, query?: Object | undefined, ids?: any[] | undefined) =&gt; any&apos; is not assignable to type &apos;(state: Object, ...args: readonly any[]) =&gt; any&apos;.
+      Types of parameters &apos;state&apos; and &apos;state&apos; are incompatible.
+        Type &apos;Object&apos; is not assignable to type &apos;string&apos;." source="TS2322" />
+</file>
+<file name="assets/js/data/cart/default-state.ts">
+<error line="73" column="4" severity="error" message="Type &apos;&quot;&quot;&apos; is not assignable to type &apos;CurrencyCode&apos;." source="TS2322" />
+</file>
+<file name="assets/js/data/mapped-types.ts">
+<error line="29" column="28" severity="error" message="Type &apos;S[selector]&apos; does not satisfy the constraint &apos;Function&apos;.
+  Type &apos;S[FunctionKeys&lt;S&gt;]&apos; is not assignable to type &apos;Function&apos;.
+    Type &apos;S[NonUndefined&lt;S[keyof S]&gt; extends Function ? keyof S : never]&apos; is not assignable to type &apos;Function&apos;.
+      Type &apos;S[keyof S]&apos; is not assignable to type &apos;Function&apos;.
+        Type &apos;S[string] | S[number] | S[symbol]&apos; is not assignable to type &apos;Function&apos;.
+          Type &apos;S[string]&apos; is not assignable to type &apos;Function&apos;." source="TS2344" />
+<error line="30" column="19" severity="error" message="Type &apos;S[selector]&apos; does not satisfy the constraint &apos;(...args: any) =&gt; any&apos;.
+  Type &apos;S[FunctionKeys&lt;S&gt;]&apos; is not assignable to type &apos;(...args: any) =&gt; any&apos;.
+    Type &apos;S[NonUndefined&lt;S[keyof S]&gt; extends Function ? keyof S : never]&apos; is not assignable to type &apos;(...args: any) =&gt; any&apos;.
+      Type &apos;S[keyof S]&apos; is not assignable to type &apos;(...args: any) =&gt; any&apos;.
+        Type &apos;S[string] | S[number] | S[symbol]&apos; is not assignable to type &apos;(...args: any) =&gt; any&apos;.
+          Type &apos;S[string]&apos; is not assignable to type &apos;(...args: any) =&gt; any&apos;." source="TS2344" />
+</file>
+<file name="assets/js/data/cart/actions.ts">
+<error line="14" column="10" severity="error" message="Module &apos;&quot;@wordpress/data&quot;&apos; has no exported member &apos;controls&apos;." source="TS2305" />
+<error line="224" column="23" severity="error" message="Argument of type &apos;unknown&apos; is not assignable to parameter of type &apos;ResponseError | null | undefined&apos;." source="TS2345" />
+<error line="226" column="8" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
+<error line="227" column="23" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
+<error line="260" column="23" severity="error" message="Argument of type &apos;unknown&apos; is not assignable to parameter of type &apos;ResponseError | null | undefined&apos;." source="TS2345" />
+<error line="264" column="8" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
+<error line="265" column="23" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
+<error line="300" column="23" severity="error" message="Argument of type &apos;unknown&apos; is not assignable to parameter of type &apos;ResponseError | null | undefined&apos;." source="TS2345" />
+<error line="304" column="8" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
+<error line="305" column="23" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
+<error line="344" column="23" severity="error" message="Argument of type &apos;unknown&apos; is not assignable to parameter of type &apos;ResponseError | null | undefined&apos;." source="TS2345" />
+<error line="347" column="8" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
+<error line="348" column="23" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
+<error line="382" column="23" severity="error" message="Argument of type &apos;unknown&apos; is not assignable to parameter of type &apos;ResponseError | null | undefined&apos;." source="TS2345" />
+<error line="385" column="8" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
+<error line="386" column="23" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
+<error line="428" column="23" severity="error" message="Argument of type &apos;unknown&apos; is not assignable to parameter of type &apos;ResponseError | null | undefined&apos;." source="TS2345" />
+<error line="431" column="8" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
+<error line="432" column="23" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
+<error line="463" column="23" severity="error" message="Argument of type &apos;unknown&apos; is not assignable to parameter of type &apos;ResponseError | null | undefined&apos;." source="TS2345" />
+<error line="467" column="8" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
+<error line="468" column="23" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
+<error line="514" column="23" severity="error" message="Argument of type &apos;unknown&apos; is not assignable to parameter of type &apos;ResponseError | null | undefined&apos;." source="TS2345" />
+<error line="518" column="8" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
+<error line="519" column="23" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
+</file>
+<file name="assets/js/data/cart/resolvers.ts">
+<error line="5" column="10" severity="error" message="Module &apos;&quot;@wordpress/data&quot;&apos; has no exported member &apos;controls&apos;." source="TS2305" />
+</file>
+<file name="assets/js/data/cart/reducers.ts">
+<error line="25" column="18" severity="error" message="Property &apos;type&apos; does not exist on type &apos;Partial&lt;unknown&gt;&apos;." source="TS2339" />
+<error line="29" column="34" severity="error" message="Property &apos;cartItem&apos; does not exist on type &apos;Partial&lt;unknown&gt;&apos;." source="TS2339" />
+<error line="30" column="20" severity="error" message="Property &apos;cartItem&apos; does not exist on type &apos;Partial&lt;unknown&gt;&apos;." source="TS2339" />
+<error line="50" column="18" severity="error" message="Property &apos;type&apos; does not exist on type &apos;Partial&lt;unknown&gt;&apos;." source="TS2339" />
+<error line="52" column="16" severity="error" message="Property &apos;error&apos; does not exist on type &apos;Partial&lt;unknown&gt;&apos;." source="TS2339" />
+<error line="55" column="42" severity="error" message="Property &apos;error&apos; does not exist on type &apos;Partial&lt;unknown&gt;&apos;." source="TS2339" />
+<error line="60" column="16" severity="error" message="Property &apos;error&apos; does not exist on type &apos;Partial&lt;unknown&gt;&apos;." source="TS2339" />
+<error line="63" column="23" severity="error" message="Property &apos;error&apos; does not exist on type &apos;Partial&lt;unknown&gt;&apos;." source="TS2339" />
+<error line="68" column="16" severity="error" message="Property &apos;response&apos; does not exist on type &apos;Partial&lt;unknown&gt;&apos;." source="TS2339" />
+<error line="74" column="17" severity="error" message="Property &apos;response&apos; does not exist on type &apos;Partial&lt;unknown&gt;&apos;." source="TS2339" />
+<error line="80" column="16" severity="error" message="Property &apos;couponCode&apos; does not exist on type &apos;Partial&lt;unknown&gt;&apos;." source="TS2339" />
+<error line="80" column="37" severity="error" message="Property &apos;couponCode&apos; does not exist on type &apos;Partial&lt;unknown&gt;&apos;." source="TS2339" />
+<error line="85" column="30" severity="error" message="Property &apos;couponCode&apos; does not exist on type &apos;Partial&lt;unknown&gt;&apos;." source="TS2339" />
+<error line="97" column="17" severity="error" message="Property &apos;billingAddress&apos; does not exist on type &apos;Partial&lt;unknown&gt;&apos;." source="TS2339" />
+<error line="109" column="17" severity="error" message="Property &apos;shippingAddress&apos; does not exist on type &apos;Partial&lt;unknown&gt;&apos;." source="TS2339" />
+<error line="116" column="16" severity="error" message="Property &apos;couponCode&apos; does not exist on type &apos;Partial&lt;unknown&gt;&apos;." source="TS2339" />
+<error line="116" column="37" severity="error" message="Property &apos;couponCode&apos; does not exist on type &apos;Partial&lt;unknown&gt;&apos;." source="TS2339" />
+<error line="121" column="30" severity="error" message="Property &apos;couponCode&apos; does not exist on type &apos;Partial&lt;unknown&gt;&apos;." source="TS2339" />
+<error line="131" column="31" severity="error" message="Property &apos;cartItemKey&apos; does not exist on type &apos;Partial&lt;unknown&gt;&apos;." source="TS2339" />
+<error line="133" column="16" severity="error" message="Property &apos;isPendingQuantity&apos; does not exist on type &apos;Partial&lt;unknown&gt;&apos;." source="TS2339" />
+<error line="133" column="44" severity="error" message="Property &apos;cartItemKey&apos; does not exist on type &apos;Partial&lt;unknown&gt;&apos;." source="TS2339" />
+<error line="134" column="38" severity="error" message="Property &apos;cartItemKey&apos; does not exist on type &apos;Partial&lt;unknown&gt;&apos;." source="TS2339" />
+<error line="143" column="31" severity="error" message="Property &apos;cartItemKey&apos; does not exist on type &apos;Partial&lt;unknown&gt;&apos;." source="TS2339" />
+<error line="145" column="16" severity="error" message="Property &apos;isPendingDelete&apos; does not exist on type &apos;Partial&lt;unknown&gt;&apos;." source="TS2339" />
+<error line="145" column="42" severity="error" message="Property &apos;cartItemKey&apos; does not exist on type &apos;Partial&lt;unknown&gt;&apos;." source="TS2339" />
+<error line="146" column="36" severity="error" message="Property &apos;cartItemKey&apos; does not exist on type &apos;Partial&lt;unknown&gt;&apos;." source="TS2339" />
+<error line="169" column="38" severity="error" message="Property &apos;isResolving&apos; does not exist on type &apos;Partial&lt;unknown&gt;&apos;." source="TS2339" />
+<error line="178" column="38" severity="error" message="Property &apos;isResolving&apos; does not exist on type &apos;Partial&lt;unknown&gt;&apos;." source="TS2339" />
+<error line="187" column="30" severity="error" message="Property &apos;isCartDataStale&apos; does not exist on type &apos;Partial&lt;unknown&gt;&apos;." source="TS2339" />
+</file>
+<file name="assets/js/base/utils/errors.js">
+<error line="26" column="14" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
+<error line="33" column="3" severity="error" message="Type &apos;string | undefined&apos; is not assignable to type &apos;string&apos;.
+  Type &apos;undefined&apos; is not assignable to type &apos;string&apos;." source="TS2322" />
+<error line="45" column="16" severity="error" message="Property &apos;data&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="45" column="33" severity="error" message="Property &apos;code&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="46" column="49" severity="error" message="Property &apos;data&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="52" column="19" severity="error" message="Property &apos;message&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="59" column="34" severity="error" message="Property &apos;message&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+</file>
+<file name="assets/js/base/utils/address.ts">
+<error line="92" column="46" severity="error" message="Argument of type &apos;string[]&apos; is not assignable to parameter of type &apos;(keyof AddressFields)[]&apos;.
+  Type &apos;string&apos; is not assignable to type &apos;keyof AddressFields&apos;." source="TS2345" />
+</file>
+<file name="assets/js/base/utils/shipping-rates.js">
+<error line="4" column="12" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
+<error line="13" column="12" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
+</file>
+<file name="assets/js/base/components/block-error-boundary/index.tsx">
+<error line="58" column="6" severity="error" message="Type &apos;{ showErrorBlock: boolean; errorMessage: string | null; header: string | undefined; imageUrl: string | undefined; text: ReactNode; errorMessagePrefix: string | undefined; button: ReactNode; }&apos; is not assignable to type &apos;BlockErrorProps&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+  Types of property &apos;imageUrl&apos; are incompatible.
+    Type &apos;string | undefined&apos; is not assignable to type &apos;string&apos;.
+      Type &apos;undefined&apos; is not assignable to type &apos;string&apos;." source="TS2375" />
+<error line="58" column="6" severity="error" message="&apos;BlockError&apos; cannot be used as a JSX component.
+  Its return type &apos;ReactNode&apos; is not a valid JSX element.
+    Type &apos;undefined&apos; is not assignable to type &apos;Element | null&apos;." source="TS2786" />
+</file>
+<file name="assets/js/base/utils/render-frontend.tsx">
+<error line="60" column="4" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(props: BlockErrorBoundaryProps | Readonly&lt;BlockErrorBoundaryProps&gt;): BlockErrorBoundary&apos;, gave the following error.
+    Property &apos;text&apos; is missing in type &apos;{ children: Element; }&apos; but required in type &apos;Readonly&lt;BlockErrorBoundaryProps&gt;&apos;.
+  Overload 2 of 2, &apos;(props: BlockErrorBoundaryProps, context: any): BlockErrorBoundary&apos;, gave the following error.
+    Property &apos;text&apos; is missing in type &apos;{ children: Element; }&apos; but required in type &apos;Readonly&lt;BlockErrorBoundaryProps&gt;&apos;." source="TS2769" />
+<error line="168" column="27" severity="error" message="Argument of type &apos;{ Block: BlockType&lt;TProps, TAttributes&gt; | null; containers: NodeListOf&lt;Element&gt;; getProps: GetPropsFn&lt;TProps, TAttributes&gt; | undefined; getErrorBoundaryProps: ((el: HTMLElement, i: number) =&gt; Record&lt;...&gt;) | undefined; }&apos; is not assignable to parameter of type &apos;RenderBlockInContainersParams&lt;TProps, TAttributes&gt;&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+  Types of property &apos;getProps&apos; are incompatible.
+    Type &apos;GetPropsFn&lt;TProps, TAttributes&gt; | undefined&apos; is not assignable to type &apos;GetPropsFn&lt;TProps, TAttributes&gt;&apos;.
+      Type &apos;undefined&apos; is not assignable to type &apos;GetPropsFn&lt;TProps, TAttributes&gt;&apos;." source="TS2379" />
+<error line="199" column="27" severity="error" message="Argument of type &apos;{ Block: BlockType&lt;TProps, TAttributes&gt; | null; containers: NodeListOf&lt;Element&gt;; getProps: GetPropsFn&lt;TProps, TAttributes&gt; | undefined; getErrorBoundaryProps: ((el: HTMLElement, i: number) =&gt; Record&lt;...&gt;) | undefined; }&apos; is not assignable to parameter of type &apos;RenderBlockInContainersParams&lt;TProps, TAttributes&gt;&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+  Types of property &apos;getProps&apos; are incompatible.
+    Type &apos;GetPropsFn&lt;TProps, TAttributes&gt; | undefined&apos; is not assignable to type &apos;GetPropsFn&lt;TProps, TAttributes&gt;&apos;.
+      Type &apos;undefined&apos; is not assignable to type &apos;GetPropsFn&lt;TProps, TAttributes&gt;&apos;." source="TS2379" />
+<error line="244" column="30" severity="error" message="Argument of type &apos;{ Block: BlockType&lt;TProps, TAttributes&gt; | null; getProps: GetPropsFn&lt;TProps, TAttributes&gt; | undefined; getErrorBoundaryProps: ((el: HTMLElement, i: number) =&gt; Record&lt;...&gt;) | undefined; selector: string; wrappers: NodeListOf&lt;...&gt;; }&apos; is not assignable to parameter of type &apos;RenderBlockOutsideWrappersParams&lt;TProps, TAttributes&gt;&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+  Types of property &apos;getProps&apos; are incompatible.
+    Type &apos;GetPropsFn&lt;TProps, TAttributes&gt; | undefined&apos; is not assignable to type &apos;GetPropsFn&lt;TProps, TAttributes&gt;&apos;.
+      Type &apos;undefined&apos; is not assignable to type &apos;GetPropsFn&lt;TProps, TAttributes&gt;&apos;." source="TS2379" />
+</file>
+<file name="assets/js/base/utils/get-valid-block-attributes.js">
+<error line="5" column="12" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
+<error line="6" column="13" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
+<error line="9" column="8" severity="error" message="Variable &apos;attributes&apos; implicitly has type &apos;any[]&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="12" column="30" severity="error" message="Element implicitly has an &apos;any&apos; type because index expression is not of type &apos;number&apos;." source="TS7015" />
+<error line="13" column="13" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;Object&apos;.
+  No index signature with a parameter of type &apos;string&apos; was found on type &apos;Object&apos;." source="TS7053" />
+<error line="15" column="6" severity="error" message="Variable &apos;attributes&apos; implicitly has an &apos;any[]&apos; type." source="TS7005" />
+<error line="15" column="18" severity="error" message="Element implicitly has an &apos;any&apos; type because index expression is not of type &apos;number&apos;." source="TS7015" />
+<error line="16" column="22" severity="error" message="Element implicitly has an &apos;any&apos; type because index expression is not of type &apos;number&apos;." source="TS7015" />
+<error line="17" column="22" severity="error" message="Element implicitly has an &apos;any&apos; type because index expression is not of type &apos;number&apos;." source="TS7015" />
+<error line="20" column="6" severity="error" message="Variable &apos;attributes&apos; implicitly has an &apos;any[]&apos; type." source="TS7005" />
+<error line="20" column="18" severity="error" message="Element implicitly has an &apos;any&apos; type because index expression is not of type &apos;number&apos;." source="TS7015" />
+<error line="20" column="51" severity="error" message="Element implicitly has an &apos;any&apos; type because index expression is not of type &apos;number&apos;." source="TS7015" />
+<error line="24" column="6" severity="error" message="Variable &apos;attributes&apos; implicitly has an &apos;any[]&apos; type." source="TS7005" />
+<error line="24" column="18" severity="error" message="Element implicitly has an &apos;any&apos; type because index expression is not of type &apos;number&apos;." source="TS7015" />
+<error line="24" column="53" severity="error" message="Element implicitly has an &apos;any&apos; type because index expression is not of type &apos;number&apos;." source="TS7015" />
+<error line="27" column="6" severity="error" message="Variable &apos;attributes&apos; implicitly has an &apos;any[]&apos; type." source="TS7005" />
+<error line="27" column="18" severity="error" message="Element implicitly has an &apos;any&apos; type because index expression is not of type &apos;number&apos;." source="TS7015" />
+<error line="27" column="41" severity="error" message="Element implicitly has an &apos;any&apos; type because index expression is not of type &apos;number&apos;." source="TS7015" />
+<error line="31" column="4" severity="error" message="Variable &apos;attributes&apos; implicitly has an &apos;any[]&apos; type." source="TS7005" />
+<error line="31" column="16" severity="error" message="Element implicitly has an &apos;any&apos; type because index expression is not of type &apos;number&apos;." source="TS7015" />
+<error line="31" column="24" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;Object&apos;.
+  No index signature with a parameter of type &apos;string&apos; was found on type &apos;Object&apos;." source="TS7053" />
+<error line="35" column="9" severity="error" message="Variable &apos;attributes&apos; implicitly has an &apos;any[]&apos; type." source="TS7005" />
+</file>
+<file name="assets/js/base/utils/product-data.js">
+<error line="8" column="17" severity="error" message="Property &apos;is_purchasable&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="30" column="42" severity="error" message="Property &apos;type&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+</file>
+<file name="assets/js/data/cart/controls.js">
+<error line="18" column="31" severity="error" message="Parameter &apos;preserveCartData&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+</file>
+<file name="assets/js/utils/notices.ts">
+<error line="12" column="52" severity="error" message="Property &apos;type&apos; does not exist on type &apos;Notice&apos;." source="TS2339" />
+</file>
+<file name="assets/js/data/checkout/thunks.ts">
+<error line="5" column="10" severity="error" message="Module &apos;&quot;@wordpress/notices&quot;&apos; has no exported member &apos;store&apos;." source="TS2305" />
+<error line="57" column="11" severity="error" message="Property &apos;createErrorNotice&apos; does not exist on type &apos;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__rich-text/store/actions&quot;)&apos;." source="TS2339" />
+<error line="92" column="12" severity="error" message="Property &apos;createErrorNotice&apos; does not exist on type &apos;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__rich-text/store/actions&quot;)&apos;." source="TS2339" />
+</file>
+<file name="assets/js/data/checkout/reducers.ts">
+<error line="164" column="25" severity="error" message="Property &apos;SET_PRISTINE&apos; does not exist on type &apos;{ readonly SET_IDLE: &quot;SET_IDLE&quot;; readonly SET_REDIRECT_URL: &quot;SET_REDIRECT_URL&quot;; readonly SET_COMPLETE: &quot;SET_CHECKOUT_COMPLETE&quot;; readonly SET_BEFORE_PROCESSING: &quot;SET_BEFORE_PROCESSING&quot;; ... 11 more ...; readonly SET_IS_CART: &quot;SET_IS_CART&quot;; }&apos;." source="TS2339" />
+</file>
+<file name="assets/js/data/checkout/index.ts">
+<error line="21" column="44" severity="error" message="Argument of type &apos;{ reducer: (state: CheckoutState | undefined, action: actions.CheckoutAction) =&gt; CheckoutState; selectors: typeof selectors; actions: typeof actions; }&apos; is not assignable to parameter of type &apos;StoreConfig&lt;CheckoutState&gt;&apos;.
+  Types of property &apos;actions&apos; are incompatible.
+    Type &apos;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/data/checkout/actions&quot;)&apos; is not assignable to type &apos;{ [k: string]: (...args: readonly any[]) =&gt; AnyAction | Generator&lt;any, any, unknown&gt;; }&apos;.
+      Property &apos;__internalProcessCheckoutResponse&apos; is incompatible with index signature.
+        Type &apos;(response: CheckoutResponse) =&gt; ({ dispatch, }: { dispatch: DispatchFromMap&lt;typeof actions&gt;; }) =&gt; void&apos; is not assignable to type &apos;(...args: readonly any[]) =&gt; AnyAction | Generator&lt;any, any, unknown&gt;&apos;.
+          Type &apos;({ dispatch, }: { dispatch: DispatchFromMap&lt;typeof actions&gt;; }) =&gt; void&apos; is not assignable to type &apos;AnyAction | Generator&lt;any, any, unknown&gt;&apos;." source="TS2345" />
+</file>
+<file name="assets/js/previews/cart.ts">
+<error line="75" column="4" severity="error" message="Property &apos;price_range&apos; is missing in type &apos;{ currency_code: &quot;USD&quot;; currency_symbol: string; currency_minor_unit: number; currency_decimal_separator: string; currency_thousand_separator: string; currency_prefix: string; currency_suffix: string; price: string; regular_price: string; sale_price: string; raw_prices: { ...; }; }&apos; but required in type &apos;CartItemPrices&apos;." source="TS2741" />
+<error line="141" column="4" severity="error" message="Property &apos;price_range&apos; is missing in type &apos;{ currency_code: &quot;USD&quot;; currency_symbol: string; currency_minor_unit: number; currency_decimal_separator: string; currency_thousand_separator: string; currency_prefix: string; currency_suffix: string; price: string; regular_price: string; sale_price: string; raw_prices: { ...; }; }&apos; but required in type &apos;CartItemPrices&apos;." source="TS2741" />
+<error line="180" column="4" severity="error" message="Property &apos;price_range&apos; is missing in type &apos;{ currency_code: &quot;USD&quot;; currency_symbol: string; currency_minor_unit: number; currency_decimal_separator: string; currency_thousand_separator: string; currency_prefix: string; currency_suffix: string; price: string; regular_price: string; sale_price: string; raw_prices: { ...; }; }&apos; but required in type &apos;ProductResponseItemPrices&apos;." source="TS2741" />
+<error line="215" column="4" severity="error" message="Property &apos;price_range&apos; is missing in type &apos;{ currency_code: &quot;USD&quot;; currency_symbol: string; currency_minor_unit: number; currency_decimal_separator: string; currency_thousand_separator: string; currency_prefix: string; currency_suffix: string; price: string; regular_price: string; sale_price: string; raw_prices: { ...; }; }&apos; but required in type &apos;ProductResponseItemPrices&apos;." source="TS2741" />
+<error line="252" column="4" severity="error" message="Property &apos;price_range&apos; is missing in type &apos;{ currency_code: &quot;USD&quot;; currency_symbol: string; currency_minor_unit: number; currency_decimal_separator: string; currency_thousand_separator: string; currency_prefix: string; currency_suffix: string; price: string; regular_price: string; sale_price: string; raw_prices: { ...; }; }&apos; but required in type &apos;ProductResponseItemPrices&apos;." source="TS2741" />
+<error line="290" column="4" severity="error" message="Property &apos;price_range&apos; is missing in type &apos;{ currency_code: &quot;USD&quot;; currency_symbol: string; currency_minor_unit: number; currency_decimal_separator: string; currency_thousand_separator: string; currency_prefix: string; currency_suffix: string; price: string; regular_price: string; sale_price: string; raw_prices: { ...; }; }&apos; but required in type &apos;ProductResponseItemPrices&apos;." source="TS2741" />
+<error line="327" column="4" severity="error" message="Property &apos;price_range&apos; is missing in type &apos;{ currency_code: &quot;USD&quot;; currency_symbol: string; currency_minor_unit: number; currency_decimal_separator: string; currency_thousand_separator: string; currency_prefix: string; currency_suffix: string; price: string; regular_price: string; sale_price: string; raw_prices: { ...; }; }&apos; but required in type &apos;ProductResponseItemPrices&apos;." source="TS2741" />
+<error line="365" column="4" severity="error" message="Property &apos;price_range&apos; is missing in type &apos;{ currency_code: &quot;USD&quot;; currency_symbol: string; currency_minor_unit: number; currency_decimal_separator: string; currency_thousand_separator: string; currency_prefix: string; currency_suffix: string; price: string; regular_price: string; sale_price: string; raw_prices: { ...; }; }&apos; but required in type &apos;ProductResponseItemPrices&apos;." source="TS2741" />
+<error line="411" column="5" severity="error" message="Type &apos;{ currency_code: &quot;USD&quot;; currency_symbol: string; currency_minor_unit: number; currency_decimal_separator: string; currency_thousand_separator: string; currency_prefix: string; currency_suffix: string; total: string; total_tax: string; tax_lines: { ...; }[]; }&apos; is not assignable to type &apos;CartResponseFeeItemTotals&apos;.
+  Object literal may only specify known properties, and &apos;tax_lines&apos; does not exist in type &apos;CartResponseFeeItemTotals&apos;." source="TS2322" />
+</file>
+<file name="assets/js/data/payment/utils/check-payment-methods.ts">
+<error line="15" column="10" severity="error" message="Module &apos;&quot;@wordpress/notices&quot;&apos; has no exported member &apos;store&apos;." source="TS2305" />
+<error line="143" column="5" severity="error" message="Argument of type &apos;unknown&apos; is not assignable to parameter of type &apos;CartShippingRate[]&apos;." source="TS2345" />
+<error line="174" column="37" severity="error" message="Argument of type &apos;Record&lt;string, unknown&gt;&apos; is not assignable to parameter of type &apos;CanMakePaymentArgument&apos;.
+  Type &apos;Record&lt;string, unknown&gt;&apos; is missing the following properties from type &apos;CanMakePaymentArgument&apos;: cart, cartTotals, cartNeedsShipping, billingData, and 3 more." source="TS2345" />
+<error line="186" column="13" severity="error" message="Property &apos;createErrorNotice&apos; does not exist on type &apos;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__rich-text/store/actions&quot;)&apos;." source="TS2339" />
+</file>
+<file name="assets/js/data/payment/thunks.ts">
+<error line="4" column="10" severity="error" message="Module &apos;&quot;@wordpress/notices&quot;&apos; has no exported member &apos;store&apos;." source="TS2305" />
+<error line="22" column="13" severity="error" message="Binding element &apos;registry&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="74" column="23" severity="error" message="Property &apos;meta&apos; does not exist on type &apos;never&apos;." source="TS2339" />
+<error line="90" column="24" severity="error" message="Property &apos;message&apos; does not exist on type &apos;never&apos;." source="TS2339" />
+<error line="90" column="49" severity="error" message="Property &apos;message&apos; does not exist on type &apos;never&apos;." source="TS2339" />
+<error line="91" column="39" severity="error" message="Property &apos;message&apos; does not exist on type &apos;never&apos;." source="TS2339" />
+<error line="95" column="23" severity="error" message="Property &apos;messageContext&apos; does not exist on type &apos;never&apos;." source="TS2339" />
+<error line="101" column="21" severity="error" message="Property &apos;meta&apos; does not exist on type &apos;never&apos;." source="TS2339" />
+<error line="109" column="24" severity="error" message="Property &apos;message&apos; does not exist on type &apos;never&apos;." source="TS2339" />
+<error line="109" column="49" severity="error" message="Property &apos;message&apos; does not exist on type &apos;never&apos;." source="TS2339" />
+<error line="110" column="39" severity="error" message="Property &apos;message&apos; does not exist on type &apos;never&apos;." source="TS2339" />
+<error line="114" column="23" severity="error" message="Property &apos;messageContext&apos; does not exist on type &apos;never&apos;." source="TS2339" />
+<error line="120" column="41" severity="error" message="Property &apos;validationErrors&apos; does not exist on type &apos;never&apos;." source="TS2339" />
+</file>
+<file name="assets/js/data/payment/actions.ts">
+<error line="51" column="19" severity="error" message="Binding element &apos;select&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="51" column="27" severity="error" message="Binding element &apos;dispatch&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="122" column="19" severity="error" message="Binding element &apos;dispatch&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="122" column="29" severity="error" message="Binding element &apos;select&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="170" column="19" severity="error" message="Binding element &apos;select&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="170" column="27" severity="error" message="Binding element &apos;dispatch&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+</file>
+<file name="assets/js/data/payment/index.ts">
+<error line="25" column="44" severity="error" message="Argument of type &apos;{ reducer: Reducer&lt;PaymentMethodDataState, AnyAction&gt;; selectors: typeof selectors; actions: typeof actions; controls: any; }&apos; is not assignable to parameter of type &apos;StoreConfig&lt;PaymentMethodDataState&gt;&apos;.
+  Types of property &apos;actions&apos; are incompatible.
+    Type &apos;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/data/payment/actions&quot;)&apos; is not assignable to type &apos;{ [k: string]: (...args: readonly any[]) =&gt; AnyAction | Generator&lt;any, any, unknown&gt;; }&apos;.
+      Property &apos;__internalUpdateAvailablePaymentMethods&apos; is incompatible with index signature.
+        Type &apos;() =&gt; ({ select, dispatch }: { select: any; dispatch: any; }) =&gt; Promise&lt;void&gt;&apos; is not assignable to type &apos;(...args: readonly any[]) =&gt; AnyAction | Generator&lt;any, any, unknown&gt;&apos;.
+          Type &apos;({ select, dispatch }: { select: any; dispatch: any; }) =&gt; Promise&lt;void&gt;&apos; is not assignable to type &apos;AnyAction | Generator&lt;any, any, unknown&gt;&apos;." source="TS2345" />
+</file>
+<file name="assets/js/data/query-state/utils.js">
+<error line="1" column="37" severity="error" message="Parameter &apos;state&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="1" column="44" severity="error" message="Parameter &apos;context&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+</file>
+<file name="assets/js/data/query-state/reducers.js">
+<error line="14" column="10" severity="error" message="Property &apos;type&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="14" column="16" severity="error" message="Property &apos;context&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="14" column="25" severity="error" message="Property &apos;queryKey&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="14" column="35" severity="error" message="Property &apos;value&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+</file>
+<file name="assets/js/data/query-state/index.js">
+<error line="16" column="2" severity="error" message="Type &apos;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/data/query-state/actions&quot;)&apos; is not assignable to type &apos;{ [k: string]: (...args: readonly any[]) =&gt; AnyAction | Generator&lt;any, any, unknown&gt;; }&apos;.
+  Property &apos;setQueryValue&apos; is incompatible with index signature.
+    Type &apos;(context: string, queryKey: string, value: any) =&gt; Object&apos; is not assignable to type &apos;(...args: readonly any[]) =&gt; AnyAction | Generator&lt;any, any, unknown&gt;&apos;.
+      Type &apos;Object&apos; is not assignable to type &apos;AnyAction | Generator&lt;any, any, unknown&gt;&apos;.
+        The &apos;Object&apos; type is assignable to very few other types. Did you mean to use the &apos;any&apos; type instead?" source="TS2322" />
+</file>
+<file name="packages/checkout/filter-registry/index.ts">
+<error line="36" column="37" severity="error" message="Cannot find name &apos;T&apos;." source="TS2304" />
+</file>
+<file name="packages/checkout/blocks-registry/register-checkout-block.ts">
+<error line="34" column="3" severity="error" message="Type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos; is not assignable to type &apos;Function&apos;.
+  Type &apos;null&apos; is not assignable to type &apos;Function&apos;." source="TS2322" />
+<error line="44" column="43" severity="error" message="Property &apos;lock&apos; does not exist on type &apos;{}&apos;." source="TS2339" />
+</file>
+<file name="packages/checkout/index.js">
+<error line="6" column="34" severity="error" message="Could not find a declaration file for module &apos;wordpress-components&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/wordpress-components/build/index.js&apos; implicitly has an &apos;any&apos; type.
+  If the &apos;@wordpress/components&apos; package actually exposes this module, consider sending a pull request to amend &apos;https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/wordpress__components&apos;" source="TS7016" />
+</file>
+<file name="assets/js/blocks-registry/block-components/register-block-component.js">
+<error line="42" column="2" severity="error" message="Type &apos;Function&apos; is not assignable to type &apos;RegisteredBlockComponent&apos;." source="TS2322" />
+<error line="53" column="7" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;Object&apos;.
+  No index signature with a parameter of type &apos;string&apos; was found on type &apos;Object&apos;." source="TS7053" />
+<error line="54" column="15" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;Object&apos;.
+  No index signature with a parameter of type &apos;string&apos; was found on type &apos;Object&apos;." source="TS7053" />
+<error line="58" column="4" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;Object&apos;.
+  No index signature with a parameter of type &apos;string&apos; was found on type &apos;Object&apos;." source="TS7053" />
+<error line="59" column="4" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;Object&apos;.
+  No index signature with a parameter of type &apos;string&apos; was found on type &apos;Object&apos;." source="TS7053" />
+<error line="78" column="28" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;Object&apos;.
+  No index signature with a parameter of type &apos;string&apos; was found on type &apos;Object&apos;." source="TS7053" />
+</file>
+<file name="assets/js/base/components/product-price/index.tsx">
+<error line="285" column="5" severity="error" message="Type &apos;{ currency: Currency | Record&lt;string, never&gt;; price: string | number; priceClassName: string | undefined; priceStyle: CSSProperties | undefined; regularPrice: string | number; regularPriceClassName: string | undefined; regularPriceStyle: CSSProperties | undefined; }&apos; is not assignable to type &apos;SalePriceProps&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+  Types of property &apos;regularPriceClassName&apos; are incompatible.
+    Type &apos;string | undefined&apos; is not assignable to type &apos;string&apos;.
+      Type &apos;undefined&apos; is not assignable to type &apos;string&apos;." source="TS2375" />
+<error line="297" column="5" severity="error" message="Type &apos;{ currency: Currency | Record&lt;string, never&gt;; maxPrice: string | number; minPrice: string | number; priceClassName: string | undefined; priceStyle: CSSProperties | undefined; }&apos; is not assignable to type &apos;PriceRangeProps&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+  Types of property &apos;priceClassName&apos; are incompatible.
+    Type &apos;string | undefined&apos; is not assignable to type &apos;string&apos;.
+      Type &apos;undefined&apos; is not assignable to type &apos;string&apos;." source="TS2375" />
+<error line="307" column="5" severity="error" message="Type &apos;{ className: string; currency: Currency | Record&lt;string, never&gt;; value: string | number; style: CSSProperties | undefined; }&apos; is not assignable to type &apos;FormattedMonetaryAmountProps&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+  Types of property &apos;style&apos; are incompatible.
+    Type &apos;CSSProperties | undefined&apos; is not assignable to type &apos;CSSProperties&apos;.
+      Type &apos;undefined&apos; is not assignable to type &apos;Properties&lt;string | number, string &amp; {}&gt;&apos;." source="TS2375" />
+</file>
+<file name="assets/js/shared/context/inner-block-layout-context.js">
+<error line="26" column="2" severity="error" message="Binding element &apos;children&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="33" column="37" severity="error" message="Property &apos;isLoading&apos; is missing in type &apos;{ parentName: string; parentClassName: string; }&apos; but required in type &apos;{ parentName: string; parentClassName: string; isLoading: boolean; }&apos;." source="TS2741" />
+</file>
+<file name="assets/js/base/hooks/use-container-queries.ts">
+<error line="36" column="7" severity="error" message="Object is possibly &apos;null&apos;." source="TS2531" />
+<error line="38" column="14" severity="error" message="Object is possibly &apos;null&apos;." source="TS2531" />
+<error line="40" column="14" severity="error" message="Object is possibly &apos;null&apos;." source="TS2531" />
+</file>
+<file name="assets/js/base/hooks/use-position-relative-to-viewport.js">
+<error line="26" column="13" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
+<error line="75" column="24" severity="error" message="Argument of type &apos;null&apos; is not assignable to parameter of type &apos;Element&apos;." source="TS2345" />
+</file>
+<file name="node_modules/@types/wordpress__block-editor/index.d.ts">
+<error line="21" column="14" severity="error" message="Cannot redeclare block-scoped variable &apos;store&apos;." source="TS2451" />
+</file>
+<file name="assets/js/utils/global-style.js">
+<error line="5" column="10" severity="error" message="Module &apos;&quot;@wordpress/block-editor&quot;&apos; has no exported member &apos;__experimentalGetSpacingClassesAndStyles&apos;." source="TS2305" />
+</file>
+<file name="assets/js/utils/products.js">
+<error line="5" column="12" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
+<error line="20" column="12" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
+</file>
+<file name="assets/js/base/hooks/use-spacing-props.ts">
+<error line="5" column="10" severity="error" message="Module &apos;&quot;@wordpress/block-editor&quot;&apos; has no exported member &apos;__experimentalGetSpacingClassesAndStyles&apos;." source="TS2305" />
+</file>
+<file name="assets/js/base/hooks/use-color-props.ts">
+<error line="5" column="10" severity="error" message="Module &apos;&quot;@wordpress/block-editor&quot;&apos; has no exported member &apos;__experimentalUseColorProps&apos;." source="TS2305" />
+</file>
+<file name="assets/js/base/hooks/use-border-props.ts">
+<error line="5" column="10" severity="error" message="Module &apos;&quot;@wordpress/block-editor&quot;&apos; has no exported member &apos;__experimentalUseBorderProps&apos;." source="TS2305" />
+</file>
+<file name="assets/js/base/context/providers/editor-context.js">
+<error line="8" column="56" severity="error" message="Namespace &apos;&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/types/type-defs/contexts&quot;&apos; has no exported member &apos;EditorDataContext&apos;." source="TS2694" />
+<error line="9" column="52" severity="error" message="Namespace &apos;&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/types/type-defs/cart&quot;&apos; has no exported member &apos;CartData&apos;." source="TS2694" />
+<error line="59" column="12" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;any&apos; can&apos;t be used to index type &apos;Object&apos;." source="TS7053" />
+</file>
+<file name="assets/js/base/context/hooks/cart/use-store-cart-event-listeners.ts">
+<error line="20" column="23" severity="error" message="Parameter &apos;e&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="23" column="24" severity="error" message="Property &apos;invalidateResolutionForStore&apos; does not exist on type &apos;DispatchFromMap&lt;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/data/cart/actions&quot;)&gt;&apos;." source="TS2339" />
+</file>
+<file name="assets/js/base/context/hooks/cart/use-store-cart.ts">
+<error line="74" column="2" severity="error" message="Type &apos;&quot;&quot;&apos; is not assignable to type &apos;CurrencyCode&apos;." source="TS2322" />
+<error line="146" column="3" severity="error" message="Argument of type &apos;(select: any, { dispatch }: { dispatch: any; }) =&gt; StoreCart | { cartCoupons: any; cartItems: any; crossSellsProducts: any; cartFees: any; cartItemsCount: any; cartItemsWeight: any; cartNeedsPayment: any; ... 13 more ...; receiveCart: any; } | { ...; }&apos; is not assignable to parameter of type &apos;(s: { (storeNameOrDescriptor: string | StoreDescriptor): SelectorMap; (key: &quot;core/rich-text&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__rich-text/store/selectors&quot;); (key: &quot;core/notices&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-bloc...&apos;." source="TS2345" />
+<error line="146" column="5" severity="error" message="Parameter &apos;select&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="146" column="15" severity="error" message="Binding element &apos;dispatch&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="227" column="44" severity="error" message="Argument of type &apos;Record&lt;string, unknown&gt;&apos; is not assignable to parameter of type &apos;CartResponseShippingAddress | CartResponseBillingAddress&apos;.
+  Type &apos;Record&lt;string, unknown&gt;&apos; is missing the following properties from type &apos;CartResponseBillingAddress&apos;: email, company, phone, address_1, and 7 more." source="TS2345" />
+<error line="228" column="47" severity="error" message="Argument of type &apos;Record&lt;string, unknown&gt;&apos; is not assignable to parameter of type &apos;CartResponseShippingAddress | CartResponseBillingAddress&apos;." source="TS2345" />
+<error line="229" column="48" severity="error" message="Argument of type &apos;Record&lt;string, unknown&gt;&apos; is not assignable to parameter of type &apos;CartResponseShippingAddress | CartResponseBillingAddress&apos;." source="TS2345" />
+<error line="245" column="3" severity="error" message="Type &apos;StoreCart&apos; is not assignable to type &apos;undefined&apos;." source="TS2322" />
+<error line="248" column="2" severity="error" message="Type &apos;undefined&apos; is not assignable to type &apos;StoreCart&apos;." source="TS2322" />
+</file>
+<file name="assets/js/base/context/hooks/cart/use-store-cart-coupons.ts">
+<error line="41" column="3" severity="error" message="Type &apos;&quot;applyCoupon&quot; | &quot;removeCoupon&quot; | &quot;receiveApplyingCoupon&quot; | &quot;isApplyingCoupon&quot; | &quot;isRemovingCoupon&quot;&apos; does not satisfy the constraint &apos;keyof StoreCartCoupon&apos;.
+  Type &apos;&quot;receiveApplyingCoupon&quot;&apos; is not assignable to type &apos;keyof StoreCartCoupon&apos;." source="TS2344" />
+<error line="47" column="3" severity="error" message="Argument of type &apos;(select: any, { dispatch }: { dispatch: any; }) =&gt; { applyCoupon: any; removeCoupon: any; isApplyingCoupon: any; isRemovingCoupon: any; receiveApplyingCoupon: any; }&apos; is not assignable to parameter of type &apos;(s: { (storeNameOrDescriptor: string | StoreDescriptor): SelectorMap; (key: &quot;core/rich-text&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__rich-text/store/selectors&quot;); (key: &quot;core/notices&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-bloc...&apos;." source="TS2345" />
+<error line="47" column="5" severity="error" message="Parameter &apos;select&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="47" column="15" severity="error" message="Binding element &apos;dispatch&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="64" column="5" severity="error" message="Property &apos;then&apos; does not exist on type &apos;void&apos;." source="TS2339" />
+<error line="64" column="13" severity="error" message="Parameter &apos;result&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="84" column="14" severity="error" message="Parameter &apos;error&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="92" column="5" severity="error" message="Cannot find name &apos;receiveApplyingCoupon&apos;." source="TS2304" />
+<error line="98" column="5" severity="error" message="Property &apos;then&apos; does not exist on type &apos;void&apos;." source="TS2339" />
+<error line="98" column="13" severity="error" message="Parameter &apos;result&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="118" column="14" severity="error" message="Parameter &apos;error&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="124" column="5" severity="error" message="Cannot find name &apos;receiveApplyingCoupon&apos;." source="TS2304" />
+</file>
+<file name="assets/js/base/context/hooks/cart/use-store-cart-item-quantity.ts">
+<error line="149" column="3" severity="error" message="Type &apos;() =&gt; Promise&lt;boolean&gt; | Promise&lt;void&gt;&apos; is not assignable to type &apos;() =&gt; Promise&lt;boolean&gt;&apos;.
+  Type &apos;Promise&lt;boolean&gt; | Promise&lt;void&gt;&apos; is not assignable to type &apos;Promise&lt;boolean&gt;&apos;.
+    Type &apos;Promise&lt;void&gt;&apos; is not assignable to type &apos;Promise&lt;boolean&gt;&apos;.
+      Type &apos;void&apos; is not assignable to type &apos;boolean&apos;." source="TS2322" />
+</file>
+<file name="assets/js/base/context/hooks/use-query-state.js">
+<error line="28" column="13" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
+<error line="131" column="5" severity="error" message="Argument of type &apos;Object | undefined&apos; is not assignable to parameter of type &apos;any[] | ComparableObject&apos;.
+  Type &apos;undefined&apos; is not assignable to type &apos;any[] | ComparableObject&apos;." source="TS2345" />
+</file>
+<file name="assets/js/base/context/hooks/collections/use-collection.ts">
+<error line="103" column="35" severity="error" message="Cannot find name &apos;T&apos;." source="TS2304" />
+</file>
+<file name="assets/js/base/context/hooks/collections/use-collection-data.ts">
+<error line="87" column="7" severity="error" message="Parameter &apos;attribute&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+</file>
+<file name="assets/js/base/context/hooks/shipping/use-shipping-data.ts">
+<error line="55" column="33" severity="error" message="Argument of type &apos;CartResponseShippingRate[]&apos; is not assignable to parameter of type &apos;CartShippingRate[]&apos;." source="TS2345" />
+<error line="68" column="3" severity="error" message="Type &apos;CartResponseShippingRate[]&apos; is not assignable to type &apos;CartShippingRate[]&apos;.
+  Type &apos;CartResponseShippingRate&apos; is not assignable to type &apos;CartShippingRate&apos;.
+    Types of property &apos;package_id&apos; are incompatible.
+      Type &apos;string | number&apos; is not assignable to type &apos;number&apos;.
+        Type &apos;string&apos; is not assignable to type &apos;number&apos;." source="TS2322" />
+</file>
+<file name="assets/js/base/context/hooks/use-checkout-notices.js">
+<error line="12" column="56" severity="error" message="Namespace &apos;&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/types/type-defs/contexts&quot;&apos; has no exported member &apos;StoreNoticeObject&apos;." source="TS2694" />
+<error line="13" column="53" severity="error" message="Namespace &apos;&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/types/type-defs/hooks&quot;&apos; has no exported member &apos;CheckoutNotices&apos;." source="TS2694" />
+</file>
+<file name="assets/js/base/context/providers/cart-checkout/shipping/constants.js">
+<error line="2" column="56" severity="error" message="Namespace &apos;&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/types/type-defs/contexts&quot;&apos; has no exported member &apos;ShippingErrorTypes&apos;." source="TS2694" />
+<error line="3" column="56" severity="error" message="Namespace &apos;&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/types/type-defs/shipping&quot;&apos; has no exported member &apos;ShippingAddress&apos;." source="TS2694" />
+<error line="4" column="56" severity="error" message="Namespace &apos;&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/types/type-defs/contexts&quot;&apos; has no exported member &apos;ShippingDataContext&apos;." source="TS2694" />
+</file>
+<file name="assets/js/base/context/providers/cart-checkout/shipping/utils.js">
+<error line="6" column="44" severity="error" message="Parameter &apos;errors&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="7" column="24" severity="error" message="Parameter &apos;error&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+</file>
+<file name="assets/js/base/context/providers/cart-checkout/shipping/event-emit.js">
+<error line="25" column="65" severity="error" message="Argument of type &apos;Function&apos; is not assignable to parameter of type &apos;Dispatch&lt;ActionType&gt;&apos;.
+  Type &apos;Function&apos; provides no match for the signature &apos;(value: ActionType): void&apos;." source="TS2345" />
+<error line="26" column="59" severity="error" message="Argument of type &apos;Function&apos; is not assignable to parameter of type &apos;Dispatch&lt;ActionType&gt;&apos;." source="TS2345" />
+<error line="29" column="3" severity="error" message="Argument of type &apos;Function&apos; is not assignable to parameter of type &apos;Dispatch&lt;ActionType&gt;&apos;." source="TS2345" />
+<error line="33" column="3" severity="error" message="Argument of type &apos;Function&apos; is not assignable to parameter of type &apos;Dispatch&lt;ActionType&gt;&apos;." source="TS2345" />
+</file>
+<file name="assets/js/base/context/providers/cart-checkout/shipping/index.js">
+<error line="32" column="56" severity="error" message="Namespace &apos;&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/types/type-defs/contexts&quot;&apos; has no exported member &apos;ShippingDataContext&apos;." source="TS2694" />
+<error line="67" column="42" severity="error" message="Property &apos;onSuccess&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="68" column="61" severity="error" message="Property &apos;onFail&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="70" column="42" severity="error" message="Property &apos;onSelectSuccess&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="72" column="42" severity="error" message="Property &apos;onSelectFail&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+</file>
+<file name="assets/js/base/context/hooks/use-store-add-to-cart.ts">
+<error line="93" column="3" severity="error" message="Type &apos;(quantity?: number) =&gt; Promise&lt;void&gt;&apos; is not assignable to type &apos;(quantity?: number | undefined) =&gt; Promise&lt;boolean&gt;&apos;.
+  Type &apos;Promise&lt;void&gt;&apos; is not assignable to type &apos;Promise&lt;boolean&gt;&apos;." source="TS2322" />
+</file>
+<file name="assets/js/base/context/providers/add-to-cart-form/form-state/actions.js">
+<error line="42" column="27" severity="error" message="Parameter &apos;data&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="50" column="17" severity="error" message="Parameter &apos;quantity&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="54" column="22" severity="error" message="Parameter &apos;data&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+</file>
+<file name="assets/js/base/context/providers/add-to-cart-form/form-state/reducer.js">
+<error line="46" column="11" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="55" column="11" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="64" column="24" severity="error" message="Property &apos;quantity&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="75" column="15" severity="error" message="Property &apos;requestParams&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="88" column="11" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="97" column="14" severity="error" message="Property &apos;hasError&apos; does not exist on type &apos;Object | { status: string; hasError: boolean; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; }&apos;.
+  Property &apos;hasError&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="103" column="11" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="113" column="11" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="121" column="21" severity="error" message="Property &apos;hasError&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="128" column="11" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="129" column="11" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="137" column="21" severity="error" message="Property &apos;hasError&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="149" column="3" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="149" column="12" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object | { status: string; hasError: boolean; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
+  Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="151" column="3" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="151" column="12" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object | { status: string; hasError: boolean; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
+  Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+</file>
+<file name="assets/js/base/context/providers/add-to-cart-form/form-state/event-emit.js">
+<error line="34" column="3" severity="error" message="Argument of type &apos;Function&apos; is not assignable to parameter of type &apos;Dispatch&lt;ActionType&gt;&apos;." source="TS2345" />
+<error line="38" column="3" severity="error" message="Argument of type &apos;Function&apos; is not assignable to parameter of type &apos;Dispatch&lt;ActionType&gt;&apos;." source="TS2345" />
+<error line="42" column="3" severity="error" message="Argument of type &apos;Function&apos; is not assignable to parameter of type &apos;Dispatch&lt;ActionType&gt;&apos;." source="TS2345" />
+</file>
+<file name="assets/js/base/context/providers/add-to-cart-form/form-state/index.js">
+<error line="39" column="56" severity="error" message="Namespace &apos;&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/types/type-defs/contexts&quot;&apos; has no exported member &apos;AddToCartFormContext&apos;." source="TS2694" />
+<error line="60" column="44" severity="error" message="Parameter &apos;callback&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="61" column="42" severity="error" message="Parameter &apos;callback&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="62" column="34" severity="error" message="Parameter &apos;callback&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="67" column="18" severity="error" message="Parameter &apos;quantity&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="68" column="18" severity="error" message="Parameter &apos;hasError&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="69" column="25" severity="error" message="Parameter &apos;response&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="70" column="23" severity="error" message="Parameter &apos;data&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="113" column="7" severity="error" message="Property &apos;onAddToCartAfterProcessingWithSuccess&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="116" column="7" severity="error" message="Property &apos;onAddToCartAfterProcessingWithError&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="119" column="7" severity="error" message="Property &apos;onAddToCartBeforeProcessing&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="129" column="36" severity="error" message="Argument of type &apos;{ type: string; }&apos; is not assignable to parameter of type &apos;{ quantity: number; type: string; data: Object; }&apos;.
+  Type &apos;{ type: string; }&apos; is missing the following properties from type &apos;{ quantity: number; type: string; data: Object; }&apos;: quantity, data" source="TS2345" />
+<error line="130" column="37" severity="error" message="Argument of type &apos;{ type: string; }&apos; is not assignable to parameter of type &apos;{ quantity: number; type: string; data: Object; }&apos;.
+  Type &apos;{ type: string; }&apos; is missing the following properties from type &apos;{ quantity: number; type: string; data: Object; }&apos;: quantity, data" source="TS2345" />
+<error line="132" column="20" severity="error" message="Argument of type &apos;{ type: string; quantity: any; }&apos; is not assignable to parameter of type &apos;{ quantity: number; type: string; data: Object; }&apos;.
+  Property &apos;data&apos; is missing in type &apos;{ type: string; quantity: any; }&apos; but required in type &apos;{ quantity: number; type: string; data: Object; }&apos;." source="TS2345" />
+<error line="134" column="20" severity="error" message="Argument of type &apos;{ type: string; }&apos; is not assignable to parameter of type &apos;{ quantity: number; type: string; data: Object; }&apos;.
+  Type &apos;{ type: string; }&apos; is missing the following properties from type &apos;{ quantity: number; type: string; data: Object; }&apos;: quantity, data" source="TS2345" />
+<error line="136" column="20" severity="error" message="Argument of type &apos;{ type: string; data: any; }&apos; is not assignable to parameter of type &apos;{ quantity: number; type: string; data: Object; }&apos;.
+  Property &apos;quantity&apos; is missing in type &apos;{ type: string; data: any; }&apos; but required in type &apos;{ quantity: number; type: string; data: Object; }&apos;." source="TS2345" />
+<error line="138" column="15" severity="error" message="Argument of type &apos;{ type: string; data: any; }&apos; is not assignable to parameter of type &apos;{ quantity: number; type: string; data: Object; }&apos;.
+  Property &apos;quantity&apos; is missing in type &apos;{ type: string; data: any; }&apos; but required in type &apos;{ quantity: number; type: string; data: Object; }&apos;." source="TS2345" />
+<error line="139" column="20" severity="error" message="Argument of type &apos;{ type: string; }&apos; is not assignable to parameter of type &apos;{ quantity: number; type: string; data: Object; }&apos;.
+  Type &apos;{ type: string; }&apos; is missing the following properties from type &apos;{ quantity: number; type: string; data: Object; }&apos;: quantity, data" source="TS2345" />
+<error line="149" column="18" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="149" column="37" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
+  Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="151" column="6" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="151" column="14" severity="error" message="Property &apos;id&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="151" column="44" severity="error" message="Argument of type &apos;Object | undefined&apos; is not assignable to parameter of type &apos;Object&apos;.
+  Type &apos;undefined&apos; is not assignable to type &apos;Object&apos;." source="TS2345" />
+<error line="154" column="14" severity="error" message="Argument of type &apos;{ type: string; }&apos; is not assignable to parameter of type &apos;{ quantity: number; type: string; data: Object; }&apos;.
+  Type &apos;{ type: string; }&apos; is missing the following properties from type &apos;{ quantity: number; type: string; data: Object; }&apos;: quantity, data" source="TS2345" />
+<error line="156" column="14" severity="error" message="Argument of type &apos;{ type: string; }&apos; is not assignable to parameter of type &apos;{ quantity: number; type: string; data: Object; }&apos;.
+  Type &apos;{ type: string; }&apos; is missing the following properties from type &apos;{ quantity: number; type: string; data: Object; }&apos;: quantity, data" source="TS2345" />
+<error line="158" column="7" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="158" column="26" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
+  Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="164" column="18" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="164" column="37" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
+  Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="188" column="16" severity="error" message="Argument of type &apos;{ type: string; }&apos; is not assignable to parameter of type &apos;{ quantity: number; type: string; data: Object; }&apos;." source="TS2345" />
+<error line="190" column="16" severity="error" message="Argument of type &apos;{ type: string; }&apos; is not assignable to parameter of type &apos;{ quantity: number; type: string; data: Object; }&apos;.
+  Type &apos;{ type: string; }&apos; is missing the following properties from type &apos;{ quantity: number; type: string; data: Object; }&apos;: quantity, data" source="TS2345" />
+<error line="195" column="3" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="195" column="22" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
+  Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="200" column="12" severity="error" message="Property &apos;id&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="207" column="8" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="207" column="27" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
+  Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="213" column="25" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="213" column="44" severity="error" message="Property &apos;processingResponse&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
+  Property &apos;processingResponse&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="216" column="34" severity="error" message="Parameter &apos;observerResponses&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="218" column="34" severity="error" message="Parameter &apos;response&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="235" column="9" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="235" column="28" severity="error" message="Property &apos;hasError&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
+  Property &apos;hasError&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="253" column="18" severity="error" message="Property &apos;id&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="257" column="16" severity="error" message="Argument of type &apos;{ type: string; }&apos; is not assignable to parameter of type &apos;{ quantity: number; type: string; data: Object; }&apos;." source="TS2345" />
+<error line="271" column="16" severity="error" message="Argument of type &apos;{ type: string; }&apos; is not assignable to parameter of type &apos;{ quantity: number; type: string; data: Object; }&apos;." source="TS2345" />
+<error line="273" column="16" severity="error" message="Argument of type &apos;{ type: string; }&apos; is not assignable to parameter of type &apos;{ quantity: number; type: string; data: Object; }&apos;." source="TS2345" />
+<error line="278" column="3" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="278" column="22" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
+  Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="279" column="3" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="279" column="22" severity="error" message="Property &apos;hasError&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
+  Property &apos;hasError&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="280" column="3" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="280" column="22" severity="error" message="Property &apos;processingResponse&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
+  Property &apos;processingResponse&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="284" column="12" severity="error" message="Property &apos;id&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="287" column="61" severity="error" message="Argument of type &apos;Object | undefined&apos; is not assignable to parameter of type &apos;Object&apos;.
+  Type &apos;undefined&apos; is not assignable to type &apos;Object&apos;." source="TS2345" />
+<error line="294" column="16" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="294" column="24" severity="error" message="Property &apos;type&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="295" column="47" severity="error" message="Argument of type &apos;Object | undefined&apos; is not assignable to parameter of type &apos;Object&apos;.
+  Type &apos;undefined&apos; is not assignable to type &apos;Object&apos;." source="TS2345" />
+<error line="296" column="22" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="296" column="30" severity="error" message="Property &apos;has_options&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="300" column="4" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="300" column="23" severity="error" message="Property &apos;quantity&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
+  Property &apos;quantity&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="300" column="44" severity="error" message="Property &apos;add_to_cart&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="301" column="25" severity="error" message="Property &apos;add_to_cart&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="302" column="25" severity="error" message="Property &apos;add_to_cart&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="303" column="24" severity="error" message="Property &apos;add_to_cart&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="304" column="18" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="304" column="37" severity="error" message="Property &apos;requestParams&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
+  Property &apos;requestParams&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="305" column="11" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="305" column="30" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
+  Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="306" column="15" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="306" column="34" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
+  Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="307" column="17" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="307" column="36" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
+  Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="309" column="4" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="309" column="23" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
+  Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="311" column="4" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="311" column="23" severity="error" message="Property &apos;status&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
+  Property &apos;status&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="312" column="13" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="312" column="32" severity="error" message="Property &apos;hasError&apos; does not exist on type &apos;Object | { status: string; constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; } | ... 4 more ... | { ...; }&apos;.
+  Property &apos;hasError&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+</file>
+<file name="assets/js/base/context/providers/add-to-cart-form/form/submit/index.js">
+<error line="88" column="18" severity="error" message="Property &apos;setNonce&apos; does not exist on type &apos;typeof apiFetch&apos;." source="TS2339" />
+<error line="91" column="43" severity="error" message="Parameter &apos;response&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="128" column="35" severity="error" message="Parameter &apos;response&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+</file>
+<file name="assets/js/base/context/providers/cart-checkout/checkout-processor.js">
+<error line="172" column="7" severity="error" message="Variable &apos;unsubscribeProcessing&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="181" column="5" severity="error" message="Variable &apos;unsubscribeProcessing&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="227" column="9" severity="error" message="Property &apos;shipping_address&apos; does not exist on type &apos;{ extensions: { [x: string]: Record&lt;string, unknown&gt;; }; payment_method: string | undefined; payment_data: { key: string; value: unknown; }[]; billing_address: BillingAddress; customer_note: string; create_account: boolean; } | { ...; }&apos;.
+  Property &apos;shipping_address&apos; does not exist on type &apos;{ extensions: { [x: string]: Record&lt;string, unknown&gt;; }; payment_method: string | undefined; payment_data: { key: string; value: unknown; }[]; billing_address: BillingAddress; customer_note: string; create_account: boolean; }&apos;." source="TS2339" />
+<error line="256" column="35" severity="error" message="Parameter &apos;response&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="266" column="9" severity="error" message="Argument of type &apos;{ id: string; context: string; __unstableHTML: boolean; }&apos; is not assignable to parameter of type &apos;Partial&lt;Options&gt;&apos;.
+  Object literal may only specify known properties, and &apos;__unstableHTML&apos; does not exist in type &apos;Partial&lt;Options&gt;&apos;." source="TS2345" />
+<error line="270" column="10" severity="error" message="Parameter &apos;additionalError&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="274" column="10" severity="error" message="Argument of type &apos;{ id: any; context: string; __unstableHTML: boolean; }&apos; is not assignable to parameter of type &apos;Partial&lt;Options&gt;&apos;.
+  Object literal may only specify known properties, and &apos;__unstableHTML&apos; does not exist in type &apos;Partial&lt;Options&gt;&apos;." source="TS2345" />
+<error line="297" column="8" severity="error" message="Argument of type &apos;{ id: string; context: string; __unstableHTML: boolean; }&apos; is not assignable to parameter of type &apos;Partial&lt;Options&gt;&apos;.
+  Object literal may only specify known properties, and &apos;__unstableHTML&apos; does not exist in type &apos;Partial&lt;Options&gt;&apos;." source="TS2345" />
+</file>
+<file name="assets/js/base/context/providers/cart-checkout/checkout-provider.js">
+<error line="4" column="28" severity="error" message="Could not find a declaration file for module &apos;@wordpress/plugins&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@wordpress/plugins/build/index.js&apos; implicitly has an &apos;any&apos; type.
+  Try `npm i --save-dev @types/wordpress__plugins` if it exists or add a new declaration (.d.ts) file containing `declare module &apos;@wordpress/plugins&apos;;`" source="TS7016" />
+<error line="30" column="27" severity="error" message="Type &apos;string | undefined&apos; is not assignable to type &apos;string&apos;.
+  Type &apos;undefined&apos; is not assignable to type &apos;string&apos;." source="TS2322" />
+<error line="31" column="4" severity="error" message="Type &apos;Element&apos; is missing the following properties from type &apos;ReactChildren&apos;: map, forEach, count, only, toArray" source="TS2739" />
+<error line="38" column="8" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(props: BlockErrorBoundaryProps | Readonly&lt;BlockErrorBoundaryProps&gt;): BlockErrorBoundary&apos;, gave the following error.
+    Type &apos;(() =&gt; null) | null&apos; is not assignable to type &apos;(props: RenderErrorProps) =&gt; ReactNode&apos;.
+      Type &apos;null&apos; is not assignable to type &apos;(props: RenderErrorProps) =&gt; ReactNode&apos;.
+  Overload 2 of 2, &apos;(props: BlockErrorBoundaryProps, context: any): BlockErrorBoundary&apos;, gave the following error.
+    Type &apos;(() =&gt; null) | null&apos; is not assignable to type &apos;(props: RenderErrorProps) =&gt; ReactNode&apos;.
+      Type &apos;null&apos; is not assignable to type &apos;(props: RenderErrorProps) =&gt; ReactNode&apos;." source="TS2769" />
+</file>
+<file name="assets/js/base/context/providers/cart-checkout/cart/index.js">
+<error line="20" column="4" severity="error" message="Type &apos;Object | undefined&apos; is not assignable to type &apos;Object&apos;.
+  Type &apos;undefined&apos; is not assignable to type &apos;Object&apos;." source="TS2322" />
+</file>
+<file name="assets/js/base/context/providers/store-notices/components/store-notices-container.js">
+<error line="6" column="24" severity="error" message="Could not find a declaration file for module &apos;wordpress-components&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/wordpress-components/build/index.js&apos; implicitly has an &apos;any&apos; type.
+  If the &apos;@wordpress/components&apos; package actually exposes this module, consider sending a pull request to amend &apos;https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/wordpress__components&apos;" source="TS7016" />
+<error line="30" column="2" severity="error" message="Binding element &apos;className&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="32" column="2" severity="error" message="Binding element &apos;additionalNotices&apos; implicitly has an &apos;any[]&apos; type." source="TS7031" />
+<error line="46" column="33" severity="error" message="Property &apos;type&apos; does not exist on type &apos;Notice&apos;." source="TS2339" />
+</file>
+<file name="assets/js/base/context/providers/store-snackbar-notices/components/snackbar-notices-container.js">
+<error line="5" column="30" severity="error" message="Could not find a declaration file for module &apos;wordpress-components&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/wordpress-components/build/index.js&apos; implicitly has an &apos;any&apos; type.
+  If the &apos;@wordpress/components&apos; package actually exposes this module, consider sending a pull request to amend &apos;https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/wordpress__components&apos;" source="TS7016" />
+<error line="18" column="2" severity="error" message="Binding element &apos;className&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="36" column="24" severity="error" message="Property &apos;type&apos; does not exist on type &apos;Notice&apos;." source="TS2339" />
+<error line="42" column="6" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;{}&apos;.
+  No index signature with a parameter of type &apos;string&apos; was found on type &apos;{}&apos;." source="TS7053" />
+<error line="53" column="17" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;{}&apos;.
+  No index signature with a parameter of type &apos;string&apos; was found on type &apos;{}&apos;." source="TS7053" />
+</file>
+<file name="assets/js/base/context/providers/container-width-context.js">
+<error line="10" column="56" severity="error" message="Namespace &apos;&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/types/type-defs/contexts&quot;&apos; has no exported member &apos;ContainerWidthContext&apos;." source="TS2694" />
+</file>
+<file name="assets/js/base/context/providers/index.js">
+<error line="6" column="1" severity="error" message="Module &apos;./cart-checkout&apos; has already exported a member named &apos;React&apos;. Consider explicitly re-exporting to resolve the ambiguity." source="TS2308" />
+</file>
+<file name="assets/js/base/context/hooks/use-checkout-extension-data.ts">
+<error line="12" column="15" severity="error" message="Module &apos;&quot;../../../data/checkout/types&quot;&apos; declares &apos;CheckoutState&apos; locally, but it is not exported." source="TS2459" />
+</file>
+<file name="assets/js/shared/hocs/with-product-data-context.js">
+<error line="16" column="10" severity="error" message="Property &apos;productId&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="16" column="21" severity="error" message="Property &apos;OriginalComponent&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="16" column="40" severity="error" message="Property &apos;postId&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="16" column="48" severity="error" message="Property &apos;product&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="18" column="20" severity="error" message="Property &apos;isDescendentOfQueryLoop&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="21" column="3" severity="error" message="Argument of type &apos;{ include: any; }&apos; is not assignable to parameter of type &apos;Query&apos;.
+  Object literal may only specify known properties, and &apos;include&apos; does not exist in type &apos;Query&apos;." source="TS2345" />
+<error line="54" column="11" severity="error" message="Parameter &apos;props&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+</file>
+<file name="assets/js/shared/hocs/with-filtered-attributes.js">
+<error line="12" column="27" severity="error" message="Parameter &apos;OriginalComponent&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="13" column="12" severity="error" message="Parameter &apos;ownProps&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+</file>
+<file name="assets/js/atomic/blocks/product-elements/price/block.js">
+<error line="52" column="18" severity="error" message="Type &apos;string | undefined&apos; is not assignable to type &apos;&quot;center&quot; | &quot;left&quot; | &quot;right&quot; | undefined&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the type of the target." source="TS2412" />
+<error line="57" column="49" severity="error" message="Argument of type &apos;{ currency_code: string; currency_symbol: string; currency_minor_unit: number; currency_decimal_separator: string; currency_thousand_separator: string; currency_prefix: string; currency_suffix: string; price: string; regular_price: string; sale_price: string; price_range: null; }&apos; is not assignable to parameter of type &apos;CurrencyResponse | Record&lt;string, never&gt; | CartShippingPackageShippingRate | undefined&apos;.
+  Type &apos;{ currency_code: string; currency_symbol: string; currency_minor_unit: number; currency_decimal_separator: string; currency_thousand_separator: string; currency_prefix: string; currency_suffix: string; price: string; regular_price: string; sale_price: string; price_range: null; }&apos; is not assignable to type &apos;Record&lt;string, never&gt;&apos;.
+    Property &apos;currency_code&apos; is incompatible with index signature.
+      Type &apos;string&apos; is not assignable to type &apos;never&apos;." source="TS2345" />
+<error line="66" column="4" severity="error" message="Type &apos;string | undefined&apos; is not assignable to type &apos;&quot;center&quot; | &quot;left&quot; | &quot;right&quot; | undefined&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the type of the target." source="TS2412" />
+<error line="74" column="36" severity="error" message="Property &apos;min_amount&apos; does not exist on type &apos;never&apos;." source="TS2339" />
+<error line="75" column="36" severity="error" message="Property &apos;max_amount&apos; does not exist on type &apos;never&apos;." source="TS2339" />
+</file>
+<file name="assets/js/atomic/blocks/product-elements/image/block.js">
+<error line="138" column="19" severity="error" message="Binding element &apos;image&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="138" column="26" severity="error" message="Binding element &apos;loaded&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="138" column="34" severity="error" message="Binding element &apos;showFullSize&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="138" column="48" severity="error" message="Binding element &apos;fallbackAlt&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+</file>
+<file name="assets/js/atomic/blocks/product-elements/rating/block.tsx">
+<error line="55" column="35" severity="error" message="Argument of type &apos;{ id: number; name: string; parent: number; type: string; variation: string; permalink: string; sku: string; short_description: string; description: string; on_sale: boolean; prices: { currency_code: string; ... 9 more ...; price_range: null; }; ... 14 more ...; add_to_cart: { ...; }; }&apos; is not assignable to parameter of type &apos;Omit&lt;ProductResponseItem, &quot;average_rating&quot;&gt; &amp; { average_rating: string; }&apos;.
+  Type &apos;{ id: number; name: string; parent: number; type: string; variation: string; permalink: string; sku: string; short_description: string; description: string; on_sale: boolean; prices: { currency_code: string; ... 9 more ...; price_range: null; }; ... 14 more ...; add_to_cart: { ...; }; }&apos; is not assignable to type &apos;Omit&lt;ProductResponseItem, &quot;average_rating&quot;&gt;&apos;.
+    Types of property &apos;prices&apos; are incompatible.
+      Property &apos;raw_prices&apos; is missing in type &apos;{ currency_code: string; currency_symbol: string; currency_minor_unit: number; currency_decimal_separator: string; currency_thousand_separator: string; currency_prefix: string; currency_suffix: string; price: string; regular_price: string; sale_price: string; price_range: null; }&apos; but required in type &apos;ProductResponseItemPrices&apos;." source="TS2345" />
+<error line="74" column="34" severity="error" message="Argument of type &apos;{ id: number; name: string; parent: number; type: string; variation: string; permalink: string; sku: string; short_description: string; description: string; on_sale: boolean; prices: { currency_code: string; ... 9 more ...; price_range: null; }; ... 14 more ...; add_to_cart: { ...; }; }&apos; is not assignable to parameter of type &apos;ProductResponseItem&apos;.
+  Types of property &apos;prices&apos; are incompatible.
+    Property &apos;raw_prices&apos; is missing in type &apos;{ currency_code: string; currency_symbol: string; currency_minor_unit: number; currency_decimal_separator: string; currency_thousand_separator: string; currency_prefix: string; currency_suffix: string; price: string; regular_price: string; sale_price: string; price_range: null; }&apos; but required in type &apos;ProductResponseItemPrices&apos;." source="TS2345" />
+</file>
+<file name="assets/js/atomic/blocks/product-elements/button/block.js">
+<error line="100" column="3" severity="error" message="Property &apos;id&apos; does not exist on type &apos;Object | undefined&apos;." source="TS2339" />
+<error line="101" column="3" severity="error" message="Property &apos;permalink&apos; does not exist on type &apos;Object | undefined&apos;." source="TS2339" />
+<error line="102" column="3" severity="error" message="Property &apos;add_to_cart&apos; does not exist on type &apos;Object | undefined&apos;." source="TS2339" />
+<error line="103" column="3" severity="error" message="Property &apos;has_options&apos; does not exist on type &apos;Object | undefined&apos;." source="TS2339" />
+<error line="104" column="3" severity="error" message="Property &apos;is_purchasable&apos; does not exist on type &apos;Object | undefined&apos;." source="TS2339" />
+<error line="105" column="3" severity="error" message="Property &apos;is_in_stock&apos; does not exist on type &apos;Object | undefined&apos;." source="TS2339" />
+<error line="110" column="3" severity="error" message="Expected 1 arguments, but got 2." source="TS2554" />
+<error line="168" column="5" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="168" column="17" severity="error" message="Property &apos;className&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="169" column="5" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="169" column="18" severity="error" message="Property &apos;className&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="176" column="8" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="176" column="20" severity="error" message="Property &apos;style&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="177" column="8" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="177" column="21" severity="error" message="Property &apos;style&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="178" column="8" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="178" column="25" severity="error" message="Property &apos;style&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="179" column="8" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="179" column="22" severity="error" message="Property &apos;style&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="214" column="5" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="214" column="17" severity="error" message="Property &apos;className&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="215" column="5" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="215" column="18" severity="error" message="Property &apos;className&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="218" column="8" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="218" column="20" severity="error" message="Property &apos;style&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="219" column="8" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="219" column="21" severity="error" message="Property &apos;style&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="220" column="8" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="220" column="25" severity="error" message="Property &apos;style&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="221" column="8" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="221" column="22" severity="error" message="Property &apos;style&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+</file>
+<file name="assets/js/base/components/summary/utils.js">
+<error line="4" column="23" severity="error" message="Could not find a declaration file for module &apos;@wordpress/wordcount&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@wordpress/wordcount/build/index.js&apos; implicitly has an &apos;any&apos; type.
+  Try `npm i --save-dev @types/wordpress__wordcount` if it exists or add a new declaration (.d.ts) file containing `declare module &apos;@wordpress/wordcount&apos;;`" source="TS7016" />
+</file>
+<file name="assets/js/atomic/blocks/product-elements/add-to-cart/shared/add-to-cart-button.js">
+<error line="120" column="4" severity="error" message="Type &apos;{ children: string; className: string; href: string; onClick: () =&gt; any; rel: string; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; ButtonProps&apos;.
+  Property &apos;href&apos; does not exist on type &apos;IntrinsicAttributes &amp; ButtonProps&apos;." source="TS2322" />
+</file>
+<file name="assets/js/atomic/blocks/product-elements/add-to-cart/shared/quantity-input.js">
+<error line="52" column="14" severity="error" message="Expected 0 arguments, but got 1." source="TS2554" />
+<error line="67" column="15" severity="error" message="Expected 0 arguments, but got 1." source="TS2554" />
+</file>
+<file name="assets/js/atomic/blocks/product-elements/add-to-cart/product-types/variable/variation-attributes/attribute-select-control.js">
+<error line="6" column="31" severity="error" message="Could not find a declaration file for module &apos;wordpress-components&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/wordpress-components/build/index.js&apos; implicitly has an &apos;any&apos; type.
+  If the &apos;@wordpress/components&apos; package actually exposes this module, consider sending a pull request to amend &apos;https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/wordpress__components&apos;" source="TS7016" />
+</file>
+<file name="assets/js/atomic/blocks/product-elements/add-to-cart/product-types/variable/variation-attributes/utils.js">
+<error line="39" column="13" severity="error" message="Property &apos;forEach&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="39" column="26" severity="error" message="Binding element &apos;id&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="39" column="30" severity="error" message="Binding element &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="40" column="3" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;`id:${any}`&apos; can&apos;t be used to index type &apos;{}&apos;." source="TS7053" />
+<error line="42" column="37" severity="error" message="Parameter &apos;acc&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="42" column="44" severity="error" message="Binding element &apos;name&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="42" column="50" severity="error" message="Binding element &apos;value&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="61" column="13" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
+<error line="85" column="30" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;Object&apos;.
+  No index signature with a parameter of type &apos;string&apos; was found on type &apos;Object&apos;." source="TS7053" />
+<error line="87" column="5" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;Object&apos;.
+  No index signature with a parameter of type &apos;string&apos; was found on type &apos;Object&apos;." source="TS7053" />
+<error line="131" column="13" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
+<error line="132" column="13" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
+<error line="175" column="28" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;Object&apos;.
+  No index signature with a parameter of type &apos;string&apos; was found on type &apos;Object&apos;." source="TS7053" />
+<error line="196" column="8" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;Object&apos;.
+  No index signature with a parameter of type &apos;string&apos; was found on type &apos;Object&apos;." source="TS7053" />
+<error line="202" column="3" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;{}&apos;.
+  No index signature with a parameter of type &apos;string&apos; was found on type &apos;{}&apos;." source="TS7053" />
+<error line="231" column="24" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
+<error line="232" column="6" severity="error" message="Parameter &apos;term&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="235" column="4" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;any&apos; can&apos;t be used to index type &apos;{}&apos;." source="TS7053" />
+<error line="235" column="19" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
+</file>
+<file name="assets/js/atomic/blocks/product-elements/add-to-cart/product-types/variable/variation-attributes/attribute-picker.js">
+<error line="89" column="14" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;{}&apos;.
+  No index signature with a parameter of type &apos;string&apos; was found on type &apos;{}&apos;." source="TS7053" />
+<error line="102" column="16" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;Object&apos;.
+  No index signature with a parameter of type &apos;string&apos; was found on type &apos;Object&apos;." source="TS7053" />
+<error line="103" column="14" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;{}&apos;.
+  No index signature with a parameter of type &apos;string&apos; was found on type &apos;{}&apos;." source="TS7053" />
+<error line="104" column="19" severity="error" message="Parameter &apos;selected&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+</file>
+<file name="assets/js/atomic/blocks/product-elements/add-to-cart/product-types/variable/variation-attributes/index.js">
+<error line="16" column="44" severity="error" message="Property &apos;attributes&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="17" column="62" severity="error" message="Property &apos;variations&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="20" column="23" severity="error" message="Property &apos;length&apos; does not exist on type &apos;{}&apos;." source="TS2339" />
+<error line="29" column="35" severity="error" message="Property &apos;setRequestParams&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+</file>
+<file name="assets/js/atomic/blocks/product-elements/add-to-cart/product-types/grouped/group-list/index.js">
+<error line="4" column="29" severity="error" message="Could not find a declaration file for module &apos;wordpress-components&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/wordpress-components/build/index.js&apos; implicitly has an &apos;any&apos; type.
+  If the &apos;@wordpress/components&apos; package actually exposes this module, consider sending a pull request to amend &apos;https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/wordpress__components&apos;" source="TS7016" />
+</file>
+<file name="assets/js/atomic/blocks/product-elements/save.js">
+<error line="6" column="18" severity="error" message="Binding element &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+</file>
+<file name="assets/js/atomic/blocks/product-elements/shared/config.tsx">
+<error line="31" column="2" severity="error" message="Type &apos;{ category: string; keywords: string[]; icon: { src: Element; }; supports: { html: false; }; ancestor: string[]; save: ({ attributes }: { attributes: any; }) =&gt; Element | null; deprecated: { attributes: {}; save(): null; }[]; }&apos; is not assignable to type &apos;Omit&lt;BlockConfiguration&lt;{}&gt;, &quot;title&quot; | &quot;attributes&quot;&gt;&apos;.
+  Object literal may only specify known properties, and &apos;ancestor&apos; does not exist in type &apos;Omit&lt;BlockConfiguration&lt;{}&gt;, &quot;title&quot; | &quot;attributes&quot;&gt;&apos;." source="TS2322" />
+</file>
+<file name="assets/js/editor-components/heading-toolbar/heading-level-icon.js">
+<error line="6" column="45" severity="error" message="Binding element &apos;level&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="26" column="14" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;any&apos; can&apos;t be used to index type &apos;{ 1: string; 2: string; 3: string; 4: string; 5: string; 6: string; }&apos;." source="TS7053" />
+</file>
+<file name="assets/js/editor-components/heading-toolbar/index.js">
+<error line="20" column="22" severity="error" message="Parameter &apos;targetLevel&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="20" column="35" severity="error" message="Parameter &apos;selectedLevel&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="20" column="50" severity="error" message="Parameter &apos;onChange&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+</file>
+<file name="assets/js/editor-components/search-list-control/search-list-control.tsx">
+<error line="213" column="41" severity="error" message="Argument of type &apos;boolean | undefined&apos; is not assignable to parameter of type &apos;boolean&apos;.
+  Type &apos;undefined&apos; is not assignable to type &apos;boolean&apos;." source="TS2345" />
+</file>
+<file name="assets/js/editor-components/utils/index.js">
+<error line="119" column="12" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
+<error line="149" column="12" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
+<error line="209" column="12" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
+</file>
+<file name="assets/js/hocs/with-attributes.js">
+<error line="16" column="12" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
+<error line="31" column="11" severity="error" message="Parameter &apos;props&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="45" column="44" severity="error" message="Parameter &apos;attribute&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="67" column="17" severity="error" message="Argument of type &apos;{ message: string; type: string; }&apos; is not assignable to parameter of type &apos;SetStateAction&lt;null&gt;&apos;.
+  Type &apos;{ message: string; type: string; }&apos; provides no match for the signature &apos;(prevState: null): null&apos;." source="TS2345" />
+<error line="89" column="33" severity="error" message="Parameter &apos;term&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="101" column="16" severity="error" message="Argument of type &apos;{ message: string; type: string; }&apos; is not assignable to parameter of type &apos;SetStateAction&lt;null&gt;&apos;." source="TS2345" />
+</file>
+<file name="assets/js/hocs/with-categories.js">
+<error line="21" column="11" severity="error" message="A spread argument must either have a tuple type or be passed to a rest parameter." source="TS2556" />
+<error line="37" column="4" severity="error" message="Expected 1 arguments, but got 0." source="TS2554" />
+<error line="60" column="6" severity="error" message="Type &apos;{ error: null; isLoading: boolean; categories: never[]; children?: ReactNode; }&apos; is not assignable to type &apos;InnerProps&apos;.
+  &apos;{ error: null; isLoading: boolean; categories: never[]; children?: ReactNode; }&apos; is assignable to the constraint of type &apos;InnerProps&apos;, but &apos;InnerProps&apos; could be instantiated with a different subtype of constraint &apos;{}&apos;." source="TS2322" />
+</file>
+<file name="assets/js/hocs/with-category.js">
+<error line="21" column="11" severity="error" message="A spread argument must either have a tuple type or be passed to a rest parameter." source="TS2556" />
+<error line="37" column="23" severity="error" message="Parameter &apos;prevProps&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="79" column="6" severity="error" message="Type &apos;{ error: null; getCategory: () =&gt; void; isLoading: boolean; category: any; children?: ReactNode; }&apos; is not assignable to type &apos;InnerProps&apos;.
+  &apos;{ error: null; getCategory: () =&gt; void; isLoading: boolean; category: any; children?: ReactNode; }&apos; is assignable to the constraint of type &apos;InnerProps&apos;, but &apos;InnerProps&apos; could be instantiated with a different subtype of constraint &apos;{}&apos;." source="TS2322" />
+</file>
+<file name="assets/js/hocs/with-product.js">
+<error line="33" column="23" severity="error" message="Parameter &apos;prevProps&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="71" column="6" severity="error" message="Type &apos;{ error: null; getProduct: () =&gt; void; isLoading: boolean; product: any; children?: ReactNode; }&apos; is not assignable to type &apos;InnerProps&apos;.
+  &apos;{ error: null; getProduct: () =&gt; void; isLoading: boolean; product: any; children?: ReactNode; }&apos; is assignable to the constraint of type &apos;InnerProps&apos;, but &apos;InnerProps&apos; could be instantiated with a different subtype of constraint &apos;{}&apos;." source="TS2322" />
+</file>
+<file name="assets/js/hocs/with-product-variations.js">
+<error line="21" column="2" severity="error" message="Argument of type &apos;&lt;InnerProps extends {}&gt;(OriginalComponent: ComponentType&lt;InnerProps&gt;) =&gt; typeof WrappedComponent&apos; is not assignable to parameter of type &apos;HigherOrderComponent&lt;{}&gt;&apos;.
+  Type &apos;typeof WrappedComponent&apos; is not assignable to type &apos;ComponentType&lt;InnerProps&gt;&apos;.
+    Type &apos;typeof WrappedComponent&apos; is not assignable to type &apos;ComponentClass&lt;InnerProps, any&gt;&apos;.
+      Types of property &apos;propTypes&apos; are incompatible.
+        Type &apos;{ selected: PropTypes.Requireable&lt;any[]&gt;; showVariations: PropTypes.Requireable&lt;boolean&gt;; }&apos; is not assignable to type &apos;WeakValidationMap&lt;InnerProps&gt;&apos;." source="TS2345" />
+<error line="37" column="24" severity="error" message="Parameter &apos;prevProps&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="59" column="31" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;any&apos; can&apos;t be used to index type &apos;{}&apos;." source="TS7053" />
+<error line="64" column="8" severity="error" message="Parameter &apos;findProduct&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="87" column="10" severity="error" message="Parameter &apos;variation&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="115" column="17" severity="error" message="Parameter &apos;itemId&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="117" column="29" severity="error" message="Parameter &apos;p&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="120" column="23" severity="error" message="Parameter &apos;variationId&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="123" column="8" severity="error" message="Parameter &apos;p&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="125" column="30" severity="error" message="Binding element &apos;id&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="168" column="7" severity="error" message="Type &apos;{ error: any; expandedProduct: any; isLoading: any; variations: {}; variationsLoading: boolean; children?: ReactNode; }&apos; is not assignable to type &apos;InnerProps&apos;.
+  &apos;{ error: any; expandedProduct: any; isLoading: any; variations: {}; variationsLoading: boolean; children?: ReactNode; }&apos; is assignable to the constraint of type &apos;InnerProps&apos;, but &apos;InnerProps&apos; could be instantiated with a different subtype of constraint &apos;{}&apos;." source="TS2322" />
+</file>
+<file name="assets/js/hocs/with-transform-single-select-to-multiple-select.js">
+<error line="14" column="2" severity="error" message="Argument of type &apos;&lt;InnerProps extends {}&gt;(OriginalComponent: ComponentType&lt;InnerProps&gt;) =&gt; typeof WrappedComponent&apos; is not assignable to parameter of type &apos;HigherOrderComponent&lt;{}&gt;&apos;.
+  Type &apos;typeof WrappedComponent&apos; is not assignable to type &apos;ComponentType&lt;InnerProps&gt;&apos;.
+    Type &apos;typeof WrappedComponent&apos; is not assignable to type &apos;ComponentClass&lt;InnerProps, any&gt;&apos;.
+      Types of property &apos;propTypes&apos; are incompatible.
+        Type &apos;{ selected: PropTypes.Requireable&lt;string | number&gt;; }&apos; is not assignable to type &apos;WeakValidationMap&lt;InnerProps&gt;&apos;." source="TS2345" />
+<error line="21" column="7" severity="error" message="Type &apos;{ children?: ReactNode; }&apos; is not assignable to type &apos;InnerProps&apos;.
+  &apos;{ children?: ReactNode; }&apos; is assignable to the constraint of type &apos;InnerProps&apos;, but &apos;InnerProps&apos; could be instantiated with a different subtype of constraint &apos;{}&apos;." source="TS2322" />
+<error line="23" column="7" severity="error" message="Type &apos;{ selected: any[]; children?: ReactNode; }&apos; is not assignable to type &apos;InnerProps&apos;.
+  &apos;{ selected: any[]; children?: ReactNode; }&apos; is assignable to the constraint of type &apos;InnerProps&apos;, but &apos;InnerProps&apos; could be instantiated with a different subtype of constraint &apos;{}&apos;." source="TS2322" />
+</file>
+<file name="assets/js/editor-components/product-control/index.js">
+<error line="19" column="38" severity="error" message="An import path cannot end with a &apos;.tsx&apos; extension. Consider importing &apos;@woocommerce/editor-components/expandable-search-list-item/expandable-search-list-item.js&apos; instead." source="TS2691" />
+<error line="43" column="2" severity="error" message="Binding element &apos;expandedProduct&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="44" column="2" severity="error" message="Binding element &apos;error&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="45" column="2" severity="error" message="Binding element &apos;instanceId&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="46" column="2" severity="error" message="Binding element &apos;isCompact&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="47" column="2" severity="error" message="Binding element &apos;isLoading&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="48" column="2" severity="error" message="Binding element &apos;onChange&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="49" column="2" severity="error" message="Binding element &apos;onSearch&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="50" column="2" severity="error" message="Binding element &apos;products&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="51" column="2" severity="error" message="Binding element &apos;renderItem&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="52" column="2" severity="error" message="Binding element &apos;selected&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="53" column="2" severity="error" message="Binding element &apos;showVariations&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="54" column="2" severity="error" message="Binding element &apos;variations&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="55" column="2" severity="error" message="Binding element &apos;variationsLoading&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="57" column="37" severity="error" message="Parameter &apos;args&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="218" column="3" severity="error" message="Argument of type &apos;ComponentType&lt;Omit&lt;{ expandedProduct: any; error: any; instanceId: any; isCompact: any; isLoading: any; onChange: any; onSearch: any; products: any; renderItem: any; selected: any; showVariations: any; variations: any; variationsLoading: any; }, &quot;instanceId&quot;&gt;&gt;&apos; is not assignable to parameter of type &apos;FunctionComponent&lt;Record&lt;string, unknown&gt;&gt;&apos;.
+  Type &apos;ComponentClass&lt;Omit&lt;{ expandedProduct: any; error: any; instanceId: any; isCompact: any; isLoading: any; onChange: any; onSearch: any; products: any; renderItem: any; selected: any; showVariations: any; variations: any; variationsLoading: any; }, &quot;instanceId&quot;&gt;, any&gt;&apos; is not assignable to type &apos;FunctionComponent&lt;Record&lt;string, unknown&gt;&gt;&apos;.
+    Type &apos;ComponentClass&lt;Omit&lt;{ expandedProduct: any; error: any; instanceId: any; isCompact: any; isLoading: any; onChange: any; onSearch: any; products: any; renderItem: any; selected: any; showVariations: any; variations: any; variationsLoading: any; }, &quot;instanceId&quot;&gt;, any&gt;&apos; provides no match for the signature &apos;(props: PropsWithChildren&lt;Record&lt;string, unknown&gt;&gt;, context?: any): ReactElement&lt;any, any&gt; | null&apos;." source="TS2345" />
+</file>
+<file name="assets/js/atomic/blocks/product-elements/shared/with-product-selector.js">
+<error line="23" column="51" severity="error" message="Parameter &apos;OriginalComponent&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="24" column="11" severity="error" message="Parameter &apos;props&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="41" column="27" severity="error" message="Property &apos;icon&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="42" column="28" severity="error" message="Property &apos;label&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="45" column="25" severity="error" message="Property &apos;description&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="46" column="28" severity="error" message="Property &apos;description&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="51" column="9" severity="error" message="Type &apos;{ selected: any; showVariations: true; onChange: (value?: any[]) =&gt; void; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; { selected: number[]; } &amp; { children?: ReactNode; }&apos;.
+  Property &apos;showVariations&apos; does not exist on type &apos;IntrinsicAttributes &amp; { selected: number[]; } &amp; { children?: ReactNode; }&apos;." source="TS2322" />
+<error line="52" column="22" severity="error" message="Parameter &apos;value&apos; implicitly has an &apos;any[]&apos; type." source="TS7006" />
+</file>
+<file name="assets/js/atomic/blocks/product-elements/title/index.ts">
+<error line="46" column="5" severity="error" message="Type &apos;{ __experimentalSelector?: string; spacing?: Partial&lt;SpacingProps&gt; | { margin: true; __experimentalSkipSerialization: true; } | undefined; typography?: Partial&lt;TypographyProps&gt; | { ...; } | undefined; ... 10 more ...; lock?: boolean | undefined; }&apos; is not assignable to type &apos;BlockSupports&apos;.
+  Types of property &apos;color&apos; are incompatible.
+    Type &apos;Partial&lt;ColorProps&gt; | { text: true; background: true; link: false; gradients: true; __experimentalSkipSerialization: true; } | undefined&apos; is not assignable to type &apos;Partial&lt;ColorProps&gt; | undefined&apos;.
+      Type &apos;{ text: true; background: true; link: false; gradients: true; __experimentalSkipSerialization: true; }&apos; is not assignable to type &apos;Partial&lt;ColorProps&gt;&apos;.
+        Object literal may only specify known properties, and &apos;__experimentalSkipSerialization&apos; does not exist in type &apos;Partial&lt;ColorProps&gt;&apos;." source="TS2322" />
+</file>
+<file name="assets/js/atomic/blocks/product-elements/price/edit.js">
+<error line="20" column="23" severity="error" message="Binding element &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="20" column="35" severity="error" message="Binding element &apos;setAttributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="20" column="50" severity="error" message="Binding element &apos;context&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+</file>
+<file name="assets/js/atomic/blocks/product-elements/price/attributes.js">
+<error line="20" column="3" severity="error" message="Type &apos;{ textAlign: { type: string; }; productId: { type: string; default: number; }; isDescendentOfQueryLoop: { type: string; default: boolean; }; }&apos; is not assignable to type &apos;{ productId: { type: string; default: number; }; isDescendentOfQueryLoop: { type: string; default: boolean; }; }&apos;.
+  Object literal may only specify known properties, and &apos;textAlign&apos; does not exist in type &apos;{ productId: { type: string; default: number; }; isDescendentOfQueryLoop: { type: string; default: boolean; }; }&apos;." source="TS2322" />
+</file>
+<file name="assets/js/atomic/blocks/product-elements/image/edit.js">
+<error line="14" column="2" severity="error" message="Module &apos;&quot;@wordpress/components&quot;&apos; has no exported member &apos;__experimentalToggleGroupControl&apos;." source="TS2305" />
+<error line="16" column="2" severity="error" message="Module &apos;&quot;@wordpress/components&quot;&apos; has no exported member &apos;__experimentalToggleGroupControlOption&apos;." source="TS2305" />
+<error line="24" column="18" severity="error" message="Binding element &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="24" column="30" severity="error" message="Binding element &apos;setAttributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="24" column="45" severity="error" message="Binding element &apos;context&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="94" column="21" severity="error" message="Parameter &apos;value&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="146" column="21" severity="error" message="Parameter &apos;value&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+</file>
+<file name="assets/js/atomic/blocks/product-elements/image/index.js">
+<error line="46" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{}&gt;, settings?: Partial&lt;BlockConfiguration&lt;{}&gt;&gt; | undefined): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{}&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{}&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{}&gt;): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ apiVersion: number; name: string; title: string; icon: { src: JSX.Element; }; keywords: string[]; description: string; usesContext: string[]; ancestor: string[]; textdomain: string; attributes: { ...; }; ... 16 more ...; merge?: ((attributes: {}, attributesToMerge: {}) =&gt; Partial&lt;...&gt;) | undefined; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{}&gt;&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+      Type &apos;{ apiVersion: number; name: string; title: string; icon: { src: JSX.Element; }; keywords: string[]; description: string; usesContext: string[]; ancestor: string[]; textdomain: string; attributes: { ...; }; ... 16 more ...; merge?: ((attributes: {}, attributesToMerge: {}) =&gt; Partial&lt;...&gt;) | undefined; }&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;{}&gt;, &quot;icon&quot;&gt;&gt;&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+        Types of property &apos;edit&apos; are incompatible.
+          Type &apos;({ attributes, setAttributes, context }: { attributes: any; setAttributes: any; context: any; }) =&gt; Element&apos; is not assignable to type &apos;ComponentType&lt;BlockEditProps&lt;{}&gt;&gt; | undefined&apos;.
+            Type &apos;({ attributes, setAttributes, context }: { attributes: any; setAttributes: any; context: any; }) =&gt; Element&apos; is not assignable to type &apos;FunctionComponent&lt;BlockEditProps&lt;{}&gt;&gt;&apos;.
+              Types of parameters &apos;__0&apos; and &apos;props&apos; are incompatible.
+                Property &apos;context&apos; is missing in type &apos;BlockEditProps&lt;{}&gt; &amp; { children?: ReactNode; }&apos; but required in type &apos;{ attributes: any; setAttributes: any; context: any; }&apos;." source="TS2769" />
+</file>
+<file name="assets/js/atomic/blocks/product-elements/rating/index.ts">
+<error line="25" column="2" severity="error" message="Type &apos;{ apiVersion: number; title: string; description: string; usesContext: string[]; ancestor: string[]; icon: { src: JSX.Element; }; attributes: { productId: { type: string; default: number; }; isDescendentOfQueryLoop: { ...; }; }; supports: { ...; }; edit: (props: any) =&gt; JSX.Element; }&apos; is not assignable to type &apos;BlockConfiguration&lt;{}&gt;&apos;.
+  Object literal may only specify known properties, and &apos;ancestor&apos; does not exist in type &apos;BlockConfiguration&lt;{}&gt;&apos;." source="TS2322" />
+</file>
+<file name="assets/js/atomic/blocks/product-elements/button/edit.js">
+<error line="13" column="18" severity="error" message="Binding element &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="13" column="30" severity="error" message="Binding element &apos;setAttributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="13" column="45" severity="error" message="Binding element &apos;context&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+</file>
+<file name="assets/js/atomic/blocks/product-elements/button/index.js">
+<error line="35" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{}&gt;, settings?: Partial&lt;BlockConfiguration&lt;{}&gt;&gt; | undefined): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{}&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{}&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{}&gt;): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ apiVersion: number; title: string; description: string; ancestor: string[]; usesContext: string[]; icon: { src: JSX.Element; }; attributes: { productId: { type: string; default: number; }; isDescendentOfQueryLoop: { ...; }; }; ... 19 more ...; merge?: ((attributes: {}, attributesToMerge: {}) =&gt; Partial&lt;...&gt;) | und...&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{}&gt;&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+      Type &apos;{ apiVersion: number; title: string; description: string; ancestor: string[]; usesContext: string[]; icon: { src: JSX.Element; }; attributes: { productId: { type: string; default: number; }; isDescendentOfQueryLoop: { ...; }; }; ... 19 more ...; merge?: ((attributes: {}, attributesToMerge: {}) =&gt; Partial&lt;...&gt;) | und...&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;{}&gt;, &quot;icon&quot;&gt;&gt;&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+        Types of property &apos;edit&apos; are incompatible.
+          Type &apos;({ attributes, setAttributes, context }: { attributes: any; setAttributes: any; context: any; }) =&gt; Element&apos; is not assignable to type &apos;ComponentType&lt;BlockEditProps&lt;{}&gt;&gt; | undefined&apos;.
+            Type &apos;({ attributes, setAttributes, context }: { attributes: any; setAttributes: any; context: any; }) =&gt; Element&apos; is not assignable to type &apos;FunctionComponent&lt;BlockEditProps&lt;{}&gt;&gt;&apos;.
+              Types of parameters &apos;__0&apos; and &apos;props&apos; are incompatible.
+                Property &apos;context&apos; is missing in type &apos;BlockEditProps&lt;{}&gt; &amp; { children?: ReactNode; }&apos; but required in type &apos;{ attributes: any; setAttributes: any; context: any; }&apos;." source="TS2769" />
+</file>
+<file name="assets/js/atomic/blocks/product-elements/sale-badge/index.ts">
+<error line="30" column="2" severity="error" message="Type &apos;{ title: string; description: string; icon: { src: JSX.Element; }; apiVersion: number; supports: { __experimentalSelector?: string; spacing?: { padding: boolean; __experimentalSkipSerialization: boolean; }; color?: { ...; }; typography?: { ...; }; __experimentalBorder?: { ...; }; html: boolean; }; ... 21 more ...; m...&apos; is not assignable to type &apos;BlockConfiguration&lt;{}&gt;&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+  Object literal may only specify known properties, and &apos;ancestor&apos; does not exist in type &apos;BlockConfiguration&lt;{}&gt;&apos;." source="TS2375" />
+</file>
+<file name="assets/js/editor-components/edit-product-link/index.js">
+<error line="18" column="40" severity="error" message="Property &apos;productId&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+</file>
+<file name="assets/js/atomic/blocks/product-elements/sku/index.ts">
+<error line="25" column="2" severity="error" message="Type &apos;{ apiVersion: number; title: string; description: string; icon: { src: JSX.Element; }; usesContext: string[]; ancestor: string[]; attributes: Record&lt;string, Record&lt;string, unknown&gt;&gt;; edit: (props: any) =&gt; JSX.Element; }&apos; is not assignable to type &apos;BlockConfiguration&lt;{}&gt;&apos;.
+  Object literal may only specify known properties, and &apos;ancestor&apos; does not exist in type &apos;BlockConfiguration&lt;{}&gt;&apos;." source="TS2322" />
+</file>
+<file name="assets/js/atomic/blocks/product-elements/category-list/index.ts">
+<error line="36" column="5" severity="error" message="Type &apos;{ color?: { text: true; link: true; background: false; __experimentalSkipSerialization: true; }; typography?: { fontSize: true; lineHeight: true; __experimentalFontStyle: true; __experimentalFontWeight: true; __experimentalSkipSerialization: true; }; __experimentalSelector?: string; }&apos; is not assignable to type &apos;BlockSupports&apos;.
+  Types of property &apos;color&apos; are incompatible.
+    Type &apos;{ text: true; link: true; background: false; __experimentalSkipSerialization: true; }&apos; is not assignable to type &apos;Partial&lt;ColorProps&gt;&apos;.
+      Object literal may only specify known properties, and &apos;__experimentalSkipSerialization&apos; does not exist in type &apos;Partial&lt;ColorProps&gt;&apos;." source="TS2322" />
+<error line="49" column="2" severity="error" message="Type &apos;({ attributes }: Props) =&gt; JSX.Element&apos; is not assignable to type &apos;ComponentType&lt;BlockSaveProps&lt;{}&gt;&gt;&apos;.
+  Type &apos;({ attributes }: Props) =&gt; JSX.Element&apos; is not assignable to type &apos;FunctionComponent&lt;BlockSaveProps&lt;{}&gt;&gt;&apos;.
+    Types of parameters &apos;__0&apos; and &apos;props&apos; are incompatible.
+      Type &apos;PropsWithChildren&lt;BlockSaveProps&lt;{}&gt;&gt;&apos; is not assignable to type &apos;Props&apos;.
+        Types of property &apos;attributes&apos; are incompatible.
+          Type &apos;Readonly&lt;{}&gt;&apos; is not assignable to type &apos;Record&lt;string, unknown&gt; &amp; { className: string; }&apos;.
+            Property &apos;className&apos; is missing in type &apos;Readonly&lt;{}&gt;&apos; but required in type &apos;{ className: string; }&apos;." source="TS2322" />
+</file>
+<file name="assets/js/atomic/blocks/product-elements/add-to-cart/edit.js">
+<error line="25" column="18" severity="error" message="Binding element &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="25" column="30" severity="error" message="Binding element &apos;setAttributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="36" column="21" severity="error" message="Type &apos;{ productId: number; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; Object&apos;.
+  Property &apos;productId&apos; does not exist on type &apos;IntrinsicAttributes &amp; Object&apos;." source="TS2322" />
+</file>
+<file name="assets/js/atomic/blocks/product-elements/add-to-cart/product-types/variable/variation-attributes/test/index.js">
+<error line="195" column="38" severity="error" message="Argument of type &apos;null&apos; is not assignable to parameter of type &apos;Object&apos;." source="TS2345" />
+<error line="252" column="56" severity="error" message="Argument of type &apos;null&apos; is not assignable to parameter of type &apos;Object&apos;." source="TS2345" />
+<error line="475" column="34" severity="error" message="Argument of type &apos;null&apos; is not assignable to parameter of type &apos;Object | undefined&apos;." source="TS2345" />
+</file>
+<file name="assets/js/atomic/blocks/product-elements/title/test/block.test.js">
+<error line="22" column="6" severity="error" message="Property &apos;isLoading&apos; is missing in type &apos;{ children: Element; product: { id: number; name: string; permalink: string; }; }&apos; but required in type &apos;{ product: any; children: Object; isLoading: boolean; }&apos;." source="TS2741" />
+<error line="23" column="7" severity="error" message="Type &apos;{ showProductLink: false; }&apos; is missing the following properties from type &apos;Attributes&apos;: headingLevel, align" source="TS2739" />
+<error line="37" column="6" severity="error" message="Property &apos;isLoading&apos; is missing in type &apos;{ children: Element; product: { id: number; name: string; permalink: string; }; }&apos; but required in type &apos;{ product: any; children: Object; isLoading: boolean; }&apos;." source="TS2741" />
+<error line="38" column="7" severity="error" message="Type &apos;{ showProductLink: true; }&apos; is missing the following properties from type &apos;Attributes&apos;: headingLevel, align" source="TS2739" />
+<error line="45" column="12" severity="error" message="Object is possibly &apos;null&apos;." source="TS2531" />
+<error line="46" column="12" severity="error" message="Object is possibly &apos;null&apos;." source="TS2531" />
+<error line="51" column="6" severity="error" message="Property &apos;isLoading&apos; is missing in type &apos;{ children: Element; product: { id: number; name: string; permalink: string; }; }&apos; but required in type &apos;{ product: any; children: Object; isLoading: boolean; }&apos;." source="TS2741" />
+<error line="52" column="7" severity="error" message="Type &apos;{ showProductLink: true; linkTarget: string; }&apos; is missing the following properties from type &apos;Attributes&apos;: headingLevel, align" source="TS2739" />
+<error line="59" column="12" severity="error" message="Object is possibly &apos;null&apos;." source="TS2531" />
+<error line="60" column="12" severity="error" message="Object is possibly &apos;null&apos;." source="TS2531" />
+</file>
+<file name="assets/js/atomic/utils/create-blocks-from-template.js">
+<error line="9" column="12" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
+<error line="11" column="14" severity="error" message="&apos;createBlocksFromTemplate&apos; implicitly has return type &apos;any&apos; because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions." source="TS7023" />
+<error line="13" column="9" severity="error" message="&apos;children&apos; implicitly has type &apos;any&apos; because it does not have a type annotation and is referenced directly or indirectly in its own initializer." source="TS7022" />
+</file>
+<file name="assets/js/atomic/utils/render-parent-block.tsx">
+<error line="144" column="2" severity="error" message="Type &apos;(string | Element | null)[]&apos; is not assignable to type &apos;(Element | null)[]&apos;.
+  Type &apos;string | Element | null&apos; is not assignable to type &apos;Element | null&apos;.
+    Type &apos;string&apos; is not assignable to type &apos;Element&apos;." source="TS2322" />
+</file>
+<file name="assets/js/atomic/utils/render-standalone-blocks.js">
+<error line="17" column="22" severity="error" message="Parameter &apos;el&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="22" column="4" severity="error" message="Type &apos;RegisteredBlockComponent&apos; is not assignable to type &apos;BlockType&lt;Record&lt;string, unknown&gt;, Record&lt;string, unknown&gt;&gt; | null&apos;.
+  Type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos; is not assignable to type &apos;BlockType&lt;Record&lt;string, unknown&gt;, Record&lt;string, unknown&gt;&gt; | null&apos;.
+    Type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos; is not assignable to type &apos;BlockType&lt;Record&lt;string, unknown&gt;, Record&lt;string, unknown&gt;&gt;&apos;.
+      Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
+        Type &apos;BlockProps&lt;Record&lt;string, unknown&gt;, Record&lt;string, unknown&gt;&gt;&apos; is not assignable to type &apos;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos;.
+          Type &apos;BlockProps&lt;Record&lt;string, unknown&gt;, Record&lt;string, unknown&gt;&gt;&apos; has no properties in common with type &apos;RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos;." source="TS2322" />
+</file>
+<file name="node_modules/@types/webpack-env/index.d.ts">
+<error line="297" column="13" severity="error" message="Cannot redeclare block-scoped variable &apos;__webpack_public_path__&apos;." source="TS2451" />
+</file>
+<file name="assets/js/base/components/combobox/index.tsx">
+<error line="8" column="33" severity="error" message="Could not find a declaration file for module &apos;wordpress-components&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/wordpress-components/build/index.js&apos; implicitly has an &apos;any&apos; type.
+  If the &apos;@wordpress/components&apos; package actually exposes this module, consider sending a pull request to amend &apos;https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/wordpress__components&apos;" source="TS7016" />
+<error line="148" column="32" severity="error" message="Argument of type &apos;({ id, className, label, onChange, options, value, required, errorMessage, errorId: incomingErrorId, instanceId, autoComplete, }: ComboboxProps) =&gt; JSX.Element&apos; is not assignable to parameter of type &apos;ComponentType&lt;{ instanceId: string | number; }&gt;&apos;.
+  Type &apos;({ id, className, label, onChange, options, value, required, errorMessage, errorId: incomingErrorId, instanceId, autoComplete, }: ComboboxProps) =&gt; JSX.Element&apos; is not assignable to type &apos;FunctionComponent&lt;{ instanceId: string | number; }&gt;&apos;.
+    Types of parameters &apos;__0&apos; and &apos;props&apos; are incompatible.
+      Type &apos;PropsWithChildren&lt;{ instanceId: string | number; }&gt;&apos; is missing the following properties from type &apos;ComboboxProps&apos;: errorId, id, label, onChange, and 2 more." source="TS2345" />
+</file>
+<file name="assets/js/base/components/country-input/country-input.tsx">
+<error line="50" column="5" severity="error" message="Type &apos;{ id: string; label: string; onChange: (filterValue: string) =&gt; void; options: { value: string; label: &quot;&amp;#197;land Islands&quot; | &quot;Afghanistan&quot; | &quot;Albania&quot; | &quot;Algeria&quot; | &quot;American Samoa&quot; | &quot;Andorra&quot; | ... 242 more ... | &quot;Zimbabwe&quot;; }[]; ... 4 more ...; autoComplete: string; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; Omit&lt;{ instanceId: string | number; }, &quot;instanceId&quot;&gt; &amp; { children?: ReactNode; }&apos;.
+  Property &apos;id&apos; does not exist on type &apos;IntrinsicAttributes &amp; Omit&lt;{ instanceId: string | number; }, &quot;instanceId&quot;&gt; &amp; { children?: ReactNode; }&apos;." source="TS2322" />
+</file>
+<file name="assets/js/base/components/state-input/state-input.tsx">
+<error line="93" column="6" severity="error" message="Type &apos;{ className: string; id: string; label: string; onChange: (stateValue: string) =&gt; void; options: { value: string; label: string; }[]; value: string; errorMessage: string; required: boolean; autoComplete: string; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; Omit&lt;{ instanceId: string | number; }, &quot;instanceId&quot;&gt; &amp; { children?: ReactNode; }&apos;.
+  Property &apos;className&apos; does not exist on type &apos;IntrinsicAttributes &amp; Omit&lt;{ instanceId: string | number; }, &quot;instanceId&quot;&gt; &amp; { children?: ReactNode; }&apos;." source="TS2322" />
+</file>
+<file name="assets/js/base/components/state-input/billing-state-input.tsx">
+<error line="13" column="21" severity="error" message="Type &apos;Record&lt;string, string&gt;&apos; is not assignable to type &apos;Record&lt;string, Record&lt;string, string&gt;&gt;&apos;.
+  &apos;string&apos; index signatures are incompatible.
+    Type &apos;string&apos; is not assignable to type &apos;Record&lt;string, string&gt;&apos;." source="TS2322" />
+</file>
+<file name="assets/js/base/components/cart-checkout/address-form/address-form.tsx">
+<error line="162" column="8" severity="error" message="Type &apos;{ key: &quot;country&quot;; id: string; label: string; value: string; autoComplete: string; onChange: (newValue: string) =&gt; void; errorId: string | null; errorMessage: string | undefined; required: boolean; }&apos; is not assignable to type &apos;CountryInputProps&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+  Types of property &apos;errorMessage&apos; are incompatible.
+    Type &apos;string | undefined&apos; is not assignable to type &apos;string&apos;.
+      Type &apos;undefined&apos; is not assignable to type &apos;string&apos;." source="TS2375" />
+<error line="196" column="8" severity="error" message="Type &apos;{ key: &quot;state&quot;; id: string; country: string; label: string; value: string; autoComplete: string; onChange: (newValue: string) =&gt; void; errorMessage: string | undefined; required: boolean; }&apos; is not assignable to type &apos;StateInputProps&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+  Types of property &apos;errorMessage&apos; are incompatible.
+    Type &apos;string | undefined&apos; is not assignable to type &apos;string&apos;.
+      Type &apos;undefined&apos; is not assignable to type &apos;string&apos;." source="TS2375" />
+</file>
+<file name="assets/js/base/components/cart-checkout/form-step/index.tsx">
+<error line="81" column="6" severity="error" message="Type &apos;{ title: string; stepHeadingContent: Element | undefined; }&apos; is not assignable to type &apos;StepHeadingProps&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+  Types of property &apos;stepHeadingContent&apos; are incompatible.
+    Type &apos;Element | undefined&apos; is not assignable to type &apos;Element&apos;.
+      Type &apos;undefined&apos; is not assignable to type &apos;Element&apos;." source="TS2375" />
+</file>
+<file name="assets/js/base/components/cart-checkout/product-summary/index.tsx">
+<error line="32" column="4" severity="error" message="Type &apos;{ className: string | undefined; source: string; maxLength: number; countType: WordCountType; }&apos; is not assignable to type &apos;SummaryProps&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+  Types of property &apos;className&apos; are incompatible.
+    Type &apos;string | undefined&apos; is not assignable to type &apos;string&apos;.
+      Type &apos;undefined&apos; is not assignable to type &apos;string&apos;." source="TS2375" />
+</file>
+<file name="assets/js/base/components/cart-checkout/product-sale-badge/index.tsx">
+<error line="7" column="15" severity="error" message="Module &apos;&quot;@woocommerce/price-format&quot;&apos; has no exported member &apos;Currency&apos;." source="TS2305" />
+</file>
+<file name="assets/js/base/components/cart-checkout/shipping-calculator/index.tsx">
+<error line="30" column="5" severity="error" message="Type &apos;Partial&lt;keyof ShippingAddress&gt;[]&apos; is not assignable to type &apos;Partial&lt;keyof AddressFields&gt;[]&apos;.
+  Type &apos;Partial&lt;keyof ShippingAddress&gt;&apos; is not assignable to type &apos;Partial&lt;keyof AddressFields&gt;&apos;.
+    Type &apos;&quot;phone&quot;&apos; is not assignable to type &apos;Partial&lt;keyof AddressFields&gt;&apos;." source="TS2322" />
+</file>
+<file name="assets/js/base/components/chip/chip.tsx">
+<error line="66" column="4" severity="error" message="Type &apos;{ children: (false | {} | Element | null)[]; className: string; }&apos; is not assignable to type &apos;IntrinsicAttributes&apos;.
+  Property &apos;children&apos; does not exist on type &apos;IntrinsicAttributes&apos;." source="TS2322" />
+</file>
+<file name="assets/js/base/components/chip/removable-chip.tsx">
+<error line="95" column="4" severity="error" message="Type &apos;{ children: Element; className: string; element: string | undefined; screenReaderText: string; text: string | Element; radius?: &quot;none&quot; | &quot;medium&quot; | &quot;large&quot; | &quot;small&quot;; }&apos; is not assignable to type &apos;ChipProps&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+  Types of property &apos;element&apos; are incompatible.
+    Type &apos;string | undefined&apos; is not assignable to type &apos;string&apos;.
+      Type &apos;undefined&apos; is not assignable to type &apos;string&apos;." source="TS2375" />
+</file>
+<file name="assets/js/base/components/cart-checkout/totals/shipping/shipping-rate-selector.js">
+<error line="5" column="24" severity="error" message="Could not find a declaration file for module &apos;wordpress-components&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/wordpress-components/build/index.js&apos; implicitly has an &apos;any&apos; type.
+  If the &apos;@wordpress/components&apos; package actually exposes this module, consider sending a pull request to amend &apos;https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/wordpress__components&apos;" source="TS7016" />
+<error line="14" column="2" severity="error" message="Binding element &apos;hasRates&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="15" column="2" severity="error" message="Binding element &apos;shippingRates&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="16" column="2" severity="error" message="Binding element &apos;isLoadingRates&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="24" column="5" severity="error" message="Property &apos;renderOption&apos; is missing in type &apos;{ className: string; collapsible: true; noResultsMessage: Element; shippingRates: any; isLoadingRates: any; context: &quot;woocommerce/cart&quot;; }&apos; but required in type &apos;ShippingRatesControlProps&apos;." source="TS2741" />
+</file>
+<file name="assets/js/base/components/cart-checkout/totals/shipping/has-shipping-rate.js">
+<error line="5" column="12" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
+</file>
+<file name="assets/js/base/components/cart-checkout/totals/shipping/index.tsx">
+<error line="9" column="15" severity="error" message="Module &apos;&quot;@woocommerce/price-format&quot;&apos; has no exported member &apos;Currency&apos;." source="TS2305" />
+</file>
+<file name="assets/js/base/components/cart-checkout/address-form/test/index.js">
+<error line="14" column="36" severity="error" message="Parameter &apos;ui&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="15" column="22" severity="error" message="Binding element &apos;children&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="83" column="33" severity="error" message="Binding element &apos;type&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="92" column="5" severity="error" message="Type &apos;string[]&apos; is not assignable to type &apos;(keyof AddressFields)[]&apos;." source="TS2322" />
+<error line="102" column="37" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;ShippingAddress&apos;.
+  No index signature with a parameter of type &apos;string&apos; was found on type &apos;ShippingAddress&apos;." source="TS7053" />
+<error line="116" column="17" severity="error" message="Argument of type &apos;{ country: string; countryKey: string; city: string; state: string; postcode: string; }&apos; is not assignable to parameter of type &apos;{ country?: null | undefined; city?: null | undefined; state?: null | undefined; postcode?: null | undefined; }&apos;.
+  Types of property &apos;country&apos; are incompatible.
+    Type &apos;string&apos; is not assignable to type &apos;null | undefined&apos;." source="TS2345" />
+<error line="118" column="43" severity="error" message="Property &apos;toHaveTextContent&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="121" column="40" severity="error" message="Property &apos;toHaveTextContent&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="124" column="41" severity="error" message="Property &apos;toHaveTextContent&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="127" column="44" severity="error" message="Property &apos;toHaveTextContent&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="135" column="17" severity="error" message="Argument of type &apos;{ country: string; countryKey: string; city: string; state: string; postcode: string; }&apos; is not assignable to parameter of type &apos;{ country?: null | undefined; city?: null | undefined; state?: null | undefined; postcode?: null | undefined; }&apos;." source="TS2345" />
+<error line="138" column="45" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="139" column="47" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="140" column="49" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="142" column="17" severity="error" message="Argument of type &apos;{ country: string; countryKey: string; city: string; postcode: string; }&apos; is not assignable to parameter of type &apos;{ country?: null | undefined; city?: null | undefined; state?: null | undefined; postcode?: null | undefined; }&apos;.
+  Types of property &apos;country&apos; are incompatible.
+    Type &apos;string&apos; is not assignable to type &apos;null | undefined&apos;." source="TS2345" />
+<error line="145" column="51" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;Matchers&lt;void, HTMLElement | null&gt;&apos;." source="TS2339" />
+<error line="147" column="17" severity="error" message="Argument of type &apos;{ country: string; countryKey: string; city: string; state: string; postcode: string; }&apos; is not assignable to parameter of type &apos;{ country?: null | undefined; city?: null | undefined; state?: null | undefined; postcode?: null | undefined; }&apos;.
+  Types of property &apos;country&apos; are incompatible.
+    Type &apos;string&apos; is not assignable to type &apos;null | undefined&apos;." source="TS2345" />
+<error line="150" column="52" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="156" column="17" severity="error" message="Argument of type &apos;{ country: string; countryKey: string; city: string; postcode: string; }&apos; is not assignable to parameter of type &apos;{ country?: null | undefined; city?: null | undefined; state?: null | undefined; postcode?: null | undefined; }&apos;." source="TS2345" />
+<error line="158" column="19" severity="error" message="Type &apos;string&apos; is not assignable to type &apos;null | undefined&apos;." source="TS2322" />
+<error line="159" column="48" severity="error" message="Property &apos;value&apos; does not exist on type &apos;HTMLElement&apos;." source="TS2339" />
+<error line="162" column="17" severity="error" message="Argument of type &apos;{ country: string; countryKey: string; city: string; state: string; postcode: string; }&apos; is not assignable to parameter of type &apos;{ country?: null | undefined; city?: null | undefined; state?: null | undefined; postcode?: null | undefined; }&apos;." source="TS2345" />
+<error line="163" column="19" severity="error" message="Type &apos;string&apos; is not assignable to type &apos;null | undefined&apos;." source="TS2322" />
+<error line="164" column="48" severity="error" message="Property &apos;value&apos; does not exist on type &apos;HTMLElement&apos;." source="TS2339" />
+</file>
+<file name="assets/js/base/components/cart-checkout/product-details/test/index.js">
+<error line="19" column="20" severity="error" message="Type &apos;({ name: string; value: string; display?: never; } | { name: string; value: string; display: string; } | { value: string; name?: never; display?: never; })[]&apos; is not assignable to type &apos;ProductResponseItemData[]&apos;.
+  Type &apos;{ name: string; value: string; display?: never; } | { name: string; value: string; display: string; } | { value: string; name?: never; display?: never; }&apos; is not assignable to type &apos;ProductResponseItemData&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+    Type &apos;{ value: string; name?: never; display?: never; }&apos; is not assignable to type &apos;ProductResponseItemData&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+      Type &apos;{ value: string; name?: never; display?: never; }&apos; is not assignable to type &apos;ProductResponseItemBaseData &amp; { key: string; name?: never; }&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+        Property &apos;key&apos; is missing in type &apos;{ value: string; name?: never; display?: never; }&apos; but required in type &apos;{ key: string; name?: never; }&apos;." source="TS2322" />
+<error line="50" column="9" severity="error" message="Variable &apos;details&apos; implicitly has type &apos;any[]&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="52" column="30" severity="error" message="Variable &apos;details&apos; implicitly has an &apos;any[]&apos; type." source="TS7005" />
+</file>
+<file name="storybook/custom-controls/currency.ts">
+<error line="28" column="14" severity="error" message="Type &apos;{ [k: string]: { code: CurrencyCode; decimal_separator: string; minor_unit: number; prefix: string; suffix: string; symbol: string; thousand_separator: string; }; }&apos; is not assignable to type &apos;Record&lt;string, CurrencyResponse&gt;&apos;.
+  &apos;string&apos; index signatures are incompatible.
+    Type &apos;{ code: CurrencyCode; decimal_separator: string; minor_unit: number; prefix: string; suffix: string; symbol: string; thousand_separator: string; }&apos; is missing the following properties from type &apos;CurrencyResponse&apos;: currency_code, currency_symbol, currency_minor_unit, currency_decimal_separator, and 3 more." source="TS2322" />
+</file>
+<file name="assets/js/base/components/cart-checkout/totals/footer-item/test/index.tsx">
+<error line="51" column="22" severity="error" message="Type &apos;{ code: string; decimalSeparator: string; minorUnit: number; prefix: string; suffix: string; symbol: string; thousandSeparator: string; }&apos; is not assignable to type &apos;Currency&apos;.
+  Types of property &apos;code&apos; are incompatible.
+    Type &apos;string&apos; is not assignable to type &apos;CurrencyCode&apos;." source="TS2322" />
+<error line="51" column="44" severity="error" message="Type &apos;{ currency_code: string; currency_decimal_separator: string; currency_minor_unit: number; currency_prefix: string; currency_suffix: string; currency_symbol: string; currency_thousand_separator: string; ... 11 more ...; total_tax: string; }&apos; is not assignable to type &apos;LooselyMustHave&lt;CartResponseTotals, &quot;total_tax&quot; | &quot;total_price&quot;&gt;&apos;.
+  Type &apos;{ currency_code: string; currency_decimal_separator: string; currency_minor_unit: number; currency_prefix: string; currency_suffix: string; currency_symbol: string; currency_thousand_separator: string; ... 11 more ...; total_tax: string; }&apos; is not assignable to type &apos;Partial&lt;CartResponseTotals&gt;&apos;.
+    Types of property &apos;currency_code&apos; are incompatible.
+      Type &apos;string&apos; is not assignable to type &apos;CurrencyCode&apos;." source="TS2322" />
+<error line="65" column="22" severity="error" message="Type &apos;{ code: string; decimalSeparator: string; minorUnit: number; prefix: string; suffix: string; symbol: string; thousandSeparator: string; }&apos; is not assignable to type &apos;Currency&apos;." source="TS2322" />
+<error line="65" column="44" severity="error" message="Type &apos;{ total_tax: string; total_items_tax: string; currency_code: string; currency_decimal_separator: string; currency_minor_unit: number; currency_prefix: string; currency_suffix: string; ... 11 more ...; total_shipping_tax: string; }&apos; is not assignable to type &apos;LooselyMustHave&lt;CartResponseTotals, &quot;total_tax&quot; | &quot;total_price&quot;&gt;&apos;.
+  Type &apos;{ total_tax: string; total_items_tax: string; currency_code: string; currency_decimal_separator: string; currency_minor_unit: number; currency_prefix: string; currency_suffix: string; ... 11 more ...; total_shipping_tax: string; }&apos; is not assignable to type &apos;Partial&lt;CartResponseTotals&gt;&apos;.
+    Types of property &apos;currency_code&apos; are incompatible.
+      Type &apos;string&apos; is not assignable to type &apos;CurrencyCode&apos;." source="TS2322" />
+<error line="77" column="22" severity="error" message="Type &apos;{ code: string; decimalSeparator: string; minorUnit: number; prefix: string; suffix: string; symbol: string; thousandSeparator: string; }&apos; is not assignable to type &apos;Currency&apos;." source="TS2322" />
+<error line="77" column="44" severity="error" message="Type &apos;{ total_tax: string; total_items_tax: string; currency_code: string; currency_decimal_separator: string; currency_minor_unit: number; currency_prefix: string; currency_suffix: string; ... 11 more ...; total_shipping_tax: string; }&apos; is not assignable to type &apos;LooselyMustHave&lt;CartResponseTotals, &quot;total_tax&quot; | &quot;total_price&quot;&gt;&apos;.
+  Type &apos;{ total_tax: string; total_items_tax: string; currency_code: string; currency_decimal_separator: string; currency_minor_unit: number; currency_prefix: string; currency_suffix: string; ... 11 more ...; total_shipping_tax: string; }&apos; is not assignable to type &apos;Partial&lt;CartResponseTotals&gt;&apos;.
+    Types of property &apos;currency_code&apos; are incompatible.
+      Type &apos;string&apos; is not assignable to type &apos;CurrencyCode&apos;." source="TS2322" />
+</file>
+<file name="assets/js/base/components/form-token-field/index.tsx">
+<error line="4" column="52" severity="error" message="Could not find a declaration file for module &apos;wordpress-components&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/wordpress-components/build/index.js&apos; implicitly has an &apos;any&apos; type.
+  If the &apos;@wordpress/components&apos; package actually exposes this module, consider sending a pull request to amend &apos;https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/wordpress__components&apos;" source="TS7016" />
+</file>
+<file name="assets/js/base/components/label/test/index.js">
+<error line="45" column="7" severity="error" message="Type &apos;{ className: string; &apos;data-foo&apos;: string; }&apos; is not assignable to type &apos;HTMLProps&lt;HTMLElement&gt;&apos;.
+  Object literal may only specify known properties, and &apos;&apos;data-foo&apos;&apos; does not exist in type &apos;HTMLProps&lt;HTMLElement&gt;&apos;." source="TS2322" />
+<error line="60" column="7" severity="error" message="Type &apos;{ className: string; &apos;data-foo&apos;: string; }&apos; is not assignable to type &apos;HTMLProps&lt;HTMLElement&gt;&apos;.
+  Object literal may only specify known properties, and &apos;&apos;data-foo&apos;&apos; does not exist in type &apos;HTMLProps&lt;HTMLElement&gt;&apos;." source="TS2322" />
+<error line="75" column="7" severity="error" message="Type &apos;{ className: string; &apos;data-foo&apos;: string; }&apos; is not assignable to type &apos;HTMLProps&lt;HTMLElement&gt;&apos;.
+  Object literal may only specify known properties, and &apos;&apos;data-foo&apos;&apos; does not exist in type &apos;HTMLProps&lt;HTMLElement&gt;&apos;." source="TS2322" />
+</file>
+<file name="assets/js/base/components/price-slider/constrain-range-slider-values.ts">
+<error line="41" column="17" severity="error" message="Argument of type &apos;number | null | undefined&apos; is not assignable to parameter of type &apos;number | undefined&apos;.
+  Type &apos;null&apos; is not assignable to type &apos;number | undefined&apos;." source="TS2345" />
+<error line="45" column="17" severity="error" message="Argument of type &apos;number | null | undefined&apos; is not assignable to parameter of type &apos;number | undefined&apos;." source="TS2345" />
+<error line="49" column="17" severity="error" message="Argument of type &apos;number | null | undefined&apos; is not assignable to parameter of type &apos;number | undefined&apos;." source="TS2345" />
+<error line="53" column="17" severity="error" message="Argument of type &apos;number | null | undefined&apos; is not assignable to parameter of type &apos;number | undefined&apos;." source="TS2345" />
+</file>
+<file name="assets/js/base/components/price-slider/index.tsx">
+<error line="127" column="20" severity="error" message="Argument of type &apos;number | null | undefined&apos; is not assignable to parameter of type &apos;number&apos;.
+  Type &apos;undefined&apos; is not assignable to type &apos;number&apos;." source="TS2345" />
+<error line="127" column="49" severity="error" message="Argument of type &apos;number | null | undefined&apos; is not assignable to parameter of type &apos;number&apos;.
+  Type &apos;undefined&apos; is not assignable to type &apos;number&apos;." source="TS2345" />
+<error line="135" column="16" severity="error" message="Argument of type &apos;number | null&apos; is not assignable to parameter of type &apos;number&apos;.
+  Type &apos;null&apos; is not assignable to type &apos;number&apos;." source="TS2345" />
+<error line="136" column="16" severity="error" message="Argument of type &apos;number | null&apos; is not assignable to parameter of type &apos;number&apos;.
+  Type &apos;null&apos; is not assignable to type &apos;number&apos;." source="TS2345" />
+<error line="148" column="10" severity="error" message="Object is possibly &apos;null&apos;." source="TS2531" />
+<error line="148" column="21" severity="error" message="Object is possibly &apos;null&apos; or &apos;undefined&apos;." source="TS2533" />
+<error line="149" column="9" severity="error" message="Object is possibly &apos;null&apos; or &apos;undefined&apos;." source="TS2533" />
+<error line="149" column="25" severity="error" message="Object is possibly &apos;null&apos; or &apos;undefined&apos;." source="TS2533" />
+<error line="154" column="10" severity="error" message="Object is possibly &apos;null&apos;." source="TS2531" />
+<error line="154" column="21" severity="error" message="Object is possibly &apos;null&apos; or &apos;undefined&apos;." source="TS2533" />
+<error line="155" column="9" severity="error" message="Object is possibly &apos;null&apos; or &apos;undefined&apos;." source="TS2533" />
+<error line="155" column="25" severity="error" message="Object is possibly &apos;null&apos; or &apos;undefined&apos;." source="TS2533" />
+<error line="193" column="41" severity="error" message="Object is possibly &apos;null&apos; or &apos;undefined&apos;." source="TS2533" />
+<error line="194" column="41" severity="error" message="Object is possibly &apos;null&apos; or &apos;undefined&apos;." source="TS2533" />
+<error line="223" column="10" severity="error" message="Type &apos;[number, number | null] | [number | null, number]&apos; is not assignable to type &apos;[number, number]&apos;.
+  Type &apos;[number, number | null]&apos; is not assignable to type &apos;[number, number]&apos;.
+    Type at position 1 in source is not compatible with type at position 1 in target.
+      Type &apos;number | null&apos; is not assignable to type &apos;number&apos;.
+        Type &apos;null&apos; is not assignable to type &apos;number&apos;." source="TS2322" />
+<error line="273" column="9" severity="error" message="Object is possibly &apos;null&apos;." source="TS2531" />
+<error line="273" column="26" severity="error" message="Object is possibly &apos;null&apos;." source="TS2531" />
+<error line="275" column="11" severity="error" message="Type &apos;number | null&apos; is not assignable to type &apos;number&apos;.
+  Type &apos;null&apos; is not assignable to type &apos;number&apos;." source="TS2322" />
+<error line="282" column="16" severity="error" message="Argument of type &apos;number&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2345" />
+<error line="283" column="16" severity="error" message="Argument of type &apos;number&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2345" />
+<error line="288" column="7" severity="error" message="Type &apos;number | null&apos; is not assignable to type &apos;number&apos;.
+  Type &apos;null&apos; is not assignable to type &apos;number&apos;." source="TS2322" />
+<error line="288" column="22" severity="error" message="Type &apos;number | null&apos; is not assignable to type &apos;number&apos;.
+  Type &apos;null&apos; is not assignable to type &apos;number&apos;." source="TS2322" />
+<error line="323" column="3" severity="error" message="Object is possibly &apos;null&apos;." source="TS2531" />
+<error line="326" column="3" severity="error" message="Object is possibly &apos;null&apos;." source="TS2531" />
+<error line="339" column="4" severity="error" message="Type &apos;(event: React.MouseEvent&lt;HTMLDivElement&gt;) =&gt; void&apos; is not assignable to type &apos;FocusEventHandler&lt;HTMLDivElement&gt;&apos;.
+  Types of parameters &apos;event&apos; and &apos;event&apos; are incompatible.
+    Type &apos;FocusEvent&lt;HTMLDivElement, Element&gt;&apos; is missing the following properties from type &apos;MouseEvent&lt;HTMLDivElement, MouseEvent&gt;&apos;: altKey, button, buttons, clientX, and 13 more." source="TS2322" />
+<error line="355" column="7" severity="error" message="Type &apos;number | null | undefined&apos; is not assignable to type &apos;string | number | readonly string[] | undefined&apos;.
+  Type &apos;null&apos; is not assignable to type &apos;string | number | readonly string[] | undefined&apos;." source="TS2322" />
+<error line="362" column="7" severity="error" message="Type &apos;number | null | undefined&apos; is not assignable to type &apos;string | number | undefined&apos;.
+  Type &apos;null&apos; is not assignable to type &apos;string | number | undefined&apos;." source="TS2322" />
+<error line="363" column="7" severity="error" message="Type &apos;number | null | undefined&apos; is not assignable to type &apos;string | number | undefined&apos;." source="TS2322" />
+<error line="376" column="7" severity="error" message="Type &apos;number | null | undefined&apos; is not assignable to type &apos;string | number | readonly string[] | undefined&apos;." source="TS2322" />
+<error line="383" column="7" severity="error" message="Type &apos;number | null | undefined&apos; is not assignable to type &apos;string | number | undefined&apos;." source="TS2322" />
+<error line="384" column="7" severity="error" message="Type &apos;number | null | undefined&apos; is not assignable to type &apos;string | number | undefined&apos;." source="TS2322" />
+<error line="411" column="9" severity="error" message="Type &apos;number | null | undefined&apos; is not assignable to type &apos;number&apos;.
+  Type &apos;undefined&apos; is not assignable to type &apos;number&apos;." source="TS2322" />
+<error line="413" column="9" severity="error" message="Type &apos;number | null&apos; is not assignable to type &apos;number&apos;.
+  Type &apos;null&apos; is not assignable to type &apos;number&apos;." source="TS2322" />
+<error line="423" column="8" severity="error" message="Type &apos;number | null&apos; is not assignable to type &apos;string | number&apos;.
+  Type &apos;null&apos; is not assignable to type &apos;string | number&apos;." source="TS2322" />
+<error line="440" column="9" severity="error" message="Type &apos;number | null | undefined&apos; is not assignable to type &apos;number&apos;.
+  Type &apos;undefined&apos; is not assignable to type &apos;number&apos;." source="TS2322" />
+<error line="451" column="8" severity="error" message="Type &apos;number | null&apos; is not assignable to type &apos;string | number&apos;." source="TS2322" />
+<error line="466" column="8" severity="error" message="Type &apos;number | null&apos; is not assignable to type &apos;string | number&apos;." source="TS2322" />
+<error line="470" column="8" severity="error" message="Type &apos;number | null&apos; is not assignable to type &apos;string | number&apos;." source="TS2322" />
+<error line="482" column="11" severity="error" message="Type &apos;number | null | undefined&apos; is not assignable to type &apos;number&apos;.
+  Type &apos;undefined&apos; is not assignable to type &apos;number&apos;." source="TS2322" />
+<error line="483" column="11" severity="error" message="Type &apos;number | null | undefined&apos; is not assignable to type &apos;number&apos;.
+  Type &apos;undefined&apos; is not assignable to type &apos;number&apos;." source="TS2322" />
+</file>
+<file name="assets/js/base/components/product-list/product-list.tsx">
+<error line="255" column="14" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
+<error line="257" column="8" severity="error" message="Type &apos;unknown&apos; is not assignable to type &apos;Partial&lt;ProductResponseItem&gt;&apos;." source="TS2322" />
+<error line="273" column="33" severity="error" message="Argument of type &apos;({ attributes, currentPage, onPageChange, onSortChange, sortValue, scrollToTop, }: ProductListProps) =&gt; JSX.Element&apos; is not assignable to parameter of type &apos;FunctionComponent&lt;Record&lt;string, unknown&gt;&gt;&apos;.
+  Types of parameters &apos;__0&apos; and &apos;props&apos; are incompatible.
+    Type &apos;PropsWithChildren&lt;Record&lt;string, unknown&gt;&gt;&apos; is missing the following properties from type &apos;ProductListProps&apos;: attributes, currentPage, onPageChange, onSortChange, and 2 more." source="TS2345" />
+</file>
+<file name="assets/js/base/components/product-price/test/index.js">
+<error line="44" column="5" severity="error" message="Type &apos;{ code: string; currency_code: string; currency_decimal_separator: string; currency_minor_unit: number; currency_prefix: string; currency_suffix: string; currency_symbol: string; currency_thousand_separator: string; ... 10 more ...; thousandSeparator: string; }&apos; is not assignable to type &apos;Currency | Record&lt;string, never&gt;&apos;.
+  Type &apos;{ code: string; currency_code: string; currency_decimal_separator: string; currency_minor_unit: number; currency_prefix: string; currency_suffix: string; currency_symbol: string; currency_thousand_separator: string; ... 10 more ...; thousandSeparator: string; }&apos; is not assignable to type &apos;Record&lt;string, never&gt;&apos;.
+    Property &apos;code&apos; is incompatible with index signature.
+      Type &apos;string&apos; is not assignable to type &apos;never&apos;." source="TS2322" />
+<error line="56" column="5" severity="error" message="Type &apos;{ code: string; currency_code: string; currency_decimal_separator: string; currency_minor_unit: number; currency_prefix: string; currency_suffix: string; currency_symbol: string; currency_thousand_separator: string; ... 10 more ...; thousandSeparator: string; }&apos; is not assignable to type &apos;Currency | Record&lt;string, never&gt;&apos;." source="TS2322" />
+</file>
+<file name="assets/js/base/components/radio-control-accordion/index.js">
+<error line="13" column="2" severity="error" message="Binding element &apos;className&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="14" column="2" severity="error" message="Binding element &apos;instanceId&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="15" column="2" severity="error" message="Binding element &apos;id&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="16" column="2" severity="error" message="Binding element &apos;selected&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="17" column="2" severity="error" message="Binding element &apos;onChange&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="18" column="2" severity="error" message="Binding element &apos;options&apos; implicitly has an &apos;any[]&apos; type." source="TS7031" />
+<error line="73" column="32" severity="error" message="Argument of type &apos;({ className, instanceId, id, selected, onChange, options, }: { className: any; instanceId: any; id: any; selected: any; onChange: any; options?: any[] | undefined; }) =&gt; 0 | Element&apos; is not assignable to parameter of type &apos;ComponentType&lt;{ className: any; instanceId: any; id: any; selected: any; onChange: any; options?: any[] | undefined; }&gt;&apos;.
+  Type &apos;({ className, instanceId, id, selected, onChange, options, }: { className: any; instanceId: any; id: any; selected: any; onChange: any; options?: any[] | undefined; }) =&gt; 0 | Element&apos; is not assignable to type &apos;FunctionComponent&lt;{ className: any; instanceId: any; id: any; selected: any; onChange: any; options?: any[] | undefined; }&gt;&apos;.
+    Type &apos;0 | Element&apos; is not assignable to type &apos;ReactElement&lt;any, any&gt; | null&apos;.
+      Type &apos;number&apos; is not assignable to type &apos;ReactElement&lt;any, any&gt;&apos;." source="TS2345" />
+</file>
+<file name="assets/js/base/components/reviews/review-list-item/index.js">
+<error line="14" column="26" severity="error" message="Parameter &apos;review&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="14" column="34" severity="error" message="Parameter &apos;imageType&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="14" column="45" severity="error" message="Parameter &apos;isLoading&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="54" column="28" severity="error" message="Parameter &apos;review&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="80" column="32" severity="error" message="Parameter &apos;review&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="96" column="27" severity="error" message="Parameter &apos;review&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="105" column="25" severity="error" message="Parameter &apos;review&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="120" column="27" severity="error" message="Parameter &apos;review&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="153" column="28" severity="error" message="Binding element &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="163" column="10" severity="error" message="Property &apos;rating&apos; does not exist on type &apos;{}&apos;." source="TS2339" />
+<error line="164" column="20" severity="error" message="Operator &apos;&gt;&apos; cannot be applied to types &apos;boolean&apos; and &apos;number&apos;." source="TS2365" />
+</file>
+<file name="assets/js/base/components/reviews/review-list/index.js">
+<error line="13" column="24" severity="error" message="Binding element &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="13" column="36" severity="error" message="Binding element &apos;reviews&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="32" column="20" severity="error" message="Parameter &apos;review&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="32" column="28" severity="error" message="Parameter &apos;i&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+</file>
+<file name="assets/js/base/components/reviews/review-sort-select/index.js">
+<error line="13" column="30" severity="error" message="Binding element &apos;onChange&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="13" column="40" severity="error" message="Binding element &apos;readOnly&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="13" column="50" severity="error" message="Binding element &apos;value&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="39" column="4" severity="error" message="Type &apos;{ className: string; label: string; onChange: any; options: { key: string; label: string; }[]; readOnly: any; screenReaderLabel: string; value: any; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; Omit&lt;SortSelectProps, &quot;instanceId&quot;&gt; &amp; { children?: ReactNode; }&apos;.
+  Property &apos;readOnly&apos; does not exist on type &apos;IntrinsicAttributes &amp; Omit&lt;SortSelectProps, &quot;instanceId&quot;&gt; &amp; { children?: ReactNode; }&apos;." source="TS2322" />
+</file>
+<file name="assets/js/base/components/sidebar-layout/sidebar.js">
+<error line="7" column="43" severity="error" message="Property &apos;className&apos; does not exist on type &apos;{ children?: ReactNode; }&apos;." source="TS2339" />
+</file>
+<file name="assets/js/base/components/sidebar-layout/main.js">
+<error line="7" column="40" severity="error" message="Property &apos;className&apos; does not exist on type &apos;{ children?: ReactNode; }&apos;." source="TS2339" />
+</file>
+<file name="assets/js/base/components/sidebar-layout/sidebar-layout.js">
+<error line="13" column="27" severity="error" message="Binding element &apos;children&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="13" column="37" severity="error" message="Binding element &apos;className&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+</file>
+<file name="assets/js/base/components/tabs/index.js">
+<error line="14" column="2" severity="error" message="Binding element &apos;className&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="16" column="2" severity="error" message="Binding element &apos;tabs&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="18" column="2" severity="error" message="Binding element &apos;initialTabName&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="20" column="2" severity="error" message="Binding element &apos;instanceId&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="21" column="2" severity="error" message="Binding element &apos;id&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="38" column="21" severity="error" message="Binding element &apos;name&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="38" column="27" severity="error" message="Binding element &apos;title&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="38" column="45" severity="error" message="Binding element &apos;tabAriaLabel&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="52" column="33" severity="error" message="Expected 0 arguments, but got 1." source="TS2554" />
+<error line="64" column="20" severity="error" message="Binding element &apos;name&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="64" column="26" severity="error" message="Binding element &apos;content&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+</file>
+<file name="assets/js/base/context/utils.js">
+<error line="36" column="4" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;Object&apos;.
+  No index signature with a parameter of type &apos;string&apos; was found on type &apos;Object&apos;." source="TS7053" />
+<error line="37" column="11" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;Object&apos;.
+  No index signature with a parameter of type &apos;string&apos; was found on type &apos;Object&apos;." source="TS7053" />
+<error line="43" column="11" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;Object&apos;.
+  No index signature with a parameter of type &apos;string&apos; was found on type &apos;Object&apos;." source="TS7053" />
+<error line="44" column="11" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;Object&apos;.
+  No index signature with a parameter of type &apos;string&apos; was found on type &apos;Object&apos;." source="TS7053" />
+<error line="45" column="5" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;Object&apos;.
+  No index signature with a parameter of type &apos;string&apos; was found on type &apos;Object&apos;." source="TS7053" />
+<error line="49" column="6" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;Object&apos;.
+  No index signature with a parameter of type &apos;string&apos; was found on type &apos;Object&apos;." source="TS7053" />
+<error line="50" column="33" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;Object&apos;.
+  No index signature with a parameter of type &apos;string&apos; was found on type &apos;Object&apos;." source="TS7053" />
+</file>
+<file name="assets/js/base/context/event-emit/test/emitters.js">
+<error line="8" column="6" severity="error" message="Variable &apos;observerA&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="9" column="6" severity="error" message="Variable &apos;observerB&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="10" column="6" severity="error" message="Variable &apos;observerPromiseWithResolvedValue&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="45" column="38" severity="error" message="Argument of type &apos;{ test: {}; }&apos; is not assignable to parameter of type &apos;EventObserversType&apos;.
+  Property &apos;test&apos; is incompatible with index signature.
+    Type &apos;{}&apos; is missing the following properties from type &apos;Map&lt;string, ObserverType&gt;&apos;: clear, delete, forEach, get, and 8 more." source="TS2345" />
+<error line="46" column="22" severity="error" message="Property &apos;toHaveErroredWith&apos; does not exist on type &apos;JestMatchers&lt;Console&gt;&apos;." source="TS2339" />
+<error line="47" column="12" severity="error" message="Variable &apos;observerA&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="48" column="12" severity="error" message="Variable &apos;observerB&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="54" column="18" severity="error" message="Property &apos;delete&apos; does not exist on type &apos;{}&apos;." source="TS2339" />
+<error line="57" column="5" severity="error" message="Argument of type &apos;{ test: {}; }&apos; is not assignable to parameter of type &apos;EventObserversType&apos;.
+  Property &apos;test&apos; is incompatible with index signature.
+    Type &apos;{}&apos; is not assignable to type &apos;ObserversType&apos;." source="TS2345" />
+<error line="61" column="26" severity="error" message="Property &apos;toHaveErrored&apos; does not exist on type &apos;Matchers&lt;void, Console&gt;&apos;." source="TS2339" />
+<error line="62" column="12" severity="error" message="Variable &apos;observerB&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="63" column="12" severity="error" message="Variable &apos;observerPromiseWithResolvedValue&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="70" column="18" severity="error" message="Property &apos;set&apos; does not exist on type &apos;{}&apos;." source="TS2339" />
+<error line="76" column="5" severity="error" message="Argument of type &apos;{ test: {}; }&apos; is not assignable to parameter of type &apos;EventObserversType&apos;.
+  Property &apos;test&apos; is incompatible with index signature.
+    Type &apos;{}&apos; is not assignable to type &apos;ObserversType&apos;." source="TS2345" />
+<error line="80" column="26" severity="error" message="Property &apos;toHaveErrored&apos; does not exist on type &apos;Matchers&lt;void, Console&gt;&apos;." source="TS2339" />
+<error line="82" column="12" severity="error" message="Variable &apos;observerPromiseWithResolvedValue&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="87" column="18" severity="error" message="Property &apos;set&apos; does not exist on type &apos;{}&apos;." source="TS2339" />
+<error line="93" column="5" severity="error" message="Argument of type &apos;{ test: {}; }&apos; is not assignable to parameter of type &apos;EventObserversType&apos;.
+  Property &apos;test&apos; is incompatible with index signature.
+    Type &apos;{}&apos; is not assignable to type &apos;ObserversType&apos;." source="TS2345" />
+<error line="97" column="22" severity="error" message="Property &apos;toHaveErrored&apos; does not exist on type &apos;JestMatchers&lt;Console&gt;&apos;." source="TS2339" />
+<error line="99" column="12" severity="error" message="Variable &apos;observerPromiseWithResolvedValue&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="114" column="26" severity="error" message="Property &apos;toHaveErrored&apos; does not exist on type &apos;Matchers&lt;void, Console&gt;&apos;." source="TS2339" />
+</file>
+<file name="assets/js/base/context/hooks/cart/test/use-store-cart-item-quantity.js">
+<error line="27" column="17" severity="error" message="Parameter &apos;a&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="31" column="6" severity="error" message="Variable &apos;registry&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="31" column="16" severity="error" message="Variable &apos;renderer&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="33" column="33" severity="error" message="Parameter &apos;Component&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="34" column="29" severity="error" message="Variable &apos;registry&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="39" column="29" severity="error" message="Parameter &apos;options&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="41" column="11" severity="error" message="Type &apos;{ isPendingDelete: boolean; quantity: number; setItemQuantity: Dispatch&lt;SetStateAction&lt;number&gt;&gt;; removeItem: () =&gt; Promise&lt;boolean&gt;; cartItemQuantityErrors: CartResponseErrorItem[]; }&apos; has no properties in common with type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLDivElement&gt;, HTMLDivElement&gt;&apos;." source="TS2559" />
+<error line="44" column="6" severity="error" message="Variable &apos;mockRemoveItemFromCart&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="45" column="6" severity="error" message="Variable &apos;mockChangeCartItemQuantity&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="46" column="25" severity="error" message="Binding element &apos;isPendingDelete&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="46" column="42" severity="error" message="Binding element &apos;isPendingQuantity&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="55" column="3" severity="error" message="Variable &apos;registry&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="72" column="3" severity="error" message="Variable &apos;registry&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="81" column="3" severity="error" message="Variable &apos;mockRemoveItemFromCart&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="82" column="3" severity="error" message="Variable &apos;mockChangeCartItemQuantity&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="88" column="34" severity="error" message="Property &apos;mockReturnValue&apos; does not exist on type &apos;(options?: { shouldSelect: boolean; }) =&gt; StoreCart&apos;." source="TS2339" />
+<error line="106" column="5" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="115" column="5" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="132" column="27" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="138" column="12" severity="error" message="Variable &apos;mockRemoveItemFromCart&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="153" column="32" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="159" column="12" severity="error" message="Variable &apos;mockChangeCartItemQuantity&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="171" column="33" severity="error" message="Property &apos;mockReturnValue&apos; does not exist on type &apos;(options?: { shouldSelect: boolean; }) =&gt; StoreCart&apos;." source="TS2339" />
+<error line="187" column="4" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="197" column="33" severity="error" message="Property &apos;mockReturnValue&apos; does not exist on type &apos;(options?: { shouldSelect: boolean; }) =&gt; StoreCart&apos;." source="TS2339" />
+<error line="212" column="31" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+</file>
+<file name="assets/js/base/context/hooks/cart/test/use-store-cart.js">
+<error line="26" column="6" severity="error" message="Variable &apos;registry&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="26" column="16" severity="error" message="Variable &apos;renderer&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="112" column="8" severity="error" message="Variable &apos;mockCartErrors&apos; implicitly has type &apos;any[]&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="123" column="15" severity="error" message="Variable &apos;mockCartErrors&apos; implicitly has an &apos;any[]&apos; type." source="TS7005" />
+<error line="136" column="33" severity="error" message="Parameter &apos;Component&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="137" column="29" severity="error" message="Variable &apos;registry&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="142" column="29" severity="error" message="Parameter &apos;options&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="144" column="15" severity="error" message="Type &apos;{ cartCoupons: CartResponseCoupons; cartItems: CartItem[]; crossSellsProducts: ProductResponseItem[]; cartFees: CartResponseFeeItem[]; ... 14 more ...; paymentRequirements: string[]; }&apos; is not assignable to type &apos;number&apos;." source="TS2322" />
+<error line="151" column="47" severity="error" message="Variable &apos;mockCartErrors&apos; implicitly has an &apos;any[]&apos; type." source="TS7005" />
+<error line="159" column="3" severity="error" message="Variable &apos;registry&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="172" column="20" severity="error" message="Property &apos;mockReset&apos; does not exist on type &apos;() =&gt; any&apos;." source="TS2339" />
+<error line="177" column="21" severity="error" message="Property &apos;mockReturnValue&apos; does not exist on type &apos;() =&gt; any&apos;." source="TS2339" />
+<error line="194" column="5" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="213" column="5" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="222" column="21" severity="error" message="Property &apos;mockReturnValue&apos; does not exist on type &apos;() =&gt; any&apos;." source="TS2339" />
+<error line="243" column="5" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+</file>
+<file name="assets/js/base/context/hooks/collections/test/use-collection.js">
+<error line="20" column="15" severity="error" message="Parameter &apos;props&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="24" column="35" severity="error" message="Parameter &apos;error&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="31" column="16" severity="error" message="Type &apos;{ error: {}; }&apos; is not assignable to type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLDivElement&gt;, HTMLDivElement&gt;&apos;.
+  Property &apos;error&apos; does not exist on type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLDivElement&gt;, HTMLDivElement&gt;&apos;." source="TS2322" />
+<error line="39" column="6" severity="error" message="Variable &apos;registry&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="39" column="16" severity="error" message="Variable &apos;mocks&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="39" column="23" severity="error" message="Variable &apos;renderer&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="40" column="21" severity="error" message="Parameter &apos;testRenderer&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="49" column="33" severity="error" message="Parameter &apos;Component&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="49" column="44" severity="error" message="Parameter &apos;props&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="50" column="29" severity="error" message="Variable &apos;registry&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="59" column="7" severity="error" message="Binding element &apos;options&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="61" column="12" severity="error" message="Type &apos;{ results: unknown; isLoading: boolean; }&apos; is not assignable to type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLDivElement&gt;, HTMLDivElement&gt;&apos;.
+  Type &apos;{ results: unknown; isLoading: boolean; }&apos; is not assignable to type &apos;HTMLAttributes&lt;HTMLDivElement&gt;&apos;.
+    Types of property &apos;results&apos; are incompatible.
+      Type &apos;unknown&apos; is not assignable to type &apos;number | undefined&apos;." source="TS2322" />
+<error line="74" column="3" severity="error" message="Variable &apos;registry&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="102" column="18" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="104" column="22" severity="error" message="Property &apos;toHaveErrored&apos; does not exist on type &apos;JestMatchers&lt;Console&gt;&apos;." source="TS2339" />
+<error line="105" column="4" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="124" column="18" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="126" column="22" severity="error" message="Property &apos;toHaveErrored&apos; does not exist on type &apos;JestMatchers&lt;Console&gt;&apos;." source="TS2339" />
+<error line="127" column="4" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="146" column="34" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="149" column="5" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="161" column="46" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="169" column="5" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="179" column="55" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="182" column="4" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="201" column="34" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="204" column="5" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="216" column="46" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="224" column="5" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="234" column="55" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="237" column="4" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="241" column="3" severity="error" message="Variable &apos;mocks&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="242" column="6" severity="error" message="Parameter &apos;state&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="242" column="13" severity="error" message="Rest parameter &apos;args&apos; implicitly has an &apos;any[]&apos; type." source="TS7019" />
+<error line="258" column="33" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="261" column="4" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="272" column="43" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="276" column="11" severity="error" message="Variable &apos;mocks&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="281" column="4" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="292" column="43" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+</file>
+<file name="assets/js/base/context/hooks/payment-methods/test/use-payment-method-interface.js">
+<error line="54" column="30" severity="error" message="Argument of type &apos;{ total_items: string; total_items_tax: string; total_fees: string; total_fees_tax: string; total_discount: string; total_discount_tax: string; total_shipping: string; total_shipping_tax: string; total_tax: string; }&apos; is not assignable to parameter of type &apos;CartResponseTotals&apos;.
+  Type &apos;{ total_items: string; total_items_tax: string; total_fees: string; total_fees_tax: string; total_discount: string; total_discount_tax: string; total_shipping: string; total_shipping_tax: string; total_tax: string; }&apos; is missing the following properties from type &apos;CartResponseTotals&apos;: total_price, tax_lines, currency_code, currency_symbol, and 5 more." source="TS2345" />
+<error line="57" column="30" severity="error" message="Argument of type &apos;{ total_items: string; total_items_tax: string; total_fees: string; total_fees_tax: string; total_discount: string; total_discount_tax: string; total_shipping: string; total_shipping_tax: string; total_tax: string; }&apos; is not assignable to parameter of type &apos;CartResponseTotals&apos;." source="TS2345" />
+</file>
+<file name="assets/js/base/context/hooks/test/use-checkout-submit.js">
+<error line="33" column="6" severity="error" message="Variable &apos;registry&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="33" column="16" severity="error" message="Variable &apos;renderer&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="35" column="33" severity="error" message="Parameter &apos;Component&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="36" column="29" severity="error" message="Variable &apos;registry&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="64" column="24" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+</file>
+<file name="assets/js/base/context/hooks/test/use-query-state.js">
+<error line="23" column="6" severity="error" message="Variable &apos;registry&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="23" column="16" severity="error" message="Variable &apos;mocks&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="34" column="14" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
+<error line="40" column="30" severity="error" message="Property &apos;root&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="55" column="29" severity="error" message="Variable &apos;registry&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="67" column="13" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
+<error line="74" column="64" severity="error" message="Parameter &apos;props&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="78" column="9" severity="error" message="Type &apos;{ queryState: any; setQueryState: any; }&apos; is not assignable to type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLDivElement&gt;, HTMLDivElement&gt;&apos;.
+  Property &apos;queryState&apos; does not exist on type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLDivElement&gt;, HTMLDivElement&gt;&apos;." source="TS2322" />
+<error line="96" column="3" severity="error" message="Variable &apos;mocks&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="97" column="3" severity="error" message="Variable &apos;mocks&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="98" column="3" severity="error" message="Variable &apos;registry&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="101" column="25" severity="error" message="Variable &apos;mocks&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="104" column="27" severity="error" message="Variable &apos;mocks&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="112" column="7" severity="error" message="Variable &apos;renderer&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="119" column="5" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="126" column="34" severity="error" message="Variable &apos;mocks&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="134" column="53" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="161" column="7" severity="error" message="Variable &apos;renderer&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="168" column="5" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="175" column="34" severity="error" message="Variable &apos;mocks&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="184" column="53" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="216" column="7" severity="error" message="Variable &apos;renderer&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="221" column="33" severity="error" message="Variable &apos;mocks&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="230" column="37" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="244" column="5" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="255" column="37" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+</file>
+<file name="assets/js/base/context/hooks/test/use-store-products.js">
+<error line="19" column="6" severity="error" message="Variable &apos;registry&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="19" column="23" severity="error" message="Variable &apos;renderer&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="20" column="21" severity="error" message="Parameter &apos;testRenderer&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="30" column="33" severity="error" message="Parameter &apos;Component&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="30" column="44" severity="error" message="Parameter &apos;props&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="31" column="29" severity="error" message="Variable &apos;registry&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="38" column="7" severity="error" message="Binding element &apos;query&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="40" column="12" severity="error" message="Type &apos;{ products: ProductResponseItem[]; totalProducts: number; productsLoading: boolean; }&apos; has no properties in common with type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLDivElement&gt;, HTMLDivElement&gt;&apos;." source="TS2559" />
+<error line="54" column="3" severity="error" message="Variable &apos;registry&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="78" column="35" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="81" column="5" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="89" column="48" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="97" column="5" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="103" column="57" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="106" column="4" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+</file>
+<file name="assets/js/blocks/reviews/utils.js">
+<error line="8" column="30" severity="error" message="Parameter &apos;sortValue&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="32" column="29" severity="error" message="Parameter &apos;args&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="41" column="34" severity="error" message="Parameter &apos;reviews&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="51" column="36" severity="error" message="Parameter &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="84" column="31" severity="error" message="Parameter &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="106" column="3" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;&quot;data-product-id&quot;&apos; can&apos;t be used to index type &apos;{ &apos;data-image-type&apos;: any; &apos;data-orderby&apos;: any; &apos;data-reviews-on-page-load&apos;: any; &apos;data-reviews-on-load-more&apos;: any; &apos;data-show-load-more&apos;: any; &apos;data-show-orderby&apos;: any; }&apos;.
+  Property &apos;data-product-id&apos; does not exist on type &apos;{ &apos;data-image-type&apos;: any; &apos;data-orderby&apos;: any; &apos;data-reviews-on-page-load&apos;: any; &apos;data-reviews-on-load-more&apos;: any; &apos;data-show-load-more&apos;: any; &apos;data-show-orderby&apos;: any; }&apos;." source="TS7053" />
+<error line="110" column="3" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;&quot;data-category-ids&quot;&apos; can&apos;t be used to index type &apos;{ &apos;data-image-type&apos;: any; &apos;data-orderby&apos;: any; &apos;data-reviews-on-page-load&apos;: any; &apos;data-reviews-on-load-more&apos;: any; &apos;data-show-load-more&apos;: any; &apos;data-show-orderby&apos;: any; }&apos;.
+  Property &apos;data-category-ids&apos; does not exist on type &apos;{ &apos;data-image-type&apos;: any; &apos;data-orderby&apos;: any; &apos;data-reviews-on-page-load&apos;: any; &apos;data-reviews-on-load-more&apos;: any; &apos;data-show-load-more&apos;: any; &apos;data-show-orderby&apos;: any; }&apos;." source="TS7053" />
+</file>
+<file name="assets/js/base/hocs/with-reviews.js">
+<error line="40" column="21" severity="error" message="Parameter &apos;f&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="66" column="23" severity="error" message="Parameter &apos;prevProps&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="77" column="25" severity="error" message="Parameter &apos;prevProps&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="77" column="36" severity="error" message="Parameter &apos;nextProps&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="94" column="12" severity="error" message="Parameter &apos;reviewsToSkip&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="109" column="10" severity="error" message="Property &apos;category_id&apos; does not exist on type &apos;{ order: any; orderby: any; per_page: number; offset: any; }&apos;." source="TS2339" />
+<error line="115" column="10" severity="error" message="Property &apos;product_id&apos; does not exist on type &apos;{ order: any; orderby: any; per_page: number; offset: any; }&apos;." source="TS2339" />
+<error line="147" column="24" severity="error" message="Parameter &apos;oldReviews&apos; implicitly has an &apos;any[]&apos; type." source="TS7006" />
+<error line="184" column="22" severity="error" message="Parameter &apos;e&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="212" column="10" severity="error" message="Property &apos;displayName&apos; does not exist on type &apos;Function&apos;." source="TS2339" />
+</file>
+<file name="assets/js/base/hocs/test/with-reviews.js">
+<error line="40" column="38" severity="error" message="Parameter &apos;props&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="43" column="4" severity="error" message="Type &apos;{ error: any; getReviews: any; appendReviews: any; onChangeArgs: any; isLoading: any; reviews: any; totalReviews: any; }&apos; is not assignable to type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLDivElement&gt;, HTMLDivElement&gt;&apos;.
+  Property &apos;error&apos; does not exist on type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLDivElement&gt;, HTMLDivElement&gt;&apos;." source="TS2322" />
+<error line="66" column="6" severity="error" message="Variable &apos;renderer&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="68" column="24" severity="error" message="Property &apos;mockReset&apos; does not exist on type &apos;(args: any) =&gt; Promise&lt;any&gt;&apos;." source="TS2339" />
+<error line="74" column="6" severity="error" message="Property &apos;mockImplementationOnce&apos; does not exist on type &apos;(args: any) =&gt; Promise&lt;any&gt;&apos;." source="TS2339" />
+<error line="98" column="4" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="118" column="25" severity="error" message="Property &apos;mockImplementation&apos; does not exist on type &apos;(args: any) =&gt; Promise&lt;any&gt;&apos;." source="TS2339" />
+<error line="128" column="18" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="143" column="25" severity="error" message="Property &apos;mockImplementation&apos; does not exist on type &apos;(args: any) =&gt; Promise&lt;any&gt;&apos;." source="TS2339" />
+<error line="144" column="30" severity="error" message="Property &apos;mockImplementation&apos; does not exist on type &apos;(error: { json?: Function | undefined; message?: string | undefined; type?: string | undefined; }) =&gt; Promise&lt;{ message: string; type: string; }&gt;&apos;." source="TS2339" />
+<error line="151" column="24" severity="error" message="This expression is not callable.
+  Type &apos;Promise&lt;never&gt;&apos; has no call signatures." source="TS2349" />
+<error line="154" column="18" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+</file>
+<file name="assets/js/base/hocs/with-scroll-to-top/test/index.js">
+<error line="27" column="20" severity="error" message="Binding element &apos;inView&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+</file>
+<file name="assets/js/base/hooks/test/use-position-relative-to-viewport.js">
+<error line="62" column="41" severity="error" message="Parameter &apos;entries&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+</file>
+<file name="assets/js/base/hooks/test/use-previous.js">
+<error line="15" column="28" severity="error" message="Binding element &apos;testValue&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="15" column="39" severity="error" message="Binding element &apos;validation&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="17" column="15" severity="error" message="Type &apos;{ testValue: any; previousValue: any; }&apos; is not assignable to type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLDivElement&gt;, HTMLDivElement&gt;&apos;.
+  Property &apos;testValue&apos; does not exist on type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLDivElement&gt;, HTMLDivElement&gt;&apos;." source="TS2322" />
+<error line="20" column="6" severity="error" message="Variable &apos;renderer&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="25" column="37" severity="error" message="Property &apos;validation&apos; is missing in type &apos;{ testValue: number; }&apos; but required in type &apos;{ testValue: any; validation: any; }&apos;." source="TS2741" />
+<error line="27" column="21" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="29" column="4" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="39" column="37" severity="error" message="Property &apos;validation&apos; is missing in type &apos;{ testValue: number; }&apos; but required in type &apos;{ testValue: any; validation: any; }&apos;." source="TS2741" />
+<error line="43" column="4" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="43" column="22" severity="error" message="Property &apos;validation&apos; is missing in type &apos;{ testValue: number; }&apos; but required in type &apos;{ testValue: any; validation: any; }&apos;." source="TS2741" />
+<error line="45" column="15" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="47" column="4" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="52" column="4" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="52" column="22" severity="error" message="Property &apos;validation&apos; is missing in type &apos;{ testValue: number; }&apos; but required in type &apos;{ testValue: any; validation: any; }&apos;." source="TS2741" />
+<error line="54" column="15" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="56" column="4" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="71" column="4" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="75" column="15" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="77" column="4" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="82" column="4" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="86" column="15" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="88" column="4" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+</file>
+<file name="assets/js/base/hooks/test/use-shallow-equal.js">
+<error line="15" column="28" severity="error" message="Binding element &apos;testValue&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="17" column="15" severity="error" message="Type &apos;{ newValue: any; }&apos; is not assignable to type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLDivElement&gt;, HTMLDivElement&gt;&apos;.
+  Property &apos;newValue&apos; does not exist on type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLDivElement&gt;, HTMLDivElement&gt;&apos;." source="TS2322" />
+<error line="19" column="6" severity="error" message="Variable &apos;renderer&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="37" column="20" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="41" column="5" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="43" column="20" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="65" column="20" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="69" column="5" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="71" column="20" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+</file>
+<file name="assets/js/blocks/active-filters/block.tsx">
+<error line="174" column="35" severity="error" message="Argument of type &apos;unknown&apos; is not assignable to parameter of type &apos;StoreAttributes[]&apos;." source="TS2345" />
+<error line="182" column="35" severity="error" message="Parameter &apos;attribute&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+</file>
+<file name="assets/js/editor-components/block-title/index.js">
+<error line="15" column="2" severity="error" message="Binding element &apos;className&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="16" column="2" severity="error" message="Binding element &apos;headingLevel&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="17" column="2" severity="error" message="Binding element &apos;onChange&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="18" column="2" severity="error" message="Binding element &apos;heading&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="19" column="2" severity="error" message="Binding element &apos;instanceId&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="23" column="4" severity="error" message="Type &apos;{ children: Element[]; className: any; }&apos; is not assignable to type &apos;IntrinsicAttributes&apos;.
+  Property &apos;children&apos; does not exist on type &apos;IntrinsicAttributes&apos;." source="TS2322" />
+</file>
+<file name="assets/js/blocks/filter-wrapper/upgrade.tsx">
+<error line="28" column="12" severity="error" message="Property &apos;getBlockParentsByBlockName&apos; does not exist on type &apos;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__block-editor/store/selectors&quot;)&apos;." source="TS2339" />
+</file>
+<file name="assets/js/blocks/active-filters/edit.tsx">
+<error line="13" column="2" severity="error" message="Module &apos;&quot;@wordpress/components&quot;&apos; has no exported member &apos;__experimentalToggleGroupControl&apos;." source="TS2305" />
+<error line="15" column="2" severity="error" message="Module &apos;&quot;@wordpress/components&quot;&apos; has no exported member &apos;__experimentalToggleGroupControlOption&apos;." source="TS2305" />
+</file>
+<file name="assets/js/blocks/active-filters/index.tsx">
+<error line="18" column="20" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;Attributes&gt;, settings?: Partial&lt;BlockConfiguration&lt;Attributes&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { html: boolean; multiple: boolean; inserter: boolean; color: { text: boolean; background: boolean; }; lock: boolean; }; attributes: { ...; }; textdomain: string; apiVersion: number; $schema: string; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;Attributes&gt;&apos;.
+      Type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { html: boolean; multiple: boolean; inserter: boolean; color: { text: boolean; background: boolean; }; lock: boolean; }; attributes: { ...; }; textdomain: string; apiVersion: number; $schema: string; }&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;Attributes&gt;, &quot;icon&quot;&gt;&gt;&apos;.
+        Types of property &apos;attributes&apos; are incompatible.
+          Property &apos;heading&apos; is missing in type &apos;{ displayStyle: { type: string; default: string; }; headingLevel: { type: string; default: number; }; }&apos; but required in type &apos;{ readonly heading: BlockAttribute&lt;string&gt;; readonly headingLevel: BlockAttribute&lt;number&gt;; readonly displayStyle: BlockAttribute&lt;string&gt;; readonly className?: BlockAttribute&lt;...&gt;; }&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;Attributes&gt;): Block&lt;Attributes&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { html: boolean; multiple: boolean; inserter: boolean; color: { text: boolean; background: boolean; }; lock: boolean; }; attributes: { ...; }; textdomain: string; apiVersion: number; $schema: string; }&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2769" />
+</file>
+<file name="assets/js/blocks/attribute-filter/checkbox-filter.tsx">
+<error line="36" column="4" severity="error" message="Type &apos;{ className: string; options: DisplayOption[] | undefined; checked: string[] | undefined; onChange: (value: string) =&gt; void; isLoading: false; isDisabled: false; }&apos; is not assignable to type &apos;CheckboxListProps&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+  Types of property &apos;checked&apos; are incompatible.
+    Type &apos;string[] | undefined&apos; is not assignable to type &apos;string[]&apos;.
+      Type &apos;undefined&apos; is not assignable to type &apos;string[]&apos;." source="TS2375" />
+</file>
+<file name="assets/js/blocks/attribute-filter/block.tsx">
+<error line="22" column="24" severity="error" message="Could not find a declaration file for module &apos;wordpress-components&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/wordpress-components/build/index.js&apos; implicitly has an &apos;any&apos; type.
+  If the &apos;@wordpress/components&apos; package actually exposes this module, consider sending a pull request to amend &apos;https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/wordpress__components&apos;" source="TS7016" />
+</file>
+<file name="assets/js/blocks/attribute-filter/edit.tsx">
+<error line="28" column="2" severity="error" message="Module &apos;&quot;@wordpress/components&quot;&apos; has no exported member &apos;__experimentalToggleGroupControl&apos;." source="TS2305" />
+<error line="30" column="2" severity="error" message="Module &apos;&quot;@wordpress/components&quot;&apos; has no exported member &apos;__experimentalToggleGroupControlOption&apos;." source="TS2305" />
+<error line="153" column="5" severity="error" message="Type &apos;{ id: number; name: string; }[]&apos; is not assignable to type &apos;SearchListItemsType&apos;.
+  Type &apos;{ id: number; name: string; }[]&apos; is not assignable to type &apos;SearchListItemType[]&apos;.
+    Type &apos;{ id: number; name: string; }&apos; is missing the following properties from type &apos;SearchListItemType&apos;: value, parent, count, children, breadcrumbs" source="TS2322" />
+<error line="154" column="5" severity="error" message="Type &apos;{ id: number; name: string; }[]&apos; is not assignable to type &apos;SearchListItemsType&apos;." source="TS2322" />
+</file>
+<file name="assets/js/blocks/attribute-filter/index.tsx">
+<error line="18" column="20" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;BlockAttributes&gt;, settings?: Partial&lt;BlockConfiguration&lt;BlockAttributes&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { html: boolean; color: { text: boolean; background: boolean; }; inserter: boolean; lock: boolean; }; ... 4 more ...; $schema: string; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;BlockAttributes&gt;&apos;.
+      Type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { html: boolean; color: { text: boolean; background: boolean; }; inserter: boolean; lock: boolean; }; ... 4 more ...; $schema: string; }&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;BlockAttributes&gt;, &quot;icon&quot;&gt;&gt;&apos;.
+        Types of property &apos;attributes&apos; are incompatible.
+          Property &apos;heading&apos; is missing in type &apos;{ className: { type: string; default: string; }; attributeId: { type: string; default: number; }; showCounts: { type: string; default: boolean; }; queryType: { type: string; default: string; }; headingLevel: { ...; }; displayStyle: { ...; }; showFilterButton: { ...; }; selectType: { ...; }; isPreview: { ...; }; }&apos; but required in type &apos;{ readonly className?: BlockAttribute&lt;string | undefined&gt;; readonly attributeId: BlockAttribute&lt;number&gt;; readonly showCounts: BlockAttribute&lt;boolean&gt;; ... 6 more ...; readonly isPreview?: BlockAttribute&lt;...&gt;; }&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;BlockAttributes&gt;): Block&lt;BlockAttributes&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { html: boolean; color: { text: boolean; background: boolean; }; inserter: boolean; lock: boolean; }; ... 4 more ...; $schema: string; }&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2769" />
+</file>
+<file name="assets/js/blocks/attribute-filter/test/block.tsx">
+<error line="19" column="33" severity="error" message="Cannot find name &apos;SetWindowUrlParams&apos;." source="TS2304" />
+<error line="154" column="26" severity="error" message="Property &apos;toBeDisabled&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="162" column="30" severity="error" message="Property &apos;toBeDisabled&apos; does not exist on type &apos;Matchers&lt;void, HTMLElement&gt;&apos;." source="TS2339" />
+<error line="168" column="28" severity="error" message="Expected 1 arguments, but got 0." source="TS2554" />
+<error line="170" column="26" severity="error" message="Property &apos;toBeDisabled&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="175" column="5" severity="error" message="Expected 1 arguments, but got 0." source="TS2554" />
+<error line="178" column="30" severity="error" message="Property &apos;toBeDisabled&apos; does not exist on type &apos;Matchers&lt;void, HTMLElement&gt;&apos;." source="TS2339" />
+<error line="185" column="30" severity="error" message="Property &apos;toBeDisabled&apos; does not exist on type &apos;Matchers&lt;void, HTMLElement&gt;&apos;." source="TS2339" />
+<error line="188" column="26" severity="error" message="Property &apos;toBeDisabled&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+</file>
+<file name="assets/js/blocks/cart/block.js">
+<error line="25" column="55" severity="error" message="Expected 0 arguments, but got 1." source="TS2554" />
+<error line="27" column="18" severity="error" message="Binding element &apos;children&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="29" column="10" severity="error" message="Property &apos;hasDarkControls&apos; does not exist on type &apos;{}&apos;." source="TS2339" />
+<error line="44" column="27" severity="error" message="Binding element &apos;scrollToTop&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="69" column="19" severity="error" message="Binding element &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="69" column="31" severity="error" message="Binding element &apos;children&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="69" column="41" severity="error" message="Binding element &apos;scrollToTop&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="84" column="3" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(props: BlockErrorBoundaryProps | Readonly&lt;BlockErrorBoundaryProps&gt;): BlockErrorBoundary&apos;, gave the following error.
+    Type &apos;unknown&apos; is not assignable to type &apos;boolean&apos;.
+  Overload 2 of 2, &apos;(props: BlockErrorBoundaryProps, context: any): BlockErrorBoundary&apos;, gave the following error.
+    Type &apos;unknown&apos; is not assignable to type &apos;boolean&apos;." source="TS2769" />
+<error line="96" column="33" severity="error" message="Argument of type &apos;({ attributes, children, scrollToTop }: { attributes: any; children: any; scrollToTop: any; }) =&gt; Element&apos; is not assignable to parameter of type &apos;FunctionComponent&lt;Record&lt;string, unknown&gt;&gt;&apos;.
+  Types of parameters &apos;__0&apos; and &apos;props&apos; are incompatible.
+    Type &apos;PropsWithChildren&lt;Record&lt;string, unknown&gt;&gt;&apos; is missing the following properties from type &apos;{ attributes: any; children: any; scrollToTop: any; }&apos;: attributes, scrollToTop" source="TS2345" />
+</file>
+<file name="assets/js/blocks/cart-checkout-shared/hacks.ts">
+<error line="58" column="44" severity="error" message="Property &apos;getSelectedBlock&apos; does not exist on type &apos;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__rich-text/store/selectors&quot;)&apos;." source="TS2339" />
+<error line="81" column="10" severity="error" message="Property &apos;getBlock&apos; does not exist on type &apos;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__rich-text/store/selectors&quot;)&apos;." source="TS2339" />
+<error line="91" column="43" severity="error" message="Property &apos;default&apos; does not exist on type &apos;BlockAttribute&lt;any&gt;&apos;.
+  Property &apos;default&apos; does not exist on type &apos;&quot;string&quot;&apos;." source="TS2339" />
+<error line="92" column="39" severity="error" message="Property &apos;default&apos; does not exist on type &apos;BlockAttribute&lt;any&gt;&apos;.
+  Property &apos;default&apos; does not exist on type &apos;&quot;string&quot;&apos;." source="TS2339" />
+<error line="175" column="2" severity="error" message="Type &apos;Omit&lt;{ ref: MutableRefObject&lt;HTMLElement | undefined&gt;; }, &quot;ref&quot;&gt; &amp; Merged &amp; Reserved&apos; is not assignable to type &apos;Record&lt;string, unknown&gt;&apos;.
+  Index signature for type &apos;string&apos; is missing in type &apos;Omit&lt;{ ref: MutableRefObject&lt;HTMLElement | undefined&gt;; }, &quot;ref&quot;&gt; &amp; Merged &amp; Reserved&apos;." source="TS2322" />
+</file>
+<file name="assets/js/blocks/cart-checkout-shared/use-forced-layout.ts">
+<error line="14" column="2" severity="error" message="Module &apos;&quot;@wordpress/blocks&quot;&apos; has no exported member &apos;createBlocksFromInnerBlocksTemplate&apos;." source="TS2305" />
+<error line="23" column="34" severity="error" message="Property &apos;remove&apos; does not exist on type &apos;Attribute&apos;.
+  Property &apos;remove&apos; does not exist on type &apos;{ source: &quot;attribute&quot;; attribute: string; selector?: string | undefined; } &amp; { type: &quot;boolean&quot;; default?: boolean | undefined; }&apos;." source="TS2339" />
+<error line="23" column="70" severity="error" message="Property &apos;remove&apos; does not exist on type &apos;string | number | boolean&apos;.
+  Property &apos;remove&apos; does not exist on type &apos;string&apos;." source="TS2339" />
+</file>
+<file name="assets/js/blocks/cart-checkout-shared/use-view-switcher.tsx">
+<error line="7" column="24" severity="error" message="Module &apos;&quot;@wordpress/components&quot;&apos; has no exported member &apos;ToolbarDropdownMenu&apos;." source="TS2305" />
+<error line="32" column="10" severity="error" message="Property &apos;getBlock&apos; does not exist on type &apos;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__rich-text/store/selectors&quot;)&apos;." source="TS2339" />
+<error line="32" column="20" severity="error" message="Property &apos;getSelectedBlockClientId&apos; does not exist on type &apos;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__rich-text/store/selectors&quot;)&apos;." source="TS2339" />
+<error line="32" column="46" severity="error" message="Property &apos;getBlockParentsByBlockName&apos; does not exist on type &apos;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__rich-text/store/selectors&quot;)&apos;." source="TS2339" />
+</file>
+<file name="assets/js/editor-components/default-notice/index.tsx">
+<error line="52" column="6" severity="error" message="Object is of type &apos;unknown&apos;." source="TS2571" />
+<error line="128" column="4" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(props: Props, context?: any): ReactElement&lt;any, any&gt; | Component&lt;Props, any, any&gt; | null&apos;, gave the following error.
+    Type &apos;{ children: string | Element; className: string; status: &quot;warning&quot; | &quot;success&quot;; onRemove: () =&gt; void; spokenMessage: string; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; Props&apos;.
+      Property &apos;spokenMessage&apos; does not exist on type &apos;IntrinsicAttributes &amp; Props&apos;.
+  Overload 2 of 2, &apos;(props: PropsWithChildren&lt;Props&gt;, context?: any): ReactElement&lt;any, any&gt; | Component&lt;Props, any, any&gt; | null&apos;, gave the following error.
+    Type &apos;{ children: string | Element; className: string; status: &quot;warning&quot; | &quot;success&quot;; onRemove: () =&gt; void; spokenMessage: string; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; Props &amp; { children?: ReactNode; }&apos;.
+      Property &apos;spokenMessage&apos; does not exist on type &apos;IntrinsicAttributes &amp; Props &amp; { children?: ReactNode; }&apos;." source="TS2769" />
+</file>
+<file name="assets/js/editor-components/feedback-prompt/index.js">
+<error line="67" column="3" severity="error" message="&apos;FeedbackPrompt&apos; cannot be used as a JSX component.
+  Its return type &apos;false | Element&apos; is not a valid JSX element.
+    Type &apos;boolean&apos; is not assignable to type &apos;Element&apos;." source="TS2786" />
+<error line="77" column="3" severity="error" message="&apos;FeedbackPrompt&apos; cannot be used as a JSX component.
+  Its return type &apos;false | Element&apos; is not a valid JSX element." source="TS2786" />
+</file>
+<file name="assets/js/blocks/cart-checkout-shared/sidebar-notices/index.tsx">
+<error line="28" column="6" severity="error" message="Cannot redeclare block-scoped variable &apos;store&apos;." source="TS2451" />
+<error line="32" column="21" severity="error" message="Parameter &apos;props&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="49" column="13" severity="error" message="Property &apos;getBlockParentsByBlockName&apos; does not exist on type &apos;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__rich-text/store/selectors&quot;)&apos;." source="TS2339" />
+<error line="49" column="41" severity="error" message="Property &apos;getBlockName&apos; does not exist on type &apos;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__rich-text/store/selectors&quot;)&apos;." source="TS2339" />
+</file>
+<file name="assets/js/blocks/cart/inner-blocks/filled-cart-block/index.tsx">
+<error line="13" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{}&gt;, settings?: Partial&lt;BlockConfiguration&lt;{}&gt;&gt; | undefined): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{}&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{}&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{}&gt;): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: ({ clientId }: { clientId: string; }) =&gt; JSX.Element; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{}&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: ({ clientId }: { clientId: string; }) =&gt; Element; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{}&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
+</file>
+<file name="assets/js/blocks/cart/inner-blocks/cart-items-block/index.tsx">
+<error line="12" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{}&gt;, settings?: Partial&lt;BlockConfiguration&lt;{}&gt;&gt; | undefined): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{}&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{}&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{}&gt;): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: ({ clientId }: Props) =&gt; JSX.Element; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{}&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: ({ clientId }: Props) =&gt; Element; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{}&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
+</file>
+<file name="assets/js/blocks/cart/inner-blocks/cart-line-items-block/index.tsx">
+<error line="12" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ className: string; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ className: string; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ className: string; }&gt;): Block&lt;{ className: string; }&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: ({ attributes, }: { attributes: { className: string; }; }) =&gt; JSX.Element; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: ({ attributes, }: { attributes: { className: string; }; }) =&gt; Element; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
+</file>
+<file name="assets/js/blocks/cart/inner-blocks/cart-cross-sells-block/index.tsx">
+<error line="13" column="20" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{}&gt;, settings?: Partial&lt;BlockConfiguration&lt;{}&gt;&gt; | undefined): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: boolean; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; }; parent: string[]; textdomain: string; apiVersion: number; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{}&gt;&apos;.
+      Property &apos;attributes&apos; is missing in type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: boolean; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; }; parent: string[]; textdomain: string; apiVersion: number; }&apos; but required in type &apos;Pick&lt;Block&lt;{}&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{}&gt;): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: boolean; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; }; parent: string[]; textdomain: string; apiVersion: number; }&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2769" />
+</file>
+<file name="assets/js/blocks/cart/cart-cross-sells-product-list/cart-cross-sells-product.tsx">
+<error line="51" column="8" severity="error" message="Type &apos;{}&apos; is missing the following properties from type &apos;BlockAttributes&apos;: productId, align, isDescendentOfQueryLoop" source="TS2739" />
+</file>
+<file name="assets/js/blocks/cart/inner-blocks/cart-cross-sells-products/index.tsx">
+<error line="13" column="20" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ className?: string; columns: number; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ className?: string; columns: number; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: boolean; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; lock: boolean; }; attributes: { ...; }; parent: string[]; textdomain: string; apiVersion: number; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className?: string; columns: number; }&gt;&apos;.
+      Type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: boolean; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; lock: boolean; }; attributes: { ...; }; parent: string[]; textdomain: string; apiVersion: number; }&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;{ className?: string; columns: number; }&gt;, &quot;icon&quot;&gt;&gt;&apos;.
+        The types of &apos;attributes.columns&apos; are incompatible between these types.
+          Type &apos;{ type: string; default: number; }&apos; is not assignable to type &apos;BlockAttribute&lt;number&gt;&apos;.
+            Type &apos;{ type: string; default: number; }&apos; is missing the following properties from type &apos;Query&lt;number&gt;&apos;: source, selector, query
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ className?: string; columns: number; }&gt;): Block&lt;{ className?: string; columns: number; }&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: boolean; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; lock: boolean; }; attributes: { ...; }; parent: string[]; textdomain: string; apiVersion: number; }&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2769" />
+</file>
+<file name="assets/js/blocks/cart/inner-blocks/cart-totals-block/index.tsx">
+<error line="12" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{}&gt;, settings?: Partial&lt;BlockConfiguration&lt;{}&gt;&gt; | undefined): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{}&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{}&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{}&gt;): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: ({ clientId }: { clientId: string; }) =&gt; JSX.Element; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{}&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: ({ clientId }: { clientId: string; }) =&gt; Element; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{}&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
+</file>
+<file name="assets/js/blocks/cart-checkout-shared/payment-methods/no-payment-methods/index.js">
+<error line="5" column="45" severity="error" message="Could not find a declaration file for module &apos;wordpress-components&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/wordpress-components/build/index.js&apos; implicitly has an &apos;any&apos; type.
+  If the &apos;@wordpress/components&apos; package actually exposes this module, consider sending a pull request to amend &apos;https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/wordpress__components&apos;" source="TS7016" />
+</file>
+<file name="assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-error-boundary.js">
+<error line="9" column="10" severity="error" message="Module &apos;&quot;@woocommerce/base-context/hooks&quot;&apos; has no exported member &apos;noticeContexts&apos;." source="TS2305" />
+<error line="14" column="35" severity="error" message="Parameter &apos;error&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+</file>
+<file name="assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-options.js">
+<error line="60" column="22" severity="error" message="No overload matches this call.
+  The last overload gave the following error.
+    Argument of type &apos;number | boolean | {} | ReactElement&lt;any, string | JSXElementConstructor&lt;any&gt;&gt; | Iterable&lt;ReactNode&gt; | ReactPortal | null | undefined&apos; is not assignable to parameter of type &apos;ReactElement&lt;any, string | JSXElementConstructor&lt;any&gt;&gt;&apos;.
+      Type &apos;undefined&apos; is not assignable to type &apos;ReactElement&lt;any, string | JSXElementConstructor&lt;any&gt;&gt;&apos;." source="TS2769" />
+<error line="65" column="24" severity="error" message="Type &apos;boolean | undefined&apos; is not assignable to type &apos;boolean&apos;." source="TS2322" />
+<error line="66" column="22" severity="error" message="No overload matches this call.
+  The last overload gave the following error.
+    Argument of type &apos;ReactNode&apos; is not assignable to parameter of type &apos;ReactElement&lt;any, string | JSXElementConstructor&lt;any&gt;&gt;&apos;.
+      Type &apos;undefined&apos; is not assignable to type &apos;ReactElement&lt;any, string | JSXElementConstructor&lt;any&gt;&gt;&apos;." source="TS2769" />
+</file>
+<file name="assets/js/blocks/cart-checkout-shared/payment-methods/saved-payment-method-options.js">
+<error line="17" column="56" severity="error" message="Namespace &apos;&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/types/type-defs/contexts&quot;&apos; has no exported member &apos;CustomerPaymentMethod&apos;." source="TS2694" />
+<error line="18" column="56" severity="error" message="Namespace &apos;&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/types/type-defs/contexts&quot;&apos; has no exported member &apos;PaymentStatusDispatch&apos;." source="TS2694" />
+<error line="89" column="19" severity="error" message="Parameter &apos;token&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="126" column="6" severity="error" message="No overload matches this call.
+  The last overload gave the following error.
+    Argument of type &apos;ReactNode&apos; is not assignable to parameter of type &apos;ReactElement&lt;any, string | JSXElementConstructor&lt;any&gt;&gt;&apos;." source="TS2769" />
+</file>
+<file name="assets/js/blocks/cart-checkout-shared/payment-methods/payment-methods.js">
+<error line="50" column="7" severity="error" message="Type &apos;string[]&apos; is not assignable to type &apos;string&apos;." source="TS2322" />
+</file>
+<file name="assets/js/blocks/cart/inner-blocks/cart-express-payment-block/edit.tsx">
+<error line="6" column="37" severity="error" message="Could not find a declaration file for module &apos;wordpress-components&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/wordpress-components/build/index.js&apos; implicitly has an &apos;any&apos; type.
+  If the &apos;@wordpress/components&apos; package actually exposes this module, consider sending a pull request to amend &apos;https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/wordpress__components&apos;" source="TS7016" />
+</file>
+<file name="assets/js/blocks/cart/inner-blocks/cart-express-payment-block/index.tsx">
+<error line="12" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ className: string; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ className: string; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ className: string; }&gt;): Block&lt;{ className: string; }&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: ({ attributes, }: { attributes: { className: string; }; }) =&gt; JSX.Element | null; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: ({ attributes, }: { attributes: { className: string; }; }) =&gt; Element | null; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
+</file>
+<file name="assets/js/editor-components/page-selector/index.js">
+<error line="12" column="26" severity="error" message="Binding element &apos;setPageId&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="12" column="37" severity="error" message="Binding element &apos;pageId&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="12" column="45" severity="error" message="Binding element &apos;labels&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="31" column="8" severity="error" message="Type &apos;number&apos; is not assignable to type &apos;string&apos;." source="TS2322" />
+<error line="33" column="7" severity="error" message="Type &apos;{ label: string; value: number; }&apos; is not assignable to type &apos;Option&apos;.
+  Types of property &apos;value&apos; are incompatible.
+    Type &apos;number&apos; is not assignable to type &apos;string&apos;." source="TS2322" />
+<error line="35" column="29" severity="error" message="Argument of type &apos;Record&lt;string, any&gt;&apos; is not assignable to parameter of type &apos;{ title: { raw: string; }; slug: string; }&apos;.
+  Type &apos;Record&lt;string, any&gt;&apos; is missing the following properties from type &apos;{ title: { raw: string; }; slug: string; }&apos;: title, slug" source="TS2345" />
+</file>
+<file name="assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/block.tsx">
+<error line="62" column="4" severity="error" message="Type &apos;{ children: string; className: string; href: unknown; disabled: boolean; onClick: () =&gt; void; showSpinner: boolean; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; ButtonProps&apos;.
+  Property &apos;href&apos; does not exist on type &apos;IntrinsicAttributes &amp; ButtonProps&apos;." source="TS2322" />
+</file>
+<file name="assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/edit.tsx">
+<error line="47" column="21" severity="error" message="Parameter &apos;id&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+</file>
+<file name="assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/index.tsx">
+<error line="13" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ checkoutPageId: number; className: string; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ checkoutPageId: number; className: string; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ checkoutPageId: number; className: string; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ checkoutPageId: number; className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ checkoutPageId: number; className: string; }&gt;): Block&lt;{ checkoutPageId: number; className: string; }&gt; | undefined&apos;, gave the following error.
+    Property &apos;className&apos; is missing in type &apos;{ checkoutPageId: { type: string; default: number; }; lock: { type: string; default: { move: boolean; remove: boolean; }; }; }&apos; but required in type &apos;{ readonly checkoutPageId: BlockAttribute&lt;number&gt;; readonly className: BlockAttribute&lt;string&gt;; }&apos;." source="TS2769" />
+</file>
+<file name="assets/js/blocks/cart/inner-blocks/empty-cart-block/index.tsx">
+<error line="13" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{}&gt;, settings?: Partial&lt;BlockConfiguration&lt;{}&gt;&gt; | undefined): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{}&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{}&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{}&gt;): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: ({ clientId }: { clientId: string; }) =&gt; JSX.Element; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{}&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: ({ clientId }: { clientId: string; }) =&gt; Element; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{}&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
+</file>
+<file name="assets/js/blocks/cart/inner-blocks/cart-accepted-payment-methods-block/block.tsx">
+<error line="14" column="40" severity="error" message="Argument of type &apos;EmptyObjectType | Record&lt;string, PaymentMethodConfigInstance&gt; | Record&lt;string, ExpressPaymentMethodConfigInstance&gt;&apos; is not assignable to parameter of type &apos;PaymentMethods&apos;.
+  Type &apos;Record&lt;string, ExpressPaymentMethodConfigInstance&gt;&apos; is not assignable to type &apos;PaymentMethods&apos;." source="TS2345" />
+</file>
+<file name="assets/js/blocks/cart/inner-blocks/cart-accepted-payment-methods-block/index.tsx">
+<error line="12" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ className: string; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ className: string; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ className: string; }&gt;): Block&lt;{ className: string; }&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: ({ attributes, }: { attributes: { className: string; }; }) =&gt; JSX.Element; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: ({ attributes, }: { attributes: { className: string; }; }) =&gt; Element; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
+</file>
+<file name="assets/js/blocks/cart/inner-blocks/cart-order-summary-block/index.tsx">
+<error line="13" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{}&gt;, settings?: Partial&lt;BlockConfiguration&lt;{}&gt;&gt; | undefined): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{}&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{}&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{}&gt;): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: ({ clientId }: { clientId: string; }) =&gt; JSX.Element; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{}&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: ({ clientId }: { clientId: string; }) =&gt; Element; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{}&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
+</file>
+<file name="assets/js/blocks/cart/inner-blocks/cart-order-summary-subtotal/index.tsx">
+<error line="13" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ className: string; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ className: string; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ className: string; }&gt;): Block&lt;{ className: string; }&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: ({ attributes, }: { attributes: { className: string; }; setAttributes: (attributes: Record&lt;string, unknown&gt;) =&gt; void; }) =&gt; JSX.Element; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: ({ attributes, }: { attributes: { className: string; }; setAttributes: (attributes: Record&lt;string, unknown&gt;) =&gt; void; }) =&gt; Element; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
+</file>
+<file name="assets/js/blocks/cart/inner-blocks/cart-order-summary-fee/index.tsx">
+<error line="13" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ className: string; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ className: string; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ className: string; }&gt;): Block&lt;{ className: string; }&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: ({ attributes, }: { attributes: { className: string; }; setAttributes: (attributes: Record&lt;string, unknown&gt;) =&gt; void; }) =&gt; JSX.Element; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: ({ attributes, }: { attributes: { className: string; }; setAttributes: (attributes: Record&lt;string, unknown&gt;) =&gt; void; }) =&gt; Element; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
+</file>
+<file name="assets/js/blocks/cart/inner-blocks/cart-order-summary-discount/index.tsx">
+<error line="13" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ className: string; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ className: string; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ className: string; }&gt;): Block&lt;{ className: string; }&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: ({ attributes, }: { attributes: { className: string; }; setAttributes: (attributes: Record&lt;string, unknown&gt;) =&gt; void; }) =&gt; JSX.Element; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: ({ attributes, }: { attributes: { className: string; }; setAttributes: (attributes: Record&lt;string, unknown&gt;) =&gt; void; }) =&gt; Element; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
+</file>
+<file name="assets/js/blocks/cart/inner-blocks/cart-order-summary-shipping/index.tsx">
+<error line="14" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ isShippingCalculatorEnabled: boolean; className: string; lock: { move: boolean; remove: boolean; }; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ isShippingCalculatorEnabled: boolean; className: string; lock: { ...; }; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ isShippingCalculatorEnabled: boolean; className: string; lock: { move: boolean; remove: boolean; }; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ isShippingCalculatorEnabled: boolean; className: string; lock: { move: boolean; remove: boolean; }; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ isShippingCalculatorEnabled: boolean; className: string; lock: { move: boolean; remove: boolean; }; }&gt;): Block&lt;{ isShippingCalculatorEnabled: boolean; className: string; lock: { ...; }; }&gt; | undefined&apos;, gave the following error.
+    Property &apos;className&apos; is missing in type &apos;{ isShippingCalculatorEnabled: { type: string; default: unknown; }; lock: { type: string; default: { move: boolean; remove: boolean; }; }; }&apos; but required in type &apos;{ readonly isShippingCalculatorEnabled: BlockAttribute&lt;boolean&gt;; readonly className: BlockAttribute&lt;string&gt;; readonly lock: BlockAttribute&lt;{ move: boolean; remove: boolean; }&gt;; }&apos;." source="TS2769" />
+</file>
+<file name="assets/js/blocks/cart/inner-blocks/cart-order-summary-coupon-form/index.tsx">
+<error line="12" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ className: string; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ className: string; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ className: string; }&gt;): Block&lt;{ className: string; }&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: ({ attributes, }: { attributes: { className: string; }; setAttributes: (attributes: Record&lt;string, unknown&gt;) =&gt; void; }) =&gt; JSX.Element; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: ({ attributes, }: { attributes: { className: string; }; setAttributes: (attributes: Record&lt;string, unknown&gt;) =&gt; void; }) =&gt; Element; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
+</file>
+<file name="assets/js/blocks/cart/inner-blocks/cart-order-summary-taxes/index.tsx">
+<error line="14" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ className: string; showRateAfterTaxName: boolean; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ className: string; showRateAfterTaxName: boolean; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; showRateAfterTaxName: boolean; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ className: string; showRateAfterTaxName: boolean; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ className: string; showRateAfterTaxName: boolean; }&gt;): Block&lt;{ className: string; showRateAfterTaxName: boolean; }&gt; | undefined&apos;, gave the following error.
+    Property &apos;className&apos; is missing in type &apos;{ showRateAfterTaxName: { type: string; default: unknown; }; lock: { type: string; default: { remove: boolean; move: boolean; }; }; }&apos; but required in type &apos;{ readonly className: BlockAttribute&lt;string&gt;; readonly showRateAfterTaxName: BlockAttribute&lt;boolean&gt;; }&apos;." source="TS2769" />
+</file>
+<file name="assets/js/blocks/cart/inner-blocks/cart-order-summary-heading/index.tsx">
+<error line="13" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ content: string; className: string; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ content: string; className: string; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ content: string; className: string; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ content: string; className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ content: string; className: string; }&gt;): Block&lt;{ content: string; className: string; }&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: ({ attributes, setAttributes, }: { attributes: { content: string; className: string; }; setAttributes: (attributes: Record&lt;string, unknown&gt;) =&gt; void; }) =&gt; JSX.Element; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ content: string; className: string; }&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: ({ attributes, setAttributes, }: { attributes: { content: string; className: string; }; setAttributes: (attributes: Record&lt;string, unknown&gt;) =&gt; void; }) =&gt; Element; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{ content: string; className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
+</file>
+<file name="assets/js/blocks/cart/edit.js">
+<error line="56" column="25" severity="error" message="Binding element &apos;className&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="56" column="36" severity="error" message="Binding element &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="56" column="48" severity="error" message="Binding element &apos;setAttributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="56" column="63" severity="error" message="Binding element &apos;clientId&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="74" column="3" severity="error" message="Type &apos;{}[][]&apos; is not assignable to type &apos;TemplateArray&apos;.
+  Type &apos;{}[]&apos; is not assignable to type &apos;Template&apos;.
+    Target requires 1 element(s) but source may have fewer." source="TS2322" />
+<error line="113" column="9" severity="error" message="Type &apos;{}[][]&apos; is not assignable to type &apos;readonly Template[]&apos;." source="TS2322" />
+</file>
+<file name="assets/js/blocks/cart/inner-blocks/cart-items-block/frontend.tsx">
+<error line="15" column="4" severity="error" message="Type &apos;{ children: Element; className: string; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; RefAttributes&lt;any&gt;&apos;.
+  Property &apos;children&apos; does not exist on type &apos;IntrinsicAttributes &amp; RefAttributes&lt;any&gt;&apos;." source="TS2322" />
+</file>
+<file name="assets/js/blocks/cart/inner-blocks/cart-totals-block/frontend.tsx">
+<error line="20" column="4" severity="error" message="Type &apos;{ children: Element | Element[]; className: string; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; RefAttributes&lt;any&gt;&apos;.
+  Property &apos;children&apos; does not exist on type &apos;IntrinsicAttributes &amp; RefAttributes&lt;any&gt;&apos;." source="TS2322" />
+</file>
+<file name="assets/js/blocks/cart/inner-blocks/register-components.ts">
+<error line="18" column="2" severity="error" message="Type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: string[]; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; lock: boolean; }; ... 4 more ...; apiVersion: number; }&apos; is not assignable to type &apos;CheckoutBlockOptionsMetadata&apos;.
+  The types of &apos;supports.align&apos; are incompatible between these types.
+    Type &apos;string[]&apos; is not assignable to type &apos;boolean | readonly BlockAlignment[] | undefined&apos;.
+      Type &apos;string[]&apos; is not assignable to type &apos;readonly BlockAlignment[]&apos;.
+        Type &apos;string&apos; is not assignable to type &apos;BlockAlignment&apos;." source="TS2322" />
+<error line="19" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ children, className, }: { children: Element | Element[]; className: string; }) =&gt; Element | null&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
+  Type &apos;LazyExoticComponent&lt;({ children, className, }: { children: Element | Element[]; className: string; }) =&gt; Element | null&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos;.
+    Type &apos;LazyExoticComponent&lt;({ children, className, }: { children: Element | Element[]; className: string; }) =&gt; Element | null&gt;&apos; is not assignable to type &apos;ExoticComponent&lt;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&gt;&apos;.
+      Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
+        Type &apos;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos; is not assignable to type &apos;{ children: Element | Element[]; className: string; }&apos;.
+          Property &apos;className&apos; is missing in type &apos;{ children?: ReactNode; }&apos; but required in type &apos;{ children: Element | Element[]; className: string; }&apos;." source="TS2322" />
+<error line="29" column="2" severity="error" message="Type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: string[]; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; lock: boolean; }; ... 4 more ...; apiVersion: number; }&apos; is not assignable to type &apos;CheckoutBlockOptionsMetadata&apos;.
+  The types of &apos;supports.align&apos; are incompatible between these types.
+    Type &apos;string[]&apos; is not assignable to type &apos;boolean | readonly BlockAlignment[] | undefined&apos;." source="TS2322" />
+<error line="30" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ children, className, }: { children: Element; className: string; }) =&gt; Element | null&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
+  Type &apos;LazyExoticComponent&lt;({ children, className, }: { children: Element; className: string; }) =&gt; Element | null&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos;.
+    Type &apos;LazyExoticComponent&lt;({ children, className, }: { children: Element; className: string; }) =&gt; Element | null&gt;&apos; is not assignable to type &apos;ExoticComponent&lt;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&gt;&apos;.
+      Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
+        Type &apos;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos; is not assignable to type &apos;{ children: Element; className: string; }&apos;.
+          Property &apos;className&apos; is missing in type &apos;{ children?: ReactNode; }&apos; but required in type &apos;{ children: Element; className: string; }&apos;." source="TS2322" />
+<error line="41" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ children, className, }: { children: Element; className: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
+  Type &apos;LazyExoticComponent&lt;({ children, className, }: { children: Element; className: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos;.
+    Type &apos;LazyExoticComponent&lt;({ children, className, }: { children: Element; className: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;ExoticComponent&lt;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&gt;&apos;.
+      Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
+        Type &apos;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos; is not assignable to type &apos;{ children: Element; className: string; }&apos;.
+          Property &apos;className&apos; is missing in type &apos;{ children?: ReactNode; }&apos; but required in type &apos;{ children: Element; className: string; }&apos;." source="TS2322" />
+<error line="52" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ className }: { className: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
+  Type &apos;LazyExoticComponent&lt;({ className }: { className: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos;.
+    Type &apos;LazyExoticComponent&lt;({ className }: { className: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;ExoticComponent&lt;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&gt;&apos;.
+      Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
+        Type &apos;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos; is not assignable to type &apos;{ className: string; }&apos;.
+          Property &apos;className&apos; is missing in type &apos;{ children?: ReactNode; }&apos; but required in type &apos;{ className: string; }&apos;." source="TS2322" />
+<error line="63" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ children, className, }: Props) =&gt; Element | null&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
+  Type &apos;LazyExoticComponent&lt;({ children, className, }: Props) =&gt; Element | null&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos;.
+    Type &apos;LazyExoticComponent&lt;({ children, className, }: Props) =&gt; Element | null&gt;&apos; is not assignable to type &apos;ExoticComponent&lt;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&gt;&apos;.
+      Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
+        Type &apos;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos; is not assignable to type &apos;Props&apos;.
+          Type &apos;{ children?: ReactNode; }&apos; is not assignable to type &apos;Props&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+            Types of property &apos;children&apos; are incompatible.
+              Type &apos;ReactNode&apos; is not assignable to type &apos;Element | Element[]&apos;.
+                Type &apos;undefined&apos; is not assignable to type &apos;Element | Element[]&apos;." source="TS2322" />
+<error line="74" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ className, columns }: BlockProps) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
+  Type &apos;LazyExoticComponent&lt;({ className, columns }: BlockProps) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos;.
+    Type &apos;LazyExoticComponent&lt;({ className, columns }: BlockProps) =&gt; Element&gt;&apos; is not assignable to type &apos;ExoticComponent&lt;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&gt;&apos;.
+      Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
+        Type &apos;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos; is not assignable to type &apos;BlockProps&apos;.
+          Property &apos;columns&apos; is missing in type &apos;{ children?: ReactNode; }&apos; but required in type &apos;BlockProps&apos;." source="TS2322" />
+<error line="85" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ children, className, }: { children: Element | Element[]; className?: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
+  Type &apos;LazyExoticComponent&lt;({ children, className, }: { children: Element | Element[]; className?: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos;.
+    Type &apos;LazyExoticComponent&lt;({ children, className, }: { children: Element | Element[]; className?: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;ExoticComponent&lt;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&gt;&apos;.
+      Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
+        Type &apos;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos; is not assignable to type &apos;{ children: Element | Element[]; className?: string; }&apos;.
+          Type &apos;{ children?: ReactNode; }&apos; is not assignable to type &apos;{ children: Element | Element[]; className?: string; }&apos;.
+            Types of property &apos;children&apos; are incompatible.
+              Type &apos;ReactNode&apos; is not assignable to type &apos;Element | Element[]&apos;." source="TS2322" />
+<error line="96" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ className }: { className: string; }) =&gt; Element | null&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
+  Type &apos;LazyExoticComponent&lt;({ className }: { className: string; }) =&gt; Element | null&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos;.
+    Type &apos;LazyExoticComponent&lt;({ className }: { className: string; }) =&gt; Element | null&gt;&apos; is not assignable to type &apos;ExoticComponent&lt;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&gt;&apos;.
+      Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
+        Type &apos;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos; is not assignable to type &apos;{ className: string; }&apos;.
+          Property &apos;className&apos; is missing in type &apos;{ children?: ReactNode; }&apos; but required in type &apos;{ className: string; }&apos;." source="TS2322" />
+<error line="118" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ className }: { className: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
+  Type &apos;LazyExoticComponent&lt;({ className }: { className: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos;.
+    Type &apos;LazyExoticComponent&lt;({ className }: { className: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;ExoticComponent&lt;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&gt;&apos;.
+      Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
+        Type &apos;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos; is not assignable to type &apos;{ className: string; }&apos;.
+          Property &apos;className&apos; is missing in type &apos;{ children?: ReactNode; }&apos; but required in type &apos;{ className: string; }&apos;." source="TS2322" />
+<error line="129" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ children, className, }: { children?: Element | Element[]; className?: string; }) =&gt; Element | null&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
+  Type &apos;LazyExoticComponent&lt;({ children, className, }: { children?: Element | Element[]; className?: string; }) =&gt; Element | null&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos;.
+    Type &apos;LazyExoticComponent&lt;({ children, className, }: { children?: Element | Element[]; className?: string; }) =&gt; Element | null&gt;&apos; is not assignable to type &apos;ExoticComponent&lt;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&gt;&apos;.
+      Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
+        Type &apos;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos; is not assignable to type &apos;{ children?: Element | Element[]; className?: string; }&apos;.
+          Type &apos;{ children?: ReactNode; }&apos; is not assignable to type &apos;{ children?: Element | Element[]; className?: string; }&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+            Types of property &apos;children&apos; are incompatible.
+              Type &apos;ReactNode&apos; is not assignable to type &apos;Element | Element[]&apos;." source="TS2322" />
+<error line="151" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ className }: { className?: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
+  Type &apos;LazyExoticComponent&lt;({ className }: { className?: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos;.
+    Type &apos;LazyExoticComponent&lt;({ className }: { className?: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;ExoticComponent&lt;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&gt;&apos;.
+      Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
+        Type &apos;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos; is not assignable to type &apos;{ className?: string; }&apos;.
+          Type &apos;{ children?: ReactNode; }&apos; has no properties in common with type &apos;{ className?: string; }&apos;." source="TS2322" />
+<error line="162" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ className }: { className: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
+  Type &apos;LazyExoticComponent&lt;({ className }: { className: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos;.
+    Type &apos;LazyExoticComponent&lt;({ className }: { className: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;ExoticComponent&lt;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&gt;&apos;.
+      Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
+        Type &apos;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos; is not assignable to type &apos;{ className: string; }&apos;.
+          Property &apos;className&apos; is missing in type &apos;{ children?: ReactNode; }&apos; but required in type &apos;{ className: string; }&apos;." source="TS2322" />
+<error line="173" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ className }: { className: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
+  Type &apos;LazyExoticComponent&lt;({ className }: { className: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos;.
+    Type &apos;LazyExoticComponent&lt;({ className }: { className: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;ExoticComponent&lt;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&gt;&apos;.
+      Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
+        Type &apos;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos; is not assignable to type &apos;{ className: string; }&apos;.
+          Property &apos;className&apos; is missing in type &apos;{ children?: ReactNode; }&apos; but required in type &apos;{ className: string; }&apos;." source="TS2322" />
+<error line="184" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ className }: { className: string; }) =&gt; Element | null&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
+  Type &apos;LazyExoticComponent&lt;({ className }: { className: string; }) =&gt; Element | null&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos;.
+    Type &apos;LazyExoticComponent&lt;({ className }: { className: string; }) =&gt; Element | null&gt;&apos; is not assignable to type &apos;ExoticComponent&lt;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&gt;&apos;.
+      Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
+        Type &apos;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos; is not assignable to type &apos;{ className: string; }&apos;.
+          Property &apos;className&apos; is missing in type &apos;{ children?: ReactNode; }&apos; but required in type &apos;{ className: string; }&apos;." source="TS2322" />
+</file>
+<file name="assets/js/blocks/cart/frontend.js">
+<error line="18" column="20" severity="error" message="Parameter &apos;el&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="27" column="21" severity="error" message="Binding element &apos;children&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+</file>
+<file name="assets/js/blocks/cart/index.js">
+<error line="51" column="14" severity="error" message="Binding element &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="63" column="15" severity="error" message="Parameter &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="63" column="27" severity="error" message="Parameter &apos;innerBlocks&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="103" column="18" severity="error" message="Parameter &apos;_&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="103" column="21" severity="error" message="Parameter &apos;innerBlocks&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="105" column="8" severity="error" message="Parameter &apos;block&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="112" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;any&gt;, settings?: Partial&lt;BlockConfiguration&lt;any&gt;&gt; | undefined): Block&lt;any&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;any&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;any&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;any&gt;): Block&lt;any&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ title: string; icon: { src: Element; }; category: string; keywords: string[]; description: string; supports: { align: string[]; html: boolean; multiple: boolean; }; example: { attributes: { isPreview: boolean; }; }; attributes: { ...; }; edit: ({ className, attributes, setAttributes, clientId }: { ...; }) =&gt; Eleme...&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;any&gt;&apos;.
+      Type &apos;{ title: string; icon: { src: Element; }; category: string; keywords: string[]; description: string; supports: { align: string[]; html: boolean; multiple: boolean; }; example: { attributes: { isPreview: boolean; }; }; attributes: { ...; }; edit: ({ className, attributes, setAttributes, clientId }: { ...; }) =&gt; Eleme...&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;any&gt;, &quot;icon&quot;&gt;&gt;&apos;.
+        Types of property &apos;attributes&apos; are incompatible.
+          Type &apos;{ isPreview: { type: string; default: boolean; save: boolean; }; hasDarkControls: { type: string; default: any; }; isShippingCalculatorEnabled: { type: string; default: any; }; checkoutPageId: { type: string; default: number; }; showRateAfterTaxName: { ...; }; align: { ...; }; }&apos; is not assignable to type &apos;{ readonly [x: string]: BlockAttribute&lt;any&gt;; }&apos;.
+            Property &apos;isPreview&apos; is incompatible with index signature.
+              Type &apos;{ type: string; default: boolean; save: boolean; }&apos; is not assignable to type &apos;BlockAttribute&lt;any&gt;&apos;.
+                Type &apos;{ type: string; default: boolean; save: boolean; }&apos; is missing the following properties from type &apos;Query&lt;any&gt;&apos;: source, selector, query" source="TS2769" />
+</file>
+<file name="node_modules/@jest/test-result/build/index.d.ts">
+<error line="11" column="14" severity="error" message="Module &apos;&quot;jest-haste-map&quot;&apos; has no exported member &apos;IHasteFS&apos;. Did you mean to use &apos;import IHasteFS from &quot;jest-haste-map&quot;&apos; instead?" source="TS2614" />
+</file>
+<file name="assets/js/blocks/cart/test/block.js">
+<error line="49" column="5" severity="error" message="Property &apos;className&apos; is missing in type &apos;{ children: Element[]; }&apos; but required in type &apos;{ children: Element | Element[]; className: string; }&apos;." source="TS2741" />
+<error line="50" column="6" severity="error" message="Property &apos;className&apos; is missing in type &apos;{ children: Element; }&apos; but required in type &apos;{ children: Element; className: string; }&apos;." source="TS2741" />
+<error line="51" column="7" severity="error" message="Property &apos;className&apos; is missing in type &apos;{}&apos; but required in type &apos;{ className: string; }&apos;." source="TS2741" />
+<error line="66" column="7" severity="error" message="Property &apos;className&apos; is missing in type &apos;{}&apos; but required in type &apos;{ className: string; }&apos;." source="TS2741" />
+<error line="67" column="7" severity="error" message="Property &apos;className&apos; is missing in type &apos;{ checkoutPageId: number; }&apos; but required in type &apos;{ checkoutPageId: number; className: string; }&apos;." source="TS2741" />
+<error line="68" column="7" severity="error" message="Property &apos;className&apos; is missing in type &apos;{}&apos; but required in type &apos;{ className: string; }&apos;." source="TS2741" />
+<error line="71" column="5" severity="error" message="Property &apos;className&apos; is missing in type &apos;{ children: Element; }&apos; but required in type &apos;{ children: Element; className: string; }&apos;." source="TS2741" />
+<error line="88" column="25" severity="error" message="Property &apos;invalidateResolutionForStore&apos; does not exist on type &apos;DispatchFromMap&lt;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/data/cart/actions&quot;)&gt;&apos;." source="TS2339" />
+<error line="89" column="38" severity="error" message="Argument of type &apos;Cart&apos; is not assignable to parameter of type &apos;CartResponse&apos;.
+  Type &apos;Cart&apos; is missing the following properties from type &apos;CartResponse&apos;: shipping_rates, shipping_address, billing_address, items_count, and 6 more." source="TS2345" />
+<error line="103" column="5" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="115" column="40" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="122" column="48" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="129" column="45" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="140" column="46" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="151" column="5" severity="error" message="Type &apos;{ showRateAfterTaxName: true; }&apos; is missing the following properties from type &apos;{ showRateAfterTaxName: boolean; isShippingCalculatorEnabled: boolean; checkoutPageId: number; }&apos;: isShippingCalculatorEnabled, checkoutPageId" source="TS2739" />
+<error line="157" column="50" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="174" column="47" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="179" column="27" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(fn: MockResponseInitFunction): FetchMock&apos;, gave the following error.
+    Argument of type &apos;(req: Request) =&gt; Promise&lt;string&gt; | undefined&apos; is not assignable to parameter of type &apos;MockResponseInitFunction&apos;.
+      Type &apos;Promise&lt;string&gt; | undefined&apos; is not assignable to type &apos;Promise&lt;string | MockResponseInit&gt;&apos;.
+        Type &apos;undefined&apos; is not assignable to type &apos;Promise&lt;string | MockResponseInit&gt;&apos;.
+  Overload 2 of 2, &apos;(response: string, responseInit?: MockParams | undefined): FetchMock&apos;, gave the following error.
+    Argument of type &apos;(req: Request) =&gt; Promise&lt;string&gt; | undefined&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2769" />
+<error line="206" column="48" severity="error" message="Property &apos;toHaveTextContent&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="227" column="25" severity="error" message="Property &apos;value&apos; does not exist on type &apos;HTMLElement&apos;." source="TS2339" />
+<error line="233" column="25" severity="error" message="Property &apos;value&apos; does not exist on type &apos;HTMLElement&apos;." source="TS2339" />
+<error line="244" column="4" severity="error" message="Type &apos;&lt;T&gt;(value: T, extensions: Record&lt;string, unknown&gt;, { cartItem }: CheckoutFilterArguments | undefined) =&gt; boolean&apos; is not assignable to type &apos;CheckoutFilterFunction&apos;.
+  Type &apos;boolean&apos; is not assignable to type &apos;T&apos;.
+    &apos;T&apos; could be instantiated with an arbitrary type which could be unrelated to &apos;boolean&apos;." source="TS2322" />
+<error line="244" column="47" severity="error" message="Property &apos;cartItem&apos; does not exist on type &apos;CheckoutFilterArguments | undefined&apos;." source="TS2339" />
+</file>
+<file name="assets/js/blocks/cart/test/slots.js">
+<error line="11" column="32" severity="error" message="Could not find a declaration file for module &apos;@wordpress/plugins&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@wordpress/plugins/build/index.js&apos; implicitly has an &apos;any&apos; type.
+  Try `npm i --save-dev @types/wordpress__plugins` if it exists or add a new declaration (.d.ts) file containing `declare module &apos;@wordpress/plugins&apos;;`" source="TS7016" />
+<error line="20" column="30" severity="error" message="Binding element &apos;cart&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="39" column="7" severity="error" message="Property &apos;cart&apos; is missing in type &apos;{}&apos; but required in type &apos;{ cart: any; }&apos;." source="TS2741" />
+<error line="54" column="25" severity="error" message="Property &apos;invalidateResolutionForStore&apos; does not exist on type &apos;DispatchFromMap&lt;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/data/cart/actions&quot;)&gt;&apos;." source="TS2339" />
+<error line="55" column="38" severity="error" message="Argument of type &apos;Cart&apos; is not assignable to parameter of type &apos;CartResponse&apos;." source="TS2345" />
+<error line="64" column="27" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(fn: MockResponseInitFunction): FetchMock&apos;, gave the following error.
+    Argument of type &apos;(req: Request) =&gt; Promise&lt;string&gt; | undefined&apos; is not assignable to parameter of type &apos;MockResponseInitFunction&apos;.
+      Type &apos;Promise&lt;string&gt; | undefined&apos; is not assignable to type &apos;Promise&lt;string | MockResponseInit&gt;&apos;.
+        Type &apos;undefined&apos; is not assignable to type &apos;Promise&lt;string | MockResponseInit&gt;&apos;.
+  Overload 2 of 2, &apos;(response: string, responseInit?: MockParams | undefined): FetchMock&apos;, gave the following error.
+    Argument of type &apos;(req: Request) =&gt; Promise&lt;string&gt; | undefined&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2769" />
+<error line="82" column="5" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+</file>
+<file name="assets/js/blocks/cart-checkout-shared/payment-methods/test/payment-methods.js">
+<error line="22" column="57" severity="error" message="Binding element &apos;onChange&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="34" column="7" severity="error" message="Binding element &apos;onChange&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="50" column="8" severity="error" message="This condition will always return &apos;false&apos; since the types &apos;&quot;core/editor&quot;&apos; and &apos;&quot;wc/store/payment&quot;&apos; have no overlap." source="TS2367" />
+<error line="104" column="5" severity="error" message="Property &apos;invalidateResolutionForStore&apos; does not exist on type &apos;DispatchFromMap&lt;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/data/cart/actions&quot;)&gt;&apos;." source="TS2339" />
+<error line="107" column="18" severity="error" message="Argument of type &apos;Cart&apos; is not assignable to parameter of type &apos;CartResponse&apos;." source="TS2345" />
+</file>
+<file name="assets/js/blocks/checkout/checkout-order-error/index.js">
+<error line="80" column="46" severity="error" message="Property &apos;code&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="99" column="26" severity="error" message="Property &apos;message&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="101" column="46" severity="error" message="Property &apos;code&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="124" column="46" severity="error" message="Property &apos;code&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+</file>
+<file name="assets/js/blocks/checkout/utils.ts">
+<error line="15" column="68" severity="error" message="Expected 0 arguments, but got 1." source="TS2554" />
+</file>
+<file name="assets/js/blocks/checkout/block.tsx">
+<error line="95" column="4" severity="error" message="Type &apos;{ allowCreateAccount: boolean; showCompanyField: boolean; requireCompanyField: boolean; showApartmentField: boolean; showPhoneField: boolean; requirePhoneField: boolean; }&apos; is missing the following properties from type &apos;CheckoutBlockContextProps&apos;: showOrderNotes, showPolicyLinks, showReturnToCart, cartPageId, showRateAfterTaxName" source="TS2739" />
+<error line="184" column="4" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(props: BlockErrorBoundaryProps | Readonly&lt;BlockErrorBoundaryProps&gt;): BlockErrorBoundary&apos;, gave the following error.
+    Type &apos;unknown&apos; is not assignable to type &apos;boolean&apos;.
+  Overload 2 of 2, &apos;(props: BlockErrorBoundaryProps, context: any): BlockErrorBoundary&apos;, gave the following error.
+    Type &apos;unknown&apos; is not assignable to type &apos;boolean&apos;." source="TS2769" />
+<error line="207" column="33" severity="error" message="Argument of type &apos;({ attributes, children, scrollToTop, }: { attributes: Attributes; children: React.ReactChildren; scrollToTop: (props: Record&lt;string, unknown&gt;) =&gt; void; }) =&gt; JSX.Element&apos; is not assignable to parameter of type &apos;FunctionComponent&lt;Record&lt;string, unknown&gt;&gt;&apos;.
+  Types of parameters &apos;__0&apos; and &apos;props&apos; are incompatible.
+    Type &apos;PropsWithChildren&lt;Record&lt;string, unknown&gt;&gt;&apos; is missing the following properties from type &apos;{ attributes: Attributes; children: ReactChildren; scrollToTop: (props: Record&lt;string, unknown&gt;) =&gt; void; }&apos;: attributes, scrollToTop" source="TS2345" />
+</file>
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-fields-block/index.tsx">
+<error line="12" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ className?: string; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ className?: string; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className?: string; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ className?: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ className?: string; }&gt;): Block&lt;{ className?: string; }&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: ({ clientId, attributes, }: { clientId: string; attributes: { className?: string; }; }) =&gt; JSX.Element; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className?: string; }&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: ({ clientId, attributes, }: { clientId: string; attributes: { className?: string; }; }) =&gt; Element; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{ className?: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
+</file>
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-totals-block/index.tsx">
+<error line="12" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ className?: string; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ className?: string; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className?: string; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ className?: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ className?: string; }&gt;): Block&lt;{ className?: string; }&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: ({ clientId, attributes, }: { clientId: string; attributes: { className?: string; }; }) =&gt; JSX.Element; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className?: string; }&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: ({ clientId, attributes, }: { clientId: string; attributes: { className?: string; }; }) =&gt; Element; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{ className?: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
+</file>
+<file name="assets/js/blocks/checkout/form-step/additional-fields.tsx">
+<error line="21" column="19" severity="error" message="Argument of type &apos;{ clientId: string; registeredBlocks: string[]; }&apos; is not assignable to parameter of type &apos;{ clientId: string; registeredBlocks: string[]; defaultTemplate: TemplateArray; }&apos;.
+  Property &apos;defaultTemplate&apos; is missing in type &apos;{ clientId: string; registeredBlocks: string[]; }&apos; but required in type &apos;{ clientId: string; registeredBlocks: string[]; defaultTemplate: TemplateArray; }&apos;." source="TS2345" />
+</file>
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/index.tsx">
+<error line="13" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt;): Block&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt; | undefined&apos;, gave the following error.
+    Type &apos;{ className: { type: string; default: string; }; lock: { type: string; default: { move: boolean; remove: boolean; }; }; }&apos; is missing the following properties from type &apos;{ readonly title: BlockAttribute&lt;string&gt;; readonly description: BlockAttribute&lt;string&gt;; readonly showStepNumber: BlockAttribute&lt;boolean&gt;; readonly className: BlockAttribute&lt;...&gt;; }&apos;: title, description, showStepNumber" source="TS2769" />
+</file>
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-terms-block/edit.tsx">
+<error line="62" column="8" severity="error" message="Property &apos;onChange&apos; is missing in type &apos;{ id: string; checked: false; }&apos; but required in type &apos;CheckboxControlProps&apos;." source="TS2741" />
+<error line="89" column="6" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(props: Props, context?: any): ReactElement&lt;any, any&gt; | Component&lt;Props, any, any&gt; | null&apos;, gave the following error.
+    Type &apos;{ className: string; label: Element; onClick: () =&gt; Window | null; }[]&apos; is not assignable to type &apos;readonly Action[]&apos;.
+      Type &apos;{ className: string; label: JSX.Element; onClick: () =&gt; Window | null; }&apos; is not assignable to type &apos;Action&apos;.
+        Type &apos;{ className: string; label: JSX.Element; onClick: () =&gt; Window | null; }&apos; is not assignable to type &apos;ButtonAction&apos;.
+          Types of property &apos;label&apos; are incompatible.
+            Type &apos;Element&apos; is not assignable to type &apos;string&apos;.
+  Overload 2 of 2, &apos;(props: PropsWithChildren&lt;Props&gt;, context?: any): ReactElement&lt;any, any&gt; | Component&lt;Props, any, any&gt; | null&apos;, gave the following error.
+    Type &apos;{ className: string; label: Element; onClick: () =&gt; Window | null; }[]&apos; is not assignable to type &apos;readonly Action[]&apos;." source="TS2769" />
+</file>
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-terms-block/index.tsx">
+<error line="11" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ text: string; checkbox: boolean; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ text: string; checkbox: boolean; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ text: string; checkbox: boolean; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ text: string; checkbox: boolean; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ text: string; checkbox: boolean; }&gt;): Block&lt;{ text: string; checkbox: boolean; }&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: ({ attributes: { checkbox, text }, setAttributes, }: { attributes: { text: string; checkbox: boolean; }; setAttributes: (attributes: Record&lt;string, unknown&gt;) =&gt; void; }) =&gt; JSX.Element; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ text: string; checkbox: boolean; }&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: ({ attributes: { checkbox, text }, setAttributes, }: { attributes: { text: string; checkbox: boolean; }; setAttributes: (attributes: Record&lt;string, unknown&gt;) =&gt; void; }) =&gt; Element; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{ text: string; checkbox: boolean; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
+</file>
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/index.tsx">
+<error line="13" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt;): Block&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt; | undefined&apos;, gave the following error.
+    Type &apos;{ className: { type: string; default: string; }; lock: { type: string; default: { remove: boolean; move: boolean; }; }; }&apos; is missing the following properties from type &apos;{ readonly title: BlockAttribute&lt;string&gt;; readonly description: BlockAttribute&lt;string&gt;; readonly showStepNumber: BlockAttribute&lt;boolean&gt;; readonly className: BlockAttribute&lt;...&gt;; }&apos;: title, description, showStepNumber" source="TS2769" />
+</file>
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/index.tsx">
+<error line="13" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt;): Block&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt; | undefined&apos;, gave the following error.
+    Type &apos;{ className: { type: string; default: string; }; lock: { type: string; default: { move: boolean; remove: boolean; }; }; }&apos; is missing the following properties from type &apos;{ readonly title: BlockAttribute&lt;string&gt;; readonly description: BlockAttribute&lt;string&gt;; readonly showStepNumber: BlockAttribute&lt;boolean&gt;; readonly className: BlockAttribute&lt;...&gt;; }&apos;: title, description, showStepNumber" source="TS2769" />
+</file>
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-actions-block/block.tsx">
+<error line="30" column="6" severity="error" message="Type &apos;{ link: string | undefined; }&apos; is not assignable to type &apos;ReturnToCartButtonProps&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+  Types of property &apos;link&apos; are incompatible.
+    Type &apos;string | undefined&apos; is not assignable to type &apos;string&apos;.
+      Type &apos;undefined&apos; is not assignable to type &apos;string&apos;." source="TS2375" />
+</file>
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-actions-block/index.tsx">
+<error line="13" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ showReturnToCart: boolean; cartPageId: number; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ showReturnToCart: boolean; cartPageId: number; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ showReturnToCart: boolean; cartPageId: number; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ showReturnToCart: boolean; cartPageId: number; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ showReturnToCart: boolean; cartPageId: number; }&gt;): Block&lt;{ showReturnToCart: boolean; cartPageId: number; }&gt; | undefined&apos;, gave the following error.
+    Type &apos;{ cartPageId: { type: string; default: number; }; showReturnToCart: { type: string; default: boolean; }; className: { type: string; default: string; }; lock: { type: string; default: { move: boolean; remove: boolean; }; }; }&apos; is not assignable to type &apos;{ readonly showReturnToCart: BlockAttribute&lt;boolean&gt;; readonly cartPageId: BlockAttribute&lt;number&gt;; }&apos;.
+      Types of property &apos;showReturnToCart&apos; are incompatible.
+        Type &apos;{ type: string; default: boolean; }&apos; is not assignable to type &apos;BlockAttribute&lt;boolean&gt;&apos;.
+          Type &apos;{ type: string; default: boolean; }&apos; is missing the following properties from type &apos;Query&lt;boolean&gt;&apos;: source, selector, query" source="TS2769" />
+</file>
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-order-note-block/index.tsx">
+<error line="12" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{}&gt;, settings?: Partial&lt;BlockConfiguration&lt;{}&gt;&gt; | undefined): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{}&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{}&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{}&gt;): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: () =&gt; JSX.Element; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{}&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: () =&gt; Element; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{}&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
+</file>
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-order-summary-block/index.tsx">
+<error line="14" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ className: unknown; lock: unknown; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ className: unknown; lock: unknown; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: unknown; lock: unknown; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ className: unknown; lock: unknown; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ className: unknown; lock: unknown; }&gt;): Block&lt;{ className: unknown; lock: unknown; }&gt; | undefined&apos;, gave the following error.
+    Type &apos;{ className: { type: string; default: string; }; lock: { type: string; default: { move: boolean; remove: boolean; }; }; }&apos; is not assignable to type &apos;{ readonly className: BlockAttribute&lt;unknown&gt;; readonly lock: BlockAttribute&lt;unknown&gt;; }&apos;.
+      Types of property &apos;className&apos; are incompatible.
+        Type &apos;{ type: string; default: string; }&apos; is not assignable to type &apos;BlockAttribute&lt;unknown&gt;&apos;.
+          Type &apos;{ type: string; default: string; }&apos; is missing the following properties from type &apos;Query&lt;unknown&gt;&apos;: source, selector, query" source="TS2769" />
+</file>
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-payment-block/index.tsx">
+<error line="13" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt;): Block&lt;{ title: string; description: string; showStepNumber: boolean; className: string; }&gt; | undefined&apos;, gave the following error.
+    Type &apos;{ className: { type: string; default: string; }; lock: { type: string; default: { move: boolean; remove: boolean; }; }; }&apos; is missing the following properties from type &apos;{ readonly title: BlockAttribute&lt;string&gt;; readonly description: BlockAttribute&lt;string&gt;; readonly showStepNumber: BlockAttribute&lt;boolean&gt;; readonly className: BlockAttribute&lt;...&gt;; }&apos;: title, description, showStepNumber" source="TS2769" />
+</file>
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-express-payment-block/edit.tsx">
+<error line="6" column="37" severity="error" message="Could not find a declaration file for module &apos;wordpress-components&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/wordpress-components/build/index.js&apos; implicitly has an &apos;any&apos; type.
+  If the &apos;@wordpress/components&apos; package actually exposes this module, consider sending a pull request to amend &apos;https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/wordpress__components&apos;" source="TS7016" />
+</file>
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-express-payment-block/index.tsx">
+<error line="12" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ className?: string; lock: { move: boolean; remove: boolean; }; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ className?: string; lock: { move: boolean; remove: boolean; }; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className?: string; lock: { move: boolean; remove: boolean; }; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ className?: string; lock: { move: boolean; remove: boolean; }; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ className?: string; lock: { move: boolean; remove: boolean; }; }&gt;): Block&lt;{ className?: string; lock: { move: boolean; remove: boolean; }; }&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: ({ attributes, }: { attributes: { className?: string; lock: { move: boolean; remove: boolean; }; }; }) =&gt; JSX.Element | null; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className?: string; lock: { move: boolean; remove: boolean; }; }&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: ({ attributes, }: { attributes: { className?: string; lock: { move: boolean; remove: boolean; }; }; }) =&gt; Element | null; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{ className?: string; lock: { move: boolean; remove: boolean; }; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
+</file>
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/no-shipping-placeholder/index.js">
+<error line="5" column="37" severity="error" message="Could not find a declaration file for module &apos;wordpress-components&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/wordpress-components/build/index.js&apos; implicitly has an &apos;any&apos; type.
+  If the &apos;@wordpress/components&apos; package actually exposes this module, consider sending a pull request to amend &apos;https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/wordpress__components&apos;" source="TS7016" />
+</file>
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/block.tsx">
+<error line="12" column="24" severity="error" message="Could not find a declaration file for module &apos;wordpress-components&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/wordpress-components/build/index.js&apos; implicitly has an &apos;any&apos; type.
+  If the &apos;@wordpress/components&apos; package actually exposes this module, consider sending a pull request to amend &apos;https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/wordpress__components&apos;" source="TS7016" />
+</file>
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/index.tsx">
+<error line="13" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ title: string; description: string; showStepNumber: boolean; allowCreateAccount: boolean; className: string; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ title: string; description: string; showStepNumber: boolean; allowCreateAccount: boolean; className: string; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ title: string; description: string; showStepNumber: boolean; allowCreateAccount: boolean; className: string; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ title: string; description: string; showStepNumber: boolean; allowCreateAccount: boolean; className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ title: string; description: string; showStepNumber: boolean; allowCreateAccount: boolean; className: string; }&gt;): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Type &apos;{ allowCreateAccount: { type: string; default: boolean; }; className: { type: string; default: string; }; lock: { type: string; default: { move: boolean; remove: boolean; }; }; }&apos; is missing the following properties from type &apos;{ readonly title: BlockAttribute&lt;string&gt;; readonly description: BlockAttribute&lt;string&gt;; readonly showStepNumber: BlockAttribute&lt;boolean&gt;; readonly allowCreateAccount: BlockAttribute&lt;...&gt;; readonly className: BlockAttribute&lt;...&gt;; }&apos;: title, description, showStepNumber" source="TS2769" />
+</file>
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-order-summary-subtotal/index.tsx">
+<error line="13" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ className: string; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ className: string; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ className: string; }&gt;): Block&lt;{ className: string; }&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: ({ attributes, }: { attributes: { className: string; }; setAttributes: (attributes: Record&lt;string, unknown&gt;) =&gt; void; }) =&gt; JSX.Element; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: ({ attributes, }: { attributes: { className: string; }; setAttributes: (attributes: Record&lt;string, unknown&gt;) =&gt; void; }) =&gt; Element; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
+</file>
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-order-summary-fee/index.tsx">
+<error line="13" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ className: string; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ className: string; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ className: string; }&gt;): Block&lt;{ className: string; }&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: ({ attributes, }: { attributes: { className: string; }; setAttributes: (attributes: Record&lt;string, unknown&gt;) =&gt; void; }) =&gt; JSX.Element; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: ({ attributes, }: { attributes: { className: string; }; setAttributes: (attributes: Record&lt;string, unknown&gt;) =&gt; void; }) =&gt; Element; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
+</file>
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-order-summary-discount/index.tsx">
+<error line="13" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ className: string; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ className: string; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ className: string; }&gt;): Block&lt;{ className: string; }&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: ({ attributes, }: { attributes: { className: string; }; setAttributes: (attributes: Record&lt;string, unknown&gt;) =&gt; void; }) =&gt; JSX.Element; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: ({ attributes, }: { attributes: { className: string; }; setAttributes: (attributes: Record&lt;string, unknown&gt;) =&gt; void; }) =&gt; Element; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
+</file>
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-order-summary-shipping/index.tsx">
+<error line="13" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ className: string; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ className: string; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ className: string; }&gt;): Block&lt;{ className: string; }&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: ({ attributes, }: { attributes: { className: string; }; }) =&gt; JSX.Element; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: ({ attributes, }: { attributes: { className: string; }; }) =&gt; Element; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
+</file>
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-order-summary-coupon-form/index.tsx">
+<error line="12" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ className: string; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ className: string; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ className: string; }&gt;): Block&lt;{ className: string; }&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: ({ attributes, }: { attributes: { className: string; }; setAttributes: (attributes: Record&lt;string, unknown&gt;) =&gt; void; }) =&gt; JSX.Element; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: ({ attributes, }: { attributes: { className: string; }; setAttributes: (attributes: Record&lt;string, unknown&gt;) =&gt; void; }) =&gt; Element; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
+</file>
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-order-summary-taxes/index.tsx">
+<error line="14" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ className: string; showRateAfterTaxName: boolean; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ className: string; showRateAfterTaxName: boolean; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; showRateAfterTaxName: boolean; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ className: string; showRateAfterTaxName: boolean; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ className: string; showRateAfterTaxName: boolean; }&gt;): Block&lt;{ className: string; showRateAfterTaxName: boolean; }&gt; | undefined&apos;, gave the following error.
+    Property &apos;className&apos; is missing in type &apos;{ showRateAfterTaxName: { type: string; default: unknown; }; lock: { type: string; default: { remove: boolean; move: boolean; }; }; }&apos; but required in type &apos;{ readonly className: BlockAttribute&lt;string&gt;; readonly showRateAfterTaxName: BlockAttribute&lt;boolean&gt;; }&apos;." source="TS2769" />
+</file>
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-order-summary-cart-items/index.tsx">
+<error line="13" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ className: string; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ className: string; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ className: string; }&gt;): Block&lt;{ className: string; }&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: ({ attributes, }: { attributes: { className: string; }; setAttributes: (attributes: Record&lt;string, unknown&gt;) =&gt; void; }) =&gt; JSX.Element; save: () =&gt; JSX.Element; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ className: string; }&gt;&apos;.
+      Type &apos;{ icon: { src: Element; }; edit: ({ attributes, }: { attributes: { className: string; }; setAttributes: (attributes: Record&lt;string, unknown&gt;) =&gt; void; }) =&gt; Element; save: () =&gt; Element; }&apos; is missing the following properties from type &apos;Pick&lt;Block&lt;{ className: string; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;: title, category, attributes" source="TS2769" />
+</file>
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-fields-block/frontend.tsx">
+<error line="20" column="4" severity="error" message="Type &apos;{ children: Element; className: string; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; RefAttributes&lt;any&gt;&apos;.
+  Property &apos;children&apos; does not exist on type &apos;IntrinsicAttributes &amp; RefAttributes&lt;any&gt;&apos;." source="TS2322" />
+</file>
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-terms-block/frontend.tsx">
+<error line="93" column="7" severity="error" message="Type &apos;Element&apos; is not assignable to type &apos;ReactChildren&apos;." source="TS2322" />
+</file>
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-totals-block/frontend.tsx">
+<error line="20" column="4" severity="error" message="Type &apos;{ children: Element; className: string; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; RefAttributes&lt;any&gt;&apos;.
+  Property &apos;children&apos; does not exist on type &apos;IntrinsicAttributes &amp; RefAttributes&lt;any&gt;&apos;." source="TS2322" />
+</file>
+<file name="assets/js/blocks/checkout/inner-blocks/register-components.ts">
+<error line="20" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ children, className, }: { children: Element; className?: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
+  Type &apos;LazyExoticComponent&lt;({ children, className, }: { children: Element; className?: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos;.
+    Type &apos;LazyExoticComponent&lt;({ children, className, }: { children: Element; className?: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;ExoticComponent&lt;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&gt;&apos;.
+      Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
+        Type &apos;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos; is not assignable to type &apos;{ children: Element; className?: string; }&apos;.
+          Type &apos;{ children?: ReactNode; }&apos; is not assignable to type &apos;{ children: Element; className?: string; }&apos;.
+            Types of property &apos;children&apos; are incompatible.
+              Type &apos;ReactNode&apos; is not assignable to type &apos;Element&apos;.
+                Type &apos;undefined&apos; is not assignable to type &apos;Element&apos;." source="TS2322" />
+<error line="30" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ className }: { className?: string; }) =&gt; Element | null&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
+  Type &apos;LazyExoticComponent&lt;({ className }: { className?: string; }) =&gt; Element | null&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos;.
+    Type &apos;LazyExoticComponent&lt;({ className }: { className?: string; }) =&gt; Element | null&gt;&apos; is not assignable to type &apos;ExoticComponent&lt;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&gt;&apos;.
+      Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
+        Type &apos;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos; is not assignable to type &apos;{ className?: string; }&apos;.
+          Type &apos;{ children?: ReactNode; }&apos; has no properties in common with type &apos;{ className?: string; }&apos;." source="TS2322" />
+<error line="90" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ className }: { className?: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
+  Type &apos;LazyExoticComponent&lt;({ className }: { className?: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos;.
+    Type &apos;LazyExoticComponent&lt;({ className }: { className?: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;ExoticComponent&lt;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&gt;&apos;.
+      Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
+        Type &apos;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos; is not assignable to type &apos;{ className?: string; }&apos;.
+          Type &apos;{ children?: ReactNode; }&apos; has no properties in common with type &apos;{ className?: string; }&apos;." source="TS2322" />
+<error line="100" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;ComponentType&lt;Omit&lt;{ text: string; checkbox: boolean; instanceId: string; className?: string; }, &quot;instanceId&quot;&gt;&gt;&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
+  Type &apos;LazyExoticComponent&lt;ComponentType&lt;Omit&lt;{ text: string; checkbox: boolean; instanceId: string; className?: string; }, &quot;instanceId&quot;&gt;&gt;&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos;.
+    Type &apos;LazyExoticComponent&lt;ComponentType&lt;Omit&lt;{ text: string; checkbox: boolean; instanceId: string; className?: string; }, &quot;instanceId&quot;&gt;&gt;&gt;&apos; is not assignable to type &apos;ExoticComponent&lt;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&gt;&apos;.
+      Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
+        Type &apos;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos; is not assignable to type &apos;(Omit&lt;{ text: string; checkbox: boolean; instanceId: string; className?: string; }, &quot;instanceId&quot;&gt; &amp; RefAttributes&lt;Component&lt;Omit&lt;{ text: string; checkbox: boolean; instanceId: string; className?: string; }, &quot;instanceId&quot;&gt;, any, any&gt;&gt;) | (Omit&lt;...&gt; &amp; { ...; })&apos;.
+          Type &apos;{ children?: ReactNode; }&apos; is not assignable to type &apos;(Omit&lt;{ text: string; checkbox: boolean; instanceId: string; className?: string; }, &quot;instanceId&quot;&gt; &amp; RefAttributes&lt;Component&lt;Omit&lt;{ text: string; checkbox: boolean; instanceId: string; className?: string; }, &quot;instanceId&quot;&gt;, any, any&gt;&gt;) | (Omit&lt;...&gt; &amp; { ...; })&apos;.
+            Type &apos;{ children?: ReactNode; }&apos; is not assignable to type &apos;Omit&lt;{ text: string; checkbox: boolean; instanceId: string; className?: string; }, &quot;instanceId&quot;&gt; &amp; { children?: ReactNode; }&apos;.
+              Type &apos;{ children?: ReactNode; }&apos; is missing the following properties from type &apos;Omit&lt;{ text: string; checkbox: boolean; instanceId: string; className?: string; }, &quot;instanceId&quot;&gt;&apos;: checkbox, text" source="TS2322" />
+<error line="120" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ children, className, }: { children: Element; className?: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
+  Type &apos;LazyExoticComponent&lt;({ children, className, }: { children: Element; className?: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos;.
+    Type &apos;LazyExoticComponent&lt;({ children, className, }: { children: Element; className?: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;ExoticComponent&lt;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&gt;&apos;.
+      Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
+        Type &apos;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos; is not assignable to type &apos;{ children: Element; className?: string; }&apos;.
+          Type &apos;{ children?: ReactNode; }&apos; is not assignable to type &apos;{ children: Element; className?: string; }&apos;.
+            Types of property &apos;children&apos; are incompatible.
+              Type &apos;ReactNode&apos; is not assignable to type &apos;Element&apos;." source="TS2322" />
+<error line="130" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ children, className, }: { children: Element | Element[]; className?: string; }) =&gt; Element | null&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
+  Type &apos;LazyExoticComponent&lt;({ children, className, }: { children: Element | Element[]; className?: string; }) =&gt; Element | null&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos;.
+    Type &apos;LazyExoticComponent&lt;({ children, className, }: { children: Element | Element[]; className?: string; }) =&gt; Element | null&gt;&apos; is not assignable to type &apos;ExoticComponent&lt;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&gt;&apos;.
+      Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
+        Type &apos;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos; is not assignable to type &apos;{ children: Element | Element[]; className?: string; }&apos;.
+          Type &apos;{ children?: ReactNode; }&apos; is not assignable to type &apos;{ children: Element | Element[]; className?: string; }&apos;.
+            Types of property &apos;children&apos; are incompatible.
+              Type &apos;ReactNode&apos; is not assignable to type &apos;Element | Element[]&apos;." source="TS2322" />
+<error line="140" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ className }: { className: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
+  Type &apos;LazyExoticComponent&lt;({ className }: { className: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos;.
+    Type &apos;LazyExoticComponent&lt;({ className }: { className: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;ExoticComponent&lt;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&gt;&apos;.
+      Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
+        Type &apos;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos; is not assignable to type &apos;{ className: string; }&apos;.
+          Property &apos;className&apos; is missing in type &apos;{ children?: ReactNode; }&apos; but required in type &apos;{ className: string; }&apos;." source="TS2322" />
+<error line="151" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ className }: { className?: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
+  Type &apos;LazyExoticComponent&lt;({ className }: { className?: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos;.
+    Type &apos;LazyExoticComponent&lt;({ className }: { className?: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;ExoticComponent&lt;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&gt;&apos;.
+      Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
+        Type &apos;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos; is not assignable to type &apos;{ className?: string; }&apos;.
+          Type &apos;{ children?: ReactNode; }&apos; has no properties in common with type &apos;{ className?: string; }&apos;." source="TS2322" />
+<error line="162" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ className }: { className?: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
+  Type &apos;LazyExoticComponent&lt;({ className }: { className?: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos;.
+    Type &apos;LazyExoticComponent&lt;({ className }: { className?: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;ExoticComponent&lt;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&gt;&apos;.
+      Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
+        Type &apos;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos; is not assignable to type &apos;{ className?: string; }&apos;.
+          Type &apos;{ children?: ReactNode; }&apos; has no properties in common with type &apos;{ className?: string; }&apos;." source="TS2322" />
+<error line="173" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ className }: { className?: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
+  Type &apos;LazyExoticComponent&lt;({ className }: { className?: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos;.
+    Type &apos;LazyExoticComponent&lt;({ className }: { className?: string; }) =&gt; Element&gt;&apos; is not assignable to type &apos;ExoticComponent&lt;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&gt;&apos;.
+      Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
+        Type &apos;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos; is not assignable to type &apos;{ className?: string; }&apos;.
+          Type &apos;{ children?: ReactNode; }&apos; has no properties in common with type &apos;{ className?: string; }&apos;." source="TS2322" />
+<error line="184" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ className, }: { className?: string; }) =&gt; Element | null&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
+  Type &apos;LazyExoticComponent&lt;({ className, }: { className?: string; }) =&gt; Element | null&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos;.
+    Type &apos;LazyExoticComponent&lt;({ className, }: { className?: string; }) =&gt; Element | null&gt;&apos; is not assignable to type &apos;ExoticComponent&lt;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&gt;&apos;.
+      Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
+        Type &apos;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos; is not assignable to type &apos;{ className?: string; }&apos;.
+          Type &apos;{ children?: ReactNode; }&apos; has no properties in common with type &apos;{ className?: string; }&apos;." source="TS2322" />
+<error line="195" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ className, }: { className?: string; }) =&gt; Element | null&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
+  Type &apos;LazyExoticComponent&lt;({ className, }: { className?: string; }) =&gt; Element | null&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos;.
+    Type &apos;LazyExoticComponent&lt;({ className, }: { className?: string; }) =&gt; Element | null&gt;&apos; is not assignable to type &apos;ExoticComponent&lt;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&gt;&apos;.
+      Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
+        Type &apos;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos; is not assignable to type &apos;{ className?: string; }&apos;.
+          Type &apos;{ children?: ReactNode; }&apos; has no properties in common with type &apos;{ className?: string; }&apos;." source="TS2322" />
+</file>
+<file name="assets/js/blocks/checkout/frontend.tsx">
+<error line="65" column="2" severity="error" message="Type &apos;({ children, }: { children: React.ReactChildren; }) =&gt; React.ReactNode&apos; is not assignable to type &apos;ElementType&lt;any&gt;&apos;.
+  Type &apos;({ children, }: { children: React.ReactChildren; }) =&gt; React.ReactNode&apos; is not assignable to type &apos;FunctionComponent&lt;any&gt;&apos;.
+    Type &apos;ReactNode&apos; is not assignable to type &apos;ReactElement&lt;any, any&gt; | null&apos;.
+      Type &apos;undefined&apos; is not assignable to type &apos;ReactElement&lt;any, any&gt; | null&apos;." source="TS2322" />
+</file>
+<file name="assets/js/blocks/checkout/index.tsx">
+<error line="142" column="20" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;BlockInstance&lt;Record&lt;string, any&gt;&gt;[] | { showOrderNotes: boolean; showPolicyLinks: boolean; showReturnToCart: boolean; cartPageId: number; }&gt;, settings?: Partial&lt;...&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { align: string[]; html: boolean; multiple: boolean; }; attributes: { isPreview: { type: string; default: boolean; save: boolean; }; ... 5 more ...; requirePhoneField: { ...; }; }; textdomain: string;...&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;BlockInstance&lt;Record&lt;string, any&gt;&gt;[] | { showOrderNotes: boolean; showPolicyLinks: boolean; showReturnToCart: boolean; cartPageId: number; }&gt;&apos;.
+      Type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { align: string[]; html: boolean; multiple: boolean; }; attributes: { isPreview: { type: string; default: boolean; save: boolean; }; ... 5 more ...; requirePhoneField: { ...; }; }; textdomain: string;...&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;BlockInstance&lt;Record&lt;string, any&gt;&gt;[] | { showOrderNotes: boolean; showPolicyLinks: boolean; showReturnToCart: boolean; cartPageId: number; }&gt;, &quot;icon&quot;&gt;&gt;&apos;.
+        Types of property &apos;attributes&apos; are incompatible.
+          Type &apos;{ isPreview: { type: string; default: boolean; save: boolean; }; showCompanyField: { type: string; default: boolean; }; requireCompanyField: { type: string; default: boolean; }; allowCreateAccount: { ...; }; showApartmentField: { ...; }; showPhoneField: { ...; }; requirePhoneField: { ...; }; }&apos; is not assignable to type &apos;readonly BlockAttribute&lt;BlockInstance&lt;Record&lt;string, any&gt;&gt;&gt;[] | { readonly showOrderNotes: BlockAttribute&lt;boolean&gt;; readonly showPolicyLinks: BlockAttribute&lt;...&gt;; readonly showReturnToCart: BlockAttribute&lt;...&gt;; readonly cartPageId: BlockAttribute&lt;...&gt;; }&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;BlockInstance&lt;Record&lt;string, any&gt;&gt;[] | { showOrderNotes: boolean; showPolicyLinks: boolean; showReturnToCart: boolean; cartPageId: number; }&gt;): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { align: string[]; html: boolean; multiple: boolean; }; attributes: { isPreview: { type: string; default: boolean; save: boolean; }; ... 5 more ...; requirePhoneField: { ...; }; }; textdomain: string;...&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2769" />
+</file>
+<file name="tests/utils/find-by-text.ts">
+<error line="12" column="21" severity="error" message="Parameter &apos;_node&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+</file>
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-order-summary-block/test/block.js">
+<error line="13" column="8" severity="error" message="File &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/tests/utils/find-by-text.ts&apos; is not listed within the file list of project &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/tsconfig.json&apos;. Projects must list all files or use an &apos;include&apos; pattern." source="TS6307" />
+<error line="27" column="4" severity="error" message="Property &apos;className&apos; is missing in type &apos;{}&apos; but required in type &apos;{ className: string; }&apos;." source="TS2741" />
+<error line="198" column="39" severity="error" message="Parameter &apos;implementation&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="202" column="41" severity="error" message="Parameter &apos;value&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="215" column="5" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="218" column="5" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="223" column="5" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="226" column="5" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="237" column="5" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="246" column="5" severity="error" message="Type &apos;number&apos; is not assignable to type &apos;string&apos;." source="TS2322" />
+<error line="247" column="5" severity="error" message="Type &apos;number&apos; is not assignable to type &apos;string&apos;." source="TS2322" />
+<error line="256" column="5" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="264" column="5" severity="error" message="Type &apos;number&apos; is not assignable to type &apos;string&apos;." source="TS2322" />
+<error line="265" column="5" severity="error" message="Type &apos;number&apos; is not assignable to type &apos;string&apos;." source="TS2322" />
+<error line="282" column="6" severity="error" message="Type &apos;{ code: string; discount_type: string; totals: { total_discount: string; total_discount_tax: string; currency_code: &quot;USD&quot;; currency_symbol: string; currency_minor_unit: number; currency_decimal_separator: string; currency_thousand_separator: string; currency_prefix: string; currency_suffix: string; }; label: string; }&apos; is not assignable to type &apos;CartResponseCouponItem&apos;.
+  Object literal may only specify known properties, and &apos;label&apos; does not exist in type &apos;CartResponseCouponItem&apos;." source="TS2322" />
+<error line="289" column="5" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="305" column="7" severity="error" message="Type &apos;number&apos; is not assignable to type &apos;string&apos;." source="TS2322" />
+<error line="317" column="5" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="325" column="5" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="330" column="34" severity="error" message="Parameter &apos;setting&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="330" column="43" severity="error" message="Rest parameter &apos;rest&apos; implicitly has an &apos;any[]&apos; type." source="TS7019" />
+<error line="342" column="9" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;Matchers&lt;void, HTMLElement | null&gt;&apos;." source="TS2339" />
+<error line="352" column="54" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;Matchers&lt;void, HTMLElement | null&gt;&apos;." source="TS2339" />
+<error line="364" column="34" severity="error" message="Parameter &apos;setting&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="364" column="43" severity="error" message="Rest parameter &apos;rest&apos; implicitly has an &apos;any[]&apos; type." source="TS7019" />
+<error line="380" column="9" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;Matchers&lt;void, HTMLElement | null&gt;&apos;." source="TS2339" />
+<error line="393" column="34" severity="error" message="Parameter &apos;setting&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="393" column="43" severity="error" message="Rest parameter &apos;rest&apos; implicitly has an &apos;any[]&apos; type." source="TS7019" />
+<error line="411" column="5" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="428" column="5" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="501" column="5" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+</file>
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-terms-block/test/edit.js">
+<error line="53" column="5" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement | null&gt;&apos;." source="TS2339" />
+<error line="57" column="5" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement | null&gt;&apos;." source="TS2339" />
+<error line="64" column="5" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement | null&gt;&apos;." source="TS2339" />
+<error line="85" column="5" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement | null&gt;&apos;." source="TS2339" />
+<error line="106" column="9" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;Matchers&lt;void, HTMLElement | null&gt;&apos;." source="TS2339" />
+</file>
+<file name="assets/js/blocks/checkout/inner-blocks/checkout-terms-block/test/frontend.js">
+<error line="43" column="22" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="59" column="26" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;Matchers&lt;void, HTMLElement | null&gt;&apos;." source="TS2339" />
+</file>
+<file name="assets/js/blocks/classic-template/index.tsx">
+<error line="196" column="6" severity="error" message="Type &apos;{ attributes: { template: string; align: string; }; setAttributes: (attrs: Partial&lt;Attributes&gt;) =&gt; void; clientId: string; }&apos; is missing the following properties from type &apos;BlockEditProps&lt;Attributes&gt;&apos;: className, isSelected" source="TS2739" />
+</file>
+<file name="assets/js/blocks/classic-template/test/utils.ts">
+<error line="15" column="2" severity="error" message="An object literal cannot have multiple properties with the same name." source="TS1117" />
+</file>
+<file name="assets/js/blocks/featured-items/block-controls.tsx">
+<error line="9" column="2" severity="error" message="Module &apos;&quot;@wordpress/block-editor&quot;&apos; has no exported member &apos;MediaReplaceFlow&apos;." source="TS2305" />
+</file>
+<file name="assets/js/blocks/featured-items/image-editor.tsx">
+<error line="10" column="2" severity="error" message="Module &apos;&quot;@wordpress/block-editor&quot;&apos; has no exported member &apos;__experimentalImageEditingProvider&apos;." source="TS2305" />
+<error line="11" column="2" severity="error" message="Module &apos;&quot;@wordpress/block-editor&quot;&apos; has no exported member &apos;__experimentalImageEditor&apos;." source="TS2305" />
+</file>
+<file name="assets/js/blocks/featured-items/with-featured-item.tsx">
+<error line="8" column="10" severity="error" message="Module &apos;&quot;@wordpress/block-editor&quot;&apos; has no exported member &apos;__experimentalGetSpacingClassesAndStyles&apos;." source="TS2305" />
+</file>
+<file name="assets/js/blocks/featured-items/inspector-controls.tsx">
+<error line="11" column="2" severity="error" message="Module &apos;&quot;@wordpress/block-editor&quot;&apos; has no exported member &apos;__experimentalPanelColorGradientSettings&apos;." source="TS2305" />
+<error line="12" column="2" severity="error" message="Module &apos;&quot;@wordpress/block-editor&quot;&apos; has no exported member &apos;__experimentalUseGradient&apos;." source="TS2305" />
+<error line="19" column="2" severity="error" message="Module &apos;&quot;@wordpress/components&quot;&apos; has no exported member &apos;__experimentalToggleGroupControl&apos;." source="TS2305" />
+<error line="20" column="2" severity="error" message="Module &apos;&quot;@wordpress/components&quot;&apos; has no exported member &apos;__experimentalToggleGroupControlOption&apos;." source="TS2305" />
+</file>
+<file name="assets/js/blocks/featured-items/register.tsx">
+<error line="74" column="43" severity="error" message="Property &apos;background&apos; does not exist on type &apos;never&apos;." source="TS2339" />
+<error line="75" column="37" severity="error" message="Property &apos;text&apos; does not exist on type &apos;never&apos;." source="TS2339" />
+<error line="78" column="33" severity="error" message="Property &apos;__experimentalDuotone&apos; does not exist on type &apos;never&apos;." source="TS2339" />
+<error line="115" column="2" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{}&gt;, settings?: Partial&lt;BlockConfiguration&lt;{}&gt;&gt; | undefined): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ style?: string; script?: string; title?: string; name?: string; version?: string; description?: string | undefined; category?: string; edit: React.ComponentType&lt;BlockEditProps&lt;{}&gt;&gt; | ((props: {}) =&gt; JSX.Element) | undefined; ... 17 more ...; icon?: BlockIcon | undefined; }&apos; is not assignable to parameter of type &apos;Partial&lt;BlockConfiguration&lt;{}&gt;&gt;&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+      Types of property &apos;supports&apos; are incompatible.
+        Type &apos;BlockSupports | { __experimentalBorder?: { color: boolean; radius: boolean; width: boolean; __experimentalSkipSerialization?: boolean; }; color: { __experimentalDuotone?: any; background: any; text: any; }; ... 11 more ...; typography?: Partial&lt;...&gt; | undefined; } | undefined&apos; is not assignable to type &apos;BlockSupports | undefined&apos;.
+          Type &apos;{ __experimentalBorder?: { color: boolean; radius: boolean; width: boolean; __experimentalSkipSerialization?: boolean; }; color: { __experimentalDuotone?: any; background: any; text: any; }; spacing: { ...; }; ... 10 more ...; typography?: Partial&lt;...&gt; | undefined; }&apos; is not assignable to type &apos;BlockSupports&apos;.
+            The types of &apos;spacing.padding&apos; are incompatible between these types.
+              Type &apos;((boolean | CSSDirection[] | undefined) &amp; (boolean | CSSDirections[])) | undefined&apos; is not assignable to type &apos;boolean | CSSDirection[]&apos;.
+                Type &apos;undefined&apos; is not assignable to type &apos;boolean | CSSDirection[]&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{}&gt;): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;Partial&lt;Omit&lt;Block&lt;{}&gt;, &quot;icon&quot;&gt;&gt; &amp; Pick&lt;Block&lt;{}&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt; &amp; { icon?: BlockIcon | undefined; } &amp; ExtendedBlockSupports&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2769" />
+</file>
+<file name="assets/js/editor-components/product-category-control/index.js">
+<error line="45" column="23" severity="error" message="Parameter &apos;args&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="128" column="15" severity="error" message="Parameter &apos;n&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="146" column="24" severity="error" message="Type &apos;string&apos; is not assignable to type &apos;ErrorObject&apos;." source="TS2322" />
+<error line="153" column="5" severity="error" message="Type &apos;string | undefined&apos; is not assignable to type &apos;SearchListItemsType&apos;.
+  Type &apos;undefined&apos; is not assignable to type &apos;SearchListItemsType&apos;." source="TS2322" />
+<error line="157" column="7" severity="error" message="Object is possibly &apos;undefined&apos;." source="TS2532" />
+<error line="157" column="18" severity="error" message="Property &apos;find&apos; does not exist on type &apos;string&apos;." source="TS2339" />
+<error line="157" column="26" severity="error" message="Parameter &apos;category&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="160" column="5" severity="error" message="Type &apos;Function&apos; is not assignable to type &apos;(search: SearchListItemsType) =&gt; void&apos;.
+  Type &apos;Function&apos; provides no match for the signature &apos;(search: SearchListItemsType): void&apos;." source="TS2322" />
+<error line="163" column="5" severity="error" message="Type &apos;boolean | undefined&apos; is not assignable to type &apos;boolean&apos;.
+  Type &apos;undefined&apos; is not assignable to type &apos;boolean&apos;." source="TS2322" />
+<error line="165" column="5" severity="error" message="Type &apos;boolean | undefined&apos; is not assignable to type &apos;boolean&apos;." source="TS2322" />
+<error line="180" column="7" severity="error" message="Type &apos;Function&apos; is not assignable to type &apos;(value: string) =&gt; void&apos;.
+  Type &apos;Function&apos; provides no match for the signature &apos;(value: string): void&apos;." source="TS2322" />
+</file>
+<file name="assets/js/blocks/featured-items/with-edit-mode.tsx">
+<error line="78" column="22" severity="error" message="Type &apos;number | undefined&apos; is not assignable to type &apos;number&apos;.
+  Type &apos;undefined&apos; is not assignable to type &apos;number&apos;." source="TS2322" />
+</file>
+<file name="assets/js/blocks/featured-items/featured-category/index.tsx">
+<error line="17" column="27" severity="error" message="Argument of type &apos;{ name: string; version: string; title: string; category: string; keywords: string[]; description: string; supports: { align: string[]; html: boolean; color: { background: boolean; text: boolean; }; spacing: { ...; }; __experimentalBorder: { ...; }; }; attributes: { ...; }; textdomain: string; apiVersion: number; $s...&apos; is not assignable to parameter of type &apos;Partial&lt;Omit&lt;Block&lt;{}&gt;, &quot;icon&quot;&gt;&gt; &amp; Pick&lt;Block&lt;{}&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt; &amp; { icon?: BlockIcon | undefined; } &amp; ExtendedBlockSupports&apos;.
+  Type &apos;{ name: string; version: string; title: string; category: string; keywords: string[]; description: string; supports: { align: string[]; html: boolean; color: { background: boolean; text: boolean; }; spacing: { ...; }; __experimentalBorder: { ...; }; }; attributes: { ...; }; textdomain: string; apiVersion: number; $s...&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;{}&gt;, &quot;icon&quot;&gt;&gt;&apos;.
+    The types of &apos;supports.align&apos; are incompatible between these types.
+      Type &apos;string[]&apos; is not assignable to type &apos;boolean | readonly BlockAlignment[] | undefined&apos;.
+        Type &apos;string[]&apos; is not assignable to type &apos;readonly BlockAlignment[]&apos;." source="TS2345" />
+</file>
+<file name="assets/js/blocks/featured-items/featured-product/index.tsx">
+<error line="16" column="27" severity="error" message="Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { align: string[]; html: boolean; color: { background: boolean; text: boolean; }; spacing: { ...; }; __experimentalBorder: { ...; }; multiple: boolean; }; attributes: { ...; }; textdomain: string; api...&apos; is not assignable to parameter of type &apos;Partial&lt;Omit&lt;Block&lt;{}&gt;, &quot;icon&quot;&gt;&gt; &amp; Pick&lt;Block&lt;{}&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt; &amp; { icon?: BlockIcon | undefined; } &amp; ExtendedBlockSupports&apos;.
+  Type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { align: string[]; html: boolean; color: { background: boolean; text: boolean; }; spacing: { ...; }; __experimentalBorder: { ...; }; multiple: boolean; }; attributes: { ...; }; textdomain: string; api...&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;{}&gt;, &quot;icon&quot;&gt;&gt;&apos;.
+    The types of &apos;supports.align&apos; are incompatible between these types.
+      Type &apos;string[]&apos; is not assignable to type &apos;boolean | readonly BlockAlignment[] | undefined&apos;." source="TS2345" />
+</file>
+<file name="assets/js/blocks/filter-wrapper/frontend.ts">
+<error line="15" column="2" severity="error" message="Type &apos;({ children }: Props) =&gt; JSX.Element&apos; is not assignable to type &apos;FunctionComponent&lt;{}&gt;&apos;.
+  Types of parameters &apos;__0&apos; and &apos;props&apos; are incompatible.
+    Type &apos;{ children?: ReactNode; }&apos; is not assignable to type &apos;Props&apos;.
+      Types of property &apos;children&apos; are incompatible.
+        Type &apos;ReactNode&apos; is not assignable to type &apos;Element[]&apos;.
+          Type &apos;undefined&apos; is not assignable to type &apos;Element[]&apos;." source="TS2322" />
+</file>
+<file name="assets/js/blocks/filter-wrapper/index.tsx">
+<error line="8" column="25" severity="error" message="Module &apos;&quot;@wordpress/block-editor&quot;&apos; has no exported member &apos;useInnerBlocksProps&apos;." source="TS2305" />
+<error line="46" column="34" severity="error" message="Parameter &apos;instance&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="111" column="20" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;Attributes&gt;, settings?: Partial&lt;BlockConfiguration&lt;Attributes&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; version: string; title: string; category: string; keywords: string[]; attributes: { filterType: { type: string; }; heading: { type: string; }; }; textdomain: string; apiVersion: number; $schema: string; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;Attributes&gt;&apos;.
+      Type &apos;{ name: string; version: string; title: string; category: string; keywords: string[]; attributes: { filterType: { type: string; }; heading: { type: string; }; }; textdomain: string; apiVersion: number; $schema: string; }&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;Attributes&gt;, &quot;icon&quot;&gt;&gt;&apos;.
+        The types of &apos;attributes.heading&apos; are incompatible between these types.
+          Type &apos;{ type: string; }&apos; is not assignable to type &apos;BlockAttribute&lt;string&gt;&apos;.
+            Type &apos;{ type: string; }&apos; is missing the following properties from type &apos;Query&lt;string&gt;&apos;: source, selector, query
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;Attributes&gt;): Block&lt;Attributes&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; version: string; title: string; category: string; keywords: string[]; attributes: { filterType: { type: string; }; heading: { type: string; }; }; textdomain: string; apiVersion: number; $schema: string; }&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2769" />
+<error line="135" column="16" severity="error" message="Parameter &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="159" column="16" severity="error" message="Parameter &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="184" column="16" severity="error" message="Parameter &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="209" column="16" severity="error" message="Parameter &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="234" column="16" severity="error" message="Parameter &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="259" column="18" severity="error" message="Property &apos;idBase&apos; does not exist on type &apos;Attributes&apos;." source="TS2339" />
+<error line="259" column="26" severity="error" message="Property &apos;instance&apos; does not exist on type &apos;Attributes&apos;." source="TS2339" />
+<error line="261" column="20" severity="error" message="Property &apos;idBase&apos; does not exist on type &apos;Attributes&apos;." source="TS2339" />
+<error line="261" column="28" severity="error" message="Property &apos;instance&apos; does not exist on type &apos;Attributes&apos;." source="TS2339" />
+</file>
+<file name="assets/js/blocks/handpicked-products/block.tsx">
+<error line="4" column="30" severity="error" message="Could not find a declaration file for module &apos;@wordpress/server-side-render&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@wordpress/server-side-render/build/index.js&apos; implicitly has an &apos;any&apos; type.
+  Try `npm i --save-dev @types/wordpress__server-side-render` if it exists or add a new declaration (.d.ts) file containing `declare module &apos;@wordpress/server-side-render&apos;;`" source="TS7016" />
+</file>
+<file name="assets/js/editor-components/products-control/index.js">
+<error line="18" column="12" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
+<error line="19" column="12" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
+<error line="45" column="15" severity="error" message="Parameter &apos;n&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="63" column="3" severity="error" message="Type &apos;Element&apos; is missing the following properties from type &apos;Function&apos;: apply, call, bind, prototype, and 5 more." source="TS2740" />
+<error line="63" column="24" severity="error" message="Type &apos;string&apos; is not assignable to type &apos;ErrorObject&apos;." source="TS2322" />
+<error line="66" column="2" severity="error" message="Type &apos;Element&apos; is not assignable to type &apos;Function&apos;." source="TS2322" />
+<error line="83" column="4" severity="error" message="Type &apos;Function&apos; is not assignable to type &apos;(search: string) =&gt; void&apos;.
+  Type &apos;Function&apos; provides no match for the signature &apos;(search: string): void&apos;." source="TS2322" />
+<error line="84" column="4" severity="error" message="Type &apos;Function&apos; is not assignable to type &apos;(search: SearchListItemsType) =&gt; void&apos;." source="TS2322" />
+<error line="106" column="38" severity="error" message="Argument of type &apos;{ ({ error, onChange, onSearch, selected, products, isLoading, isCompact, }: {    error: string;    onChange: Function;    onSearch: Function;    selected: any[];    products: any[];    isLoading: boolean;    isCompact: boolean;}): Function; propTypes: { onChange: PropTypes.Validator&lt;(...args: any[]) =&gt; any&gt;; onSear...&apos; is not assignable to parameter of type &apos;FunctionComponent&lt;Record&lt;string, unknown&gt;&gt;&apos;.
+  Types of parameters &apos;__0&apos; and &apos;props&apos; are incompatible.
+    Type &apos;PropsWithChildren&lt;Record&lt;string, unknown&gt;&gt;&apos; is missing the following properties from type &apos;{ error: string; onChange: Function; onSearch: Function; selected: any[]; products: any[]; isLoading: boolean; isCompact: boolean; }&apos;: error, onChange, onSearch, selected, and 3 more." source="TS2345" />
+</file>
+<file name="assets/js/blocks/handpicked-products/edit-mode.tsx">
+<error line="55" column="6" severity="error" message="Type &apos;{ selected: number[]; onChange: (value?: never[]) =&gt; void; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; { selected: number[]; }&apos;.
+  Property &apos;onChange&apos; does not exist on type &apos;IntrinsicAttributes &amp; { selected: number[]; }&apos;." source="TS2322" />
+</file>
+<file name="assets/js/editor-components/grid-content-control/index.js">
+<error line="16" column="10" severity="error" message="Property &apos;image&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="16" column="17" severity="error" message="Property &apos;button&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="16" column="25" severity="error" message="Property &apos;price&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="16" column="32" severity="error" message="Property &apos;rating&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="16" column="40" severity="error" message="Property &apos;title&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+</file>
+<file name="assets/js/blocks/handpicked-products/inspector-controls.tsx">
+<error line="86" column="6" severity="error" message="Type &apos;{ selected: number[]; onChange: (value?: never[]) =&gt; void; isCompact: boolean; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; { selected: number[]; }&apos;.
+  Property &apos;onChange&apos; does not exist on type &apos;IntrinsicAttributes &amp; { selected: number[]; }&apos;." source="TS2322" />
+</file>
+<file name="assets/js/blocks/handpicked-products/index.tsx">
+<error line="15" column="20" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ columns: unknown; align: unknown; contentVisibility: unknown; orderby: unknown; products: unknown; alignButtons: unknown; isPreview: unknown; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ columns: unknown; align: unknown; contentVisibility: unknown; orderby: unknown; products: unknown; alignButtons: unknown; isPreview: unknown; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; title: string; category: string; keywords: string[]; description: string; supports: { align: string[]; html: boolean; }; attributes: { align: { type: string; }; columns: { type: string; default: number; }; ... 4 more ...; isPreview: { ...; }; }; textdomain: string; apiVersion: number; $schema: string...&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ columns: unknown; align: unknown; contentVisibility: unknown; orderby: unknown; products: unknown; alignButtons: unknown; isPreview: unknown; }&gt;&apos;.
+      Type &apos;{ name: string; title: string; category: string; keywords: string[]; description: string; supports: { align: string[]; html: boolean; }; attributes: { align: { type: string; }; columns: { type: string; default: number; }; ... 4 more ...; isPreview: { ...; }; }; textdomain: string; apiVersion: number; $schema: string...&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;{ columns: unknown; align: unknown; contentVisibility: unknown; orderby: unknown; products: unknown; alignButtons: unknown; isPreview: unknown; }&gt;, &quot;icon&quot;&gt;&gt;&apos;.
+        The types of &apos;attributes.columns&apos; are incompatible between these types.
+          Type &apos;{ type: string; default: number; }&apos; is not assignable to type &apos;BlockAttribute&lt;unknown&gt;&apos;.
+            Type &apos;{ type: string; default: number; }&apos; is missing the following properties from type &apos;Query&lt;unknown&gt;&apos;: source, selector, query
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ columns: unknown; align: unknown; contentVisibility: unknown; orderby: unknown; products: unknown; alignButtons: unknown; isPreview: unknown; }&gt;): Block&lt;{ columns: unknown; align: unknown; contentVisibility: unknown; orderby: unknown; products: unknown; alignButtons: unknown; isPreview: unknown; }&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; title: string; category: string; keywords: string[]; description: string; supports: { align: string[]; html: boolean; }; attributes: { align: { type: string; }; columns: { type: string; default: number; }; ... 4 more ...; isPreview: { ...; }; }; textdomain: string; apiVersion: number; $schema: string...&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2769" />
+</file>
+<file name="assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-footer-block/block.tsx">
+<error line="23" column="40" severity="error" message="Argument of type &apos;EmptyObjectType | Record&lt;string, PaymentMethodConfigInstance&gt; | Record&lt;string, ExpressPaymentMethodConfigInstance&gt;&apos; is not assignable to parameter of type &apos;PaymentMethods&apos;." source="TS2345" />
+<error line="56" column="7" severity="error" message="Type &apos;{ children: string; className: string; href: never; variant: &quot;outlined&quot;; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; ButtonProps&apos;.
+  Property &apos;href&apos; does not exist on type &apos;IntrinsicAttributes &amp; ButtonProps&apos;." source="TS2322" />
+<error line="65" column="7" severity="error" message="Type &apos;{ children: string; className: string; href: never; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; ButtonProps&apos;.
+  Property &apos;href&apos; does not exist on type &apos;IntrinsicAttributes &amp; ButtonProps&apos;." source="TS2322" />
+</file>
+<file name="assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/register-components.ts">
+<error line="24" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ children, className, }: FilledMiniCartContentsBlockProps) =&gt; Element | null&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
+  Type &apos;LazyExoticComponent&lt;({ children, className, }: FilledMiniCartContentsBlockProps) =&gt; Element | null&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos;.
+    Type &apos;LazyExoticComponent&lt;({ children, className, }: FilledMiniCartContentsBlockProps) =&gt; Element | null&gt;&apos; is not assignable to type &apos;ExoticComponent&lt;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&gt;&apos;.
+      Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
+        Type &apos;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos; is not assignable to type &apos;FilledMiniCartContentsBlockProps&apos;.
+          Property &apos;className&apos; is missing in type &apos;{ children?: ReactNode; }&apos; but required in type &apos;FilledMiniCartContentsBlockProps&apos;." source="TS2322" />
+<error line="34" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ children, className, }: EmptyMiniCartContentsBlockProps) =&gt; Element | null&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
+  Type &apos;LazyExoticComponent&lt;({ children, className, }: EmptyMiniCartContentsBlockProps) =&gt; Element | null&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos;.
+    Type &apos;LazyExoticComponent&lt;({ children, className, }: EmptyMiniCartContentsBlockProps) =&gt; Element | null&gt;&apos; is not assignable to type &apos;ExoticComponent&lt;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&gt;&apos;.
+      Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
+        Type &apos;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos; is not assignable to type &apos;EmptyMiniCartContentsBlockProps&apos;.
+          Property &apos;className&apos; is missing in type &apos;{ children?: ReactNode; }&apos; but required in type &apos;EmptyMiniCartContentsBlockProps&apos;." source="TS2322" />
+<error line="44" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ className }: MiniCartTitleBlockProps) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
+  Type &apos;LazyExoticComponent&lt;({ className }: MiniCartTitleBlockProps) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos;.
+    Type &apos;LazyExoticComponent&lt;({ className }: MiniCartTitleBlockProps) =&gt; Element&gt;&apos; is not assignable to type &apos;ExoticComponent&lt;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&gt;&apos;.
+      Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
+        Type &apos;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos; is not assignable to type &apos;MiniCartTitleBlockProps&apos;.
+          Property &apos;className&apos; is missing in type &apos;{ children?: ReactNode; }&apos; but required in type &apos;MiniCartTitleBlockProps&apos;." source="TS2322" />
+<error line="54" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ children, className, }: MiniCartItemsBlockProps) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
+  Type &apos;LazyExoticComponent&lt;({ children, className, }: MiniCartItemsBlockProps) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos;.
+    Type &apos;LazyExoticComponent&lt;({ children, className, }: MiniCartItemsBlockProps) =&gt; Element&gt;&apos; is not assignable to type &apos;ExoticComponent&lt;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&gt;&apos;.
+      Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
+        Type &apos;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos; is not assignable to type &apos;MiniCartItemsBlockProps&apos;.
+          Property &apos;className&apos; is missing in type &apos;{ children?: ReactNode; }&apos; but required in type &apos;MiniCartItemsBlockProps&apos;." source="TS2322" />
+<error line="64" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ className }: MiniCartContentsBlockProps) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
+  Type &apos;LazyExoticComponent&lt;({ className }: MiniCartContentsBlockProps) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos;.
+    Type &apos;LazyExoticComponent&lt;({ className }: MiniCartContentsBlockProps) =&gt; Element&gt;&apos; is not assignable to type &apos;ExoticComponent&lt;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&gt;&apos;.
+      Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
+        Type &apos;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos; is not assignable to type &apos;MiniCartContentsBlockProps&apos;.
+          Property &apos;className&apos; is missing in type &apos;{ children?: ReactNode; }&apos; but required in type &apos;MiniCartContentsBlockProps&apos;." source="TS2322" />
+<error line="74" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ className }: Props) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
+  Type &apos;LazyExoticComponent&lt;({ className }: Props) =&gt; Element&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos;.
+    Type &apos;LazyExoticComponent&lt;({ className }: Props) =&gt; Element&gt;&apos; is not assignable to type &apos;ExoticComponent&lt;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&gt;&apos;.
+      Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
+        Type &apos;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos; is not assignable to type &apos;Props&apos;.
+          Type &apos;{ children?: ReactNode; }&apos; has no properties in common with type &apos;Props&apos;." source="TS2322" />
+<error line="84" column="2" severity="error" message="Type &apos;LazyExoticComponent&lt;({ className, }: MiniCartShoppingButtonBlockProps) =&gt; Element | null&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt; | (() =&gt; Element | null) | null&apos;.
+  Type &apos;LazyExoticComponent&lt;({ className, }: MiniCartShoppingButtonBlockProps) =&gt; Element | null&gt;&apos; is not assignable to type &apos;LazyExoticComponent&lt;ComponentType&lt;unknown&gt;&gt;&apos;.
+    Type &apos;LazyExoticComponent&lt;({ className, }: MiniCartShoppingButtonBlockProps) =&gt; Element | null&gt;&apos; is not assignable to type &apos;ExoticComponent&lt;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&gt;&apos;.
+      Types of parameters &apos;props&apos; and &apos;props&apos; are incompatible.
+        Type &apos;{ children?: ReactNode; } | RefAttributes&lt;Component&lt;unknown, any, any&gt;&gt;&apos; is not assignable to type &apos;MiniCartShoppingButtonBlockProps&apos;.
+          Property &apos;className&apos; is missing in type &apos;{ children?: ReactNode; }&apos; but required in type &apos;MiniCartShoppingButtonBlockProps&apos;." source="TS2322" />
+</file>
+<file name="assets/js/blocks/mini-cart/block.tsx">
+<error line="106" column="6" severity="error" message="Type &apos;({ children, }: MiniCartContentsBlockProps) =&gt; JSX.Element&apos; is not assignable to type &apos;FunctionComponent&lt;{}&gt;&apos;.
+  Types of parameters &apos;__0&apos; and &apos;props&apos; are incompatible.
+    Type &apos;{ children?: ReactNode; }&apos; is not assignable to type &apos;MiniCartContentsBlockProps&apos;.
+      Types of property &apos;children&apos; are incompatible.
+        Type &apos;ReactNode&apos; is not assignable to type &apos;Element | Element[]&apos;." source="TS2322" />
+</file>
+<file name="assets/js/blocks/mini-cart/component-frontend.tsx">
+<error line="30" column="3" severity="error" message="Type &apos;(attributes: Props) =&gt; JSX.Element&apos; is not assignable to type &apos;BlockType&lt;Record&lt;string, unknown&gt;, Record&lt;string, unknown&gt;&gt;&apos;.
+  Types of parameters &apos;attributes&apos; and &apos;props&apos; are incompatible.
+    Type &apos;BlockProps&lt;Record&lt;string, unknown&gt;, Record&lt;string, unknown&gt;&gt;&apos; is missing the following properties from type &apos;Props&apos;: contents, addToCartBehaviour, hasHiddenPrice" source="TS2322" />
+</file>
+<file name="assets/js/blocks/mini-cart/index.tsx">
+<error line="36" column="3" severity="error" message="Type &apos;true&apos; has no properties in common with type &apos;Partial&lt;ColorProps&gt;&apos;." source="TS2559" />
+<error line="66" column="2" severity="error" message="Type &apos;({ attributes, setAttributes }: Props) =&gt; ReactElement&apos; is not assignable to type &apos;ComponentType&lt;BlockEditProps&lt;{}&gt;&gt; | undefined&apos;.
+  Type &apos;({ attributes, setAttributes }: Props) =&gt; ReactElement&apos; is not assignable to type &apos;FunctionComponent&lt;BlockEditProps&lt;{}&gt;&gt;&apos;.
+    Types of parameters &apos;__0&apos; and &apos;props&apos; are incompatible.
+      Type &apos;PropsWithChildren&lt;BlockEditProps&lt;{}&gt;&gt;&apos; is not assignable to type &apos;Props&apos;.
+        Types of property &apos;attributes&apos; are incompatible.
+          Type &apos;Readonly&lt;{}&gt;&apos; is missing the following properties from type &apos;Attributes&apos;: addToCartBehaviour, hasHiddenPrice" source="TS2322" />
+</file>
+<file name="assets/js/blocks/mini-cart/mini-cart-contents/edit.tsx">
+<error line="104" column="11" severity="error" message="Property &apos;selectorText&apos; does not exist on type &apos;CSSRule&apos;." source="TS2339" />
+<error line="105" column="11" severity="error" message="Property &apos;style&apos; does not exist on type &apos;CSSRule&apos;." source="TS2339" />
+<error line="110" column="35" severity="error" message="Property &apos;style&apos; does not exist on type &apos;CSSRule&apos;." source="TS2339" />
+</file>
+<file name="assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/empty-mini-cart-contents-block/index.tsx">
+<error line="14" column="20" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ lock: unknown; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ lock: unknown; }&gt;&gt; | undefined): Block&lt;{ lock: unknown; }&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: boolean; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; lock: boolean; }; attributes: { ...; }; parent: string[]; textdomain: string; apiVersion: number; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ lock: unknown; }&gt;&apos;.
+      Type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: boolean; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; lock: boolean; }; attributes: { ...; }; parent: string[]; textdomain: string; apiVersion: number; }&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;{ lock: unknown; }&gt;, &quot;icon&quot;&gt;&gt;&apos;.
+        The types of &apos;attributes[&quot;lock&quot;]&apos; are incompatible between these types.
+          Type &apos;{ type: string; default: { remove: boolean; move: boolean; }; }&apos; is not assignable to type &apos;BlockAttribute&lt;unknown&gt;&apos;.
+            Type &apos;{ type: string; default: { remove: boolean; move: boolean; }; }&apos; is missing the following properties from type &apos;Query&lt;unknown&gt;&apos;: source, selector, query
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{}&gt;): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: boolean; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; lock: boolean; }; attributes: { ...; }; parent: string[]; textdomain: string; apiVersion: number; }&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2769" />
+</file>
+<file name="assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/filled-mini-cart-contents-block/index.tsx">
+<error line="14" column="20" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ lock: unknown; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ lock: unknown; }&gt;&gt; | undefined): Block&lt;{ lock: unknown; }&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: boolean; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; lock: boolean; }; attributes: { ...; }; parent: string[]; textdomain: string; apiVersion: number; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ lock: unknown; }&gt;&apos;.
+      Type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: boolean; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; lock: boolean; }; attributes: { ...; }; parent: string[]; textdomain: string; apiVersion: number; }&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;{ lock: unknown; }&gt;, &quot;icon&quot;&gt;&gt;&apos;.
+        The types of &apos;attributes[&quot;lock&quot;]&apos; are incompatible between these types.
+          Type &apos;{ type: string; default: { remove: boolean; move: boolean; }; }&apos; is not assignable to type &apos;BlockAttribute&lt;unknown&gt;&apos;.
+            Type &apos;{ type: string; default: { remove: boolean; move: boolean; }; }&apos; is missing the following properties from type &apos;Query&lt;unknown&gt;&apos;: source, selector, query
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{}&gt;): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: boolean; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; lock: boolean; }; attributes: { ...; }; parent: string[]; textdomain: string; apiVersion: number; }&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2769" />
+</file>
+<file name="assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-title-block/edit.tsx">
+<error line="16" column="5" severity="error" message="Property &apos;className&apos; is missing in type &apos;{}&apos; but required in type &apos;MiniCartTitleBlockProps&apos;." source="TS2741" />
+</file>
+<file name="assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-title-block/index.tsx">
+<error line="13" column="20" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ lock: unknown; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ lock: unknown; }&gt;&gt; | undefined): Block&lt;{ lock: unknown; }&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: boolean; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; lock: boolean; }; attributes: { ...; }; parent: string[]; textdomain: string; apiVersion: number; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ lock: unknown; }&gt;&apos;.
+      Type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: boolean; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; lock: boolean; }; attributes: { ...; }; parent: string[]; textdomain: string; apiVersion: number; }&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;{ lock: unknown; }&gt;, &quot;icon&quot;&gt;&gt;&apos;.
+        The types of &apos;attributes[&quot;lock&quot;]&apos; are incompatible between these types.
+          Type &apos;{ type: string; default: { remove: boolean; move: boolean; }; }&apos; is not assignable to type &apos;BlockAttribute&lt;unknown&gt;&apos;.
+            Type &apos;{ type: string; default: { remove: boolean; move: boolean; }; }&apos; is missing the following properties from type &apos;Query&lt;unknown&gt;&apos;: source, selector, query
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{}&gt;): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: boolean; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; lock: boolean; }; attributes: { ...; }; parent: string[]; textdomain: string; apiVersion: number; }&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2769" />
+</file>
+<file name="assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-items-block/index.tsx">
+<error line="13" column="20" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ lock: unknown; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ lock: unknown; }&gt;&gt; | undefined): Block&lt;{ lock: unknown; }&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: boolean; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; lock: boolean; }; attributes: { ...; }; parent: string[]; textdomain: string; apiVersion: number; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ lock: unknown; }&gt;&apos;.
+      Type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: boolean; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; lock: boolean; }; attributes: { ...; }; parent: string[]; textdomain: string; apiVersion: number; }&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;{ lock: unknown; }&gt;, &quot;icon&quot;&gt;&gt;&apos;.
+        The types of &apos;attributes[&quot;lock&quot;]&apos; are incompatible between these types.
+          Type &apos;{ type: string; default: { remove: boolean; move: boolean; }; }&apos; is not assignable to type &apos;BlockAttribute&lt;unknown&gt;&apos;.
+            Type &apos;{ type: string; default: { remove: boolean; move: boolean; }; }&apos; is missing the following properties from type &apos;Query&lt;unknown&gt;&apos;: source, selector, query
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{}&gt;): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: boolean; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; lock: boolean; }; attributes: { ...; }; parent: string[]; textdomain: string; apiVersion: number; }&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2769" />
+</file>
+<file name="assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-products-table-block/index.tsx">
+<error line="13" column="20" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ lock: unknown; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ lock: unknown; }&gt;&gt; | undefined): Block&lt;{ lock: unknown; }&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: boolean; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; lock: boolean; }; attributes: { ...; }; parent: string[]; textdomain: string; apiVersion: number; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ lock: unknown; }&gt;&apos;.
+      Type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: boolean; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; lock: boolean; }; attributes: { ...; }; parent: string[]; textdomain: string; apiVersion: number; }&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;{ lock: unknown; }&gt;, &quot;icon&quot;&gt;&gt;&apos;.
+        The types of &apos;attributes[&quot;lock&quot;]&apos; are incompatible between these types.
+          Type &apos;{ type: string; default: { remove: boolean; move: boolean; }; }&apos; is not assignable to type &apos;BlockAttribute&lt;unknown&gt;&apos;.
+            Type &apos;{ type: string; default: { remove: boolean; move: boolean; }; }&apos; is missing the following properties from type &apos;Query&lt;unknown&gt;&apos;: source, selector, query
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{}&gt;): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: boolean; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; lock: boolean; }; attributes: { ...; }; parent: string[]; textdomain: string; apiVersion: number; }&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2769" />
+</file>
+<file name="assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-footer-block/index.tsx">
+<error line="13" column="20" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ lock: unknown; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ lock: unknown; }&gt;&gt; | undefined): Block&lt;{ lock: unknown; }&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: boolean; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; lock: boolean; }; attributes: { ...; }; parent: string[]; textdomain: string; apiVersion: number; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ lock: unknown; }&gt;&apos;.
+      Type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: boolean; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; lock: boolean; }; attributes: { ...; }; parent: string[]; textdomain: string; apiVersion: number; }&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;{ lock: unknown; }&gt;, &quot;icon&quot;&gt;&gt;&apos;.
+        The types of &apos;attributes[&quot;lock&quot;]&apos; are incompatible between these types.
+          Type &apos;{ type: string; default: { remove: boolean; move: boolean; }; }&apos; is not assignable to type &apos;BlockAttribute&lt;unknown&gt;&apos;.
+            Type &apos;{ type: string; default: { remove: boolean; move: boolean; }; }&apos; is missing the following properties from type &apos;Query&lt;unknown&gt;&apos;: source, selector, query
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{}&gt;): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: boolean; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; lock: boolean; }; attributes: { ...; }; parent: string[]; textdomain: string; apiVersion: number; }&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2769" />
+</file>
+<file name="assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-shopping-button-block/edit.tsx">
+<error line="18" column="6" severity="error" message="Property &apos;className&apos; is missing in type &apos;{}&apos; but required in type &apos;MiniCartShoppingButtonBlockProps&apos;." source="TS2741" />
+</file>
+<file name="assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-shopping-button-block/index.tsx">
+<error line="13" column="20" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ lock: unknown; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ lock: unknown; }&gt;&gt; | undefined): Block&lt;{ lock: unknown; }&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: boolean; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; }; attributes: { ...; }; parent: string[]; textdomain: string; apiVersion: number; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ lock: unknown; }&gt;&apos;.
+      Type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: boolean; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; }; attributes: { ...; }; parent: string[]; textdomain: string; apiVersion: number; }&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;{ lock: unknown; }&gt;, &quot;icon&quot;&gt;&gt;&apos;.
+        The types of &apos;attributes[&quot;lock&quot;]&apos; are incompatible between these types.
+          Type &apos;{ type: string; default: { remove: boolean; move: boolean; }; }&apos; is not assignable to type &apos;BlockAttribute&lt;unknown&gt;&apos;.
+            Type &apos;{ type: string; default: { remove: boolean; move: boolean; }; }&apos; is missing the following properties from type &apos;Query&lt;unknown&gt;&apos;: source, selector, query
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{}&gt;): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; supports: { align: boolean; html: boolean; multiple: boolean; reusable: boolean; inserter: boolean; }; attributes: { ...; }; parent: string[]; textdomain: string; apiVersion: number; }&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2769" />
+</file>
+<file name="assets/js/blocks/mini-cart/test/block.js">
+<error line="25" column="25" severity="error" message="Parameter &apos;props&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="59" column="25" severity="error" message="Property &apos;invalidateResolutionForStore&apos; does not exist on type &apos;DispatchFromMap&lt;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/data/cart/actions&quot;)&gt;&apos;." source="TS2339" />
+<error line="60" column="38" severity="error" message="Argument of type &apos;Cart&apos; is not assignable to parameter of type &apos;CartResponse&apos;." source="TS2345" />
+<error line="103" column="6" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="125" column="6" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="135" column="42" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="147" column="52" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;Matchers&lt;void, HTMLElement | null&gt;&apos;." source="TS2339" />
+</file>
+<file name="assets/js/blocks/price-filter/edit.tsx">
+<error line="18" column="2" severity="error" message="Module &apos;&quot;@wordpress/components&quot;&apos; has no exported member &apos;__experimentalToggleGroupControl&apos;." source="TS2305" />
+<error line="20" column="2" severity="error" message="Module &apos;&quot;@wordpress/components&quot;&apos; has no exported member &apos;__experimentalToggleGroupControlOption&apos;." source="TS2305" />
+</file>
+<file name="assets/js/blocks/price-filter/index.tsx">
+<error line="16" column="20" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;Attributes&gt;, settings?: Partial&lt;BlockConfiguration&lt;Attributes&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { html: boolean; multiple: boolean; color: { text: boolean; background: boolean; }; inserter: boolean; lock: boolean; }; ... 4 more ...; $schema: string; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;Attributes&gt;&apos;.
+      Type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { html: boolean; multiple: boolean; color: { text: boolean; background: boolean; }; inserter: boolean; lock: boolean; }; ... 4 more ...; $schema: string; }&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;Attributes&gt;, &quot;icon&quot;&gt;&gt;&apos;.
+        Types of property &apos;attributes&apos; are incompatible.
+          Property &apos;heading&apos; is missing in type &apos;{ className: { type: string; default: string; }; showInputFields: { type: string; default: boolean; }; inlineInput: { type: string; default: boolean; }; showFilterButton: { type: string; default: boolean; }; headingLevel: { ...; }; }&apos; but required in type &apos;{ readonly showFilterButton: BlockAttribute&lt;boolean&gt;; readonly showInputFields: BlockAttribute&lt;boolean&gt;; readonly inlineInput: BlockAttribute&lt;boolean&gt;; readonly heading: BlockAttribute&lt;...&gt;; readonly headingLevel: BlockAttribute&lt;...&gt;; readonly className?: BlockAttribute&lt;...&gt;; }&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;Attributes&gt;): Block&lt;Attributes&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { html: boolean; multiple: boolean; color: { text: boolean; background: boolean; }; inserter: boolean; lock: boolean; }; ... 4 more ...; $schema: string; }&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2769" />
+</file>
+<file name="assets/js/blocks/price-filter/test/use-price-constraints.js">
+<error line="16" column="28" severity="error" message="Binding element &apos;price&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="21" column="5" severity="error" message="Type &apos;{ minPriceConstraint: number | null | undefined; maxPriceConstraint: number | null | undefined; }&apos; is not assignable to type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLDivElement&gt;, HTMLDivElement&gt;&apos;.
+  Property &apos;minPriceConstraint&apos; does not exist on type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLDivElement&gt;, HTMLDivElement&gt;&apos;." source="TS2322" />
+</file>
+<file name="assets/js/editor-components/grid-layout-control/index.js">
+<error line="38" column="30" severity="error" message="Argument of type &apos;number | undefined&apos; is not assignable to parameter of type &apos;number&apos;.
+  Type &apos;undefined&apos; is not assignable to type &apos;number&apos;." source="TS2345" />
+<error line="50" column="30" severity="error" message="Argument of type &apos;number | undefined&apos; is not assignable to parameter of type &apos;number&apos;.
+  Type &apos;undefined&apos; is not assignable to type &apos;number&apos;." source="TS2345" />
+</file>
+<file name="assets/js/blocks/product-best-sellers/block.tsx">
+<error line="5" column="30" severity="error" message="Could not find a declaration file for module &apos;@wordpress/server-side-render&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@wordpress/server-side-render/build/index.js&apos; implicitly has an &apos;any&apos; type.
+  Try `npm i --save-dev @types/wordpress__server-side-render` if it exists or add a new declaration (.d.ts) file containing `declare module &apos;@wordpress/server-side-render&apos;;`" source="TS7016" />
+</file>
+<file name="assets/js/blocks/product-best-sellers/index.tsx">
+<error line="17" column="20" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ columns: unknown; rows: unknown; alignButtons: unknown; contentVisibility: unknown; categories: unknown; catOperator: unknown; isPreview: unknown; stockStatus: unknown; editMode: unknown; orderby: unknown; }&gt;, settings?: Partial&lt;...&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; title: string; category: string; keywords: string[]; description: string; supports: { align: string[]; html: boolean; }; example: { attributes: { isPreview: boolean; }; }; attributes: { columns: { ...; }; ... 8 more ...; orderby: { ...; }; }; textdomain: string; apiVersion: number; $schema: string; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ columns: unknown; rows: unknown; alignButtons: unknown; contentVisibility: unknown; categories: unknown; catOperator: unknown; isPreview: unknown; stockStatus: unknown; editMode: unknown; orderby: unknown; }&gt;&apos;.
+      Type &apos;{ name: string; title: string; category: string; keywords: string[]; description: string; supports: { align: string[]; html: boolean; }; example: { attributes: { isPreview: boolean; }; }; attributes: { columns: { ...; }; ... 8 more ...; orderby: { ...; }; }; textdomain: string; apiVersion: number; $schema: string; }&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;{ columns: unknown; rows: unknown; alignButtons: unknown; contentVisibility: unknown; categories: unknown; catOperator: unknown; isPreview: unknown; stockStatus: unknown; editMode: unknown; orderby: unknown; }&gt;, &quot;icon&quot;&gt;&gt;&apos;.
+        The types of &apos;attributes[&quot;columns&quot;]&apos; are incompatible between these types.
+          Type &apos;{ type: string; default: number; }&apos; is not assignable to type &apos;BlockAttribute&lt;unknown&gt;&apos;.
+            Type &apos;{ type: string; default: number; }&apos; is missing the following properties from type &apos;Query&lt;unknown&gt;&apos;: source, selector, query
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ columns: unknown; rows: unknown; alignButtons: unknown; contentVisibility: unknown; categories: unknown; catOperator: unknown; isPreview: unknown; stockStatus: unknown; editMode: unknown; orderby: unknown; }&gt;): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; title: string; category: string; keywords: string[]; description: string; supports: { align: string[]; html: boolean; }; example: { attributes: { isPreview: boolean; }; }; attributes: { columns: { ...; }; ... 8 more ...; orderby: { ...; }; }; textdomain: string; apiVersion: number; $schema: string; }&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2769" />
+</file>
+<file name="assets/js/blocks/product-categories/block.js">
+<error line="6" column="30" severity="error" message="Could not find a declaration file for module &apos;@wordpress/server-side-render&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@wordpress/server-side-render/build/index.js&apos; implicitly has an &apos;any&apos; type.
+  Try `npm i --save-dev @types/wordpress__server-side-render` if it exists or add a new declaration (.d.ts) file containing `declare module &apos;@wordpress/server-side-render&apos;;`" source="TS7016" />
+<error line="15" column="2" severity="error" message="Module &apos;&quot;@wordpress/components&quot;&apos; has no exported member &apos;__experimentalToggleGroupControl&apos;." source="TS2305" />
+<error line="17" column="2" severity="error" message="Module &apos;&quot;@wordpress/components&quot;&apos; has no exported member &apos;__experimentalToggleGroupControlOption&apos;." source="TS2305" />
+<error line="46" column="11" severity="error" message="Property &apos;hasCount&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="46" column="21" severity="error" message="Property &apos;hasImage&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="46" column="31" severity="error" message="Property &apos;hasEmpty&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="46" column="41" severity="error" message="Property &apos;isDropdown&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="46" column="53" severity="error" message="Property &apos;isHierarchical&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="64" column="20" severity="error" message="Parameter &apos;value&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+</file>
+<file name="assets/js/blocks/product-categories/edit.tsx">
+<error line="17" column="5" severity="error" message="Type &apos;unknown&apos; is not assignable to type &apos;IntrinsicAttributes &amp; Pick&lt;{ attributes: Object; setAttributes: (arg0: any) =&gt; any; name: string; }, &quot;name&quot; | &quot;attributes&quot; | &quot;setAttributes&quot;&gt; &amp; Pick&lt;...&gt; &amp; Pick&lt;...&gt;&apos;.
+  Type &apos;unknown&apos; is not assignable to type &apos;IntrinsicAttributes&apos;." source="TS2322" />
+<error line="17" column="16" severity="error" message="Spread types may only be created from object types." source="TS2698" />
+</file>
+<file name="assets/js/blocks/product-categories/index.tsx">
+<error line="15" column="20" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ align: unknown; hasCount: unknown; hasImage: unknown; hasEmpty: unknown; isDropdown: unknown; isHierarchical: unknown; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ align: unknown; hasCount: unknown; hasImage: unknown; hasEmpty: unknown; isDropdown: unknown; isHierarchical: unknown; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; title: string; category: string; description: string; keywords: string[]; supports: { align: string[]; html: boolean; color: { background: boolean; link: boolean; }; typography: { fontSize: boolean; lineHeight: boolean; }; }; ... 4 more ...; $schema: string; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ align: unknown; hasCount: unknown; hasImage: unknown; hasEmpty: unknown; isDropdown: unknown; isHierarchical: unknown; }&gt;&apos;.
+      Type &apos;{ name: string; title: string; category: string; description: string; keywords: string[]; supports: { align: string[]; html: boolean; color: { background: boolean; link: boolean; }; typography: { fontSize: boolean; lineHeight: boolean; }; }; ... 4 more ...; $schema: string; }&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;{ align: unknown; hasCount: unknown; hasImage: unknown; hasEmpty: unknown; isDropdown: unknown; isHierarchical: unknown; }&gt;, &quot;icon&quot;&gt;&gt;&apos;.
+        The types of &apos;attributes[&quot;align&quot;]&apos; are incompatible between these types.
+          Type &apos;{ type: string; }&apos; is not assignable to type &apos;BlockAttribute&lt;unknown&gt;&apos;.
+            Type &apos;{ type: string; }&apos; is missing the following properties from type &apos;Query&lt;unknown&gt;&apos;: source, selector, query
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{}&gt;): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; title: string; category: string; description: string; keywords: string[]; supports: { align: string[]; html: boolean; color: { background: boolean; link: boolean; }; typography: { fontSize: boolean; lineHeight: boolean; }; }; ... 4 more ...; $schema: string; }&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2769" />
+<error line="30" column="18" severity="error" message="Property &apos;idBase&apos; does not exist on type &apos;{ align: unknown; hasCount: unknown; hasImage: unknown; hasEmpty: unknown; isDropdown: unknown; isHierarchical: unknown; }&apos;." source="TS2339" />
+<error line="30" column="26" severity="error" message="Property &apos;instance&apos; does not exist on type &apos;{ align: unknown; hasCount: unknown; hasImage: unknown; hasEmpty: unknown; isDropdown: unknown; isHierarchical: unknown; }&apos;." source="TS2339" />
+<error line="33" column="20" severity="error" message="Property &apos;instance&apos; does not exist on type &apos;{ align: unknown; hasCount: unknown; hasImage: unknown; hasEmpty: unknown; isDropdown: unknown; isHierarchical: unknown; }&apos;." source="TS2339" />
+<error line="85" column="6" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;&quot;data-has-count&quot;&apos; can&apos;t be used to index type &apos;{}&apos;.
+  Property &apos;data-has-count&apos; does not exist on type &apos;{}&apos;." source="TS7053" />
+<error line="88" column="6" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;&quot;data-has-empty&quot;&apos; can&apos;t be used to index type &apos;{}&apos;.
+  Property &apos;data-has-empty&apos; does not exist on type &apos;{}&apos;." source="TS7053" />
+<error line="91" column="6" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;&quot;data-is-dropdown&quot;&apos; can&apos;t be used to index type &apos;{}&apos;.
+  Property &apos;data-is-dropdown&apos; does not exist on type &apos;{}&apos;." source="TS7053" />
+<error line="94" column="6" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;&quot;data-is-hierarchical&quot;&apos; can&apos;t be used to index type &apos;{}&apos;.
+  Property &apos;data-is-hierarchical&apos; does not exist on type &apos;{}&apos;." source="TS7053" />
+</file>
+<file name="assets/js/blocks/product-category/block.tsx">
+<error line="5" column="30" severity="error" message="Could not find a declaration file for module &apos;@wordpress/server-side-render&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@wordpress/server-side-render/build/index.js&apos; implicitly has an &apos;any&apos; type.
+  Try `npm i --save-dev @types/wordpress__server-side-render` if it exists or add a new declaration (.d.ts) file containing `declare module &apos;@wordpress/server-side-render&apos;;`" source="TS7016" />
+</file>
+<file name="assets/js/editor-components/product-stock-control/index.tsx">
+<error line="28" column="10" severity="error" message="Property &apos;outofstock&apos; does not exist on type &apos;unknown&apos;." source="TS2339" />
+<error line="28" column="25" severity="error" message="Rest types may only be created from object types." source="TS2700" />
+<error line="90" column="7" severity="error" message="Type &apos;unknown&apos; is not assignable to type &apos;ReactNode&apos;." source="TS2322" />
+</file>
+<file name="assets/js/blocks/product-category/index.tsx">
+<error line="21" column="20" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ columns: unknown; rows: unknown; alignButtons: unknown; categories: unknown; catOperator: unknown; contentVisibility: unknown; isPreview: unknown; stockStatus: unknown; editMode: unknown; orderby: unknown; }&gt;, settings?: Partial&lt;...&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; title: string; category: string; keywords: string[]; description: string; supports: { align: string[]; html: boolean; }; example: { attributes: { isPreview: boolean; }; }; attributes: { columns: { ...; }; ... 8 more ...; orderby: { ...; }; }; textdomain: string; apiVersion: number; $schema: string; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ columns: unknown; rows: unknown; alignButtons: unknown; categories: unknown; catOperator: unknown; contentVisibility: unknown; isPreview: unknown; stockStatus: unknown; editMode: unknown; orderby: unknown; }&gt;&apos;.
+      Type &apos;{ name: string; title: string; category: string; keywords: string[]; description: string; supports: { align: string[]; html: boolean; }; example: { attributes: { isPreview: boolean; }; }; attributes: { columns: { ...; }; ... 8 more ...; orderby: { ...; }; }; textdomain: string; apiVersion: number; $schema: string; }&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;{ columns: unknown; rows: unknown; alignButtons: unknown; categories: unknown; catOperator: unknown; contentVisibility: unknown; isPreview: unknown; stockStatus: unknown; editMode: unknown; orderby: unknown; }&gt;, &quot;icon&quot;&gt;&gt;&apos;.
+        The types of &apos;attributes.columns&apos; are incompatible between these types.
+          Type &apos;{ type: string; default: number; }&apos; is not assignable to type &apos;BlockAttribute&lt;unknown&gt;&apos;.
+            Type &apos;{ type: string; default: number; }&apos; is missing the following properties from type &apos;Query&lt;unknown&gt;&apos;: source, selector, query
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ columns: unknown; rows: unknown; alignButtons: unknown; categories: unknown; catOperator: unknown; contentVisibility: unknown; isPreview: unknown; stockStatus: unknown; editMode: unknown; orderby: unknown; }&gt;): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; title: string; category: string; keywords: string[]; description: string; supports: { align: string[]; html: boolean; }; example: { attributes: { isPreview: boolean; }; }; attributes: { columns: { ...; }; ... 8 more ...; orderby: { ...; }; }; textdomain: string; apiVersion: number; $schema: string; }&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2769" />
+</file>
+<file name="assets/js/blocks/product-new/block.js">
+<error line="8" column="30" severity="error" message="Could not find a declaration file for module &apos;@wordpress/server-side-render&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@wordpress/server-side-render/build/index.js&apos; implicitly has an &apos;any&apos; type.
+  Try `npm i --save-dev @types/wordpress__server-side-render` if it exists or add a new declaration (.d.ts) file containing `declare module &apos;@wordpress/server-side-render&apos;;`" source="TS7016" />
+<error line="82" column="20" severity="error" message="Parameter &apos;value&apos; implicitly has an &apos;any[]&apos; type." source="TS7006" />
+</file>
+<file name="assets/js/blocks/product-new/index.js">
+<error line="17" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ columns: unknown; rows: unknown; alignButtons: unknown; categories: unknown; catOperator: unknown; contentVisibility: unknown; isPreview: unknown; stockStatus: unknown; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ columns: unknown; rows: unknown; ... 5 more ...; stockStatus: unknown; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ columns: unknown; rows: unknown; alignButtons: unknown; categories: unknown; catOperator: unknown; contentVisibility: unknown; isPreview: unknown; stockStatus: unknown; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ columns: unknown; rows: unknown; alignButtons: unknown; categories: unknown; catOperator: unknown; contentVisibility: unknown; isPreview: unknown; stockStatus: unknown; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ columns: unknown; rows: unknown; alignButtons: unknown; categories: unknown; catOperator: unknown; contentVisibility: unknown; isPreview: unknown; stockStatus: unknown; }&gt;): Block&lt;{ ...; }&gt; | undefined&apos;, gave the following error.
+    Type &apos;{ columns: { type: string; default: any; }; rows: { type: string; default: any; }; alignButtons: { type: string; default: boolean; }; categories: { type: string; default: never[]; }; catOperator: { type: string; default: string; }; contentVisibility: { ...; }; isPreview: { ...; }; stockStatus: { ...; }; }&apos; is not assignable to type &apos;{ readonly columns: BlockAttribute&lt;unknown&gt;; readonly rows: BlockAttribute&lt;unknown&gt;; readonly alignButtons: BlockAttribute&lt;unknown&gt;; readonly categories: BlockAttribute&lt;unknown&gt;; readonly catOperator: BlockAttribute&lt;...&gt;; readonly contentVisibility: BlockAttribute&lt;...&gt;; readonly isPreview: BlockAttribute&lt;...&gt;; reado...&apos;.
+      Types of property &apos;columns&apos; are incompatible.
+        Type &apos;{ type: string; default: any; }&apos; is not assignable to type &apos;BlockAttribute&lt;unknown&gt;&apos;.
+          Type &apos;{ type: string; default: any; }&apos; is missing the following properties from type &apos;Query&lt;unknown&gt;&apos;: source, selector, query" source="TS2769" />
+</file>
+<file name="assets/js/blocks/product-on-sale/block.js">
+<error line="8" column="30" severity="error" message="Could not find a declaration file for module &apos;@wordpress/server-side-render&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@wordpress/server-side-render/build/index.js&apos; implicitly has an &apos;any&apos; type.
+  Try `npm i --save-dev @types/wordpress__server-side-render` if it exists or add a new declaration (.d.ts) file containing `declare module &apos;@wordpress/server-side-render&apos;;`" source="TS7016" />
+<error line="95" column="20" severity="error" message="Parameter &apos;value&apos; implicitly has an &apos;any[]&apos; type." source="TS7006" />
+</file>
+<file name="assets/js/blocks/product-on-sale/index.js">
+<error line="17" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ orderby: unknown; columns: unknown; rows: unknown; alignButtons: unknown; categories: unknown; catOperator: unknown; contentVisibility: unknown; isPreview: unknown; stockStatus: unknown; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ orderby: unknown; ... 7 more ...; stockStatus: unknown; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ orderby: unknown; columns: unknown; rows: unknown; alignButtons: unknown; categories: unknown; catOperator: unknown; contentVisibility: unknown; isPreview: unknown; stockStatus: unknown; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ orderby: unknown; columns: unknown; rows: unknown; alignButtons: unknown; categories: unknown; catOperator: unknown; contentVisibility: unknown; isPreview: unknown; stockStatus: unknown; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ orderby: unknown; columns: unknown; rows: unknown; alignButtons: unknown; categories: unknown; catOperator: unknown; contentVisibility: unknown; isPreview: unknown; stockStatus: unknown; }&gt;): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Type &apos;{ orderby: { type: &quot;string&quot;; default: string; }; columns: { type: string; default: any; }; rows: { type: string; default: any; }; alignButtons: { type: string; default: boolean; }; categories: { type: string; default: never[]; }; catOperator: { ...; }; contentVisibility: { ...; }; isPreview: { ...; }; stockStatus: {...&apos; is not assignable to type &apos;{ readonly orderby: BlockAttribute&lt;unknown&gt;; readonly columns: BlockAttribute&lt;unknown&gt;; readonly rows: BlockAttribute&lt;unknown&gt;; readonly alignButtons: BlockAttribute&lt;unknown&gt;; ... 4 more ...; readonly stockStatus: BlockAttribute&lt;...&gt;; }&apos;.
+      Types of property &apos;columns&apos; are incompatible.
+        Type &apos;{ type: string; default: any; }&apos; is not assignable to type &apos;BlockAttribute&lt;unknown&gt;&apos;." source="TS2769" />
+</file>
+<file name="assets/js/blocks/product-query/utils.tsx">
+<error line="5" column="10" severity="error" message="Module &apos;&quot;@wordpress/blocks&quot;&apos; has no exported member &apos;store&apos;." source="TS2305" />
+<error line="74" column="30" severity="error" message="Property &apos;getActiveBlockVariation&apos; does not exist on type &apos;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__rich-text/store/selectors&quot;)&apos;." source="TS2339" />
+</file>
+<file name="assets/js/blocks/product-query/inspector-controls.tsx">
+<error line="14" column="2" severity="error" message="Module &apos;&quot;@wordpress/components&quot;&apos; has no exported member &apos;__experimentalToolsPanel&apos;." source="TS2305" />
+<error line="16" column="2" severity="error" message="Module &apos;&quot;@wordpress/components&quot;&apos; has no exported member &apos;__experimentalToolsPanelItem&apos;." source="TS2305" />
+<error line="51" column="6" severity="error" message="Property &apos;getBlockVariations&apos; does not exist on type &apos;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__blocks/store/selectors&quot;)&apos;." source="TS2339" />
+<error line="118" column="6" severity="error" message="Type &apos;{ label: string; onChange: (statusLabels: readonly Value[]) =&gt; void; suggestions: string[]; validateInput: (value: string) =&gt; boolean; value: string[]; __experimentalExpandOnFocus: boolean; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; Props &amp; { children?: ReactNode; }&apos;.
+  Property &apos;label&apos; does not exist on type &apos;IntrinsicAttributes &amp; Props &amp; { children?: ReactNode; }&apos;." source="TS2322" />
+</file>
+<file name="assets/js/blocks/product-search/block.js">
+<error line="38" column="37" severity="error" message="Type &apos;unknown&apos; is not assignable to type &apos;string | undefined&apos;." source="TS2322" />
+<error line="61" column="7" severity="error" message="Type &apos;{ children: Element; type: &quot;submit&quot;; className: string; label: string; }&apos; is not assignable to type &apos;DetailedHTMLProps&lt;ButtonHTMLAttributes&lt;HTMLButtonElement&gt;, HTMLButtonElement&gt;&apos;.
+  Property &apos;label&apos; does not exist on type &apos;DetailedHTMLProps&lt;ButtonHTMLAttributes&lt;HTMLButtonElement&gt;, HTMLButtonElement&gt;&apos;." source="TS2322" />
+</file>
+<file name="assets/js/blocks/product-search/edit.js">
+<error line="109" column="7" severity="error" message="Type &apos;string&apos; is not assignable to type &apos;number&apos;." source="TS2322" />
+<error line="149" column="32" severity="error" message="Argument of type &apos;{ ({ attributes: { label, placeholder, formId, className, hasLabel, align }, instanceId, setAttributes, }: {    attributes: {        label: string;        placeholder: string;        formId: string;        className: string;        hasLabel: boolean;        align: string;    };    instanceId: string;    setAttribute...&apos; is not assignable to parameter of type &apos;ComponentType&lt;{ attributes: { label: string; placeholder: string; formId: string; className: string; hasLabel: boolean; align: string; }; instanceId: string; setAttributes: (arg0: any) =&gt; any; }&gt;&apos;.
+  Type &apos;{ ({ attributes: { label, placeholder, formId, className, hasLabel, align }, instanceId, setAttributes, }: {    attributes: {        label: string;        placeholder: string;        formId: string;        className: string;        hasLabel: boolean;        align: string;    };    instanceId: string;    setAttribute...&apos; is not assignable to type &apos;FunctionComponent&lt;{ attributes: { label: string; placeholder: string; formId: string; className: string; hasLabel: boolean; align: string; }; instanceId: string; setAttributes: (arg0: any) =&gt; any; }&gt;&apos;.
+    The types of &apos;propTypes.attributes&apos; are incompatible between these types.
+      Type &apos;Validator&lt;object&gt;&apos; is not assignable to type &apos;Validator&lt;{ label: string; placeholder: string; formId: string; className: string; hasLabel: boolean; align: string; }&gt;&apos;.
+        Type &apos;{}&apos; is missing the following properties from type &apos;{ label: string; placeholder: string; formId: string; className: string; hasLabel: boolean; align: string; }&apos;: label, placeholder, formId, className, and 2 more." source="TS2345" />
+</file>
+<file name="assets/js/blocks/product-search/index.tsx">
+<error line="118" column="20" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ hasLabel: unknown; label: unknown; placeholder: unknown; formId: unknown; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ hasLabel: unknown; label: unknown; placeholder: unknown; formId: unknown; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ hasLabel: unknown; label: unknown; placeholder: unknown; formId: unknown; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ hasLabel: unknown; label: unknown; placeholder: unknown; formId: unknown; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;." source="TS2769" />
+<error line="150" column="18" severity="error" message="Property &apos;idBase&apos; does not exist on type &apos;{ hasLabel: unknown; label: unknown; placeholder: unknown; formId: unknown; }&apos;." source="TS2339" />
+<error line="150" column="26" severity="error" message="Property &apos;instance&apos; does not exist on type &apos;{ hasLabel: unknown; label: unknown; placeholder: unknown; formId: unknown; }&apos;." source="TS2339" />
+<error line="152" column="20" severity="error" message="Property &apos;instance&apos; does not exist on type &apos;{ hasLabel: unknown; label: unknown; placeholder: unknown; formId: unknown; }&apos;." source="TS2339" />
+<error line="167" column="8" severity="error" message="Type &apos;{ attributes: Readonly&lt;Record&lt;string, any&gt;&gt;; children?: ReactNode; }&apos; is not assignable to type &apos;Pick&lt;{ attributes: { label: string; placeholder: string; formId: string; className: string; hasLabel: boolean; align: string; }; }, &quot;attributes&quot;&gt;&apos;.
+  Types of property &apos;attributes&apos; are incompatible.
+    Type &apos;Readonly&lt;Record&lt;string, any&gt;&gt;&apos; is missing the following properties from type &apos;{ label: string; placeholder: string; formId: string; className: string; hasLabel: boolean; align: string; }&apos;: label, placeholder, formId, className, and 2 more." source="TS2322" />
+</file>
+<file name="assets/js/editor-components/product-tag-control/index.js">
+<error line="27" column="10" severity="error" message="A spread argument must either have a tuple type or be passed to a rest parameter." source="TS2556" />
+<error line="39" column="19" severity="error" message="Argument of type &apos;{ selected: any; }&apos; is not assignable to parameter of type &apos;{ selected: any[]; search: string; }&apos;.
+  Property &apos;search&apos; is missing in type &apos;{ selected: any; }&apos; but required in type &apos;{ selected: any[]; search: string; }&apos;." source="TS2345" />
+<error line="48" column="12" severity="error" message="Parameter &apos;search&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="61" column="14" severity="error" message="Parameter &apos;args&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="113" column="16" severity="error" message="Parameter &apos;n&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="139" column="15" severity="error" message="Parameter &apos;id&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="140" column="44" severity="error" message="Property &apos;id&apos; does not exist on type &apos;never&apos;." source="TS2339" />
+<error line="144" column="6" severity="error" message="Type &apos;DebouncedFunc&lt;(search: any) =&gt; void&gt; | null&apos; is not assignable to type &apos;(search: string) =&gt; void&apos;.
+  Type &apos;null&apos; is not assignable to type &apos;(search: string) =&gt; void&apos;." source="TS2322" />
+</file>
+<file name="assets/js/blocks/product-tag/block.js">
+<error line="6" column="30" severity="error" message="Could not find a declaration file for module &apos;@wordpress/server-side-render&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@wordpress/server-side-render/build/index.js&apos; implicitly has an &apos;any&apos; type.
+  Try `npm i --save-dev @types/wordpress__server-side-render` if it exists or add a new declaration (.d.ts) file containing `declare module &apos;@wordpress/server-side-render&apos;;`" source="TS7016" />
+<error line="31" column="10" severity="error" message="A spread argument must either have a tuple type or be passed to a rest parameter." source="TS2556" />
+<error line="66" column="24" severity="error" message="Parameter &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="67" column="20" severity="error" message="Parameter &apos;prevState&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="109" column="20" severity="error" message="Parameter &apos;value&apos; implicitly has an &apos;any[]&apos; type." source="TS7006" />
+<error line="212" column="20" severity="error" message="Parameter &apos;value&apos; implicitly has an &apos;any[]&apos; type." source="TS7006" />
+</file>
+<file name="assets/js/blocks/product-tag/edit.tsx">
+<error line="17" column="5" severity="error" message="Type &apos;unknown&apos; is not assignable to type &apos;IntrinsicAttributes &amp; Omit&lt;any, &quot;speak&quot; | &quot;debouncedSpeak&quot;&gt; &amp; { children?: ReactNode; }&apos;.
+  Type &apos;unknown&apos; is not assignable to type &apos;IntrinsicAttributes&apos;." source="TS2322" />
+<error line="17" column="16" severity="error" message="Spread types may only be created from object types." source="TS2698" />
+</file>
+<file name="assets/js/blocks/product-tag/index.tsx">
+<error line="18" column="20" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ columns: unknown; rows: unknown; tags: unknown; stockStatus: unknown; alignButtons: unknown; contentVisibility: unknown; tagOperator: unknown; orderby: unknown; isPreview: unknown; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ columns: unknown; ... 7 more ...; isPreview: unknown; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; title: string; category: string; keywords: string[]; description: string; supports: { align: string[]; html: boolean; }; attributes: { columns: { type: string; default: number; }; rows: { type: string; default: number; }; ... 6 more ...; stockStatus: { ...; }; }; example: { ...; }; textdomain: string...&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ columns: unknown; rows: unknown; tags: unknown; stockStatus: unknown; alignButtons: unknown; contentVisibility: unknown; tagOperator: unknown; orderby: unknown; isPreview: unknown; }&gt;&apos;.
+      Type &apos;{ name: string; title: string; category: string; keywords: string[]; description: string; supports: { align: string[]; html: boolean; }; attributes: { columns: { type: string; default: number; }; rows: { type: string; default: number; }; ... 6 more ...; stockStatus: { ...; }; }; example: { ...; }; textdomain: string...&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;{ columns: unknown; rows: unknown; tags: unknown; stockStatus: unknown; alignButtons: unknown; contentVisibility: unknown; tagOperator: unknown; orderby: unknown; isPreview: unknown; }&gt;, &quot;icon&quot;&gt;&gt;&apos;.
+        The types of &apos;attributes.columns&apos; are incompatible between these types.
+          Type &apos;{ type: string; default: number; }&apos; is not assignable to type &apos;BlockAttribute&lt;unknown&gt;&apos;.
+            Type &apos;{ type: string; default: number; }&apos; is missing the following properties from type &apos;Query&lt;unknown&gt;&apos;: source, selector, query
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ columns: unknown; rows: unknown; tags: unknown; stockStatus: unknown; alignButtons: unknown; contentVisibility: unknown; tagOperator: unknown; orderby: unknown; isPreview: unknown; }&gt;): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; title: string; category: string; keywords: string[]; description: string; supports: { align: string[]; html: boolean; }; attributes: { columns: { type: string; default: number; }; rows: { type: string; default: number; }; ... 6 more ...; stockStatus: { ...; }; }; example: { ...; }; textdomain: string...&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2769" />
+</file>
+<file name="assets/js/blocks/product-top-rated/block.js">
+<error line="8" column="30" severity="error" message="Could not find a declaration file for module &apos;@wordpress/server-side-render&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@wordpress/server-side-render/build/index.js&apos; implicitly has an &apos;any&apos; type.
+  Try `npm i --save-dev @types/wordpress__server-side-render` if it exists or add a new declaration (.d.ts) file containing `declare module &apos;@wordpress/server-side-render&apos;;`" source="TS7016" />
+<error line="70" column="20" severity="error" message="Parameter &apos;value&apos; implicitly has an &apos;any[]&apos; type." source="TS7006" />
+</file>
+<file name="assets/js/blocks/product-top-rated/index.js">
+<error line="20" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ columns: unknown; rows: unknown; alignButtons: unknown; categories: unknown; catOperator: unknown; contentVisibility: unknown; isPreview: unknown; stockStatus: unknown; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ columns: unknown; rows: unknown; ... 5 more ...; stockStatus: unknown; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ columns: unknown; rows: unknown; alignButtons: unknown; categories: unknown; catOperator: unknown; contentVisibility: unknown; isPreview: unknown; stockStatus: unknown; }&gt;&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ columns: unknown; rows: unknown; alignButtons: unknown; categories: unknown; catOperator: unknown; contentVisibility: unknown; isPreview: unknown; stockStatus: unknown; }&gt;, &quot;title&quot; | &quot;category&quot; | &quot;attributes&quot;&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ columns: unknown; rows: unknown; alignButtons: unknown; categories: unknown; catOperator: unknown; contentVisibility: unknown; isPreview: unknown; stockStatus: unknown; }&gt;): Block&lt;{ ...; }&gt; | undefined&apos;, gave the following error.
+    Type &apos;{ columns: { type: string; default: any; }; rows: { type: string; default: any; }; alignButtons: { type: string; default: boolean; }; categories: { type: string; default: never[]; }; catOperator: { type: string; default: string; }; contentVisibility: { ...; }; isPreview: { ...; }; stockStatus: { ...; }; }&apos; is not assignable to type &apos;{ readonly columns: BlockAttribute&lt;unknown&gt;; readonly rows: BlockAttribute&lt;unknown&gt;; readonly alignButtons: BlockAttribute&lt;unknown&gt;; readonly categories: BlockAttribute&lt;unknown&gt;; readonly catOperator: BlockAttribute&lt;...&gt;; readonly contentVisibility: BlockAttribute&lt;...&gt;; readonly isPreview: BlockAttribute&lt;...&gt;; reado...&apos;.
+      Types of property &apos;columns&apos; are incompatible.
+        Type &apos;{ type: string; default: any; }&apos; is not assignable to type &apos;BlockAttribute&lt;unknown&gt;&apos;." source="TS2769" />
+</file>
+<file name="assets/js/blocks/products/base-utils.js">
+<error line="17" column="14" severity="error" message="&apos;getProductLayoutConfig&apos; implicitly has return type &apos;any&apos; because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions." source="TS7023" />
+<error line="24" column="10" severity="error" message="Property &apos;name&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="26" column="14" severity="error" message="Property &apos;attributes&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="29" column="12" severity="error" message="Property &apos;innerBlocks&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="30" column="39" severity="error" message="Property &apos;innerBlocks&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+</file>
+<file name="assets/js/blocks/products/edit-utils.js">
+<error line="9" column="46" severity="error" message="Parameter &apos;blockTitle&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="9" column="58" severity="error" message="Parameter &apos;blockIcon&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="39" column="49" severity="error" message="Parameter &apos;blockTitle&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="39" column="61" severity="error" message="Parameter &apos;blockIcon&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+</file>
+<file name="assets/js/blocks/products/edit.js">
+<error line="7" column="43" severity="error" message="Parameter &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="7" column="55" severity="error" message="Parameter &apos;setAttributes&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="28" column="40" severity="error" message="Parameter &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="28" column="52" severity="error" message="Parameter &apos;setAttributes&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+</file>
+<file name="assets/js/blocks/products/utils.js">
+<error line="6" column="36" severity="error" message="Parameter &apos;blockClassName&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="6" column="52" severity="error" message="Parameter &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+</file>
+<file name="assets/js/blocks/products/all-products/block.js">
+<error line="43" column="6" severity="error" message="Type &apos;{ attributes: any; urlParameterSuffix: any; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; Pick&lt;ProductListContainerProps, &quot;attributes&quot;&gt; &amp; Pick&lt;InferProps&lt;{ attributes: Validator&lt;object&gt;; hideOutOfStockItems: Requireable&lt;...&gt;; }&gt;, &quot;hideOutOfStockItems&quot;&gt; &amp; Pick&lt;...&gt;&apos;.
+  Property &apos;urlParameterSuffix&apos; does not exist on type &apos;IntrinsicAttributes &amp; Pick&lt;ProductListContainerProps, &quot;attributes&quot;&gt; &amp; Pick&lt;InferProps&lt;{ attributes: Validator&lt;object&gt;; hideOutOfStockItems: Requireable&lt;...&gt;; }&gt;, &quot;hideOutOfStockItems&quot;&gt; &amp; Pick&lt;...&gt;&apos;." source="TS2322" />
+</file>
+<file name="assets/js/blocks/products/all-products/deprecated.js">
+<error line="18" column="10" severity="error" message="Binding element &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+</file>
+<file name="assets/js/blocks/products/all-products/edit.js">
+<error line="183" column="10" severity="error" message="Variable &apos;newBlocks&apos; implicitly has type &apos;any[]&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="185" column="34" severity="error" message="Argument of type &apos;string | { imageSizing: string; }&apos; is not assignable to parameter of type &apos;string&apos;.
+  Type &apos;{ imageSizing: string; }&apos; is not assignable to type &apos;string&apos;." source="TS2345" />
+<error line="188" column="40" severity="error" message="Variable &apos;newBlocks&apos; implicitly has an &apos;any[]&apos; type." source="TS7005" />
+<error line="199" column="20" severity="error" message="Property &apos;renderAppender&apos; does not exist on type &apos;{ template: any; templateLock: boolean; allowedBlocks: string[]; }&apos;." source="TS2339" />
+<error line="222" column="11" severity="error" message="Property &apos;isLoading&apos; is missing in type &apos;{ children: Element; product: { id: number; name: string; variation: string; permalink: string; sku: string; short_description: string; description: string; price: string; price_html: string; ... 9 more ...; on_sale: boolean; }; }&apos; but required in type &apos;{ product: any; children: Object; isLoading: boolean; }&apos;." source="TS2741" />
+<error line="225" column="12" severity="error" message="Type &apos;{ template: any; templateLock: boolean; allowedBlocks: string[]; }&apos; is not assignable to type &apos;Props&apos;.
+  Types of property &apos;templateLock&apos; are incompatible.
+    Type &apos;boolean&apos; is not assignable to type &apos;EditorTemplateLock | undefined&apos;." source="TS2322" />
+</file>
+<file name="assets/js/blocks/products/all-products/frontend.js">
+<error line="20" column="20" severity="error" message="Parameter &apos;el&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+</file>
+<file name="assets/js/blocks/products/all-products/save.js">
+<error line="11" column="33" severity="error" message="Binding element &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="16" column="4" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;string&apos; can&apos;t be used to index type &apos;{}&apos;.
+  No index signature with a parameter of type &apos;string&apos; was found on type &apos;{}&apos;." source="TS7053" />
+</file>
+<file name="assets/js/blocks/products/all-products/index.js">
+<error line="36" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{}&gt;, settings?: Partial&lt;BlockConfiguration&lt;{}&gt;&gt; | undefined): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{}&gt;&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{}&gt;): Block&lt;{}&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ icon: { src: JSX.Element; }; edit: any; save: ({ attributes }: { attributes: any; }) =&gt; JSX.Element; deprecated: { attributes: { columns: { type: string; }; rows: { type: string; }; alignButtons: { type: string; }; contentVisibility: { ...; }; orderby: { ...; }; layoutConfig: { ...; }; isPreview: { ...; }; } &amp; { ....&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{}&gt;&apos;.
+      Type &apos;{ icon: { src: JSX.Element; }; edit: any; save: ({ attributes }: { attributes: any; }) =&gt; JSX.Element; deprecated: { attributes: { columns: { type: string; }; rows: { type: string; }; alignButtons: { type: string; }; contentVisibility: { ...; }; orderby: { ...; }; layoutConfig: { ...; }; isPreview: { ...; }; } &amp; { ....&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;{}&gt;, &quot;icon&quot;&gt;&gt;&apos;.
+        Types of property &apos;deprecated&apos; are incompatible.
+          Type &apos;{ attributes: { columns: { type: string; }; rows: { type: string; }; alignButtons: { type: string; }; contentVisibility: { type: string; }; orderby: { type: string; }; layoutConfig: { type: string; }; isPreview: { ...; }; } &amp; { ...; }; save({ attributes }: { ...; }): Element; }[]&apos; is not assignable to type &apos;readonly BlockDeprecation&lt;{}, Record&lt;string, any&gt;&gt;[]&apos;.
+            Type &apos;{ attributes: { columns: { type: string; }; rows: { type: string; }; alignButtons: { type: string; }; contentVisibility: { type: string; }; orderby: { type: string; }; layoutConfig: { type: string; }; isPreview: { ...; }; } &amp; { ...; }; save({ attributes }: { ...; }): Element; }&apos; is not assignable to type &apos;BlockDeprecation&lt;{}, Record&lt;string, any&gt;&gt;&apos;.
+              Types of property &apos;attributes&apos; are incompatible.
+                Type &apos;{ columns: { type: string; }; rows: { type: string; }; alignButtons: { type: string; }; contentVisibility: { type: string; }; orderby: { type: string; }; layoutConfig: { type: string; }; isPreview: { type: string; default: boolean; }; } &amp; { ...; }&apos; is not assignable to type &apos;{ readonly [x: string]: BlockAttribute&lt;any&gt;; }&apos;.
+                  Property &apos;&quot;columns&quot;&apos; is incompatible with index signature.
+                    Type &apos;{ type: string; }&apos; is not assignable to type &apos;BlockAttribute&lt;any&gt;&apos;.
+                      Type &apos;{ type: string; }&apos; is missing the following properties from type &apos;Query&lt;any&gt;&apos;: source, selector, query" source="TS2769" />
+</file>
+<file name="assets/js/blocks/products-by-attribute/block.tsx">
+<error line="4" column="30" severity="error" message="Could not find a declaration file for module &apos;@wordpress/server-side-render&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@wordpress/server-side-render/build/index.js&apos; implicitly has an &apos;any&apos; type.
+  Try `npm i --save-dev @types/wordpress__server-side-render` if it exists or add a new declaration (.d.ts) file containing `declare module &apos;@wordpress/server-side-render&apos;;`" source="TS7016" />
+</file>
+<file name="assets/js/editor-components/product-attribute-term-control/index.js">
+<error line="15" column="38" severity="error" message="An import path cannot end with a &apos;.tsx&apos; extension. Consider importing &apos;@woocommerce/editor-components/expandable-search-list-item/expandable-search-list-item.js&apos; instead." source="TS2691" />
+<error line="23" column="2" severity="error" message="Binding element &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="24" column="2" severity="error" message="Binding element &apos;error&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="25" column="2" severity="error" message="Binding element &apos;expandedAttribute&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="26" column="2" severity="error" message="Binding element &apos;onChange&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="27" column="2" severity="error" message="Binding element &apos;onExpandAttribute&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="28" column="2" severity="error" message="Binding element &apos;onOperatorChange&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="29" column="2" severity="error" message="Binding element &apos;instanceId&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="30" column="2" severity="error" message="Binding element &apos;isCompact&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="31" column="2" severity="error" message="Binding element &apos;isLoading&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="32" column="2" severity="error" message="Binding element &apos;operator&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="33" column="2" severity="error" message="Binding element &apos;selected&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="34" column="2" severity="error" message="Binding element &apos;termsAreLoading&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="35" column="2" severity="error" message="Binding element &apos;termsList&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="37" column="23" severity="error" message="Parameter &apos;args&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="60" column="21" severity="error" message="Binding element &apos;id&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="141" column="15" severity="error" message="Parameter &apos;n&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="164" column="5" severity="error" message="Property &apos;isSingle&apos; is missing in type &apos;{ className: string; list: any[]; isLoading: any; selected: any; onChange: any; renderItem: (args: any) =&gt; Element; messages: { clear: string; list: string; noItems: string; search: string; selected: (n: any) =&gt; string; updated: string; }; isCompact: any; isHierarchical: true; }&apos; but required in type &apos;SearchListControlProps&apos;." source="TS2741" />
+<error line="169" column="16" severity="error" message="Binding element &apos;id&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+</file>
+<file name="assets/js/blocks/products-by-attribute/edit-mode.tsx">
+<error line="63" column="24" severity="error" message="Type &apos;{ id: never; attr_slug: never; }[]&apos; is not assignable to type &apos;string[]&apos;.
+  Type &apos;{ id: never; attr_slug: never; }&apos; is not assignable to type &apos;string&apos;." source="TS2322" />
+<error line="67" column="24" severity="error" message="Type &apos;string&apos; is not assignable to type &apos;&quot;all&quot; | &quot;any&quot;&apos;." source="TS2322" />
+</file>
+<file name="assets/js/blocks/products-by-attribute/inspector-controls.tsx">
+<error line="78" column="24" severity="error" message="Type &apos;{ id: never; attr_slug: never; }[]&apos; is not assignable to type &apos;string[]&apos;.
+  Type &apos;{ id: never; attr_slug: never; }&apos; is not assignable to type &apos;string&apos;." source="TS2322" />
+<error line="82" column="24" severity="error" message="Type &apos;string&apos; is not assignable to type &apos;&quot;all&quot; | &quot;any&quot;&apos;." source="TS2322" />
+</file>
+<file name="assets/js/blocks/products-by-attribute/index.tsx">
+<error line="15" column="20" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ columns: unknown; rows: unknown; stockStatus: unknown; attributes: unknown; attrOperator: unknown; contentVisibility: unknown; orderby: unknown; alignButtons: unknown; isPreview: unknown; }&gt;, settings?: Partial&lt;BlockConfiguration&lt;{ columns: unknown; ... 7 more ...; isPreview: unknown; }&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; title: string; category: string; keywords: string[]; description: string; supports: { align: string[]; html: boolean; }; attributes: { attributes: { type: string; default: never[]; }; attrOperator: { ...; }; ... 6 more ...; stockStatus: { ...; }; }; textdomain: string; apiVersion: number; $schema: st...&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ columns: unknown; rows: unknown; stockStatus: unknown; attributes: unknown; attrOperator: unknown; contentVisibility: unknown; orderby: unknown; alignButtons: unknown; isPreview: unknown; }&gt;&apos;.
+      Type &apos;{ name: string; title: string; category: string; keywords: string[]; description: string; supports: { align: string[]; html: boolean; }; attributes: { attributes: { type: string; default: never[]; }; attrOperator: { ...; }; ... 6 more ...; stockStatus: { ...; }; }; textdomain: string; apiVersion: number; $schema: st...&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;{ columns: unknown; rows: unknown; stockStatus: unknown; attributes: unknown; attrOperator: unknown; contentVisibility: unknown; orderby: unknown; alignButtons: unknown; isPreview: unknown; }&gt;, &quot;icon&quot;&gt;&gt;&apos;.
+        The types of &apos;attributes.columns&apos; are incompatible between these types.
+          Type &apos;{ type: string; default: number; }&apos; is not assignable to type &apos;BlockAttribute&lt;unknown&gt;&apos;.
+            Type &apos;{ type: string; default: number; }&apos; is missing the following properties from type &apos;Query&lt;unknown&gt;&apos;: source, selector, query
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ columns: unknown; rows: unknown; stockStatus: unknown; attributes: unknown; attrOperator: unknown; contentVisibility: unknown; orderby: unknown; alignButtons: unknown; isPreview: unknown; }&gt;): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; title: string; category: string; keywords: string[]; description: string; supports: { align: string[]; html: boolean; }; attributes: { attributes: { type: string; default: never[]; }; attrOperator: { ...; }; ... 6 more ...; stockStatus: { ...; }; }; textdomain: string; apiVersion: number; $schema: st...&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2769" />
+</file>
+<file name="assets/js/blocks/rating-filter/index.tsx">
+<error line="16" column="20" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;Attributes&gt;, settings?: Partial&lt;BlockConfiguration&lt;Attributes&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { html: boolean; multiple: boolean; color: { __experimentalDefaultControls: { text: boolean; }; }; inserter: boolean; lock: boolean; }; ... 4 more ...; $schema: string; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;Attributes&gt;&apos;.
+      Type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { html: boolean; multiple: boolean; color: { __experimentalDefaultControls: { text: boolean; }; }; inserter: boolean; lock: boolean; }; ... 4 more ...; $schema: string; }&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;Attributes&gt;, &quot;icon&quot;&gt;&gt;&apos;.
+        The types of &apos;attributes.className&apos; are incompatible between these types.
+          Type &apos;{ type: string; default: string; }&apos; is not assignable to type &apos;BlockAttribute&lt;string | undefined&gt;&apos;.
+            Type &apos;{ type: string; default: string; }&apos; is missing the following properties from type &apos;Query&lt;string | undefined&gt;&apos;: source, selector, query
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;Attributes&gt;): Block&lt;Attributes&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { html: boolean; multiple: boolean; color: { __experimentalDefaultControls: { text: boolean; }; }; inserter: boolean; lock: boolean; }; ... 4 more ...; $schema: string; }&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2769" />
+</file>
+<file name="assets/js/blocks/reviews/edit-utils.js">
+<error line="15" column="2" severity="error" message="Module &apos;&quot;@wordpress/components&quot;&apos; has no exported member &apos;__experimentalToggleGroupControl&apos;." source="TS2305" />
+<error line="17" column="2" severity="error" message="Module &apos;&quot;@wordpress/components&quot;&apos; has no exported member &apos;__experimentalToggleGroupControlOption&apos;." source="TS2305" />
+<error line="20" column="35" severity="error" message="Parameter &apos;editMode&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="20" column="45" severity="error" message="Parameter &apos;setAttributes&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="20" column="60" severity="error" message="Parameter &apos;buttonTitle&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="35" column="49" severity="error" message="Parameter &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="35" column="61" severity="error" message="Parameter &apos;setAttributes&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="118" column="20" severity="error" message="Parameter &apos;value&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="168" column="46" severity="error" message="Parameter &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="168" column="58" severity="error" message="Parameter &apos;setAttributes&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+</file>
+<file name="assets/js/blocks/reviews/editor-block.js">
+<error line="64" column="7" severity="error" message="Property &apos;onClick&apos; is missing in type &apos;{ screenReaderLabel: string; }&apos; but required in type &apos;LoadMoreButtonProps&apos;." source="TS2741" />
+</file>
+<file name="assets/js/blocks/reviews/editor-container-block.js">
+<error line="17" column="2" severity="error" message="Binding element &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="18" column="2" severity="error" message="Binding element &apos;icon&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="19" column="2" severity="error" message="Binding element &apos;name&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="20" column="2" severity="error" message="Binding element &apos;noReviewsPlaceholder&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="62" column="23" severity="error" message="Parameter &apos;callback&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+</file>
+<file name="assets/js/blocks/reviews/frontend-block.js">
+<error line="21" column="12" severity="error" message="Generic type &apos;Array&lt;T&gt;&apos; requires 1 type argument(s)." source="TS2314" />
+<error line="41" column="17" severity="error" message="Property &apos;showOrderby&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="48" column="17" severity="error" message="Property &apos;showLoadMore&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+</file>
+<file name="assets/js/blocks/reviews/frontend-container-block.js">
+<error line="20" column="10" severity="error" message="A spread argument must either have a tuple type or be passed to a rest parameter." source="TS2556" />
+<error line="42" column="19" severity="error" message="Parameter &apos;event&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="51" column="23" severity="error" message="Binding element &apos;newReviews&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+</file>
+<file name="assets/js/blocks/reviews/frontend.js">
+<error line="17" column="20" severity="error" message="Parameter &apos;el&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+</file>
+<file name="assets/js/blocks/reviews/save.js">
+<error line="12" column="20" severity="error" message="Binding element &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+</file>
+<file name="assets/js/blocks/reviews/all-reviews/edit.js">
+<error line="39" column="28" severity="error" message="Property &apos;showProductName&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="42" column="39" severity="error" message="Property &apos;showProductName&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="75" column="26" severity="error" message="Type &apos;() =&gt; JSX.Element&apos; is not assignable to type &apos;ReactElementLike&apos;." source="TS2322" />
+</file>
+<file name="assets/js/blocks/reviews/all-reviews/index.js">
+<error line="21" column="20" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ showProductName: unknown; editMode: unknown; imageType: unknown; orderby: unknown; reviewsOnLoadMore: unknown; reviewsOnPageLoad: unknown; showLoadMore: unknown; showOrderby: unknown; showReviewDate: unknown; showReviewerName: unknown; showReviewImage: unknown; showReviewRating: unknown; showReviewContent: unknown; previewReviews: unknown; }&gt;, settings?: Partial&lt;...&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ showProductName: unknown; editMode: unknown; imageType: unknown; orderby: unknown; reviewsOnLoadMore: unknown; reviewsOnPageLoad: unknown; showLoadMore: unknown; showOrderby: unknown; showReviewDate: unknown; showReviewerName: unknown; showReviewImage: unknown; showReviewRating: unknown; showRev...&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ showProductName: unknown; editMode: unknown; imageType: unknown; orderby: unknown; reviewsOnLoadMore: unknown; reviewsOnPageLoad: unknown; showLoadMore: unknown; showOrderby: unknown; showReviewDate: unknown; showReviewerName: unknown; showReviewImage: unknown; showReviewRating: unknown; showReviewConte...&apos;." source="TS2769" />
+<error line="71" column="18" severity="error" message="Property &apos;idBase&apos; does not exist on type &apos;{ showProductName: unknown; editMode: unknown; imageType: unknown; orderby: unknown; reviewsOnLoadMore: unknown; reviewsOnPageLoad: unknown; showLoadMore: unknown; showOrderby: unknown; showReviewDate: unknown; showReviewerName: unknown; showReviewImage: unknown; showReviewRating: unknown; showReviewContent: unknown...&apos;." source="TS2339" />
+<error line="71" column="26" severity="error" message="Property &apos;instance&apos; does not exist on type &apos;{ showProductName: unknown; editMode: unknown; imageType: unknown; orderby: unknown; reviewsOnLoadMore: unknown; reviewsOnPageLoad: unknown; showLoadMore: unknown; showOrderby: unknown; showReviewDate: unknown; showReviewerName: unknown; showReviewImage: unknown; showReviewRating: unknown; showReviewContent: unknown...&apos;." source="TS2339" />
+<error line="73" column="20" severity="error" message="Property &apos;instance&apos; does not exist on type &apos;{ showProductName: unknown; editMode: unknown; imageType: unknown; orderby: unknown; reviewsOnLoadMore: unknown; reviewsOnPageLoad: unknown; showLoadMore: unknown; showOrderby: unknown; showReviewDate: unknown; showReviewerName: unknown; showReviewImage: unknown; showReviewRating: unknown; showReviewContent: unknown...&apos;." source="TS2339" />
+</file>
+<file name="assets/js/blocks/reviews/reviews-by-category/edit.js">
+<error line="41" column="10" severity="error" message="Property &apos;editMode&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="41" column="20" severity="error" message="Property &apos;categoryIds&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="51" column="29" severity="error" message="Property &apos;categoryIds&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="52" column="20" severity="error" message="Parameter &apos;value&apos; implicitly has an &apos;any[]&apos; type." source="TS7006" />
+<error line="68" column="28" severity="error" message="Property &apos;showProductName&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="71" column="39" severity="error" message="Property &apos;showProductName&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="123" column="29" severity="error" message="Property &apos;categoryIds&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="124" column="20" severity="error" message="Parameter &apos;value&apos; implicitly has an &apos;any[]&apos; type." source="TS7006" />
+<error line="163" column="26" severity="error" message="Type &apos;() =&gt; JSX.Element&apos; is not assignable to type &apos;ReactElementLike&apos;." source="TS2322" />
+</file>
+<file name="assets/js/blocks/reviews/reviews-by-category/index.js">
+<error line="19" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ categoryIds: unknown; showProductName: unknown; editMode: unknown; imageType: unknown; orderby: unknown; reviewsOnLoadMore: unknown; reviewsOnPageLoad: unknown; showLoadMore: unknown; showOrderby: unknown; showReviewDate: unknown; showReviewerName: unknown; showReviewImage: unknown; showReviewRating: unknown; showReviewContent: unknown; previewReviews: unknown; }&gt;, settings?: Partial&lt;...&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ categoryIds: unknown; showProductName: unknown; editMode: unknown; imageType: unknown; orderby: unknown; reviewsOnLoadMore: unknown; reviewsOnPageLoad: unknown; showLoadMore: unknown; showOrderby: unknown; showReviewDate: unknown; showReviewerName: unknown; showReviewImage: unknown; showReviewRa...&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ categoryIds: unknown; showProductName: unknown; editMode: unknown; imageType: unknown; orderby: unknown; reviewsOnLoadMore: unknown; reviewsOnPageLoad: unknown; showLoadMore: unknown; showOrderby: unknown; showReviewDate: unknown; showReviewerName: unknown; showReviewImage: unknown; showReviewRating: un...&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ categoryIds: unknown; showProductName: unknown; editMode: unknown; imageType: unknown; orderby: unknown; reviewsOnLoadMore: unknown; reviewsOnPageLoad: unknown; showLoadMore: unknown; showOrderby: unknown; showReviewDate: unknown; showReviewerName: unknown; showReviewImage: unknown; showReviewRating: unknown; showReviewContent: unknown; previewReviews: unknown; }&gt;): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Type &apos;{ categoryIds: { type: &quot;array&quot;; default: never[]; }; showProductName: { type: &quot;boolean&quot;; default: true; }; editMode: { type: string; default: boolean; }; imageType: { type: string; default: string; }; orderby: { ...; }; ... 9 more ...; previewReviews: { ...; }; }&apos; is not assignable to type &apos;{ readonly categoryIds: BlockAttribute&lt;unknown&gt;; readonly showProductName: BlockAttribute&lt;unknown&gt;; readonly editMode: BlockAttribute&lt;unknown&gt;; readonly imageType: BlockAttribute&lt;...&gt;; ... 10 more ...; readonly previewReviews: BlockAttribute&lt;...&gt;; }&apos;.
+      Types of property &apos;editMode&apos; are incompatible.
+        Type &apos;{ type: string; default: boolean; }&apos; is not assignable to type &apos;BlockAttribute&lt;unknown&gt;&apos;." source="TS2769" />
+<error line="77" column="11" severity="error" message="Type &apos;{ constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; }&apos; is missing the following properties from type &apos;Omit&lt;{ attributes: Object; debouncedSpeak: (arg0: any) =&gt; any; setAttributes: (arg0: any) =&gt; any; }, &quot;speak&quot; | &quot;debouncedSpeak&quot;&gt;&apos;: attributes, setAttributes" source="TS2739" />
+</file>
+<file name="assets/js/blocks/reviews/reviews-by-product/no-reviews-placeholder.js">
+<error line="11" column="34" severity="error" message="Binding element &apos;error&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="11" column="41" severity="error" message="Binding element &apos;getProduct&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="11" column="53" severity="error" message="Binding element &apos;isLoading&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="11" column="64" severity="error" message="Binding element &apos;product&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+</file>
+<file name="assets/js/blocks/reviews/reviews-by-product/edit.js">
+<error line="41" column="10" severity="error" message="Property &apos;editMode&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="41" column="20" severity="error" message="Property &apos;productId&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="43" column="37" severity="error" message="Parameter &apos;args&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="82" column="29" severity="error" message="Property &apos;productId&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="83" column="7" severity="error" message="Type &apos;{ selected: any; onChange: (value?: any[]) =&gt; void; renderItem: (args: any) =&gt; Element; isCompact: boolean; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; { selected: number[]; } &amp; { children?: ReactNode; }&apos;.
+  Property &apos;onChange&apos; does not exist on type &apos;IntrinsicAttributes &amp; { selected: number[]; } &amp; { children?: ReactNode; }&apos;." source="TS2322" />
+<error line="83" column="20" severity="error" message="Parameter &apos;value&apos; implicitly has an &apos;any[]&apos; type." source="TS7006" />
+<error line="142" column="29" severity="error" message="Property &apos;productId&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="143" column="7" severity="error" message="Type &apos;{ selected: any; onChange: (value?: any[]) =&gt; void; queryArgs: { orderby: string; order: string; }; renderItem: (args: any) =&gt; Element; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; { selected: number[]; } &amp; { children?: ReactNode; }&apos;.
+  Property &apos;onChange&apos; does not exist on type &apos;IntrinsicAttributes &amp; { selected: number[]; } &amp; { children?: ReactNode; }&apos;." source="TS2322" />
+<error line="143" column="20" severity="error" message="Parameter &apos;value&apos; implicitly has an &apos;any[]&apos; type." source="TS7006" />
+<error line="186" column="5" severity="error" message="Type &apos;ComponentType&lt;{ error: any; getProduct: any; isLoading: any; product: any; }&gt;&apos; is not assignable to type &apos;ReactElementLike&apos;.
+  Type &apos;ComponentClass&lt;{ error: any; getProduct: any; isLoading: any; product: any; }, any&gt;&apos; is missing the following properties from type &apos;ReactElementLike&apos;: type, props, key" source="TS2322" />
+</file>
+<file name="assets/js/blocks/reviews/reviews-by-product/index.js">
+<error line="19" column="1" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;{ productId: unknown; editMode: unknown; imageType: unknown; orderby: unknown; reviewsOnLoadMore: unknown; reviewsOnPageLoad: unknown; showLoadMore: unknown; showOrderby: unknown; showReviewDate: unknown; showReviewerName: unknown; showReviewImage: unknown; showReviewRating: unknown; showReviewContent: unknown; previewReviews: unknown; }&gt;, settings?: Partial&lt;...&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;string&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;{ productId: unknown; editMode: unknown; imageType: unknown; orderby: unknown; reviewsOnLoadMore: unknown; reviewsOnPageLoad: unknown; showLoadMore: unknown; showOrderby: unknown; showReviewDate: unknown; showReviewerName: unknown; showReviewImage: unknown; showReviewRating: unknown; showReviewCon...&apos;.
+      Type &apos;string&apos; is not assignable to type &apos;Pick&lt;Block&lt;{ productId: unknown; editMode: unknown; imageType: unknown; orderby: unknown; reviewsOnLoadMore: unknown; reviewsOnPageLoad: unknown; showLoadMore: unknown; showOrderby: unknown; showReviewDate: unknown; showReviewerName: unknown; showReviewImage: unknown; showReviewRating: unknown; showReviewContent: un...&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;{ productId: unknown; editMode: unknown; imageType: unknown; orderby: unknown; reviewsOnLoadMore: unknown; reviewsOnPageLoad: unknown; showLoadMore: unknown; showOrderby: unknown; showReviewDate: unknown; showReviewerName: unknown; showReviewImage: unknown; showReviewRating: unknown; showReviewContent: unknown; previewReviews: unknown; }&gt;): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Type &apos;{ productId: { type: &quot;number&quot;; }; editMode: { type: string; default: boolean; }; imageType: { type: string; default: string; }; orderby: { type: string; default: string; }; reviewsOnLoadMore: { type: string; default: number; }; ... 8 more ...; previewReviews: { ...; }; }&apos; is not assignable to type &apos;{ readonly productId: BlockAttribute&lt;unknown&gt;; readonly editMode: BlockAttribute&lt;unknown&gt;; readonly imageType: BlockAttribute&lt;unknown&gt;; readonly orderby: BlockAttribute&lt;unknown&gt;; ... 9 more ...; readonly previewReviews: BlockAttribute&lt;...&gt;; }&apos;.
+      Types of property &apos;editMode&apos; are incompatible.
+        Type &apos;{ type: string; default: boolean; }&apos; is not assignable to type &apos;BlockAttribute&lt;unknown&gt;&apos;." source="TS2769" />
+<error line="68" column="11" severity="error" message="Type &apos;{ constructor: Function; toString(): string; toLocaleString(): string; valueOf(): Object; hasOwnProperty(v: PropertyKey): boolean; isPrototypeOf(v: Object): boolean; propertyIsEnumerable(v: PropertyKey): boolean; }&apos; is missing the following properties from type &apos;Omit&lt;{ attributes: Object; debouncedSpeak: (arg0: any) =&gt; any; setAttributes: (arg0: any) =&gt; any; }, &quot;speak&quot; | &quot;debouncedSpeak&quot;&gt;&apos;: attributes, setAttributes" source="TS2739" />
+</file>
+<file name="assets/js/blocks/single-product/block.js">
+<error line="31" column="64" severity="error" message="Property &apos;id&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+</file>
+<file name="assets/js/blocks/single-product/frontend.js">
+<error line="18" column="20" severity="error" message="Parameter &apos;el&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="25" column="2" severity="error" message="Type &apos;ComponentType&lt;{ isLoading: boolean; product: Object; children: ReactChildren; }&gt;&apos; is not assignable to type &apos;FunctionComponent&lt;{}&gt;&apos;.
+  Type &apos;ComponentClass&lt;{ isLoading: boolean; product: Object; children: ReactChildren; }, any&gt;&apos; is not assignable to type &apos;FunctionComponent&lt;{}&gt;&apos;.
+    Type &apos;ComponentClass&lt;{ isLoading: boolean; product: Object; children: ReactChildren; }, any&gt;&apos; provides no match for the signature &apos;(props: { children?: ReactNode; }, context?: any): ReactElement&lt;any, any&gt; | null&apos;." source="TS2322" />
+</file>
+<file name="assets/js/blocks/single-product/edit/api-error.js">
+<error line="17" column="3" severity="error" message="Type &apos;string&apos; is not assignable to type &apos;ErrorObject&apos;." source="TS2322" />
+<error line="19" column="3" severity="error" message="Type &apos;(arg0: any) =&gt; any&apos; is not assignable to type &apos;() =&gt; void&apos;." source="TS2322" />
+</file>
+<file name="assets/js/blocks/single-product/edit/shared-product-control.js">
+<error line="15" column="25" severity="error" message="Property &apos;productId&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="16" column="3" severity="error" message="Type &apos;{ selected: any; showVariations: true; onChange: (value?: any[]) =&gt; void; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; { selected: number[]; } &amp; { children?: ReactNode; }&apos;.
+  Property &apos;showVariations&apos; does not exist on type &apos;IntrinsicAttributes &amp; { selected: number[]; } &amp; { children?: ReactNode; }&apos;." source="TS2322" />
+<error line="17" column="16" severity="error" message="Parameter &apos;value&apos; implicitly has an &apos;any[]&apos; type." source="TS7006" />
+</file>
+<file name="assets/js/blocks/single-product/edit/layout-editor.js">
+<error line="78" column="7" severity="error" message="Type &apos;{}[][]&apos; is not assignable to type &apos;readonly Template[]&apos;.
+  Type &apos;{}[]&apos; is not assignable to type &apos;Template&apos;.
+    Target requires 1 element(s) but source may have fewer." source="TS2322" />
+<error line="81" column="7" severity="error" message="Type &apos;false&apos; is not assignable to type &apos;ComponentType&lt;{}&gt; | undefined&apos;." source="TS2322" />
+</file>
+<file name="assets/js/blocks/single-product/edit/index.js">
+<error line="46" column="10" severity="error" message="Property &apos;productId&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="46" column="21" severity="error" message="Property &apos;isPreview&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="65" column="5" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(props: BlockErrorBoundaryProps | Readonly&lt;BlockErrorBoundaryProps&gt;): BlockErrorBoundary&apos;, gave the following error.
+    Property &apos;text&apos; is missing in type &apos;{ children: Element[]; header: string; }&apos; but required in type &apos;Readonly&lt;BlockErrorBoundaryProps&gt;&apos;.
+  Overload 2 of 2, &apos;(props: BlockErrorBoundaryProps, context: any): BlockErrorBoundary&apos;, gave the following error.
+    Property &apos;text&apos; is missing in type &apos;{ children: Element[]; header: string; }&apos; but required in type &apos;Readonly&lt;BlockErrorBoundaryProps&gt;&apos;." source="TS2769" />
+<error line="113" column="24" severity="error" message="Type &apos;{ productId: any; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; Object&apos;.
+  Property &apos;productId&apos; does not exist on type &apos;IntrinsicAttributes &amp; Object&apos;." source="TS2322" />
+</file>
+<file name="assets/js/blocks/single-product/save.js">
+<error line="7" column="18" severity="error" message="Binding element &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+</file>
+<file name="assets/js/blocks/stock-filter/index.tsx">
+<error line="17" column="20" severity="error" message="No overload matches this call.
+  Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;Attributes&gt;, settings?: Partial&lt;BlockConfiguration&lt;Attributes&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { html: boolean; multiple: boolean; color: { link: boolean; __experimentalDefaultControls: { ...; }; }; inserter: boolean; lock: boolean; }; ... 4 more ...; $schema: string; }&apos; is not assignable to parameter of type &apos;BlockConfiguration&lt;Attributes&gt;&apos;.
+      Type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { html: boolean; multiple: boolean; color: { link: boolean; __experimentalDefaultControls: { ...; }; }; inserter: boolean; lock: boolean; }; ... 4 more ...; $schema: string; }&apos; is not assignable to type &apos;Partial&lt;Omit&lt;Block&lt;Attributes&gt;, &quot;icon&quot;&gt;&gt;&apos;.
+        Types of property &apos;attributes&apos; are incompatible.
+          Property &apos;heading&apos; is missing in type &apos;{ className: { type: string; default: string; }; headingLevel: { type: string; default: number; }; showCounts: { type: string; default: boolean; }; showFilterButton: { type: string; default: boolean; }; isPreview: { ...; }; }&apos; but required in type &apos;{ readonly className?: BlockAttribute&lt;string | undefined&gt;; readonly heading: BlockAttribute&lt;string&gt;; readonly headingLevel: BlockAttribute&lt;number&gt;; readonly showCounts: BlockAttribute&lt;...&gt;; readonly showFilterButton: BlockAttribute&lt;...&gt;; readonly isPreview?: BlockAttribute&lt;...&gt;; }&apos;.
+  Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;Attributes&gt;): Block&lt;Attributes&gt; | undefined&apos;, gave the following error.
+    Argument of type &apos;{ name: string; version: string; title: string; description: string; category: string; keywords: string[]; supports: { html: boolean; multiple: boolean; color: { link: boolean; __experimentalDefaultControls: { ...; }; }; inserter: boolean; lock: boolean; }; ... 4 more ...; $schema: string; }&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2769" />
+</file>
+<file name="assets/js/blocks/stock-filter/test/block.js">
+<error line="46" column="28" severity="error" message="Parameter &apos;props&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+</file>
+<file name="assets/js/blocks-registry/block-components/test/index.js">
+<error line="19" column="24" severity="error" message="Parameter &apos;args&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="49" column="24" severity="error" message="Parameter &apos;args&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="56" column="22" severity="error" message="Property &apos;toHaveWarned&apos; does not exist on type &apos;JestMatchers&lt;Console&gt;&apos;." source="TS2339" />
+<error line="73" column="22" severity="error" message="Property &apos;toHaveWarned&apos; does not exist on type &apos;JestMatchers&lt;Console&gt;&apos;." source="TS2339" />
+</file>
+<file name="assets/js/blocks-registry/payment-methods/test/payment-method-config-helper.ts">
+<error line="84" column="28" severity="error" message="Property &apos;billingAddress&apos; does not exist on type &apos;CanMakePaymentArgument&apos;." source="TS2339" />
+<error line="126" column="7" severity="error" message="Argument of type &apos;{ cartTotals: { total_items: string; total_items_tax: string; total_fees: string; total_fees_tax: string; total_discount: string; total_discount_tax: string; total_shipping: string; total_shipping_tax: string; ... 9 more ...; currency_suffix: string; }; ... 4 more ...; paymentRequirements: string[]; }&apos; is not assignable to parameter of type &apos;CanMakePaymentArgument&apos;.
+  Type &apos;{ cartTotals: { total_items: string; total_items_tax: string; total_fees: string; total_fees_tax: string; total_discount: string; total_discount_tax: string; total_shipping: string; total_shipping_tax: string; ... 9 more ...; currency_suffix: string; }; ... 4 more ...; paymentRequirements: string[]; }&apos; is missing the following properties from type &apos;CanMakePaymentArgument&apos;: cart, billingData" source="TS2345" />
+<error line="147" column="7" severity="error" message="Argument of type &apos;{ cartTotals: { total_items: string; total_items_tax: string; total_fees: string; total_fees_tax: string; total_discount: string; total_discount_tax: string; total_shipping: string; total_shipping_tax: string; ... 9 more ...; currency_suffix: string; }; ... 4 more ...; paymentRequirements: string[]; }&apos; is not assignable to parameter of type &apos;CanMakePaymentArgument&apos;." source="TS2345" />
+<error line="164" column="8" severity="error" message="Argument of type &apos;{ cartTotals: { total_items: string; total_items_tax: string; total_fees: string; total_fees_tax: string; total_discount: string; total_discount_tax: string; total_shipping: string; total_shipping_tax: string; ... 9 more ...; currency_suffix: string; }; ... 4 more ...; paymentRequirements: string[]; }&apos; is not assignable to parameter of type &apos;CanMakePaymentArgument&apos;." source="TS2345" />
+<error line="174" column="7" severity="error" message="Argument of type &apos;{ cartTotals: { total_items: string; total_items_tax: string; total_fees: string; total_fees_tax: string; total_discount: string; total_discount_tax: string; total_shipping: string; total_shipping_tax: string; ... 9 more ...; currency_suffix: string; }; ... 4 more ...; paymentRequirements: string[]; }&apos; is not assignable to parameter of type &apos;CanMakePaymentArgument&apos;." source="TS2345" />
+<error line="183" column="7" severity="error" message="Argument of type &apos;{ cartTotals: { total_items: string; total_items_tax: string; total_fees: string; total_fees_tax: string; total_discount: string; total_discount_tax: string; total_shipping: string; total_shipping_tax: string; ... 9 more ...; currency_suffix: string; }; ... 4 more ...; paymentRequirements: string[]; }&apos; is not assignable to parameter of type &apos;CanMakePaymentArgument&apos;." source="TS2345" />
+<error line="192" column="7" severity="error" message="Argument of type &apos;{ cartTotals: { total_items: string; total_items_tax: string; total_fees: string; total_fees_tax: string; total_discount: string; total_discount_tax: string; total_shipping: string; total_shipping_tax: string; ... 9 more ...; currency_suffix: string; }; ... 4 more ...; paymentRequirements: string[]; }&apos; is not assignable to parameter of type &apos;CanMakePaymentArgument&apos;." source="TS2345" />
+<error line="203" column="7" severity="error" message="Argument of type &apos;{ cartTotals: { total_items: string; total_items_tax: string; total_fees: string; total_fees_tax: string; total_discount: string; total_discount_tax: string; total_shipping: string; total_shipping_tax: string; ... 9 more ...; currency_suffix: string; }; ... 4 more ...; paymentRequirements: string[]; }&apos; is not assignable to parameter of type &apos;CanMakePaymentArgument&apos;." source="TS2345" />
+<error line="204" column="22" severity="error" message="Property &apos;toHaveErrored&apos; does not exist on type &apos;JestMatchers&lt;Console&gt;&apos;." source="TS2339" />
+<error line="214" column="7" severity="error" message="Argument of type &apos;{ cartTotals: { total_items: string; total_items_tax: string; total_fees: string; total_fees_tax: string; total_discount: string; total_discount_tax: string; total_shipping: string; total_shipping_tax: string; ... 9 more ...; currency_suffix: string; }; ... 4 more ...; paymentRequirements: string[]; }&apos; is not assignable to parameter of type &apos;CanMakePaymentArgument&apos;." source="TS2345" />
+<error line="215" column="26" severity="error" message="Property &apos;toHaveErrored&apos; does not exist on type &apos;Matchers&lt;void, Console&gt;&apos;." source="TS2339" />
+</file>
+<file name="assets/js/blocks-registry/payment-methods/test/registry.ts">
+<error line="21" column="25" severity="error" message="Property &apos;toHaveErrored&apos; does not exist on type &apos;Matchers&lt;void, Console&gt;&apos;." source="TS2339" />
+<error line="28" column="21" severity="error" message="Property &apos;toHaveErrored&apos; does not exist on type &apos;JestMatchers&lt;Console&gt;&apos;." source="TS2339" />
+<error line="44" column="25" severity="error" message="Property &apos;toHaveErrored&apos; does not exist on type &apos;Matchers&lt;void, Console&gt;&apos;." source="TS2339" />
+<error line="63" column="5" severity="error" message="Type &apos;boolean&apos; is not assignable to type &apos;CanMakePaymentExtensionCallback&apos;." source="TS2322" />
+<error line="69" column="21" severity="error" message="Property &apos;toHaveErrored&apos; does not exist on type &apos;JestMatchers&lt;Console&gt;&apos;." source="TS2339" />
+</file>
+<file name="assets/js/data/cart/test/reducers.js">
+<error line="4" column="24" severity="error" message="Could not find a declaration file for module &apos;deep-freeze&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/deep-freeze/index.js&apos; implicitly has an &apos;any&apos; type.
+  Try `npm i --save-dev @types/deep-freeze` if it exists or add a new declaration (.d.ts) file containing `declare module &apos;deep-freeze&apos;;`" source="TS7016" />
+</file>
+<file name="assets/js/data/cart/test/resolvers.js">
+<error line="12" column="7" severity="error" message="Variable &apos;fulfillment&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="19" column="5" severity="error" message="Variable &apos;fulfillment&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="20" column="23" severity="error" message="Variable &apos;fulfillment&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="37" column="7" severity="error" message="Type &apos;{}&apos; is missing the following properties from type &apos;CartResponseTotals&apos;: total_items, total_items_tax, total_fees, total_fees_tax, and 14 more." source="TS2740" />
+<error line="40" column="22" severity="error" message="Variable &apos;fulfillment&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="46" column="7" severity="error" message="Variable &apos;fulfillment&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="53" column="5" severity="error" message="Variable &apos;fulfillment&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="54" column="23" severity="error" message="Variable &apos;fulfillment&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="56" column="22" severity="error" message="Variable &apos;fulfillment&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+</file>
+<file name="assets/js/data/cart/test/selectors.js">
+<error line="156" column="24" severity="error" message="Argument of type &apos;{ cartData: { coupons: { code: string; totals: { currency_code: string; currency_symbol: string; currency_minor_unit: number; currency_decimal_separator: string; currency_thousand_separator: string; currency_prefix: string; currency_suffix: string; total_discount: string; total_discount_tax: string; }; }[]; ... 5 mo...&apos; is not assignable to parameter of type &apos;CartState&apos;.
+  Type &apos;{ cartData: { coupons: { code: string; totals: { currency_code: string; currency_symbol: string; currency_minor_unit: number; currency_decimal_separator: string; currency_thousand_separator: string; currency_prefix: string; currency_suffix: string; total_discount: string; total_discount_tax: string; }; }[]; ... 5 mo...&apos; is missing the following properties from type &apos;CartState&apos;: cartItemsPendingQuantity, cartItemsPendingDelete" source="TS2345" />
+<error line="162" column="26" severity="error" message="Argument of type &apos;{ cartData: { coupons: { code: string; totals: { currency_code: string; currency_symbol: string; currency_minor_unit: number; currency_decimal_separator: string; currency_thousand_separator: string; currency_prefix: string; currency_suffix: string; total_discount: string; total_discount_tax: string; }; }[]; ... 5 mo...&apos; is not assignable to parameter of type &apos;CartState&apos;." source="TS2345" />
+<error line="168" column="24" severity="error" message="Argument of type &apos;{ cartData: { coupons: { code: string; totals: { currency_code: string; currency_symbol: string; currency_minor_unit: number; currency_decimal_separator: string; currency_thousand_separator: string; currency_prefix: string; currency_suffix: string; total_discount: string; total_discount_tax: string; }; }[]; ... 5 mo...&apos; is not assignable to parameter of type &apos;CartState&apos;." source="TS2345" />
+<error line="174" column="26" severity="error" message="Argument of type &apos;{ cartData: { coupons: { code: string; totals: { currency_code: string; currency_symbol: string; currency_minor_unit: number; currency_decimal_separator: string; currency_thousand_separator: string; currency_prefix: string; currency_suffix: string; total_discount: string; total_discount_tax: string; }; }[]; ... 5 mo...&apos; is not assignable to parameter of type &apos;CartState&apos;." source="TS2345" />
+<error line="180" column="29" severity="error" message="Argument of type &apos;{ cartData: { coupons: { code: string; totals: { currency_code: string; currency_symbol: string; currency_minor_unit: number; currency_decimal_separator: string; currency_thousand_separator: string; currency_prefix: string; currency_suffix: string; total_discount: string; total_discount_tax: string; }; }[]; ... 5 mo...&apos; is not assignable to parameter of type &apos;CartState&apos;." source="TS2345" />
+<error line="186" column="34" severity="error" message="Argument of type &apos;{ cartData: { coupons: { code: string; totals: { currency_code: string; currency_symbol: string; currency_minor_unit: number; currency_decimal_separator: string; currency_thousand_separator: string; currency_prefix: string; currency_suffix: string; total_discount: string; total_discount_tax: string; }; }[]; ... 5 mo...&apos; is not assignable to parameter of type &apos;CartState&apos;." source="TS2345" />
+<error line="194" column="29" severity="error" message="Argument of type &apos;{ cartData: { coupons: { code: string; totals: { currency_code: string; currency_symbol: string; currency_minor_unit: number; currency_decimal_separator: string; currency_thousand_separator: string; currency_prefix: string; currency_suffix: string; total_discount: string; total_discount_tax: string; }; }[]; ... 5 mo...&apos; is not assignable to parameter of type &apos;CartState&apos;." source="TS2345" />
+<error line="200" column="34" severity="error" message="Argument of type &apos;{ cartData: { coupons: { code: string; totals: { currency_code: string; currency_symbol: string; currency_minor_unit: number; currency_decimal_separator: string; currency_thousand_separator: string; currency_prefix: string; currency_suffix: string; total_discount: string; total_discount_tax: string; }; }[]; ... 5 mo...&apos; is not assignable to parameter of type &apos;CartState&apos;." source="TS2345" />
+</file>
+<file name="assets/js/data/collections/test/reducers.js">
+<error line="4" column="24" severity="error" message="Could not find a declaration file for module &apos;deep-freeze&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/deep-freeze/index.js&apos; implicitly has an &apos;any&apos; type.
+  Try `npm i --save-dev @types/deep-freeze` if it exists or add a new declaration (.d.ts) file containing `declare module &apos;deep-freeze&apos;;`" source="TS7016" />
+<error line="61" column="5" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;&quot;wc/blocks&quot;&apos; can&apos;t be used to index type &apos;Object&apos;.
+  Property &apos;wc/blocks&apos; does not exist on type &apos;Object&apos;." source="TS7053" />
+<error line="79" column="4" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;&quot;wc/blocks&quot;&apos; can&apos;t be used to index type &apos;Object&apos;.
+  Property &apos;wc/blocks&apos; does not exist on type &apos;Object&apos;." source="TS7053" />
+<error line="94" column="4" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;&quot;wc/blocks&quot;&apos; can&apos;t be used to index type &apos;Object&apos;.
+  Property &apos;wc/blocks&apos; does not exist on type &apos;Object&apos;." source="TS7053" />
+</file>
+<file name="assets/js/data/collections/test/resolvers.js">
+<error line="4" column="10" severity="error" message="Module &apos;&quot;@wordpress/data&quot;&apos; has no exported member &apos;controls&apos;." source="TS2305" />
+<error line="19" column="7" severity="error" message="Variable &apos;fulfillment&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="26" column="55" severity="error" message="A spread argument must either have a tuple type or be passed to a rest parameter." source="TS2556" />
+<error line="29" column="4" severity="error" message="Variable &apos;fulfillment&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="42" column="23" severity="error" message="Variable &apos;fulfillment&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="51" column="19" severity="error" message="Type &apos;undefined&apos; is not assignable to type &apos;string | null&apos;." source="TS2322" />
+<error line="52" column="19" severity="error" message="Type &apos;undefined&apos; is not assignable to type &apos;boolean&apos;." source="TS2322" />
+<error line="64" column="22" severity="error" message="Variable &apos;fulfillment&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="73" column="5" severity="error" message="Variable &apos;fulfillment&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="74" column="23" severity="error" message="Variable &apos;fulfillment&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="86" column="23" severity="error" message="Variable &apos;fulfillment&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="93" column="20" severity="error" message="Type &apos;undefined&apos; is not assignable to type &apos;Headers&apos;." source="TS2322" />
+<error line="103" column="5" severity="error" message="Variable &apos;fulfillment&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="104" column="5" severity="error" message="Variable &apos;fulfillment&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="105" column="23" severity="error" message="Variable &apos;fulfillment&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="117" column="19" severity="error" message="Type &apos;{ foo: string; }&apos; is not assignable to type &apos;Headers&apos;.
+  Object literal may only specify known properties, and &apos;foo&apos; does not exist in type &apos;Headers&apos;." source="TS2322" />
+<error line="121" column="22" severity="error" message="Variable &apos;fulfillment&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="129" column="6" severity="error" message="Variable &apos;fulfillment&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="130" column="19" severity="error" message="Rest parameter &apos;testArgs&apos; implicitly has an &apos;any[]&apos; type." source="TS7019" />
+<error line="131" column="40" severity="error" message="A spread argument must either have a tuple type or be passed to a rest parameter." source="TS2556" />
+<error line="134" column="21" severity="error" message="Variable &apos;fulfillment&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="153" column="21" severity="error" message="Variable &apos;fulfillment&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="163" column="20" severity="error" message="Variable &apos;fulfillment&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+</file>
+<file name="assets/js/data/collections/test/selectors.js">
+<error line="6" column="25" severity="error" message="Parameter &apos;total&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="9" column="10" severity="error" message="Parameter &apos;key&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="9" column="19" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;any&apos; can&apos;t be used to index type &apos;{ total: any; }&apos;." source="TS7053" />
+<error line="10" column="10" severity="error" message="Parameter &apos;key&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="10" column="22" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;any&apos; can&apos;t be used to index type &apos;{ total: any; }&apos;." source="TS7053" />
+<error line="94" column="6" severity="error" message="Argument of type &apos;{ &apos;wc/blocks&apos;: { products: { &apos;[]&apos;: { &apos;?someQuery=2&apos;: { items: string[]; headers: { get: (key: any) =&gt; any; has: (key: any) =&gt; boolean; }; }; }; }; &apos;products/attributes&apos;: { &apos;[10]&apos;: { &apos;?someQuery=2&apos;: { items: string[]; headers: { get: (key: any) =&gt; any; has: (key: any) =&gt; boolean; }; }; }; }; &apos;products/attributes/term...&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2345" />
+<error line="106" column="11" severity="error" message="Expected 4-6 arguments, but got 3." source="TS2554" />
+<error line="112" column="25" severity="error" message="Argument of type &apos;{ &apos;wc/blocks&apos;: { products: { &apos;[]&apos;: { &apos;?someQuery=2&apos;: { items: string[]; headers: { get: (key: any) =&gt; any; has: (key: any) =&gt; boolean; }; }; }; }; &apos;products/attributes&apos;: { &apos;[10]&apos;: { &apos;?someQuery=2&apos;: { items: string[]; headers: { get: (key: any) =&gt; any; has: (key: any) =&gt; boolean; }; }; }; }; &apos;products/attributes/term...&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2345" />
+</file>
+<file name="assets/js/data/payment/test/reducers.js">
+<error line="4" column="24" severity="error" message="Could not find a declaration file for module &apos;deep-freeze&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/deep-freeze/index.js&apos; implicitly has an &apos;any&apos; type.
+  Try `npm i --save-dev @types/deep-freeze` if it exists or add a new declaration (.d.ts) file containing `declare module &apos;deep-freeze&apos;;`" source="TS7016" />
+</file>
+<file name="assets/js/data/payment/test/selectors.js">
+<error line="32" column="7" severity="error" message="This condition will always return &apos;false&apos; since the types &apos;&quot;core/editor&quot;&apos; and &apos;&quot;wc/store/cart&quot;&apos; have no overlap." source="TS2367" />
+<error line="54" column="17" severity="error" message="Parameter &apos;setting&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="54" column="26" severity="error" message="Rest parameter &apos;rest&apos; implicitly has an &apos;any[]&apos; type." source="TS7019" />
+<error line="161" column="41" severity="error" message="Property &apos;invalidateResolutionForStore&apos; does not exist on type &apos;DispatchFromMap&lt;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/data/cart/actions&quot;)&gt;&apos;." source="TS2339" />
+<error line="164" column="19" severity="error" message="Argument of type &apos;Cart&apos; is not assignable to parameter of type &apos;CartResponse&apos;." source="TS2345" />
+<error line="243" column="41" severity="error" message="Property &apos;invalidateResolutionForStore&apos; does not exist on type &apos;DispatchFromMap&lt;typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/assets/js/data/cart/actions&quot;)&gt;&apos;." source="TS2339" />
+<error line="246" column="19" severity="error" message="Argument of type &apos;Cart&apos; is not assignable to parameter of type &apos;CartResponse&apos;." source="TS2345" />
+<error line="270" column="33" severity="error" message="Type &apos;{ onChange: () =&gt; undefined; }&apos; is not assignable to type &apos;IntrinsicAttributes&apos;.
+  Property &apos;onChange&apos; does not exist on type &apos;IntrinsicAttributes&apos;." source="TS2322" />
+</file>
+<file name="assets/js/data/payment/test/set-default-payment-method.ts">
+<error line="35" column="10" severity="error" message="This condition will always return &apos;false&apos; since the types &apos;&quot;core/editor&quot;&apos; and &apos;&quot;wc/store/payment&quot;&apos; have no overlap." source="TS2367" />
+<error line="60" column="10" severity="error" message="This condition will always return &apos;false&apos; since the types &apos;&quot;core/editor&quot;&apos; and &apos;&quot;wc/store/payment&quot;&apos; have no overlap." source="TS2367" />
+<error line="79" column="10" severity="error" message="This condition will always return &apos;false&apos; since the types &apos;&quot;core/editor&quot;&apos; and &apos;&quot;wc/store/payment&quot;&apos; have no overlap." source="TS2367" />
+<error line="123" column="10" severity="error" message="This condition will always return &apos;false&apos; since the types &apos;&quot;core/editor&quot;&apos; and &apos;&quot;wc/store/payment&quot;&apos; have no overlap." source="TS2367" />
+</file>
+<file name="assets/js/data/query-state/test/reducers.js">
+<error line="4" column="24" severity="error" message="Could not find a declaration file for module &apos;deep-freeze&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/deep-freeze/index.js&apos; implicitly has an &apos;any&apos; type.
+  Try `npm i --save-dev @types/deep-freeze` if it exists or add a new declaration (.d.ts) file containing `declare module &apos;deep-freeze&apos;;`" source="TS7016" />
+</file>
+<file name="assets/js/data/query-state/test/selectors.js">
+<error line="4" column="24" severity="error" message="Could not find a declaration file for module &apos;deep-freeze&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/deep-freeze/index.js&apos; implicitly has an &apos;any&apos; type.
+  Try `npm i --save-dev @types/deep-freeze` if it exists or add a new declaration (.d.ts) file containing `declare module &apos;deep-freeze&apos;;`" source="TS7016" />
+</file>
+<file name="assets/js/data/schema/test/reducers.js">
+<error line="4" column="24" severity="error" message="Could not find a declaration file for module &apos;deep-freeze&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/deep-freeze/index.js&apos; implicitly has an &apos;any&apos; type.
+  Try `npm i --save-dev @types/deep-freeze` if it exists or add a new declaration (.d.ts) file containing `declare module &apos;deep-freeze&apos;;`" source="TS7016" />
+</file>
+<file name="assets/js/data/schema/test/resolvers.js">
+<error line="5" column="10" severity="error" message="Module &apos;&quot;@wordpress/data&quot;&apos; has no exported member &apos;controls&apos;." source="TS2305" />
+<error line="32" column="7" severity="error" message="Variable &apos;fulfillment&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="36" column="4" severity="error" message="Variable &apos;fulfillment&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="45" column="22" severity="error" message="Variable &apos;fulfillment&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="52" column="4" severity="error" message="Variable &apos;fulfillment&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="53" column="22" severity="error" message="Variable &apos;fulfillment&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+</file>
+<file name="assets/js/data/schema/test/selectors.js">
+<error line="4" column="24" severity="error" message="Could not find a declaration file for module &apos;deep-freeze&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/deep-freeze/index.js&apos; implicitly has an &apos;any&apos; type.
+  Try `npm i --save-dev @types/deep-freeze` if it exists or add a new declaration (.d.ts) file containing `declare module &apos;deep-freeze&apos;;`" source="TS7016" />
+<error line="14" column="28" severity="error" message="Parameter &apos;callback&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="38" column="5" severity="error" message="Parameter &apos;namespace&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="38" column="16" severity="error" message="Parameter &apos;resourceName&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="38" column="30" severity="error" message="Parameter &apos;ids&apos; implicitly has an &apos;any[]&apos; type." source="TS7006" />
+<error line="40" column="32" severity="error" message="Expected 1 arguments, but got 4." source="TS2554" />
+<error line="94" column="23" severity="error" message="Parameter &apos;namespace&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="95" column="32" severity="error" message="Expected 1 arguments, but got 2." source="TS2554" />
+</file>
+<file name="assets/js/editor-components/error-placeholder/stories/error-placeholder.tsx">
+<error line="33" column="4" severity="error" message="Type &apos;{ onRetry: (() =&gt; void) | undefined; isLoading: any; className?: string; error: ErrorObject; }&apos; is not assignable to type &apos;ErrorPlaceholderProps&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+  Types of property &apos;onRetry&apos; are incompatible.
+    Type &apos;(() =&gt; void) | undefined&apos; is not assignable to type &apos;() =&gt; void&apos;.
+      Type &apos;undefined&apos; is not assignable to type &apos;() =&gt; void&apos;." source="TS2375" />
+<error line="67" column="10" severity="error" message="Type &apos;{ onRetry: undefined; className?: string; error: ErrorObject; isLoading: boolean; }&apos; is not assignable to type &apos;ErrorPlaceholderProps&apos; with &apos;exactOptionalPropertyTypes: true&apos;. Consider adding &apos;undefined&apos; to the types of the target&apos;s properties.
+  Types of property &apos;onRetry&apos; are incompatible.
+    Type &apos;undefined&apos; is not assignable to type &apos;() =&gt; void&apos;." source="TS2375" />
+</file>
+<file name="assets/js/editor-components/expandable-search-list-item/expandable-search-list-item.tsx">
+<error line="37" column="5" severity="error" message="Type &apos;SearchListItem&apos; is missing the following properties from type &apos;SearchListItemType&apos;: name, value, parent, count, and 2 more." source="TS2740" />
+<error line="38" column="5" severity="error" message="Type &apos;() =&gt; void&apos; is not assignable to type &apos;(item: SearchListItemType) =&gt; () =&gt; void&apos;.
+  Type &apos;void&apos; is not assignable to type &apos;() =&gt; void&apos;." source="TS2322" />
+</file>
+<file name="assets/js/editor-components/search-list-control/test/hierarchy.js">
+<error line="24" column="4" severity="error" message="Type &apos;{ id: number; name: string; parent: number; }&apos; is missing the following properties from type &apos;SearchListItemType&apos;: value, count, children, breadcrumbs" source="TS2739" />
+<error line="25" column="4" severity="error" message="Type &apos;{ id: number; name: string; parent: number; }&apos; is missing the following properties from type &apos;SearchListItemType&apos;: value, count, children, breadcrumbs" source="TS2739" />
+<error line="46" column="32" severity="error" message="Argument of type &apos;{ id: number; name: string; parent: number; }[]&apos; is not assignable to parameter of type &apos;SearchListItemsType&apos;.
+  Type &apos;{ id: number; name: string; parent: number; }[]&apos; is not assignable to type &apos;SearchListItemType[]&apos;.
+    Type &apos;{ id: number; name: string; parent: number; }&apos; is missing the following properties from type &apos;SearchListItemType&apos;: value, count, children, breadcrumbs" source="TS2345" />
+<error line="115" column="32" severity="error" message="Argument of type &apos;{ id: number; name: string; parent: number; }[]&apos; is not assignable to parameter of type &apos;SearchListItemsType&apos;.
+  Type &apos;{ id: number; name: string; parent: number; }[]&apos; is not assignable to type &apos;SearchListItemType[]&apos;.
+    Type &apos;{ id: number; name: string; parent: number; }&apos; is missing the following properties from type &apos;SearchListItemType&apos;: value, count, children, breadcrumbs" source="TS2345" />
+<error line="164" column="32" severity="error" message="Argument of type &apos;{ id: number; name: string; parent: number; }[]&apos; is not assignable to parameter of type &apos;SearchListItemsType&apos;.
+  Type &apos;{ id: number; name: string; parent: number; }[]&apos; is not assignable to type &apos;SearchListItemType[]&apos;.
+    Type &apos;{ id: number; name: string; parent: number; }&apos; is missing the following properties from type &apos;SearchListItemType&apos;: value, count, children, breadcrumbs" source="TS2345" />
+</file>
+<file name="assets/js/editor-components/search-list-control/test/index.js">
+<error line="40" column="5" severity="error" message="Type &apos;{ id: number; name: string; }[]&apos; is not assignable to type &apos;SearchListItemsType&apos;.
+  Type &apos;{ id: number; name: string; }[]&apos; is not assignable to type &apos;SearchListItemType[]&apos;.
+    Type &apos;{ id: number; name: string; }&apos; is missing the following properties from type &apos;SearchListItemType&apos;: value, parent, count, children, breadcrumbs" source="TS2322" />
+<error line="53" column="5" severity="error" message="Type &apos;{ id: number; name: string; }[]&apos; is not assignable to type &apos;SearchListItemsType&apos;." source="TS2322" />
+<error line="65" column="5" severity="error" message="Type &apos;{ id: number; name: string; }[]&apos; is not assignable to type &apos;SearchListItemsType&apos;." source="TS2322" />
+<error line="66" column="18" severity="error" message="Type &apos;{ id: number; name: string; }&apos; is not assignable to type &apos;SearchListItemType&apos;." source="TS2322" />
+<error line="77" column="5" severity="error" message="Type &apos;{ id: number; name: string; }[]&apos; is not assignable to type &apos;SearchListItemsType&apos;." source="TS2322" />
+<error line="78" column="18" severity="error" message="Type &apos;{ id: number; name: string; }&apos; is not assignable to type &apos;SearchListItemType&apos;." source="TS2322" />
+<error line="78" column="29" severity="error" message="Type &apos;{ id: number; name: string; }&apos; is not assignable to type &apos;SearchListItemType&apos;." source="TS2322" />
+<error line="88" column="5" severity="error" message="Type &apos;{ instanceId: number; list: []; selected: []; onChange: (...args: any[]) =&gt; void; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; SearchListControlProps&apos;.
+  Property &apos;instanceId&apos; does not exist on type &apos;IntrinsicAttributes &amp; SearchListControlProps&apos;." source="TS2322" />
+<error line="101" column="5" severity="error" message="Type &apos;{ id: number; name: string; }[]&apos; is not assignable to type &apos;SearchListItemsType&apos;." source="TS2322" />
+<error line="115" column="5" severity="error" message="Type &apos;{ id: number; name: string; }[]&apos; is not assignable to type &apos;SearchListItemsType&apos;." source="TS2322" />
+<error line="123" column="4" severity="error" message="Argument of type &apos;Element | null&apos; is not assignable to parameter of type &apos;Document | Node | Element | Window&apos;.
+  Type &apos;null&apos; is not assignable to type &apos;Document | Node | Element | Window&apos;." source="TS2345" />
+<error line="143" column="5" severity="error" message="Type &apos;{ id: number; name: string; }[]&apos; is not assignable to type &apos;SearchListItemsType&apos;." source="TS2322" />
+<error line="151" column="4" severity="error" message="Argument of type &apos;Element | null&apos; is not assignable to parameter of type &apos;Document | Node | Element | Window&apos;." source="TS2345" />
+<error line="166" column="5" severity="error" message="Type &apos;{ id: number; name: string; }[]&apos; is not assignable to type &apos;SearchListItemsType&apos;." source="TS2322" />
+<error line="181" column="5" severity="error" message="Type &apos;{ id: number; name: string; }[]&apos; is not assignable to type &apos;SearchListItemsType&apos;." source="TS2322" />
+<error line="191" column="26" severity="error" message="Binding element &apos;item&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="197" column="5" severity="error" message="Type &apos;{ id: number; name: string; }[]&apos; is not assignable to type &apos;SearchListItemsType&apos;." source="TS2322" />
+<error line="210" column="5" severity="error" message="Type &apos;{ id: number; name: string; parent: number; }[]&apos; is not assignable to type &apos;SearchListItemsType&apos;.
+  Type &apos;{ id: number; name: string; parent: number; }[]&apos; is not assignable to type &apos;SearchListItemType[]&apos;.
+    Type &apos;{ id: number; name: string; parent: number; }&apos; is missing the following properties from type &apos;SearchListItemType&apos;: value, count, children, breadcrumbs" source="TS2322" />
+</file>
+<file name="assets/js/editor-components/tag/test/index.js">
+<error line="15" column="30" severity="error" message="Property &apos;id&apos; is missing in type &apos;{ label: string; }&apos; but required in type &apos;{ className?: string; id: string | number; label: string; popoverContents?: Element; remove?: (id: string | number) =&gt; () =&gt; void; screenReaderLabel?: string; }&apos;." source="TS2741" />
+<error line="20" column="46" severity="error" message="Type &apos;() =&gt; void&apos; is not assignable to type &apos;(id: string | number) =&gt; () =&gt; void&apos;.
+  Type &apos;void&apos; is not assignable to type &apos;() =&gt; void&apos;." source="TS2322" />
+<error line="26" column="5" severity="error" message="Property &apos;id&apos; is missing in type &apos;{ label: string; popoverContents: Element; }&apos; but required in type &apos;{ className?: string; id: string | number; label: string; popoverContents?: Element; remove?: (id: string | number) =&gt; () =&gt; void; screenReaderLabel?: string; }&apos;." source="TS2741" />
+<error line="33" column="5" severity="error" message="Property &apos;id&apos; is missing in type &apos;{ label: string; screenReaderLabel: string; }&apos; but required in type &apos;{ className?: string; id: string | number; label: string; popoverContents?: Element; remove?: (id: string | number) =&gt; () =&gt; void; screenReaderLabel?: string; }&apos;." source="TS2741" />
+</file>
+<file name="assets/js/editor-components/view-switcher/index.js">
+<error line="17" column="2" severity="error" message="Binding element &apos;className&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="19" column="2" severity="error" message="Binding element &apos;views&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="20" column="2" severity="error" message="Binding element &apos;defaultView&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="21" column="2" severity="error" message="Binding element &apos;instanceId&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="22" column="2" severity="error" message="Binding element &apos;render&apos; implicitly has an &apos;any&apos; type." source="TS7031" />
+<error line="38" column="21" severity="error" message="Parameter &apos;view&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+</file>
+<file name="assets/js/extensions/google-analytics/utils.ts">
+<error line="10" column="34" severity="error" message="Cannot find namespace &apos;Gtag&apos;." source="TS2503" />
+<error line="22" column="4" severity="error" message="Cannot find namespace &apos;Gtag&apos;." source="TS2503" />
+<error line="54" column="3" severity="error" message="Type &apos;{ id: string; name: string; list_name: string; category: string; price: string; }&apos; is not assignable to type &apos;ImpressionItem&apos;.
+  Object literal may only specify known properties, and &apos;id&apos; does not exist in type &apos;ImpressionItem&apos;." source="TS2322" />
+<error line="69" column="13" severity="error" message="Cannot find namespace &apos;Gtag&apos;." source="TS2503" />
+<error line="70" column="16" severity="error" message="Cannot find namespace &apos;Gtag&apos;." source="TS2503" />
+<error line="70" column="37" severity="error" message="Cannot find namespace &apos;Gtag&apos;." source="TS2503" />
+<error line="70" column="56" severity="error" message="Cannot find namespace &apos;Gtag&apos;." source="TS2503" />
+<error line="72" column="14" severity="error" message="Cannot find name &apos;gtag&apos;." source="TS2304" />
+<error line="77" column="9" severity="error" message="Property &apos;gtag&apos; does not exist on type &apos;Window &amp; typeof globalThis&apos;." source="TS2339" />
+</file>
+<file name="assets/js/hocs/test/with-categories.js">
+<error line="31" column="4" severity="error" message="Type &apos;{ error: any; isLoading: any; categories: any; }&apos; is not assignable to type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLDivElement&gt;, HTMLDivElement&gt;&apos;.
+  Property &apos;error&apos; does not exist on type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLDivElement&gt;, HTMLDivElement&gt;&apos;." source="TS2322" />
+<error line="31" column="18" severity="error" message="Property &apos;error&apos; does not exist on type &apos;{ children?: ReactNode; }&apos;." source="TS2339" />
+<error line="32" column="22" severity="error" message="Property &apos;isLoading&apos; does not exist on type &apos;{ children?: ReactNode; }&apos;." source="TS2339" />
+<error line="33" column="23" severity="error" message="Property &apos;categories&apos; does not exist on type &apos;{ children?: ReactNode; }&apos;." source="TS2339" />
+<error line="42" column="6" severity="error" message="Variable &apos;renderer&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="44" column="27" severity="error" message="Property &apos;mockReset&apos; does not exist on type &apos;(queryArgs: Object) =&gt; Promise&lt;any&gt;&apos;." source="TS2339" />
+<error line="49" column="28" severity="error" message="Property &apos;mockImplementation&apos; does not exist on type &apos;(queryArgs: Object) =&gt; Promise&lt;any&gt;&apos;." source="TS2339" />
+<error line="63" column="28" severity="error" message="Property &apos;mockImplementation&apos; does not exist on type &apos;(queryArgs: Object) =&gt; Promise&lt;any&gt;&apos;." source="TS2339" />
+<error line="70" column="18" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="84" column="28" severity="error" message="Property &apos;mockImplementation&apos; does not exist on type &apos;(queryArgs: Object) =&gt; Promise&lt;any&gt;&apos;." source="TS2339" />
+<error line="87" column="30" severity="error" message="Property &apos;mockImplementation&apos; does not exist on type &apos;(error: { json?: Function | undefined; message?: string | undefined; type?: string | undefined; }) =&gt; Promise&lt;{ message: string; type: string; }&gt;&apos;." source="TS2339" />
+<error line="94" column="24" severity="error" message="This expression is not callable.
+  Type &apos;Promise&lt;never&gt;&apos; has no call signatures." source="TS2349" />
+<error line="97" column="18" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+</file>
+<file name="assets/js/hocs/test/with-category.js">
+<error line="29" column="4" severity="error" message="Type &apos;{ error: any; getCategory: any; isLoading: any; category: any; }&apos; is not assignable to type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLDivElement&gt;, HTMLDivElement&gt;&apos;.
+  Property &apos;error&apos; does not exist on type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLDivElement&gt;, HTMLDivElement&gt;&apos;." source="TS2322" />
+<error line="29" column="18" severity="error" message="Property &apos;error&apos; does not exist on type &apos;{ children?: ReactNode; }&apos;." source="TS2339" />
+<error line="30" column="24" severity="error" message="Property &apos;getCategory&apos; does not exist on type &apos;{ children?: ReactNode; }&apos;." source="TS2339" />
+<error line="31" column="22" severity="error" message="Property &apos;isLoading&apos; does not exist on type &apos;{ children?: ReactNode; }&apos;." source="TS2339" />
+<error line="32" column="21" severity="error" message="Property &apos;category&apos; does not exist on type &apos;{ children?: ReactNode; }&apos;." source="TS2339" />
+<error line="37" column="45" severity="error" message="Type &apos;{ attributes: { categoryId: number; }; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; { children?: ReactNode; }&apos;.
+  Property &apos;attributes&apos; does not exist on type &apos;IntrinsicAttributes &amp; { children?: ReactNode; }&apos;." source="TS2322" />
+<error line="41" column="6" severity="error" message="Variable &apos;renderer&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="43" column="25" severity="error" message="Property &apos;mockReset&apos; does not exist on type &apos;(categoryId: number) =&gt; Promise&lt;any&gt;&apos;." source="TS2339" />
+<error line="48" column="26" severity="error" message="Property &apos;mockImplementation&apos; does not exist on type &apos;(categoryId: number) =&gt; Promise&lt;any&gt;&apos;." source="TS2339" />
+<error line="62" column="4" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="62" column="36" severity="error" message="Type &apos;{ attributes: { categoryId: number; }; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; { children?: ReactNode; }&apos;.
+  Property &apos;attributes&apos; does not exist on type &apos;IntrinsicAttributes &amp; { children?: ReactNode; }&apos;." source="TS2322" />
+<error line="73" column="18" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="83" column="26" severity="error" message="Property &apos;mockImplementation&apos; does not exist on type &apos;(categoryId: number) =&gt; Promise&lt;any&gt;&apos;." source="TS2339" />
+<error line="83" column="48" severity="error" message="Parameter &apos;categoryId&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="90" column="18" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="108" column="26" severity="error" message="Property &apos;mockImplementation&apos; does not exist on type &apos;(categoryId: number) =&gt; Promise&lt;any&gt;&apos;." source="TS2339" />
+<error line="111" column="30" severity="error" message="Property &apos;mockImplementation&apos; does not exist on type &apos;(error: { json?: Function | undefined; message?: string | undefined; type?: string | undefined; }) =&gt; Promise&lt;{ message: string; type: string; }&gt;&apos;." source="TS2339" />
+<error line="118" column="24" severity="error" message="This expression is not callable.
+  Type &apos;Promise&lt;never&gt;&apos; has no call signatures." source="TS2349" />
+<error line="121" column="18" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+</file>
+<file name="assets/js/hocs/test/with-product-variations.js">
+<error line="35" column="4" severity="error" message="Type &apos;{ error: any; expandedProduct: any; isLoading: any; variations: any; variationsLoading: any; }&apos; is not assignable to type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLDivElement&gt;, HTMLDivElement&gt;&apos;.
+  Property &apos;error&apos; does not exist on type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLDivElement&gt;, HTMLDivElement&gt;&apos;." source="TS2322" />
+<error line="35" column="18" severity="error" message="Property &apos;error&apos; does not exist on type &apos;{ children?: ReactNode; }&apos;." source="TS2339" />
+<error line="36" column="28" severity="error" message="Property &apos;expandedProduct&apos; does not exist on type &apos;{ children?: ReactNode; }&apos;." source="TS2339" />
+<error line="37" column="22" severity="error" message="Property &apos;isLoading&apos; does not exist on type &apos;{ children?: ReactNode; }&apos;." source="TS2339" />
+<error line="38" column="23" severity="error" message="Property &apos;variations&apos; does not exist on type &apos;{ children?: ReactNode; }&apos;." source="TS2339" />
+<error line="39" column="30" severity="error" message="Property &apos;variationsLoading&apos; does not exist on type &apos;{ children?: ReactNode; }&apos;." source="TS2339" />
+<error line="46" column="4" severity="error" message="Type &apos;{ error: null; isLoading: boolean; products: ({ id: number; name: string; variations: { id: number; }[]; } | { id: number; name: string; variations?: never; })[]; selected: number[]; showVariations: boolean; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; { children?: ReactNode; }&apos;.
+  Property &apos;error&apos; does not exist on type &apos;IntrinsicAttributes &amp; { children?: ReactNode; }&apos;." source="TS2322" />
+<error line="56" column="6" severity="error" message="Variable &apos;renderer&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="58" column="34" severity="error" message="Property &apos;mockReset&apos; does not exist on type &apos;(product: number) =&gt; Promise&lt;any&gt;&apos;." source="TS2339" />
+<error line="63" column="35" severity="error" message="Property &apos;mockImplementation&apos; does not exist on type &apos;(product: number) =&gt; Promise&lt;any&gt;&apos;." source="TS2339" />
+<error line="79" column="6" severity="error" message="Type &apos;{ error: null; isLoading: boolean; products: ({ id: number; name: string; variations: { id: number; }[]; } | { id: number; name: string; variations?: never; })[]; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; { children?: ReactNode; }&apos;.
+  Property &apos;error&apos; does not exist on type &apos;IntrinsicAttributes &amp; { children?: ReactNode; }&apos;." source="TS2322" />
+<error line="90" column="6" severity="error" message="Type &apos;{ error: null; isLoading: boolean; products: ({ id: number; name: string; variations: { id: number; }[]; } | { id: number; name: string; variations?: never; })[]; selected: number[]; showVariations: boolean; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; { children?: ReactNode; }&apos;.
+  Property &apos;error&apos; does not exist on type &apos;IntrinsicAttributes &amp; { children?: ReactNode; }&apos;." source="TS2322" />
+<error line="105" column="6" severity="error" message="Type &apos;{ error: null; isLoading: boolean; products: ({ id: number; name: string; variations: { id: number; }[]; } | { id: number; name: string; variations?: never; })[]; selected: number[]; showVariations: boolean; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; { children?: ReactNode; }&apos;.
+  Property &apos;error&apos; does not exist on type &apos;IntrinsicAttributes &amp; { children?: ReactNode; }&apos;." source="TS2322" />
+<error line="120" column="6" severity="error" message="Type &apos;{ error: null; isLoading: boolean; products: ({ id: number; name: string; variations: { id: number; }[]; } | { id: number; name: string; variations?: never; })[]; selected: number[]; showVariations: boolean; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; { children?: ReactNode; }&apos;.
+  Property &apos;error&apos; does not exist on type &apos;IntrinsicAttributes &amp; { children?: ReactNode; }&apos;." source="TS2322" />
+<error line="136" column="35" severity="error" message="Property &apos;mockImplementation&apos; does not exist on type &apos;(product: number) =&gt; Promise&lt;any&gt;&apos;." source="TS2339" />
+<error line="143" column="18" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="163" column="35" severity="error" message="Property &apos;mockImplementation&apos; does not exist on type &apos;(product: number) =&gt; Promise&lt;any&gt;&apos;." source="TS2339" />
+<error line="166" column="30" severity="error" message="Property &apos;mockImplementation&apos; does not exist on type &apos;(error: { json?: Function | undefined; message?: string | undefined; type?: string | undefined; }) =&gt; Promise&lt;{ message: string; type: string; }&gt;&apos;." source="TS2339" />
+<error line="173" column="24" severity="error" message="This expression is not callable.
+  Type &apos;Promise&lt;never&gt;&apos; has no call signatures." source="TS2349" />
+<error line="176" column="18" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+</file>
+<file name="assets/js/hocs/test/with-product.js">
+<error line="29" column="4" severity="error" message="Type &apos;{ error: any; getProduct: any; isLoading: any; product: any; }&apos; is not assignable to type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLDivElement&gt;, HTMLDivElement&gt;&apos;.
+  Property &apos;error&apos; does not exist on type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLDivElement&gt;, HTMLDivElement&gt;&apos;." source="TS2322" />
+<error line="29" column="18" severity="error" message="Property &apos;error&apos; does not exist on type &apos;{ children?: ReactNode; }&apos;." source="TS2339" />
+<error line="30" column="23" severity="error" message="Property &apos;getProduct&apos; does not exist on type &apos;{ children?: ReactNode; }&apos;." source="TS2339" />
+<error line="31" column="22" severity="error" message="Property &apos;isLoading&apos; does not exist on type &apos;{ children?: ReactNode; }&apos;." source="TS2339" />
+<error line="32" column="20" severity="error" message="Property &apos;product&apos; does not exist on type &apos;{ children?: ReactNode; }&apos;." source="TS2339" />
+<error line="37" column="45" severity="error" message="Type &apos;{ attributes: { productId: number; }; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; { children?: ReactNode; }&apos;.
+  Property &apos;attributes&apos; does not exist on type &apos;IntrinsicAttributes &amp; { children?: ReactNode; }&apos;." source="TS2322" />
+<error line="41" column="6" severity="error" message="Variable &apos;renderer&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="43" column="24" severity="error" message="Property &apos;mockReset&apos; does not exist on type &apos;(productId: number) =&gt; Promise&lt;any&gt;&apos;." source="TS2339" />
+<error line="48" column="25" severity="error" message="Property &apos;mockImplementation&apos; does not exist on type &apos;(productId: number) =&gt; Promise&lt;any&gt;&apos;." source="TS2339" />
+<error line="62" column="4" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="62" column="36" severity="error" message="Type &apos;{ attributes: { productId: number; }; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; { children?: ReactNode; }&apos;.
+  Property &apos;attributes&apos; does not exist on type &apos;IntrinsicAttributes &amp; { children?: ReactNode; }&apos;." source="TS2322" />
+<error line="73" column="18" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="83" column="25" severity="error" message="Property &apos;mockImplementation&apos; does not exist on type &apos;(productId: number) =&gt; Promise&lt;any&gt;&apos;." source="TS2339" />
+<error line="83" column="47" severity="error" message="Parameter &apos;productId&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="90" column="18" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="108" column="25" severity="error" message="Property &apos;mockImplementation&apos; does not exist on type &apos;(productId: number) =&gt; Promise&lt;any&gt;&apos;." source="TS2339" />
+<error line="109" column="30" severity="error" message="Property &apos;mockImplementation&apos; does not exist on type &apos;(error: { json?: Function | undefined; message?: string | undefined; type?: string | undefined; }) =&gt; Promise&lt;{ message: string; type: string; }&gt;&apos;." source="TS2339" />
+<error line="116" column="24" severity="error" message="This expression is not callable.
+  Type &apos;Promise&lt;never&gt;&apos; has no call signatures." source="TS2349" />
+<error line="119" column="18" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+</file>
+<file name="assets/js/hocs/test/with-searched-products.js">
+<error line="24" column="11" severity="error" message="Cannot assign to &apos;getProducts&apos; because it is a read-only property." source="TS2540" />
+<error line="32" column="17" severity="error" message="Cannot assign to &apos;useDebouncedCallback&apos; because it is a read-only property." source="TS2540" />
+<error line="39" column="40" severity="error" message="Property &apos;mockClear&apos; does not exist on type &apos;&lt;T extends (...args: any[]) =&gt; ReturnType&lt;T&gt;&gt;(func: T, wait?: number | undefined, options?: Options | undefined) =&gt; DebouncedState&lt;T&gt;&apos;." source="TS2339" />
+<error line="40" column="25" severity="error" message="Property &apos;mockClear&apos; does not exist on type &apos;({ selected, search, queryArgs, }: { selected: number[]; search?: string | undefined; queryArgs?: Record&lt;string, unknown&gt; | undefined; }) =&gt; Promise&lt;unknown&gt;&apos;." source="TS2339" />
+<error line="46" column="6" severity="error" message="Type &apos;{ products: unknown; selected: unknown; isLoading: unknown; onSearch: unknown; }&apos; is not assignable to type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLDivElement&gt;, HTMLDivElement&gt;&apos;.
+  Property &apos;products&apos; does not exist on type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLDivElement&gt;, HTMLDivElement&gt;&apos;." source="TS2322" />
+<error line="56" column="7" severity="error" message="Variable &apos;props&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="56" column="14" severity="error" message="Variable &apos;renderer&apos; implicitly has type &apos;any&apos; in some locations where its type cannot be determined." source="TS7034" />
+<error line="65" column="12" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="74" column="12" severity="error" message="Variable &apos;renderer&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+<error line="77" column="5" severity="error" message="Variable &apos;props&apos; implicitly has an &apos;any&apos; type." source="TS7005" />
+</file>
+<file name="assets/js/hocs/test/with-transform-single-select-to-multiple-select.js">
+<error line="15" column="14" severity="error" message="Type &apos;{ selected: any; }&apos; is not assignable to type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLDivElement&gt;, HTMLDivElement&gt;&apos;.
+  Property &apos;selected&apos; does not exist on type &apos;DetailedHTMLProps&lt;HTMLAttributes&lt;HTMLDivElement&gt;, HTMLDivElement&gt;&apos;." source="TS2322" />
+<error line="15" column="31" severity="error" message="Property &apos;selected&apos; does not exist on type &apos;{ children?: ReactNode; }&apos;." source="TS2339" />
+<error line="23" column="20" severity="error" message="Type &apos;{ selected: number; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; { children?: ReactNode; }&apos;.
+  Property &apos;selected&apos; does not exist on type &apos;IntrinsicAttributes &amp; { children?: ReactNode; }&apos;." source="TS2322" />
+<error line="31" column="20" severity="error" message="Type &apos;{ selected: null; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; { children?: ReactNode; }&apos;.
+  Property &apos;selected&apos; does not exist on type &apos;IntrinsicAttributes &amp; { children?: ReactNode; }&apos;." source="TS2322" />
+</file>
+<file name="assets/js/middleware/store-api-nonce.js">
+<error line="27" column="22" severity="error" message="Property &apos;url&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="27" column="37" severity="error" message="Property &apos;path&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="28" column="26" severity="error" message="Property &apos;method&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="28" column="44" severity="error" message="Property &apos;method&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="41" column="19" severity="error" message="Property &apos;get&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="42" column="14" severity="error" message="Property &apos;get&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="43" column="14" severity="error" message="Property &apos;Nonce&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="45" column="19" severity="error" message="Property &apos;get&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="46" column="14" severity="error" message="Property &apos;get&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="47" column="6" severity="error" message="Element implicitly has an &apos;any&apos; type because expression of type &apos;&quot;Nonce-Timestamp&quot;&apos; can&apos;t be used to index type &apos;Object&apos;.
+  Property &apos;Nonce-Timestamp&apos; does not exist on type &apos;Object&apos;." source="TS7053" />
+<error line="84" column="29" severity="error" message="Parameter &apos;request&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="105" column="32" severity="error" message="Property &apos;data&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="106" column="12" severity="error" message="Property &apos;data&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="107" column="13" severity="error" message="Property &apos;data&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
+<error line="114" column="10" severity="error" message="Property &apos;setNonce&apos; does not exist on type &apos;typeof apiFetch&apos;." source="TS2339" />
+</file>
+<file name="assets/js/payment-method-extensions/payment-methods/cod/index.js">
+<error line="61" column="51" severity="error" message="Parameter &apos;shippingMethodId&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="83" column="24" severity="error" message="Argument of type &apos;{ name: string; label: JSX.Element; content: JSX.Element; edit: JSX.Element; canMakePayment: ({ cartNeedsShipping, selectedShippingMethods }: { cartNeedsShipping: boolean; selectedShippingMethods: boolean; }) =&gt; boolean; ariaLabel: any; supports: { ...; }; }&apos; is not assignable to parameter of type &apos;PaymentMethodConfiguration | LegacyRegisterPaymentMethodFunction&apos;.
+  Type &apos;{ name: string; label: JSX.Element; content: JSX.Element; edit: JSX.Element; canMakePayment: ({ cartNeedsShipping, selectedShippingMethods }: { cartNeedsShipping: boolean; selectedShippingMethods: boolean; }) =&gt; boolean; ariaLabel: any; supports: { ...; }; }&apos; is not assignable to type &apos;PaymentMethodConfiguration&apos;.
+    Types of property &apos;canMakePayment&apos; are incompatible.
+      Type &apos;({ cartNeedsShipping, selectedShippingMethods }: {    cartNeedsShipping: boolean;    selectedShippingMethods: boolean;}) =&gt; boolean&apos; is not assignable to type &apos;CanMakePaymentCallback&apos;.
+        Types of parameters &apos;__0&apos; and &apos;cartData&apos; are incompatible.
+          Type &apos;CanMakePaymentArgument&apos; is not assignable to type &apos;{ cartNeedsShipping: boolean; selectedShippingMethods: boolean; }&apos;.
+            Types of property &apos;selectedShippingMethods&apos; are incompatible.
+              Type &apos;Record&lt;string, unknown&gt;&apos; is not assignable to type &apos;boolean&apos;." source="TS2345" />
+</file>
+<file name="assets/js/utils/test/notices.js">
+<error line="19" column="11" severity="error" message="Property &apos;mockReturnValue&apos; does not exist on type &apos;{ (storeNameOrDescriptor: string | StoreDescriptor): SelectorMap; (key: &quot;core/rich-text&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__rich-text/store/selectors&quot;); (key: &quot;core/notices&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/n...&apos;." source="TS2339" />
+<error line="46" column="11" severity="error" message="Property &apos;mockReturnValue&apos; does not exist on type &apos;{ (storeNameOrDescriptor: string | StoreDescriptor): SelectorMap; (key: &quot;core/rich-text&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__rich-text/store/selectors&quot;); (key: &quot;core/notices&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/n...&apos;." source="TS2339" />
+<error line="55" column="11" severity="error" message="Property &apos;mockReturnValue&apos; does not exist on type &apos;{ (storeNameOrDescriptor: string | StoreDescriptor): SelectorMap; (key: &quot;core/rich-text&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__rich-text/store/selectors&quot;); (key: &quot;core/notices&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/n...&apos;." source="TS2339" />
+<error line="94" column="13" severity="error" message="Property &apos;mockReturnValue&apos; does not exist on type &apos;{ (storeNameOrDescriptor: string | StoreDescriptor): DispatcherMap; (key: &quot;core/rich-text&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__rich-text/store/actions&quot;); (key: &quot;core/notices&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/n...&apos;." source="TS2339" />
+<error line="98" column="12" severity="error" message="Expected 1 arguments, but got 0." source="TS2554" />
+<error line="103" column="12" severity="error" message="Expected 1 arguments, but got 0." source="TS2554" />
+<error line="111" column="11" severity="error" message="Property &apos;mockReturnValue&apos; does not exist on type &apos;{ (storeNameOrDescriptor: string | StoreDescriptor): SelectorMap; (key: &quot;core/rich-text&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__rich-text/store/selectors&quot;); (key: &quot;core/notices&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/n...&apos;." source="TS2339" />
+<error line="115" column="13" severity="error" message="Property &apos;mockReturnValue&apos; does not exist on type &apos;{ (storeNameOrDescriptor: string | StoreDescriptor): DispatcherMap; (key: &quot;core/rich-text&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@types/wordpress__rich-text/store/actions&quot;); (key: &quot;core/notices&quot;): typeof import(&quot;/home/runner/work/woocommerce-blocks/woocommerce-blocks/n...&apos;." source="TS2339" />
+<error line="119" column="12" severity="error" message="Expected 1 arguments, but got 0." source="TS2554" />
+</file>
+<file name="assets/js/utils/test/products.js">
+<error line="16" column="20" severity="error" message="Expected 1 arguments, but got 0." source="TS2554" />
+<error line="22" column="44" severity="error" message="Argument of type &apos;{}&apos; is not assignable to parameter of type &apos;{ images: any[]; }&apos;.
+  Property &apos;images&apos; is missing in type &apos;{}&apos; but required in type &apos;{ images: any[]; }&apos;." source="TS2345" />
+<error line="28" column="46" severity="error" message="Type &apos;null&apos; is not assignable to type &apos;any[]&apos;." source="TS2322" />
+<error line="56" column="20" severity="error" message="Expected 1 arguments, but got 0." source="TS2554" />
+<error line="62" column="43" severity="error" message="Argument of type &apos;{}&apos; is not assignable to parameter of type &apos;{ images: any[]; }&apos;.
+  Property &apos;images&apos; is missing in type &apos;{}&apos; but required in type &apos;{ images: any[]; }&apos;." source="TS2345" />
+<error line="68" column="45" severity="error" message="Type &apos;null&apos; is not assignable to type &apos;any[]&apos;." source="TS2322" />
+</file>
+<file name="packages/checkout/blocks-registry/test/index.js">
+<error line="16" column="24" severity="error" message="Parameter &apos;blockName&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="16" column="35" severity="error" message="Parameter &apos;options&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="17" column="45" severity="error" message="Expected 1 arguments, but got 2." source="TS2554" />
+</file>
+<file name="packages/checkout/components/text-input/test/validated-text-input.tsx">
+<error line="92" column="9" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;Matchers&lt;void, HTMLElement | null&gt;&apos;." source="TS2339" />
+<error line="93" column="45" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+<error line="114" column="39" severity="error" message="Property &apos;toBeInTheDocument&apos; does not exist on type &apos;JestMatchers&lt;HTMLElement&gt;&apos;." source="TS2339" />
+</file>
+<file name="packages/checkout/filter-registry/test/index.js">
+<error line="31" column="9" severity="error" message="Property &apos;toUpperCase&apos; does not exist on type &apos;T&apos;." source="TS2339" />
+<error line="31" column="25" severity="error" message="Object is possibly &apos;null&apos; or &apos;undefined&apos;." source="TS2533" />
+<error line="49" column="35" severity="error" message="Property &apos;toUpperCase&apos; does not exist on type &apos;T&apos;." source="TS2339" />
+<error line="55" column="5" severity="error" message="Type &apos;(val: string) =&gt; boolean&apos; is not assignable to type &apos;(value: string) =&gt; true | Error&apos;.
+  Type &apos;boolean&apos; is not assignable to type &apos;true | Error&apos;." source="TS2322" />
+</file>
+<file name="storybook/main.js">
+<error line="20" column="24" severity="error" message="Parameter &apos;config&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+</file>
+<file name="storybook/__mocks__/woocommerce-block-settings.js">
+<error line="1" column="15" severity="error" message="An import path cannot end with a &apos;.ts&apos; extension. Consider importing &apos;../../assets/js/settings/blocks/index.js&apos; instead." source="TS2691" />
+</file>
+</checkstyle>

--- a/src/BlockTypes/ProductSaleBadge.php
+++ b/src/BlockTypes/ProductSaleBadge.php
@@ -98,7 +98,7 @@ class ProductSaleBadge extends AbstractBlock {
 		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes );
 
 		$output  = '';
-		$output .= '<div class="wc-block-components-product-sale-badge ' . $classes_and_styles['classes'] . '" style="' . $classes_and_styles['styles'] . '"">';
+		$output .= '<div class="wc-block-components-product-sale-badge ' . $classes_and_styles['classes'] . ' ' . $attributes['className'] . '" style="' . $classes_and_styles['styles'] . '"">';
 		$output .= '<span class="wc-block-components-product-sale-badge__text" aria-hidden="true">' . __( 'Sale', 'woo-gutenberg-products-block' ) . '</span>';
 		$output .= '<span class="screen-reader-text">' . __(
 			'Product on sale',

--- a/src/BlockTypes/ProductSaleBadge.php
+++ b/src/BlockTypes/ProductSaleBadge.php
@@ -96,9 +96,10 @@ class ProductSaleBadge extends AbstractBlock {
 		}
 
 		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes );
+		$classname          = isset( $attributes['className'] ) ? $attributes['className'] : '';
 
 		$output  = '';
-		$output .= '<div class="wc-block-components-product-sale-badge ' . $classes_and_styles['classes'] . ' ' . $attributes['className'] . '" style="' . $classes_and_styles['styles'] . '"">';
+		$output .= '<div class="wc-block-components-product-sale-badge ' . $classes_and_styles['classes'] . ' ' . $classname . '" style="' . $classes_and_styles['styles'] . '"">';
 		$output .= '<span class="wc-block-components-product-sale-badge__text" aria-hidden="true">' . __( 'Sale', 'woo-gutenberg-products-block' ) . '</span>';
 		$output .= '<span class="screen-reader-text">' . __(
 			'Product on sale',

--- a/src/BlockTypes/ProductSaleBadge.php
+++ b/src/BlockTypes/ProductSaleBadge.php
@@ -1,6 +1,8 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
+use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
+
 /**
  * ProductSaleBadge class.
  */
@@ -54,12 +56,56 @@ class ProductSaleBadge extends AbstractBlock {
 	}
 
 	/**
-	 * Register script and style assets for the block type before it is registered.
+	 * Overwrite parent method to prevent script registration.
 	 *
-	 * This registers the scripts; it does not enqueue them.
+	 * It is necessary to register and enqueues assets during the render
+	 * phase because we want to load assets only if the block has the content.
 	 */
 	protected function register_block_type_assets() {
-		parent::register_block_type_assets();
-		$this->register_chunk_translations( [ $this->block_name ] );
+		return null;
+	}
+
+	/**
+	 * Register the context.
+	 */
+	protected function get_block_type_uses_context() {
+		return [ 'query', 'queryId', 'postId' ];
+	}
+
+	/**
+	 * Include and render the block.
+	 *
+	 * @param array    $attributes Block attributes. Default empty array.
+	 * @param string   $content    Block content. Default empty string.
+	 * @param WP_Block $block      Block instance.
+	 * @return string Rendered block type output.
+	 */
+	protected function render( $attributes, $content, $block ) {
+		if ( ! empty( $content ) ) {
+			parent::register_block_type_assets();
+			$this->register_chunk_translations( [ $this->block_name ] );
+			return $content;
+		}
+
+		$post_id    = $block->context['postId'];
+		$product    = wc_get_product( $post_id );
+		$is_on_sale = $product->is_on_sale();
+
+		if ( ! $is_on_sale ) {
+			return null;
+		}
+
+		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes );
+
+		$output  = '';
+		$output .= '<div class="wc-block-components-product-sale-badge ' . $classes_and_styles['classes'] . '" style="' . $classes_and_styles['styles'] . '"">';
+		$output .= '<span class="wc-block-components-product-sale-badge__text" aria-hidden="true">' . __( 'Sale', 'woo-gutenberg-products-block' ) . '</span>';
+		$output .= '<span class="screen-reader-text">' . __(
+			'Product on sale',
+			'woo-gutenberg-products-block'
+		) . '</span>';
+		$output .= '</div>';
+
+		return $output;
 	}
 }

--- a/src/Utils/StyleAttributesUtils.php
+++ b/src/Utils/StyleAttributesUtils.php
@@ -327,6 +327,27 @@ class StyleAttributesUtils {
 		return null;
 	}
 
+
+	/**
+	 * If spacing value is in preset format, convert it to a CSS var. Else return same value
+	 * For example:
+	 * "var:preset|spacing|50" -> "var(--wp--preset--spacing--50)"
+	 * "50px" -> "50px"
+	 *
+	 * @param string $spacing_value value to be processed.
+	 *
+	 * @return (string)
+	 */
+	public static function get_spacing_value( $spacing_value ) {
+		// If value is in format: var:preset|spacing|50.
+		if ( is_string( $spacing_value ) && str_contains( $spacing_value, 'var:preset|spacing|' ) ) {
+			$spacing_value = str_replace( 'var:preset|spacing|', '', 'var:preset|spacing|50' );
+			return sprintf( 'var(--wp--preset--spacing--%s)', $spacing_value );
+		}
+
+		return $spacing_value;
+	}
+
 	/**
 	 * Get class and style for padding from attributes.
 	 *
@@ -341,9 +362,23 @@ class StyleAttributesUtils {
 			return null;
 		}
 
+		$padding_top    = $padding['top'] ? self::get_spacing_value( $padding['top'] ) : null;
+		$padding_right  = $padding['right'] ? self::get_spacing_value( $padding['right'] ) : null;
+		$padding_bottom = $padding['bottom'] ? self::get_spacing_value( $padding['bottom'] ) : null;
+		$padding_left   = $padding['left'] ? self::get_spacing_value( $padding['left'] ) : null;
+
 		return array(
 			'class' => null,
-			'style' => sprintf( 'padding: %s;', implode( ' ', $padding ) ),
+			'style' => sprintf(
+				'padding-top:%s;
+				padding-right:%s;
+				padding-bottom:%s;
+				padding-left:%s;',
+				$padding_top,
+				$padding_right,
+				$padding_bottom,
+				$padding_left
+			),
 		);
 	}
 

--- a/src/Utils/StyleAttributesUtils.php
+++ b/src/Utils/StyleAttributesUtils.php
@@ -339,7 +339,7 @@ class StyleAttributesUtils {
 	 * @return (string)
 	 */
 	public static function get_spacing_value( $spacing_value ) {
-		// If value is in format: var:preset|spacing|50.
+		// Used following code as reference: https://github.com/WordPress/gutenberg/blob/cff6d70d6ff5a26e212958623dc3130569f95685/lib/block-supports/layout.php/#L219-L225.
 		if ( is_string( $spacing_value ) && str_contains( $spacing_value, 'var:preset|spacing|' ) ) {
 			$spacing_value = str_replace( 'var:preset|spacing|', '', 'var:preset|spacing|50' );
 			return sprintf( 'var(--wp--preset--spacing--%s)', $spacing_value );


### PR DESCRIPTION
Adds Product Query support for the atomic Sale badge block

On the client side, when the Sale badge block is used within the product query block, the markup will be rendered on the server side - No javascript related to Sale badge block will be rendered.

Fixes #7331 

#### Testing
1. Checkout this branch and run npm start
2. Be sure that you have latest version of the Gutenberg feature plugin installed and activated
3. Create a post/page and add the Product Query block.
4. Add `Sale Badge` block to Post Template of product query block as shown in video below:
https://user-images.githubusercontent.com/16707866/202644003-ee85857b-a01f-4b4f-819a-ec910b630dd5.mov
5. Now save the post & Open the frontend side and confirm that: 
 - No JS related to the Product Sale Badge block is loaded (search in your network tab for product-sale-badge-frontend.js). As you can see in the screenshot below, `product-sale-badge-frontend.js` showing before the changes made in this PR. This shouldn't be visible in network tab anymore.
<img width="865" alt="image" src="https://user-images.githubusercontent.com/16707866/202644926-7f4be5d4-1bab-4b3d-ae9f-80586df8df98.png"> 

 - The UI of the block is identical to on the editor side.
 - That the settings are reflected correctly (eg: custom style). Try changing custom style from the sidebar(Shown in screenshot below): 
<img width="289" alt="image" src="https://user-images.githubusercontent.com/16707866/202645737-954c18e1-32ad-4096-a080-007e6e0d446f.png">

 - `ADDITIONAL CSS CLASS(ES)`(available in advanced toggle in sidebar) should be added to the container div
<img width="273" alt="image" src="https://user-images.githubusercontent.com/16707866/202675897-6478bedf-d02c-44d5-b9e1-105582c5e1c3.png">

* [X] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [X] Experimental
