### PR TITLE
Add to Cart Block: no render the selector of the product when the block is added in the Product Query Block

### DIFF
--- a/assets/js/atomic/blocks/product-elements/add-to-cart/edit.js
+++ b/assets/js/atomic/blocks/product-elements/add-to-cart/edit.js
@@ -13,6 +13,7 @@ import {
 } from '@wordpress/components';
 import { InspectorControls } from '@wordpress/block-editor';
 import { productSupportsAddToCartForm } from '@woocommerce/base-utils';
+import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -22,9 +23,16 @@ import Block from './block';
 import withProductSelector from '../shared/with-product-selector';
 import { BLOCK_TITLE, BLOCK_ICON } from './constants';
 
-const Edit = ( { attributes, setAttributes } ) => {
+const Edit = ( { attributes, setAttributes, context } ) => {
 	const { product } = useProductDataContext();
 	const { className, showFormElements } = attributes;
+
+	const isDescendentOfQueryLoop = Number.isFinite( context.queryId );
+
+	useEffect(
+		() => setAttributes( { isDescendentOfQueryLoop } ),
+		[ setAttributes, isDescendentOfQueryLoop ]
+	);
 
 	return (
 		<div


### PR DESCRIPTION
This PR fixes a bug reported by @tarunvijwani.

Before this PR, when the `Add to Cart` Block was configured to be displayed by default (with `INNER_BLOCKS_TEMPLATE`) in the `Product Grid` Block, the selector for choosing the product was rendered.

![image](https://user-images.githubusercontent.com/4463174/203796307-5c4d439c-6afd-4208-b49e-c9e0b0c864ea.png)

![image](https://user-images.githubusercontent.com/4463174/203796324-49768c64-c2c5-455d-b966-40ab8dc5fab8.png)

This PR fixes this wrong behavior. 


### Testing


#### User Facing Testing

1. Open the file `assets/js/blocks/product-query/constants.ts`.
2. In the `INNER_BLOCKS_TEMPLATE` adds `woocommerce/product-add-to-cart` (as in the image above).
3. Open the post editor.
4. Add the Product Query Block.
5. Be sure that the Add to Cart Block is rendered correctly.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental

