### PR TITLE
Rename configurateFilterProductsByAttributeBlock() to configureAttributeFilterBlock()

### DIFF
--- a/tests/e2e/specs/shopper/active-filters.test.ts
+++ b/tests/e2e/specs/shopper/active-filters.test.ts
@@ -66,9 +66,7 @@ const insertBlocks = async () => {
 	await insertBlock( block.name );
 };
 
-const configurateFilterByAttributeBlock = async (
-	pageOrCanvas: Page | Frame
-) => {
+const configureAttributeFilterBlock = async ( pageOrCanvas: Page | Frame ) => {
 	await pageOrCanvas.$eval(
 		selectors.editor.firstAttributeInTheList,
 		( el ) => ( el as HTMLElement ).click()
@@ -99,7 +97,7 @@ describe( 'Shopper → Active Filters Block', () => {
 
 			await insertBlocks();
 			await insertBlockUsingSlash( 'All Products' );
-			await configurateFilterByAttributeBlock( page );
+			await configureAttributeFilterBlock( page );
 			await publishPost();
 
 			const link = await page.evaluate( () =>
@@ -223,7 +221,7 @@ describe( 'Shopper → Active Filters Block', () => {
 			await insertBlocks();
 
 			const canvasEl = canvas();
-			await configurateFilterByAttributeBlock( canvasEl );
+			await configureAttributeFilterBlock( canvasEl );
 			await saveTemplate();
 		} );
 

--- a/tests/e2e/specs/shopper/active-filters.test.ts
+++ b/tests/e2e/specs/shopper/active-filters.test.ts
@@ -66,7 +66,7 @@ const insertBlocks = async () => {
 	await insertBlock( block.name );
 };
 
-const configurateFilterProductsByAttributeBlock = async (
+const configurateFilterByAttributeBlock = async (
 	pageOrCanvas: Page | Frame
 ) => {
 	await pageOrCanvas.$eval(
@@ -99,7 +99,7 @@ describe( 'Shopper → Active Filters Block', () => {
 
 			await insertBlocks();
 			await insertBlockUsingSlash( 'All Products' );
-			await configurateFilterProductsByAttributeBlock( page );
+			await configurateFilterByAttributeBlock( page );
 			await publishPost();
 
 			const link = await page.evaluate( () =>
@@ -223,7 +223,7 @@ describe( 'Shopper → Active Filters Block', () => {
 			await insertBlocks();
 
 			const canvasEl = canvas();
-			await configurateFilterProductsByAttributeBlock( canvasEl );
+			await configurateFilterByAttributeBlock( canvasEl );
 			await saveTemplate();
 		} );
 


### PR DESCRIPTION
Small PR to improve the naming of a function that I noticed while doing another code review: we were using `configurateFilterProductsByAttributeBlock()` but, given the new block name, `configureAttributeFilterBlock()` makes more sense.

### Testing

#### User Facing Testing

1. Make sure tests continue passing.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
