### PR TITLE
Add "Just Arrived Full Hero" commerce adjacent pattern

### DIFF
--- a/patterns/just-arrived-full-hero.php
+++ b/patterns/just-arrived-full-hero.php
@@ -5,8 +5,7 @@
  * Categories: WooCommerce
  */
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}},"elements":{"link":{"color":{"text":"var:preset|color|black"}}}},"textColor":"black","layout":{"inherit":true,"type":"constrained"}} -->
-<div class="wp-block-group alignfull has-black-color has-text-color has-link-color" style="margin-top:0px;margin-bottom:0px"><!-- wp:cover {"useFeaturedImage":true,"dimRatio":0,"minHeight":50,"minHeightUnit":"vw","contentPosition":"center center","isDark":false,"align":"full","style":{"spacing":{"padding":{"left":"50vw"}}}} -->
+<!-- wp:cover {"useFeaturedImage":true,"dimRatio":0,"minHeight":50,"minHeightUnit":"vw","contentPosition":"center center","isDark":false,"align":"full","style":{"spacing":{"padding":{"left":"50vw"}}}} -->
 <div class="wp-block-cover alignfull is-light" style="padding-left:50vw;min-height:50vw"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:heading {"style":{"spacing":{"margin":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}},"typography":{"fontSize":"40px","fontStyle":"normal","fontWeight":"700"}}} -->
 <h2 id="just-arrived" style="margin-top:0px;margin-right:0px;margin-bottom:0px;margin-left:0px;font-size:40px;font-style:normal;font-weight:700">Just arrived</h2>
 <!-- /wp:heading -->
@@ -20,6 +19,5 @@
 <div class="wp-block-button is-style-fill"><a class="wp-block-button__link has-white-color has-black-background-color has-text-color has-background wp-element-button">Shop now</a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div></div>
-<!-- /wp:cover --></div>
-<!-- /wp:group -->
+<!-- /wp:cover -->
 

--- a/patterns/just-arrived-full-hero.php
+++ b/patterns/just-arrived-full-hero.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Title: WooCommerce Just Arrived Full Hero
+ * Slug: woocommerce-blocks/just-arrived-full-hero
+ * Categories: WooCommerce
+ */
+?>
+<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px","bottom":"0px"}},"elements":{"link":{"color":{"text":"var:preset|color|black"}}}},"textColor":"black","layout":{"inherit":true,"type":"constrained"}} -->
+<div class="wp-block-group alignfull has-black-color has-text-color has-link-color" style="margin-top:0px;margin-bottom:0px"><!-- wp:cover {"useFeaturedImage":true,"dimRatio":0,"minHeight":50,"minHeightUnit":"vw","contentPosition":"center center","isDark":false,"align":"full","style":{"spacing":{"padding":{"left":"50vw"}}}} -->
+<div class="wp-block-cover alignfull is-light" style="padding-left:50vw;min-height:50vw"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:heading {"style":{"spacing":{"margin":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}},"typography":{"fontSize":"40px","fontStyle":"normal","fontWeight":"700"}}} -->
+<h2 id="just-arrived" style="margin-top:0px;margin-right:0px;margin-bottom:0px;margin-left:0px;font-size:40px;font-style:normal;font-weight:700">Just arrived</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"}}} -->
+<p style="font-size:16px">Our early autumn collection is here.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:buttons {"style":{"spacing":{"blockGap":"0px"}}} -->
+<div class="wp-block-buttons"><!-- wp:button {"backgroundColor":"black","textColor":"white","className":"is-style-fill"} -->
+<div class="wp-block-button is-style-fill"><a class="wp-block-button__link has-white-color has-black-background-color has-text-color has-background wp-element-button">Shop now</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div></div>
+<!-- /wp:cover --></div>
+<!-- /wp:group -->
+

--- a/patterns/just-arrived-full-hero.php
+++ b/patterns/just-arrived-full-hero.php
@@ -6,17 +6,17 @@
  */
 ?>
 <!-- wp:cover {"useFeaturedImage":true,"dimRatio":0,"minHeight":50,"minHeightUnit":"vw","contentPosition":"center center","isDark":false,"align":"full","style":{"spacing":{"padding":{"left":"50vw"}}}} -->
-<div class="wp-block-cover alignfull is-light" style="padding-left:50vw;min-height:50vw"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:heading {"style":{"spacing":{"margin":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}},"typography":{"fontSize":"40px","fontStyle":"normal","fontWeight":"700"}}} -->
-<h2 id="just-arrived" style="margin-top:0px;margin-right:0px;margin-bottom:0px;margin-left:0px;font-size:40px;font-style:normal;font-weight:700">Just arrived</h2>
+<div class="wp-block-cover alignfull is-light" style="padding-left:50vw;min-height:50vw"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:heading {"style":{"spacing":{"margin":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}},"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"x-large"} -->
+<h2 class="has-x-large-font-size" id="just-arrived" style="margin-top:0px;margin-right:0px;margin-bottom:0px;margin-left:0px;font-style:normal;font-weight:700"><?php esc_html_e( 'Just arrived', 'woo-gutenberg-products-block' ); ?></h2>
 <!-- /wp:heading -->
 
-<!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"}}} -->
-<p style="font-size:16px">Our early autumn collection is here.</p>
+<!-- wp:paragraph {"fontSize":"medium"} -->
+<p class="has-medium-font-size"><?php esc_html_e( 'Our early autumn collection is here.', 'woo-gutenberg-products-block' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:buttons {"style":{"spacing":{"blockGap":"0px"}}} -->
-<div class="wp-block-buttons"><!-- wp:button {"backgroundColor":"black","textColor":"white","className":"is-style-fill"} -->
-<div class="wp-block-button is-style-fill"><a class="wp-block-button__link has-white-color has-black-background-color has-text-color has-background wp-element-button">Shop now</a></div>
+<div class="wp-block-buttons"><!-- wp:button {"backgroundColor":"black","textColor":"white","className":"is-style-fill","fontSize":"small"} -->
+<div class="wp-block-button has-custom-font-size is-style-fill has-small-font-size"><a class="wp-block-button__link has-white-color has-black-background-color has-text-color has-background wp-element-button"><?php esc_html_e( 'Shop now', 'woo-gutenberg-products-block' ); ?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div></div>
 <!-- /wp:cover -->


### PR DESCRIPTION
The "Just Arrived Full Hero" commerce adjacent patterns is a straightforward hero block that can be used as inspiration for merchants on the home page to showcase an attention grabber image with simple callout text, and button block link to whatever page they want.

cc @vivialice for design review.

**NOTE:** The frontend screenshots were with images that _won't_ ship with this pattern.

## Screenshots

The following screenshots were with the Twenty Twenty Three theme and the "Whisper" style.

### Editor
![CleanShot 2022-12-01 at 11 48 40@2x](https://user-images.githubusercontent.com/1429108/205112047-f8cbb07b-1ca5-44cf-8fe8-2caaea8f82de.png)

### Pattern preview in Editor
![CleanShot 2022-12-01 at 11 49 00@2x](https://user-images.githubusercontent.com/1429108/205112159-b3c23989-4ad6-42a7-bc2f-01fe8871762f.png)

### Desktop frontend

![CleanShot 2022-12-01 at 11 50 22@2x](https://user-images.githubusercontent.com/1429108/205112222-779c8fec-40a8-43ec-aa73-69ab4dd7652c.png)

### Mobile frontend
<img width="321" alt="CleanShot 2022-12-01 at 11 50 54@2x" src="https://user-images.githubusercontent.com/1429108/205112297-b6f65c96-2a6e-42e3-bb3e-f843776cc6ba.png">

### Tablet frontend
<img width="465" alt="CleanShot 2022-12-01 at 11 51 17@2x" src="https://user-images.githubusercontent.com/1429108/205112332-02d8af9e-56e8-481f-bac3-1b4c9270b264.png">

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
* [ ] Unit tests
* [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Create a new page and edit it.
2. Browse to the WooCommerce category for Block patterns and look for the WooCommerce Just Arrived Full Hero pattern in the "Explore All Patterns" dialog. Click to insert.
<img width="1229" alt="CleanShot 2022-12-01 at 11 58 25@2x" src="https://user-images.githubusercontent.com/1429108/205113567-04310b49-ea2d-40d6-8e73-ed276e81d15c.png">
3. Verify the pattern inserted on the page. It may look different depending on the theme 

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> The "Just Arrived Full Hero" block pattern has been added. It is a straightforward hero design that can be used with an attention-grabber image some simple callout text, and a button block that can be linked to any page.
