### PR TITLE
Add validation to local pickup fields

### DIFF
--- a/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/attributes.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/attributes.tsx
@@ -7,6 +7,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import formStepAttributes from '../../form-step/attributes';
+import { defaultShippingText, defaultLocalPickupText } from './constants';
 
 export default {
 	...formStepAttributes( {
@@ -30,11 +31,11 @@ export default {
 	},
 	localPickupText: {
 		type: 'string',
-		default: __( 'Local Pickup', 'woo-gutenberg-products-block' ),
+		default: defaultLocalPickupText,
 	},
 	shippingText: {
 		type: 'string',
-		default: __( 'Shipping', 'woo-gutenberg-products-block' ),
+		default: defaultShippingText,
 	},
 	lock: {
 		type: 'object',

--- a/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/block.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/block.tsx
@@ -16,6 +16,7 @@ import { Icon, store, shipping } from '@wordpress/icons';
 import './style.scss';
 import { RatePrice, getLocalPickupPrices, getShippingPrices } from './shared';
 import type { minMaxPrices } from './shared';
+import { defaultLocalPickupText, defaultShippingText } from './constants';
 
 const LocalPickupSelector = ( {
 	checked,
@@ -144,7 +145,7 @@ const Block = ( {
 				rate={ getShippingPrices( shippingRates[ 0 ]?.shipping_rates ) }
 				showPrice={ showPrice }
 				showIcon={ showIcon }
-				toggleText={ shippingText }
+				toggleText={ shippingText || defaultShippingText }
 			/>
 			<LocalPickupSelector
 				checked={ checked }
@@ -154,7 +155,7 @@ const Block = ( {
 				multiple={ shippingRates.length > 1 }
 				showPrice={ showPrice }
 				showIcon={ showIcon }
-				toggleText={ localPickupText }
+				toggleText={ localPickupText || defaultLocalPickupText }
 			/>
 		</RadioGroup>
 	);

--- a/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/constants.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/constants.tsx
@@ -1,0 +1,14 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export const defaultLocalPickupText = __(
+	'Local Pickup',
+	'woo-gutenberg-products-block'
+);
+
+export const defaultShippingText = __(
+	'Shipping',
+	'woo-gutenberg-products-block'
+);

--- a/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/edit.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/edit.tsx
@@ -35,6 +35,7 @@ import {
 import { RatePrice, getLocalPickupPrices, getShippingPrices } from './shared';
 import type { minMaxPrices } from './shared';
 import './style.scss';
+import { defaultShippingText, defaultLocalPickupText } from './constants';
 
 const LocalPickupSelector = ( {
 	checked,
@@ -71,6 +72,7 @@ const LocalPickupSelector = ( {
 			) }
 			<RichText
 				value={ toggleText }
+				placeholder={ defaultLocalPickupText }
 				tagName="span"
 				className="wc-block-checkout__shipping-method-option-title"
 				onChange={ ( value ) =>
@@ -133,6 +135,7 @@ const ShippingSelector = ( {
 			) }
 			<RichText
 				value={ toggleText }
+				placeholder={ defaultShippingText }
 				tagName="span"
 				className="wc-block-checkout__shipping-method-option-title"
 				onChange={ ( value ) =>

--- a/assets/js/extensions/shipping-methods/pickup-location/edit-location/form.tsx
+++ b/assets/js/extensions/shipping-methods/pickup-location/edit-location/form.tsx
@@ -53,6 +53,7 @@ const Form = ( {
 				value={ values.name }
 				onChange={ setLocationField( 'name' ) }
 				autoComplete="off"
+				required={ true }
 			/>
 			<TextControl
 				label={ __( 'Address', 'woo-gutenberg-products-block' ) }

--- a/assets/js/extensions/shipping-methods/pickup-location/edit-location/index.tsx
+++ b/assets/js/extensions/shipping-methods/pickup-location/edit-location/index.tsx
@@ -68,8 +68,14 @@ const EditLocation = ( {
 					</Button>
 					<Button
 						variant="primary"
-						onClick={ () => {
-							if ( formRef?.current?.reportValidity() ) {
+						onClick={ (
+							event: React.MouseEvent<
+								HTMLButtonElement,
+								MouseEvent
+							>
+						) => {
+							const target = event.target as HTMLButtonElement;
+							if ( target?.form?.reportValidity() ) {
 								onSave( values );
 								onClose();
 							}

--- a/assets/js/extensions/shipping-methods/pickup-location/edit-location/index.tsx
+++ b/assets/js/extensions/shipping-methods/pickup-location/edit-location/index.tsx
@@ -68,14 +68,10 @@ const EditLocation = ( {
 					</Button>
 					<Button
 						variant="primary"
-						onClick={ (
-							event: React.MouseEvent<
-								HTMLButtonElement,
-								MouseEvent
-							>
-						) => {
-							const target = event.target as HTMLButtonElement;
-							if ( target?.form?.reportValidity() ) {
+						onClick={ () => {
+							const form =
+								formRef?.current as unknown as HTMLFormElement;
+							if ( form.reportValidity() ) {
 								onSave( values );
 								onClose();
 							}

--- a/assets/js/extensions/shipping-methods/pickup-location/edit-location/index.tsx
+++ b/assets/js/extensions/shipping-methods/pickup-location/edit-location/index.tsx
@@ -69,8 +69,10 @@ const EditLocation = ( {
 					<Button
 						variant="primary"
 						onClick={ () => {
-							onSave( values );
-							onClose();
+							if ( formRef?.current?.reportValidity() ) {
+								onSave( values );
+								onClose();
+							}
 						} }
 					>
 						{ __( 'Done', 'woo-gutenberg-products-block' ) }

--- a/assets/js/extensions/shipping-methods/pickup-location/general-settings.tsx
+++ b/assets/js/extensions/shipping-methods/pickup-location/general-settings.tsx
@@ -98,6 +98,7 @@ const GeneralSettings = () => {
 					onChange={ setSettingField( 'title' ) }
 					disabled={ false }
 					autoComplete="off"
+					required={ true }
 				/>
 				<CheckboxControl
 					checked={ showCosts }

--- a/assets/js/extensions/shipping-methods/pickup-location/save.tsx
+++ b/assets/js/extensions/shipping-methods/pickup-location/save.tsx
@@ -26,7 +26,12 @@ const SaveSettings = () => {
 				variant="primary"
 				isBusy={ isSaving }
 				disabled={ isSaving }
-				onClick={ save }
+				onClick={ ( event ) => {
+					if ( event.target.form.reportValidity() ) {
+						save();
+					}
+				} }
+				type="submit"
 			>
 				{ __( 'Save changes', 'woo-gutenberg-products-block' ) }
 			</Button>

--- a/assets/js/extensions/shipping-methods/pickup-location/save.tsx
+++ b/assets/js/extensions/shipping-methods/pickup-location/save.tsx
@@ -26,8 +26,11 @@ const SaveSettings = () => {
 				variant="primary"
 				isBusy={ isSaving }
 				disabled={ isSaving }
-				onClick={ ( event ) => {
-					if ( event.target.form.reportValidity() ) {
+				onClick={ (
+					event: React.MouseEvent< HTMLButtonElement, MouseEvent >
+				) => {
+					const target = event.target as HTMLButtonElement;
+					if ( target?.form?.reportValidity() ) {
 						save();
 					}
 				} }

--- a/assets/js/extensions/shipping-methods/pickup-location/settings-page.tsx
+++ b/assets/js/extensions/shipping-methods/pickup-location/settings-page.tsx
@@ -11,7 +11,7 @@ import LocationSettings from './location-settings';
 import SaveSettings from './save';
 import { SettingsProvider } from './settings-context';
 
-const SettingsWrapper = styled.div`
+const SettingsWrapper = styled.form`
 	margin: 48px auto 0;
 	max-width: 1032px;
 	display: flex;


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This adds simple validation to form fields to prevent empty values from being persisted. It adds it to the modal, the general form, and the editor.
<!-- Reference any related issues or PRs here -->

Fixes #7988
Fixes #7989
Fixes #7991

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Screenshots

<img width="648" alt="image" src="https://user-images.githubusercontent.com/6165348/208938395-bb4e2e38-4e25-4c9c-bcd7-b30641bfd393.png">
<img width="742" alt="image" src="https://user-images.githubusercontent.com/6165348/208938716-6a0f7164-23bc-43b3-a1d8-53aaeae56354.png">
<img width="575" alt="image" src="https://user-images.githubusercontent.com/6165348/208939332-fe897d5d-83d1-498a-a5ad-4ed9b6dac2e7.png">


### Testing

1. On the settings screen, empty the local pickup title, attempt to save, you should get an error and it won't save.
2. Fill the field, you can now save.
3. In the location modal, you can't add a new location without a title.
4. In the editor, if you empty the toggle title, you should see a placeholder with the original value. Saving regardless will show the original value in the frontend.

