### PR TITLE
Add checkout data store docs

### DIFF
--- a/docs/internal-developers/data-store/README.md
+++ b/docs/internal-developers/data-store/README.md
@@ -2,6 +2,7 @@
 
 ## Table of contents <!-- omit in toc -->
 
+-   [Checkout](./checkout.md)
 -   [Validation](./validation.md)
 
 In our project, we leverage [`@wordpress/data`](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-data/) data stores to hold information about the state of various WooCommerce blocks.

--- a/docs/internal-developers/data-store/checkout.md
+++ b/docs/internal-developers/data-store/checkout.md
@@ -1,0 +1,48 @@
+# Checkout data store
+
+The checkout data store is used to track the status of the **checkout** (not including payment), it stores things like the order ID, the customer ID, the order notes, whether the "use shipping as billing" box is checked etc.
+
+The initial state of the checkout store is:
+
+```js
+{
+	redirectUrl: '',
+	status: STATUS.PRISTINE,
+	hasError: false,
+	orderId: checkoutData.order_id,
+	customerId: checkoutData.customer_id,
+	calculatingCount: 0,
+	orderNotes: '',
+	useShippingAsBilling: isSameAddress(
+	checkoutData.billing_address,
+	checkoutData.shipping_address
+	),
+	shouldCreateAccount: false,
+	extensionData: {},
+};
+```
+
+## Properties
+
+- `redirectUrl` - Set when the checkout is completed. The payment method being used can set this, and it will be sent back to the block in the checkout response.
+- `status` - one of:
+    - `PRISTINE` (Checkout is in its initialized state.)
+    - `IDLE` (When checkout state has changed but there is no activity happening.)
+    - `COMPLETE` (After the `AFTER_PROCESSING` event emitters have completed. This status triggers the checkout redirect.)
+    - `BEFORE_PROCESSING` (This is the state before checkout processing begins after the checkout button has been pressed/submitted.)
+    - `PROCESSING` (After `BEFORE_PROCESSING` status emitters have finished successfully. Payment processing is started on this checkout status.)
+  `AFTER_PROCESSING` (After server side checkout processing is completed this status is set.)
+- `calculatingCount` - This is used to track when a request is being made to the server, for example to update the shipping method selection or to update the customer's address. When the request begins, `calculatingCount` increases, and when it completes, `calculatingCount` decreases.
+- `orderNotes` - the value of the order notes textarea.
+- `useShippingAsBilling` - Whether the `Use same address for billing` checkbox is checked.
+- `shouldCreateAccount` - whether the `Create account` checkbox is checked.
+- `extensionData` - data added to the data store by extensions.
+
+
+## Observers
+
+Extensions can register "observers" which will respond to specific events in the Checkout flow. More information on these can be found in the [checkout flow and events documentation](../../internal-developers/block-client-apis/checkout/checkout-flow-and-events.md). Thar documentation also contains information about the general flow of the checkout system, whereas this documentation only describes how the data is affected during checkout.
+
+## Status changes
+
+When the checkout loads, the items above are populated as described. When the user presses the "Place order" button, the checkout status changes to `BEFORE_PROCESSING`. The observers fire as per the above documentation, and if they all succeed, the status changes to `PROCESSING`. At this point the request is made to the server, and on its return (successful or not) it changes to `AFTER_PROCESSING`. If there was an error, the status returns to `IDLE`, and `hasError` is set to true. If there was not an error, and the checkout was successful, the status changes to `COMPLETE` and the redirect is triggered.


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR adds a brief description of the checkout data store for internal developers.

<!-- Reference any related issues or PRs here -->

Fixes #6771

#### User Facing Testing

1. Please read the new docs and check they make sense.
2. Please think about whether these add any value that can't be got from [the checkout flow and events docs](https://github.com/woocommerce/woocommerce-blocks/blob/74dd439d3d7efa8c1614ddf20c5ac0c3f67b5458/docs/internal-developers/block-client-apis/checkout/checkout-flow-and-events.md#L19).
3. If you feel the docs added in this PR are superfluous, please reject the PR and we can close it.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Skipping
