### PR TITLE
Mini Cart block: fix compatibility with `Page Optimize` and `Product Bundles` plugins

### DIFF
--- a/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/register-components.ts
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/register-components.ts
@@ -2,25 +2,15 @@
  * External dependencies
  */
 import { WC_BLOCKS_BUILD_URL } from '@woocommerce/block-settings';
-import { registerCheckoutBlock } from '@woocommerce/blocks-checkout';
+import { registerBlockComponent } from '@woocommerce/blocks-registry';
 import { lazy } from '@wordpress/element';
-/**
- * Internal dependencies
- */
-import emptyMiniCartContentsMetadata from './empty-mini-cart-contents-block/block.json';
-import filledMiniCartMetadata from './filled-mini-cart-contents-block/block.json';
-import miniCartTitleMetadata from './mini-cart-title-block/block.json';
-import miniCartProductsTableMetadata from './mini-cart-products-table-block/block.json';
-import miniCartFooterMetadata from './mini-cart-footer-block/block.json';
-import miniCartItemsMetadata from './mini-cart-items-block/block.json';
-import miniCartShoppingButtonMetadata from './mini-cart-shopping-button-block/block.json';
 
 // Modify webpack publicPath at runtime based on location of WordPress Plugin.
 // eslint-disable-next-line no-undef,camelcase
 __webpack_public_path__ = WC_BLOCKS_BUILD_URL;
 
-registerCheckoutBlock( {
-	metadata: filledMiniCartMetadata,
+registerBlockComponent( {
+	blockName: 'woocommerce/filled-mini-cart-contents-block',
 	component: lazy(
 		() =>
 			import(
@@ -29,8 +19,8 @@ registerCheckoutBlock( {
 	),
 } );
 
-registerCheckoutBlock( {
-	metadata: emptyMiniCartContentsMetadata,
+registerBlockComponent( {
+	blockName: 'woocommerce/empty-mini-cart-contents-block',
 	component: lazy(
 		() =>
 			import(
@@ -39,8 +29,8 @@ registerCheckoutBlock( {
 	),
 } );
 
-registerCheckoutBlock( {
-	metadata: miniCartTitleMetadata,
+registerBlockComponent( {
+	blockName: 'woocommerce/mini-cart-title-block',
 	component: lazy(
 		() =>
 			import(
@@ -49,8 +39,8 @@ registerCheckoutBlock( {
 	),
 } );
 
-registerCheckoutBlock( {
-	metadata: miniCartItemsMetadata,
+registerBlockComponent( {
+	blockName: 'woocommerce/mini-cart-items-block',
 	component: lazy(
 		() =>
 			import(
@@ -59,8 +49,8 @@ registerCheckoutBlock( {
 	),
 } );
 
-registerCheckoutBlock( {
-	metadata: miniCartProductsTableMetadata,
+registerBlockComponent( {
+	blockName: 'woocommerce/mini-cart-products-table-block',
 	component: lazy(
 		() =>
 			import(
@@ -69,8 +59,8 @@ registerCheckoutBlock( {
 	),
 } );
 
-registerCheckoutBlock( {
-	metadata: miniCartFooterMetadata,
+registerBlockComponent( {
+	blockName: 'woocommerce/mini-cart-footer-block',
 	component: lazy(
 		() =>
 			import(
@@ -79,8 +69,8 @@ registerCheckoutBlock( {
 	),
 } );
 
-registerCheckoutBlock( {
-	metadata: miniCartShoppingButtonMetadata,
+registerBlockComponent( {
+	blockName: 'woocommerce/mini-cart-shopping-button-block',
 	component: lazy(
 		() =>
 			import(


### PR DESCRIPTION
This PR fixes an issue when the Mini Cart block is used on a WordPress website with [Page Optimize](https://wordpress.org/plugins/page-optimize/) and [Product Bundles](https://woocommerce.com/products/product-bundles/) plugins enabled.

The drawer of the Mini Cart block wasn't loaded (with an empty Card and with a filled Cart)

![image](https://user-images.githubusercontent.com/4463174/204826343-bd7aae38-20a4-458b-bcb0-c94fa8db495c.png)

### Technical details
This PR is just a fix Mini Cart inner blocks are registered. The original fix is fixed by #7794. In any case, I think that we should merge this PR too.


Kudos to @Aljullu, @nerrad, @senadir, and @daledupreez, that helps me during the investigation!

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->


1. Install Page Optimize, Product Bundles, and WooCommerce Blocks (stable version).
2. Enable a block theme.
3. Customize the block theme and add the Mini Cart block in the header via Site Editor.
4. Save the changes.
5. Go to the front-end and click on the Mini Cart. The drawer should open without any content (as in the image above).
6. Go on `wp-admin`.
7. Disable WooCommerce Blocks.
8. Install a WooCommerce Blocks build using this branch (you can download the link generated by the automation).
9. Repeat step 5. Now the drawer should show the Cart.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental


### Changelog

> Mini Cart block: fix compatibility with `Page Optimize` and `Product Bundles` plugins