### PR TITLE
Fix the incorrect layout of Rating and Price in Classic Template and Products block

### DIFF
--- a/assets/js/base/components/product-rating/index.tsx
+++ b/assets/js/base/components/product-rating/index.tsx
@@ -7,7 +7,6 @@ import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import './style.scss';
 
 const Rating = ( {
 	className,

--- a/assets/js/base/components/product-rating/style.scss
+++ b/assets/js/base/components/product-rating/style.scss
@@ -1,7 +1,0 @@
-.wc-block-components-product-rating {
-	&__stars {
-		display: inline-block;
-		line-height: 1;
-		height: 1em;
-	}
-}

--- a/assets/js/blocks/rating-filter/style.scss
+++ b/assets/js/blocks/rating-filter/style.scss
@@ -29,6 +29,12 @@
 		}
 	}
 
+	.wc-block-components-product-rating__stars {
+		display: inline-block;
+		line-height: 1;
+		height: 1em;
+	}
+
 	.wc-blocks-components-form-token-field-wrapper {
 		flex-grow: 1;
 		max-width: unset;


### PR DESCRIPTION
This PR fixes: https://github.com/woocommerce/woocommerce-blocks/issues/7931

Rating was incorrectly displayed in Products block and Classic Template.

There were styles (specifically: `display: inline-block`) required in Filter by Rating that were added globally and influenced the layout of Rating in Products block as well as Classic template.
- The styles were moved to the Filter by Rating block
- Empty style.scss file from Filter by Rating has been removed

Fixes #7931 

### Screenshots

| Case | Before | After |
| ------ | ----- | ----- |
|   Products block (was: left-aligned Ratings)     |    <img width="332" alt="image" src="https://user-images.githubusercontent.com/20098064/207349105-62ff7ee4-49d3-4f0e-aa3f-d906f1bf2b3d.png">   |   <img width="334" alt="image" src="https://user-images.githubusercontent.com/20098064/207348578-04970b79-cb8d-497d-823b-71d9eaa88bbe.png">   |
|   Classic Template (was: inlined Ratings and Price)     |  <img width="237" alt="image" src="https://user-images.githubusercontent.com/20098064/207349319-f7020e66-4c77-4ea9-a991-151cabd515ac.png">     |   <img width="247" alt="image" src="https://user-images.githubusercontent.com/20098064/207348409-4465be9d-529d-49db-a056-e4c3f844a6e6.png">   |

### Testing

#### User Facing Testing

Prerequisites:
- make sure you have at least one product _with_ rating

Steps:

1. Go to Editor and add blocks:
  - Filter by Rating
  - All Products,
  - Products
  - Classic Template
2. In the frontend check the above blocks

**Expected:**
- The layout of product in Products and Classic Template is as on the screenshots above
- The layout of the Filter by Rating and All Products doesn't change

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Classic Products Template and Products: Improve the layout of the Rating.
