### PR TITLE
Add Pickup Location Blank Slate

### DIFF
--- a/assets/js/extensions/shipping-methods/pickup-location/location-settings.tsx
+++ b/assets/js/extensions/shipping-methods/pickup-location/location-settings.tsx
@@ -119,6 +119,10 @@ const LocationSettings = () => {
 				setData={ ( newData ) => {
 					setPickupLocations( newData as SortablePickupLocation[] );
 				} }
+				placeholder={ __(
+					'When you add a pickup location, it will appear here.',
+					'woo-gutenberg-products-block'
+				) }
 				footerContent={ FooterContent }
 			/>
 			{ editingLocation && (

--- a/assets/js/extensions/shipping-methods/shared-components/sortable-table/index.tsx
+++ b/assets/js/extensions/shipping-methods/shared-components/sortable-table/index.tsx
@@ -55,7 +55,7 @@ const TableRow = ( {
 	return (
 		<tr ref={ setNodeRef } style={ style }>
 			<>
-				<td>
+				<td style={ { width: '1%' } }>
 					<Icon
 						icon={ dragHandle }
 						size={ 14 }
@@ -168,11 +168,13 @@ export const SortableTable = ( {
 	setData,
 	className,
 	footerContent: FooterContent,
+	placeholder,
 }: {
 	columns: ColumnProps[];
 	data: SortableData[];
 	setData: ( data: SortableData[] ) => void;
 	className?: string;
+	placeholder?: string | ( () => JSX.Element );
 	footerContent?: () => JSX.Element;
 } ): JSX.Element => {
 	const items = useMemo( () => data.map( ( { id } ) => id ), [ data ] );
@@ -216,19 +218,14 @@ export const SortableTable = ( {
 			<StyledTable className={ `${ className } sortable-table` }>
 				<thead>
 					<tr>
-						<th
-							className={ `sortable-table__sort` }
-							style={ { width: '1%' } }
-						>
-							&nbsp;
-						</th>
-						{ columns.map( ( column ) => (
+						{ columns.map( ( column, index ) => (
 							<th
 								key={ column.name }
 								{ ...getColumnProps(
 									column,
 									`sortable-table__column`
 								) }
+								colSpan={ index === 0 ? 2 : 1 }
 							>
 								{ column.label }
 							</th>
@@ -249,7 +246,7 @@ export const SortableTable = ( {
 						items={ items }
 						strategy={ verticalListSortingStrategy }
 					>
-						{ data &&
+						{ data && data.length ? (
 							data.map(
 								( row ) =>
 									row && (
@@ -285,7 +282,14 @@ export const SortableTable = ( {
 											) ) }
 										</TableRow>
 									)
-							) }
+							)
+						) : (
+							<tr>
+								<td colSpan={ columns.length + 1 }>
+									{ placeholder }
+								</td>
+							</tr>
+						) }
 					</SortableContext>
 				</tbody>
 			</StyledTable>

--- a/assets/js/extensions/shipping-methods/shared-components/sortable-table/index.tsx
+++ b/assets/js/extensions/shipping-methods/shared-components/sortable-table/index.tsx
@@ -246,7 +246,7 @@ export const SortableTable = ( {
 						items={ items }
 						strategy={ verticalListSortingStrategy }
 					>
-						{ data && data.length ? (
+						{ !! data.length ? (
 							data.map(
 								( row ) =>
 									row && (


### PR DESCRIPTION
Adds a blank slate to the pickup locations table if no locations exist. Content is passed in by the consumer.

Closes #7789

### Screenshots

![Screenshot 2022-12-07 at 11 36 30](https://user-images.githubusercontent.com/90977/206169750-12caf151-f078-4bb0-97ea-fe3f647c6026.png)

### Testing

1. Remove all locations
2. See the placeholder state
3. Add location
4. Placeholder is gone

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental
