### PR TITLE
Remove purple color from WC Blocks icons

### DIFF
--- a/assets/css/editor.scss
+++ b/assets/css/editor.scss
@@ -33,10 +33,6 @@
 	}
 }
 
-svg.wc-block-editor-components-block-icon {
-	color: $studio-woocommerce-purple-50;
-}
-
 svg.wc-block-editor-components-block-icon--sparkles path {
 	fill: currentColor;
 }


### PR DESCRIPTION
WordPress 6.2 will start using purple icons for template parts. In order to avoid confusion with WooCommerce blocks, we should remove the purple color from our blocks icons.

### Testing

#### User Facing Testing

0. Install the latest version of Gutenberg.
1. Go to Appearance > Site Editor.
2. Edit any of the templates.
3. Add a WC Blocks somewhere (ie: Mini Cart block).
4. Verify the icon of the block is black instead of purple.

Before | After
--- | ---
![imatge](https://user-images.githubusercontent.com/3616980/212675510-a01ff919-98b2-45b2-91b1-7f3740188e40.png) |  ![imatge](https://user-images.githubusercontent.com/3616980/212675617-a0c78d4d-f856-4349-83e5-3e4cfa68139f.png)

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Make WC Blocks icons black instead of purple.
