### PR TITLE
Refactor Filter Wrapper to remove usage of useInnerBlocksProps

### DIFF
--- a/assets/js/blocks/filter-wrapper/index.tsx
+++ b/assets/js/blocks/filter-wrapper/index.tsx
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { createBlock, registerBlockType } from '@wordpress/blocks';
 import type { BlockInstance } from '@wordpress/blocks';
 import { toggle } from '@woocommerce/icons';
-import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
 import {
 	Icon,
 	category,
@@ -111,10 +111,11 @@ const transformFilterBlock = (
 registerBlockType( metadata, {
 	edit,
 	save() {
-		const innerBlocksProps = useInnerBlocksProps.save(
-			useBlockProps.save()
+		return (
+			<div { ...useBlockProps.save() }>
+				<InnerBlocks.Content />
+			</div>
 		);
-		return <div { ...innerBlocksProps } />;
 	},
 	variations: [
 		{


### PR DESCRIPTION
`useInnerBlocksProps` is not available in WP 5.8. It breaks the Editor when the page contains filter blocks. This PR fix that issue by refactoring Filter Wrapper to use `<InnerBlocks.Content>` instead of the hook.

### Testing instruction

1. Downgrade WP to 5.8, WC to 7.2.2
2. Add a new page.
3. Insert and configure a Filter by Attribute Block
4. See block works as expected.
5. Don't see any error related to filter block.

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Fix hangs in the block editor with WordPress 5.8.