### PR TITLE
Allow observers to set `billingAddress` by returning `billingData`

### DIFF
--- a/assets/js/data/payment/test/thunks.tsx
+++ b/assets/js/data/payment/test/thunks.tsx
@@ -77,7 +77,7 @@ describe( 'wc/store/payment thunks', () => {
 			} );
 
 			currentObservers.payment_processing.set( 'test3', {
-				callback: testCallbackWithMetadata,
+				callback: testSuccessCallbackWithMetadata,
 				priority: 10,
 			} );
 

--- a/assets/js/data/payment/test/thunks.tsx
+++ b/assets/js/data/payment/test/thunks.tsx
@@ -46,7 +46,7 @@ describe( 'wc/store/payment thunks', () => {
 			 * If an observer returns billingAddress, shippingAddress, or paymentData, then the values of these
 			 * should be updated in the data stores.
 			 */
-			const testBillingAddress = {
+			const testShippingAddress = {
 				first_name: 'test',
 				last_name: 'test',
 				company: 'test',
@@ -56,13 +56,21 @@ describe( 'wc/store/payment thunks', () => {
 				state: 'test',
 				postcode: 'test',
 				country: 'test',
-				email: 'test',
 				phone: 'test',
+			};
+			const testBillingAddress = {
+				...testShippingAddress,
+				email: 'test@test.com',
+			};
+			const testPaymentMethodData = {
+				payment_method: 'test',
 			};
 			const testCallbackWithMetadata = jest.fn().mockReturnValue( {
 				type: 'success',
 				meta: {
 					billingAddress: testBillingAddress,
+					shippingAddress: testShippingAddress,
+					paymentMethodData: testPaymentMethodData,
 				},
 			} );
 
@@ -72,11 +80,16 @@ describe( 'wc/store/payment thunks', () => {
 			} );
 
 			const setBillingAddressMock = jest.fn();
+			const setShippingAddressMock = jest.fn();
+			const setPaymentMethodDataMock = jest.fn();
 			const registryMock = {
 				dispatch: jest.fn().mockImplementation( ( store: string ) => {
 					return {
 						...wpDataFunctions.dispatch( store ),
 						setBillingAddress: setBillingAddressMock,
+						setShippingAddress: setShippingAddressMock,
+						__internalSetPaymentMethodData:
+							setPaymentMethodDataMock,
 					};
 				} ),
 			};
@@ -87,11 +100,22 @@ describe( 'wc/store/payment thunks', () => {
 				currentObservers,
 				jest.fn()
 			)( {
+				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+				// @ts-ignore - it would be too much work to mock the entire registry, so we only mock dispatch on it,
+				// which is all we need to test this thunk.
 				registry: registryMock,
 				dispatch: wpDataFunctions.dispatch( PAYMENT_STORE_KEY ),
 			} );
 
-			expect( setBillingAddressMock ).toHaveBeenCalled();
+			expect( setBillingAddressMock ).toHaveBeenCalledWith(
+				testBillingAddress
+			);
+			// expect( setShippingAddressMock ).toHaveBeenCalledWith(
+			// 	testShippingAddress
+			// );
+			expect( setPaymentMethodDataMock ).toHaveBeenCalledWith(
+				testPaymentMethodData
+			);
 		} );
 	} );
 } );

--- a/assets/js/data/payment/test/thunks.tsx
+++ b/assets/js/data/payment/test/thunks.tsx
@@ -9,6 +9,31 @@ import { EventObserversType } from '@woocommerce/base-context';
  */
 import { PAYMENT_STORE_KEY } from '../index';
 import { __internalEmitPaymentProcessingEvent } from '../thunks';
+
+/**
+ * If an observer returns billingAddress, shippingAddress, or paymentData, then the values of these
+ * should be updated in the data stores.
+ */
+const testShippingAddress = {
+	first_name: 'test',
+	last_name: 'test',
+	company: 'test',
+	address_1: 'test',
+	address_2: 'test',
+	city: 'test',
+	state: 'test',
+	postcode: 'test',
+	country: 'test',
+	phone: 'test',
+};
+const testBillingAddress = {
+	...testShippingAddress,
+	email: 'test@test.com',
+};
+const testPaymentMethodData = {
+	payment_method: 'test',
+};
+
 describe( 'wc/store/payment thunks', () => {
 	const testPaymentProcessingCallback = jest.fn();
 	const testPaymentProcessingCallback2 = jest.fn();
@@ -41,31 +66,8 @@ describe( 'wc/store/payment thunks', () => {
 			expect( testPaymentProcessingCallback2 ).toHaveBeenCalled();
 		} );
 
-		it( 'sets metadata if an observer returns it', async () => {
-			/**
-			 * If an observer returns billingAddress, shippingAddress, or paymentData, then the values of these
-			 * should be updated in the data stores.
-			 */
-			const testShippingAddress = {
-				first_name: 'test',
-				last_name: 'test',
-				company: 'test',
-				address_1: 'test',
-				address_2: 'test',
-				city: 'test',
-				state: 'test',
-				postcode: 'test',
-				country: 'test',
-				phone: 'test',
-			};
-			const testBillingAddress = {
-				...testShippingAddress,
-				email: 'test@test.com',
-			};
-			const testPaymentMethodData = {
-				payment_method: 'test',
-			};
-			const testCallbackWithMetadata = jest.fn().mockReturnValue( {
+		it( 'sets metadata if successful observers return it', async () => {
+			const testSuccessCallbackWithMetadata = jest.fn().mockReturnValue( {
 				type: 'success',
 				meta: {
 					billingAddress: testBillingAddress,

--- a/assets/js/data/payment/test/thunks.tsx
+++ b/assets/js/data/payment/test/thunks.tsx
@@ -1,0 +1,97 @@
+/**
+ * External dependencies
+ */
+import * as wpDataFunctions from '@wordpress/data';
+import { EventObserversType } from '@woocommerce/base-context';
+
+/**
+ * Internal dependencies
+ */
+import { PAYMENT_STORE_KEY } from '../index';
+import { __internalEmitPaymentProcessingEvent } from '../thunks';
+describe( 'wc/store/payment thunks', () => {
+	const testPaymentProcessingCallback = jest.fn();
+	const testPaymentProcessingCallback2 = jest.fn();
+	const currentObservers: EventObserversType = {
+		payment_processing: new Map(),
+	};
+	currentObservers.payment_processing.set( 'test', {
+		callback: testPaymentProcessingCallback,
+		priority: 10,
+	} );
+	currentObservers.payment_processing.set( 'test2', {
+		callback: testPaymentProcessingCallback2,
+		priority: 10,
+	} );
+
+	describe( '__internalEmitPaymentProcessingEvent', () => {
+		beforeEach( () => {
+			jest.resetAllMocks();
+		} );
+		it( 'calls all registered observers', async () => {
+			const {
+				__internalEmitPaymentProcessingEvent:
+					__internalEmitPaymentProcessingEventFromStore,
+			} = wpDataFunctions.dispatch( PAYMENT_STORE_KEY );
+			await __internalEmitPaymentProcessingEventFromStore(
+				currentObservers,
+				jest.fn()
+			);
+			expect( testPaymentProcessingCallback ).toHaveBeenCalled();
+			expect( testPaymentProcessingCallback2 ).toHaveBeenCalled();
+		} );
+
+		it( 'sets metadata if an observer returns it', async () => {
+			/**
+			 * If an observer returns billingAddress, shippingAddress, or paymentData, then the values of these
+			 * should be updated in the data stores.
+			 */
+			const testBillingAddress = {
+				first_name: 'test',
+				last_name: 'test',
+				company: 'test',
+				address_1: 'test',
+				address_2: 'test',
+				city: 'test',
+				state: 'test',
+				postcode: 'test',
+				country: 'test',
+				email: 'test',
+				phone: 'test',
+			};
+			const testCallbackWithMetadata = jest.fn().mockReturnValue( {
+				type: 'success',
+				meta: {
+					billingAddress: testBillingAddress,
+				},
+			} );
+
+			currentObservers.payment_processing.set( 'test3', {
+				callback: testCallbackWithMetadata,
+				priority: 10,
+			} );
+
+			const setBillingAddressMock = jest.fn();
+			const registryMock = {
+				dispatch: jest.fn().mockImplementation( ( store: string ) => {
+					return {
+						...wpDataFunctions.dispatch( store ),
+						setBillingAddress: setBillingAddressMock,
+					};
+				} ),
+			};
+
+			// Await here because the function returned by the __internalEmitPaymentProcessingEvent action creator
+			// (a thunk) returns a Promise.
+			await __internalEmitPaymentProcessingEvent(
+				currentObservers,
+				jest.fn()
+			)( {
+				registry: registryMock,
+				dispatch: wpDataFunctions.dispatch( PAYMENT_STORE_KEY ),
+			} );
+
+			expect( setBillingAddressMock ).toHaveBeenCalled();
+		} );
+	} );
+} );

--- a/assets/js/data/payment/test/thunks.tsx
+++ b/assets/js/data/payment/test/thunks.tsx
@@ -90,8 +90,6 @@ describe( 'wc/store/payment thunks', () => {
 						...wpDataFunctions.dispatch( store ),
 						setBillingAddress: setBillingAddressMock,
 						setShippingAddress: setShippingAddressMock,
-						__internalSetPaymentMethodData:
-							setPaymentMethodDataMock,
 					};
 				} ),
 			};
@@ -106,15 +104,18 @@ describe( 'wc/store/payment thunks', () => {
 				// @ts-ignore - it would be too much work to mock the entire registry, so we only mock dispatch on it,
 				// which is all we need to test this thunk.
 				registry: registryMock,
-				dispatch: wpDataFunctions.dispatch( PAYMENT_STORE_KEY ),
+				dispatch: {
+					...wpDataFunctions.dispatch( PAYMENT_STORE_KEY ),
+					__internalSetPaymentMethodData: setPaymentMethodDataMock,
+				},
 			} );
 
 			expect( setBillingAddressMock ).toHaveBeenCalledWith(
 				testBillingAddress
 			);
-			// expect( setShippingAddressMock ).toHaveBeenCalledWith(
-			// 	testShippingAddress
-			// );
+			expect( setShippingAddressMock ).toHaveBeenCalledWith(
+				testShippingAddress
+			);
 			expect( setPaymentMethodDataMock ).toHaveBeenCalledWith(
 				testPaymentMethodData
 			);

--- a/assets/js/data/payment/thunks.ts
+++ b/assets/js/data/payment/thunks.ts
@@ -52,7 +52,7 @@ export const __internalEmitPaymentProcessingEvent: emitProcessingEventType = (
 		const { createErrorNotice, removeNotice } =
 			registry.dispatch( 'core/notices' );
 		removeNotice( 'wc-payment-error', noticeContexts.PAYMENTS );
-		emitEventWithAbort(
+		return emitEventWithAbort(
 			currentObserver,
 			EMIT_TYPES.PAYMENT_PROCESSING,
 			{}

--- a/assets/js/data/payment/thunks.ts
+++ b/assets/js/data/payment/thunks.ts
@@ -72,10 +72,17 @@ export const __internalEmitPaymentProcessingEvent: emitProcessingEventType = (
 				) {
 					errorResponse = response;
 				}
+				// Extensions may return shippingData, shippingAddress, billingData, and billingAddress in the response,
+				// so we need to check for all. If we detect either shippingData or billingData we need to show a
+				// deprecated warning for it, but also apply the changes to the wc/store/cart store.
 				const {
 					billingAddress: billingAddressFromResponse,
+
+					// Deprecated, but keeping it for now, for compatibility with extensions returning it.
 					billingData: billingDataFromResponse,
 					shippingAddress: shippingAddressFromResponse,
+
+					// Deprecated, but keeping it for now, for compatibility with extensions returning it.
 					shippingData: shippingDataFromResponse,
 				} = response?.meta || {};
 

--- a/assets/js/data/payment/thunks.ts
+++ b/assets/js/data/payment/thunks.ts
@@ -113,8 +113,7 @@ export const __internalEmitPaymentProcessingEvent: emitProcessingEventType = (
 				registry.dispatch( CART_STORE_KEY );
 
 			if ( successResponse && ! errorResponse ) {
-				const { paymentMethodData, shippingData } =
-					successResponse?.meta || {};
+				const { paymentMethodData } = successResponse?.meta || {};
 
 				if ( billingAddress && isBillingAddress( billingAddress ) ) {
 					setBillingAddress( billingAddress );
@@ -123,9 +122,7 @@ export const __internalEmitPaymentProcessingEvent: emitProcessingEventType = (
 					typeof shippingAddress !== 'undefined' &&
 					isShippingAddress( shippingAddress )
 				) {
-					setShippingAddress(
-						shippingData as Record< string, unknown >
-					);
+					setShippingAddress( shippingAddress );
 				}
 				dispatch.__internalSetPaymentMethodData( paymentMethodData );
 				dispatch.__internalSetPaymentSuccess();

--- a/assets/js/data/payment/thunks.ts
+++ b/assets/js/data/payment/thunks.ts
@@ -141,7 +141,6 @@ export const __internalEmitPaymentProcessingEvent: emitProcessingEventType = (
 				}
 
 				const { paymentMethodData } = errorResponse?.meta || {};
-
 				if ( billingAddress && isBillingAddress( billingAddress ) ) {
 					setBillingAddress( billingAddress );
 				}

--- a/assets/js/data/payment/thunks.ts
+++ b/assets/js/data/payment/thunks.ts
@@ -84,7 +84,7 @@ export const __internalEmitPaymentProcessingEvent: emitProcessingEventType = (
 						{
 							version: '9.4.0',
 							alternative: 'billingAddress',
-							link: '',
+							link: 'https://github.com/woocommerce/woocommerce-blocks/pull/6369',
 						}
 					);
 				}

--- a/assets/js/data/payment/thunks.ts
+++ b/assets/js/data/payment/thunks.ts
@@ -88,7 +88,7 @@ export const __internalEmitPaymentProcessingEvent: emitProcessingEventType = (
 					deprecated(
 						'returning billingData from an onPaymentProcessing observer in WooCommerce Blocks',
 						{
-							version: '9.4.0',
+							version: '9.5.0',
 							alternative: 'billingAddress',
 							link: 'https://github.com/woocommerce/woocommerce-blocks/pull/6369',
 						}
@@ -101,7 +101,7 @@ export const __internalEmitPaymentProcessingEvent: emitProcessingEventType = (
 					deprecated(
 						'returning shippingData from an onPaymentProcessing observer in WooCommerce Blocks',
 						{
-							version: '9.4.0',
+							version: '9.5.0',
 							alternative: 'shippingAddress',
 							link: 'https://github.com/woocommerce/woocommerce-blocks/pull/8163',
 						}

--- a/assets/js/data/payment/thunks.ts
+++ b/assets/js/data/payment/thunks.ts
@@ -2,11 +2,11 @@
  * External dependencies
  */
 import { store as noticesStore } from '@wordpress/notices';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
  */
-
 import {
 	emitEventWithAbort,
 	isErrorResponse,
@@ -70,8 +70,24 @@ export const __internalEmitPaymentProcessingEvent: emitProcessingEventType = (
 				registry.dispatch( CART_STORE_KEY );
 
 			if ( successResponse && ! errorResponse ) {
-				const { paymentMethodData, billingAddress, shippingData } =
-					successResponse?.meta || {};
+				const {
+					paymentMethodData,
+					billingAddress,
+					billingData,
+					shippingData,
+				} = successResponse?.meta || {};
+
+				if ( billingData ) {
+					setBillingAddress( billingData );
+					deprecated(
+						'returning billingData from an onPaymentProcessing observer in WooCommerce Blocks',
+						{
+							version: '9.4.0',
+							alternative: 'billingAddress',
+							link: '',
+						}
+					);
+				}
 
 				if ( billingAddress ) {
 					setBillingAddress( billingAddress );

--- a/assets/js/data/payment/thunks.ts
+++ b/assets/js/data/payment/thunks.ts
@@ -18,6 +18,10 @@ import {
 import { EMIT_TYPES } from '../../base/context/providers/cart-checkout/payment-events/event-emit';
 import type { emitProcessingEventType } from './types';
 import { CART_STORE_KEY } from '../cart';
+import {
+	isBillingAddress,
+	isShippingAddress,
+} from '../../types/type-guards/address';
 
 export const __internalSetExpressPaymentError = ( message?: string ) => {
 	return ( { registry } ) => {
@@ -112,10 +116,13 @@ export const __internalEmitPaymentProcessingEvent: emitProcessingEventType = (
 				const { paymentMethodData, shippingData } =
 					successResponse?.meta || {};
 
-				if ( billingAddress ) {
+				if ( billingAddress && isBillingAddress( billingAddress ) ) {
 					setBillingAddress( billingAddress );
 				}
-				if ( typeof shippingAddress !== 'undefined' ) {
+				if (
+					typeof shippingAddress !== 'undefined' &&
+					isShippingAddress( shippingAddress )
+				) {
 					setShippingAddress(
 						shippingData as Record< string, unknown >
 					);
@@ -135,7 +142,7 @@ export const __internalEmitPaymentProcessingEvent: emitProcessingEventType = (
 
 				const { paymentMethodData } = errorResponse?.meta || {};
 
-				if ( billingAddress ) {
+				if ( billingAddress && isBillingAddress( billingAddress ) ) {
 					setBillingAddress( billingAddress );
 				}
 				dispatch.__internalSetPaymentFailed();

--- a/assets/js/types/type-guards/address.ts
+++ b/assets/js/types/type-guards/address.ts
@@ -1,0 +1,28 @@
+/**
+ * External dependencies
+ */
+import type { BillingAddress, ShippingAddress } from '@woocommerce/settings';
+import { objectHasProp } from '@woocommerce/types';
+
+export const isShippingAddress = (
+	address: unknown
+): address is ShippingAddress => {
+	const keys = [
+		'first_name',
+		'last_name',
+		'company',
+		'address_1',
+		'address_2',
+		'city',
+		'state',
+		'postcode',
+		'country',
+		'phone',
+	];
+	return keys.every( ( key ) => objectHasProp( address, key ) );
+};
+export const isBillingAddress = (
+	address: unknown
+): address is BillingAddress => {
+	return isShippingAddress( address ) && objectHasProp( address, 'email' );
+};

--- a/assets/js/types/type-guards/test/index.ts
+++ b/assets/js/types/type-guards/test/index.ts
@@ -3,6 +3,11 @@
  */
 import { isObject } from '@woocommerce/types';
 
+/**
+ * Internal dependencies
+ */
+import { isBillingAddress, isShippingAddress } from '../address';
+
 describe( 'type-guards', () => {
 	describe( 'Testing isObject()', () => {
 		it( 'Correctly identifies an object', () => {
@@ -12,6 +17,79 @@ describe( 'type-guards', () => {
 		it( 'Correctly rejects object-like things', () => {
 			expect( isObject( [] ) ).toBe( false );
 			expect( isObject( null ) ).toBe( false );
+		} );
+	} );
+
+	describe( 'testing isShippingAddress()', () => {
+		it( 'Correctly identifies a shipping address object', () => {
+			expect( isShippingAddress( {} ) ).toBe( false );
+			expect( isShippingAddress( { test: 'object' } ) ).toBe( false );
+
+			const shippingAddress = {
+				first_name: 'John',
+				last_name: 'Doe',
+				company: 'ACME',
+				address_1: '123 Main St',
+				address_2: 'Suite 1',
+				city: 'Anytown',
+				state: 'CA',
+				postcode: '12345',
+				country: 'US',
+				phone: '555-555-5555',
+			};
+			expect( isShippingAddress( shippingAddress ) ).toBe( true );
+		} );
+
+		it( 'Correctly rejects non-shipping address objects', () => {
+			const nonShippingAddress = {
+				first_name: 'John',
+				last_name: 'Doe',
+				company: 'ACME',
+				address_1: '123 Main St',
+				city: 'Anytown',
+				state: 'CA',
+				postcode: '12345',
+				country: 'US',
+				phone: '555-555-5555',
+				email: '',
+			};
+			expect( isShippingAddress( nonShippingAddress ) ).toBe( false );
+		} );
+	} );
+	describe( 'testing isBillingAddress()', () => {
+		it( 'Correctly identifies a shipping address object', () => {
+			expect( isBillingAddress( {} ) ).toBe( false );
+			expect( isBillingAddress( { test: 'object' } ) ).toBe( false );
+
+			const billingAddress = {
+				first_name: 'John',
+				last_name: 'Doe',
+				company: 'ACME',
+				address_1: '123 Main St',
+				address_2: 'Suite 1',
+				city: 'Anytown',
+				state: 'CA',
+				postcode: '12345',
+				country: 'US',
+				phone: '555-555-5555',
+				email: 'jon@doe.com',
+			};
+			expect( isBillingAddress( billingAddress ) ).toBe( true );
+		} );
+
+		it( 'Correctly rejects non-billing address objects', () => {
+			const nonBillingAddress = {
+				first_name: 'John',
+				last_name: 'Doe',
+				company: 'ACME',
+				address_1: '123 Main St',
+				city: 'Anytown',
+				state: 'CA',
+				country: 'US',
+				phone: '555-555-5555',
+				email: '',
+			};
+			expect( isBillingAddress( nonBillingAddress ) ).toBe( false );
 		} );
 	} );
 } );


### PR DESCRIPTION
This is required since we didn't correctly deprecate `billingData` when we changed the name to `billingAddress`, so some extensions could still be returning `billingData` to the `onPaymentProcessing` observer.

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [ ] E2E tests

#### Internal Developer Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Install the Stripe plugin from source.
2. Go to https://github.com/woocommerce/woocommerce-gateway-stripe/blob/8ffd22aff3b06eda02a1ae2fd8368b71450b36a9/client/blocks/credit-card/use-payment-processing.js#L136 and change `billingData` to:
```js
billingData: {
  ...bilingData,
  first_name: 'Set from',
  last_name: 'Stripe plugin',
}
```
3. Add `shippingData` too - this can be a copy of `billingData`.
4. Add items to your cart and load the Checkout block.
5. Open the console and enable `Preserve log`.
6. Check out using Stripe.
7. Ensure you see a deprecated notice for `billingData`.
8. Edit the previous code, and change the key: `billingData` to `billingAddress`
```js
billingAddress: {
  ...bilingData,
  first_name: 'Set from',
  last_name: 'Stripe plugin',
}
```
9. Also add `shippingAddress` - this can be a copy of `billingAddress`.
9. Check out again and ensure the deprecation notice does not appear.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Skipping.
