### PR TITLE
Fix: workflows using comment-aggregator are failing on trunk

### DIFF
--- a/.github/comments-aggregator/README.md
+++ b/.github/comments-aggregator/README.md
@@ -28,7 +28,7 @@ This action is meant to be used as the poster/commenter. Instead of having exist
 
 - **`repo-token`** (required): This is the GitHub token. This is required to manipulate PR comments.
 - **`section-id`** (required): The unique ID that helps this action to update the correct part of the aggregated comment.
-- **`content`** (required): The comment content.
+- **`content`** (option): The comment content. Default to empty. If nothing was provided, this action will stop gracefully.
 - **`order`** (optional): The order of the comment part inside the aggregated comment. Default to 10.
 
 ## More examples

--- a/.github/comments-aggregator/action.yml
+++ b/.github/comments-aggregator/action.yml
@@ -9,7 +9,7 @@ inputs:
         required: true
     content:
         description: 'Comment content'
-        required: true
+        default: ''
     order:
         description: 'Order of the comment'
         required: false 

--- a/.github/comments-aggregator/index.js
+++ b/.github/comments-aggregator/index.js
@@ -16,12 +16,17 @@ const runner = async () => {
 		const payload = context.payload;
 		const repo = payload.repository.name;
 		const owner = payload.repository.owner.login;
+
+		// Only run this action on pull requests.
+		if ( ! payload.pull_request?.number ) {
+			return;
+		}
+
 		const sectionId = getInput( 'section-id', {
 			required: true,
 		} );
-		const content = getInput( 'content', {
-			required: true,
-		} );
+
+		const content = getInput( 'content' );
 		const order = getInput( 'order' );
 
 		if ( ! sectionId || ! content ) {

--- a/.github/comments-aggregator/utils.js
+++ b/.github/comments-aggregator/utils.js
@@ -1,7 +1,7 @@
 const identifier = `<!-- comments-aggregator -->`;
 const separator = '<!-- separator -->';
 const footerText =
-	'[comments-aggregator](https://github.com/woocommerce/woocommerce-blocks/tree/trunk/.github/comments-aggregator).';
+	'[comments-aggregator](https://github.com/woocommerce/woocommerce-blocks/tree/trunk/.github/comments-aggregator)';
 const footer = `\n> <sub>${ footerText }</sub>\n${ identifier }`;
 
 function getSectionId( section ) {

--- a/.github/monitor-typescript-errors/index.js
+++ b/.github/monitor-typescript-errors/index.js
@@ -59,7 +59,6 @@ const runner = async () => {
 	}
 
 	if ( process.env[ 'CURRENT_BRANCH' ] === 'trunk' ) {
-		setOutput( 'comment', '' );
 		try {
 			await addRecord( currentCheckStyleFileContentParsed.totalErrors );
 		} catch ( error ) {

--- a/.github/monitor-typescript-errors/index.js
+++ b/.github/monitor-typescript-errors/index.js
@@ -59,6 +59,7 @@ const runner = async () => {
 	}
 
 	if ( process.env[ 'CURRENT_BRANCH' ] === 'trunk' ) {
+		setOutput( 'comment', '' );
 		try {
 			await addRecord( currentCheckStyleFileContentParsed.totalErrors );
 		} catch ( error ) {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Follow-up #7973 

This PR updates the `comment-aggregator` action to prevent it run on the trunk. This PR will fix the failed job like https://github.com/woocommerce/woocommerce-blocks/actions/runs/3750578628/jobs/6370472465