### PR TITLE
Add `CartEventContext` and dispatch events when pressing proceed to checkout button

### DIFF
--- a/assets/js/base/context/providers/cart-checkout/cart-events/event-emit.ts
+++ b/assets/js/base/context/providers/cart-checkout/cart-events/event-emit.ts
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import { useMemo } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import {
+	emitterCallback,
+	reducer,
+	emitEvent,
+	emitEventWithAbort,
+	ActionType,
+} from '../../../event-emit';
+
+// These events are emitted when the Cart status is BEFORE_PROCESSING and AFTER_PROCESSING
+// to enable third parties to hook into the cart process
+const EVENTS = {
+	PROCEED_TO_CHECKOUT: 'cart_proceed_to_checkout',
+};
+
+type EventEmittersType = Record< string, ReturnType< typeof emitterCallback > >;
+
+/**
+ * Receives a reducer dispatcher and returns an object with the
+ * various event emitters for the payment processing events.
+ *
+ * Calling the event registration function with the callback will register it
+ * for the event emitter and will return a dispatcher for removing the
+ * registered callback (useful for implementation in `useEffect`).
+ *
+ * @param {Function} observerDispatch The emitter reducer dispatcher.
+ * @return {Object} An object with the various payment event emitter registration functions
+ */
+const useEventEmitters = (
+	observerDispatch: React.Dispatch< ActionType >
+): EventEmittersType => {
+	const eventEmitters = useMemo(
+		() => ( {
+			onProceedToCheckout: emitterCallback(
+				EVENTS.PROCEED_TO_CHECKOUT,
+				observerDispatch
+			),
+		} ),
+		[ observerDispatch ]
+	);
+	return eventEmitters;
+};
+
+export { EVENTS, useEventEmitters, reducer, emitEvent, emitEventWithAbort };

--- a/assets/js/base/context/providers/cart-checkout/cart-events/index.tsx
+++ b/assets/js/base/context/providers/cart-checkout/cart-events/index.tsx
@@ -47,7 +47,7 @@ export const useCartEventsContext = () => {
 export const CartEventsProvider = ( {
 	children,
 }: {
-	children: React.ReactChildren;
+	children: React.ReactNode;
 } ): JSX.Element => {
 	const [ observers, observerDispatch ] = useReducer( emitReducer, {} );
 	const currentObservers = useRef( observers );

--- a/assets/js/base/context/providers/cart-checkout/cart-events/index.tsx
+++ b/assets/js/base/context/providers/cart-checkout/cart-events/index.tsx
@@ -1,0 +1,78 @@
+/**
+ * External dependencies
+ */
+
+import {
+	createContext,
+	useContext,
+	useReducer,
+	useRef,
+	useEffect,
+} from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import {
+	useEventEmitters,
+	reducer as emitReducer,
+	emitEventWithAbort,
+	EVENTS,
+} from './event-emit';
+import type { emitterCallback } from '../../../event-emit';
+
+type CartEventsContextType = {
+	// Used to register a callback that will fire when the cart has been processed and has an error.
+	onProceedToCheckout: ReturnType< typeof emitterCallback >;
+	// Used to register a callback that will fire when the cart has been processed and has an error.
+	dispatchOnProceedToCheckout: () => Promise< unknown[] >;
+};
+
+const CartEventsContext = createContext< CartEventsContextType >( {
+	onProceedToCheckout: () => () => void null,
+	dispatchOnProceedToCheckout: () => new Promise( () => void null ),
+} );
+
+export const useCartEventsContext = () => {
+	return useContext( CartEventsContext );
+};
+
+/**
+ * Checkout Events provider
+ * Emit Checkout events and provide access to Checkout event handlers
+ *
+ * @param {Object} props          Incoming props for the provider.
+ * @param {Object} props.children The children being wrapped.
+ */
+export const CartEventsProvider = ( {
+	children,
+}: {
+	children: React.ReactChildren;
+} ): JSX.Element => {
+	const [ observers, observerDispatch ] = useReducer( emitReducer, {} );
+	const currentObservers = useRef( observers );
+	const { onProceedToCheckout } = useEventEmitters( observerDispatch );
+
+	// set observers on ref so it's always current.
+	useEffect( () => {
+		currentObservers.current = observers;
+	}, [ observers ] );
+
+	const dispatchOnProceedToCheckout = async () => {
+		return await emitEventWithAbort(
+			currentObservers.current,
+			EVENTS.PROCEED_TO_CHECKOUT,
+			null
+		);
+	};
+
+	const cartEvents = {
+		onProceedToCheckout,
+		dispatchOnProceedToCheckout,
+	};
+	return (
+		<CartEventsContext.Provider value={ cartEvents }>
+			{ children }
+		</CartEventsContext.Provider>
+	);
+};

--- a/assets/js/base/context/providers/cart-checkout/cart-events/test/index.tsx
+++ b/assets/js/base/context/providers/cart-checkout/cart-events/test/index.tsx
@@ -13,7 +13,7 @@ import Block from '../../../../../../blocks/cart/inner-blocks/proceed-to-checkou
 
 describe( 'CartEventsProvider', () => {
 	it( 'allows observers to unsubscribe', async () => {
-		const mockObserver = jest.fn();
+		const mockObserver = jest.fn().mockReturnValue( { type: 'error' } );
 		const MockObserverComponent = () => {
 			const { onProceedToCheckout } = useCartEventsContext();
 			useEffect( () => {

--- a/assets/js/base/context/providers/cart-checkout/cart-events/test/index.tsx
+++ b/assets/js/base/context/providers/cart-checkout/cart-events/test/index.tsx
@@ -35,6 +35,10 @@ describe( 'CartEventsProvider', () => {
 		);
 		expect( screen.getByText( 'Mock observer' ) ).toBeInTheDocument();
 		const button = screen.getByText( 'Proceed to Checkout' );
+
+		// Forcibly set the button URL to # to prevent JSDOM error: `["Error: Not implemented: navigation (except hash changes)`
+		button.parentElement?.removeAttribute( 'href' );
+
 		// Click twice. The observer should unsubscribe after the first click.
 		button.click();
 		button.click();

--- a/assets/js/base/context/providers/cart-checkout/cart-events/test/index.tsx
+++ b/assets/js/base/context/providers/cart-checkout/cart-events/test/index.tsx
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import { useCartEventsContext } from '@woocommerce/base-context';
+import { useEffect } from '@wordpress/element';
+import { render, screen, waitFor } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { CartEventsProvider } from '../index';
+import Block from '../../../../../../blocks/cart/inner-blocks/proceed-to-checkout-block/block';
+
+describe( 'CartEventsProvider', () => {
+	it( 'allows observers to unsubscribe', async () => {
+		const mockObserver = jest.fn();
+		const MockObserverComponent = () => {
+			const { onProceedToCheckout } = useCartEventsContext();
+			useEffect( () => {
+				const unsubscribe = onProceedToCheckout( () => {
+					mockObserver();
+					unsubscribe();
+				} );
+			}, [ onProceedToCheckout ] );
+			return <div>Mock observer</div>;
+		};
+
+		render(
+			<CartEventsProvider>
+				<div>
+					<MockObserverComponent />
+					<Block checkoutPageId={ 0 } className="test-block" />
+				</div>
+			</CartEventsProvider>
+		);
+		expect( screen.getByText( 'Mock observer' ) ).toBeInTheDocument();
+		const button = screen.getByText( 'Proceed to Checkout' );
+		// Click twice. The observer should unsubscribe after the first click.
+		button.click();
+		button.click();
+		await waitFor( () => {
+			expect( mockObserver ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+} );

--- a/assets/js/base/context/providers/cart-checkout/index.js
+++ b/assets/js/base/context/providers/cart-checkout/index.js
@@ -1,6 +1,7 @@
 export * from './payment-events';
 export * from './shipping';
 export * from './checkout-events';
+export * from './cart-events';
 export * from './cart';
 export * from './checkout-processor';
 export * from './checkout-provider';

--- a/assets/js/blocks/cart/block.js
+++ b/assets/js/blocks/cart/block.js
@@ -5,11 +5,15 @@ import { __ } from '@wordpress/i18n';
 import { useStoreCart } from '@woocommerce/base-context/hooks';
 import { useEffect } from '@wordpress/element';
 import LoadingMask from '@woocommerce/base-components/loading-mask';
-import { CartProvider, noticeContexts } from '@woocommerce/base-context';
 import { CURRENT_USER_IS_ADMIN } from '@woocommerce/settings';
 import BlockErrorBoundary from '@woocommerce/base-components/block-error-boundary';
 import { translateJQueryEventToNative } from '@woocommerce/base-utils';
 import withScrollToTop from '@woocommerce/base-hocs/with-scroll-to-top';
+import {
+	CartEventsProvider,
+	CartProvider,
+	noticeContexts,
+} from '@woocommerce/base-context';
 import {
 	SlotFillProvider,
 	StoreNoticesContainer,
@@ -85,8 +89,10 @@ const Block = ( { attributes, children, scrollToTop } ) => (
 		<StoreNoticesContainer context={ noticeContexts.CART } />
 		<SlotFillProvider>
 			<CartProvider>
-				<Cart attributes={ attributes }>{ children }</Cart>
-				<ScrollOnError scrollToTop={ scrollToTop } />
+				<CartEventsProvider>
+					<Cart attributes={ attributes }>{ children }</Cart>
+					<ScrollOnError scrollToTop={ scrollToTop } />
+				</CartEventsProvider>
 			</CartProvider>
 		</SlotFillProvider>
 	</BlockErrorBoundary>

--- a/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/block.tsx
+++ b/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/block.tsx
@@ -79,27 +79,23 @@ const Block = ( {
 	const { dispatchOnProceedToCheckout } = useCartEventsContext();
 
 	const submitContainerContents = (
-		<div>
-			<Button
-				className="wc-block-cart__submit-button"
-				href={ filteredLink }
-				disabled={ isCalculating }
-				onClick={ ( e ) => {
-					dispatchOnProceedToCheckout().then(
-						( observerResponses ) => {
-							if ( observerResponses.some( isErrorResponse ) ) {
-								e.preventDefault();
-								return;
-							}
-							setShowSpinner( true );
-						}
-					);
-				} }
-				showSpinner={ showSpinner }
-			>
-				{ label }
-			</Button>
-		</div>
+		<Button
+			className="wc-block-cart__submit-button"
+			href={ filteredLink }
+			disabled={ isCalculating }
+			onClick={ ( e ) => {
+				dispatchOnProceedToCheckout().then( ( observerResponses ) => {
+					if ( observerResponses.some( isErrorResponse ) ) {
+						e.preventDefault();
+						return;
+					}
+					setShowSpinner( true );
+				} );
+			} }
+			showSpinner={ showSpinner }
+		>
+			{ label }
+		</Button>
 	);
 
 	// Get the body background color to use as the sticky container background color.

--- a/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/block.tsx
+++ b/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/block.tsx
@@ -10,6 +10,8 @@ import { getSetting } from '@woocommerce/settings';
 import { useSelect } from '@wordpress/data';
 import { CART_STORE_KEY, CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
 import { applyCheckoutFilter } from '@woocommerce/blocks-checkout';
+import { isErrorResponse } from '@woocommerce/base-context';
+import { useCartEventsContext } from '@woocommerce/base-context/providers';
 
 /**
  * Internal dependencies
@@ -74,16 +76,30 @@ const Block = ( {
 		arg: { cart },
 	} );
 
+	const { dispatchOnProceedToCheckout } = useCartEventsContext();
+
 	const submitContainerContents = (
-		<Button
-			className="wc-block-cart__submit-button"
-			href={ filteredLink }
-			disabled={ isCalculating }
-			onClick={ () => setShowSpinner( true ) }
-			showSpinner={ showSpinner }
-		>
-			{ label }
-		</Button>
+		<div>
+			<Button
+				className="wc-block-cart__submit-button"
+				href={ filteredLink }
+				disabled={ isCalculating }
+				onClick={ ( e ) => {
+					dispatchOnProceedToCheckout().then(
+						( observerResponses ) => {
+							if ( observerResponses.some( isErrorResponse ) ) {
+								e.preventDefault();
+								return;
+							}
+							setShowSpinner( true );
+						}
+					);
+				} }
+				showSpinner={ showSpinner }
+			>
+				{ label }
+			</Button>
+		</div>
 	);
 
 	// Get the body background color to use as the sticky container background color.

--- a/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/test/block.tsx
+++ b/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/test/block.tsx
@@ -1,13 +1,17 @@
 /**
  * External dependencies
  */
-import { render, screen } from '@testing-library/react';
+
+import { render, screen, waitFor } from '@testing-library/react';
 import { registerCheckoutFilters } from '@woocommerce/blocks-checkout';
+import { useCartEventsContext } from '@woocommerce/base-context';
+import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import Block from '../block';
+import { CartEventsProvider } from '../../../../../base/context/providers';
 
 describe( 'Proceed to checkout block', () => {
 	it( 'allows the text to be filtered', () => {
@@ -48,5 +52,34 @@ describe( 'Proceed to checkout block', () => {
 		);
 		//@todo When https://github.com/WordPress/gutenberg/issues/22850 is complete use that new matcher here for more specific error message assertion.
 		expect( console ).toHaveErrored();
+		it( 'dispatches the onProceedToCheckout event when the button is clicked', async () => {
+			const mockObserver = jest.fn();
+			const MockObserverComponent = () => {
+				const { onProceedToCheckout } = useCartEventsContext();
+				useEffect( () => {
+					return onProceedToCheckout( mockObserver );
+				}, [ onProceedToCheckout ] );
+				return <div>Mock observer</div>;
+			};
+
+			render(
+				<CartEventsProvider>
+					<div>
+						<MockObserverComponent />
+						<Block
+							buttonLabel={ 'Proceed to checkout' }
+							checkoutPageId={ 0 }
+							className="test-block"
+						/>
+					</div>
+				</CartEventsProvider>
+			);
+			expect( screen.getByText( 'Mock observer' ) ).toBeInTheDocument();
+			const button = screen.getByText( 'Proceed to Checkout' );
+			button.click();
+			await waitFor( () => {
+				expect( mockObserver ).toHaveBeenCalled();
+			} );
+		} );
 	} );
 } );

--- a/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/test/block.tsx
+++ b/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/test/block.tsx
@@ -54,7 +54,7 @@ describe( 'Proceed to checkout block', () => {
 		expect( console ).toHaveErrored();
 	} );
 	it( 'dispatches the onProceedToCheckout event when the button is clicked', async () => {
-		const mockObserver = jest.fn();
+		const mockObserver = jest.fn().mockReturnValue( { type: 'error' } );
 		const MockObserverComponent = () => {
 			const { onProceedToCheckout } = useCartEventsContext();
 			useEffect( () => {
@@ -77,6 +77,10 @@ describe( 'Proceed to checkout block', () => {
 		);
 		expect( screen.getByText( 'Mock observer' ) ).toBeInTheDocument();
 		const button = screen.getByText( 'Proceed to Checkout' );
+
+		// Forcibly set the button URL to # to prevent JSDOM error: `["Error: Not implemented: navigation (except hash changes)`
+		button.parentElement?.removeAttribute( 'href' );
+
 		button.click();
 		await waitFor( () => {
 			expect( mockObserver ).toHaveBeenCalled();

--- a/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/test/block.tsx
+++ b/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/test/block.tsx
@@ -52,34 +52,34 @@ describe( 'Proceed to checkout block', () => {
 		);
 		//@todo When https://github.com/WordPress/gutenberg/issues/22850 is complete use that new matcher here for more specific error message assertion.
 		expect( console ).toHaveErrored();
-		it( 'dispatches the onProceedToCheckout event when the button is clicked', async () => {
-			const mockObserver = jest.fn();
-			const MockObserverComponent = () => {
-				const { onProceedToCheckout } = useCartEventsContext();
-				useEffect( () => {
-					return onProceedToCheckout( mockObserver );
-				}, [ onProceedToCheckout ] );
-				return <div>Mock observer</div>;
-			};
+	} );
+	it( 'dispatches the onProceedToCheckout event when the button is clicked', async () => {
+		const mockObserver = jest.fn();
+		const MockObserverComponent = () => {
+			const { onProceedToCheckout } = useCartEventsContext();
+			useEffect( () => {
+				return onProceedToCheckout( mockObserver );
+			}, [ onProceedToCheckout ] );
+			return <div>Mock observer</div>;
+		};
 
-			render(
-				<CartEventsProvider>
-					<div>
-						<MockObserverComponent />
-						<Block
-							buttonLabel={ 'Proceed to checkout' }
-							checkoutPageId={ 0 }
-							className="test-block"
-						/>
-					</div>
-				</CartEventsProvider>
-			);
-			expect( screen.getByText( 'Mock observer' ) ).toBeInTheDocument();
-			const button = screen.getByText( 'Proceed to Checkout' );
-			button.click();
-			await waitFor( () => {
-				expect( mockObserver ).toHaveBeenCalled();
-			} );
+		render(
+			<CartEventsProvider>
+				<div>
+					<MockObserverComponent />
+					<Block
+						buttonLabel={ 'Proceed to Checkout' }
+						checkoutPageId={ 0 }
+						className="test-block"
+					/>
+				</div>
+			</CartEventsProvider>
+		);
+		expect( screen.getByText( 'Mock observer' ) ).toBeInTheDocument();
+		const button = screen.getByText( 'Proceed to Checkout' );
+		button.click();
+		await waitFor( () => {
+			expect( mockObserver ).toHaveBeenCalled();
 		} );
 	} );
 } );

--- a/assets/js/blocks/mini-cart/mini-cart-contents/block.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/block.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { DrawerCloseButton } from '@woocommerce/base-components/drawer';
+import { CartEventsProvider } from '@woocommerce/base-context';
 
 /**
  * Internal dependencies
@@ -20,8 +21,10 @@ export const MiniCartContentsBlock = (
 
 	return (
 		<>
-			<DrawerCloseButton />
-			{ children }
+			<CartEventsProvider>
+				<DrawerCloseButton />
+				{ children }
+			</CartEventsProvider>
 		</>
 	);
 };

--- a/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-checkout-button-block/block.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-checkout-button-block/block.tsx
@@ -5,6 +5,10 @@ import { CHECKOUT_URL } from '@woocommerce/block-settings';
 import Button from '@woocommerce/base-components/button';
 import classNames from 'classnames';
 import { useStyleProps } from '@woocommerce/base-hooks';
+import {
+	isErrorResponse,
+	useCartEventsContext,
+} from '@woocommerce/base-context';
 
 /**
  * Internal dependencies
@@ -24,6 +28,7 @@ const Block = ( {
 	style,
 }: MiniCartCheckoutButtonBlockProps ): JSX.Element | null => {
 	const styleProps = useStyleProps( { style } );
+	const { dispatchOnProceedToCheckout } = useCartEventsContext();
 
 	if ( ! CHECKOUT_URL ) {
 		return null;
@@ -39,6 +44,13 @@ const Block = ( {
 			variant={ getVariant( className, 'contained' ) }
 			style={ styleProps.style }
 			href={ CHECKOUT_URL }
+			onClick={ ( e ) => {
+				dispatchOnProceedToCheckout().then( ( observerResponses ) => {
+					if ( observerResponses.some( isErrorResponse ) ) {
+						e.preventDefault();
+					}
+				} );
+			} }
 		>
 			{ checkoutButtonLabel || defaultCheckoutButtonLabel }
 		</Button>

--- a/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-checkout-button-block/test/block.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-checkout-button-block/test/block.tsx
@@ -13,16 +13,12 @@ import { render, screen, waitFor } from '@testing-library/react';
  */
 import Block from '../block';
 
-const assignMock = jest.fn();
-
-delete window.location;
-window.location = { assign: assignMock };
-
-afterEach( () => {
-	assignMock.mockClear();
-} );
 describe( 'Mini Cart Checkout Button Block', () => {
 	it( 'dispatches the onProceedToCheckout event when the button is clicked', async () => {
+		Object.defineProperty( window, 'location', {
+			writable: true,
+			value: { assign: jest.fn() },
+		} );
 		const mockObserver = jest.fn().mockReturnValue( { type: 'error' } );
 		const MockObserverComponent = () => {
 			const { onProceedToCheckout } = useCartEventsContext();

--- a/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-checkout-button-block/test/block.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-checkout-button-block/test/block.tsx
@@ -39,7 +39,7 @@ describe( 'Mini Cart Checkout Button Block', () => {
 		const button = screen.getByText( 'Proceed to Checkout' );
 
 		// Forcibly set the button URL to # to prevent JSDOM error: `["Error: Not implemented: navigation (except hash changes)`
-		button.parentElement.setAttribute( 'href', '#' );
+		button.parentElement?.removeAttribute( 'href' );
 		button.click();
 		await waitFor( () => {
 			expect( mockObserver ).toHaveBeenCalled();

--- a/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-checkout-button-block/test/block.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-checkout-button-block/test/block.tsx
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import {
+	CartEventsProvider,
+	useCartEventsContext,
+} from '@woocommerce/base-context';
+import { useEffect } from '@wordpress/element';
+import { render, screen, waitFor } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import Block from '../block';
+describe( 'Mini Cart Checkout Button Block', () => {
+	it( 'dispatches the onProceedToCheckout event when the button is clicked', async () => {
+		const mockObserver = jest.fn();
+		const MockObserverComponent = () => {
+			const { onProceedToCheckout } = useCartEventsContext();
+			useEffect( () => {
+				return onProceedToCheckout( mockObserver );
+			}, [ onProceedToCheckout ] );
+			return <div>Mock observer</div>;
+		};
+
+		render(
+			<CartEventsProvider>
+				<div>
+					<MockObserverComponent />
+					<Block
+						checkoutButtonLabel={ 'Proceed to Checkout' }
+						className="test-block"
+					/>
+				</div>
+			</CartEventsProvider>
+		);
+		expect( screen.getByText( 'Mock observer' ) ).toBeInTheDocument();
+		const button = screen.getByText( 'Proceed to Checkout' );
+		button.click();
+		await waitFor( () => {
+			expect( mockObserver ).toHaveBeenCalled();
+		} );
+	} );
+} );

--- a/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-checkout-button-block/test/block.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-checkout-button-block/test/block.tsx
@@ -39,7 +39,7 @@ describe( 'Mini Cart Checkout Button Block', () => {
 		const button = screen.getByText( 'Proceed to Checkout' );
 
 		// Forcibly set the button URL to # to prevent JSDOM error: `["Error: Not implemented: navigation (except hash changes)`
-		button.setAttribute( 'href', '#' );
+		button.parentElement.setAttribute( 'href', '#' );
 		button.click();
 		await waitFor( () => {
 			expect( mockObserver ).toHaveBeenCalled();

--- a/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-checkout-button-block/test/block.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-checkout-button-block/test/block.tsx
@@ -12,6 +12,15 @@ import { render, screen, waitFor } from '@testing-library/react';
  * Internal dependencies
  */
 import Block from '../block';
+
+const assignMock = jest.fn();
+
+delete window.location;
+window.location = { assign: assignMock };
+
+afterEach( () => {
+	assignMock.mockClear();
+} );
 describe( 'Mini Cart Checkout Button Block', () => {
 	it( 'dispatches the onProceedToCheckout event when the button is clicked', async () => {
 		const mockObserver = jest.fn().mockReturnValue( { type: 'error' } );

--- a/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-checkout-button-block/test/block.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-checkout-button-block/test/block.tsx
@@ -15,10 +15,6 @@ import Block from '../block';
 
 describe( 'Mini Cart Checkout Button Block', () => {
 	it( 'dispatches the onProceedToCheckout event when the button is clicked', async () => {
-		Object.defineProperty( window, 'location', {
-			writable: true,
-			value: { assign: jest.fn() },
-		} );
 		const mockObserver = jest.fn().mockReturnValue( { type: 'error' } );
 		const MockObserverComponent = () => {
 			const { onProceedToCheckout } = useCartEventsContext();
@@ -41,6 +37,9 @@ describe( 'Mini Cart Checkout Button Block', () => {
 		);
 		expect( screen.getByText( 'Mock observer' ) ).toBeInTheDocument();
 		const button = screen.getByText( 'Proceed to Checkout' );
+
+		// Forcibly set the button URL to # to prevent JSDOM error: `["Error: Not implemented: navigation (except hash changes)`
+		button.setAttribute( 'href', '#' );
 		button.click();
 		await waitFor( () => {
 			expect( mockObserver ).toHaveBeenCalled();

--- a/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-checkout-button-block/test/block.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-checkout-button-block/test/block.tsx
@@ -14,7 +14,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import Block from '../block';
 describe( 'Mini Cart Checkout Button Block', () => {
 	it( 'dispatches the onProceedToCheckout event when the button is clicked', async () => {
-		const mockObserver = jest.fn();
+		const mockObserver = jest.fn().mockReturnValue( { type: 'error' } );
 		const MockObserverComponent = () => {
 			const { onProceedToCheckout } = useCartEventsContext();
 			useEffect( () => {

--- a/tests/js/setup-globals.js
+++ b/tests/js/setup-globals.js
@@ -86,7 +86,7 @@ global.wcSettings = {
 		checkout: {
 			id: 0,
 			title: '',
-			permalink: '',
+			permalink: 'https://local/checkout/',
 		},
 		privacy: {
 			id: 0,


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

This is a re-do of https://github.com/woocommerce/woocommerce-blocks/pull/7694 but it targets `trunk` instead.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [ ] E2E tests

#### Internal dev testing
1. Go to https://github.com/woocommerce/woocommerce-blocks/blob/aa78099bb15bf5bfdce42cf6b423a391365a6992/assets/js/base/components/quantity-selector/index.tsx#L77
2. Add this code, it will register an observer to the `onProceedToCheckout` event, and show a confirmation box. Pressing cancel will cause the observer to return an error object, this should abort the proceed to checkout aciton.

```js
	const { onProceedToCheckout } = useCartEventsContext();
	useEffect(
		() =>
			onProceedToCheckout( () => {
				const confirmation = confirm(
					'onProceedToCheckout fired, pressing OK will proceed to checkout, cancelling will stop it.'
				);
				if ( ! confirmation ) {
					return { error: true, type: 'error' };
				}
			} ),
		[ onProceedToCheckout ]
	);
```

3. Add an item to your cart (only add one or the `confirm` will happen multiple times).
4. Press Proceed to Checkout and in the confirmation dialogue, press cancel, verify you do not go to Checkout.
5. Press Proceed to Checkout again, but this time press OK. Verify you get taken to the Checkout block.

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1.  Ensure you can navigate from the Cart to the Checkout block using the Proceed to Checkout button.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Skipping
