### PR TITLE
Update GH token to fine grained token

### DIFF
--- a/.github/workflows/automate-team-review-assignment-config.yml
+++ b/.github/workflows/automate-team-review-assignment-config.yml
@@ -12,4 +12,4 @@ jobs:
               uses: acq688/Request-Reviewer-For-Team-Action@v1.1
               with:
                   config: '.github/automate-team-review-assignment-config.yml'
-                  GITHUB_TOKEN: ${{ secrets.PAT_FOR_ACTIONS }}
+                  GITHUB_TOKEN: ${{ secrets.FINE_GRAINED_TOKEN_ACTIONS }}


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR replaces the token used for the `automate team review assignment` workflow to use a fine grained access token owned by the `woocommercebot` user, as discussed (P2: pdqwkG-r3-p2#comment-342 , Issue: https://github.com/woocommerce/woocommerce-blocks/issues/7473)

<!-- Reference any related issues or PRs here -->

Fixes #7473 

### Testing

#### User Facing Testing

1. If there is a reviewer assigned to this PR and the Auto Team Review Assignment workflow has no errors, all should be well. Note that the workflow can finish successfully, but the action can actually finish unsuccessfully. 

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->