### PR TITLE
Make each Bundle Analyzer report open in new tab with the proper title

### DIFF
--- a/bin/webpack-configs.js
+++ b/bin/webpack-configs.js
@@ -496,7 +496,9 @@ const getPaymentsConfig = ( options = {} ) => {
 			],
 		},
 		plugins: [
-			...getSharedPlugins( { bundleAnalyzerReportTitle: 'Payment' } ),
+			...getSharedPlugins( {
+				bundleAnalyzerReportTitle: 'Payment Method Extensions',
+			} ),
 			new ProgressBarPlugin(
 				getProgressBarPluginConfig( 'Payment Method Extensions' )
 			),
@@ -590,7 +592,9 @@ const getExtensionsConfig = ( options = {} ) => {
 			],
 		},
 		plugins: [
-			...getSharedPlugins( { bundleAnalyzerReportTitle: 'Extensions' } ),
+			...getSharedPlugins( {
+				bundleAnalyzerReportTitle: 'Experimental Extensions',
+			} ),
 			new ProgressBarPlugin(
 				getProgressBarPluginConfig( 'Experimental Extensions' )
 			),

--- a/bin/webpack-configs.js
+++ b/bin/webpack-configs.js
@@ -34,25 +34,31 @@ const isProduction = NODE_ENV === 'production';
 /**
  * Shared config for all script builds.
  */
-const sharedPlugins = [
-	CHECK_CIRCULAR_DEPS === 'true'
-		? new CircularDependencyPlugin( {
-				exclude: /node_modules/,
-				cwd: process.cwd(),
-				failOnError: 'warn',
-		  } )
-		: false,
-	// The WP_BUNDLE_ANALYZER global variable enables a utility that represents bundle
-	// content as a convenient interactive zoomable treemap.
-	process.env.WP_BUNDLE_ANALYZER && new BundleAnalyzerPlugin(),
-	new DependencyExtractionWebpackPlugin( {
-		injectPolyfill: true,
-		combineAssets: ASSET_CHECK,
-		outputFormat: ASSET_CHECK ? 'json' : 'php',
-		requestToExternal,
-		requestToHandle,
-	} ),
-].filter( Boolean );
+let initialBundleAnalyzerPort = 8888;
+const getSharedPlugins = ( { bundleAnalyzerReportTitle } ) =>
+	[
+		CHECK_CIRCULAR_DEPS === 'true'
+			? new CircularDependencyPlugin( {
+					exclude: /node_modules/,
+					cwd: process.cwd(),
+					failOnError: 'warn',
+			  } )
+			: false,
+		// The WP_BUNDLE_ANALYZER global variable enables a utility that represents bundle
+		// content as a convenient interactive zoomable treemap.
+		process.env.WP_BUNDLE_ANALYZER &&
+			new BundleAnalyzerPlugin( {
+				analyzerPort: initialBundleAnalyzerPort++,
+				reportTitle: bundleAnalyzerReportTitle,
+			} ),
+		new DependencyExtractionWebpackPlugin( {
+			injectPolyfill: true,
+			combineAssets: ASSET_CHECK,
+			outputFormat: ASSET_CHECK ? 'json' : 'php',
+			requestToExternal,
+			requestToHandle,
+		} ),
+	].filter( Boolean );
 
 /**
  * Build config for core packages.
@@ -104,7 +110,7 @@ const getCoreConfig = ( options = {} ) => {
 			],
 		},
 		plugins: [
-			...sharedPlugins,
+			...getSharedPlugins( { bundleAnalyzerReportTitle: 'Core' } ),
 			new ProgressBarPlugin( getProgressBarPluginConfig( 'Core' ) ),
 			new CreateFileWebpack( {
 				path: './',
@@ -252,7 +258,7 @@ const getMainConfig = ( options = {} ) => {
 			],
 		},
 		plugins: [
-			...sharedPlugins,
+			...getSharedPlugins( { bundleAnalyzerReportTitle: 'Main' } ),
 			new ProgressBarPlugin( getProgressBarPluginConfig( 'Main' ) ),
 			new CopyWebpackPlugin( {
 				patterns: [
@@ -389,7 +395,7 @@ const getFrontConfig = ( options = {} ) => {
 			],
 		},
 		plugins: [
-			...sharedPlugins,
+			...getSharedPlugins( { bundleAnalyzerReportTitle: 'Frontend' } ),
 			new ProgressBarPlugin( getProgressBarPluginConfig( 'Frontend' ) ),
 		],
 		resolve: {
@@ -490,7 +496,7 @@ const getPaymentsConfig = ( options = {} ) => {
 			],
 		},
 		plugins: [
-			...sharedPlugins,
+			...getSharedPlugins( { bundleAnalyzerReportTitle: 'Payment' } ),
 			new ProgressBarPlugin(
 				getProgressBarPluginConfig( 'Payment Method Extensions' )
 			),
@@ -584,7 +590,7 @@ const getExtensionsConfig = ( options = {} ) => {
 			],
 		},
 		plugins: [
-			...sharedPlugins,
+			...getSharedPlugins( { bundleAnalyzerReportTitle: 'Extensions' } ),
 			new ProgressBarPlugin(
 				getProgressBarPluginConfig( 'Experimental Extensions' )
 			),


### PR DESCRIPTION
There are currently five building processes. When running `npm run analyze-bundles`, five reports are generated. However one report overrides the previous one (in the same tab/port) and it's time dependant. Whichever finishes the last, this one will be displayed as final.

Looking at the reports through this process is confusing as it seems it evolves, rather then overrides and the final report may different between runs (in fact those are simply different reports you may see, but it may look like different build result).

This PR makes each Bundle Analyzer report open in new tab on a separate port and with a proper title: Core, Main, Frontend, Payments, Extensions (see videos below).

### Screenshots

| Before | After |
| ------ | ----- |
|   https://user-images.githubusercontent.com/20098064/209946491-0b316966-7291-431e-8ee4-56c6dba45e91.mov |   https://user-images.githubusercontent.com/20098064/209946425-cc9dc092-3c15-4c73-995b-8265dff0adb5.mov  |






#### User Facing Testing

1. When in project, run `npm run analyze-bundles`

**Expected:** Bundle Analyzer reports are open in 5 separate tabs, each named accordingly: Core, Main, Frontend, Payments, Extensions

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->
