### PR TITLE
Product Query: Add `Sorted by title` preset.

### DIFF
--- a/assets/js/blocks/product-query/inspector-controls/popular-presets.tsx
+++ b/assets/js/blocks/product-query/inspector-controls/popular-presets.tsx
@@ -13,7 +13,7 @@ import { setQueryAttribute } from '../utils';
 const PRESETS = [
 	{
 		key: 'title/asc',
-		name: __( 'Sort by title', 'woo-gutenberg-products-block' ),
+		name: __( 'Sorted by title', 'woo-gutenberg-products-block' ),
 	},
 	{ key: 'date/desc', name: __( 'Newest', 'woo-gutenberg-products-block' ) },
 	{

--- a/assets/js/blocks/product-query/inspector-controls/popular-presets.tsx
+++ b/assets/js/blocks/product-query/inspector-controls/popular-presets.tsx
@@ -11,6 +11,10 @@ import { ProductQueryBlock, ProductQueryBlockQuery } from '../types';
 import { setQueryAttribute } from '../utils';
 
 const PRESETS = [
+	{
+		key: 'title/asc',
+		name: __( 'Sort by title', 'woo-gutenberg-products-block' ),
+	},
 	{ key: 'date/desc', name: __( 'Newest', 'woo-gutenberg-products-block' ) },
 	{
 		key: 'popularity/desc',


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

This PR adds a `Sorted by title` option to Popular Filters dropdown, which match with the default ordering of the Product Query block.

Fixes #7942

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Add a new page.
2. Add the Products (Beta) block to the page.
3. See products are ordered by title.
4. Open the sidebar setting.
5. See the Popular Filters setting is expanded by default and the `Sorted by title` is selected.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Product Query: Add `Sorted by title` preset to Popular Filters.