### PR TITLE
Use cart item key instead of index in shipping items

### DIFF
--- a/src/StoreApi/Schemas/V1/CartShippingRateSchema.php
+++ b/src/StoreApi/Schemas/V1/CartShippingRateSchema.php
@@ -262,7 +262,7 @@ class CartShippingRateSchema extends AbstractSchema {
 		$items = array();
 		foreach ( $package['contents'] as $item_id => $values ) {
 			$items[] = [
-				'key'      => $item_id,
+				'key'      => $values['key'],
 				'name'     => $values['data']->get_name(),
 				'quantity' => $values['quantity'],
 			];

--- a/src/StoreApi/Schemas/V1/CartShippingRateSchema.php
+++ b/src/StoreApi/Schemas/V1/CartShippingRateSchema.php
@@ -260,7 +260,7 @@ class CartShippingRateSchema extends AbstractSchema {
 	 */
 	protected function prepare_package_items_response( $package ) {
 		$items = array();
-		foreach ( $package['contents'] as $item_id => $values ) {
+		foreach ( $package['contents'] as $values ) {
 			$items[] = [
 				'key'      => $values['key'],
 				'name'     => $values['data']->get_name(),


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
In Shipping response, we include an items array, the key in that array was the index of an item, I switched to be the key instead.
<!-- Reference any related issues or PRs here -->

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/8074

### Testing

1. Add an item to Cart
2. In console, check the network request
3. Match cart.items[].key with shipping_rates[].items[].key, they should match.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->
