### PR TITLE
Ensure Slot/Fills render in editor

### DIFF
--- a/assets/js/base/components/cart-checkout/shipping-rates-control/index.tsx
+++ b/assets/js/base/components/cart-checkout/shipping-rates-control/index.tsx
@@ -10,7 +10,7 @@ import {
 	getShippingRatesPackageCount,
 	getShippingRatesRateCount,
 } from '@woocommerce/base-utils';
-import { useStoreCart, useEditorContext } from '@woocommerce/base-context';
+import { useStoreCart } from '@woocommerce/base-context';
 import { CartResponseShippingRate } from '@woocommerce/types';
 import { ReactElement } from 'react';
 
@@ -166,8 +166,6 @@ const ShippingRatesControl = ( {
 		},
 		context,
 	};
-	const { isEditor } = useEditorContext();
-
 	return (
 		<LoadingMask
 			isLoading={ isLoadingRates }
@@ -177,26 +175,14 @@ const ShippingRatesControl = ( {
 			) }
 			showSpinner={ true }
 		>
-			{ isEditor ? (
+			<ExperimentalOrderShippingPackages.Slot { ...slotFillProps } />
+			<ExperimentalOrderShippingPackages>
 				<Packages
 					packages={ shippingRates }
 					noResultsMessage={ noResultsMessage }
 					renderOption={ renderOption }
 				/>
-			) : (
-				<>
-					<ExperimentalOrderShippingPackages.Slot
-						{ ...slotFillProps }
-					/>
-					<ExperimentalOrderShippingPackages>
-						<Packages
-							packages={ shippingRates }
-							noResultsMessage={ noResultsMessage }
-							renderOption={ renderOption }
-						/>
-					</ExperimentalOrderShippingPackages>
-				</>
-			) }
+			</ExperimentalOrderShippingPackages>
 		</LoadingMask>
 	);
 };

--- a/assets/js/blocks/cart/edit.js
+++ b/assets/js/blocks/cart/edit.js
@@ -12,6 +12,7 @@ import {
 import BlockErrorBoundary from '@woocommerce/base-components/block-error-boundary';
 import { EditorProvider, CartProvider } from '@woocommerce/base-context';
 import { previewCart } from '@woocommerce/resource-previews';
+import { SlotFillProvider } from '@woocommerce/blocks-checkout';
 
 /**
  * Internal dependencies
@@ -86,13 +87,15 @@ export const Edit = ( { className, attributes, setAttributes, clientId } ) => {
 							hasDarkControls,
 						} }
 					>
-						<CartProvider>
-							<InnerBlocks
-								allowedBlocks={ ALLOWED_BLOCKS }
-								template={ defaultTemplate }
-								templateLock={ false }
-							/>
-						</CartProvider>
+						<SlotFillProvider>
+							<CartProvider>
+								<InnerBlocks
+									allowedBlocks={ ALLOWED_BLOCKS }
+									template={ defaultTemplate }
+									templateLock={ false }
+								/>
+							</CartProvider>
+						</SlotFillProvider>
 					</CartBlockContext.Provider>
 				</EditorProvider>
 			</BlockErrorBoundary>

--- a/assets/js/blocks/checkout/edit.tsx
+++ b/assets/js/blocks/checkout/edit.tsx
@@ -19,6 +19,7 @@ import {
 	ToggleControl,
 	CheckboxControl,
 } from '@wordpress/components';
+import { SlotFillProvider } from '@woocommerce/blocks-checkout';
 import type { TemplateArray } from '@wordpress/blocks';
 import { CartCheckoutFeedbackPrompt } from '@woocommerce/editor-components/feedback-prompt';
 
@@ -147,38 +148,40 @@ export const Edit = ( {
 			<EditorProvider
 				previewData={ { previewCart, previewSavedPaymentMethods } }
 			>
-				<CheckoutProvider>
-					<SidebarLayout
-						className={ classnames( 'wc-block-checkout', {
-							'has-dark-controls': attributes.hasDarkControls,
-						} ) }
-					>
-						<CheckoutBlockControlsContext.Provider
-							value={ { addressFieldControls } }
+				<SlotFillProvider>
+					<CheckoutProvider>
+						<SidebarLayout
+							className={ classnames( 'wc-block-checkout', {
+								'has-dark-controls': attributes.hasDarkControls,
+							} ) }
 						>
-							<CheckoutBlockContext.Provider
-								value={ {
-									showCompanyField,
-									requireCompanyField,
-									showApartmentField,
-									showPhoneField,
-									requirePhoneField,
-									showOrderNotes,
-									showPolicyLinks,
-									showReturnToCart,
-									cartPageId,
-									showRateAfterTaxName,
-								} }
+							<CheckoutBlockControlsContext.Provider
+								value={ { addressFieldControls } }
 							>
-								<InnerBlocks
-									allowedBlocks={ ALLOWED_BLOCKS }
-									template={ defaultTemplate }
-									templateLock="insert"
-								/>
-							</CheckoutBlockContext.Provider>
-						</CheckoutBlockControlsContext.Provider>
-					</SidebarLayout>
-				</CheckoutProvider>
+								<CheckoutBlockContext.Provider
+									value={ {
+										showCompanyField,
+										requireCompanyField,
+										showApartmentField,
+										showPhoneField,
+										requirePhoneField,
+										showOrderNotes,
+										showPolicyLinks,
+										showReturnToCart,
+										cartPageId,
+										showRateAfterTaxName,
+									} }
+								>
+									<InnerBlocks
+										allowedBlocks={ ALLOWED_BLOCKS }
+										template={ defaultTemplate }
+										templateLock="insert"
+									/>
+								</CheckoutBlockContext.Provider>
+							</CheckoutBlockControlsContext.Provider>
+						</SidebarLayout>
+					</CheckoutProvider>
+				</SlotFillProvider>
 			</EditorProvider>
 		</div>
 	);


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR will ensure Slot/Fills are rendered in the editor. To do this the Edit functions for the Cart and Checkout blocks now render a `SlotFillProvider` from the `@woocommerce/blocks-checkout` package.

<!-- Reference any related issues or PRs here -->

Fixes #7939

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
| <img width="465" alt="image" src="https://user-images.githubusercontent.com/5656702/210839660-b243fba7-17e8-4425-a213-4c1a2eaeb770.png"> | <img width="479" alt="image" src="https://user-images.githubusercontent.com/5656702/210838310-5914c0b2-24d5-4fe5-8328-5f21accf98f5.png"> |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### Internal Developer Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Go to your `plugins` directory, execute: `npx @wordpress/create-block -t @woocommerce/extend-cart-checkout-block slot-fill-test`.
2. Activate the "Slot fill test" plugin.
3. Open `slot-fill-test` and edit `src/js/index.js`. Change the  file to this:
```js
/**
 * External dependencies
 */
import { registerPlugin } from '@wordpress/plugins';
import {
	ExperimentalOrderMeta,
	ExperimentalOrderShippingPackages,
} from '@woocommerce/blocks-checkout';
import { getSetting } from '@woocommerce/settings';
/**
 * Internal dependencies
 */
import './style.scss';

import { registerFilters } from './filters';
import { ExampleComponent } from './ExampleComponent';

const exampleDataFromSettings = getSetting('slot-fill-test_data');

const render = () => {
	return (
		<>
			<ExperimentalOrderShippingPackages>
				<div>test</div>
			</ExperimentalOrderShippingPackages>
			<ExperimentalOrderMeta>
				<ExampleComponent data={exampleDataFromSettings} />
			</ExperimentalOrderMeta>
		</>
	);
};

registerPlugin('slot-fill-test', {
	render,
	scope: 'woocommerce-checkout',
});

registerFilters();
```
4. run `npm run build`
5. Add the Checkout block to a page and ensure the `test` div you added is rendered.
5. Ensure you can also see the `Data passed to this component: This is some example data from the server` Fill rendered under the Checkout sidebar.
6. Open the Cart in the editor and ensure you can see `Data passed to this component: This is some example data from the server` rendered below the sidebar.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Allow Slot/Fills in the Cart and Checkout blocks to correctly render in the Block Editor.
