### PR TITLE
Remove account creation setting from Checkout block

### DIFF
--- a/assets/js/blocks/checkout/block.json
+++ b/assets/js/blocks/checkout/block.json
@@ -24,10 +24,6 @@
 			"type": "boolean",
 			"default": false
 		},
-		"allowCreateAccount": {
-			"type": "boolean",
-			"default": false
-		},
 		"showApartmentField": {
 			"type": "boolean",
 			"default": true

--- a/assets/js/blocks/checkout/block.tsx
+++ b/assets/js/blocks/checkout/block.tsx
@@ -69,7 +69,6 @@ const Checkout = ( {
 	const { cartItems, cartIsLoading } = useStoreCart();
 
 	const {
-		allowCreateAccount,
 		showCompanyField,
 		requireCompanyField,
 		showApartmentField,
@@ -87,7 +86,6 @@ const Checkout = ( {
 
 	if (
 		isLoginRequired( customerId ) &&
-		allowCreateAccount &&
 		getSetting( 'checkoutAllowsSignup', false )
 	) {
 		<LoginPrompt />;
@@ -96,7 +94,6 @@ const Checkout = ( {
 	return (
 		<CheckoutBlockContext.Provider
 			value={ {
-				allowCreateAccount,
 				showCompanyField,
 				requireCompanyField,
 				showApartmentField,

--- a/assets/js/blocks/checkout/context.ts
+++ b/assets/js/blocks/checkout/context.ts
@@ -7,7 +7,6 @@ import { createContext, useContext } from '@wordpress/element';
  * Context consumed by inner blocks.
  */
 export type CheckoutBlockContextProps = {
-	allowCreateAccount: boolean;
 	showCompanyField: boolean;
 	showApartmentField: boolean;
 	showPhoneField: boolean;
@@ -22,12 +21,10 @@ export type CheckoutBlockContextProps = {
 
 export type CheckoutBlockControlsContextProps = {
 	addressFieldControls: () => JSX.Element | null;
-	accountControls: () => JSX.Element | null;
 };
 
 export const CheckoutBlockContext: React.Context< CheckoutBlockContextProps > =
 	createContext< CheckoutBlockContextProps >( {
-		allowCreateAccount: false,
 		showCompanyField: false,
 		showApartmentField: false,
 		showPhoneField: false,
@@ -43,7 +40,6 @@ export const CheckoutBlockContext: React.Context< CheckoutBlockContextProps > =
 export const CheckoutBlockControlsContext: React.Context< CheckoutBlockControlsContextProps > =
 	createContext< CheckoutBlockControlsContextProps >( {
 		addressFieldControls: () => null,
-		accountControls: () => null,
 	} );
 
 export const useCheckoutBlockContext = (): CheckoutBlockContextProps => {

--- a/assets/js/blocks/checkout/edit.tsx
+++ b/assets/js/blocks/checkout/edit.tsx
@@ -53,7 +53,6 @@ export const Edit = ( {
 	setAttributes: ( attributes: Record< string, unknown > ) => undefined;
 } ): JSX.Element => {
 	const {
-		allowCreateAccount,
 		showCompanyField,
 		requireCompanyField,
 		showApartmentField,
@@ -76,31 +75,6 @@ export const Edit = ( {
 		newAttributes[ key ] = ! ( attributes[ key ] as boolean );
 		setAttributes( newAttributes );
 	};
-
-	const accountControls = (): JSX.Element => (
-		<InspectorControls>
-			<PanelBody
-				title={ __(
-					'Account options',
-					'woo-gutenberg-products-block'
-				) }
-			>
-				<ToggleControl
-					label={ __(
-						'Allow shoppers to sign up for a user account during checkout',
-						'woo-gutenberg-products-block'
-					) }
-					checked={ allowCreateAccount }
-					onChange={ () =>
-						setAttributes( {
-							allowCreateAccount: ! allowCreateAccount,
-						} )
-					}
-				/>
-			</PanelBody>
-			<CartCheckoutFeedbackPrompt />
-		</InspectorControls>
-	);
 
 	const addressFieldControls = (): JSX.Element => (
 		<InspectorControls>
@@ -180,14 +154,10 @@ export const Edit = ( {
 						} ) }
 					>
 						<CheckoutBlockControlsContext.Provider
-							value={ {
-								addressFieldControls,
-								accountControls,
-							} }
+							value={ { addressFieldControls } }
 						>
 							<CheckoutBlockContext.Provider
 								value={ {
-									allowCreateAccount,
 									showCompanyField,
 									requireCompanyField,
 									showApartmentField,

--- a/assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/block.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/block.tsx
@@ -16,11 +16,7 @@ import { isEmail } from '@wordpress/url';
  * Internal dependencies
  */
 
-const Block = ( {
-	allowCreateAccount,
-}: {
-	allowCreateAccount: boolean;
-} ): JSX.Element => {
+const Block = (): JSX.Element => {
 	const { customerId, shouldCreateAccount } = useSelect( ( select ) => {
 		const store = select( CHECKOUT_STORE_KEY );
 		return {
@@ -40,7 +36,6 @@ const Block = ( {
 	};
 
 	const createAccountUI = ! customerId &&
-		allowCreateAccount &&
 		getSetting( 'checkoutAllowsGuest', false ) &&
 		getSetting( 'checkoutAllowsSignup', false ) && (
 			<CheckboxControl

--- a/assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/edit.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/edit.tsx
@@ -2,7 +2,10 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { useBlockProps } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
+import { PanelBody, ExternalLink } from '@wordpress/components';
+import { ADMIN_URL } from '@woocommerce/settings';
 import { innerBlockAreas } from '@woocommerce/blocks-checkout';
 import Noninteractive from '@woocommerce/base-components/noninteractive';
 
@@ -15,10 +18,6 @@ import {
 	AdditionalFieldsContent,
 } from '../../form-step';
 import Block from './block';
-import {
-	useCheckoutBlockContext,
-	useCheckoutBlockControlsContext,
-} from '../../context';
 
 export const Edit = ( {
 	attributes,
@@ -32,8 +31,6 @@ export const Edit = ( {
 	};
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
 } ): JSX.Element => {
-	const { allowCreateAccount } = useCheckoutBlockContext();
-	const { accountControls: Controls } = useCheckoutBlockControlsContext();
 	return (
 		<FormStepBlock
 			attributes={ attributes }
@@ -43,9 +40,28 @@ export const Edit = ( {
 				attributes?.className
 			) }
 		>
-			<Controls />
+			<InspectorControls>
+				<PanelBody
+					title={ __( 'Account', 'woo-gutenberg-products-block' ) }
+				>
+					<p className="wc-block-checkout__controls-text">
+						{ __(
+							'Account creation and guest checkout settings can be managed in the WooCommerce settings.',
+							'woo-gutenberg-products-block'
+						) }
+					</p>
+					<ExternalLink
+						href={ `${ ADMIN_URL }admin.php?page=wc-settings&tab=account` }
+					>
+						{ __(
+							'Manage account settings',
+							'woo-gutenberg-products-block'
+						) }
+					</ExternalLink>
+				</PanelBody>
+			</InspectorControls>
 			<Noninteractive>
-				<Block allowCreateAccount={ allowCreateAccount } />
+				<Block />
 			</Noninteractive>
 			<AdditionalFields block={ innerBlockAreas.CONTACT_INFORMATION } />
 		</FormStepBlock>

--- a/assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/edit.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/edit.tsx
@@ -8,6 +8,7 @@ import { PanelBody, ExternalLink } from '@wordpress/components';
 import { ADMIN_URL } from '@woocommerce/settings';
 import { innerBlockAreas } from '@woocommerce/blocks-checkout';
 import Noninteractive from '@woocommerce/base-components/noninteractive';
+import { CartCheckoutFeedbackPrompt } from '@woocommerce/editor-components/feedback-prompt';
 
 /**
  * Internal dependencies
@@ -59,6 +60,7 @@ export const Edit = ( {
 						) }
 					</ExternalLink>
 				</PanelBody>
+				<CartCheckoutFeedbackPrompt />
 			</InspectorControls>
 			<Noninteractive>
 				<Block />

--- a/assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/frontend.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/frontend.tsx
@@ -13,7 +13,6 @@ import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
 import Block from './block';
 import attributes from './attributes';
 import LoginPrompt from './login-prompt';
-import { useCheckoutBlockContext } from '../../context';
 
 const FrontendBlock = ( {
 	title,
@@ -24,7 +23,6 @@ const FrontendBlock = ( {
 }: {
 	title: string;
 	description: string;
-	allowCreateAccount: boolean;
 	showStepNumber: boolean;
 	children: JSX.Element;
 	className?: string;
@@ -32,7 +30,6 @@ const FrontendBlock = ( {
 	const checkoutIsProcessing = useSelect( ( select ) =>
 		select( CHECKOUT_STORE_KEY ).isProcessing()
 	);
-	const { allowCreateAccount } = useCheckoutBlockContext();
 
 	return (
 		<FormStep
@@ -47,7 +44,7 @@ const FrontendBlock = ( {
 			showStepNumber={ showStepNumber }
 			stepHeadingContent={ () => <LoginPrompt /> }
 		>
-			<Block allowCreateAccount={ allowCreateAccount } />
+			<Block />
 			{ children }
 		</FormStep>
 	);

--- a/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/attributes.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/attributes.tsx
@@ -13,10 +13,6 @@ export default {
 		defaultTitle: __( 'Shipping options', 'woo-gutenberg-products-block' ),
 		defaultDescription: '',
 	} ),
-	allowCreateAccount: {
-		type: 'boolean',
-		default: false,
-	},
 	className: {
 		type: 'string',
 		default: '',

--- a/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/edit.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/edit.tsx
@@ -34,7 +34,6 @@ export const Edit = ( {
 		title: string;
 		description: string;
 		showStepNumber: boolean;
-		allowCreateAccount: boolean;
 		className: string;
 	};
 	setAttributes: ( attributes: Record< string, unknown > ) => void;

--- a/assets/js/blocks/checkout/types.ts
+++ b/assets/js/blocks/checkout/types.ts
@@ -5,7 +5,6 @@ export type InnerBlockTemplate = [
 ];
 
 export interface Attributes extends Record< string, boolean | number > {
-	allowCreateAccount: boolean;
 	hasDarkControls: boolean;
 	showCompanyField: boolean;
 	showApartmentField: boolean;

--- a/tests/e2e/specs/shopper/cart-checkout/account.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/account.test.js
@@ -1,11 +1,6 @@
 /**
  * External dependencies
  */
-import {
-	visitBlockPage,
-	selectBlockByName,
-	saveOrPublish,
-} from '@woocommerce/blocks-test-utils';
 import { setCheckbox } from '@woocommerce/e2e-utils';
 import { visitAdminPage } from '@wordpress/e2e-test-utils';
 
@@ -14,13 +9,6 @@ import { visitAdminPage } from '@wordpress/e2e-test-utils';
  */
 import { shopper, merchant, clickLink } from '../../../../utils';
 import { SIMPLE_PHYSICAL_PRODUCT_NAME } from '.../../../../utils/constants';
-import { openBlockEditorSettings } from '../../../utils';
-
-const block = {
-	name: 'Checkout',
-	slug: 'woocommerce/checkout',
-	class: '.wp-block-woocommerce-checkout',
-};
 
 if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 ) {
 	// Skips all the tests if it's a WooCommerce Core process environment.
@@ -41,18 +29,6 @@ describe( 'Shopper → Checkout → Account', () => {
 		//Enable guest checkout option.
 		await setCheckbox( '#woocommerce_enable_guest_checkout' );
 		await clickLink( 'button[name="save"]' );
-		await visitBlockPage( `${ block.name } Block` );
-		await selectBlockByName( block.slug );
-		await selectBlockByName(
-			'woocommerce/checkout-contact-information-block'
-		);
-		await openBlockEditorSettings();
-		//Enable shoppers to sign up at checkout option.
-		// eslint-disable-next-line jest/no-standalone-expect
-		await expect( page ).toClick( 'label', {
-			text: 'Allow shoppers to sign up for a user account during checkout',
-		} );
-		await saveOrPublish();
 		await merchant.logout();
 	} );
 


### PR DESCRIPTION
Fixes #5716 

Currently, both the WooCommerce Core and the Checkout block contain a setting for allowing to create an account during checkout. Unfortunately, this option only works, if merchants activate the account creation during checkout on both locations. This PR aims to remove the account creation setting from the Checkout block and add a notification with a link to the corresponding settings page in WooCommerce core. This pattern can also been seen when selecting the `Shipping Options` and `Payment Options` inner blocks.

### Screenshots

<table>
<tr>
<td>Before:
<br><br>

![5716-before](https://user-images.githubusercontent.com/3323310/207572991-f9a62b8d-8849-4159-a8a2-20b74b71df8b.png)
</td>
<td>After:
<br><br>

![5716-after](https://user-images.githubusercontent.com/3323310/207572998-1ca7f9e8-0eed-4922-9d74-0333681dbccc.png)
</td>
</tr>
</table>

### Testing

#### User Facing Testing

1. Create a test page and add the Checkout block.
2. Select the `Contact Information` inner block.
3. Verify that the `Allow shoppers to sign up for a user account during checkout` setting is no longer visible.
4. Verify that a notification with a link to the account settings in WooCommerce core is visible in the sidebar.
5. Go to the frontend and add a product to the cart.
6. Go to the checkout and place the order.
7. Verify that the order can be placed, and this PR does not break the Checkout block.

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Enhancement: Remove account creation setting from Checkout block