### PR TITLE
WIP - Add the possibility to create a specific Single Product Template

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -3,6 +3,7 @@ namespace Automattic\WooCommerce\Blocks;
 
 use Automattic\WooCommerce\Blocks\Domain\Package;
 use Automattic\WooCommerce\Blocks\Templates\ProductAttributeTemplate;
+use Automattic\WooCommerce\Blocks\Templates\SingleProductTemplate;
 use Automattic\WooCommerce\Blocks\Utils\BlockTemplateUtils;
 
 /**
@@ -195,6 +196,8 @@ class BlockTemplatesController {
 
 		list( $template_id, $template_slug ) = $template_name_parts;
 
+		$template_slug = 'taxonomy-product_type' === $template_slug ? 'single-product' : $template_slug;
+
 		// If the theme has an archive-product.html template, but not a taxonomy-product_cat/tag/attribute.html template let's use the themes archive-product.html template.
 		if ( BlockTemplateUtils::template_is_eligible_for_product_archive_fallback_from_theme( $template_slug ) ) {
 			$template_path   = BlockTemplateUtils::get_theme_template_path( 'archive-product' );
@@ -223,6 +226,7 @@ class BlockTemplatesController {
 
 		// If we don't have a template let Gutenberg do its thing.
 		if ( ! $this->block_template_is_available( $template_slug, $template_type ) ) {
+			error_log( "Template not available: $template_slug" );
 			return $template;
 		}
 
@@ -252,8 +256,9 @@ class BlockTemplatesController {
 			return $query_result;
 		}
 
-		$post_type      = isset( $query['post_type'] ) ? $query['post_type'] : '';
-		$slugs          = isset( $query['slug__in'] ) ? $query['slug__in'] : array();
+		$post_type = isset( $query['post_type'] ) ? $query['post_type'] : '';
+		$slugs     = isset( $query['slug__in'] ) ? $query['slug__in'] : array();
+
 		$template_files = $this->get_block_templates( $slugs, $template_type );
 
 		// @todo: Add apply_filters to _gutenberg_get_template_files() in Gutenberg to prevent duplication of logic.
@@ -394,6 +399,7 @@ class BlockTemplatesController {
 
 			$template_slug = BlockTemplateUtils::generate_template_slug_from_path( $template_file );
 
+			$template_slug = 'single-product' === $template_slug ? SingleProductTemplate::SLUG : $template_slug;
 			// This template does not have a slug we're looking for. Skip it.
 			if ( is_array( $slugs ) && count( $slugs ) > 0 && ! in_array( $template_slug, $slugs, true ) ) {
 				continue;

--- a/src/Domain/Bootstrap.php
+++ b/src/Domain/Bootstrap.php
@@ -24,6 +24,7 @@ use Automattic\WooCommerce\Blocks\Registry\Container;
 use Automattic\WooCommerce\Blocks\Templates\ClassicTemplatesCompatibility;
 use Automattic\WooCommerce\Blocks\Templates\ProductAttributeTemplate;
 use Automattic\WooCommerce\Blocks\Templates\ProductSearchResultsTemplate;
+use Automattic\WooCommerce\Blocks\Templates\SingleProductTemplate;
 use Automattic\WooCommerce\StoreApi\RoutesController;
 use Automattic\WooCommerce\StoreApi\SchemaController;
 use Automattic\WooCommerce\StoreApi\StoreApi;
@@ -124,6 +125,7 @@ class Bootstrap {
 		$this->container->get( BlockTypesController::class );
 		$this->container->get( BlockTemplatesController::class );
 		$this->container->get( ProductSearchResultsTemplate::class );
+		$this->container->get( SingleProductTemplate::class );
 		$this->container->get( ProductAttributeTemplate::class );
 		$this->container->get( ClassicTemplatesCompatibility::class );
 		$this->container->get( BlockPatterns::class );
@@ -256,6 +258,13 @@ class Bootstrap {
 			ProductSearchResultsTemplate::class,
 			function () {
 				return new ProductSearchResultsTemplate();
+			}
+		);
+
+		$this->container->register(
+			SingleProductTemplate::class,
+			function () {
+				return new SingleProductTemplate();
 			}
 		);
 		$this->container->register(

--- a/src/Templates/SingleProductTemplate.php
+++ b/src/Templates/SingleProductTemplate.php
@@ -1,0 +1,50 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\Templates;
+
+/**
+ * SingleProductTemplate class.
+ *
+ * @internal
+ */
+class SingleProductTemplate {
+
+	const SLUG = 'taxonomy-product_type';
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->init();
+	}
+
+	/**
+	 * Initialization method.
+	 */
+	protected function init() {
+		add_filter( 'single_template_hierarchy', array( $this, 'update_single_template_hierarchy' ), 10, 3 );
+	}
+
+	/**
+	 * Render the single product template.
+	 *
+	 * @param array $templates Templates that match the search hierarchy.
+	 */
+	public function update_single_template_hierarchy( $templates ) {
+
+		if ( ! is_product() || ! wc_current_theme_is_fse_theme() ) {
+			return $templates;
+		}
+
+		global $post;
+
+		$post_id      = $post->ID;
+		$product      = wc_get_product( $post_id );
+		$product_type = $product->get_type();
+
+		if ( ! isset( $product_type ) ) {
+			return array( self::SLUG );
+		}
+
+		return array( 'taxonomy-product_type-' . $product_type, self::SLUG );
+	}
+}

--- a/src/Utils/BlockTemplateUtils.php
+++ b/src/Utils/BlockTemplateUtils.php
@@ -6,6 +6,7 @@ use Automattic\WooCommerce\Blocks\Templates\ProductSearchResultsTemplate;
 use Automattic\WooCommerce\Blocks\Domain\Services\FeatureGating;
 use Automattic\WooCommerce\Blocks\Options;
 use Automattic\WooCommerce\Blocks\Templates\MiniCartTemplate;
+use Automattic\WooCommerce\Blocks\Templates\SingleProductTemplate;
 
 /**
  * Utility methods used for serving block templates from WooCommerce Blocks.
@@ -13,6 +14,8 @@ use Automattic\WooCommerce\Blocks\Templates\MiniCartTemplate;
  */
 class BlockTemplateUtils {
 	const ELIGIBLE_FOR_ARCHIVE_PRODUCT_FALLBACK = array( 'taxonomy-product_cat', 'taxonomy-product_tag', ProductAttributeTemplate::SLUG );
+	const ELIGIBLE_FOR_SINGLE_PRODUCT_FALLBACK  = array( 'taxonomy-product_type' );
+
 	/**
 	 * Directory names for block templates
 	 *
@@ -187,6 +190,8 @@ class BlockTemplateUtils {
 	public static function build_template_result_from_file( $template_file, $template_type ) {
 		$template_file = (object) $template_file;
 
+		$template_file->slug = 'single-product' === $template_file->slug ? SingleProductTemplate::SLUG : $template_file->slug;
+
 		// If the theme has an archive-products.html template but does not have product taxonomy templates
 		// then we will load in the archive-product.html template from the theme to use for product taxonomies on the frontend.
 		$template_is_from_theme = 'theme' === $template_file->source;
@@ -298,7 +303,7 @@ class BlockTemplateUtils {
 	 */
 	public static function get_plugin_block_template_types() {
 		$plugin_template_types = array(
-			'single-product'                   => array(
+			SingleProductTemplate::SLUG        => array(
 				'title'       => _x( 'Single Product', 'Template name', 'woo-gutenberg-products-block' ),
 				'description' => __( 'Displays a single product.', 'woo-gutenberg-products-block' ),
 			),


### PR DESCRIPTION
This PR allows the merchant to create a dedicated Single Product Template for each product type.
⚠️ For testing this PR, it is necessary to use WooCommerce build created from [this branch](https://github.com/woocommerce/woocommerce/pull/36425) is necessary.

![Screen Capture on 2023-01-13 at 18-12-52](https://user-images.githubusercontent.com/4463174/212391224-9bb5ed4b-b4df-4702-b4c9-f7858bcbf771.gif)


## Technical Details


In this PR, I changed the slug of the Single Product Template to `taxonomy-product_type`. In this way, for Gutenberg, there will be a general template for this taxonomy and will not render this UI during the creation of a new specific Single Product Template ([Gutenberg code](https://github.com/WordPress/gutenberg/blob/e14f3dc0da27ceb7a81650db2a2f8bf5dcc141ad/packages/edit-site/src/components/add-new-template/add-custom-template-modal.js/#L175-L177))

![image](https://user-images.githubusercontent.com/4463174/212391052-ab923164-25ff-41dd-ac09-e87de07e6c99.png)


Also, to render the right template on the frontend, it is necessary to change the hierarchy of the single template via the [`single_template_hiearchy` hook](https://github.com/woocommerce/woocommerce-blocks/blob/46479d265c8bd5ac3a12e0aadeb8322a2b9822db/src/Templates/SingleProductTemplate.php/#L24-L25). 

The current code doesn’t handle all the cases, but I imagine that the correct hierarchy is (from top to down):

1. Single Product Template for a specific product: `single-product-{name}.html`
2. Single Product Template for a specific type: `taxonomy-product_type-{product-type}.html` or  `single-product_type-{product-type}.html`
3. Single Product Template (single-product.html)





<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|        |       |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1.
2.
3.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Add suggested changelog entry here.
