### PR TITLE
Enable Product SKU and Product Stock Indicator in Core

### DIFF
--- a/assets/js/atomic/blocks/product-elements/sku/index.ts
+++ b/assets/js/atomic/blocks/product-elements/sku/index.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { registerFeaturePluginBlockType } from '@woocommerce/block-settings';
+import { registerBlockType } from '@wordpress/blocks';
 import type { BlockConfiguration } from '@wordpress/blocks';
 
 /**
@@ -31,7 +31,7 @@ const blockConfig: BlockConfiguration = {
 	edit,
 };
 
-registerFeaturePluginBlockType( 'woocommerce/product-sku', {
+registerBlockType( 'woocommerce/product-sku', {
 	...sharedConfig,
 	...blockConfig,
 } );

--- a/assets/js/atomic/blocks/product-elements/stock-indicator/index.ts
+++ b/assets/js/atomic/blocks/product-elements/stock-indicator/index.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { registerFeaturePluginBlockType } from '@woocommerce/block-settings';
+import { registerBlockType } from '@wordpress/blocks';
 import type { BlockConfiguration } from '@wordpress/blocks';
 
 /**
@@ -35,6 +35,6 @@ const blockConfig: BlockConfiguration = {
 	],
 };
 
-registerFeaturePluginBlockType( 'woocommerce/product-stock-indicator', {
+registerBlockType( 'woocommerce/product-stock-indicator', {
 	...blockConfig,
 } );

--- a/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md
+++ b/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md
@@ -33,8 +33,6 @@ The majority of our feature flagging is blocks, this is a list of them:
 
 ### Feature plugin flag
 
--   ⚛️ Product SKU ([JS flag](https://github.com/woocommerce/woocommerce-blocks/blob/4c18b1ff8511ede063e2082316a68eddc8231b51/assets/js/atomic/blocks/product-elements/sku/index.ts#L34)).
--   ⚛️ Product stock indicator ([JS flag](https://github.com/woocommerce/woocommerce-blocks/blob/4c18b1ff8511ede063e2082316a68eddc8231b51/assets/js/atomic/blocks/product-elements/stock-indicator/index.ts#L38)).
 
 ### Experimental flag
 


### PR DESCRIPTION
This PR enables the _Product SKU_ and _Product Stock Indicator_ blocks in WC core.

#### Other Checks

- [x] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).

### Testing

#### User Facing Testing

1. Create a post or page and add the _Products (Beta)_ block.
2. Be sure that _Product SKU_ and _Product Stock Indicator_ blocks are visible and can be added.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Enable Product SKU and Product Stock Indicator blocks into WC core.
