### PR TITLE
Fix: unable to customize All Products block

### DIFF
--- a/assets/js/blocks/cart-checkout-shared/sidebar-notices/index.tsx
+++ b/assets/js/blocks/cart-checkout-shared/sidebar-notices/index.tsx
@@ -36,7 +36,7 @@ const withSidebarNotices = createHigherOrderComponent(
 
 		// Show sidebar notices only when a WooCommerce block is selected.
 		if ( ! blockName.startsWith( 'woocommerce/' ) || ! isBlockSelected ) {
-			return <BlockEdit { ...props } />;
+			return <BlockEdit key="edit" { ...props } />;
 		}
 
 		const [
@@ -115,7 +115,7 @@ const withSidebarNotices = createHigherOrderComponent(
 					</InspectorControls>
 				) }
 
-				<BlockEdit { ...props } />
+				<BlockEdit key="edit" { ...props } />
 			</>
 		);
 	},


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #8139 

In https://github.com/woocommerce/woocommerce-blocks/pull/7435, we improve the performance of our filter for the Sidebar compatibility notice. But at the same time, PR introduced a bug breaking the edit mode of the  All Products block. This PR fix that issue by adding the same key to both returned `BlockEdit` components, following the same tactic in https://github.com/WordPress/gutenberg/pull/31833. @ntsekouras can you explain more why having an `edit` key makes the difference here?

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots


https://user-images.githubusercontent.com/5423135/211474577-78268f43-06d9-4c0f-8373-0f6389f0b74c.mov



### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Add `All Products` block to the page.
2. Toggle Edit mode (click the pencil icon in the toolbar).
3. Try moving/adding/removing inner blocks.
4. Click on the `Done` button, see the customizations applied in the editor preview.
5. Save the page, see the customizations applied on the front end.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Fix: All Products block customization issue. 
