### PR TITLE
Load `wc-blocks-registry` at the load of the page instead of lazy load it

### DIFF
--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -103,7 +103,7 @@ class MiniCart extends AbstractBlock {
 		$script = [
 			'handle'       => 'wc-' . $this->block_name . '-block-frontend',
 			'path'         => $this->asset_api->get_block_asset_build_path( $this->block_name . '-frontend' ),
-			'dependencies' => [],
+			'dependencies' => [ 'wc-blocks-registry' ],
 		];
 		return $key ? $script[ $key ] : $script;
 	}
@@ -273,7 +273,7 @@ class MiniCart extends AbstractBlock {
 				}
 			}
 		}
-		if ( ! $script->src ) {
+		if ( ! $script->src || 'wc-blocks-registry' === $script->handle ) {
 			return;
 		}
 


### PR DESCRIPTION
This PR is a follow-up of #7794. 
During tests, we noticed that the approach in #7794 does not always work. So, at least for now, we decided to load the package `wc-blocks-registry` at the load of the page.



### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Install Page Optimize and Product Bundles.
2. Enable a block theme.
3. Customize the block theme and add the Mini Cart block in the header via Site Editor.
4. Save the changes.
5. In the frontend, lick on the Mini Cart. The drawer should open and show the "empty cart" message. 
6. Go to the shop page and add a product to your cart.
7. Click on the Mini Cart. The drawer should open and show the product you just added.


* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Mini Cart block: Load `wc-blocks-registry` package at the page's load instead of lazy load it.
