### PR TITLE
Hide `core/no-results` as default in Product Query if WP <= 5.9

### DIFF
--- a/assets/js/blocks/product-query/constants.ts
+++ b/assets/js/blocks/product-query/constants.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { getSetting } from '@woocommerce/settings';
+import { getSetting, isWpVersion } from '@woocommerce/settings';
 import type { InnerBlockTemplate } from '@wordpress/blocks';
 
 /**
@@ -110,5 +110,7 @@ export const INNER_BLOCKS_TEMPLATE: InnerBlockTemplate[] = [
 		},
 		[],
 	],
-	[ 'core/query-no-results' ],
+	...( isWpVersion( '6.0', '>=' )
+		? [ [ 'core/query-no-results' ] as InnerBlockTemplate ]
+		: [] ),
 ];


### PR DESCRIPTION
As `core/no-results` was not available until WP 6.0 we need to only add it to the default template for the Products (Beta) block if the WP version is sufficient.

Fixes #8069

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Make sure you have WordPress 5.9 or lower installed in your testing instance.
2. Add a “Products (Beta)” block.
3. Make sure the block can be added and is working correctly.
4. Install a WordPress version >= to 6.0.
5. Add a new “Products (Beta)” block.
6. Make sure the block contains the `core/no-results` block by default.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Products (Beta): Add compatibility to WordPress 5.9.