### PR TITLE
Disable translations test on the `Checkout` block

### DIFF
--- a/tests/e2e/specs/shopper/cart-checkout/translations.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/translations.test.js
@@ -52,7 +52,8 @@ describe( 'Shopper → Cart & Checkout → Translations', () => {
 		await expect( orderSummary ).toMatch( 'Totaal' );
 	} );
 
-	it( 'User can view translated Checkout block', async () => {
+	// The translation of WooCommerce Core is taking over translations of WC Blocks. We have to fix this issue https://github.com/woocommerce/woocommerce-blocks/issues/7775 before we can enable this test.
+	it.skip( 'User can view translated Checkout block', async () => {
 		await shopper.block.goToCheckout();
 
 		const contactHeading = await page.$(


### PR DESCRIPTION
This PR disables translations test on the `Checkout` block. 
In the next cooldown, we have to address this issue (#7775) and enable this test again.

### Testing
1. Be sure that the test doesn't run.


* [X] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->