### PR TITLE
Product Query: Add order by “Top rated” as a preset

### DIFF
--- a/assets/js/blocks/product-query/inspector-controls/popular-presets.tsx
+++ b/assets/js/blocks/product-query/inspector-controls/popular-presets.tsx
@@ -16,6 +16,10 @@ const PRESETS = [
 		key: 'popularity/desc',
 		name: __( 'Best Selling', 'woo-gutenberg-products-block' ),
 	},
+	{
+		key: 'rating/desc',
+		name: __( 'Top Rated', 'woo-gutenberg-products-block' ),
+	},
 ];
 
 export function PopularPresets( props: ProductQueryBlock ) {

--- a/src/BlockTypes/ProductQuery.php
+++ b/src/BlockTypes/ProductQuery.php
@@ -28,7 +28,7 @@ class ProductQuery extends AbstractBlock {
 	 *
 	 * @var array
 	 */
-	protected $custom_order_opts = array( 'popularity' );
+	protected $custom_order_opts = array( 'popularity', 'rating' );
 
 	/**
 	 * All the query args related to the filter by attributes block.
@@ -238,6 +238,7 @@ class ProductQuery extends AbstractBlock {
 
 		$meta_keys = array(
 			'popularity' => 'total_sales',
+			'rating'     => '_wc_average_rating',
 		);
 
 		return array(

--- a/src/BlockTypes/ProductQuery.php
+++ b/src/BlockTypes/ProductQuery.php
@@ -209,7 +209,9 @@ class ProductQuery extends AbstractBlock {
 	 * @return array
 	 */
 	public function extend_rest_query_allowed_params( $params ) {
-		$params['orderby']['enum'] = array_merge( $params['orderby']['enum'], $this->custom_order_opts );
+		$original_enum = isset( $params['orderby']['enum'] ) ? $params['orderby']['enum'] : array();
+
+		$params['orderby']['enum'] = array_merge( $original_enum, $this->custom_order_opts );
 		return $params;
 	}
 


### PR DESCRIPTION
> **Warning**
> This PR is blocked by #7687, that is why the branch target is not set as `trunk`.

This PR adds support for the second preset: “Top rated products”. By selecting this, users can sort products by their average rating.

This builds on the [previously added REST API filter](https://github.com/woocommerce/woocommerce-blocks/pull/7687) to enable further allowed sort orders.

Fixes #7326 

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Testing

#### User Facing Testing

> **Warning**
> Ensure you have at least one product with a rating associated.

1. Add a Product Query block.
2. Change “Newest” to “Top rated” on the Popular Filters dropdown..
3. Ensure the new order is based on the average rating. 
4. Ensure the order is the same on the front-end (save the page and check the ordering is correct).

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental

### Changelog

> Product Query: add option to sort products by “Top rated”