### PR TITLE
Use DAY_IN_SECONDS constant instead of calculating the value

### DIFF
--- a/src/StoreApi/Routes/V1/AbstractCartRoute.php
+++ b/src/StoreApi/Routes/V1/AbstractCartRoute.php
@@ -193,7 +193,7 @@ abstract class AbstractCartRoute extends AbstractRoute {
 	 * @return int
 	 */
 	protected function get_cart_token_expiration() {
-		return time() + intval( apply_filters( 'wc_session_expiration', 60 * 60 * 48 ) );
+		return time() + intval( apply_filters( 'wc_session_expiration', DAY_IN_SECONDS * 2 ) );
 	}
 
 	/**


### PR DESCRIPTION
Tiny PR that replaces a multiplication with `DAY_IN_SECONDS`, which should make the code easier to read.

### Testing

#### User Facing Testing

1. Add this code to any PHP file (ie: `woocommerce-gutenberg-products-block.php`):
```PHP
add_filter(
	'wc_session_expiration',
	function( $expiration ) {
		print_r( $expiration );
	}
);
```
2. In the frontend go to the Cart page with the Cart block.
3. Verify the printed value is `172800` (seconds in two days).

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
