### PR TITLE
Ensure Checkout order summary and totals block cannot be removed

### DIFF
--- a/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-block/block.json
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-block/block.json
@@ -9,7 +9,8 @@
 		"html": false,
 		"multiple": false,
 		"reusable": false,
-		"inserter": false
+		"inserter": false,
+		"lock": false
 	},
 	"attributes": {
 		"lock": {

--- a/assets/js/blocks/checkout/inner-blocks/checkout-totals-block/block.json
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-totals-block/block.json
@@ -9,7 +9,8 @@
 		"html": false,
 		"multiple": false,
 		"reusable": false,
-		"inserter": false
+		"inserter": false,
+		"lock": false
 	},
 	"attributes": {
 		"className": {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
The Checkout Order Summary block and Checkout Totals block could be removed in the editor by unlocking and deleting them. When doing so, they reappeared. This PR ensures the blocks cannot be unlocked and removed. It does this by removing the option to "lock" (and therefore unlock) these blocks in their `block.json` files.


<!-- Reference any related issues or PRs here -->

Fixes #7227 (It doesn't explain why the block was re-added, but it prevents removal and subsequent re-adding, so the user should not experience this).

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Add the Checkout block to a page and then open the List View in the Gutenberg editor.
2. From the List View select the Checkout Totals Block, ensure you cannot remove it.
3. Try to unlock it and remove it, ensure that this is not possible.
4. Repeat for Checkout Order Summary block.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Ensure the Checkout Totals and Checkout Order Summary blocks cannot be removed from the Checkout block.
