### PR TITLE
Update Shipping Calculator Handling so errors are reported to the customer

### DIFF
--- a/assets/js/base/components/cart-checkout/shipping-calculator/address.tsx
+++ b/assets/js/base/components/cart-checkout/shipping-calculator/address.tsx
@@ -6,7 +6,7 @@ import Button from '@woocommerce/base-components/button';
 import { useState } from '@wordpress/element';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 import type { ShippingAddress, AddressFields } from '@woocommerce/settings';
-import { VALIDATION_STORE_KEY } from '@woocommerce/block-data';
+import { VALIDATION_STORE_KEY, CART_STORE_KEY } from '@woocommerce/block-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
@@ -18,22 +18,28 @@ import { AddressForm } from '../address-form';
 interface ShippingCalculatorAddressProps {
 	address: ShippingAddress;
 	onUpdate: ( address: ShippingAddress ) => void;
+	onCancel: () => void;
 	addressFields: Partial< keyof AddressFields >[];
 }
 const ShippingCalculatorAddress = ( {
 	address: initialAddress,
 	onUpdate,
+	onCancel,
 	addressFields,
 }: ShippingCalculatorAddressProps ): JSX.Element => {
 	const [ address, setAddress ] = useState( initialAddress );
 	const { showAllValidationErrors } = useDispatch( VALIDATION_STORE_KEY );
 
-	const { hasValidationErrors } = useSelect( ( select ) => {
-		const store = select( VALIDATION_STORE_KEY );
-		return {
-			hasValidationErrors: store.hasValidationErrors,
-		};
-	} );
+	const { hasValidationErrors, isCustomerDataUpdating } = useSelect(
+		( select ) => {
+			return {
+				hasValidationErrors:
+					select( VALIDATION_STORE_KEY ).hasValidationErrors,
+				isCustomerDataUpdating:
+					select( CART_STORE_KEY ).isCustomerDataUpdating(),
+			};
+		}
+	);
 
 	const validateSubmit = () => {
 		showAllValidationErrors();
@@ -49,10 +55,20 @@ const ShippingCalculatorAddress = ( {
 			/>
 			<Button
 				className="wc-block-components-shipping-calculator-address__button"
-				disabled={ isShallowEqual( address, initialAddress ) }
+				disabled={ isCustomerDataUpdating }
 				onClick={ ( e ) => {
 					e.preventDefault();
+					const addressChanged = ! isShallowEqual(
+						address,
+						initialAddress
+					);
+
+					if ( ! addressChanged ) {
+						return onCancel();
+					}
+
 					const isAddressValid = validateSubmit();
+
 					if ( isAddressValid ) {
 						return onUpdate( address );
 					}

--- a/assets/js/base/components/cart-checkout/shipping-calculator/index.tsx
+++ b/assets/js/base/components/cart-checkout/shipping-calculator/index.tsx
@@ -3,6 +3,10 @@
  */
 import type { ShippingAddress } from '@woocommerce/settings';
 import { useCustomerData } from '@woocommerce/base-context/hooks';
+import { dispatch } from '@wordpress/data';
+import { CART_STORE_KEY, processErrorResponse } from '@woocommerce/block-data';
+import { StoreNoticesContainer } from '@woocommerce/blocks-checkout';
+import { removeNoticesWithContext } from '@woocommerce/base-utils';
 
 /**
  * Internal dependencies
@@ -12,6 +16,7 @@ import './style.scss';
 
 interface ShippingCalculatorProps {
 	onUpdate?: ( newAddress: ShippingAddress ) => void;
+	onCancel?: () => void;
 	addressFields?: Partial< keyof ShippingAddress >[];
 }
 
@@ -19,19 +24,36 @@ const ShippingCalculator = ( {
 	onUpdate = () => {
 		/* Do nothing */
 	},
+	onCancel = () => {
+		/* Do nothing */
+	},
 	addressFields = [ 'country', 'state', 'city', 'postcode' ],
 }: ShippingCalculatorProps ): JSX.Element => {
-	const { shippingAddress, setShippingAddress, setBillingAddress } =
-		useCustomerData();
+	const { shippingAddress } = useCustomerData();
+	const noticeContext = 'wc/cart/shipping-calculator';
 	return (
 		<div className="wc-block-components-shipping-calculator">
+			<StoreNoticesContainer context={ noticeContext } />
 			<ShippingCalculatorAddress
 				address={ shippingAddress }
 				addressFields={ addressFields }
+				onCancel={ onCancel }
 				onUpdate={ ( newAddress ) => {
-					setShippingAddress( newAddress );
-					setBillingAddress( newAddress );
-					onUpdate( newAddress );
+					// Updates the address and waits for the result.
+					dispatch( CART_STORE_KEY )
+						.updateCustomerData(
+							{
+								shipping_address: newAddress,
+							},
+							false
+						)
+						.then( () => {
+							removeNoticesWithContext( noticeContext );
+							onUpdate( newAddress );
+						} )
+						.catch( ( response ) => {
+							processErrorResponse( response, noticeContext );
+						} );
 				} }
 			/>
 		</div>

--- a/assets/js/base/components/cart-checkout/totals/shipping/index.tsx
+++ b/assets/js/base/components/cart-checkout/totals/shipping/index.tsx
@@ -57,6 +57,8 @@ export const TotalsShipping = ( {
 	} );
 	const totalShippingValue = getTotalShippingValue( values );
 	const hasRates = hasShippingRate( shippingRates ) || totalShippingValue > 0;
+	const showShippingCalculatorForm =
+		showCalculator && isShippingCalculatorOpen;
 	const selectedShippingRates = shippingRates.flatMap(
 		( shippingPackage ) => {
 			return shippingPackage.shipping_rates
@@ -113,20 +115,25 @@ export const TotalsShipping = ( {
 				}
 				currency={ currency }
 			/>
-			{ showCalculator && isShippingCalculatorOpen && (
+			{ showShippingCalculatorForm && (
 				<ShippingCalculator
 					onUpdate={ () => {
 						setIsShippingCalculatorOpen( false );
 					} }
+					onCancel={ () => {
+						setIsShippingCalculatorOpen( false );
+					} }
 				/>
 			) }
-			{ showRateSelector && cartHasCalculatedShipping && (
-				<ShippingRateSelector
-					hasRates={ hasRates }
-					shippingRates={ shippingRates }
-					isLoadingRates={ isLoadingRates }
-				/>
-			) }
+			{ showRateSelector &&
+				cartHasCalculatedShipping &&
+				! showShippingCalculatorForm && (
+					<ShippingRateSelector
+						hasRates={ hasRates }
+						shippingRates={ shippingRates }
+						isLoadingRates={ isLoadingRates }
+					/>
+				) }
 		</div>
 	);
 };

--- a/assets/js/base/utils/create-notice.ts
+++ b/assets/js/base/utils/create-notice.ts
@@ -92,3 +92,12 @@ export const removeAllNotices = () => {
 		} );
 	} );
 };
+
+export const removeNoticesWithContext = ( context: string ) => {
+	const { removeNotice } = dispatch( 'core/notices' );
+	const { getNotices } = select( 'core/notices' );
+
+	getNotices( context ).forEach( ( notice ) => {
+		removeNotice( notice.id, context );
+	} );
+};

--- a/assets/js/data/utils/index.js
+++ b/assets/js/data/utils/index.js
@@ -1,3 +1,3 @@
 export { default as hasInState } from './has-in-state';
 export { default as updateState } from './update-state';
-export { default as processErrorResponse } from './process-error-response';
+export * from './process-error-response';

--- a/assets/js/data/utils/process-error-response.ts
+++ b/assets/js/data/utils/process-error-response.ts
@@ -34,7 +34,9 @@ const isApiResponse = ( response: unknown ): response is ApiErrorResponse => {
  * - Supports 1 level of nesting.
  * - Decodes HTML entities in error messages.
  */
-const getErrorDetails = ( response: ApiErrorResponse ): ApiParamError[] => {
+export const getErrorDetails = (
+	response: ApiErrorResponse
+): ApiParamError[] => {
 	const errorDetails = objectHasProp( response.data, 'details' )
 		? Object.entries( response.data.details )
 		: null;
@@ -88,7 +90,10 @@ const getErrorDetails = ( response: ApiErrorResponse ): ApiParamError[] => {
 /**
  * Processes the response for an invalid param error, with response code rest_invalid_param.
  */
-const processInvalidParamResponse = ( response: ApiErrorResponse ) => {
+const processInvalidParamResponse = (
+	response: ApiErrorResponse,
+	context: string | undefined
+) => {
 	const errorDetails = getErrorDetails( response );
 
 	errorDetails.forEach( ( { code, message, id, param } ) => {
@@ -96,7 +101,7 @@ const processInvalidParamResponse = ( response: ApiErrorResponse ) => {
 			case 'invalid_email':
 				createNotice( 'error', message, {
 					id,
-					context: noticeContexts.CONTACT_INFORMATION,
+					context: context || noticeContexts.CONTACT_INFORMATION,
 				} );
 				return;
 		}
@@ -104,13 +109,13 @@ const processInvalidParamResponse = ( response: ApiErrorResponse ) => {
 			case 'billing_address':
 				createNoticeIfVisible( 'error', message, {
 					id,
-					context: noticeContexts.BILLING_ADDRESS,
+					context: context || noticeContexts.BILLING_ADDRESS,
 				} );
 				break;
 			case 'shipping_address':
 				createNoticeIfVisible( 'error', message, {
 					id,
-					context: noticeContexts.SHIPPING_ADDRESS,
+					context: context || noticeContexts.SHIPPING_ADDRESS,
 				} );
 				break;
 		}
@@ -122,7 +127,10 @@ const processInvalidParamResponse = ( response: ApiErrorResponse ) => {
  *
  * This is where we can handle specific error codes and display notices in specific contexts.
  */
-const processErrorResponse = ( response: ApiErrorResponse ) => {
+export const processErrorResponse = (
+	response: ApiErrorResponse,
+	context: string | undefined
+) => {
 	if ( ! isApiResponse( response ) ) {
 		return;
 	}
@@ -131,18 +139,16 @@ const processErrorResponse = ( response: ApiErrorResponse ) => {
 		case 'woocommerce_rest_invalid_email_address':
 			createNotice( 'error', response.message, {
 				id: response.code,
-				context: noticeContexts.CONTACT_INFORMATION,
+				context: context || noticeContexts.CONTACT_INFORMATION,
 			} );
 			break;
 		case 'rest_invalid_param':
-			processInvalidParamResponse( response );
+			processInvalidParamResponse( response, context );
 			break;
 		default:
 			createNotice( 'error', response.message || DEFAULT_ERROR_MESSAGE, {
 				id: response.code,
-				context: noticeContexts.CHECKOUT,
+				context: context || noticeContexts.CHECKOUT,
 			} );
 	}
 };
-
-export default processErrorResponse;


### PR DESCRIPTION
The original issue was that:

> Inserting an invalid address won't update the shipping costs calculations

This applied to the calculator because it would set the customer address and close, before checking if the update was successful. I also noticed when testing this, once the calculator is open you cannot close it. I also made it replace the shipping method display, so they only display once you're done with the calculator.

With this in mind I've made the following improvements:

1. When you open the calculator, if you make no changes you can hit update and close the form (it was suck open prior)
2. When you submit an address via the calculator, the form will not close until the request is complete.
3. If the request fails, the error notice is shown inline with the form

![Screenshot 2023-01-13 at 11 53 44](https://user-images.githubusercontent.com/90977/212314612-e2852bec-e963-4cbd-81d7-d79ad73d46ce.png)

Fixes #7486

### Testing

#### User Facing Testing

1. Add something to your cart and go to the cart page
2. Click "change address"
3. Enter a valid address and click update
4. Wait a short while and the form will close, rates will update, and your new address will be displayed
5. Click "change address" again
6. This time, enter an invalid postcode. For example, using a numeric postcode for a GB address.
7. Click update. Wait a short while and the form will remain open - an error will be shown above the form.
8. Correct the error and submit successfully.

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Improved update behaviour of the shipping calculator so errors are displayed to the customer.
