### PR TITLE
Fix e2e tests after Product Query block name change

### DIFF
--- a/tests/e2e/specs/backend/product-query.test.ts
+++ b/tests/e2e/specs/backend/product-query.test.ts
@@ -22,7 +22,7 @@ import {
 } from '../../utils';
 
 const block = {
-	name: 'Product Query',
+	name: 'Products (Beta)',
 	slug: 'woocommerce/product-query',
 	class: '.wp-block-query',
 };

--- a/tests/e2e/specs/backend/product-query/advanced-filters.ts
+++ b/tests/e2e/specs/backend/product-query/advanced-filters.ts
@@ -26,7 +26,7 @@ import {
 } from '../../../utils';
 
 const block = {
-	name: 'Product Query',
+	name: 'Products (Beta)',
 	slug: 'core/query',
 	class: '.wp-block-query',
 };

--- a/tests/e2e/specs/backend/product-query/atomic-blocks.test.ts
+++ b/tests/e2e/specs/backend/product-query/atomic-blocks.test.ts
@@ -20,7 +20,7 @@ import {
 } from '../../../utils';
 
 const block = {
-	name: 'Product Query',
+	name: 'Products (Beta)',
 	slug: 'woocommerce/product-query',
 	class: '.wp-block-query',
 };
@@ -45,7 +45,7 @@ describeOrSkip( GUTENBERG_EDITOR_CONTEXT === 'gutenberg' )(
 		afterAll( async () => {
 			await visitBlockPage( `${ block.name } Block` );
 			await setPostContent( '' );
-			await insertBlock( 'Product Query' );
+			await insertBlock( 'Products (Beta)' );
 			await saveOrPublish();
 		} );
 

--- a/tests/e2e/specs/shopper/filter-products-by-attribute.test.ts
+++ b/tests/e2e/specs/shopper/filter-products-by-attribute.test.ts
@@ -242,7 +242,7 @@ describe.skip( `${ block.name } Block`, () => {
 				title: block.name,
 			} );
 
-			await insertBlock( 'Product Query' );
+			await insertBlock( 'Products (Beta)' );
 			await insertBlock( block.name );
 			await page.waitForNetworkIdle();
 

--- a/tests/e2e/specs/shopper/filter-products-by-price.test.ts
+++ b/tests/e2e/specs/shopper/filter-products-by-price.test.ts
@@ -241,7 +241,7 @@ describe.skip( `${ block.name } Block`, () => {
 				title: block.name,
 			} );
 
-			await insertBlock( 'Product Query' );
+			await insertBlock( 'Products (Beta)' );
 			await insertBlock( block.name );
 			await insertBlock( 'Active Filters' );
 			await page.waitForNetworkIdle();


### PR DESCRIPTION
This PR updates the tests which were relying on the `Product Query` block name to use `Products (Beta)`. It doesn't update the `Product Query` string anywhere else in the database.