### PR TITLE
Pickup location forced layout on frontend

### DIFF
--- a/assets/js/blocks/cart-checkout-shared/use-forced-layout.ts
+++ b/assets/js/blocks/cart-checkout-shared/use-forced-layout.ts
@@ -63,7 +63,7 @@ export const useForcedLayout = ( {
 			const newBlock = createBlock( block.name );
 			insertBlock( newBlock, position, clientId, false );
 		},
-		// We need to skip insertBlock here due to a cache issue in wordpress.com that causes an inifinite loop, see https://github.com/Automattic/wp-calypso/issues/66092 for an expanded doc.
+		// We need to skip insertBlock here due to a cache issue in wordpress.com that causes an infinite loop, see https://github.com/Automattic/wp-calypso/issues/66092 for an expanded doc.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 		[ clientId ]
 	);

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -146,6 +146,18 @@ class Checkout extends AbstractBlock {
 			$content = preg_replace( $regex_for_order_summary, $order_summary_with_inner_blocks, $content );
 		}
 
+		/**
+		 * Add the Local Pickup toggle to checkouts missing this forced template.
+		 */
+		$local_pickup_inner_blocks = '<div data-block-name="woocommerce/checkout-shipping-method-block" class="wp-block-woocommerce-checkout-shipping-method-block"></div>' . PHP_EOL . PHP_EOL . '<div data-block-name="woocommerce/checkout-pickup-options-block" class="wp-block-woocommerce-checkout-pickup-options-block"></div>' . PHP_EOL . PHP_EOL . '$0';
+		$has_local_pickup_regex    = '/<div[\n\r\s\ta-zA-Z0-9_\-=\'"]*data-block-name="woocommerce\/checkout-shipping-method-block"[\n\r\s\ta-zA-Z0-9_\-=\'"]*>/mi';
+		$has_local_pickup          = preg_match( $has_local_pickup_regex, $content );
+
+		if ( ! $has_local_pickup ) {
+			$shipping_address_block_regex = '/<div[\n\r\s\ta-zA-Z0-9_\-=\'"]*data-block-name="woocommerce\/checkout-shipping-address-block" class="wp-block-woocommerce-checkout-shipping-address-block"[\n\r\s\ta-zA-Z0-9_\-=\'"]*><\/div>/mi';
+			$content                      = preg_replace( $shipping_address_block_regex, $local_pickup_inner_blocks, $content );
+		}
+
 		return $content;
 	}
 


### PR DESCRIPTION
Force the new pickup location blocks into the checkout layout on the frontend.

Fixes #7896

### Testing

1. Use trunk. Create checkout block on a page.
2. Switch to this branch.
3. View checkout on the frontend. Confirm the pickup location and shipping toggle blocks are above the shipping address block, not at the bottom of the layout.
