### PR TITLE
Prevent Mini Cart loading the same script twice

### DIFF
--- a/assets/js/base/utils/lazy-load-script.ts
+++ b/assets/js/base/utils/lazy-load-script.ts
@@ -26,8 +26,16 @@ interface AppendScriptAttributesParam {
  * This function checks whether an element matching that selector exists.
  * Useful to know if a script has already been appended to the page.
  */
-const isScriptTagInDOM = ( scriptId: string ): boolean => {
-	const scriptElements = document.querySelectorAll( `script#${ scriptId }` );
+const isScriptTagInDOM = ( scriptId: string, src = '' ): boolean => {
+	const srcParts = src.split( '?' );
+	if ( srcParts?.length > 1 ) {
+		src = srcParts[ 0 ];
+	}
+	const selector = src
+		? `script#${ scriptId }, script[src*="${ src }"]`
+		: `script#${ scriptId }`;
+	const scriptElements = document.querySelectorAll( selector );
+
 	return scriptElements.length > 0;
 };
 
@@ -37,7 +45,10 @@ const isScriptTagInDOM = ( scriptId: string ): boolean => {
  */
 const appendScript = ( attributes: AppendScriptAttributesParam ): void => {
 	// Abort if id is not valid or a script with the same id exists.
-	if ( ! isString( attributes.id ) || isScriptTagInDOM( attributes.id ) ) {
+	if (
+		! isString( attributes.id ) ||
+		isScriptTagInDOM( attributes.id, attributes?.src )
+	) {
 		return;
 	}
 	const scriptElement = document.createElement( 'script' );
@@ -92,7 +103,7 @@ const lazyLoadScript = ( {
 	translations,
 }: LazyLoadScriptParams ): Promise< void > => {
 	return new Promise( ( resolve, reject ) => {
-		if ( isScriptTagInDOM( `${ handle }-js` ) ) {
+		if ( isScriptTagInDOM( `${ handle }-js`, src ) ) {
 			resolve();
 		}
 

--- a/assets/js/base/utils/preload-script.ts
+++ b/assets/js/base/utils/preload-script.ts
@@ -13,9 +13,12 @@ const preloadScript = ( {
 	src,
 	version,
 }: PreloadScriptParams ): void => {
-	const handleScriptElements = document.querySelectorAll(
-		`#${ handle }-js, #${ handle }-js-prefetch`
-	);
+	const srcParts = src.split( '?' );
+	if ( srcParts?.length > 1 ) {
+		src = srcParts[ 0 ];
+	}
+	const selector = `#${ handle }-js, #${ handle }-js-prefetch, script[src*="${ src }"]`;
+	const handleScriptElements = document.querySelectorAll( selector );
 
 	if ( handleScriptElements.length === 0 ) {
 		const prefetchLink = document.createElement( 'link' );


### PR DESCRIPTION
This is an alternative approach to fix the issue described in #7791.

The issue seemed to be that we were loading several `wc-blocks-registry` scripts, so we were registering the Mini Cart inner components in one registry, but then trying to fetch them from another registry which was empty. This issue was reproducible with Product Bundles because their script (`wc-pb-checkout-blocks`) has a dependency on `wc-blocks-checkout` which depends on `wc-blocks-registry`.

This PR changes the way the Mini Cart block checks if a script has already been loaded in the page to avoid loading it twice. Until now, we were relying on the ids of the `script` elements. But for some reason which I don't understand yet, `wc-blocks-registry` isn't getting the proper id. So now, in addition to the previous method, we also check for the `src` attribute of the `script` elements, so if they are duplicated, we avoid loading (and preloading) the script.

As mentioned in #7791, thanks to @gigitux, @nerrad, @senadir, and @daledupreez for helping research this issue.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. Install Page Optimize and Product Bundles.
2. Enable a block theme.
3. Customize the block theme and add the Mini Cart block in the header via Site Editor.
4. Save the changes.
5. In the frontend, lick on the Mini Cart. The drawer should open and show the "empty cart" message. 
6. Go to the shop page and add a product to your cart.
7. Click on the Mini Cart. The drawer should open and show the product you just added.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Mini Cart block: fix compatibility with `Page Optimize` and `Product Bundles` plugins