### PR TITLE
Fix Query Loop crash when an icon of a variation is registered with src attribute

### DIFF
--- a/assets/js/blocks/product-query/variations/product-query.tsx
+++ b/assets/js/blocks/product-query/variations/product-query.tsx
@@ -36,14 +36,12 @@ if ( isFeaturePluginBuild() ) {
 		title: __( 'Products (Beta)', 'woo-gutenberg-products-block' ),
 		isActive: ( blockAttributes ) =>
 			blockAttributes.namespace === VARIATION_NAME,
-		icon: {
-			src: (
-				<Icon
-					icon={ stacks }
-					className="wc-block-editor-components-block-icon wc-block-editor-components-block-icon--stacks"
-				/>
-			),
-		},
+		icon: (
+			<Icon
+				icon={ stacks }
+				className="wc-block-editor-components-block-icon wc-block-editor-components-block-icon--stacks"
+			/>
+		),
 		attributes: {
 			...QUERY_DEFAULT_ATTRIBUTES,
 			namespace: VARIATION_NAME,

--- a/assets/js/blocks/product-query/variations/product-query.tsx
+++ b/assets/js/blocks/product-query/variations/product-query.tsx
@@ -54,6 +54,6 @@ if ( isFeaturePluginBuild() ) {
 			? [ ...DEFAULT_ALLOWED_CONTROLS, 'wooInherit' ]
 			: DEFAULT_ALLOWED_CONTROLS,
 		innerBlocks: INNER_BLOCKS_TEMPLATE,
-		scope: [ 'block', 'inserter' ],
+		scope: [ 'inserter' ],
 	} );
 }

--- a/assets/js/blocks/product-query/variations/products-on-sale.tsx
+++ b/assets/js/blocks/product-query/variations/products-on-sale.tsx
@@ -51,6 +51,6 @@ if ( isExperimentalBuild() ) {
 			DISABLED_INSPECTOR_CONTROLS
 		),
 		innerBlocks: INNER_BLOCKS_TEMPLATE,
-		scope: [ 'block', 'inserter' ],
+		scope: [ 'inserter' ],
 	} );
 }

--- a/assets/js/blocks/product-query/variations/products-on-sale.tsx
+++ b/assets/js/blocks/product-query/variations/products-on-sale.tsx
@@ -3,8 +3,9 @@
  */
 import { isExperimentalBuild } from '@woocommerce/block-settings';
 import { registerBlockVariation } from '@wordpress/blocks';
+import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Icon, percent } from '@wordpress/icons';
+import { percent } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -27,14 +28,12 @@ if ( isExperimentalBuild() ) {
 		isActive: ( blockAttributes ) =>
 			blockAttributes.namespace === VARIATION_NAME ||
 			blockAttributes.query?.__woocommerceOnSale === true,
-		icon: {
-			src: (
-				<Icon
-					icon={ percent }
-					className="wc-block-editor-components-block-icon wc-block-editor-components-block-icon--percent"
-				/>
-			),
-		},
+		icon: (
+			<Icon
+				icon={ percent }
+				className="wc-block-editor-components-block-icon wc-block-editor-components-block-icon--percent"
+			/>
+		),
 		attributes: {
 			...QUERY_DEFAULT_ATTRIBUTES,
 			namespace: VARIATION_NAME,


### PR DESCRIPTION
This PR fixes a Query Loop block crash when the user adds the Query Loop and selects "Start Blank" option. The reason is that the component [`__experimentalBlockVariationPicker`](https://github.com/WordPress/gutenberg/blob/1c0d02fc779785ec11d2412127102f32cd636a03/packages/block-library/src/query/edit/query-placeholder.js/#L127-L128) doesn't support icons registered with the src attribute.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|![Screen Capture on 2022-12-06 at 10-37-19](https://user-images.githubusercontent.com/4463174/205876634-9e98a75f-8bfe-44d5-92f6-47c4ca9a9f7a.gif)|![Screen Capture on 2022-12-06 at 10-44-26](https://user-images.githubusercontent.com/4463174/205876762-17339d80-7c64-40f3-9dc0-b0f9d855e84f.gif)|

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Add the Query Loop block.
2. Click on `Start Blank`.
3. Be sure that the Query Loop block doesn't crash.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental


