### PR TITLE
Avoid usage of `@wordpress/components` inside base components

### DIFF
--- a/assets/js/atomic/blocks/product-elements/button/supports.ts
+++ b/assets/js/atomic/blocks/product-elements/button/supports.ts
@@ -1,12 +1,9 @@
+/* eslint-disable @wordpress/no-unsafe-wp-apis */
 /**
  * External dependencies
  */
 import { isFeaturePluginBuild } from '@woocommerce/block-settings';
-
-/**
- * Internal dependencies
- */
-import { hasSpacingStyleSupport } from '../../../../utils/global-style';
+import { __experimentalGetSpacingClassesAndStyles } from '@wordpress/block-editor';
 
 export const supports = {
 	...( isFeaturePluginBuild() && {
@@ -20,7 +17,7 @@ export const supports = {
 			radius: true,
 			__experimentalSkipSerialization: true,
 		},
-		...( hasSpacingStyleSupport() && {
+		...( __experimentalGetSpacingClassesAndStyles === 'function' && {
 			spacing: {
 				margin: true,
 				padding: true,

--- a/assets/js/atomic/blocks/product-elements/button/supports.ts
+++ b/assets/js/atomic/blocks/product-elements/button/supports.ts
@@ -17,7 +17,7 @@ export const supports = {
 			radius: true,
 			__experimentalSkipSerialization: true,
 		},
-		...( __experimentalGetSpacingClassesAndStyles === 'function' && {
+		...( typeof __experimentalGetSpacingClassesAndStyles === 'function' && {
 			spacing: {
 				margin: true,
 				padding: true,

--- a/assets/js/atomic/blocks/product-elements/image/supports.ts
+++ b/assets/js/atomic/blocks/product-elements/image/supports.ts
@@ -20,7 +20,7 @@ export const supports = {
 			fontSize: true,
 			__experimentalSkipSerialization: true,
 		},
-		...( __experimentalGetSpacingClassesAndStyles === 'function' && {
+		...( typeof __experimentalGetSpacingClassesAndStyles === 'function' && {
 			spacing: {
 				margin: true,
 				__experimentalSkipSerialization: true,

--- a/assets/js/atomic/blocks/product-elements/image/supports.ts
+++ b/assets/js/atomic/blocks/product-elements/image/supports.ts
@@ -1,8 +1,9 @@
+/* eslint-disable @wordpress/no-unsafe-wp-apis */
 /**
  * External dependencies
  */
 import { isFeaturePluginBuild } from '@woocommerce/block-settings';
-import { hasSpacingStyleSupport } from '@woocommerce/utils';
+import { __experimentalGetSpacingClassesAndStyles } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -19,7 +20,7 @@ export const supports = {
 			fontSize: true,
 			__experimentalSkipSerialization: true,
 		},
-		...( hasSpacingStyleSupport() && {
+		...( __experimentalGetSpacingClassesAndStyles === 'function' && {
 			spacing: {
 				margin: true,
 				__experimentalSkipSerialization: true,

--- a/assets/js/atomic/blocks/product-elements/rating/support.ts
+++ b/assets/js/atomic/blocks/product-elements/rating/support.ts
@@ -17,7 +17,7 @@ export const supports = {
 			fontSize: true,
 			__experimentalSkipSerialization: true,
 		},
-		...( __experimentalGetSpacingClassesAndStyles === 'function' && {
+		...( typeof __experimentalGetSpacingClassesAndStyles === 'function' && {
 			spacing: {
 				margin: true,
 				__experimentalSkipSerialization: true,

--- a/assets/js/atomic/blocks/product-elements/rating/support.ts
+++ b/assets/js/atomic/blocks/product-elements/rating/support.ts
@@ -1,12 +1,9 @@
+/* eslint-disable @wordpress/no-unsafe-wp-apis */
 /**
  * External dependencies
  */
 import { isFeaturePluginBuild } from '@woocommerce/block-settings';
-
-/**
- * Internal dependencies
- */
-import { hasSpacingStyleSupport } from '../../../../utils/global-style';
+import { __experimentalGetSpacingClassesAndStyles } from '@wordpress/block-editor';
 
 export const supports = {
 	...( isFeaturePluginBuild() && {
@@ -20,7 +17,7 @@ export const supports = {
 			fontSize: true,
 			__experimentalSkipSerialization: true,
 		},
-		...( hasSpacingStyleSupport() && {
+		...( __experimentalGetSpacingClassesAndStyles === 'function' && {
 			spacing: {
 				margin: true,
 				__experimentalSkipSerialization: true,

--- a/assets/js/atomic/blocks/product-elements/sale-badge/support.ts
+++ b/assets/js/atomic/blocks/product-elements/sale-badge/support.ts
@@ -1,12 +1,9 @@
+/* eslint-disable @wordpress/no-unsafe-wp-apis */
 /**
  * External dependencies
  */
 import { isFeaturePluginBuild } from '@woocommerce/block-settings';
-
-/**
- * Internal dependencies
- */
-import { hasSpacingStyleSupport } from '../../../../utils/global-style';
+import { __experimentalGetSpacingClassesAndStyles } from '@wordpress/block-editor';
 
 export const supports = {
 	html: false,
@@ -27,7 +24,7 @@ export const supports = {
 			width: true,
 			__experimentalSkipSerialization: true,
 		},
-		...( hasSpacingStyleSupport() && {
+		...( __experimentalGetSpacingClassesAndStyles === 'function' && {
 			spacing: {
 				padding: true,
 				__experimentalSkipSerialization: true,

--- a/assets/js/atomic/blocks/product-elements/sale-badge/support.ts
+++ b/assets/js/atomic/blocks/product-elements/sale-badge/support.ts
@@ -24,7 +24,7 @@ export const supports = {
 			width: true,
 			__experimentalSkipSerialization: true,
 		},
-		...( __experimentalGetSpacingClassesAndStyles === 'function' && {
+		...( typeof __experimentalGetSpacingClassesAndStyles === 'function' && {
 			spacing: {
 				padding: true,
 				__experimentalSkipSerialization: true,

--- a/assets/js/atomic/blocks/product-elements/title/index.ts
+++ b/assets/js/atomic/blocks/product-elements/title/index.ts
@@ -46,7 +46,7 @@ const blockConfig: BlockConfiguration = {
 				gradients: true,
 				__experimentalSkipSerialization: true,
 			},
-			...( __experimentalGetSpacingClassesAndStyles === 'function' && {
+			...( typeof __experimentalGetSpacingClassesAndStyles === 'function' && {
 				spacing: {
 					margin: true,
 					__experimentalSkipSerialization: true,

--- a/assets/js/atomic/blocks/product-elements/title/index.ts
+++ b/assets/js/atomic/blocks/product-elements/title/index.ts
@@ -1,9 +1,11 @@
+/* eslint-disable @wordpress/no-unsafe-wp-apis */
 /**
  * External dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
 import type { BlockConfiguration } from '@wordpress/blocks';
 import { isFeaturePluginBuild } from '@woocommerce/block-settings';
+import { __experimentalGetSpacingClassesAndStyles } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -17,7 +19,6 @@ import {
 	BLOCK_DESCRIPTION as description,
 } from './constants';
 import { Save } from './save';
-import { hasSpacingStyleSupport } from '../../../../utils/global-style';
 
 const blockConfig: BlockConfiguration = {
 	...sharedConfig,
@@ -45,7 +46,7 @@ const blockConfig: BlockConfiguration = {
 				gradients: true,
 				__experimentalSkipSerialization: true,
 			},
-			...( hasSpacingStyleSupport() && {
+			...( __experimentalGetSpacingClassesAndStyles === 'function' && {
 				spacing: {
 					margin: true,
 					__experimentalSkipSerialization: true,

--- a/assets/js/atomic/blocks/product-elements/title/index.ts
+++ b/assets/js/atomic/blocks/product-elements/title/index.ts
@@ -46,7 +46,8 @@ const blockConfig: BlockConfiguration = {
 				gradients: true,
 				__experimentalSkipSerialization: true,
 			},
-			...( typeof __experimentalGetSpacingClassesAndStyles === 'function' && {
+			...( typeof __experimentalGetSpacingClassesAndStyles ===
+				'function' && {
 				spacing: {
 					margin: true,
 					__experimentalSkipSerialization: true,

--- a/assets/js/base/README.MD
+++ b/assets/js/base/README.MD
@@ -1,0 +1,17 @@
+# Base Components/Context/Hooks
+
+Base components are designed to be used on the frontend of a store. Due to this, we need to avoid using heavy WordPress externals as dependencies (wp-components, wp-block-editor, etc). To get around this, import from a local package instead.
+
+e.g. Instead of importing from `@wordpress/components`, use:
+
+```js
+import { Component } from 'wordpress-components';
+```
+
+And instead of importing from `@wordpress/block-editor`, use:
+
+```js
+import { Component } from 'wordpress-block-editor';
+```
+
+Check the built `.assets.php` files to ensure extra dependencies aren't being added to the build.

--- a/assets/js/base/README.MD
+++ b/assets/js/base/README.MD
@@ -8,10 +8,4 @@ e.g. Instead of importing from `@wordpress/components`, use:
 import { Component } from 'wordpress-components';
 ```
 
-And instead of importing from `@wordpress/block-editor`, use:
-
-```js
-import { Component } from 'wordpress-block-editor';
-```
-
 Check the built `.assets.php` files to ensure extra dependencies aren't being added to the build.

--- a/assets/js/base/README.MD
+++ b/assets/js/base/README.MD
@@ -8,4 +8,4 @@ e.g. Instead of importing from `@wordpress/components`, use:
 import { Component } from 'wordpress-components';
 ```
 
-Check the built `.assets.php` files to ensure extra dependencies aren't being added to the build.
+Check the built `*.assets.php` files to ensure extra dependencies aren't being added to the build.

--- a/assets/js/base/components/drawer/index.tsx
+++ b/assets/js/base/components/drawer/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Modal } from '@wordpress/components';
+import { Modal } from 'wordpress-components';
 import { useDebounce } from 'use-debounce';
 import classNames from 'classnames';
 

--- a/assets/js/base/hooks/use-border-props.ts
+++ b/assets/js/base/hooks/use-border-props.ts
@@ -16,6 +16,7 @@ type WithStyle = {
 };
 
 // @todo The @wordpress/block-editor dependency should never be used on the frontend of the store due to excessive side and its dependency on @wordpress/components
+// @see https://github.com/woocommerce/woocommerce-blocks/issues/8071
 export const useBorderProps = (
 	attributes: unknown
 ): WithStyle & WithClass => {

--- a/assets/js/base/hooks/use-border-props.ts
+++ b/assets/js/base/hooks/use-border-props.ts
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { __experimentalUseBorderProps } from '@wordpress/block-editor';
+import { __experimentalUseBorderProps } from 'wordpress-block-editor';
 import { isFeaturePluginBuild } from '@woocommerce/block-settings';
 import { isObject } from '@woocommerce/types';
 import { parseStyle } from '@woocommerce/base-utils';

--- a/assets/js/base/hooks/use-border-props.ts
+++ b/assets/js/base/hooks/use-border-props.ts
@@ -18,7 +18,10 @@ type WithStyle = {
 export const useBorderProps = (
 	attributes: unknown
 ): WithStyle & WithClass => {
-	if ( ! isFeaturePluginBuild() ) {
+	if (
+		! isFeaturePluginBuild() ||
+		__experimentalUseBorderProps !== 'function'
+	) {
 		return {
 			className: '',
 			style: {},

--- a/assets/js/base/hooks/use-border-props.ts
+++ b/assets/js/base/hooks/use-border-props.ts
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { __experimentalUseBorderProps } from 'wordpress-block-editor';
+import { __experimentalUseBorderProps } from '@wordpress/block-editor';
 import { isFeaturePluginBuild } from '@woocommerce/block-settings';
 import { isObject } from '@woocommerce/types';
 import { parseStyle } from '@woocommerce/base-utils';
@@ -15,6 +15,7 @@ type WithStyle = {
 	style: Record< string, unknown >;
 };
 
+// @todo The @wordpress/block-editor dependency should never be used on the frontend of the store due to excessive side and its dependency on @wordpress/components
 export const useBorderProps = (
 	attributes: unknown
 ): WithStyle & WithClass => {

--- a/assets/js/base/hooks/use-border-props.ts
+++ b/assets/js/base/hooks/use-border-props.ts
@@ -18,10 +18,7 @@ type WithStyle = {
 export const useBorderProps = (
 	attributes: unknown
 ): WithStyle & WithClass => {
-	if (
-		! isFeaturePluginBuild() ||
-		__experimentalUseBorderProps !== 'function'
-	) {
+	if ( ! isFeaturePluginBuild() ) {
 		return {
 			className: '',
 			style: {},

--- a/assets/js/base/hooks/use-color-props.ts
+++ b/assets/js/base/hooks/use-color-props.ts
@@ -16,6 +16,7 @@ type WithStyle = {
 };
 
 // @todo The @wordpress/block-editor dependency should never be used on the frontend of the store due to excessive side and its dependency on @wordpress/components
+// @see https://github.com/woocommerce/woocommerce-blocks/issues/8071
 export const useColorProps = ( attributes: unknown ): WithStyle & WithClass => {
 	if ( ! isFeaturePluginBuild() ) {
 		return {

--- a/assets/js/base/hooks/use-color-props.ts
+++ b/assets/js/base/hooks/use-color-props.ts
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { __experimentalUseColorProps } from 'wordpress-block-editor';
+import { __experimentalUseColorProps } from '@wordpress/block-editor';
 import { isFeaturePluginBuild } from '@woocommerce/block-settings';
 import { isObject } from '@woocommerce/types';
 import { parseStyle } from '@woocommerce/base-utils';
@@ -15,6 +15,7 @@ type WithStyle = {
 	style: Record< string, unknown >;
 };
 
+// @todo The @wordpress/block-editor dependency should never be used on the frontend of the store due to excessive side and its dependency on @wordpress/components
 export const useColorProps = ( attributes: unknown ): WithStyle & WithClass => {
 	if ( ! isFeaturePluginBuild() ) {
 		return {

--- a/assets/js/base/hooks/use-color-props.ts
+++ b/assets/js/base/hooks/use-color-props.ts
@@ -16,7 +16,10 @@ type WithStyle = {
 };
 
 export const useColorProps = ( attributes: unknown ): WithStyle & WithClass => {
-	if ( ! isFeaturePluginBuild() ) {
+	if (
+		! isFeaturePluginBuild() ||
+		__experimentalUseColorProps !== 'function'
+	) {
 		return {
 			className: '',
 			style: {},

--- a/assets/js/base/hooks/use-color-props.ts
+++ b/assets/js/base/hooks/use-color-props.ts
@@ -16,10 +16,7 @@ type WithStyle = {
 };
 
 export const useColorProps = ( attributes: unknown ): WithStyle & WithClass => {
-	if (
-		! isFeaturePluginBuild() ||
-		__experimentalUseColorProps !== 'function'
-	) {
+	if ( ! isFeaturePluginBuild() ) {
 		return {
 			className: '',
 			style: {},

--- a/assets/js/base/hooks/use-color-props.ts
+++ b/assets/js/base/hooks/use-color-props.ts
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { __experimentalUseColorProps } from '@wordpress/block-editor';
+import { __experimentalUseColorProps } from 'wordpress-block-editor';
 import { isFeaturePluginBuild } from '@woocommerce/block-settings';
 import { isObject } from '@woocommerce/types';
 import { parseStyle } from '@woocommerce/base-utils';

--- a/assets/js/base/hooks/use-spacing-props.ts
+++ b/assets/js/base/hooks/use-spacing-props.ts
@@ -12,10 +12,7 @@ type WithStyle = {
 };
 
 export const useSpacingProps = ( attributes: unknown ): WithStyle => {
-	if (
-		! isFeaturePluginBuild() ||
-		__experimentalGetSpacingClassesAndStyles !== 'function'
-	) {
+	if ( ! isFeaturePluginBuild() ) {
 		return {
 			style: {},
 		};

--- a/assets/js/base/hooks/use-spacing-props.ts
+++ b/assets/js/base/hooks/use-spacing-props.ts
@@ -12,6 +12,7 @@ type WithStyle = {
 };
 
 // @todo The @wordpress/block-editor dependency should never be used on the frontend of the store due to excessive side and its dependency on @wordpress/components
+// @see https://github.com/woocommerce/woocommerce-blocks/issues/8071
 export const useSpacingProps = ( attributes: unknown ): WithStyle => {
 	if ( ! isFeaturePluginBuild() ) {
 		return {

--- a/assets/js/base/hooks/use-spacing-props.ts
+++ b/assets/js/base/hooks/use-spacing-props.ts
@@ -12,7 +12,10 @@ type WithStyle = {
 };
 
 export const useSpacingProps = ( attributes: unknown ): WithStyle => {
-	if ( ! isFeaturePluginBuild() ) {
+	if (
+		! isFeaturePluginBuild() ||
+		__experimentalGetSpacingClassesAndStyles !== 'function'
+	) {
 		return {
 			style: {},
 		};

--- a/assets/js/base/hooks/use-spacing-props.ts
+++ b/assets/js/base/hooks/use-spacing-props.ts
@@ -2,10 +2,9 @@
 /**
  * External dependencies
  */
-import { __experimentalGetSpacingClassesAndStyles } from '@wordpress/block-editor';
+import { __experimentalGetSpacingClassesAndStyles } from 'wordpress-block-editor';
 import { isFeaturePluginBuild } from '@woocommerce/block-settings';
 import { isObject } from '@woocommerce/types';
-import { hasSpacingStyleSupport } from '@woocommerce/utils';
 import { parseStyle } from '@woocommerce/base-utils';
 
 type WithStyle = {
@@ -13,7 +12,7 @@ type WithStyle = {
 };
 
 export const useSpacingProps = ( attributes: unknown ): WithStyle => {
-	if ( ! isFeaturePluginBuild() || ! hasSpacingStyleSupport() ) {
+	if ( ! isFeaturePluginBuild() ) {
 		return {
 			style: {},
 		};

--- a/assets/js/base/hooks/use-spacing-props.ts
+++ b/assets/js/base/hooks/use-spacing-props.ts
@@ -2,7 +2,7 @@
 /**
  * External dependencies
  */
-import { __experimentalGetSpacingClassesAndStyles } from 'wordpress-block-editor';
+import { __experimentalGetSpacingClassesAndStyles } from '@wordpress/block-editor';
 import { isFeaturePluginBuild } from '@woocommerce/block-settings';
 import { isObject } from '@woocommerce/types';
 import { parseStyle } from '@woocommerce/base-utils';
@@ -11,6 +11,7 @@ type WithStyle = {
 	style: Record< string, unknown >;
 };
 
+// @todo The @wordpress/block-editor dependency should never be used on the frontend of the store due to excessive side and its dependency on @wordpress/components
 export const useSpacingProps = ( attributes: unknown ): WithStyle => {
 	if ( ! isFeaturePluginBuild() ) {
 		return {

--- a/assets/js/types/type-defs/blocks.ts
+++ b/assets/js/types/type-defs/blocks.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import type { BlockEditProps, BlockInstance } from '@wordpress/blocks';
-import { LazyExoticComponent } from 'react';
+import type { LazyExoticComponent } from 'react';
 
 export type EditorBlock< T > = BlockInstance< T > & BlockEditProps< T >;
 

--- a/assets/js/types/type-defs/cart-response.ts
+++ b/assets/js/types/type-defs/cart-response.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { CurrencyResponse } from './currency';
+import type { CurrencyResponse } from './currency';
 import type { CartItem } from './cart';
 import type { ProductResponseItem } from './product-response';
 

--- a/assets/js/types/type-defs/cart.ts
+++ b/assets/js/types/type-defs/cart.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { CurrencyCode } from '@woocommerce/types';
+import type { CurrencyCode } from '@woocommerce/types';
 
 /**
  * Internal dependencies

--- a/assets/js/types/type-defs/checkout.ts
+++ b/assets/js/types/type-defs/checkout.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { ShippingAddress, BillingAddress } from '@woocommerce/settings';
+import type { ShippingAddress, BillingAddress } from '@woocommerce/settings';
 
 /**
  * Internal dependencies

--- a/assets/js/types/type-defs/hooks.ts
+++ b/assets/js/types/type-defs/hooks.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { ProductResponseItem } from '@woocommerce/types';
+import type { ProductResponseItem } from '@woocommerce/types';
 
 /**
  * Internal dependencies

--- a/assets/js/types/type-defs/payment-method-interface.ts
+++ b/assets/js/types/type-defs/payment-method-interface.ts
@@ -5,7 +5,7 @@
 import type PaymentMethodLabel from '@woocommerce/base-components/cart-checkout/payment-method-label';
 import type PaymentMethodIcons from '@woocommerce/base-components/cart-checkout/payment-method-icons';
 import type LoadingMask from '@woocommerce/base-components/loading-mask';
-import { ValidationInputError } from '@woocommerce/blocks-checkout';
+import type { ValidationInputError } from '@woocommerce/blocks-checkout';
 
 /**
  * Internal dependencies

--- a/assets/js/types/type-defs/payments.ts
+++ b/assets/js/types/type-defs/payments.ts
@@ -7,7 +7,7 @@ import type { ReactNode } from 'react';
  * Internal dependencies
  */
 import type { CartTotals, Cart } from './cart';
-import {
+import type {
 	CartResponseBillingAddress,
 	CartResponseShippingAddress,
 } from './cart-response';

--- a/assets/js/types/type-defs/product-response.ts
+++ b/assets/js/types/type-defs/product-response.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { CurrencyResponse } from './currency';
+import type { CurrencyResponse } from './currency';
 
 export interface ProductResponseItemPrices extends CurrencyResponse {
 	price: string;

--- a/assets/js/types/type-guards/attributes.ts
+++ b/assets/js/types/type-guards/attributes.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { AttributeTerm, AttributeQuery } from '../type-defs';
+import type { AttributeTerm, AttributeQuery } from '../type-defs';
 import { objectHasProp } from './object';
 
 export const isAttributeTerm = ( term: unknown ): term is AttributeTerm => {

--- a/assets/js/types/type-guards/cart-response-totals.ts
+++ b/assets/js/types/type-guards/cart-response-totals.ts
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { CartResponseTotals } from '../type-defs';
+import type { CartResponseTotals } from '../type-defs';
 import { isObject } from './object';
 
 // It is the only way to create a type that contains all the object's keys and gets type-checking.

--- a/assets/js/utils/global-style.js
+++ b/assets/js/utils/global-style.js
@@ -1,8 +1,0 @@
-/* eslint-disable @wordpress/no-unsafe-wp-apis */
-/**
- * External dependencies
- */
-import { __experimentalGetSpacingClassesAndStyles } from '@wordpress/block-editor';
-
-export const hasSpacingStyleSupport = () =>
-	typeof __experimentalGetSpacingClassesAndStyles === 'function';

--- a/assets/js/utils/index.ts
+++ b/assets/js/utils/index.ts
@@ -1,7 +1,6 @@
 export * from './attributes-query';
 export * from './attributes';
 export * from './filters';
-export * from './global-style';
 export * from './notices';
 export * from './products';
 export * from './shared-attributes';

--- a/package.json
+++ b/package.json
@@ -248,8 +248,7 @@
 		"snakecase-keys": "5.4.2",
 		"trim-html": "0.1.9",
 		"use-debounce": "7.0.1",
-		"wordpress-components": "npm:@wordpress/components@14.2.0",
-		"wordpress-block-editor": "npm:@wordpress/block-editor@8.2.0"
+		"wordpress-components": "npm:@wordpress/components@14.2.0"
 	},
 	"peerDependencies": {
 		"react": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -248,7 +248,8 @@
 		"snakecase-keys": "5.4.2",
 		"trim-html": "0.1.9",
 		"use-debounce": "7.0.1",
-		"wordpress-components": "npm:@wordpress/components@14.2.0"
+		"wordpress-components": "npm:@wordpress/components@14.2.0",
+		"wordpress-block-editor": "npm:@wordpress/block-editor@8.2.0"
 	},
 	"peerDependencies": {
 		"react": "^17.0.0",

--- a/storybook/webpack.config.js
+++ b/storybook/webpack.config.js
@@ -41,9 +41,6 @@ module.exports = ( { config: storybookConfig } ) => {
 		'wordpress-components': require.resolve(
 			'../node_modules/wordpress-components'
 		),
-		'wordpress-block-editor': require.resolve(
-			'../node_modules/wordpress-block-editor'
-		),
 	};
 	storybookConfig.module.rules.push(
 		{

--- a/storybook/webpack.config.js
+++ b/storybook/webpack.config.js
@@ -41,6 +41,9 @@ module.exports = ( { config: storybookConfig } ) => {
 		'wordpress-components': require.resolve(
 			'../node_modules/wordpress-components'
 		),
+		'wordpress-block-editor': require.resolve(
+			'../node_modules/wordpress-block-editor'
+		),
 	};
 	storybookConfig.module.rules.push(
 		{


### PR DESCRIPTION
I spent some time investigating the usage of `@wordpress/components` in our `base` directory and fixed the violations I found.

- I found one violation where the `Modal` component was being imported from `@wordpress/components`. I swapped this to `wordpress-components`
- I found usage of `@wordpress/block-editor` within the `utils` directory. To avoid polluting that import, I moved the `hasSpacingStyleSupport` function check inline where used. This prevents a `@wordpress/block-editor` dependency whenever `utils` are used.
- I added missing `type` prefixes within the `@wordpress/types` directory.
- Given the changes I discovered, I added a README file inside `base` as a reminder that `@wordpress/components` should not be used directly within this directory.

There were three violations I am unable to fix, so I have added todos. The following hooks all have a `@wordpress/block-editor` dependency, and by extension, a dependency on `@wordpress/components`.

- `useBorderProps`
- `useColorProps`
- `useSpacingProps`

These hooks might need to be refactored to create styles based on props internally instead of relying on the experimental hooks from `@wordpress/block-editor` because I don't believe they are suitable for the frontend of the store. Or I guess they could be used in editor context only, and the styles saved to the HTML somehow.

cc @woocommerce/woo-fse 

Closes #5611

### Testing

Confirm successful build and test suite passes.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->
