### PR TITLE
Products: Fix variable products add to cart

### DIFF
--- a/src/BlockTypes/ProductButton.php
+++ b/src/BlockTypes/ProductButton.php
@@ -101,7 +101,7 @@ class ProductButton extends AbstractBlock {
 					esc_url( $product->add_to_cart_url() ),
 					esc_attr( $product->get_id() ),
 					esc_attr( $product->get_sku() ),
-					$product->is_purchasable() ? 'ajax_add_to_cart add_to_cart_button' : '',
+					$product->is_purchasable() && ! $product->has_options() ? 'ajax_add_to_cart add_to_cart_button' : '',
 					esc_attr( $product->get_type() ),
 					esc_attr( $styles_and_classes['classes'] ),
 					esc_attr( $styles_and_classes['styles'] ),


### PR DESCRIPTION
Variable products would get added to cart via the button, even when the button said “Select options” and contained a link. This PR fixes this problem: when products have options, the button doesn't get hydrated with the AJAX functionality.

Fixes #8147

### Testing

#### User Facing Testing

0. Make sure you have at least one variable product.
1. Add a “Products (Beta)” block and publish your page.
2. Make sure that on the front-end the button under your variable product says “Select options” (or equivalent in your language) and, when clicked, it does **not** add the product to cart but rather redirects to the product page.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Products (Beta): Fixed an issue where variable products buttons would add the product to cart instead of directing the user to the product page.
