### PR TITLE
Maintain Local Pickup Selection

### DIFF
--- a/assets/js/data/checkout/default-state.ts
+++ b/assets/js/data/checkout/default-state.ts
@@ -28,7 +28,7 @@ export type CheckoutState = {
 	// Should a user account be created?
 	shouldCreateAccount: boolean;
 	// If customer wants to checkout with a local pickup option.
-	prefersCollection: boolean;
+	prefersCollection?: boolean | undefined;
 	// Custom checkout data passed to the store API on processing.
 	extensionData: Record< string, Record< string, unknown > >;
 };
@@ -46,6 +46,6 @@ export const defaultState: CheckoutState = {
 		checkoutData.shipping_address
 	),
 	shouldCreateAccount: false,
-	prefersCollection: false,
+	prefersCollection: undefined,
 	extensionData: {},
 };

--- a/assets/js/data/checkout/selectors.ts
+++ b/assets/js/data/checkout/selectors.ts
@@ -1,8 +1,14 @@
 /**
+ * External dependencies
+ */
+import { select } from '@wordpress/data';
+
+/**
  * Internal dependencies
  */
 import { STATUS } from './constants';
 import { CheckoutState } from './default-state';
+import { STORE_KEY as cartStoreKey } from '../cart/constants';
 
 export const getCustomerId = ( state: CheckoutState ) => {
 	return state.customerId;
@@ -69,5 +75,12 @@ export const isCalculating = ( state: CheckoutState ) => {
 };
 
 export const prefersCollection = ( state: CheckoutState ) => {
+	if ( state.prefersCollection === undefined ) {
+		const shippingRates = select( cartStoreKey ).getShippingRates();
+		const selectedRate = shippingRates[ 0 ].shipping_rates.find(
+			( rate ) => rate.selected
+		);
+		return selectedRate?.method_id === 'pickup_location';
+	}
 	return state.prefersCollection;
 };


### PR DESCRIPTION
Selects either shipping or local pickup's default state based on the selected shipping rate (first package).

Fixes #7892

### Testing

#### User Facing Testing

1. Select pickup on the cart page
2. Go to the checkout
3. Pickup should be selected in the new toggle block
