### PR TITLE
Refresh shipping cache when saving Local Pickup

### DIFF
--- a/src/Shipping/PickupLocation.php
+++ b/src/Shipping/PickupLocation.php
@@ -101,7 +101,7 @@ class PickupLocation extends WC_Shipping_Method {
 		$hide_save_button = true;
 
 		wp_enqueue_script( 'wc-shipping-method-pickup-location' );
-
+		\WC_Cache_Helper::get_transient_version( 'shipping', true );
 		echo '<h2>' . esc_html__( 'Local pickup', 'woo-gutenberg-products-block' ) . '</h2>';
 		echo '<div class="wrap"><div id="wc-shipping-method-pickup-location-settings-container"></div></div>';
 	}

--- a/src/Shipping/PickupLocation.php
+++ b/src/Shipping/PickupLocation.php
@@ -101,7 +101,7 @@ class PickupLocation extends WC_Shipping_Method {
 		$hide_save_button = true;
 
 		wp_enqueue_script( 'wc-shipping-method-pickup-location' );
-		\WC_Cache_Helper::get_transient_version( 'shipping', true );
+
 		echo '<h2>' . esc_html__( 'Local pickup', 'woo-gutenberg-products-block' ) . '</h2>';
 		echo '<div class="wrap"><div id="wc-shipping-method-pickup-location-settings-container"></div></div>';
 	}

--- a/src/Shipping/ShippingController.php
+++ b/src/Shipping/ShippingController.php
@@ -56,8 +56,8 @@ class ShippingController {
 		add_filter( 'woocommerce_local_pickup_methods', array( $this, 'register_local_pickup_method' ) );
 		add_filter( 'woocommerce_customer_taxable_address', array( $this, 'filter_taxable_address' ) );
 		add_filter( 'woocommerce_shipping_packages', array( $this, 'filter_shipping_packages' ) );
-		add_filter( 'pre_update_option_pickup_location_settings', array( $this, 'flush_cache' ) );
-		add_filter( 'pre_update_option_pickup_locations', array( $this, 'flush_cache' ) );
+		add_filter( 'pre_update_option_woocommerce_pickup_location_settings', array( $this, 'flush_cache' ) );
+		add_filter( 'pre_update_option_pickup_location_pickup_locations', array( $this, 'flush_cache' ) );
 	}
 
 	/**

--- a/src/Shipping/ShippingController.php
+++ b/src/Shipping/ShippingController.php
@@ -56,6 +56,8 @@ class ShippingController {
 		add_filter( 'woocommerce_local_pickup_methods', array( $this, 'register_local_pickup_method' ) );
 		add_filter( 'woocommerce_customer_taxable_address', array( $this, 'filter_taxable_address' ) );
 		add_filter( 'woocommerce_shipping_packages', array( $this, 'filter_shipping_packages' ) );
+		add_filter( 'pre_update_option_pickup_location_settings', array( $this, 'flush_cache' ) );
+		add_filter( 'pre_update_option_pickup_locations', array( $this, 'flush_cache' ) );
 	}
 
 	/**
@@ -236,6 +238,17 @@ class ShippingController {
 		return $methods;
 	}
 
+	/**
+	 * Everytime we save or update local pickup settings, we flush the shipping
+	 * transient group.
+	 *
+	 * @param array $settings The setting array we're saving.
+	 * @return array $settings The setting array we're saving.
+	 */
+	public function flush_cache( $settings ) {
+		\WC_Cache_Helper::get_transient_version( 'shipping', true );
+		return $settings;
+	}
 	/**
 	 * Filter the location used for taxes based on the chosen pickup location.
 	 *


### PR DESCRIPTION
This issue was found as part of testing 9.5.0 release.

When shipping zones is never touched, and you enable local pickup, the cache is never updated, causing a false positive and having `needs_shipping` be `false`, this causes checkout to proceed without shipping.

In this PR, we always flesh cache after each setting save, for both locations and settings.

### Testing steps

1. In a fresh website, don't touch shipping zones (also don't use `woo-test-env`).
2. Enable only Local Pickup.
3. Visit Checkout, you should see local pickup rates working fine.
