### PR TITLE
Add "Store Info Alternating Image and Text" commerce adjacent pattern

### DIFF
--- a/patterns/store-info-alt-image-and-text.php
+++ b/patterns/store-info-alt-image-and-text.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Title: WooCommerce Alternate Image and Text
+ * Title: WooCommerce Alternating Image and Text
  * Slug: woocommerce-blocks/alt-image-and-text
  * Categories: WooCommerce
  */

--- a/patterns/store-info-alt-image-and-text.php
+++ b/patterns/store-info-alt-image-and-text.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Title: WooCommerce Alternate Image and Text
+ * Slug: woocommerce-blocks/alt-image-and-text
+ * Categories: WooCommerce
+ */
+?>
+<!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"4vh","padding":{"top":"8vh","bottom":"8vh"}}}} -->
+<div class="wp-block-group alignwide" style="padding-top:8vh;padding-bottom:8vh"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":"40px"}}} -->
+<div class="wp-block-columns alignwide"><!-- wp:column {"width":"50%"} -->
+<div class="wp-block-column" style="flex-basis:50%"><!-- wp:image -->
+<figure class="wp-block-image"><img alt=""/></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"50%","style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
+<div class="wp-block-column" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px;flex-basis:50%"><!-- wp:paragraph {"placeholder":"Content…","fontSize":"small"} -->
+<p class="has-small-font-size">THE GOODS</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"style":{"typography":{"lineHeight":"1.3"},"spacing":{"margin":{"top":"var:preset|spacing|20","right":"0","bottom":"0","left":"0"}}},"fontSize":"x-large"} -->
+<h2 class="has-x-large-font-size" id="all-items-are-100-hand-made-using-the-potter-s-wheel-or-traditional-techniques-created-with-love-and-care-in-australia" style="margin-top:var(--wp--preset--spacing--20);margin-right:0;margin-bottom:0;margin-left:0;line-height:1.3">Created with love and care in Australia.</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"style":{"typography":{"lineHeight":"1.65"}}} -->
+<p style="line-height:1.65">All items are 100% hand-made, using the potter’s wheel or traditional techniques.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:list {"style":{"typography":{"lineHeight":"2"}}} -->
+<ul style="line-height:2"><!-- wp:list-item -->
+<li>Timeless style.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Earthy, organic feel.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Enduring quality.</li>
+<!-- /wp:list-item -->
+
+<!-- wp:list-item -->
+<li>Unique, one-of-a-kind pieces.</li>
+<!-- /wp:list-item --></ul>
+<!-- /wp:list --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":"40px"}}} -->
+<div class="wp-block-columns alignwide"><!-- wp:column {"width":"50%"} -->
+<div class="wp-block-column" style="flex-basis:50%"><!-- wp:paragraph {"placeholder":"Content…","fontSize":"small"} -->
+<p class="has-small-font-size">ABOUT US</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:heading {"style":{"typography":{"lineHeight":"1.3"},"spacing":{"margin":{"top":"var:preset|spacing|20"}}},"fontSize":"x-large"} -->
+<h2 class="has-x-large-font-size" id="all-items-are-100-hand-made-using-the-potter-s-wheel-or-traditional-techniques-created-with-love-and-care-in-australia" style="margin-top:var(--wp--preset--spacing--20);line-height:1.3">Marl is an independent studio and artisanal gallery.</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"style":{"typography":{"fontSize":"18px"}}} -->
+<p style="font-size:18px">We specialize in limited collections of handmade tableware. We collaborate with restaurants and cafes to create unique items that complement the menu perfectly. Please get in touch if you want to know more about our process and pricing.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:buttons {"style":{"spacing":{"margin":{"top":"20px","bottom":"20px"}}}} -->
+<div class="wp-block-buttons" style="margin-top:20px;margin-bottom:20px"><!-- wp:button {"style":{"border":{"radius":"100px"},"spacing":{"padding":{"top":"6px","bottom":"6px","left":"36px","right":"36px"}}},"className":"is-style-outline","fontSize":"small"} -->
+<div class="wp-block-button has-custom-font-size is-style-outline has-small-font-size"><a class="wp-block-button__link wp-element-button" style="border-radius:100px;padding-top:6px;padding-right:36px;padding-bottom:6px;padding-left:36px">LEARN MORE</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"50%"} -->
+<div class="wp-block-column" style="flex-basis:50%"><!-- wp:image -->
+<figure class="wp-block-image"><img alt=""/></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group -->


### PR DESCRIPTION
The "Store Info Alternating Image and Text" commerce adjacent pattern is a block that can be used as inspiration for merchants wanting to showcase some basic information about the store. In the example pattern some details about the types of products and the store itself.

cc @vivialice for design review

**NOTE:** The frontend screenshots were with images that _won't_ ship with this pattern.

## Screenshots

The following screenshots were with the Twenty Twenty Three theme and the "Whisper" style.

### Editor
![CleanShot 2022-12-02 at 08 46 34@2x](https://user-images.githubusercontent.com/1429108/205306904-f5e069c7-5deb-4201-891e-372fc9f2f4ea.png)

### Pattern preview in Editor
![CleanShot 2022-12-02 at 08 41 39@2x](https://user-images.githubusercontent.com/1429108/205306945-6cc1b143-4813-400d-8e80-dd4249be9175.png)

### Desktop frontend
![CleanShot 2022-12-02 at 08 43 32@2x](https://user-images.githubusercontent.com/1429108/205306996-ee60abd9-984e-46b8-956f-b1c981f1143a.png)

### Mobile frontend
![CleanShot 2022-12-02 at 08 45 14@2x](https://user-images.githubusercontent.com/1429108/205307022-9cdb2d35-9344-468f-b0dd-bc1584cbff70.png)

### Tablet frontend
<img width="507" alt="CleanShot 2022-12-02 at 08 45 25@2x" src="https://user-images.githubusercontent.com/1429108/205307049-783bbc66-395d-48e5-afd0-a782c610c493.png">

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
* [ ] Unit tests
* [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Create a new page and edit it.
2. Browse to the WooCommerce category for Block patterns and look for the "WooCommerce Alternating Image and Text" pattern in the "Explore All Patterns" dialog. Click to insert.
![CleanShot 2022-12-02 at 08 41 39@2x](https://user-images.githubusercontent.com/1429108/205306945-6cc1b143-4813-400d-8e80-dd4249be9175.png)
3. Verify the pattern inserted on the page. It may look different depending on the theme being used with testing.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> The "WooCommerce Alternating Image and Text" block pattern has been added. This design can be used by adding two attention-grabbing images, customizing the text to match your needs and customizing the button block to be linked to any page.
