### PR TITLE
Refactor `useForcedLayout` to subscribe to store changes and to batch block insertions

### DIFF
--- a/assets/js/blocks/cart-checkout-shared/use-forced-layout.ts
+++ b/assets/js/blocks/cart-checkout-shared/use-forced-layout.ts
@@ -1,20 +1,17 @@
 /**
  * External dependencies
  */
-import {
-	useLayoutEffect,
-	useRef,
-	useCallback,
-	useMemo,
-} from '@wordpress/element';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useRef, useEffect } from '@wordpress/element';
+import { useRegistry, dispatch } from '@wordpress/data';
 import {
 	createBlock,
 	getBlockType,
 	createBlocksFromInnerBlocksTemplate,
+	BlockInstance,
 } from '@wordpress/blocks';
 import type { Block, TemplateArray } from '@wordpress/blocks';
 import { isEqual } from 'lodash';
+import { MutableRefObject } from 'react';
 
 interface LockableBlock extends Block {
 	attributes: {
@@ -113,114 +110,74 @@ export const useForcedLayout = ( {
 	registeredBlocks: Array< string >;
 	// The default template for the inner blocks in this layout.
 	defaultTemplate: TemplateArray;
-} ): void => {
+} ) => {
 	const currentRegisteredBlocks = useRef( registeredBlocks );
 	const currentDefaultTemplate = useRef( defaultTemplate );
 
-	const { insertBlock, replaceInnerBlocks } =
-		useDispatch( 'core/block-editor' );
+	const registry = useRegistry();
+	useEffect( () => {
+		const { replaceInnerBlocks } = dispatch( 'core/block-editor' );
+		return registry.subscribe( () => {
+			const innerBlocks = registry
+				.select( 'core/block-editor' )
+				.getBlocks( clientId );
 
-	const { innerBlocks, registeredBlockTypes } = useSelect(
-		( select ) => {
-			return {
-				innerBlocks:
-					select( 'core/block-editor' ).getBlocks( clientId ),
-				registeredBlockTypes: currentRegisteredBlocks.current.map(
-					( blockName ) => getBlockType( blockName )
-				),
-			};
-		},
-		[ clientId, currentRegisteredBlocks.current ]
-	);
-
-	const appendBlock = useCallback(
-		( block, position ) => {
-			const newBlock = createBlock( block.name );
-			insertBlock( newBlock, position, clientId, false );
-		},
-		// We need to skip insertBlock here due to a cache issue in wordpress.com that causes an inifinite loop, see https://github.com/Automattic/wp-calypso/issues/66092 for an expanded doc.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-		[ clientId ]
-	);
-
-	const lockedBlockTypes = useMemo(
-		() =>
-			registeredBlockTypes.filter(
-				( block: Block | undefined ) => block && isBlockLocked( block )
-			),
-		[ registeredBlockTypes ]
-	) as Block[];
-
-	/**
-	 * If the current inner blocks differ from the registered blocks, push the differences.
-	 */
-	useLayoutEffect( () => {
-		if ( ! clientId ) {
-			return;
-		}
-
-		// If there are NO inner blocks, sync with the given template.
-		if (
-			innerBlocks.length === 0 &&
-			currentDefaultTemplate.current.length > 0
-		) {
-			const nextBlocks = createBlocksFromInnerBlocksTemplate(
-				currentDefaultTemplate.current
-			);
-			if ( ! isEqual( nextBlocks, innerBlocks ) ) {
-				replaceInnerBlocks( clientId, nextBlocks );
-				return;
-			}
-		}
-
-		// Find registered locked blocks missing from Inner Blocks and append them.
-		lockedBlockTypes.forEach( ( block ) => {
-			// If the locked block type is already in the layout, we can skip this one.
+			// If there are NO inner blocks, sync with the given template.
 			if (
-				innerBlocks.find(
-					( { name }: { name: string } ) => name === block.name
-				)
+				innerBlocks.length === 0 &&
+				currentDefaultTemplate.current.length > 0
 			) {
+				const nextBlocks = createBlocksFromInnerBlocksTemplate(
+					currentDefaultTemplate.current
+				);
+				if ( ! isEqual( nextBlocks, innerBlocks ) ) {
+					replaceInnerBlocks( clientId, nextBlocks );
+					return;
+				}
+			}
+
+			const registeredBlockTypes = currentRegisteredBlocks.current.map(
+				( blockName: string ) => getBlockType( blockName )
+			);
+
+			const missingBlocks = getMissingBlocks(
+				innerBlocks,
+				registeredBlockTypes
+			);
+
+			if ( missingBlocks.length === 0 ) {
 				return;
 			}
 
-			// Is the forced block part of the default template, find it's original position.
-			const defaultTemplatePosition =
-				currentDefaultTemplate.current.findIndex(
-					( [ blockName ] ) => blockName === block.name
-				);
+			// Initially set as -1, so we can skip checking the position multiple times. Later on in the map callback,
+			// we check where the forced blocks should be inserted. This gets set to >= 0 if we find a missing block,
+			// so we know we can skip calculating it.
+			let insertAtPosition = -1;
+			const blockConfig = missingBlocks.map( ( block ) => {
+				const defaultTemplatePosition =
+					currentDefaultTemplate.current.findIndex(
+						( [ blockName ] ) => blockName === block.name
+					);
+				const createdBlock = createBlock( block.name );
 
-			switch ( defaultTemplatePosition ) {
-				case -1:
-					// The block is not part of the default template so we append it to the current layout.
-					appendBlock( block, innerBlocks.length );
-					break;
-				case 0:
-					// The block was the first block in the default layout, so prepend it to the current layout.
-					appendBlock( block, 0 );
-					break;
-				default:
-					// The new layout may have extra blocks compared to the default template, so rather than insert
-					// at the default position, we should append it after another default block.
-					const adjacentBlock =
-						currentDefaultTemplate.current[
-							defaultTemplatePosition - 1
-						];
-					const position = innerBlocks.findIndex(
-						( { name: blockName } ) =>
-							blockName === adjacentBlock[ 0 ]
-					);
-					appendBlock(
-						block,
-						position === -1 ? defaultTemplatePosition : position + 1
-					);
-					break;
-			}
+				// As mentioned above, if this is not -1, this is the first time we're calculating the position, if it's
+				// already been calculated we can skip doing so.
+				if ( insertAtPosition === -1 ) {
+					insertAtPosition = findBlockPosition( {
+						defaultTemplatePosition,
+						innerBlocks,
+						currentDefaultTemplate,
+					} );
+				}
+
+				return createdBlock;
+			} );
+
+			registry.batch( () => {
+				registry
+					.dispatch( 'core/block-editor' )
+					.insertBlocks( blockConfig, insertAtPosition, clientId );
+			} );
 		} );
-		/*
-		We need to skip replaceInnerBlocks here due to a cache issue in wordpress.com that causes an inifinite loop, see https://github.com/Automattic/wp-calypso/issues/66092 for an expanded doc.
-		 @todo Add replaceInnerBlocks and insertBlock after fixing https://github.com/Automattic/wp-calypso/issues/66092
-		*/
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ clientId, innerBlocks, lockedBlockTypes, appendBlock ] );
+	}, [ clientId, registry ] );
 };

--- a/assets/js/blocks/cart-checkout-shared/use-forced-layout.ts
+++ b/assets/js/blocks/cart-checkout-shared/use-forced-layout.ts
@@ -68,7 +68,39 @@ const getMissingBlocks = (
 /**
  * This hook is used to determine the position that a missing block should be inserted at.
  *
- * Responsible for ensuring FORCED blocks exist in the inner block layout. Forced blocks cannot be removed.
+ * @return The index to insert the missing block at.
+ */
+const findBlockPosition = ( {
+	defaultTemplatePosition,
+	innerBlocks,
+	currentDefaultTemplate,
+}: {
+	defaultTemplatePosition: number;
+	innerBlocks: BlockInstance[];
+	currentDefaultTemplate: MutableRefObject< TemplateArray >;
+} ) => {
+	switch ( defaultTemplatePosition ) {
+		case -1:
+			// The block is not part of the default template, so we append it to the current layout.
+			return innerBlocks.length;
+		// defaultTemplatePosition defaults to 0, so if this happens we can just return, this is because the block was
+		// the first block in the default layout, so we can prepend it to the current layout.
+		case 0:
+			return 0;
+		default:
+			// The new layout may have extra blocks compared to the default template, so rather than insert
+			// at the default position, we should append it after another default block.
+			const adjacentBlock =
+				currentDefaultTemplate.current[ defaultTemplatePosition - 1 ];
+			const position = innerBlocks.findIndex(
+				( { name: blockName } ) => blockName === adjacentBlock[ 0 ]
+			);
+			return position === -1 ? defaultTemplatePosition : position + 1;
+	}
+};
+
+/**
+ * Hook to ensure FORCED blocks are rendered in the correct place.
  */
 export const useForcedLayout = ( {
 	clientId,

--- a/assets/js/blocks/cart-checkout-shared/use-forced-layout.ts
+++ b/assets/js/blocks/cart-checkout-shared/use-forced-layout.ts
@@ -13,13 +13,26 @@ import {
 	getBlockType,
 	createBlocksFromInnerBlocksTemplate,
 } from '@wordpress/blocks';
-import type { Block, AttributeSource, TemplateArray } from '@wordpress/blocks';
+import type { Block, TemplateArray } from '@wordpress/blocks';
 import { isEqual } from 'lodash';
 
+interface LockableBlock extends Block {
+	attributes: {
+		lock?: {
+			type: 'object';
+			remove?: boolean;
+			move: boolean;
+			default?: {
+				remove?: boolean;
+				move?: boolean;
+			};
+		};
+	};
+}
 const isBlockLocked = ( {
 	attributes,
 }: {
-	attributes: Record< string, AttributeSource.Attribute >;
+	attributes: LockableBlock[ 'attributes' ];
 } ) => Boolean( attributes.lock?.remove || attributes.lock?.default?.remove );
 
 /**

--- a/assets/js/blocks/cart-checkout-shared/use-forced-layout.ts
+++ b/assets/js/blocks/cart-checkout-shared/use-forced-layout.ts
@@ -33,8 +33,8 @@ const isBlockLocked = ( {
 } ) => Boolean( attributes.lock?.remove || attributes.lock?.default?.remove );
 
 /**
- * This hook is used to determine which blocks are missing from a block. Given the list of inner blocks of a block
- * ID for a block, we can check any registered blocks that:
+ * This hook is used to determine which blocks are missing from a block. Given the list of inner blocks of a block, we
+ * can check for any registered blocks that:
  * a) Are locked,
  * b) Have the parent set as the current block, and
  * c) Are not present in the list of inner blocks.

--- a/assets/js/blocks/cart-checkout-shared/use-forced-layout.ts
+++ b/assets/js/blocks/cart-checkout-shared/use-forced-layout.ts
@@ -36,7 +36,37 @@ const isBlockLocked = ( {
 } ) => Boolean( attributes.lock?.remove || attributes.lock?.default?.remove );
 
 /**
- * useForcedLayout hook
+ * This hook is used to determine which blocks are missing from a block. Given the list of inner blocks of a block
+ * ID for a block, we can check any registered blocks that:
+ * a) Are locked,
+ * b) Have the parent set as the current block, and
+ * c) Are not present in the list of inner blocks.
+ */
+const getMissingBlocks = (
+	innerBlocks: BlockInstance[],
+	registeredBlockTypes: ( LockableBlock | undefined )[]
+) => {
+	const lockedBlockTypes = registeredBlockTypes.filter(
+		( block: LockableBlock | undefined ) => block && isBlockLocked( block )
+	);
+	const missingBlocks: LockableBlock[] = [];
+	lockedBlockTypes.forEach( ( lockedBlock ) => {
+		if ( typeof lockedBlock === 'undefined' ) {
+			return;
+		}
+		const existingBlock = innerBlocks.find(
+			( block ) => block.name === lockedBlock.name
+		);
+
+		if ( ! existingBlock ) {
+			missingBlocks.push( lockedBlock );
+		}
+	} );
+	return missingBlocks;
+};
+
+/**
+ * This hook is used to determine the position that a missing block should be inserted at.
  *
  * Responsible for ensuring FORCED blocks exist in the inner block layout. Forced blocks cannot be removed.
  */


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
Following on from the discussion in pca54o-4GY-p2#comment-4658 I implemented the suggestion of @jsnajdr. I altered `useForcedLayout` to subscribe to changes to `core/block-editor` in the registry. I also batched the action dispatches to that store. Whereas we previously inserted blocks individually, we now insert multiple blocks at once if necessary.

I added two new functions (the functionality already existed in the old `useForcedLayout` hook, I just separated it): `getMissingBlocks` and `findBlockPosition`. These functions find which registered blocks are missing from a forced layout, and find the index that these blocks should be inserted at, respectively.

<!-- Reference any related issues or PRs here -->

Fixes #7367


### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
#### Internal dev testing

1.  Add WooCommerce Gift Cards, EU VAT Number, and a new plugin generated by the `@woocommerce/extend-cart-checkout-block` template. (Go to `plugins` and exectue: `npx @wordpress/create-block -t @woocommerce/extend-cart-checkout-block my-test-plugin`).
2. Activate them all, and ensure taxes are enabled in WooCommerce (go to WooCommerce -> Settings -> General -> `Enable tax rates and calculations`)
3. Create a new page, add the Cart block. Ensure it loads correctly. Save the page and reload, ensure it's still there.
4. Load this new page on the front-end. Check it renders and works correctly.
5. Create a new page and add the Checkout block. Ensure it loads correctly. Ensure you see the `I want to receive updates about products and promotions.` checkbox in the Contact Information block, ensure you see the VAT Number block rendered at the bottom of the Checkout block (this is intentional).
6. Check the Gift Card boxes appear in the totals sidebar (should see two of them, one checkbox and one "Have a gift card?" panel).
8. Open on the front end and check the VAT Number box is there and the newsletter checkbox. You can also buy and redeem a gift card on your account and check that too, but it's not necessary as long as the "Have a gift card?" panel appears.
9. Repeat these tests on wpcom and ensure nothing breaks!

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Add the Cart and Checkout blocks to two new pages.
2. Ensure they load correctly on the editor and on the front end.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->
I tested the performance of my version by logging the difference in `performance.now()` between the start and end of the `subscribe` function (this is where most of the work gets done) and in the old version by logging the difference in `performance.now()` in the `useLayoutEffect`. I took an average of the values of every timestamp collected when inserting a new block and it averaged out around 10ms for both implementations.

I also took the following measurements:

| Metric | Trunk | This branch |
| --- | --- | --- |
| Number of hook calls | 156 | 58 |
| Subscription calls |  (added a subscribe to the registry just to check): 3390 | 434 |
| Heap memory use | Avg: 1026mb | Avg: 479mb |
| Actions dispatched to core/block-editor store | 76 | 67 |

### Changelog

> Skipping