### PR TITLE
Refactor Filter Wrapper to remove usage of useInnerBlocksProps

### DIFF
--- a/assets/js/blocks/filter-wrapper/index.tsx
+++ b/assets/js/blocks/filter-wrapper/index.tsx
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { createBlock, registerBlockType } from '@wordpress/blocks';
 import type { BlockInstance } from '@wordpress/blocks';
 import { toggle } from '@woocommerce/icons';
-import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
 import {
 	Icon,
 	category,
@@ -111,10 +111,11 @@ const transformFilterBlock = (
 registerBlockType( metadata, {
 	edit,
 	save() {
-		const innerBlocksProps = useInnerBlocksProps.save(
-			useBlockProps.save()
+		return (
+			<div { ...useBlockProps.save() }>
+				<InnerBlocks.Content />
+			</div>
 		);
-		return <div { ...innerBlocksProps } />;
 	},
 	variations: [
 		{

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -3246,7 +3246,6 @@
           Type &apos;undefined&apos; is not assignable to type &apos;Element[]&apos;." source="TS2322" />
 </file>
 <file name="assets/js/blocks/filter-wrapper/index.tsx">
-<error line="8" column="25" severity="error" message="Module &apos;&quot;@wordpress/block-editor&quot;&apos; has no exported member &apos;useInnerBlocksProps&apos;." source="TS2305" />
 <error line="46" column="34" severity="error" message="Parameter &apos;instance&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
 <error line="111" column="20" severity="error" message="No overload matches this call.
   Overload 1 of 2, &apos;(metadata: BlockConfiguration&lt;Attributes&gt;, settings?: Partial&lt;BlockConfiguration&lt;Attributes&gt;&gt; | undefined): Block&lt;...&gt; | undefined&apos;, gave the following error.
@@ -3257,15 +3256,15 @@
             Type &apos;{ type: string; }&apos; is missing the following properties from type &apos;Query&lt;string&gt;&apos;: source, selector, query
   Overload 2 of 2, &apos;(name: string, settings: BlockConfiguration&lt;Attributes&gt;): Block&lt;Attributes&gt; | undefined&apos;, gave the following error.
     Argument of type &apos;{ name: string; version: string; title: string; category: string; keywords: string[]; attributes: { filterType: { type: string; }; heading: { type: string; }; }; textdomain: string; apiVersion: number; $schema: string; }&apos; is not assignable to parameter of type &apos;string&apos;." source="TS2769" />
-<error line="135" column="16" severity="error" message="Parameter &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="159" column="16" severity="error" message="Parameter &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="184" column="16" severity="error" message="Parameter &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="209" column="16" severity="error" message="Parameter &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="234" column="16" severity="error" message="Parameter &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
-<error line="259" column="18" severity="error" message="Property &apos;idBase&apos; does not exist on type &apos;Attributes&apos;." source="TS2339" />
-<error line="259" column="26" severity="error" message="Property &apos;instance&apos; does not exist on type &apos;Attributes&apos;." source="TS2339" />
-<error line="261" column="20" severity="error" message="Property &apos;idBase&apos; does not exist on type &apos;Attributes&apos;." source="TS2339" />
-<error line="261" column="28" severity="error" message="Property &apos;instance&apos; does not exist on type &apos;Attributes&apos;." source="TS2339" />
+<error line="136" column="16" severity="error" message="Parameter &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="160" column="16" severity="error" message="Parameter &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="185" column="16" severity="error" message="Parameter &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="210" column="16" severity="error" message="Parameter &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="235" column="16" severity="error" message="Parameter &apos;attributes&apos; implicitly has an &apos;any&apos; type." source="TS7006" />
+<error line="260" column="18" severity="error" message="Property &apos;idBase&apos; does not exist on type &apos;Attributes&apos;." source="TS2339" />
+<error line="260" column="26" severity="error" message="Property &apos;instance&apos; does not exist on type &apos;Attributes&apos;." source="TS2339" />
+<error line="262" column="20" severity="error" message="Property &apos;idBase&apos; does not exist on type &apos;Attributes&apos;." source="TS2339" />
+<error line="262" column="28" severity="error" message="Property &apos;instance&apos; does not exist on type &apos;Attributes&apos;." source="TS2339" />
 </file>
 <file name="assets/js/blocks/handpicked-products/block.tsx">
 <error line="4" column="30" severity="error" message="Could not find a declaration file for module &apos;@wordpress/server-side-render&apos;. &apos;/home/runner/work/woocommerce-blocks/woocommerce-blocks/node_modules/@wordpress/server-side-render/build/index.js&apos; implicitly has an &apos;any&apos; type.


### PR DESCRIPTION
`useInnerBlocksProps` is not available in WP 5.8. It breaks the Editor when the page contains filter blocks. This PR fix that issue by refactoring Filter Wrapper to use `<InnerBlocks.Content>` instead of the hook.

### Testing instruction

1. Downgrade WP to 5.8, WC to 7.2.2
2. Add a new page.
3. Insert and configure a Filter by Attribute Block
4. See block works as expected.
5. Don't see any error related to filter block.
