### PR TITLE
Remove opinionated styles from Button component on TT3 and Zaino themes

### DIFF
--- a/assets/js/base/components/button/index.tsx
+++ b/assets/js/base/components/button/index.tsx
@@ -63,6 +63,7 @@ const Button = ( {
 }: ButtonProps ): JSX.Element => {
 	const buttonClassName = classNames(
 		'wc-block-components-button',
+		'wp-element-button',
 		className,
 		variant,
 		{

--- a/assets/js/base/components/button/style.scss
+++ b/assets/js/base/components/button/style.scss
@@ -1,15 +1,9 @@
 .wc-block-components-button:not(.is-link) {
-	@include reset-typography();
 	align-items: center;
 	display: inline-flex;
-	font-weight: bold;
 	min-height: 3em;
 	justify-content: center;
-	line-height: 1;
-	padding: 0 em($gap);
 	text-align: center;
-	text-decoration: none;
-	text-transform: none;
 	position: relative;
 	transition: box-shadow 0.1s linear;
 
@@ -38,25 +32,8 @@
 		}
 	}
 
-	&.contained {
-		background-color: $gray-900;
-		color: $white;
-
-		&:disabled,
-		&:hover,
-		&:focus,
-		&:active {
-			background-color: $gray-900;
-			color: $white;
-		}
-
-		&:hover {
-			opacity: 0.9;
-		}
-	}
-
 	&.outlined {
-		background-color: transparent;
+		background: transparent;
 		color: currentColor;
 
 		&:not(:focus) {
@@ -75,6 +52,46 @@
 			background-color: $gray-900;
 			color: $white;
 			opacity: 1;
+		}
+	}
+}
+
+body:not(.theme-twentytwentythree, .theme-zaino) .wc-block-components-button:not(.is-link) {
+	@include reset-typography();
+	font-weight: bold;
+	line-height: 1;
+	padding: 0 em($gap);
+	text-decoration: none;
+	text-transform: none;
+
+	&:focus {
+		box-shadow: 0 0 0 2px $studio-blue;
+		box-shadow: inset 0 0 0 1px $white, 0 0 0 2px $studio-blue;
+		outline: 3px solid transparent;
+	}
+
+	&.text {
+		color: $gray-900;
+
+		&:hover {
+			opacity: 0.9;
+		}
+	}
+
+	&.contained {
+		background-color: $gray-900;
+		color: $white;
+
+		&:disabled,
+		&:hover,
+		&:focus,
+		&:active {
+			background-color: $gray-900;
+			color: $white;
+		}
+
+		&:hover {
+			opacity: 0.9;
 		}
 	}
 }

--- a/assets/js/base/components/button/style.scss
+++ b/assets/js/base/components/button/style.scss
@@ -57,10 +57,10 @@
 
 	&.outlined {
 		background-color: transparent;
-		color: $gray-900;
+		color: currentColor;
 
 		&:not(:focus) {
-			box-shadow: inset 0 0 0 1px $gray-900;
+			box-shadow: inset 0 0 0 1px currentColor;
 		}
 
 		&:disabled,

--- a/assets/js/blocks/mini-cart/style.scss
+++ b/assets/js/blocks/mini-cart/style.scss
@@ -151,17 +151,7 @@ h2.wc-block-mini-cart__title {
 		}
 
 		.wc-block-components-button.outlined {
-			color: currentColor;
 			display: none;
-
-			&:not(:focus) {
-				box-shadow: inset 0 0 0 1px currentColor;
-			}
-
-			&:hover,
-			&:focus {
-				color: $white;
-			}
 
 			@media only screen and (min-width: 480px) {
 				display: inline-flex;

--- a/assets/js/blocks/mini-cart/style.scss
+++ b/assets/js/blocks/mini-cart/style.scss
@@ -147,7 +147,6 @@ h2.wc-block-mini-cart__title {
 
 		.wc-block-components-button {
 			flex-grow: 1;
-			font-weight: 600;
 		}
 
 		.wc-block-components-button.outlined {


### PR DESCRIPTION
Part of #7972.

This PR makes it so in TT3 and Zaino themes, the Button component inherits the styles from the theme, instead of using opinionated ones. There should be no change in other block themes and classic themes.

### Screenshots

Screenshots are from the Mini Cart block, but these changes also impact the Cart and Checkout blocks.
Theme | Before | After
--- | --- | ---
Storefront | ![imatge](https://user-images.githubusercontent.com/3616980/208656157-f6f319a2-b0c6-4b88-911b-8e4475298283.png) | ![imatge](https://user-images.githubusercontent.com/3616980/208655029-43955e39-d24f-44ab-8d1a-22e90e4dce20.png)
Twenty Twenty One | ![imatge](https://user-images.githubusercontent.com/3616980/208656399-790d0272-d51c-4e22-81b1-ea211f1c2d96.png) | ![imatge](https://user-images.githubusercontent.com/3616980/208655140-d2a360c2-067b-4be3-97f9-6e25532186c2.png)
Twenty Twenty Two | ![imatge](https://user-images.githubusercontent.com/3616980/208656284-4dbab0c9-cbe3-4769-8c6f-d57a61e39521.png) | ![imatge](https://user-images.githubusercontent.com/3616980/208655207-d7e1fe76-0394-486e-b4d8-fe748b56a9aa.png)
Twenty Twenty Three (Canary) | ![imatge](https://user-images.githubusercontent.com/3616980/208655843-c5c1d1e2-e1ac-4cf9-a9db-46e911373482.png) | ![imatge](https://user-images.githubusercontent.com/3616980/208655555-f73849ed-2140-4529-9166-364f103f5ec4.png)
Twenty Twenty Three (Pilgrimage) | ![imatge](https://user-images.githubusercontent.com/3616980/208655758-4d1acf68-8f1d-4d53-accb-ae5b09d42e02.png)| ![imatge](https://user-images.githubusercontent.com/3616980/208655655-3379041a-bc5d-4bf5-a787-8f0df297e919.png)
Twenty Twenty Three (Whisper) | ![imatge](https://user-images.githubusercontent.com/3616980/208655906-1c7c1c2c-cf78-40f3-bcc9-1ded95a9526c.png) | ![imatge](https://user-images.githubusercontent.com/3616980/208655389-c9341393-fdc8-4cf0-bf4c-8ff75331f14f.png)
Zaino | ![imatge](https://user-images.githubusercontent.com/3616980/208656009-85d207e4-44d4-4d1e-85dc-2a4cddcff72d.png)| ![imatge](https://user-images.githubusercontent.com/3616980/208655323-797b8b1d-b0a6-4782-900d-6d643c51574a.png)

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

**Preparation:**

Create three posts, one with the Mini Cart block, another one with the Cart block and the last one with the Checkout block.

**Test different themes:**

1. Twenty Twenty Three:
    1.1. Install it from here: https://wordpress.org/themes/twentytwentythree/
    1.2. Go to the pages created in step 1 and verify the Mini Cart, Cart and Checkout buttons **follow** the theme styles.
    1.3. Go to Apperance > Editor > Styles > Browse Styles and change between style variations. Verify the buttons follow the styles in all of them.

2. Twenty Twenty Two (or another block theme):
    2.1. Install it from here: https://wordpress.org/themes/twentytwentytwo/
    2.2. Go to the pages created in step 1 and verify the Mini Cart, Cart and Checkout buttons **don't follow** the theme styles. Instead, they have opinionated styles.

3. Storefront (or another classic theme):
    3.1. Install it from here: https://wordpress.org/themes/storefront/
    3.2. Go to the pages created in step 1 and verify the Mini Cart, Cart and Checkout buttons **don't follow** the theme styles. Instead, they have opinionated styles.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Update Mini Cart, Cart and Checkout button styles so they follow theme styles in Twenty Twenty Three and Zaino themes.
