### PR TITLE
Fix query results of ProductQuery block by removing the default stock status query attribute

### DIFF
--- a/assets/js/blocks/product-query/constants.ts
+++ b/assets/js/blocks/product-query/constants.ts
@@ -61,9 +61,11 @@ export const QUERY_DEFAULT_ATTRIBUTES: QueryBlockAttributes = {
 		exclude: [],
 		sticky: '',
 		inherit: false,
-		__woocommerceStockStatus: GLOBAL_HIDE_OUT_OF_STOCK
-			? Object.keys( objectOmit( STOCK_STATUS_OPTIONS, 'outofstock' ) )
-			: Object.keys( STOCK_STATUS_OPTIONS ),
+		...( GLOBAL_HIDE_OUT_OF_STOCK && {
+			__woocommerceStockStatus: Object.keys(
+				objectOmit( STOCK_STATUS_OPTIONS, 'outofstock' )
+			),
+		} ),
 	},
 };
 


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR fixes the query results issue of the Product Query block which is caused by the default stock status query attribute.

Currently, we set the stock status attribute of the Product Query block to all available statuses: `instock`, `outofstock`, and `onbackorder`. This cause two issues:

- The default query includes an unnecessary meta query.
- The existence of a stock meta query (for `instock`, `outofstock`, and `onbackorder`) affects the query results as described in #7746. While I agree that the query result shouldn't be different as we're querying for all stock statuses, we should make the Product Query block return the same query results as the corresponding PHP query loop.

<!-- Reference any related issues or PRs here -->

Fixes #7746

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|   ![image](https://user-images.githubusercontent.com/5423135/203941739-ca4ca2db-3efa-4af6-80e2-7f7d9fa60991.png)     |    ![image](https://user-images.githubusercontent.com/5423135/203941718-4183ef26-e6f6-4732-917a-6fdc8fcc9aef.png)   |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

0. Use the sample product data provided by WooCommerce.
1. On a new page, add the Product Query block and `[recent_products]` shortcode block.
2. Change the layout of the Product Query to 4 products per row x 2 rows.
3. Save the page and view it in a new tab.
4. See the products inside the Product Query block (the front end and the editor) and the Recent Products shortcode are the same.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental

### Performance Impact

The performance of the default Product Query block should be improved because it doesn't use meta_query for the default state.
