### PR TITLE
Update FormTokenField styles after @wordpress/components update

### DIFF
--- a/assets/js/base/components/form-token-field/style.scss
+++ b/assets/js/base/components/form-token-field/style.scss
@@ -31,7 +31,6 @@
 
 		.components-form-token-field__token-text,
 		input[type="text"].components-form-token-field__input {
-			min-height: calc(31.5px - 0.5em);
 			padding: em(5px) 0 em(5px) 4px;
 			margin: 0;
 		}
@@ -63,8 +62,6 @@
 	}
 
 	.components-form-token-field__suggestion {
-		padding: emp(8px);
-
 		&.is-selected {
 			background: $gray-100;
 			color: $gray-800;

--- a/assets/js/base/components/form-token-field/style.scss
+++ b/assets/js/base/components/form-token-field/style.scss
@@ -20,10 +20,20 @@
 		border-radius: 0;
 		box-shadow: none;
 		color: #000;
+		padding: $gap-smaller;
 		position: relative;
 
+		> .components-flex {
+			box-sizing: border-box;
+			padding-bottom: 0;
+			padding-top: 0;
+		}
+
+		.components-form-token-field__token-text,
 		input[type="text"].components-form-token-field__input {
-			min-height: 30px;
+			min-height: calc(31.5px - 0.5em);
+			padding: em(5px) 0 em(5px) 4px;
+			margin: 0;
 		}
 	}
 
@@ -53,7 +63,7 @@
 	}
 
 	.components-form-token-field__suggestion {
-		padding: 8px;
+		padding: emp(8px);
 
 		&.is-selected {
 			background: $gray-100;
@@ -62,10 +72,12 @@
 	}
 
 	&.single-selection {
+		.components-flex-item {
+			width: 100%;
+		}
 		.components-form-token-field__token {
 			margin-right: 0;
 			position: relative;
-			width: 100%;
 			z-index: 1;
 		}
 
@@ -79,14 +91,16 @@
 			width: 100%;
 		}
 
-		.components-form-token-field__token + input[type="text"].components-form-token-field__input {
-			position: absolute;
+		.components-flex-item + input[type="text"].components-form-token-field__input {
+			display: none;
 		}
 
-		.is-active .components-form-token-field__token + input[type="text"].components-form-token-field__input {
+		.is-active .components-flex-item + input[type="text"].components-form-token-field__input {
 			border: 1px solid $gray-600;
-			margin: 0 2px 4px;
-			padding: 0 5px;
+			border-radius: em(4px);
+			display: block;
+			margin-bottom: em(4px);
+			padding: em(5px);
 			position: static;
 		}
 

--- a/assets/js/blocks/attribute-filter/style.scss
+++ b/assets/js/blocks/attribute-filter/style.scss
@@ -25,7 +25,6 @@
 		box-shadow: none;
 		border-radius: 0;
 		height: 1em;
-		margin-top: $gap;
 	}
 
 	&.style-dropdown {
@@ -43,7 +42,7 @@
 
 		> svg {
 			position: absolute;
-			right: 8px;
+			right: 12px;
 			top: 50%;
 			transform: translateY(-50%);
 			pointer-events: none;
@@ -89,7 +88,6 @@
 	.wc-blocks-components-form-token-field-wrapper .components-form-token-field__input-container {
 		@include reset-typography();
 		border: 0;
-		padding: $gap-smaller;
 		border-radius: inherit;
 
 		.components-form-token-field__input {
@@ -102,14 +100,14 @@
 
 		.components-form-token-field__suggestions-list {
 			border: 1px solid $gray-700;
-			border-radius: 4px;
+			border-radius: em(4px);
 			margin-top: $gap-smaller;
 			max-height: 21em;
 
 			.components-form-token-field__suggestion {
 				color: $black;
 				border: 1px solid $gray-400;
-				border-radius: 4px;
+				border-radius: em(4px);
 				margin: $gap-small;
 				padding: $gap-small;
 			}
@@ -178,15 +176,12 @@
 }
 
 .wc-blocks-components-form-token-field-wrapper:not(.single-selection) .components-form-token-field__input-container {
-	padding: $gap-smallest 30px $gap-smallest  $gap-smaller;
-
 	.components-form-token-field__token-text {
 		background-color: $white;
 		border: 1px solid;
 		border-right: 0;
 		border-radius: 25px 0 0 25px;
 		padding: em($gap-smallest) em($gap-smaller) em($gap-smallest) em($gap-small);
-		line-height: 22px;
 	}
 
 	> .components-form-token-field__input {

--- a/assets/js/blocks/rating-filter/style.scss
+++ b/assets/js/blocks/rating-filter/style.scss
@@ -22,7 +22,7 @@
 
 		> svg {
 			position: absolute;
-			right: 8px;
+			right: 12px;
 			top: 50%;
 			transform: translateY(-50%);
 			pointer-events: none;
@@ -58,7 +58,6 @@
 	.wc-blocks-components-form-token-field-wrapper .components-form-token-field__input-container {
 		@include reset-typography();
 		border: 0;
-		padding: $gap-smaller;
 		border-radius: inherit;
 
 		.components-form-token-field__input {
@@ -71,14 +70,14 @@
 
 		.components-form-token-field__suggestions-list {
 			border: 1px solid $gray-700;
-			border-radius: 4px;
+			border-radius: em(4px);
 			margin-top: $gap-smaller;
 			max-height: 21em;
 
 			.components-form-token-field__suggestion {
 				color: $black;
 				border: 1px solid $gray-400;
-				border-radius: 4px;
+				border-radius: em(4px);
 				margin: $gap-small;
 				padding: $gap-small;
 			}
@@ -96,15 +95,12 @@
 }
 
 .wc-blocks-components-form-token-field-wrapper:not(.single-selection) .components-form-token-field__input-container {
-	padding: $gap-smallest 30px $gap-smallest  $gap-smaller;
-
 	.components-form-token-field__token-text {
 		background-color: $white;
 		border: 1px solid;
 		border-right: 0;
 		border-radius: 25px 0 0 25px;
 		padding: em($gap-smallest) em($gap-smaller) em($gap-smallest) em($gap-small);
-		line-height: 22px;
 	}
 
 	> .components-form-token-field__input {

--- a/assets/js/blocks/stock-filter/style.scss
+++ b/assets/js/blocks/stock-filter/style.scss
@@ -50,7 +50,7 @@
 
 		> svg {
 			position: absolute;
-			right: 8px;
+			right: 12px;
 			top: 50%;
 			transform: translateY(-50%);
 			pointer-events: none;
@@ -80,7 +80,6 @@
 	.wc-blocks-components-form-token-field-wrapper .components-form-token-field__input-container {
 		@include reset-typography();
 		border: 0;
-		padding: $gap-smaller;
 		border-radius: inherit;
 
 		.components-form-token-field__input {
@@ -93,14 +92,14 @@
 
 		.components-form-token-field__suggestions-list {
 			border: 1px solid $gray-700;
-			border-radius: 4px;
+			border-radius: em(4px);
 			margin-top: $gap-smaller;
 			max-height: 21em;
 
 			.components-form-token-field__suggestion {
 				color: $black;
 				border: 1px solid $gray-400;
-				border-radius: 4px;
+				border-radius: em(4px);
 				margin: $gap-small;
 				padding: $gap-small;
 			}
@@ -118,15 +117,12 @@
 }
 
 .wc-blocks-components-form-token-field-wrapper:not(.single-selection) .components-form-token-field__input-container {
-	padding: $gap-smallest 30px $gap-smallest  $gap-smaller;
-
 	.components-form-token-field__token-text {
 		background-color: $white;
 		border: 1px solid;
 		border-right: 0;
 		border-radius: 25px 0 0 25px;
 		padding: em($gap-smallest) em($gap-smaller) em($gap-smallest) em($gap-small);
-		line-height: 22px;
 	}
 
 	> .components-form-token-field__input {


### PR DESCRIPTION
This PR updates the styles of the `FormTokenField` component to fix some regressions caused by `@wordpress/components` update. cc @kmanijak 

### Screenshots

| Before | After |
| ------ | ----- |
| ![imatge](https://user-images.githubusercontent.com/3616980/210061271-310969d1-4ea8-4ddc-88e2-e7409daff59c.png) | ![imatge](https://user-images.githubusercontent.com/3616980/210061183-bde6aa71-e17e-4890-a192-8f4bfd509e70.png) |

### Testing

#### User Facing Testing

1. Create a post or page with three filter blocks: Filter by Attribute, Filter by Stock and Filter by Rating. In all of them set the display mode to _Dropdown_, and in some of them set it to _Single_ and in ohter to _Multiple_.
2. In the frontend, verify there are no visual regressions, the inputs have the same size and the user can add and remove values without problems.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
