### PR TITLE
Fix for Rating alignment when used in Products block

### DIFF
--- a/assets/js/atomic/blocks/product-elements/rating/style.scss
+++ b/assets/js/atomic/blocks/product-elements/rating/style.scss
@@ -4,6 +4,7 @@
 	margin-bottom: $gap-small;
 
 	&__stars {
+		display: inline-block;
 		overflow: hidden;
 		position: relative;
 		width: 5.3em;
@@ -49,5 +50,12 @@
 .wc-block-single-product {
 	.wc-block-components-product-rating__stars {
 		margin: 0;
+	}
+}
+
+// Fix applied specifically to Classic Template
+.woocommerce-loop-product__link {
+	.wc-block-components-product-rating__stars {
+		display: block;
 	}
 }


### PR DESCRIPTION
Fix for a correct Rating block alignment within the Products block. It is extracted [from another PR](https://github.com/woocommerce/woocommerce-blocks/pull/7929) merged into `trunk` already.

Raised bug: "Product Rating" inner block is aligned different for "Product list with full product description", "Product list with 1:1 images" and "Minimal product list" test page with "Products (Beta)" block

### Screenshots

Check the Rating position - it's expected to be left-aligned in the patterns.

| Case | Before | After |
| ------ | ----- |----- |
|     Product list with full product description   |  <img width="954" alt="image" src="https://user-images.githubusercontent.com/20098064/210593939-1d9fe7de-480f-464f-87b5-54fcafa30f2f.png">    |. <img width="851" alt="image" src="https://user-images.githubusercontent.com/20098064/210593463-63c15583-9d5c-418d-8737-376bb3d73898.png"> |
|     Product list with 1:1 images   |   <img width="990" alt="image" src="https://user-images.githubusercontent.com/20098064/210594000-a74ee3f9-1fee-4a42-95bf-07b68c181aa2.png">    |. <img width="936" alt="image" src="https://user-images.githubusercontent.com/20098064/210593608-1addf160-f941-4421-b5f3-414f0dd86a17.png"> |
|     Minimal product list   |   <img width="1002" alt="image" src="https://user-images.githubusercontent.com/20098064/210594055-a4cb98bf-709a-475f-8bcc-99382ecf1713.png">    |. <img width="814" alt="image" src="https://user-images.githubusercontent.com/20098064/210593674-0ecffccf-7a53-46e0-bec7-20b3c1fc94bf.png"> |
|     Classic Template   |   <img width="1002" alt="image" src="https://user-images.githubusercontent.com/20098064/210594055-a4cb98bf-709a-475f-8bcc-99382ecf1713.png">    |. <img width="814" alt="image" src="https://user-images.githubusercontent.com/20098064/210593674-0ecffccf-7a53-46e0-bec7-20b3c1fc94bf.png"> |

#### User Facing Testing

0. Make sure you have at least one product _with_ rating.
1. Create a post and add Products (Beta) block
2. If not yet added, add Product Rating block into the Product Template
3. Try to set each of the Rating alignment (as on a video below)
**Expected:** Starts are aligned accordingly
4. Save the post for each of the option and check the change is reflected on the frontend

https://user-images.githubusercontent.com/20098064/210591885-e95062b9-bdbc-402e-a295-c90c081a6129.mov

---

0. Make sure you have at least one product _with_ rating.
1. Create a post and add patterns [from this PR](https://github.com/woocommerce/woocommerce-blocks/pull/7857)
2. Check especially "Product list with full product description", "Product list with 1:1 images" and "Minimal product list" which showed incorrect behaviour
**Expected:** Rating is aligned as on the screenshots in the PR above

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Products: Fix the Rating block alignment
