### PR TITLE
Remove the “Products (Beta)” block from WP 6.0 or lower

### DIFF
--- a/assets/js/atomic/blocks/product-elements/rating/style.scss
+++ b/assets/js/atomic/blocks/product-elements/rating/style.scss
@@ -4,7 +4,6 @@
 	margin-bottom: $gap-small;
 
 	&__stars {
-		display: inline-block;
 		overflow: hidden;
 		position: relative;
 		width: 5.3em;
@@ -50,12 +49,5 @@
 .wc-block-single-product {
 	.wc-block-components-product-rating__stars {
 		margin: 0;
-	}
-}
-
-// Fix applied specifically to Classic Template
-.woocommerce-loop-product__link {
-	.wc-block-components-product-rating__stars {
-		display: block;
 	}
 }

--- a/assets/js/blocks/product-query/constants.ts
+++ b/assets/js/blocks/product-query/constants.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { getSetting, isWpVersion } from '@woocommerce/settings';
+import { getSetting } from '@woocommerce/settings';
 import type { InnerBlockTemplate } from '@wordpress/blocks';
 
 /**
@@ -109,7 +109,5 @@ export const INNER_BLOCKS_TEMPLATE: InnerBlockTemplate[] = [
 		},
 		[],
 	],
-	...( isWpVersion( '6.0', '>=' )
-		? [ [ 'core/query-no-results' ] as InnerBlockTemplate ]
-		: [] ),
+	[ 'core/query-no-results' ],
 ];

--- a/assets/js/blocks/product-query/index.tsx
+++ b/assets/js/blocks/product-query/index.tsx
@@ -3,6 +3,7 @@
  */
 import type { Block } from '@wordpress/blocks';
 import { addFilter } from '@wordpress/hooks';
+import { isWpVersion } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -35,8 +36,10 @@ function registerProductQueryElementsNamespace(
 	return props;
 }
 
-addFilter(
-	'blocks.registerBlockType',
-	'core/custom-class-name/attribute',
-	registerProductQueryElementsNamespace
-);
+if ( isWpVersion( '6.0', '>' ) ) {
+	addFilter(
+		'blocks.registerBlockType',
+		'core/custom-class-name/attribute',
+		registerProductQueryElementsNamespace
+	);
+}

--- a/assets/js/blocks/product-query/variations/product-query.tsx
+++ b/assets/js/blocks/product-query/variations/product-query.tsx
@@ -5,6 +5,7 @@ import { registerBlockVariation } from '@wordpress/blocks';
 import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { stacks } from '@woocommerce/icons';
+import { isWpVersion } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -18,31 +19,33 @@ import {
 
 const VARIATION_NAME = 'woocommerce/product-query';
 
-registerBlockVariation( QUERY_LOOP_ID, {
-	description: __(
-		'A block that displays a selection of products in your store.',
-		'woo-gutenberg-products-block'
-	),
-	name: VARIATION_NAME,
-	/* translators: “Products“ is the name of the block. */
-	title: __( 'Products (Beta)', 'woo-gutenberg-products-block' ),
-	isActive: ( blockAttributes ) =>
-		blockAttributes.namespace === VARIATION_NAME,
-	icon: (
-		<Icon
-			icon={ stacks }
-			className="wc-block-editor-components-block-icon wc-block-editor-components-block-icon--stacks"
-		/>
-	),
-	attributes: {
-		...QUERY_DEFAULT_ATTRIBUTES,
-		namespace: VARIATION_NAME,
-	},
-	// Gutenberg doesn't support this type yet, discussion here:
-	// https://github.com/WordPress/gutenberg/pull/43632
-	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-	// @ts-ignore
-	allowedControls: DEFAULT_ALLOWED_CONTROLS,
-	innerBlocks: INNER_BLOCKS_TEMPLATE,
-	scope: [ 'inserter' ],
-} );
+if ( isWpVersion( '6.0', '>' ) ) {
+	registerBlockVariation( QUERY_LOOP_ID, {
+		description: __(
+			'A block that displays a selection of products in your store.',
+			'woo-gutenberg-products-block'
+		),
+		name: VARIATION_NAME,
+		/* translators: “Products“ is the name of the block. */
+		title: __( 'Products (Beta)', 'woo-gutenberg-products-block' ),
+		isActive: ( blockAttributes ) =>
+			blockAttributes.namespace === VARIATION_NAME,
+		icon: (
+			<Icon
+				icon={ stacks }
+				className="wc-block-editor-components-block-icon wc-block-editor-components-block-icon--stacks"
+			/>
+		),
+		attributes: {
+			...QUERY_DEFAULT_ATTRIBUTES,
+			namespace: VARIATION_NAME,
+		},
+		// Gutenberg doesn't support this type yet, discussion here:
+		// https://github.com/WordPress/gutenberg/pull/43632
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
+		allowedControls: DEFAULT_ALLOWED_CONTROLS,
+		innerBlocks: INNER_BLOCKS_TEMPLATE,
+		scope: [ 'inserter' ],
+	} );
+}


### PR DESCRIPTION
WordPress 6.0 lacks several APIs that we used to make the Products (Beta) work. We tried to add a patchy compatibility, but it's messy and plainly not possible to hide the correct settings. So we decided (p1672851818395389-slack-C02UBB1EPEF) that it'd be better to just remove it from those versions.

Also, since #8104 applies only to the Products block, this PR reverts that fix.

Fixes #8069

### Testing

#### User Facing Testing

1. Install a WordPress version equal to 6.0 or lower.
2. Ensure that you can't add the “Products (Beta)” block.
3. Install a version higher than 6.0.
4. Ensure that you can add the “Products (Beta)” block correctly.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Products (Beta): Remove the block from WordPress versions lower than 6.0 for incompatibility reasons.