### PR TITLE
PHP 8.2: fix "Using ${var} in strings is deprecated, use {$var} instead"

### DIFF
--- a/src/StoreApi/RoutesController.php
+++ b/src/StoreApi/RoutesController.php
@@ -83,7 +83,7 @@ class RoutesController {
 		$route = $this->routes[ $version ][ $name ] ?? false;
 
 		if ( ! $route ) {
-			throw new \Exception( "${name} {$version} route does not exist" );
+			throw new \Exception( "{$name} {$version} route does not exist" );
 		}
 
 		return new $route(

--- a/src/StoreApi/SchemaController.php
+++ b/src/StoreApi/SchemaController.php
@@ -63,10 +63,10 @@ class SchemaController {
 	 * @return Schemas\V1\AbstractSchema A new instance of the requested schema.
 	 */
 	public function get( $name, $version = 1 ) {
-		$schema = $this->schemas[ "v${version}" ][ $name ] ?? false;
+		$schema = $this->schemas[ "v{$version}" ][ $name ] ?? false;
 
 		if ( ! $schema ) {
-			throw new \Exception( "${name} v{$version} schema does not exist" );
+			throw new \Exception( "{$name} v{$version} schema does not exist" );
 		}
 
 		return new $schema( $this->extend, $this );


### PR DESCRIPTION
PHP 8.2 deprecated using ${var} in strings
(https://kinsta.com/blog/php-8-2/#deprecate--string-interpolation). {$var} should be used instead. This commit fixes the occurrences of ${var} in woocommerce-blocks to prepare for the next version of PHP which is scheduled to be released early in December.

I found this in the context of testing MailPoet with PHP 8.2. I'm not familiar with the woocommerce-blocks so I might be missing something. I did not test the changes in this commit.

Here are the deprecation warnings that we are seeing:

```
PHP Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /wp-core/wp-content/plugins/woo-gutenberg-products-block/src/StoreApi/SchemaController.php on line 66
PHP Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /wp-core/wp-content/plugins/woo-gutenberg-products-block/src/StoreApi/SchemaController.php on line 69
PHP Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /wp-core/wp-content/plugins/woo-gutenberg-products-block/src/StoreApi/RoutesController.php on line 86
```

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental


### Changelog

> PHP 8.2: fix "Using ${var} in strings is deprecated, use {$var} instead"
