### PR TITLE
Add a compatibility layer to keep extensions continue working with Blockified Archive Templates

### DIFF
--- a/src/Domain/Bootstrap.php
+++ b/src/Domain/Bootstrap.php
@@ -22,6 +22,7 @@ use Automattic\WooCommerce\Blocks\Payments\Integrations\PayPal;
 use Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry;
 use Automattic\WooCommerce\Blocks\Registry\Container;
 use Automattic\WooCommerce\Blocks\Templates\ClassicTemplatesCompatibility;
+use Automattic\WooCommerce\Blocks\Templates\BlockTemplatesCompatibility;
 use Automattic\WooCommerce\Blocks\Templates\ProductAttributeTemplate;
 use Automattic\WooCommerce\Blocks\Templates\ProductSearchResultsTemplate;
 use Automattic\WooCommerce\StoreApi\RoutesController;
@@ -127,6 +128,7 @@ class Bootstrap {
 		$this->container->get( ProductSearchResultsTemplate::class );
 		$this->container->get( ProductAttributeTemplate::class );
 		$this->container->get( ClassicTemplatesCompatibility::class );
+		$this->container->get( BlockTemplatesCompatibility::class );
 		$this->container->get( BlockPatterns::class );
 		$this->container->get( PaymentsApi::class );
 		$this->container->get( ShippingController::class )->init();
@@ -270,6 +272,12 @@ class Bootstrap {
 			function ( Container $container ) {
 				$asset_data_registry = $container->get( AssetDataRegistry::class );
 				return new ClassicTemplatesCompatibility( $asset_data_registry );
+			}
+		);
+		$this->container->register(
+			BlockTemplatesCompatibility::class,
+			function () {
+				return new BlockTemplatesCompatibility();
 			}
 		);
 		$this->container->register(

--- a/src/Templates/BlockTemplatesCompatibility.php
+++ b/src/Templates/BlockTemplatesCompatibility.php
@@ -270,7 +270,7 @@ class BlockTemplatesCompatibility {
 		}
 
 		/**
-		 * When extentions implement their equivalent blocks of the template
+		 * When extensions implement their equivalent blocks of the template
 		 * hook functions, they can use this filter to register their old hooked
 		 * data here, so in the blockified template, the old hooked functions
 		 * can be removed in favor of the new blocks while keeping the old

--- a/src/Templates/BlockTemplatesCompatibility.php
+++ b/src/Templates/BlockTemplatesCompatibility.php
@@ -222,10 +222,6 @@ class BlockTemplatesCompatibility {
 	 * content.
 	 */
 	protected function remove_default_hooks() {
-		if ( ! $this->is_archive_template() ) {
-			return;
-		}
-
 		$hooks = array_merge( ...array_values( $this->get_hook_data() ) );
 		foreach ( $hooks as $hook => $data ) {
 			if ( ! isset( $data['hooked'] ) ) {

--- a/src/Templates/BlockTemplatesCompatibility.php
+++ b/src/Templates/BlockTemplatesCompatibility.php
@@ -262,7 +262,7 @@ class BlockTemplatesCompatibility {
 		 *
 		 * @param array $data Additional hooked data. Default to empty
 		 */
-		$additional_hook_data = apply_filters( 'woocommerce_blocks_hook_compatibility_additional_hook_data', array() );
+		$additional_hook_data = apply_filters( 'woocommerce_blocks_hook_compatibility_additional_data', array() );
 
 		foreach ( $additional_hook_data as $data ) {
 			if (

--- a/src/Templates/BlockTemplatesCompatibility.php
+++ b/src/Templates/BlockTemplatesCompatibility.php
@@ -1,0 +1,75 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\Templates;
+
+/**
+ * BlockTemplatesCompatibility class.
+ *
+ * To bridge the gap on compatibility with PHP hooks and blockified templates.
+ *
+ * @internal
+ */
+class BlockTemplatesCompatibility {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->init();
+	}
+
+	/**
+	 * Initialization method.
+	 */
+	protected function init() {
+		add_filter( 'render_block_data', array( $this, 'update_render_block_data' ), 10, 3 );
+		add_filter( 'render_block', array( $this, 'inject_hooks' ), 10, 2 );
+	}
+
+	public function update_render_block_data( $parsed_block, $source_block, $parent_block ) {
+		if ( $parent_block ) {
+			return $parsed_block;
+		}
+
+		array_walk( $parsed_block['innerBlocks'], array( $this, 'inner_blocks_walker' ) );
+
+		return $parsed_block;
+	}
+
+	public function inject_hooks( $block_content, $block ) {
+		if ( ! is_shop() && ! is_product_taxonomy() ) {
+			return $block_content;
+		}
+		if ( 'core/post-title' !== $block['blockName'] ) {
+			return $block_content;
+		}
+		if ( empty( $block['attrs']['isInherited'] ) ) {
+			return $block_content;
+		}
+		return $block_content . ' - hello';
+	}
+
+	protected function inner_blocks_walker( &$block ) {
+		if (
+			$block['blockName'] === 'core/query' &&
+			isset( $block['attrs']['namespace'] ) &&
+			$block['attrs']['namespace'] === 'woocommerce/product-query' &&
+			isset( $block['attrs']['query']['inherit'] ) &&
+			$block['attrs']['query']['inherit']
+		) {
+			array_walk( $block['innerBlocks'], array( $this, 'inject_attribute' ) );
+		}
+
+		if ( ! empty( $block['innerBlocks'] ) ) {
+			array_walk( $block['innerBlocks'], array( $this, 'inner_blocks_walker' ) );
+		}
+	}
+
+	protected function inject_attribute( &$block ) {
+		$block['attrs']['isInherited'] = 1;
+
+		if ( ! empty( $block['innerBlocks'] ) ) {
+			array_walk( $block['innerBlocks'], array( $this, 'inject_attribute' ) );
+		}
+	}
+
+}

--- a/src/Templates/BlockTemplatesCompatibility.php
+++ b/src/Templates/BlockTemplatesCompatibility.php
@@ -95,118 +95,189 @@ class BlockTemplatesCompatibility {
 
 		$hook_data = $this->get_hook_data();
 
-		if ( ! in_array( $block_name, array_keys( $hook_data ), true ) ) {
+		$supported_blocks = array_map(
+			function( $hook ) {
+				return $hook['block_name'];
+			},
+			array_values( $hook_data )
+		);
+
+		if ( ! in_array( $block_name, $supported_blocks, true ) ) {
 			return $block_content;
 		}
 
 		/**
-		 * If the block is empty, we don't need to inject hooks.
+		 * `core/query-no-result` is a special case because it can return two
+		 * different content depending on the context. We need to check if the
+		 * block content is empty to determine if we need to inject hooks.
 		 */
-		if ( empty( $block_content ) ) {
+		if (
+			'core/query-no-results' === $block_name &&
+			empty( trim( $block_content ) )
+		) {
 			return $block_content;
 		}
 
-		$hooks = $hook_data[ $block_name ];
+		$block_hooks = array_filter(
+			$hook_data,
+			function( $hook ) use ( $block_name ) {
+				return $hook['block_name'] === $block_name;
+			}
+		);
 
 		return sprintf(
 			'%1$s%2$s%3$s',
-			$this->get_hooks_buffer( $hooks, 'before' ),
+			$this->get_hooks_buffer( $block_hooks, 'before' ),
 			$block_content,
-			$this->get_hooks_buffer( $hooks, 'after' )
+			$this->get_hooks_buffer( $block_hooks, 'after' )
 		);
 	}
 
 	/**
-	 * Hoding the supported hooks, their positions and the hooked functions.
+	 * The hook data to inject to the rendered content of blocks. This also
+	 * contains hooked functions that will be removed by remove_default_hooks.
+	 *
+	 * The array format:
+	 * [
+	 *   <hook-name> => [
+	 *     block_name => <block-name>,
+	 *     position => before|after,
+	 *     hooked => [
+	 *       <function-name> => <priority>,
+	 *        ...
+	 *     ],
+	 *  ],
+	 * ]
+	 * Where:
+	 * - hook-name is the name of the hook that will be replaced.
+	 * - block-name is the name of the block that will replace the hook.
+	 * - position is the position of the block relative to the hook.
+	 * - hooked is an array of functions hooked to the hook that will be
+	 *   replaced. The key is the function name and the value is the
+	 *   priority.
 	 *
 	 * @return array Hook data.
 	 */
 	protected function get_hook_data() {
 		$hook_data = array(
-			'core/query'            => array(
-				'woocommerce_before_main_content' => array(
-					'position' => 'before',
-					'hooked'   => array(
-						'woocommerce_output_content_wrapper' => 10,
-						'woocommerce_breadcrumb' => 20,
-					),
-				),
-				'woocommerce_after_main_content'  => array(
-					'position' => 'after',
-					'hooked'   => array(
-						'woocommerce_output_content_wrapper_end' => 10,
-					),
+			'woocommerce_before_main_content'         => array(
+				'block_name' => 'core/query',
+				'position'   => 'before',
+				'hooked'     => array(
+					'woocommerce_output_content_wrapper' => 10,
+					'woocommerce_breadcrumb'             => 20,
 				),
 			),
-			'core/post-title'       => array(
-				'woocommerce_before_shop_loop_item_title' => array(
-					'position' => 'before',
-					'hooked'   => array(
-						'woocommerce_show_product_loop_sale_flash' => 10,
-						'woocommerce_template_loop_product_thumbnail' => 10,
-					),
-				),
-				'woocommerce_shop_loop_item_title'        => array(
-					'position' => 'after',
-					'hooked'   => array(
-						'woocommerce_template_loop_product_title' => 10,
-					),
-				),
-				'woocommerce_after_shop_loop_item_title'  => array(
-					'position' => 'before',
-					'hooked'   => array(
-						'woocommerce_template_loop_rating' => 5,
-						'woocommerce_template_loop_price'  => 10,
-					),
+			'woocommerce_after_main_content'          => array(
+				'block_name' => 'core/query',
+				'position'   => 'after',
+				'hooked'     => array(
+					'woocommerce_output_content_wrapper_end' => 10,
 				),
 			),
-			self::LOOP_ITEM_ID      => array(
-				'woocommerce_before_shop_loop_item' => array(
-					'position' => 'before',
-					'hooked'   => array(
-						'woocommerce_template_loop_product_link_open' => 10,
-					),
-				),
-				'woocommerce_after_shop_loop_item'  => array(
-					'position' => 'after',
-					'hooked'   => array(
-						'woocommerce_template_loop_product_link_close' => 5,
-						'woocommerce_template_loop_add_to_cart' => 10,
-					),
+			'woocommerce_before_shop_loop_item_title' => array(
+				'block_name' => 'core/post-title',
+				'position'   => 'before',
+				'hooked'     => array(
+					'woocommerce_show_product_loop_sale_flash' => 10,
+					'woocommerce_template_loop_product_thumbnail' => 10,
 				),
 			),
-			'core/post-template'    => array(
-				'woocommerce_before_shop_loop' => array(
-					'position' => 'before',
-					'hooked'   => array(
-						'woocommerce_output_all_notices' => 10,
-						'woocommerce_result_count'       => 20,
-						'woocommerce_catalog_ordering'   => 30,
-					),
-				),
-				'woocommerce_after_shop_loop'  => array(
-					'position' => 'after',
-					'hooked'   => array(
-						'woocommerce_pagination' => 10,
-					),
+			'woocommerce_shop_loop_item_title'        => array(
+				'block_name' => 'core/post-title',
+				'position'   => 'after',
+				'hooked'     => array(
+					'woocommerce_template_loop_product_title' => 10,
 				),
 			),
-			'core/query-no-results' => array(
-				'woocommerce_no_products_found' => array(
-					'position' => 'before',
-					'hooked'   => array(
-						'wc_no_products_found' => 10,
-					),
+			'woocommerce_after_shop_loop_item_title'  => array(
+				'block_name' => 'core/post-title',
+				'position'   => 'before',
+				'hooked'     => array(
+					'woocommerce_template_loop_rating' => 5,
+					'woocommerce_template_loop_price'  => 10,
+				),
+			),
+			'woocommerce_before_shop_loop_item'       => array(
+				'block_name' => self::LOOP_ITEM_ID,
+				'position'   => 'before',
+				'hooked'     => array(
+					'woocommerce_template_loop_product_link_open' => 10,
+				),
+			),
+			'woocommerce_after_shop_loop_item'        => array(
+				'block_name' => self::LOOP_ITEM_ID,
+				'position'   => 'after',
+				'hooked'     => array(
+					'woocommerce_template_loop_product_link_close' => 5,
+					'woocommerce_template_loop_add_to_cart' => 10,
+				),
+			),
+			'woocommerce_before_shop_loop'            => array(
+				'block_name' => 'core/post-template',
+				'position'   => 'before',
+				'hooked'     => array(
+					'woocommerce_output_all_notices' => 10,
+					'woocommerce_result_count'       => 20,
+					'woocommerce_catalog_ordering'   => 30,
+				),
+			),
+			'woocommerce_after_shop_loop'             => array(
+				'block_name' => 'core/post-template',
+				'position'   => 'after',
+				'hooked'     => array(
+					'woocommerce_pagination' => 10,
+				),
+			),
+			'woocommerce_no_products_found'           => array(
+				'block_name' => 'core/query-no-results',
+				'position'   => 'before',
+				'hooked'     => array(
+					'wc_no_products_found' => 10,
 				),
 			),
 		);
 
 		/**
-		 * Filter the hook data used to replace the default WooCommerce hooks.
+		 * When extentions implement their equivalent blocks of the template
+		 * hook functions, they can use this filter to register their old hooked
+		 * data here, so in the blockified template, the old hooked functions
+		 * can be removed in favor of the new blocks while keeping the old
+		 * hooked functions working in classic templates.
 		 *
-		 * @param array $hook_data Hook data.
+		 * Accepts an array of hooked data. The array should be in the following
+		 * format:
+		 * [
+		 *   [
+		 *     hook => <hook-name>,
+		 *     function => <function-name>,
+		 *     priority => <priority>,
+		 *  ],
+		 *  ...
+		 * ]
+		 * Where:
+		 * - hook-name is the name of the hook that have the functions hooked to.
+		 * - function-name is the hooked function name.
+		 * - priority is the priority of the hooked function.
+		 *
+		 * @param array $data Additional hooked data. Default to empty
 		 */
-		return apply_filters( 'woocommerce_blocks_hooks_compatibility_data', $hook_data );
+		$additional_hook_data = apply_filters( 'woocommerce_blocks_hook_compatibility_additional_hook_data', array() );
+
+		foreach ( $additional_hook_data as $data ) {
+			if (
+				! is_string( $data['hook'] ) ||
+				! is_int( $data['priority'] ) ||
+				! in_array( $data['hook'], array_keys( $hook_data ), true ) ||
+				isset( $hook_data[ $data['hook'] ]['hooked'][ $data['function'] ] )
+			) {
+				continue;
+			}
+
+			$hook_data[ $data['hook'] ]['hooked'][ $data['function'] ] = $data['priority'];
+		}
+
+		return $hook_data;
 	}
 
 	/**
@@ -222,8 +293,7 @@ class BlockTemplatesCompatibility {
 	 * content.
 	 */
 	protected function remove_default_hooks() {
-		$hooks = array_merge( ...array_values( $this->get_hook_data() ) );
-		foreach ( $hooks as $hook => $data ) {
+		foreach ( $this->get_hook_data() as $hook => $data ) {
 			if ( ! isset( $data['hooked'] ) ) {
 				continue;
 			}
@@ -243,8 +313,8 @@ class BlockTemplatesCompatibility {
 	 */
 	protected function get_hooks_buffer( $hooks, $position ) {
 		ob_start();
-		foreach ( array_keys( $hooks ) as $hook ) {
-			if ( $hooks[ $hook ]['position'] === $position ) {
+		foreach ( $hooks as $hook => $data ) {
+			if ( $data['position'] === $position ) {
 				do_action( $hook );
 			}
 		}

--- a/src/Templates/BlockTemplatesCompatibility.php
+++ b/src/Templates/BlockTemplatesCompatibility.php
@@ -111,6 +111,14 @@ class BlockTemplatesCompatibility {
 			return;
 		}
 
+		/**
+		 * We're only support Archive Template for now. In the future, we'll
+		 * support other templates as well.
+		 */
+		if ( ! is_shop() && ! is_product_taxonomy() ) {
+			return;
+		}
+
 		add_filter( 'render_block_data', array( $this, 'update_render_block_data' ), 10, 3 );
 		add_filter( 'render_block', array( $this, 'inject_hooks' ), 10, 2 );
 		add_action( 'after_setup_theme', array( $this, 'remove_default_hooks' ) );
@@ -165,14 +173,6 @@ class BlockTemplatesCompatibility {
 	 * @return string
 	 */
 	public function inject_hooks( $block_content, $block ) {
-		/**
-		 * We're only support Archive Template for now. In the future, we'll
-		 * support other templates as well.
-		 */
-		if ( ! is_shop() && ! is_product_taxonomy() ) {
-			return $block_content;
-		}
-
 		/**
 		 * If the block is not inherited, we don't need to inject hooks.
 		 */

--- a/src/Templates/BlockTemplatesCompatibility.php
+++ b/src/Templates/BlockTemplatesCompatibility.php
@@ -10,6 +10,92 @@ namespace Automattic\WooCommerce\Blocks\Templates;
  */
 class BlockTemplatesCompatibility {
 
+	const LOOP_ITEM_ID = 'product-loop-item';
+
+	/**
+	 * Hoding the supported hooks, their positions and the hooked functions.
+	 *
+	 * @var array $hook_data
+	 */
+	protected $hook_data = array(
+		'core/query'            => array(
+			'woocommerce_before_main_content' => array(
+				'position' => 'before',
+				'hooked'   => array(
+					'woocommerce_output_content_wrapper' => 10,
+					'woocommerce_breadcrumb'             => 20,
+				),
+			),
+			'woocommerce_after_main_content'  => array(
+				'position' => 'after',
+				'hooked'   => array(
+					'woocommerce_output_content_wrapper_end' => 10,
+				),
+			),
+		),
+		'core/post-title'       => array(
+			'woocommerce_before_shop_loop_item_title' => array(
+				'position' => 'before',
+				'hooked'   => array(
+					'woocommerce_show_product_loop_sale_flash' => 10,
+					'woocommerce_template_loop_product_thumbnail' => 10,
+				),
+			),
+			'woocommerce_shop_loop_item_title'        => array(
+				'position' => 'after',
+				'hooked'   => array(
+					'woocommerce_template_loop_product_title' => 10,
+				),
+			),
+			'woocommerce_after_shop_loop_item_title'  => array(
+				'position' => 'after',
+				'hooked'   => array(
+					'woocommerce_template_loop_rating' => 5,
+					'woocommerce_template_loop_price'  => 10,
+				),
+			),
+		),
+		self::LOOP_ITEM_ID      => array(
+			'woocommerce_before_shop_loop_item' => array(
+				'position' => 'before',
+				'hooked'   => array(
+					'woocommerce_template_loop_product_link_open' => 10,
+				),
+			),
+			'woocommerce_after_shop_loop_item'  => array(
+				'position' => 'after',
+				'hooked'   => array(
+					'woocommerce_template_loop_product_link_close' => 5,
+					'woocommerce_template_loop_add_to_cart' => 10,
+				),
+			),
+		),
+		'core/post-template'    => array(
+			'woocommerce_before_shop_loop' => array(
+				'position' => 'before',
+				'hooked'   => array(
+					'woocommerce_output_all_notices' => 10,
+					'woocommerce_result_count'       => 20,
+					'woocommerce_catalog_ordering'   => 30,
+				),
+			),
+			'woocommerce_after_shop_loop'  => array(
+				'position' => 'after',
+				'hooked'   => array(
+					'woocommerce_pagination' => 10,
+				),
+			),
+		),
+		'core/query-no-results' => array(
+			'woocommerce_no_products_found' => array(
+				'position' => 'before',
+				'hooked'   => array(
+					'wc_no_products_found' => 10,
+				),
+			),
+		),
+	);
+
 	/**
 	 * Constructor.
 	 */
@@ -21,11 +107,47 @@ class BlockTemplatesCompatibility {
 	 * Initialization method.
 	 */
 	protected function init() {
+		if ( ! wc_current_theme_is_fse_theme() ) {
+			return;
+		}
+
 		add_filter( 'render_block_data', array( $this, 'update_render_block_data' ), 10, 3 );
 		add_filter( 'render_block', array( $this, 'inject_hooks' ), 10, 2 );
+		add_action( 'after_setup_theme', array( $this, 'remove_default_hooks' ) );
 	}
 
+	/**
+	 * Remove the default callback added by WooCommerce. We replaced these
+	 * callbacks by blocks so we have to remove them to prevent duplicated
+	 * content.
+	 */
+	public function remove_default_hooks() {
+		$hooks = array_merge( ...array_values( $this->hook_data ) );
+		foreach ( $hooks as $hook => $data ) {
+			if ( ! isset( $data['hooked'] ) ) {
+				continue;
+			}
+			foreach ( $data['hooked'] as $callback => $priority ) {
+				remove_action( $hook, $callback, $priority );
+			}
+		}
+	}
+
+	/**
+	 * Update the render block data to inject our custom attribute needed to
+	 * determine which blocks belong to an inherited Products block.
+	 *
+	 * @param array         $parsed_block The block being rendered.
+	 * @param array         $source_block An un-modified copy of $parsed_block, as it appeared in the source content.
+	 * @param WP_Block|null $parent_block If this is a nested block, a reference to the parent block.
+	 *
+	 * @return array
+	 */
 	public function update_render_block_data( $parsed_block, $source_block, $parent_block ) {
+		/**
+		 * Custom data can be injected to top level block only, as Gutenberg
+		 * will use this data to render the blocks and its nested blocks.
+		 */
 		if ( $parent_block ) {
 			return $parsed_block;
 		}
@@ -35,27 +157,91 @@ class BlockTemplatesCompatibility {
 		return $parsed_block;
 	}
 
+	/**
+	 * Inject hooks to rendered content of corresponding blocks.
+	 *
+	 * @param mixed $block_content The rendered block content.
+	 * @param mixed $block         The parsed block data.
+	 * @return string
+	 */
 	public function inject_hooks( $block_content, $block ) {
+		/**
+		 * We're only support Archive Template for now. In the future, we'll
+		 * support other templates as well.
+		 */
 		if ( ! is_shop() && ! is_product_taxonomy() ) {
 			return $block_content;
 		}
-		if ( 'core/post-title' !== $block['blockName'] ) {
-			return $block_content;
-		}
+
+		/**
+		 * If the block is not inherited, we don't need to inject hooks.
+		 */
 		if ( empty( $block['attrs']['isInherited'] ) ) {
 			return $block_content;
 		}
-		return $block_content . ' - hello';
+
+		$block_name = $block['blockName'];
+
+		/**
+		 * The core/post-template has two different block names:
+		 * - core/post-template when the wrapper is rendered.
+		 * - core/null when the loop item is rendered.
+		 */
+		if (
+			'core/null' === $block_name &&
+			isset( $block['attrs']['__woocommerceNamespace'] ) &&
+			'woocommerce/product-query/product-template' === $block['attrs']['__woocommerceNamespace']
+		) {
+			$block_name = self::LOOP_ITEM_ID;
+		}
+
+		if ( ! in_array( $block_name, array_keys( $this->hook_data ), true ) ) {
+			return $block_content;
+		}
+
+		$hooks = $this->hook_data[ $block_name ];
+
+		return sprintf(
+			'%1$s%2$s%3$s',
+			$this->get_hooks_buffer( $hooks, 'before' ),
+			$block_content,
+			$this->get_hooks_buffer( $hooks, 'after' )
+		);
 	}
 
+	/**
+	 * Get the buffer content of the hooks to append/prepend to render content.
+	 *
+	 * @param array  $hooks    The hooks to be rendered.
+	 * @param string $position The position of the hooks.
+	 *
+	 * @return string
+	 */
+	protected function get_hooks_buffer( $hooks, $position ) {
+		ob_start();
+		foreach ( array_keys( $hooks ) as $hook ) {
+			if ( $hooks[ $hook ]['position'] === $position ) {
+				do_action( $hook );
+			}
+		}
+		return ob_get_clean();
+	}
+
+	/**
+	 * Loop through inner blocks recursively to find the Products blocks that
+	 * inherits query from template.
+	 *
+	 * @param array $block Parsed block data.
+	 */
 	protected function inner_blocks_walker( &$block ) {
 		if (
-			$block['blockName'] === 'core/query' &&
+			'core/query' === $block['blockName'] &&
 			isset( $block['attrs']['namespace'] ) &&
-			$block['attrs']['namespace'] === 'woocommerce/product-query' &&
+			'woocommerce/product-query' === $block['attrs']['namespace'] &&
 			isset( $block['attrs']['query']['inherit'] ) &&
 			$block['attrs']['query']['inherit']
 		) {
+			$block['attrs']['isInherited'] = 1;
 			array_walk( $block['innerBlocks'], array( $this, 'inject_attribute' ) );
 		}
 
@@ -64,6 +250,11 @@ class BlockTemplatesCompatibility {
 		}
 	}
 
+	/**
+	 * Recursively inject the custom attribute to all nested blocks.
+	 *
+	 * @param array $block Parsed block data.
+	 */
 	protected function inject_attribute( &$block ) {
 		$block['attrs']['isInherited'] = 1;
 

--- a/src/Templates/BlockTemplatesCompatibility.php
+++ b/src/Templates/BlockTemplatesCompatibility.php
@@ -295,7 +295,7 @@ class BlockTemplatesCompatibility {
 		 */
 		$additional_hook_data = apply_filters( 'woocommerce_blocks_hook_compatibility_additional_data', array() );
 
-		if ( empty( $additional_hook_data ) ) {
+		if ( empty( $additional_hook_data ) || ! is_array( $additional_hook_data ) ) {
 			return;
 		}
 

--- a/src/Templates/BlockTemplatesCompatibility.php
+++ b/src/Templates/BlockTemplatesCompatibility.php
@@ -111,17 +111,16 @@ class BlockTemplatesCompatibility {
 			return;
 		}
 
-		/**
-		 * We're only support Archive Template for now. In the future, we'll
-		 * support other templates as well.
-		 */
-		if ( ! is_shop() && ! is_product_taxonomy() ) {
-			return;
-		}
-
 		add_filter( 'render_block_data', array( $this, 'update_render_block_data' ), 10, 3 );
 		add_filter( 'render_block', array( $this, 'inject_hooks' ), 10, 2 );
-		add_action( 'after_setup_theme', array( $this, 'remove_default_hooks' ) );
+		add_action( 'template_redirect', array( $this, 'remove_default_hooks' ) );
+	}
+
+	/**
+	 * Check if current page is a product archive template.
+	 */
+	protected function is_archive_template() {
+		return is_shop() || is_product_taxonomy();
 	}
 
 	/**
@@ -130,6 +129,10 @@ class BlockTemplatesCompatibility {
 	 * content.
 	 */
 	public function remove_default_hooks() {
+		if ( ! $this->is_archive_template() ) {
+			return;
+		}
+
 		$hooks = array_merge( ...array_values( $this->hook_data ) );
 		foreach ( $hooks as $hook => $data ) {
 			if ( ! isset( $data['hooked'] ) ) {
@@ -152,6 +155,11 @@ class BlockTemplatesCompatibility {
 	 * @return array
 	 */
 	public function update_render_block_data( $parsed_block, $source_block, $parent_block ) {
+
+		if ( ! $this->is_archive_template() ) {
+			return $parsed_block;
+		}
+
 		/**
 		 * Custom data can be injected to top level block only, as Gutenberg
 		 * will use this data to render the blocks and its nested blocks.
@@ -173,6 +181,9 @@ class BlockTemplatesCompatibility {
 	 * @return string
 	 */
 	public function inject_hooks( $block_content, $block ) {
+		if ( ! $this->is_archive_template() ) {
+			return $block_content;
+		}
 		/**
 		 * If the block is not inherited, we don't need to inject hooks.
 		 */


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #8065

This PR adds a new class that acts as the compatibility layer for blockified archive templates by:
- Injecting custom attribute for the Products block that inherits query from template and its inner blocks.
- Filtering the output of those inner block, appendding/prepending the corresponding hooks to each blocks.
- Remove the default callbacks added to those hooks by WooCommerce.

The compatibility is building around Products block because loop is the main element of archive templates and hooks are placing inside and around the loop.

This PR skips these hooks:

-  `woocommerce_show_page_title`
- `woocommerce_archive_description`
- `woocommerce_sidebar`

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Run `composer dump-autoload`. 
2. Ensure the test site uses a block theme.
3. Edit the Product Catalog template.
4. Remove the Classic Template block, and replace it with Products (Beta) block.
5. Enable `Inherit query from template`.
6. Save changes. 
7. Go to the shop page on the front end, see the block works as expected.
8. In the theme `functions.php` file, add this snippet, then reload the shop page on the front end to see if the test content is displayed at the expected position:
```
add_action( 'woocommerce_before_shop_loop_item' , function () {
	echo 'Hook: woocommerce_before_shop_loop_item';
});
```

<img width="1853" alt="image" src="https://user-images.githubusercontent.com/5423135/212122727-a16c0d04-c651-4650-89fe-bb0e79b66bf0.png">

Repeat for other hooks:

- `woocommerce_before_main_content`
- `woocommerce_after_main_content`
- `woocommerce_before_shop_loop_item_title`
- `woocommerce_shop_loop_item_title`
- `woocommerce_after_shop_loop_item_title`
- `woocommerce_before_shop_loop_item`
- `woocommerce_after_shop_loop_item`
- `woocommerce_before_shop_loop`
- `woocommerce_after_shop_loop`
- `woocommerce_no_products_found`


* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Enhancement: Add a compatibility layer to keep extensions continue working with Blockified Archive Templates.