### PR TITLE
Fix overriding `archive-product` when saving a fallback template

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -108,6 +108,8 @@ class BlockTemplatesController {
 		$template_query = new \WP_Query( $wp_query_args );
 		$posts          = $template_query->posts;
 
+		// If we have more than one result from the query, it means that the current template is present in the db (has
+		// been customized by the user) and we should not return the `archive-product` template.
 		if ( count( $posts ) > 1 ) {
 			return null;
 		}

--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -93,12 +93,11 @@ class BlockTemplatesController {
 		}
 
 		$wp_query_args  = array(
-			'post_name__in'  => array( 'archive-product' ),
-			'post_type'      => $template_type,
-			'post_status'    => array( 'auto-draft', 'draft', 'publish', 'trash' ),
-			'posts_per_page' => 1,
-			'no_found_rows'  => true,
-			'tax_query'      => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+			'post_name__in' => array( 'archive-product', $slug ),
+			'post_type'     => $template_type,
+			'post_status'   => array( 'auto-draft', 'draft', 'publish', 'trash' ),
+			'no_found_rows' => true,
+			'tax_query'     => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 				array(
 					'taxonomy' => 'wp_theme',
 					'field'    => 'name',
@@ -109,6 +108,10 @@ class BlockTemplatesController {
 		$template_query = new \WP_Query( $wp_query_args );
 		$posts          = $template_query->posts;
 
+		if ( count( $posts ) > 1 ) {
+			return null;
+		}
+
 		if ( count( $posts ) > 0 ) {
 			$template = _build_block_template_result_from_post( $posts[0] );
 
@@ -117,6 +120,7 @@ class BlockTemplatesController {
 				$template->slug        = $slug;
 				$template->title       = BlockTemplateUtils::get_block_template_title( $slug );
 				$template->description = BlockTemplateUtils::get_block_template_description( $slug );
+				unset( $template->source );
 
 				return $template;
 			}


### PR DESCRIPTION
I found a bug happening when saving a template in the editor that was using the `archive-product` from the DB as a fallback. I was causing to override the `archive-product` row on the DB, thus losing it as a fallback for the other templates using it also as a fallback.

### Testing

#### User Facing Testing

1. On the `Site Editor` (`/wp-admin/site-editor.php?postType=wp_template`), make sure you have no customizations on any template.
2. Edit the `Product Catalog` template, add some customization and save.
3. On the front end, go to `/shop` and make sure you see the customization you just did.
4. On the front end, go also to a category, a tag, and an attribute page (like `product-category/clothing/`, `/product-tag/music`, `color/red`, depending on your store configuration).
5. Check that all 3 pages are using the `Product Catalog` template, meaning you see exactly the same customization you did on the `Product Catalog`.
6. Go back to the `Site Editor`, click on one of the templates using the Catalog fallback (either `Products by Category`, `Products by Tag`, or `Products by Attribute`).
7. Make some customization and save it.
8. Go back to the `Site Editor` and make sure `Product Catalog` still has its original customization.
9. Make sure the other two templates still fall back to `Product Catalog`.
10. On the front end, go to `/shop` and make sure you see the `Product Catalog` customization.
4. On the front end, go also to a category, a tag, and an attribute page and make sure you see the expected customizations.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix bug that was overriding the  `archive-product` when saving a fallback template.
