### PR TITLE
Add testing steps for WC Blocks 8.9.3 and 8.9.4

### DIFF
--- a/docs/internal-developers/testing/releases/893.md
+++ b/docs/internal-developers/testing/releases/893.md
@@ -1,0 +1,11 @@
+# Testing notes and ZIP for release 8.9.3
+
+Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.com/woocommerce/woocommerce-blocks/files/10332606/woocommerce-gutenberg-products-block.zip)
+
+## Feature plugin and package inclusion in WooCommerce
+
+### Replace additional instance of wp_is_block_theme() with wc_current_theme_is_fse_theme() [#7496](https://github.com/woocommerce/woocommerce-blocks/pull/7496)
+
+0. In WP 5.8.
+1. Create a post or page.
+2. Verify there is no fatal error and you can create the post or page and publish it.

--- a/docs/internal-developers/testing/releases/894.md
+++ b/docs/internal-developers/testing/releases/894.md
@@ -1,0 +1,25 @@
+# Testing notes and ZIP for release 8.9.4
+
+Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.com/woocommerce/woocommerce-blocks/files/10346588/woocommerce-blocks.zip)
+
+## Feature plugin and package inclusion in WooCommerce
+
+### Refactor Filter Wrapper to remove usage of useInnerBlocksProps [#8095](https://github.com/woocommerce/woocommerce-blocks/pull/8095) and Add back ToggleButtonControl component in WC Blocks 8.9 so it supports WP 5.9 [#8101](https://github.com/woocommerce/woocommerce-blocks/pull/8101)
+
+1. In WP 5.8.
+2. Create a post or page.
+3. Add the Filter by Attribute block.
+4. Select one of the attributes.
+5. Verify the block is added correctly, you can publish the post/page and there is no error.
+6. Play around with the block display settings and verify the block honors them:
+
+<img src="https://user-images.githubusercontent.com/3616980/210577549-fbb8de61-0e1a-4038-9409-735891b5bcd8.png" alt="" width="287" />
+
+7. Test also these blocks (in all of them, interact with the toggles on the sidebar of the editor and verify the block doesn't crash and the settings are applied correctly):
+   * Feature Product
+   * Featured Category
+   * Product Image (you will need to add the All Products block, click on the pencil icon to edit its inner blocks, and select the image)
+   * Active Product Filters (you will need to select the Controls inner block)
+   * Filter by Price (you will need to select the Controls inner block)
+   * Product Categories List
+

--- a/docs/internal-developers/testing/releases/README.md
+++ b/docs/internal-developers/testing/releases/README.md
@@ -105,6 +105,8 @@ Every release includes specific testing instructions for new features and bug fi
 -   [8.9.0](./890.md)
     -   [8.9.1](./891.md)
     -   [8.9.2](./892.md)
+    -   [8.9.3](./893.md)
+    -   [8.9.4](./894.md)
 -   [9.0.0](./900.md)
 -   [9.1.0](./910.md)
     -   [9.1.1](./911.md)

--- a/readme.txt
+++ b/readme.txt
@@ -220,6 +220,19 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 - Change action type name for use shipping as billing option. ([7695](https://github.com/woocommerce/woocommerce-blocks/pull/7695))
 - Block Checkout: Apply selected Local Pickup rate to entire order (all packages). ([7484](https://github.com/woocommerce/woocommerce-blocks/pull/7484))
 
+= 8.9.4 - 2023-01-04 =
+
+#### Bug fixes
+
+- Fix hangs in the block editor with WordPress 5.8. [#8095](https://github.com/woocommerce/woocommerce-blocks/pull/8095)
+- Fix Filter by Attribute block crashing in the editor of WordPress 5.8. [#8101](https://github.com/woocommerce/woocommerce-blocks/pull/8101)
+
+= 8.9.3 - 2023-01-03 =
+
+#### Bug fixes
+
+- Fix fatal error in WordPress 5.8 when creating a post or page. [#7496](https://github.com/woocommerce/woocommerce-blocks/pull/7496)
+
 = 8.9.2 - 2022-12-01 =
 
 #### Bug Fixes


### PR DESCRIPTION
Given that `release/8.9.0` can't be merged into `trunk` because there are some changes we don't want to merge. This PR adds the testing steps and changelog for WC Blocks 8.9.3 and 8.9.4.