### PR TITLE
Remove country and state autocomplete fields

### DIFF
--- a/assets/js/base/components/country-input/country-input.tsx
+++ b/assets/js/base/components/country-input/country-input.tsx
@@ -57,36 +57,6 @@ export const CountryInput = ( {
 				required={ required }
 				autoComplete={ autoComplete }
 			/>
-			{ autoComplete !== 'off' && (
-				<input
-					type="text"
-					aria-hidden={ true }
-					autoComplete={ autoComplete }
-					value={ value }
-					onChange={ ( event ) => {
-						const textValue =
-							event.target.value.toLocaleUpperCase();
-						const foundOption = options.find(
-							( option ) =>
-								( textValue.length !== 2 &&
-									option.label.toLocaleUpperCase() ===
-										textValue ) ||
-								( textValue.length === 2 &&
-									option.value.toLocaleUpperCase() ===
-										textValue )
-						);
-						onChange( foundOption ? foundOption.value : '' );
-					} }
-					style={ {
-						minHeight: '0',
-						height: '0',
-						border: '0',
-						padding: '0',
-						position: 'absolute',
-					} }
-					tabIndex={ -1 }
-				/>
-			) }
 		</div>
 	);
 };

--- a/assets/js/base/components/state-input/state-input.tsx
+++ b/assets/js/base/components/state-input/state-input.tsx
@@ -88,44 +88,23 @@ const StateInput = ( {
 
 	if ( options.length > 0 ) {
 		return (
-			<>
-				<Combobox
-					className={ classnames(
-						className,
-						'wc-block-components-state-input'
-					) }
-					id={ id }
-					label={ label }
-					onChange={ onChangeState }
-					options={ options }
-					value={ value }
-					errorMessage={ __(
-						'Please select a state.',
-						'woo-gutenberg-products-block'
-					) }
-					required={ required }
-					autoComplete={ autoComplete }
-				/>
-				{ autoComplete !== 'off' && (
-					<input
-						type="text"
-						aria-hidden={ true }
-						autoComplete={ autoComplete }
-						value={ value }
-						onChange={ ( event ) =>
-							onChangeState( event.target.value )
-						}
-						style={ {
-							minHeight: '0',
-							height: '0',
-							border: '0',
-							padding: '0',
-							position: 'absolute',
-						} }
-						tabIndex={ -1 }
-					/>
+			<Combobox
+				className={ classnames(
+					className,
+					'wc-block-components-state-input'
 				) }
-			</>
+				id={ id }
+				label={ label }
+				onChange={ onChangeState }
+				options={ options }
+				value={ value }
+				errorMessage={ __(
+					'Please select a state.',
+					'woo-gutenberg-products-block'
+				) }
+				required={ required }
+				autoComplete={ autoComplete }
+			/>
 		);
 	}
 


### PR DESCRIPTION
We have two hidden fields for the purpose of browser autocompletion, but it seems that these are no longer required for autocomplete to function.

### Testing

#### User Facing Testing

Prerequisite: Browser must have saved addresses that can be used to autocomplete forms. Preferably 2 from different counties.

1. On a new checkout, trigger autocomplete in the name field.
2. Select the address.
3. Ensure country and state fields are populated.
4. State should be a select for countries with states (US), or a text input if not.

I tested this with a US and UK-based address.

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Remove hidden autocomplete fields in checkout.
