### PR TITLE
Restrict Local Pickup

### DIFF
--- a/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/edit.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/edit.tsx
@@ -5,7 +5,7 @@ import classnames from 'classnames';
 import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
 import { Main } from '@woocommerce/base-components/sidebar-layout';
 import { innerBlockAreas } from '@woocommerce/blocks-checkout';
-import { isExperimentalBuild } from '@woocommerce/block-settings';
+import { LOCAL_PICKUP_ENABLED } from '@woocommerce/block-settings';
 import type { TemplateArray } from '@wordpress/blocks';
 
 /**
@@ -42,12 +42,12 @@ export const Edit = ( {
 		[ 'woocommerce/checkout-express-payment-block', {}, [] ],
 		[ 'woocommerce/checkout-contact-information-block', {}, [] ],
 		...[
-			isExperimentalBuild()
+			LOCAL_PICKUP_ENABLED
 				? [ 'woocommerce/checkout-shipping-method-block', {}, [] ]
 				: null,
 		],
 		...[
-			isExperimentalBuild()
+			LOCAL_PICKUP_ENABLED
 				? [ 'woocommerce/checkout-pickup-options-block', {}, [] ]
 				: null,
 		],

--- a/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/edit.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/edit.tsx
@@ -5,7 +5,6 @@ import classnames from 'classnames';
 import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
 import { Main } from '@woocommerce/base-components/sidebar-layout';
 import { innerBlockAreas } from '@woocommerce/blocks-checkout';
-import { LOCAL_PICKUP_ENABLED } from '@woocommerce/block-settings';
 import type { TemplateArray } from '@wordpress/blocks';
 
 /**
@@ -41,16 +40,8 @@ export const Edit = ( {
 	const defaultTemplate = [
 		[ 'woocommerce/checkout-express-payment-block', {}, [] ],
 		[ 'woocommerce/checkout-contact-information-block', {}, [] ],
-		...[
-			LOCAL_PICKUP_ENABLED
-				? [ 'woocommerce/checkout-shipping-method-block', {}, [] ]
-				: null,
-		],
-		...[
-			LOCAL_PICKUP_ENABLED
-				? [ 'woocommerce/checkout-pickup-options-block', {}, [] ]
-				: null,
-		],
+		[ 'woocommerce/checkout-shipping-method-block', {}, [] ],
+		[ 'woocommerce/checkout-pickup-options-block', {}, [] ],
 		[ 'woocommerce/checkout-shipping-address-block', {}, [] ],
 		[ 'woocommerce/checkout-billing-address-block', {}, [] ],
 		[ 'woocommerce/checkout-shipping-methods-block', {}, [] ],

--- a/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/edit.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/edit.tsx
@@ -7,6 +7,7 @@ import { useBlockProps } from '@wordpress/block-editor';
 import { innerBlockAreas } from '@woocommerce/blocks-checkout';
 import { useSelect } from '@wordpress/data';
 import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
+import { LOCAL_PICKUP_ENABLED } from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies
@@ -38,7 +39,7 @@ export const Edit = ( {
 	} );
 	const { className } = attributes;
 
-	if ( ! prefersCollection ) {
+	if ( ! prefersCollection || ! LOCAL_PICKUP_ENABLED ) {
 		return null;
 	}
 

--- a/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/frontend.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/frontend.tsx
@@ -6,6 +6,7 @@ import { withFilteredAttributes } from '@woocommerce/shared-hocs';
 import { FormStep } from '@woocommerce/base-components/cart-checkout';
 import { useSelect } from '@wordpress/data';
 import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
+import { LOCAL_PICKUP_ENABLED } from '@woocommerce/block-settings';
 /**
  * Internal dependencies
  */
@@ -35,7 +36,7 @@ const FrontendBlock = ( {
 		}
 	);
 
-	if ( ! prefersCollection ) {
+	if ( ! prefersCollection || ! LOCAL_PICKUP_ENABLED ) {
 		return null;
 	}
 

--- a/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/edit.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/edit.tsx
@@ -12,6 +12,7 @@ import {
 } from '@wordpress/components';
 import { Icon, store, shipping } from '@wordpress/icons';
 import { ADMIN_URL } from '@woocommerce/settings';
+import { LOCAL_PICKUP_ENABLED } from '@woocommerce/block-settings';
 import {
 	InspectorControls,
 	useBlockProps,
@@ -182,7 +183,8 @@ export const Edit = ( {
 		! needsShipping ||
 		! hasCalculatedShipping ||
 		! shippingRates ||
-		! isCollectable
+		! isCollectable ||
+		! LOCAL_PICKUP_ENABLED
 	) {
 		return null;
 	}

--- a/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/frontend.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/frontend.tsx
@@ -7,6 +7,7 @@ import { FormStep } from '@woocommerce/base-components/cart-checkout';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
 import { useShippingData } from '@woocommerce/base-context/hooks';
+import { LOCAL_PICKUP_ENABLED } from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies
@@ -56,7 +57,8 @@ const FrontendBlock = ( {
 		! needsShipping ||
 		! hasCalculatedShipping ||
 		! shippingRates ||
-		! isCollectable
+		! isCollectable ||
+		! LOCAL_PICKUP_ENABLED
 	) {
 		return null;
 	}

--- a/assets/js/blocks/checkout/inner-blocks/register-components.ts
+++ b/assets/js/blocks/checkout/inner-blocks/register-components.ts
@@ -4,7 +4,7 @@
 import { lazy } from '@wordpress/element';
 import {
 	WC_BLOCKS_BUILD_URL,
-	isExperimentalBuild,
+	LOCAL_PICKUP_ENABLED,
 } from '@woocommerce/block-settings';
 import { registerCheckoutBlock } from '@woocommerce/blocks-checkout';
 
@@ -48,7 +48,7 @@ registerCheckoutBlock( {
 	),
 } );
 
-if ( isExperimentalBuild() ) {
+if ( LOCAL_PICKUP_ENABLED ) {
 	registerCheckoutBlock( {
 		metadata: metadata.CHECKOUT_SHIPPING_METHOD,
 		component: lazy(

--- a/assets/js/settings/blocks/constants.ts
+++ b/assets/js/settings/blocks/constants.ts
@@ -56,3 +56,7 @@ export const ALLOWED_STATES = getSetting< Record< string, string > >(
 	'allowedStates',
 	{}
 );
+export const LOCAL_PICKUP_ENABLED = getSetting< boolean >(
+	'localPickupEnabled',
+	false
+);

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -243,6 +243,9 @@ class Checkout extends AbstractBlock {
 		$this->asset_data_registry->add( 'hasDarkEditorStyleSupport', current_theme_supports( 'dark-editor-style' ), true );
 		$this->asset_data_registry->register_page_id( isset( $attributes['cartPageId'] ) ? $attributes['cartPageId'] : 0 );
 
+		$local_pickup_enabled = filter_var( get_option( 'woocommerce_pickup_location_settings' )['enabled'], FILTER_VALIDATE_BOOLEAN ) ?? false;
+		$this->asset_data_registry->add( 'localPickupEnabled', $local_pickup_enabled, true );
+
 		$is_block_editor = $this->is_block_editor();
 
 		// Hydrate the following data depending on admin or frontend context.

--- a/src/Shipping/ShippingController.php
+++ b/src/Shipping/ShippingController.php
@@ -218,7 +218,10 @@ class ShippingController {
 	 * Registers the Local Pickup shipping method used by the Checkout Block.
 	 */
 	public function register_local_pickup() {
-		wc()->shipping->register_shipping_method( new PickupLocation() );
+		$checkout_page_id = wc_get_page_id( 'checkout' );
+		if ( $checkout_page_id && has_block( 'woocommerce/checkout', $checkout_page_id ) ) {
+			wc()->shipping->register_shipping_method( new PickupLocation() );
+		}
 	}
 
 	/**


### PR DESCRIPTION
In this PR, we restrict Local Pickup access so that:

- The setting page is only visible if Checkout block is your main Checkout.
- The pickup block and selector block are only visible if Local Pickup is enabled.

Fixes #7787 

### Testing steps
1. Make sure your main Checkout page is running something other than Checkout block.
2. Go to WooCommerce -> Settings -> Shipping, Local Pickup shouldn't be visible there.
3. Back to your Checkout page, switch it to use Checkout block, save.
4. Do step 2, you should see the local pickup tab now.
5. Enable local pickup from it.
6. Visit your Checkout page, you should see the selector there, same in editor.
7. Selector should be the second step, not the 6th.