### PR TITLE
Product Price: Hide alignment setting for the All Products block

### DIFF
--- a/assets/js/atomic/blocks/product-elements/price/edit.js
+++ b/assets/js/atomic/blocks/product-elements/price/edit.js
@@ -32,12 +32,14 @@ const PriceEdit = ( { attributes, setAttributes, context } ) => {
 	return (
 		<>
 			<BlockControls>
-				<AlignmentToolbar
-					value={ attributes.textAlign }
-					onChange={ ( newAlign ) => {
-						setAttributes( { textAlign: newAlign } );
-					} }
-				/>
+				{ isDescendentOfQueryLoop && (
+					<AlignmentToolbar
+						value={ attributes.textAlign }
+						onChange={ ( newAlign ) => {
+							setAttributes( { textAlign: newAlign } );
+						} }
+					/>
+				) }
 			</BlockControls>
 			<div { ...blockProps }>
 				<Block { ...blockAttrs } />

--- a/src/BlockTypes/ProductPrice.php
+++ b/src/BlockTypes/ProductPrice.php
@@ -88,7 +88,7 @@ class ProductPrice extends AbstractBlock {
 				'<div class="wc-block-components-product-price wc-block-grid__product-price %1$s">
 					%2$s
 				</div>',
-				$classes_and_styles['class'] ?? '',
+				esc_attr( $classes_and_styles['class'] ?? '' ),
 				$product->get_price_html()
 			);
 		}


### PR DESCRIPTION
Similarly to: #7790 and #7816, this PR hides the alignment option for the **Product Price** block (when being used inside of the **All Products** block).

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|![Edit_Page_“All_Products”_‹_ratings_—_WordPress-7](https://user-images.githubusercontent.com/905781/205305071-e799d9e2-27dd-40cd-98fe-1a534af25a10.jpg)|![Edit_Page_“All_Products”_‹_ratings_—_WordPress-6](https://user-images.githubusercontent.com/905781/205305088-8b8e9509-192e-4ffc-8ea3-79249a81bdd3.jpg)|

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. Add the **Product Query** block and **All Products** block to a page.
2. Add the **Product Price** block.
3. Make sure that you can set the alignment to left, center and right for the  **Product Price**  inside the **Product Query** block.
4. Make sure the alignment option is not present inside the **All Products** block.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
