### PR TITLE
Handle multiple packages coming from slots

### DIFF
--- a/assets/js/base/components/cart-checkout/shipping-rates-control-package/index.tsx
+++ b/assets/js/base/components/cart-checkout/shipping-rates-control-package/index.tsx
@@ -44,10 +44,10 @@ export type PackageRateRenderOption = (
 	option: CartShippingPackageShippingRate
 ) => PackageRateOption;
 
-// A flag can be trinary if true, false, and undefined are all valid options.
+// A flag can be ternary if true, false, and undefined are all valid options.
 // In our case, we use this for collapsible and showItems, having a boolean will force that
 // option, having undefined will let the component decide the logic based on other factors.
-export type TrinaryFlag = boolean | undefined;
+export type TernaryFlag = boolean | undefined;
 interface PackageProps {
 	/* PackageId can be a string, WooCommerce Subscriptions uses strings for example, but WooCommerce core uses numbers */
 	packageId: string | number;
@@ -55,9 +55,9 @@ interface PackageProps {
 	collapse?: boolean;
 	packageData: PackageData;
 	className?: string;
-	collapsible?: TrinaryFlag;
+	collapsible?: TernaryFlag;
 	noResultsMessage: ReactElement;
-	showItems?: TrinaryFlag;
+	showItems?: TernaryFlag;
 }
 
 export const ShippingRatesControlPackage = ( {

--- a/assets/js/base/components/cart-checkout/shipping-rates-control-package/index.tsx
+++ b/assets/js/base/components/cart-checkout/shipping-rates-control-package/index.tsx
@@ -147,7 +147,7 @@ export const ShippingRatesControlPackage = ( {
 			<Panel
 				className="wc-block-components-shipping-rates-control__package"
 				// initialOpen remembers only the first value provided to it, so by the
-				//time we know we have several packages, initialOpen would be hardcoded to true.
+				// time we know we have several packages, initialOpen would be hardcoded to true.
 				// If we're rendering a panel, we're more likely rendering several
 				// packages and we want to them to be closed initially.
 				initialOpen={ false }

--- a/assets/js/base/components/cart-checkout/shipping-rates-control-package/index.tsx
+++ b/assets/js/base/components/cart-checkout/shipping-rates-control-package/index.tsx
@@ -81,11 +81,11 @@ export const ShippingRatesControlPackage = ( {
 
 	// If collapsible is not set, we check if we have multiple packages.
 	// We sometimes don't want to collapse even if we have multiple packages.
-	const shoulldBeCollapsible = collapsible ?? multiplePackages;
+	const shouldBeCollapsible = collapsible ?? multiplePackages;
 
 	const header = (
 		<>
-			{ ( shoulldBeCollapsible || shouldShowItems ) && (
+			{ ( shouldBeCollapsible || shouldShowItems ) && (
 				<div
 					className="wc-block-components-shipping-rates-control__package-title"
 					dangerouslySetInnerHTML={ {
@@ -142,7 +142,7 @@ export const ShippingRatesControlPackage = ( {
 			renderOption={ renderOption }
 		/>
 	);
-	if ( shoulldBeCollapsible ) {
+	if ( shouldBeCollapsible ) {
 		return (
 			<Panel
 				className="wc-block-components-shipping-rates-control__package"

--- a/assets/js/base/components/cart-checkout/shipping-rates-control-package/index.tsx
+++ b/assets/js/base/components/cart-checkout/shipping-rates-control-package/index.tsx
@@ -44,6 +44,10 @@ export type PackageRateRenderOption = (
 	option: CartShippingPackageShippingRate
 ) => PackageRateOption;
 
+// A flag can be trinary if true, false, and undefined are all valid options.
+// In our case, we use this for collapsible and showItems, having a boolean will force that
+// option, having undefined will let the component decide the logic based on other factors.
+export type TrinaryFlag = boolean | undefined;
 interface PackageProps {
 	/* PackageId can be a string, WooCommerce Subscriptions uses strings for example, but WooCommerce core uses numbers */
 	packageId: string | number;
@@ -51,9 +55,9 @@ interface PackageProps {
 	collapse?: boolean;
 	packageData: PackageData;
 	className?: string;
-	collapsible?: boolean;
+	collapsible?: TrinaryFlag;
 	noResultsMessage: ReactElement;
-	showItems?: boolean;
+	showItems?: TrinaryFlag;
 }
 
 export const ShippingRatesControlPackage = ( {
@@ -62,15 +66,26 @@ export const ShippingRatesControlPackage = ( {
 	noResultsMessage,
 	renderOption,
 	packageData,
-	collapsible = false,
-	collapse = false,
-	showItems = false,
+	collapsible,
+	showItems,
 }: PackageProps ): ReactElement => {
 	const { selectShippingRate } = useSelectShippingRate();
+	const multiplePackages =
+		document.querySelectorAll(
+			'.wc-block-components-shipping-rates-control__package'
+		).length > 1;
+
+	// If showItems is not set, we check if we have multiple packages.
+	// We sometimes don't want to show items even if we have multiple packages.
+	const shouldShowItems = showItems ?? multiplePackages;
+
+	// If collapsible is not set, we check if we have multiple packages.
+	// We sometimes don't want to collapse even if we have multiple packages.
+	const shoulldBeCollapsible = collapsible ?? multiplePackages;
 
 	const header = (
 		<>
-			{ ( showItems || collapsible ) && (
+			{ ( shoulldBeCollapsible || shouldShowItems ) && (
 				<div
 					className="wc-block-components-shipping-rates-control__package-title"
 					dangerouslySetInnerHTML={ {
@@ -78,7 +93,7 @@ export const ShippingRatesControlPackage = ( {
 					} }
 				/>
 			) }
-			{ showItems && (
+			{ shouldShowItems && (
 				<ul className="wc-block-components-shipping-rates-control__package-items">
 					{ Object.values( packageData.items ).map( ( v ) => {
 						const name = decodeEntities( v.name );
@@ -127,11 +142,15 @@ export const ShippingRatesControlPackage = ( {
 			renderOption={ renderOption }
 		/>
 	);
-	if ( collapsible ) {
+	if ( shoulldBeCollapsible ) {
 		return (
 			<Panel
 				className="wc-block-components-shipping-rates-control__package"
-				initialOpen={ ! collapse }
+				// initialOpen remembers only the first value provided to it, so by the
+				//time we know we have several packages, initialOpen would be hardcoded to true.
+				// If we're rendering a panel, we're more likely rendering several
+				// packages and we want to them to be closed initially.
+				initialOpen={ false }
 				title={ header }
 			>
 				{ body }

--- a/assets/js/base/components/cart-checkout/shipping-rates-control-package/style.scss
+++ b/assets/js/base/components/cart-checkout/shipping-rates-control-package/style.scss
@@ -5,6 +5,10 @@
 		margin-bottom: 0;
 	}
 
+	&.wc-block-components-panel {
+		margin-bottom: 0;
+	}
+
 	.wc-block-components-panel__button {
 		margin-bottom: 0;
 		margin-top: 0;

--- a/assets/js/base/components/cart-checkout/shipping-rates-control/index.tsx
+++ b/assets/js/base/components/cart-checkout/shipping-rates-control/index.tsx
@@ -77,6 +77,7 @@ const Packages = ( {
 
 interface ShippingRatesControlProps {
 	collapsible?: TrinaryFlag;
+	showItems?: TrinaryFlag;
 	shippingRates: CartResponseShippingRate[];
 	className?: string;
 	isLoadingRates: boolean;
@@ -92,6 +93,7 @@ interface ShippingRatesControlProps {
  * @param {boolean}           props.isLoadingRates   True when rates are being loaded.
  * @param {string}            props.className        Class name for package rates.
  * @param {boolean|undefined} [props.collapsible]    If true, when multiple packages are rendered they can be toggled open and closed.
+ * @param {boolean|undefined} [props.showItems]      If true, when multiple packages are rendered, you can see each package's items.
  * @param {ReactElement}      props.noResultsMessage Rendered when there are no packages.
  * @param {Function}          [props.renderOption]   Function to render a shipping rate.
  * @param {string}            [props.context]        String equal to the block name where the Slot is rendered
@@ -101,6 +103,7 @@ const ShippingRatesControl = ( {
 	isLoadingRates,
 	className,
 	collapsible,
+	showItems,
 	noResultsMessage,
 	renderOption,
 	context,
@@ -158,6 +161,7 @@ const ShippingRatesControl = ( {
 	const slotFillProps = {
 		className,
 		collapsible,
+		showItems,
 		noResultsMessage,
 		renderOption,
 		extensions,

--- a/assets/js/base/components/cart-checkout/shipping-rates-control/index.tsx
+++ b/assets/js/base/components/cart-checkout/shipping-rates-control/index.tsx
@@ -19,13 +19,13 @@ import { ReactElement } from 'react';
  */
 import ShippingRatesControlPackage, {
 	PackageRateRenderOption,
-	TrinaryFlag,
+	TernaryFlag,
 } from '../shipping-rates-control-package';
 
 interface PackagesProps {
 	packages: CartResponseShippingRate[];
-	collapsible?: TrinaryFlag;
-	showItems?: TrinaryFlag;
+	collapsible?: TernaryFlag;
+	showItems?: TernaryFlag;
 	noResultsMessage: ReactElement;
 	renderOption: PackageRateRenderOption;
 }
@@ -71,8 +71,8 @@ const Packages = ( {
 };
 
 interface ShippingRatesControlProps {
-	collapsible?: TrinaryFlag;
-	showItems?: TrinaryFlag;
+	collapsible?: TernaryFlag;
+	showItems?: TernaryFlag;
 	shippingRates: CartResponseShippingRate[];
 	className?: string;
 	isLoadingRates: boolean;

--- a/assets/js/base/components/cart-checkout/shipping-rates-control/index.tsx
+++ b/assets/js/base/components/cart-checkout/shipping-rates-control/index.tsx
@@ -24,7 +24,6 @@ import ShippingRatesControlPackage, {
 
 interface PackagesProps {
 	packages: CartResponseShippingRate[];
-	collapse?: boolean;
 	collapsible?: TrinaryFlag;
 	showItems?: TrinaryFlag;
 	noResultsMessage: ReactElement;
@@ -39,15 +38,12 @@ interface PackagesProps {
  * @param {boolean|undefined}       props.collapsible      If the package should be rendered as a
  * @param {ReactElement}            props.noResultsMessage Rendered when there are no rates in a package.
  *                                                         collapsible panel.
- * @param {boolean}                 props.collapse         If the panel should be collapsed by default,
- *                                                         only works if collapsible is true.
  * @param {boolean|undefined}       props.showItems        If we should items below the package name.
  * @param {PackageRateRenderOption} [props.renderOption]   Function to render a shipping rate.
  * @return {JSX.Element|null} Rendered components.
  */
 const Packages = ( {
 	packages,
-	collapse,
 	showItems,
 	collapsible,
 	noResultsMessage,
@@ -65,7 +61,6 @@ const Packages = ( {
 					packageId={ packageId }
 					packageData={ packageData }
 					collapsible={ collapsible }
-					collapse={ collapse }
 					showItems={ showItems }
 					noResultsMessage={ noResultsMessage }
 					renderOption={ renderOption }

--- a/assets/js/base/components/cart-checkout/shipping-rates-control/index.tsx
+++ b/assets/js/base/components/cart-checkout/shipping-rates-control/index.tsx
@@ -19,13 +19,14 @@ import { ReactElement } from 'react';
  */
 import ShippingRatesControlPackage, {
 	PackageRateRenderOption,
+	TrinaryFlag,
 } from '../shipping-rates-control-package';
 
 interface PackagesProps {
 	packages: CartResponseShippingRate[];
 	collapse?: boolean;
-	collapsible?: boolean;
-	showItems?: boolean;
+	collapsible?: TrinaryFlag;
+	showItems?: TrinaryFlag;
 	noResultsMessage: ReactElement;
 	renderOption: PackageRateRenderOption;
 }
@@ -35,12 +36,12 @@ interface PackagesProps {
  *
  * @param {Object}                  props                  Incoming props.
  * @param {Array}                   props.packages         Array of packages.
- * @param {boolean}                 props.collapsible      If the package should be rendered as a
+ * @param {boolean|undefined}       props.collapsible      If the package should be rendered as a
  * @param {ReactElement}            props.noResultsMessage Rendered when there are no rates in a package.
  *                                                         collapsible panel.
  * @param {boolean}                 props.collapse         If the panel should be collapsed by default,
  *                                                         only works if collapsible is true.
- * @param {boolean}                 props.showItems        If we should items below the package name.
+ * @param {boolean|undefined}       props.showItems        If we should items below the package name.
  * @param {PackageRateRenderOption} [props.renderOption]   Function to render a shipping rate.
  * @return {JSX.Element|null} Rendered components.
  */
@@ -63,9 +64,9 @@ const Packages = ( {
 					key={ packageId }
 					packageId={ packageId }
 					packageData={ packageData }
-					collapsible={ !! collapsible }
-					collapse={ !! collapse }
-					showItems={ showItems || packages.length > 1 }
+					collapsible={ collapsible }
+					collapse={ collapse }
+					showItems={ showItems }
 					noResultsMessage={ noResultsMessage }
 					renderOption={ renderOption }
 				/>
@@ -75,7 +76,7 @@ const Packages = ( {
 };
 
 interface ShippingRatesControlProps {
-	collapsible?: boolean;
+	collapsible?: TrinaryFlag;
 	shippingRates: CartResponseShippingRate[];
 	className?: string;
 	isLoadingRates: boolean;
@@ -86,20 +87,20 @@ interface ShippingRatesControlProps {
 /**
  * Renders the shipping rates control element.
  *
- * @param {Object}       props                  Incoming props.
- * @param {Array}        props.shippingRates    Array of packages containing shipping rates.
- * @param {boolean}      props.isLoadingRates   True when rates are being loaded.
- * @param {string}       props.className        Class name for package rates.
- * @param {boolean}      [props.collapsible]    If true, when multiple packages are rendered they can be toggled open and closed.
- * @param {ReactElement} props.noResultsMessage Rendered when there are no packages.
- * @param {Function}     [props.renderOption]   Function to render a shipping rate.
- * @param {string}       [props.context]        String equal to the block name where the Slot is rendered
+ * @param {Object}            props                  Incoming props.
+ * @param {Array}             props.shippingRates    Array of packages containing shipping rates.
+ * @param {boolean}           props.isLoadingRates   True when rates are being loaded.
+ * @param {string}            props.className        Class name for package rates.
+ * @param {boolean|undefined} [props.collapsible]    If true, when multiple packages are rendered they can be toggled open and closed.
+ * @param {ReactElement}      props.noResultsMessage Rendered when there are no packages.
+ * @param {Function}          [props.renderOption]   Function to render a shipping rate.
+ * @param {string}            [props.context]        String equal to the block name where the Slot is rendered
  */
 const ShippingRatesControl = ( {
 	shippingRates,
 	isLoadingRates,
 	className,
-	collapsible = false,
+	collapsible,
 	noResultsMessage,
 	renderOption,
 	context,
@@ -165,7 +166,6 @@ const ShippingRatesControl = ( {
 			ShippingRatesControlPackage,
 		},
 		context,
-		shippingRates,
 	};
 	const { isEditor } = useEditorContext();
 
@@ -191,7 +191,6 @@ const ShippingRatesControl = ( {
 					/>
 					<ExperimentalOrderShippingPackages>
 						<Packages
-							showItems={ shippingRates.length > 1 }
 							packages={ shippingRates }
 							noResultsMessage={ noResultsMessage }
 							renderOption={ renderOption }

--- a/assets/js/base/components/cart-checkout/totals/shipping/shipping-rate-selector.js
+++ b/assets/js/base/components/cart-checkout/totals/shipping/shipping-rate-selector.js
@@ -23,7 +23,6 @@ const ShippingRateSelector = ( {
 			<legend className="screen-reader-text">{ legend }</legend>
 			<ShippingRatesControl
 				className="wc-block-components-totals-shipping__options"
-				collapsible={ true }
 				noResultsMessage={
 					<Notice
 						isDismissible={ false }

--- a/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/block.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/block.tsx
@@ -99,6 +99,7 @@ const Block = (): JSX.Element | null => {
 						</Notice>
 					}
 					renderOption={ renderShippingRatesControlOption }
+					collapsible={ false }
 					shippingRates={ shippingRates }
 					isLoadingRates={ isLoadingRates }
 					context="woocommerce/checkout"

--- a/docs/third-party-developers/extensibility/checkout-block/available-slot-fills.md
+++ b/docs/third-party-developers/extensibility/checkout-block/available-slot-fills.md
@@ -47,9 +47,6 @@ Checkout:
 
 ### Passed parameters
 
--   `collapsible`: `Boolean` If a shipping package panel should be collapsible or not, this is false in Checkout and true in Cart.
--   `collapse`: `Boolean` If a panel should be collapsed by default, this is true if there's more than 1 fill registered (Core Shipping options are registered as a fill and they're counted).
--   `showItems`: `Boolean` If we should show the content of each package, this is true if there's more than 1 fill registered (Core Shipping options are registered as a fill and they're counted).
 -   `noResultsMessage`: A React element that you can render if there are no shipping options.
 -   `renderOption`: a render function that takes a rate object and returns a render option.
 -   `cart`: `wc/store/cart` data but in `camelCase` instead of `snake_case`. [Object breakdown.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/c00da597efe4c16fcf5481c213d8052ec5df3766/assets/js/type-defs/cart.ts#L172-L188)

--- a/docs/third-party-developers/extensibility/checkout-block/available-slot-fills.md
+++ b/docs/third-party-developers/extensibility/checkout-block/available-slot-fills.md
@@ -47,6 +47,9 @@ Checkout:
 
 ### Passed parameters
 
+-   `collapsible`: `Boolean|undefined` If a shipping package panel should be collapsible or not, this is false in Checkout and undefined in Cart.
+-   `collapse`: `Boolean` If a panel should be collapsed by default, this is true if if panels are collapsible.
+-   `showItems`: `Boolean|undefined` If we should show the content of each package, this is undefined in Cart and Checkout and is left to the actual package logic to decide.
 -   `noResultsMessage`: A React element that you can render if there are no shipping options.
 -   `renderOption`: a render function that takes a rate object and returns a render option.
 -   `cart`: `wc/store/cart` data but in `camelCase` instead of `snake_case`. [Object breakdown.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/c00da597efe4c16fcf5481c213d8052ec5df3766/assets/js/type-defs/cart.ts#L172-L188)

--- a/packages/checkout/components/order-shipping-packages/index.js
+++ b/packages/checkout/components/order-shipping-packages/index.js
@@ -22,6 +22,8 @@ const Slot = ( {
 	cart,
 	components,
 	context,
+	collapsible,
+	showItems,
 } ) => {
 	return (
 		<OrderShippingPackagesSlot
@@ -30,6 +32,9 @@ const Slot = ( {
 				className
 			) }
 			fillProps={ {
+				collapse: collapsible,
+				collapsible,
+				showItems,
 				noResultsMessage,
 				renderOption,
 				extensions,

--- a/packages/checkout/components/order-shipping-packages/index.js
+++ b/packages/checkout/components/order-shipping-packages/index.js
@@ -6,7 +6,7 @@ import classnames from 'classnames';
 /**
  * Internal dependencies
  */
-import { createSlotFill, useSlot } from '../../slot';
+import { createSlotFill } from '../../slot';
 
 const slotName = '__experimentalOrderShippingPackages';
 const {
@@ -16,17 +16,13 @@ const {
 
 const Slot = ( {
 	className,
-	collapsible,
 	noResultsMessage,
 	renderOption,
 	extensions,
 	cart,
 	components,
 	context,
-	shippingRates,
 } ) => {
-	const { fills } = useSlot( slotName );
-	const hasMultiplePackages = fills.length > 1 || shippingRates?.length > 1;
 	return (
 		<OrderShippingPackagesSlot
 			className={ classnames(
@@ -34,9 +30,6 @@ const Slot = ( {
 				className
 			) }
 			fillProps={ {
-				collapsible,
-				collapse: hasMultiplePackages,
-				showItems: hasMultiplePackages,
 				noResultsMessage,
 				renderOption,
 				extensions,


### PR DESCRIPTION
This was discovered as part of working on Local Pickup.

We had an issue detecting multiple packages in which having WooCommerce Subscription enabled would cause Cart/Checkout to think there are multiple packages, even if those don't exist yet. This switches the way we detect them:

### Testing notes

- Install WooCommerce Subscription, add a subscription product.
- Visit Cart with a regular product, you should see a single shipping package, with no title or items shown.
- Add subscription product, go back to cart.
- You should see two packages, collapsed, with titles and items.
- Remove the item from cart, it should revert back to normal.
- Visit Checkout, it should not show title or items in a single package.
- Add subscription item, in Checkout, it should not be collapsible.

<img width="356" alt="image" src="https://user-images.githubusercontent.com/6165348/205310712-d6dd2151-21dd-415e-86a0-01202b53f667.png">
<img width="689" alt="image" src="https://user-images.githubusercontent.com/6165348/205315894-a4550171-5d05-4484-b68c-69aeda5535ec.png">
<img width="361" alt="image" src="https://user-images.githubusercontent.com/6165348/205315928-1123f6fc-2c2d-4507-b593-e74bd722a827.png">
<img width="711" alt="image" src="https://user-images.githubusercontent.com/6165348/205318423-332bae05-f68b-4879-8e3c-419c21820711.png">
