### PR TITLE
9.1.1 testing steps: move testing steps for PR #7909 and #7914 under 'Feature plugin'

### DIFF
--- a/docs/internal-developers/testing/releases/911.md
+++ b/docs/internal-developers/testing/releases/911.md
@@ -225,6 +225,31 @@ Steps:
 - The layout of product in Products and Classic Template is as on the screenshots above
 - The layout of the Filter by Rating and All Products doesn't change
 
+### Update MiniCart.php to fix price total amount on page load prices are including tax ([7832](https://github.com/woocommerce/woocommerce-blocks/pull/7832))
+
+1. In WooCommerce > Settings check _Enable tax rates and calculations_.
+2. In the _Tax_ tab that appears go to _Tax options_ and  set _Display prices during cart and checkout_ to _Including tax_.
+3. In _Standard rates_, create a tax rate with `Rate %` of `10`.
+4. Create a post or page and add the Mini Cart block.
+5. In the frontend, hover the Mini Cart block with the mouse and notice the price doesn't update ([before](https://user-images.githubusercontent.com/3616980/206694129-c16fcea4-8ac4-4bd7-a72a-221946c3ef08.webm) and [after](https://user-images.githubusercontent.com/3616980/206694060-eee1cccf-1ebd-435d-995d-23caca715918.webm)).
+
+### Product Query: Add `Sorted by title` preset. ([7949](https://github.com/woocommerce/woocommerce-blocks/pull/7949))
+
+1. Add a new page.
+2. Add the Products (Beta) block to the page.
+3. See products are ordered by title.
+4. Open the sidebar setting.
+5. See the Popular Filters setting is expanded by default and the `Sorted by title` is selected.
+
+### Atomic Blocks: fix ancestor definition ([7947](https://github.com/woocommerce/woocommerce-blocks/pull/7947))
+
+1. Go to Editor
+2. Add an All Products block
+3. Enter the "Edit the layout of each product" mode (click on the pencil icon)
+4. Be sure that it is possible to add atomic blocks.
+
+## Feature Plugin
+
 ### Product Elements: Fix block settings ([7914](https://github.com/woocommerce/woocommerce-blocks/pull/7914))
 
 1. Create a page and add the **Products (Beta)** block.
@@ -251,26 +276,3 @@ Steps:
 Make sure to test in both 'Linked' and 'Unlinked' modes ( one value for all 4 sides, custom values for each side, some sides not set etc. ).
 
 Make sure for any of the scenarios no PHP errors and notices are being generated and the options display correct visual results on the page (frontend).
-
-### Update MiniCart.php to fix price total amount on page load prices are including tax ([7832](https://github.com/woocommerce/woocommerce-blocks/pull/7832))
-
-1. In WooCommerce > Settings check _Enable tax rates and calculations_.
-2. In the _Tax_ tab that appears go to _Tax options_ and  set _Display prices during cart and checkout_ to _Including tax_.
-3. In _Standard rates_, create a tax rate with `Rate %` of `10`.
-4. Create a post or page and add the Mini Cart block.
-5. In the frontend, hover the Mini Cart block with the mouse and notice the price doesn't update ([before](https://user-images.githubusercontent.com/3616980/206694129-c16fcea4-8ac4-4bd7-a72a-221946c3ef08.webm) and [after](https://user-images.githubusercontent.com/3616980/206694060-eee1cccf-1ebd-435d-995d-23caca715918.webm)).
-
-### Product Query: Add `Sorted by title` preset. ([7949](https://github.com/woocommerce/woocommerce-blocks/pull/7949))
-
-1. Add a new page.
-2. Add the Products (Beta) block to the page.
-3. See products are ordered by title.
-4. Open the sidebar setting.
-5. See the Popular Filters setting is expanded by default and the `Sorted by title` is selected.
-
-### Atomic Blocks: fix ancestor definition ([7947](https://github.com/woocommerce/woocommerce-blocks/pull/7947))
-
-1. Go to Editor
-2. Add an All Products block
-3. Enter the "Edit the layout of each product" mode (click on the pencil icon)
-4. Be sure that it is possible to add atomic blocks.


### PR DESCRIPTION
The settings modified in #7909 and #7914 are not available in WC core, so we should move those testing steps under _Feature Plugin_. 

### Testing

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
