### PR TITLE
Prevent undefined variable notice on checkout

### DIFF
--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -255,7 +255,9 @@ class Checkout extends AbstractBlock {
 		$this->asset_data_registry->add( 'hasDarkEditorStyleSupport', current_theme_supports( 'dark-editor-style' ), true );
 		$this->asset_data_registry->register_page_id( isset( $attributes['cartPageId'] ) ? $attributes['cartPageId'] : 0 );
 
-		$local_pickup_enabled = filter_var( get_option( 'woocommerce_pickup_location_settings' )['enabled'], FILTER_VALIDATE_BOOLEAN ) ?? false;
+		$pickup_location_settings = get_option( 'woocommerce_pickup_location_settings', [] );
+		$local_pickup_enabled     = wc_string_to_bool( $pickup_location_settings['enabled'] ?? 'no' );
+
 		$this->asset_data_registry->add( 'localPickupEnabled', $local_pickup_enabled, true );
 
 		$is_block_editor = $this->is_block_editor();


### PR DESCRIPTION
Reported here https://github.com/woocommerce/woocommerce-blocks/pull/7433#issuecomment-1382106299

This PR fixes the notice by checking if the `enabled` property exists before casting it to boolean.

### Testing

Go to the checkout page and confirm there is no "undefined" error notice at the top of the checkout.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

cc @gigitux