### PR TITLE
Product Query: Add a better default pattern

### DIFF
--- a/assets/js/atomic/blocks/product-elements/price/block.js
+++ b/assets/js/atomic/blocks/product-elements/price/block.js
@@ -15,6 +15,7 @@ import { withProductDataContext } from '@woocommerce/shared-hocs';
 /**
  * Internal dependencies
  */
+import './style.scss';
 
 /**
  * Product Price Block Component.

--- a/assets/js/atomic/blocks/product-elements/price/style.scss
+++ b/assets/js/atomic/blocks/product-elements/price/style.scss
@@ -1,0 +1,3 @@
+.wc-block-components-product-price {
+	margin-bottom: $gap-small;
+}

--- a/assets/js/blocks/product-query/constants.ts
+++ b/assets/js/blocks/product-query/constants.ts
@@ -51,7 +51,7 @@ export const QUERY_DEFAULT_ATTRIBUTES: QueryBlockAttributes = {
 		columns: 3,
 	},
 	query: {
-		perPage: 6,
+		perPage: 9,
 		pages: 0,
 		offset: 0,
 		postType: 'product',
@@ -76,15 +76,50 @@ export const INNER_BLOCKS_TEMPLATE: InnerBlockTemplate[] = [
 		[
 			[ 'woocommerce/product-image' ],
 			[
-				'core/post-title',
+				'core/post-terms',
 				{
-					level: 3,
-					fontSize: 'large',
+					term: 'product_cat',
+					textAlign: 'center',
+					fontSize: 'small',
 				},
 				[],
 			],
-			[ 'woocommerce/product-price' ],
-			[ 'woocommerce/product-button' ],
+			[
+				'core/post-title',
+				{
+					textAlign: 'center',
+					level: 3,
+					fontSize: 'medium',
+				},
+				[],
+			],
+			[
+				'woocommerce/product-rating',
+				{
+					isDescendentOfQueryLoop: true,
+					textAlign: 'center',
+					fontSize: 'small',
+				},
+				[],
+			],
+			[
+				'woocommerce/product-price',
+				{
+					isDescendentOfQueryLoop: true,
+					textAlign: 'center',
+					fontSize: 'small',
+				},
+				[],
+			],
+			[
+				'woocommerce/product-button',
+				{
+					isDescendentOfQueryLoop: true,
+					textAlign: 'center',
+					fontSize: 'small',
+				},
+				[],
+			],
 		],
 	],
 	[ 'core/query-pagination' ],


### PR DESCRIPTION
This PR adds a default Product Query pattern based on Figma designs.

### Screenshots

Figma design:
![loop](https://user-images.githubusercontent.com/905781/205407505-71acc232-00c9-41a7-a346-6945ae0d1a0d.jpg)

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|![All_Products_–_ratings](https://user-images.githubusercontent.com/905781/205409594-f899bc22-8b29-429c-ac1e-2642bdeb82db.jpg)|![All_Products_–_ratings-3](https://user-images.githubusercontent.com/905781/205408042-34e16236-25b7-4091-8099-255548920a6d.jpg)|

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Add a page with the **Product Query** block.
2. Ensure the default pattern matches the screenshot.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
