### PR TITLE
Add an errorGroup property for the validation store

### DIFF
--- a/assets/js/base/components/cart-checkout/address-form/address-form.tsx
+++ b/assets/js/base/components/cart-checkout/address-form/address-form.tsx
@@ -153,6 +153,9 @@ const AddressForm = ( {
 					return null;
 				}
 
+				const errorGroup =
+					type === 'shipping' ? 'shippingAddress' : 'billingAddress';
+
 				if ( field.key === 'country' ) {
 					const Tag =
 						type === 'shipping'
@@ -181,6 +184,7 @@ const AddressForm = ( {
 									? 'shipping-missing-country'
 									: null
 							}
+							errorGroup={ errorGroup }
 							errorMessage={ field.errorMessage }
 							required={ field.required }
 						/>
@@ -212,6 +216,7 @@ const AddressForm = ( {
 							}
 							errorMessage={ field.errorMessage }
 							required={ field.required }
+							errorGroup={ errorGroup }
 						/>
 					);
 				}
@@ -220,6 +225,7 @@ const AddressForm = ( {
 					<ValidatedTextInput
 						key={ field.key }
 						id={ `${ id }-${ field.key }` }
+						errorGroup={ errorGroup }
 						className={ `wc-block-components-address-form__${ field.key }` }
 						label={
 							field.required ? field.label : field.optionalLabel

--- a/assets/js/base/components/combobox/index.tsx
+++ b/assets/js/base/components/combobox/index.tsx
@@ -25,6 +25,7 @@ export interface ComboboxProps {
 	autoComplete?: string;
 	className?: string;
 	errorId: string | null;
+	errorGroup?: string | undefined;
 	errorMessage?: string;
 	id: string;
 	instanceId?: string;
@@ -51,6 +52,7 @@ const Combobox = ( {
 		'woo-gutenberg-products-block'
 	),
 	errorId: incomingErrorId,
+	errorGroup = 'default',
 	instanceId = '0',
 	autoComplete = 'off',
 }: ComboboxProps ): JSX.Element => {
@@ -73,6 +75,7 @@ const Combobox = ( {
 				[ errorId ]: {
 					message: errorMessage,
 					hidden: true,
+					errorGroup,
 				},
 			} );
 		}
@@ -86,6 +89,7 @@ const Combobox = ( {
 		errorMessage,
 		required,
 		setValidationErrors,
+		errorGroup,
 	] );
 
 	// @todo Remove patch for ComboboxControl once https://github.com/WordPress/gutenberg/pull/33928 is released

--- a/assets/js/base/components/country-input/country-input.tsx
+++ b/assets/js/base/components/country-input/country-input.tsx
@@ -27,6 +27,7 @@ export const CountryInput = ( {
 		'Please select a country.',
 		'woo-gutenberg-products-block'
 	),
+	errorGroup = 'default',
 }: CountryInputWithCountriesProps ): JSX.Element => {
 	const options = useMemo(
 		() =>
@@ -56,6 +57,7 @@ export const CountryInput = ( {
 				errorMessage={ errorMessage }
 				required={ required }
 				autoComplete={ autoComplete }
+				errorGroup={ errorGroup }
 			/>
 		</div>
 	);

--- a/assets/js/base/components/state-input/StateInputProps.ts
+++ b/assets/js/base/components/state-input/StateInputProps.ts
@@ -8,6 +8,7 @@ export interface StateInputProps {
 	onChange: ( value: string ) => void;
 	required?: boolean;
 	errorMessage?: string;
+	errorGroup?: string | undefined;
 }
 
 export type StateInputWithStatesProps = StateInputProps & {

--- a/assets/js/base/components/state-input/state-input.tsx
+++ b/assets/js/base/components/state-input/state-input.tsx
@@ -36,6 +36,7 @@ const StateInput = ( {
 	autoComplete = 'off',
 	value = '',
 	required = false,
+	errorGroup = 'default',
 }: StateInputWithStatesProps ): JSX.Element => {
 	const countryStates = states[ country ];
 	const options = useMemo(
@@ -104,6 +105,7 @@ const StateInput = ( {
 				) }
 				required={ required }
 				autoComplete={ autoComplete }
+				errorGroup={ errorGroup }
 			/>
 		);
 	}
@@ -117,6 +119,7 @@ const StateInput = ( {
 			autoComplete={ autoComplete }
 			value={ value }
 			required={ required }
+			errorGroup={ errorGroup }
 		/>
 	);
 };

--- a/assets/js/data/cart/push-changes.ts
+++ b/assets/js/data/cart/push-changes.ts
@@ -118,11 +118,14 @@ const updateCustomerData = debounce( (): void => {
  */
 export const pushChanges = (): void => {
 	const store = select( STORE_KEY );
-	const hasValidationErrors =
-		select( VALIDATION_STORE_KEY ).hasValidationErrors();
+	const { hasValidationError } = select( VALIDATION_STORE_KEY );
 	const isInitialized = store.hasFinishedResolution( 'getCartData' );
 
-	if ( ! isInitialized || hasValidationErrors ) {
+	if (
+		! isInitialized ||
+		hasValidationError( 'shippingAddress' ) ||
+		hasValidationError( 'billingAddress' )
+	) {
 		return;
 	}
 

--- a/assets/js/data/validation/selectors.ts
+++ b/assets/js/data/validation/selectors.ts
@@ -36,3 +36,18 @@ export const getValidationErrorId = ( state: State, errorId: string ) => {
 export const hasValidationErrors = ( state: State ) => {
 	return Object.keys( state ).length > 0;
 };
+
+/**
+ * Whether the store has a particular type of validation error.
+ */
+export const hasValidationError = (
+	state: State,
+	errorGroup?: string | undefined
+) => {
+	if ( errorGroup ) {
+		return Object.keys( state ).some(
+			( errorId ) => state[ errorId ].errorGroup === errorGroup
+		);
+	}
+	return Object.keys( state ).length > 0;
+};

--- a/packages/checkout/components/text-input/validated-text-input.tsx
+++ b/packages/checkout/components/text-input/validated-text-input.tsx
@@ -32,7 +32,8 @@ interface ValidatedTextInputProps
 	instanceId: string;
 	className?: string | undefined;
 	ariaDescribedBy?: string | undefined;
-	errorId?: string;
+	errorId?: string | undefined;
+	errorGroup?: string | undefined;
 	focusOnMount?: boolean;
 	showError?: boolean;
 	errorMessage?: string | undefined;
@@ -51,6 +52,7 @@ const ValidatedTextInput = ( {
 	id,
 	ariaDescribedBy,
 	errorId,
+	errorGroup = 'default',
 	focusOnMount = false,
 	onChange,
 	showError = true,
@@ -111,6 +113,7 @@ const ValidatedTextInput = ( {
 						inputObject.validationMessage ||
 						__( 'Invalid value.', 'woo-gutenberg-products-block' ),
 					hidden: errorsHidden,
+					errorGroup,
 				},
 			} );
 		},
@@ -118,6 +121,7 @@ const ValidatedTextInput = ( {
 			clearValidationError,
 			customValidation,
 			errorIdString,
+			errorGroup,
 			requiredMessage,
 			setValidationErrors,
 		]


### PR DESCRIPTION
Allows errors to have a defined group (`errorGroup`) which can later be checked to see if a particular group of fields has a validation issue, for example:

```js
hasValidationError( 'shippingAddress' )
```

This allows us to push changes if an address does not have a validation issue, without other validation issues (in later steps, such as missing terms and conditions checkbox) from influencing the server push.
