### PR TITLE
Atomic Blocks: fix ancestor definition

### DIFF
--- a/assets/js/atomic/blocks/product-elements/button/index.js
+++ b/assets/js/atomic/blocks/product-elements/button/index.js
@@ -21,8 +21,8 @@ const blockConfig = {
 	title,
 	description,
 	ancestor: [
-		'@woocommerce/all-products',
-		'@woocommerce/single-product',
+		'woocommerce/all-products',
+		'woocommerce/single-product',
 		'core/post-template',
 	],
 	usesContext: [ 'query', 'queryId', 'postId' ],

--- a/assets/js/atomic/blocks/product-elements/image/index.ts
+++ b/assets/js/atomic/blocks/product-elements/image/index.ts
@@ -32,8 +32,8 @@ const blockConfig: CustomBlockConfiguration = {
 	description,
 	usesContext: [ 'query', 'queryId', 'postId' ],
 	ancestor: [
-		'@woocommerce/all-products',
-		'@woocommerce/single-product',
+		'woocommerce/all-products',
+		'woocommerce/single-product',
 		'core/post-template',
 	],
 	textdomain: 'woo-gutenberg-products-block',

--- a/assets/js/atomic/blocks/product-elements/price/index.js
+++ b/assets/js/atomic/blocks/product-elements/price/index.js
@@ -22,8 +22,8 @@ const blockConfig = {
 	title,
 	description,
 	ancestor: [
-		'@woocommerce/all-products',
-		'@woocommerce/single-product',
+		'woocommerce/all-products',
+		'woocommerce/single-product',
 		'core/post-template',
 	],
 	usesContext: [ 'query', 'queryId', 'postId' ],

--- a/assets/js/atomic/blocks/product-elements/rating/index.ts
+++ b/assets/js/atomic/blocks/product-elements/rating/index.ts
@@ -23,8 +23,8 @@ const blockConfig: BlockConfiguration = {
 	description,
 	usesContext: [ 'query', 'queryId', 'postId' ],
 	ancestor: [
-		'@woocommerce/all-products',
-		'@woocommerce/single-product',
+		'woocommerce/all-products',
+		'woocommerce/single-product',
 		'core/post-template',
 	],
 	icon: { src: icon },

--- a/assets/js/atomic/blocks/product-elements/sale-badge/index.ts
+++ b/assets/js/atomic/blocks/product-elements/sale-badge/index.ts
@@ -28,8 +28,8 @@ const blockConfig: BlockConfiguration = {
 	edit,
 	usesContext: [ 'query', 'queryId', 'postId' ],
 	ancestor: [
-		'@woocommerce/all-products',
-		'@woocommerce/single-product',
+		'woocommerce/all-products',
+		'woocommerce/single-product',
 		'core/post-template',
 	],
 };

--- a/assets/js/atomic/blocks/product-elements/shared/config.tsx
+++ b/assets/js/atomic/blocks/product-elements/shared/config.tsx
@@ -28,7 +28,7 @@ const sharedConfig: Omit< BlockConfiguration, 'attributes' | 'title' > = {
 	supports: {
 		html: false,
 	},
-	ancestor: [ '@woocommerce/all-products', '@woocommerce/single-product' ],
+	ancestor: [ 'woocommerce/all-products', 'woocommerce/single-product' ],
 	save,
 	deprecated: [
 		{

--- a/assets/js/atomic/blocks/product-elements/sku/index.ts
+++ b/assets/js/atomic/blocks/product-elements/sku/index.ts
@@ -23,8 +23,8 @@ const blockConfig: BlockConfiguration = {
 	icon: { src: icon },
 	usesContext: [ 'query', 'queryId', 'postId' ],
 	ancestor: [
-		'@woocommerce/all-products',
-		'@woocommerce/single-product',
+		'woocommerce/all-products',
+		'woocommerce/single-product',
 		'core/post-template',
 	],
 	attributes,

--- a/assets/js/atomic/blocks/product-elements/stock-indicator/index.ts
+++ b/assets/js/atomic/blocks/product-elements/stock-indicator/index.ts
@@ -29,8 +29,8 @@ const blockConfig: BlockConfiguration = {
 	edit,
 	usesContext: [ 'query', 'queryId', 'postId' ],
 	ancestor: [
-		'@woocommerce/all-products',
-		'@woocommerce/single-product',
+		'woocommerce/all-products',
+		'woocommerce/single-product',
 		'core/post-template',
 	],
 };


### PR DESCRIPTION
This PR fixes the impossibility of adding atomic blocks inside the `All Products` block.

Fixes #7946

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Go to Editor
2. Add an All Products block
3. Enter the "Edit the layout of each product" mode (click on the pencil icon)
4. Be sure that it is possible to add atomic blocks.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

