### PR TITLE
Remove feature flag from Products block

### DIFF
--- a/assets/js/blocks/product-query/variations/product-query.tsx
+++ b/assets/js/blocks/product-query/variations/product-query.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
 import { registerBlockVariation } from '@wordpress/blocks';
 import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -19,33 +18,31 @@ import {
 
 const VARIATION_NAME = 'woocommerce/product-query';
 
-if ( isFeaturePluginBuild() ) {
-	registerBlockVariation( QUERY_LOOP_ID, {
-		description: __(
-			'A block that displays a selection of products in your store.',
-			'woo-gutenberg-products-block'
-		),
-		name: VARIATION_NAME,
-		/* translators: “Products“ is the name of the block. */
-		title: __( 'Products (Beta)', 'woo-gutenberg-products-block' ),
-		isActive: ( blockAttributes ) =>
-			blockAttributes.namespace === VARIATION_NAME,
-		icon: (
-			<Icon
-				icon={ stacks }
-				className="wc-block-editor-components-block-icon wc-block-editor-components-block-icon--stacks"
-			/>
-		),
-		attributes: {
-			...QUERY_DEFAULT_ATTRIBUTES,
-			namespace: VARIATION_NAME,
-		},
-		// Gutenberg doesn't support this type yet, discussion here:
-		// https://github.com/WordPress/gutenberg/pull/43632
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-		// @ts-ignore
-		allowedControls: DEFAULT_ALLOWED_CONTROLS,
-		innerBlocks: INNER_BLOCKS_TEMPLATE,
-		scope: [ 'inserter' ],
-	} );
-}
+registerBlockVariation( QUERY_LOOP_ID, {
+	description: __(
+		'A block that displays a selection of products in your store.',
+		'woo-gutenberg-products-block'
+	),
+	name: VARIATION_NAME,
+	/* translators: “Products“ is the name of the block. */
+	title: __( 'Products (Beta)', 'woo-gutenberg-products-block' ),
+	isActive: ( blockAttributes ) =>
+		blockAttributes.namespace === VARIATION_NAME,
+	icon: (
+		<Icon
+			icon={ stacks }
+			className="wc-block-editor-components-block-icon wc-block-editor-components-block-icon--stacks"
+		/>
+	),
+	attributes: {
+		...QUERY_DEFAULT_ATTRIBUTES,
+		namespace: VARIATION_NAME,
+	},
+	// Gutenberg doesn't support this type yet, discussion here:
+	// https://github.com/WordPress/gutenberg/pull/43632
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-ignore
+	allowedControls: DEFAULT_ALLOWED_CONTROLS,
+	innerBlocks: INNER_BLOCKS_TEMPLATE,
+	scope: [ 'inserter' ],
+} );

--- a/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md
+++ b/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md
@@ -33,7 +33,6 @@ The majority of our feature flagging is blocks, this is a list of them:
 
 ### Feature plugin flag
 
--   Products (Beta) block ([JS flag](https://github.com/woocommerce/woocommerce-blocks/blob/b1aa635572b9639ac357bde1ff134b7ca15c00d6/assets/js/blocks/product-query/variations/product-query.tsx#L28)).
 -   ⚛️ Product SKU ([JS flag](https://github.com/woocommerce/woocommerce-blocks/blob/4c18b1ff8511ede063e2082316a68eddc8231b51/assets/js/atomic/blocks/product-elements/sku/index.ts#L34)).
 -   ⚛️ Product stock indicator ([JS flag](https://github.com/woocommerce/woocommerce-blocks/blob/4c18b1ff8511ede063e2082316a68eddc8231b51/assets/js/atomic/blocks/product-elements/stock-indicator/index.ts#L38)).
 


### PR DESCRIPTION
This PR enables the Products block in WC core.

#### Other Checks

- [x] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).

### Testing

#### User Facing Testing

1. Create a post or page and verify the _Products (Beta)_ block is available form the inserter.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Enable Products block into WC core.
