### PR TITLE
E2E: Change label of product filters from `Product filters` to `Advanced Filters`

### DIFF
--- a/tests/e2e/specs/backend/product-query/advanced-filters.ts
+++ b/tests/e2e/specs/backend/product-query/advanced-filters.ts
@@ -96,7 +96,7 @@ const getFrontEndProducts = async (): Promise< ElementHandle[] > => {
 };
 
 describeOrSkip( GUTENBERG_EDITOR_CONTEXT === 'gutenberg' )(
-	'Product Query > Products Filters',
+	'Product Query > Advanced Filters',
 	() => {
 		let $productFiltersPanel: ElementHandle< Node >;
 		beforeEach( async () => {

--- a/tests/e2e/specs/backend/product-query/product-filters.test.ts
+++ b/tests/e2e/specs/backend/product-query/product-filters.test.ts
@@ -48,7 +48,7 @@ const SELECTORS = {
 	) =>
 		`.components-tools-panel-header .components-dropdown-menu button[aria-expanded="${ expanded }"]`,
 	productFiltersDropdown:
-		'.components-dropdown-menu__menu[aria-label="Product filters options"]',
+		'.components-dropdown-menu__menu[aria-label="Advanced Filters options"]',
 	productFiltersDropdownItem: '.components-menu-item__button',
 	editorPreview: {
 		productsGrid: 'ul.wp-block-post-template',
@@ -63,7 +63,7 @@ const SELECTORS = {
 
 const toggleProductFilter = async ( filterName: string ) => {
 	const $productFiltersPanel = await findToolsPanelWithTitle(
-		'Product filters'
+		'Advanced Filters'
 	);
 	await expect( $productFiltersPanel ).toClick(
 		SELECTORS.productFiltersDropdownButton()
@@ -109,7 +109,7 @@ describeOrSkip( GUTENBERG_EDITOR_CONTEXT === 'gutenberg' )(
 			await openBlockEditorSettings();
 			await selectBlockByName( block.slug );
 			$productFiltersPanel = await findToolsPanelWithTitle(
-				'Product filters'
+				'Advanced Filters'
 			);
 		} );
 

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -430,9 +430,11 @@ export const openBlockEditorSettings = async () => {
  *  Wait for all Products Block is loaded completely: when the skeleton disappears, and the products are visible
  */
 export const waitForAllProductsBlockLoaded = async () => {
-	await page.waitForSelector(
-		'.wc-block-grid__products.is-loading-products'
-	);
+	try {
+		await page.waitForSelector(
+			'.wc-block-grid__products.is-loading-products'
+		);
+	} catch ( ok ) {}
 	await page.waitForSelector(
 		'.wc-block-grid__products:not(.is-loading-products)'
 	);

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -430,11 +430,22 @@ export const openBlockEditorSettings = async () => {
  *  Wait for all Products Block is loaded completely: when the skeleton disappears, and the products are visible
  */
 export const waitForAllProductsBlockLoaded = async () => {
+	/**
+	 * We use try with empty catch block here to avoid the race condition
+	 * between the block loading and the test execution. After user actions,
+	 * the products may or may not finish loading at the time we try to wait for
+	 * the loading class.
+	 *
+	 * We need to wait for the loading class to be added then removed because
+	 * only waiting for the loading class to be removed could result in a false
+	 * positive pass.
+	 */
 	try {
 		await page.waitForSelector(
 			'.wc-block-grid__products.is-loading-products'
 		);
 	} catch ( ok ) {}
+
 	await page.waitForSelector(
 		'.wc-block-grid__products:not(.is-loading-products)'
 	);


### PR DESCRIPTION
In #7687, we changed the product filters panel label from `Product filters` to `Advanced Filters`. This PR updates the test to reflect this change.

This PR also fixes the flaky test of `waitForAllProductsBlockLoaded()`.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental