### PR TITLE
Update E2E tests for Gutenberg 14.8.x

### DIFF
--- a/tests/e2e/specs/backend/cart.test.js
+++ b/tests/e2e/specs/backend/cart.test.js
@@ -136,6 +136,9 @@ describe( `${ block.name } Block`, () => {
 			await closeModalIfExists();
 			await openWidgetsEditorBlockInserter();
 			await searchForBlock( block.name );
+			await page.waitForXPath(
+				`//button//span[text()='${ block.name }']`
+			);
 			const cartButton = await page.$x(
 				`//button//span[text()='${ block.name }']`
 			);

--- a/tests/e2e/specs/backend/mini-cart.test.js
+++ b/tests/e2e/specs/backend/mini-cart.test.js
@@ -41,6 +41,7 @@ const addBlockToWidgetsArea = async () => {
 	await closeModalIfExists();
 	await openWidgetsEditorBlockInserter();
 	await searchForBlock( block.name );
+	await page.waitForXPath( block.selectors.insertButton );
 	const miniCartButton = await page.$x( block.selectors.insertButton );
 	await miniCartButton[ 0 ].click();
 };

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -167,7 +167,10 @@ export const isBlockInsertedInWidgetsArea = async ( blockName ) => {
 export async function goToSiteEditor( params = {} ) {
 	await visitAdminPage( 'site-editor.php', addQueryArgs( '', params ) );
 
-	if ( GUTENBERG_EDITOR_CONTEXT === 'gutenberg' && params.postId ) {
+	if (
+		GUTENBERG_EDITOR_CONTEXT === 'gutenberg' &&
+		( params?.postId || Object.keys( params ).length === 0 )
+	) {
 		await page.waitForSelector( SELECTORS.templateEditor.editButton );
 		await page.click( SELECTORS.templateEditor.editButton );
 	}

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -167,7 +167,7 @@ export const isBlockInsertedInWidgetsArea = async ( blockName ) => {
 export async function goToSiteEditor( params = {} ) {
 	await visitAdminPage( 'site-editor.php', addQueryArgs( '', params ) );
 
-	if ( GUTENBERG_EDITOR_CONTEXT === 'gutenberg' ) {
+	if ( GUTENBERG_EDITOR_CONTEXT === 'gutenberg' && params.postId ) {
 		await page.waitForSelector( SELECTORS.templateEditor.editButton );
 		await page.click( SELECTORS.templateEditor.editButton );
 	}

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -93,6 +93,7 @@ export async function searchForBlock( searchTerm ) {
 export async function insertBlockDontWaitForInsertClose( searchTerm ) {
 	await openGlobalBlockInserter();
 	await searchForBlock( searchTerm );
+	await page.waitForXPath( `//button//span[text()='${ searchTerm }']` );
 	const insertButton = (
 		await page.$x( `//button//span[text()='${ searchTerm }']` )
 	 )[ 0 ];
@@ -164,10 +165,12 @@ export const isBlockInsertedInWidgetsArea = async ( blockName ) => {
  * @param {'wp_template' | 'wp_template_part'} [params.postType='wp_template'] Type of template.
  */
 export async function goToSiteEditor( params = {} ) {
-	return await visitAdminPage(
-		'site-editor.php',
-		addQueryArgs( '', params )
-	);
+	await visitAdminPage( 'site-editor.php', addQueryArgs( '', params ) );
+
+	if ( GUTENBERG_EDITOR_CONTEXT === 'gutenberg' ) {
+		await page.waitForSelector( SELECTORS.templateEditor.editButton );
+		await page.click( SELECTORS.templateEditor.editButton );
+	}
 }
 
 /**
@@ -188,10 +191,6 @@ export async function goToTemplateEditor( {
 
 	await disableSiteEditorWelcomeGuide();
 	await waitForCanvas();
-	if ( GUTENBERG_EDITOR_CONTEXT === 'gutenberg' ) {
-		await page.waitForSelector( SELECTORS.templateEditor.editButton );
-		await page.click( SELECTORS.templateEditor.editButton );
-	}
 }
 
 /**

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -167,6 +167,7 @@ export const isBlockInsertedInWidgetsArea = async ( blockName ) => {
 export async function goToSiteEditor( params = {} ) {
 	await visitAdminPage( 'site-editor.php', addQueryArgs( '', params ) );
 
+	// @todo Remove the Gutenberg guard clause in goToSiteEditor when WP 6.2 is released.
 	if (
 		GUTENBERG_EDITOR_CONTEXT === 'gutenberg' &&
 		( params?.postId || Object.keys( params ).length === 0 )

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -64,6 +64,10 @@ const SELECTORS = {
 		saveButton: '.edit-site-save-button__button',
 		savePrompt: '.entities-saved-states__text-prompt',
 	},
+	templateEditor: {
+		editButton:
+			'.edit-site-layout__edit-button[aria-label="Open the editor"]',
+	},
 };
 
 /**
@@ -184,6 +188,10 @@ export async function goToTemplateEditor( {
 
 	await disableSiteEditorWelcomeGuide();
 	await waitForCanvas();
+	if ( GUTENBERG_EDITOR_CONTEXT === 'gutenberg' ) {
+		await page.waitForSelector( SELECTORS.templateEditor.editButton );
+		await page.click( SELECTORS.templateEditor.editButton );
+	}
 }
 
 /**


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #8047 

This PR updates our E2E tests to address the new updates introduced in Gutenberg 14.8:
- Waits for the blocks list to be loaded after searching for a block.
- Gutenberg now shows the preview of templates/template parts by default, this PR triggers the edit mode when visiting the Site Editor.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests
