### PR TITLE
Remove notice from shipping rate selector

### DIFF
--- a/assets/js/base/components/cart-checkout/totals/shipping/index.tsx
+++ b/assets/js/base/components/cart-checkout/totals/shipping/index.tsx
@@ -3,6 +3,7 @@
  */
 import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
+import { isAddressComplete } from '@woocommerce/base-utils';
 import { useState } from '@wordpress/element';
 import { useStoreCart } from '@woocommerce/base-context/hooks';
 import { TotalsItem } from '@woocommerce/blocks-checkout';
@@ -166,6 +167,8 @@ export const TotalsShipping = ( {
 		}
 	);
 
+	const addressComplete = isAddressComplete( shippingAddress );
+
 	return (
 		<div
 			className={ classnames(
@@ -214,6 +217,7 @@ export const TotalsShipping = ( {
 					hasRates={ hasRates }
 					shippingRates={ shippingRates }
 					isLoadingRates={ isLoadingRates }
+					isAddressComplete={ addressComplete }
 				/>
 			) }
 		</div>

--- a/assets/js/base/components/cart-checkout/totals/shipping/shipping-rate-selector.tsx
+++ b/assets/js/base/components/cart-checkout/totals/shipping/shipping-rate-selector.tsx
@@ -13,11 +13,13 @@ interface ShippingRateSelectorProps {
 	hasRates: boolean;
 	shippingRates: CartResponseShippingRate[];
 	isLoadingRates: boolean;
+	isAddressComplete: boolean;
 }
 const ShippingRateSelector = ( {
 	hasRates,
 	shippingRates,
 	isLoadingRates,
+	isAddressComplete,
 }: ShippingRateSelectorProps ): JSX.Element => {
 	const legend = hasRates
 		? __( 'Shipping options', 'woo-gutenberg-products-block' )
@@ -29,10 +31,15 @@ const ShippingRateSelector = ( {
 				className="wc-block-components-totals-shipping__options"
 				noResultsMessage={
 					<>
-						{ __(
-							'No shipping options were found.',
-							'woo-gutenberg-products-block'
-						) }
+						{ isAddressComplete
+							? __(
+									'No shipping options were found.',
+									'woo-gutenberg-products-block'
+							  )
+							: __(
+									'Add a shipping address to view shipping options.',
+									'woo-gutenberg-products-block'
+							  ) }
 					</>
 				}
 				shippingRates={ shippingRates }

--- a/assets/js/base/components/cart-checkout/totals/shipping/shipping-rate-selector.tsx
+++ b/assets/js/base/components/cart-checkout/totals/shipping/shipping-rate-selector.tsx
@@ -2,8 +2,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Notice } from 'wordpress-components';
-import classnames from 'classnames';
 import type { CartResponseShippingRate } from '@woocommerce/types';
 
 /**
@@ -30,18 +28,12 @@ const ShippingRateSelector = ( {
 			<ShippingRatesControl
 				className="wc-block-components-totals-shipping__options"
 				noResultsMessage={
-					<Notice
-						isDismissible={ false }
-						className={ classnames(
-							'wc-block-components-shipping-rates-control__no-results-notice',
-							'woocommerce-error'
-						) }
-					>
+					<>
 						{ __(
 							'No shipping options were found.',
 							'woo-gutenberg-products-block'
 						) }
-					</Notice>
+					</>
 				}
 				shippingRates={ shippingRates }
 				isLoadingRates={ isLoadingRates }

--- a/assets/js/base/utils/address.ts
+++ b/assets/js/base/utils/address.ts
@@ -100,3 +100,16 @@ export const emptyHiddenAddressFields = <
 
 	return newAddress;
 };
+
+/**
+ * Returns true if the address is complete (for the purposes of calculating shipping).
+ *
+ * @param  address The address to check.
+ *
+ * @return {boolean} True if the address is complete.
+ */
+export const isAddressComplete = (
+	address: ShippingAddress | BillingAddress
+) => {
+	return !! address.city && !! address.country && !! address.postcode;
+};

--- a/assets/js/base/utils/test/address.ts
+++ b/assets/js/base/utils/test/address.ts
@@ -1,7 +1,10 @@
 /**
  * External dependencies
  */
-import { emptyHiddenAddressFields } from '@woocommerce/base-utils';
+import {
+	emptyHiddenAddressFields,
+	isAddressComplete,
+} from '@woocommerce/base-utils';
 
 describe( 'emptyHiddenAddressFields', () => {
 	it( "Removes state from an address where the country doesn't use states", () => {
@@ -20,5 +23,53 @@ describe( 'emptyHiddenAddressFields', () => {
 		};
 		const filteredAddress = emptyHiddenAddressFields( address );
 		expect( filteredAddress ).toHaveProperty( 'state', '' );
+	} );
+} );
+
+describe( 'isAddressComplete', () => {
+	it( 'correctly checks a fully empty address', () => {
+		const address = {
+			first_name: '',
+			last_name: '',
+			company: '',
+			address_1: '',
+			address_2: '',
+			city: '',
+			postcode: '',
+			country: '',
+			state: '',
+			email: '',
+			phone: '',
+		};
+		expect( isAddressComplete( address ) ).toBe( false );
+	} );
+
+	it( 'correctly checks a partially empty address', () => {
+		const address = {
+			first_name: 'Vernon',
+			last_name: 'Dursley',
+			company: 'Grunnings',
+			address_1: '',
+			address_2: '',
+			city: '',
+			postcode: '',
+			country: '',
+			state: '',
+			email: 'test@gmail.com',
+			phone: '+12345',
+		};
+		expect( isAddressComplete( address ) ).toBe( false );
+
+		// Still incomplete as no country, city, or postcode data is present.
+		address.address_1 = '4 Privet Drive';
+		address.address_2 = 'Little Whinging';
+		expect( isAddressComplete( address ) ).toBe( false );
+
+		address.city = 'Surrey';
+		expect( isAddressComplete( address ) ).toBe( false );
+
+		address.postcode = 'WD25 7LR';
+		address.country = 'GB';
+		expect( isAddressComplete( address ) ).toBe( true );
 	} );
 } );

--- a/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/block.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/block.tsx
@@ -4,19 +4,22 @@
 import { __ } from '@wordpress/i18n';
 import { useShippingData } from '@woocommerce/base-context/hooks';
 import { ShippingRatesControl } from '@woocommerce/base-components/cart-checkout';
-import { getShippingRatesPackageCount } from '@woocommerce/base-utils';
+import {
+	getShippingRatesPackageCount,
+	isAddressComplete,
+} from '@woocommerce/base-utils';
 import { getCurrencyFromPriceResponse } from '@woocommerce/price-format';
 import FormattedMonetaryAmount from '@woocommerce/base-components/formatted-monetary-amount';
 import { useEditorContext, noticeContexts } from '@woocommerce/base-context';
 import { StoreNoticesContainer } from '@woocommerce/blocks-checkout';
 import { decodeEntities } from '@wordpress/html-entities';
-import { Notice } from 'wordpress-components';
-import classnames from 'classnames';
 import { getSetting } from '@woocommerce/settings';
 import type {
 	PackageRateOption,
 	CartShippingPackageShippingRate,
 } from '@woocommerce/types';
+import { CART_STORE_KEY } from '@woocommerce/block-data';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -59,12 +62,17 @@ const Block = (): JSX.Element | null => {
 		hasCalculatedShipping,
 	} = useShippingData();
 
+	const shippingAddress = useSelect( ( select ) => {
+		return select( CART_STORE_KEY ).getCustomerData()?.shippingAddress;
+	} );
+
 	if ( ! needsShipping ) {
 		return null;
 	}
 
 	const shippingRatesPackageCount =
 		getShippingRatesPackageCount( shippingRates );
+	const addressComplete = isAddressComplete( shippingAddress );
 
 	if (
 		! isEditor &&
@@ -91,18 +99,17 @@ const Block = (): JSX.Element | null => {
 			) : (
 				<ShippingRatesControl
 					noResultsMessage={
-						<Notice
-							isDismissible={ false }
-							className={ classnames(
-								'wc-block-components-shipping-rates-control__no-results-notice',
-								'woocommerce-error'
-							) }
-						>
-							{ __(
-								'There are no shipping options available. Please check your shipping address.',
-								'woo-gutenberg-products-block'
-							) }
-						</Notice>
+						<>
+							{ addressComplete
+								? __(
+										'There are no shipping options available. Please check your shipping address.',
+										'woo-gutenberg-products-block'
+								  )
+								: __(
+										'Add a shipping address to view shipping options.',
+										'woo-gutenberg-products-block'
+								  ) }
+						</>
 					}
 					renderOption={ renderShippingRatesControlOption }
 					collapsible={ false }


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR removes the `Notice` component shown in the shipping section of the Cart and Checkout blocks.

The notice is big and red and draws attention to it immediately, changing it to text still conveys the same information but makes it less distracting.

Also, the error notice appeared even when the shopper had not entered an address, so this is more reason to change it.

In this PR, I also changed the text displayed depending on whether there's a "full" address (country, city, and postcode) or not.

To do this I had to add a `isAddressComplete` function which checks for the country, city, and postcode. I also added tests for this.

If there's not a full address, this message will be shown in the cart:
<img width="410" alt="image" src="https://user-images.githubusercontent.com/5656702/211382070-2637aa72-993b-4dfc-884d-5f9635c50a66.png">

and in the checkout:
<img width="374" alt="image" src="https://user-images.githubusercontent.com/5656702/211381518-faee98f1-7f8e-49ca-9135-b57b49efcddb.png">

@elizaan36 I think I could use some help with the Cart message shown, it doesn't look great.  I think the Checkout one looks OK though. Should I just add space above the one in the Cart block or do you want us to look into another way of displaying this?

<!-- Reference any related issues or PRs here -->

Fixes #7730

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
| <img width="691" alt="image" src="https://user-images.githubusercontent.com/5656702/211367671-38c90c35-a807-43de-9a10-0a298b13cce6.png"> | ![image](https://user-images.githubusercontent.com/5656702/211367593-38ee3bab-89cd-4f20-b92e-0dc97a95c02b.png) |
| <img width="363" alt="image" src="https://user-images.githubusercontent.com/5656702/211368105-1ed41900-9ba0-4443-874c-6c97bdf383e5.png"> | <img width="375" alt="image" src="https://user-images.githubusercontent.com/5656702/211368030-30e125d0-d8c0-4a8f-8d1d-29f8c4fdc489.png"> |
### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. In `WooCommerce -> Settings -> Shipping` ensure "Locations not covered by your other zones" does not have any shipping methods enabled. Set up some shipping methods for your country specifically.
2. Open your site in an incognito window.
3. Add an item to your cart and open the Cart block.
4. Check that the shipping calculator is showing the `Add a shipping address to view shipping options.` message.
5. Go to the Checkout block and ensure the same message shows.
6. Go back to the Cart block and enter an address for a country that does **not** have any shipping methods available. Ensure the `No shipping options were found.` message is shown.
7. Go to the Checkout block and ensure the `No shipping options were found.` is shown there too.
8. Enter an address that **does** have shipping options, and ensure the selector shows correctly in both Cart and Checkout.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Skipping as this is mostly just a UI update.
