### PR TITLE
Add "Product Hero 2 Column 2 Row" commerce adjacent pattern.

### DIFF
--- a/patterns/product-hero-2-col-2-row.php
+++ b/patterns/product-hero-2-col-2-row.php
@@ -12,19 +12,19 @@
 <div class="wp-block-group"><!-- wp:columns {"verticalAlignment":"top"} -->
 <div class="wp-block-columns are-vertically-aligned-top"><!-- wp:column {"verticalAlignment":"top","style":{"spacing":{"padding":{"top":"30px","right":"30px","bottom":"30px","left":"30px"}}}} -->
 <div class="wp-block-column is-vertically-aligned-top" style="padding-top:30px;padding-right:30px;padding-bottom:30px;padding-left:30px"><!-- wp:heading {"style":{"typography":{"fontSize":"58px","fontStyle":"normal","fontWeight":"600"},"spacing":{"margin":{"top":"0px"}}}} -->
-<h2 id="the-eden-jacket" style="margin-top:0px;font-size:58px;font-style:normal;font-weight:600">The Eden Jacket</h2>
+<h2 id="the-eden-jacket" style="margin-top:0px;font-size:58px;font-style:normal;font-weight:600"><?php esc_html_e( 'The Eden Jacket', 'woo-gutenberg-products-block' ); ?></h2>
 <!-- /wp:heading --></div>
 <!-- /wp:column -->
 
 <!-- wp:column {"verticalAlignment":"top"} -->
 <div class="wp-block-column is-vertically-aligned-top"><!-- wp:group {"style":{"spacing":{"padding":{"top":"10px","right":"10px","bottom":"10px","left":"10px"},"blockGap":"30px"}}} -->
 <div class="wp-block-group" style="padding-top:10px;padding-right:10px;padding-bottom:10px;padding-left:10px"><!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"}}} -->
-<p style="font-size:16px">Perfect for any look featuring a mid-rise, relax fitting silhouette.</p>
+<p style="font-size:16px"><?php esc_html_e( 'Perfect for any look featuring a mid-rise, relax fitting silhouette.', 'woo-gutenberg-products-block' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:buttons -->
 <div class="wp-block-buttons"><!-- wp:button {"className":"is-style-outline"} -->
-<div class="wp-block-button is-style-outline"><a class="wp-block-button__link wp-element-button">View product</a></div>
+<div class="wp-block-button is-style-outline"><a class="wp-block-button__link wp-element-button"><?php esc_html_e( 'View product', 'woo-gutenberg-products-block' ); ?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div>
 <!-- /wp:group --></div>
@@ -37,21 +37,21 @@
 <div class="wp-block-media-text alignfull has-media-on-the-right is-stacked-on-mobile" style="grid-template-columns:auto 60%"><div class="wp-block-media-text__content"><!-- wp:columns -->
 <div class="wp-block-columns"><!-- wp:column {"style":{"spacing":{"padding":{"top":"20px","right":"20px","bottom":"20px","left":"20px"}}}} -->
 <div class="wp-block-column" style="padding-top:20px;padding-right:20px;padding-bottom:20px;padding-left:20px"><!-- wp:heading {"level":4,"style":{"typography":{"fontStyle":"normal","fontWeight":"600","lineHeight":"1","fontSize":"22px"},"spacing":{"margin":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
-<h4 id="100-silk" style="margin-top:0px;margin-right:0px;margin-bottom:0px;margin-left:0px;font-size:22px;font-style:normal;font-weight:600;line-height:1">100% Woolen</h4>
+<h4 id="100-silk" style="margin-top:0px;margin-right:0px;margin-bottom:0px;margin-left:0px;font-size:22px;font-style:normal;font-weight:600;line-height:1"><?php esc_html_e( '100% Woolen', 'woo-gutenberg-products-block' ); ?></h4>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"}}} -->
-<p style="font-size:16px">Reflect your fashionable style.</p>
+<p style="font-size:16px"><?php esc_html_e( 'Reflect your fashionable style.', 'woo-gutenberg-products-block' ); ?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:column -->
 
 <!-- wp:column {"style":{"spacing":{"padding":{"top":"20px","right":"20px","bottom":"20px","left":"20px"}}}} -->
 <div class="wp-block-column" style="padding-top:20px;padding-right:20px;padding-bottom:20px;padding-left:20px"><!-- wp:heading {"level":5,"style":{"typography":{"fontStyle":"normal","fontWeight":"600","lineHeight":"1","fontSize":"22px"},"spacing":{"margin":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
-<h5 id="100-silk" style="margin-top:0px;margin-right:0px;margin-bottom:0px;margin-left:0px;font-size:22px;font-style:normal;font-weight:600;line-height:1">Fits your wardrobe</h5>
+<h5 id="100-silk" style="margin-top:0px;margin-right:0px;margin-bottom:0px;margin-left:0px;font-size:22px;font-style:normal;font-weight:600;line-height:1"><?php esc_html_e( 'Fits your wardrobe', 'woo-gutenberg-products-block' ); ?></h5>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"}}} -->
-<p style="font-size:16px">Half tuck into your pants or layer over.</p>
+<p style="font-size:16px"><?php esc_html_e( 'Half tuck into your pants or layer over.', 'woo-gutenberg-products-block' ); ?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->
@@ -59,21 +59,21 @@
 <!-- wp:columns -->
 <div class="wp-block-columns"><!-- wp:column {"style":{"spacing":{"padding":{"top":"20px","right":"20px","bottom":"20px","left":"20px"}}}} -->
 <div class="wp-block-column" style="padding-top:20px;padding-right:20px;padding-bottom:20px;padding-left:20px"><!-- wp:heading {"level":5,"style":{"typography":{"fontStyle":"normal","fontWeight":"600","lineHeight":"1","fontSize":"22px"},"spacing":{"margin":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
-<h5 id="100-silk" style="margin-top:0px;margin-right:0px;margin-bottom:0px;margin-left:0px;font-size:22px;font-style:normal;font-weight:600;line-height:1">Versatile</h5>
+<h5 id="100-silk" style="margin-top:0px;margin-right:0px;margin-bottom:0px;margin-left:0px;font-size:22px;font-style:normal;font-weight:600;line-height:1"><?php esc_html_e( 'Versatile', 'woo-gutenberg-products-block' ); ?></h5>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"}}} -->
-<p style="font-size:16px">Button-down front for any type of mood or look.</p>
+<p style="font-size:16px"><?php esc_html_e( 'Button-down front for any type of mood or look.', 'woo-gutenberg-products-block' ); ?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:column -->
 
 <!-- wp:column {"style":{"spacing":{"padding":{"top":"20px","right":"20px","bottom":"20px","left":"20px"}}}} -->
 <div class="wp-block-column" style="padding-top:20px;padding-right:20px;padding-bottom:20px;padding-left:20px"><!-- wp:heading {"level":5,"style":{"typography":{"fontStyle":"normal","fontWeight":"600","lineHeight":"1","fontSize":"22px"},"spacing":{"margin":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
-<h5 id="100-silk" style="margin-top:0px;margin-right:0px;margin-bottom:0px;margin-left:0px;font-size:22px;font-style:normal;font-weight:600;line-height:1">Normal Fit</h5>
+<h5 id="100-silk" style="margin-top:0px;margin-right:0px;margin-bottom:0px;margin-left:0px;font-size:22px;font-style:normal;font-weight:600;line-height:1"><?php esc_html_e( 'Normal Fit', 'woo-gutenberg-products-block' ); ?></h5>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"}}} -->
-<p style="font-size:16px">42% Cupro 34% Linen 24% Viscose</p>
+<p style="font-size:16px"><?php esc_html_e( '42% Cupro 34% Linen 24% Viscose', 'woo-gutenberg-products-block' ); ?></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns --></div><figure class="wp-block-media-text__media"></figure></div>

--- a/patterns/product-hero-2-col-2-row.php
+++ b/patterns/product-hero-2-col-2-row.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Title: WooCommerce Product Hero 2 Column 2 Row
+ * Slug: woocommerce-blocks/product-hero-2-col-2-row
+ * Categories: WooCommerce
+ */
+
+?>
+<!-- wp:group {"align":"full","style":{"spacing":{"blockGap":"0px"}}} -->
+<div class="wp-block-group alignfull"><!-- wp:media-text {"align":"full","mediaWidth":40} -->
+<div class="wp-block-media-text alignfull is-stacked-on-mobile" style="grid-template-columns:40% auto"><figure class="wp-block-media-text__media"></figure><div class="wp-block-media-text__content"><!-- wp:group {"layout":{"contentSize":"760px","type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:columns {"verticalAlignment":"top"} -->
+<div class="wp-block-columns are-vertically-aligned-top"><!-- wp:column {"verticalAlignment":"top","style":{"spacing":{"padding":{"top":"30px","right":"30px","bottom":"30px","left":"30px"}}}} -->
+<div class="wp-block-column is-vertically-aligned-top" style="padding-top:30px;padding-right:30px;padding-bottom:30px;padding-left:30px"><!-- wp:heading {"style":{"typography":{"fontSize":"58px","fontStyle":"normal","fontWeight":"600"},"spacing":{"margin":{"top":"0px"}}}} -->
+<h2 id="the-eden-jacket" style="margin-top:0px;font-size:58px;font-style:normal;font-weight:600">The Eden Jacket</h2>
+<!-- /wp:heading --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"verticalAlignment":"top"} -->
+<div class="wp-block-column is-vertically-aligned-top"><!-- wp:group {"style":{"spacing":{"padding":{"top":"10px","right":"10px","bottom":"10px","left":"10px"},"blockGap":"30px"}}} -->
+<div class="wp-block-group" style="padding-top:10px;padding-right:10px;padding-bottom:10px;padding-left:10px"><!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"}}} -->
+<p style="font-size:16px">Perfect for any look featuring a mid-rise, relax fitting silhouette.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:buttons -->
+<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-outline"} -->
+<div class="wp-block-button is-style-outline"><a class="wp-block-button__link wp-element-button">View product</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div>
+<!-- /wp:group --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group --></div></div>
+<!-- /wp:media-text -->
+
+<!-- wp:media-text {"align":"full","mediaPosition":"right","mediaWidth":60} -->
+<div class="wp-block-media-text alignfull has-media-on-the-right is-stacked-on-mobile" style="grid-template-columns:auto 60%"><div class="wp-block-media-text__content"><!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column {"style":{"spacing":{"padding":{"top":"20px","right":"20px","bottom":"20px","left":"20px"}}}} -->
+<div class="wp-block-column" style="padding-top:20px;padding-right:20px;padding-bottom:20px;padding-left:20px"><!-- wp:heading {"level":4,"style":{"typography":{"fontStyle":"normal","fontWeight":"600","lineHeight":"1","fontSize":"22px"},"spacing":{"margin":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
+<h4 id="100-silk" style="margin-top:0px;margin-right:0px;margin-bottom:0px;margin-left:0px;font-size:22px;font-style:normal;font-weight:600;line-height:1">100% Woolen</h4>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"}}} -->
+<p style="font-size:16px">Reflect your fashionable style.</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"style":{"spacing":{"padding":{"top":"20px","right":"20px","bottom":"20px","left":"20px"}}}} -->
+<div class="wp-block-column" style="padding-top:20px;padding-right:20px;padding-bottom:20px;padding-left:20px"><!-- wp:heading {"level":5,"style":{"typography":{"fontStyle":"normal","fontWeight":"600","lineHeight":"1","fontSize":"22px"},"spacing":{"margin":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
+<h5 id="100-silk" style="margin-top:0px;margin-right:0px;margin-bottom:0px;margin-left:0px;font-size:22px;font-style:normal;font-weight:600;line-height:1">Fits your wardrobe</h5>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"}}} -->
+<p style="font-size:16px">Half tuck into your pants or layer over.</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column {"style":{"spacing":{"padding":{"top":"20px","right":"20px","bottom":"20px","left":"20px"}}}} -->
+<div class="wp-block-column" style="padding-top:20px;padding-right:20px;padding-bottom:20px;padding-left:20px"><!-- wp:heading {"level":5,"style":{"typography":{"fontStyle":"normal","fontWeight":"600","lineHeight":"1","fontSize":"22px"},"spacing":{"margin":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
+<h5 id="100-silk" style="margin-top:0px;margin-right:0px;margin-bottom:0px;margin-left:0px;font-size:22px;font-style:normal;font-weight:600;line-height:1">Versatile</h5>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"}}} -->
+<p style="font-size:16px">Button-down front for any type of mood or look.</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"style":{"spacing":{"padding":{"top":"20px","right":"20px","bottom":"20px","left":"20px"}}}} -->
+<div class="wp-block-column" style="padding-top:20px;padding-right:20px;padding-bottom:20px;padding-left:20px"><!-- wp:heading {"level":5,"style":{"typography":{"fontStyle":"normal","fontWeight":"600","lineHeight":"1","fontSize":"22px"},"spacing":{"margin":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
+<h5 id="100-silk" style="margin-top:0px;margin-right:0px;margin-bottom:0px;margin-left:0px;font-size:22px;font-style:normal;font-weight:600;line-height:1">Normal Fit</h5>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"style":{"typography":{"fontSize":"16px"}}} -->
+<p style="font-size:16px">42% Cupro 34% Linen 24% Viscose</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div><figure class="wp-block-media-text__media"></figure></div>
+<!-- /wp:media-text --></div>
+<!-- /wp:group -->


### PR DESCRIPTION
The "Product Hero 2 Column 2 Row" commerce adjacent pattern is a hero block that can be used as inspiration for merchants wanting to showcase the base selling points of a product with accompanying images as a 2-column, 2-row layout.

cc @vivialice for design review

**NOTE:** The frontend screenshots were with images that _won't_ ship with this pattern.

## Screenshots

The following screenshots were with the Twenty Twenty Three theme and the "Whisper" style.

### Editor
![CleanShot 2022-12-01 at 14 08 19@2x](https://user-images.githubusercontent.com/1429108/205139467-47174a83-cf99-4198-9d6f-bb9b7762ab9b.png)

### Pattern preview in Editor
![CleanShot 2022-12-01 at 14 08 45@2x](https://user-images.githubusercontent.com/1429108/205139492-6a099ce1-05b8-4bf7-9ad7-737eb3145d46.png)

### Desktop frontend
![CleanShot 2022-12-01 at 14 10 13@2x](https://user-images.githubusercontent.com/1429108/205139520-a8b0cdf9-e12a-452b-a1fd-eaf1afc694ce.png)

### Mobile frontend
![CleanShot 2022-12-01 at 14 11 27@2x](https://user-images.githubusercontent.com/1429108/205139550-24ab87cb-3c4e-434e-9e57-a15254e0705b.png)

### Tablet frontend
<img width="484" alt="CleanShot 2022-12-01 at 14 10 44@2x" src="https://user-images.githubusercontent.com/1429108/205139595-4bcf5929-0cc1-462f-9866-657a8e82aeb2.png">

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
* [ ] Unit tests
* [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Create a new page and edit it.
2. Browse to the WooCommerce category for Block patterns and look for the "WooCommerce Product Hero 2 Column 2 Row" pattern in the "Explore All Patterns" dialog. Click to insert.
![CleanShot 2022-12-01 at 14 08 45@2x](https://user-images.githubusercontent.com/1429108/205139492-6a099ce1-05b8-4bf7-9ad7-737eb3145d46.png)
3. Verify the pattern inserted on the page. It may look different depending on the theme being used with testing.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> The "WooCommerce Product Hero 2 Column 2 Row" block pattern has been added. It is a straightforward hero design that can be used by adding two attention-grabbing images, some custom product description text and customizing the button block to be linked to any page.
