### PR TITLE
Account for local pickup rates before disabling shipping in editor

### DIFF
--- a/assets/js/previews/cart.ts
+++ b/assets/js/previews/cart.ts
@@ -30,9 +30,11 @@ const displayWithTax = getSetting( 'displayCartPricesIncludingTax', false );
 // https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/src/StoreApi/docs/cart.md#cart-response
 export const previewCart: CartResponse = {
 	coupons: [],
-	shipping_rates: getSetting( 'shippingMethodsExist', false )
-		? previewShippingRates
-		: [],
+	shipping_rates:
+		getSetting( 'shippingMethodsExist', false ) ||
+		getSetting( 'localPickupEnabled', false )
+			? previewShippingRates
+			: [],
 	items: [
 		{
 			key: '1',

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -264,7 +264,7 @@ class Checkout extends AbstractBlock {
 
 		// Hydrate the following data depending on admin or frontend context.
 		if ( $is_block_editor && ! $this->asset_data_registry->exists( 'shippingMethodsExist' ) ) {
-			$methods_exist = wc_get_shipping_method_count( false, true ) > 0;
+			$methods_exist = wc_get_shipping_method_count( true, true ) > 0;
 			$this->asset_data_registry->add( 'shippingMethodsExist', $methods_exist );
 		}
 

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -264,7 +264,7 @@ class Checkout extends AbstractBlock {
 
 		// Hydrate the following data depending on admin or frontend context.
 		if ( $is_block_editor && ! $this->asset_data_registry->exists( 'shippingMethodsExist' ) ) {
-			$methods_exist = wc_get_shipping_method_count( true, true ) > 0;
+			$methods_exist = wc_get_shipping_method_count( false, true ) > 0;
 			$this->asset_data_registry->add( 'shippingMethodsExist', $methods_exist );
 		}
 


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
We return an empty shipping array to the editor when there are no enabled shipping rates, this didn't account for local pickup, in this PR, we account for it.
<!-- Reference any related issues or PRs here -->


<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Testing

1. Disable all shipping zones shipping rates.
2. Enable Local Pickup
3. Visit the editor, you should see Local pickup visible when you toggle it.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->
