### PR TITLE
Refresh the cart when using the browser back button

### DIFF
--- a/assets/js/base/context/hooks/cart/use-store-cart-event-listeners.ts
+++ b/assets/js/base/context/hooks/cart/use-store-cart-event-listeners.ts
@@ -111,7 +111,7 @@ const removeListeners = (): void => {
 };
 
 /**
- * Keeps track of jQuery and DOM events that invalidates the store resolution accordingly.
+ * This will keep track of jQuery and DOM events that invalidate the store resolution.
  */
 export const useStoreCartEventListeners = (): void => {
 	useEffect( () => {

--- a/assets/js/base/context/hooks/cart/use-store-cart-event-listeners.ts
+++ b/assets/js/base/context/hooks/cart/use-store-cart-event-listeners.ts
@@ -39,7 +39,7 @@ const refreshData = ( event: CartDataCustomEvent ): void => {
  *
  * The deprecated performance object is needed in chrome since persisted is not reliable.
  */
-const refreshDataIfPersisted = ( event: PageTransitionEvent ): void => {
+const refreshCachedCartData = ( event: PageTransitionEvent ): void => {
 	if (
 		event?.persisted ||
 		( typeof window.performance !== undefined &&
@@ -76,7 +76,7 @@ const addListeners = (): void => {
 		'wc-blocks_removed_from_cart',
 		refreshData
 	);
-	window.addEventListener( 'pageshow', refreshDataIfPersisted );
+	window.addEventListener( 'pageshow', refreshCachedCartData );
 
 	const removeJQueryAddedToCartEvent = translateJQueryEventToNative(
 		'added_to_cart',
@@ -97,7 +97,7 @@ const addListeners = (): void => {
 			'wc-blocks_removed_from_cart',
 			refreshData
 		);
-		window.removeEventListener( 'pageshow', refreshDataIfPersisted );
+		window.removeEventListener( 'pageshow', refreshCachedCartData );
 		removeJQueryAddedToCartEvent();
 		removeJQueryRemovedFromCartEvent();
 	};

--- a/assets/js/base/context/hooks/cart/use-store-cart-event-listeners.ts
+++ b/assets/js/base/context/hooks/cart/use-store-cart-event-listeners.ts
@@ -4,7 +4,10 @@
 import { useEffect } from '@wordpress/element';
 import { CART_STORE_KEY } from '@woocommerce/block-data';
 import { dispatch } from '@wordpress/data';
-import { translateJQueryEventToNative } from '@woocommerce/base-utils';
+import {
+	translateJQueryEventToNative,
+	getNavigationType,
+} from '@woocommerce/base-utils';
 
 interface StoreCartListenersType {
 	// Counts the number of consumers of this hook so we can remove listeners when no longer needed.
@@ -37,14 +40,11 @@ const refreshData = ( event: CartDataCustomEvent ): void => {
 /**
  * Refreshes data if the pageshow event is triggered by the browser history.
  *
- * The deprecated performance object is needed in chrome since persisted is not reliable.
+ * - In Chrome, `back_forward` will be returned by getNavigationType() when the browser history is used.
+ * - In safari we instead need to use `event.persisted` which is true when page cache is used.
  */
 const refreshCachedCartData = ( event: PageTransitionEvent ): void => {
-	if (
-		event?.persisted ||
-		( typeof window.performance !== undefined &&
-			window.performance.navigation.type === 2 )
-	) {
+	if ( event?.persisted || getNavigationType() === 'back_forward' ) {
 		dispatch( CART_STORE_KEY ).invalidateResolutionForStore();
 	}
 };

--- a/assets/js/base/context/hooks/cart/use-store-cart.ts
+++ b/assets/js/base/context/hooks/cart/use-store-cart.ts
@@ -138,7 +138,7 @@ export const useStoreCart = (
 	const { shouldSelect } = options;
 	const currentResults = useRef();
 
-	// This will keep track of jQuery and DOM events that invalidates the store resolution accordingly.
+	// This will keep track of jQuery and DOM events that invalidate the store resolution.
 	useStoreCartEventListeners();
 
 	const results: StoreCart = useSelect(

--- a/assets/js/base/context/hooks/cart/use-store-cart.ts
+++ b/assets/js/base/context/hooks/cart/use-store-cart.ts
@@ -138,8 +138,7 @@ export const useStoreCart = (
 	const { shouldSelect } = options;
 	const currentResults = useRef();
 
-	// This will keep track of jQuery and DOM events triggered by other blocks
-	// or components and will invalidate the store resolution accordingly.
+	// This will keep track of jQuery and DOM events that invalidates the store resolution accordingly.
 	useStoreCartEventListeners();
 
 	const results: StoreCart = useSelect(

--- a/assets/js/base/utils/get-navigation-type.ts
+++ b/assets/js/base/utils/get-navigation-type.ts
@@ -1,0 +1,18 @@
+/**
+ * Returns the navigation type for the page load.
+ */
+export const getNavigationType = () => {
+	if (
+		window.performance &&
+		window.performance.getEntriesByType( 'navigation' ).length
+	) {
+		return (
+			window.performance.getEntriesByType(
+				'navigation'
+			)[ 0 ] as PerformanceNavigationTiming
+		 ).type;
+	}
+	return '';
+};
+
+export default getNavigationType;

--- a/assets/js/base/utils/index.js
+++ b/assets/js/base/utils/index.js
@@ -9,3 +9,4 @@ export * from './derive-selected-shipping-rates';
 export * from './get-icons-from-payment-methods';
 export * from './parse-style';
 export * from './create-notice';
+export * from './get-navigation-type';

--- a/assets/js/blocks/checkout/block.tsx
+++ b/assets/js/blocks/checkout/block.tsx
@@ -14,11 +14,10 @@ import {
 	StoreNoticesContainer,
 } from '@woocommerce/blocks-checkout';
 import withScrollToTop from '@woocommerce/base-hocs/with-scroll-to-top';
-import { useDispatch, useSelect, dispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	CHECKOUT_STORE_KEY,
 	VALIDATION_STORE_KEY,
-	CART_STORE_KEY,
 } from '@woocommerce/block-data';
 
 /**
@@ -162,26 +161,6 @@ const Block = ( {
 	children: React.ReactChildren;
 	scrollToTop: ( props: Record< string, unknown > ) => void;
 } ): JSX.Element => {
-	// Refreshes the cart when the user navigates back to the page.
-	useEffect( () => {
-		const refreshCartData = ( event: PageTransitionEvent ) => {
-			// The deprecated performance object is needed in chrome.
-			const historyPage =
-				event.persisted ||
-				( typeof window.performance !== undefined &&
-					window.performance.navigation.type === 2 );
-			if ( historyPage ) {
-				dispatch( CART_STORE_KEY ).invalidateResolutionForStore();
-			}
-		};
-
-		global.addEventListener( 'pageshow', refreshCartData );
-
-		return () => {
-			global.removeEventListener( 'pageshow', refreshCartData );
-		};
-	}, [] );
-
 	return (
 		<BlockErrorBoundary
 			header={ __(

--- a/assets/js/blocks/checkout/block.tsx
+++ b/assets/js/blocks/checkout/block.tsx
@@ -14,10 +14,11 @@ import {
 	StoreNoticesContainer,
 } from '@woocommerce/blocks-checkout';
 import withScrollToTop from '@woocommerce/base-hocs/with-scroll-to-top';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useSelect, dispatch } from '@wordpress/data';
 import {
 	CHECKOUT_STORE_KEY,
 	VALIDATION_STORE_KEY,
+	CART_STORE_KEY,
 } from '@woocommerce/block-data';
 
 /**
@@ -161,6 +162,26 @@ const Block = ( {
 	children: React.ReactChildren;
 	scrollToTop: ( props: Record< string, unknown > ) => void;
 } ): JSX.Element => {
+	// Refreshes the cart when the user navigates back to the page.
+	useEffect( () => {
+		const refreshCartData = ( event: PageTransitionEvent ) => {
+			// The deprecated performance object is needed in chrome.
+			const historyPage =
+				event.persisted ||
+				( typeof window.performance !== undefined &&
+					window.performance.navigation.type === 2 );
+			if ( historyPage ) {
+				dispatch( CART_STORE_KEY ).invalidateResolutionForStore();
+			}
+		};
+
+		global.addEventListener( 'pageshow', refreshCartData );
+
+		return () => {
+			global.removeEventListener( 'pageshow', refreshCartData );
+		};
+	}, [] );
+
 	return (
 		<BlockErrorBoundary
 			header={ __(

--- a/assets/js/blocks/mini-cart/frontend.ts
+++ b/assets/js/blocks/mini-cart/frontend.ts
@@ -77,7 +77,7 @@ window.addEventListener( 'load', () => {
 	document.body.addEventListener( 'wc-blocks_adding_to_cart', loadScripts );
 
 	// Load scripts if a page is reloaded via the back button (potentially out of date cart data).
-	// Based on refreshDataIfPersisted() in assets/js/base/context/cart-checkout/cart/index.js.
+	// Based on refreshCachedCartData() in assets/js/base/context/cart-checkout/cart/index.js.
 	window.addEventListener(
 		'pageshow',
 		( event: PageTransitionEvent ): void => {

--- a/assets/js/blocks/mini-cart/frontend.ts
+++ b/assets/js/blocks/mini-cart/frontend.ts
@@ -76,6 +76,21 @@ window.addEventListener( 'load', () => {
 
 	document.body.addEventListener( 'wc-blocks_adding_to_cart', loadScripts );
 
+	// Load scripts if a page is reloaded via the back button (potentially out of date cart data).
+	// Based on refreshDataIfPersisted() in assets/js/base/context/cart-checkout/cart/index.js.
+	window.addEventListener(
+		'pageshow',
+		( event: PageTransitionEvent ): void => {
+			if (
+				event?.persisted ||
+				( typeof window.performance !== undefined &&
+					window.performance.navigation.type === 2 )
+			) {
+				loadScripts();
+			}
+		}
+	);
+
 	miniCartBlocks.forEach( ( miniCartBlock, i ) => {
 		if ( ! ( miniCartBlock instanceof HTMLElement ) ) {
 			return;

--- a/assets/js/blocks/mini-cart/frontend.ts
+++ b/assets/js/blocks/mini-cart/frontend.ts
@@ -4,6 +4,7 @@
 import { getSetting } from '@woocommerce/settings';
 import preloadScript from '@woocommerce/base-utils/preload-script';
 import lazyLoadScript from '@woocommerce/base-utils/lazy-load-script';
+import getNavigationType from '@woocommerce/base-utils/get-navigation-type';
 import { translateJQueryEventToNative } from '@woocommerce/base-utils/legacy-events';
 
 interface dependencyData {
@@ -81,11 +82,7 @@ window.addEventListener( 'load', () => {
 	window.addEventListener(
 		'pageshow',
 		( event: PageTransitionEvent ): void => {
-			if (
-				event?.persisted ||
-				( typeof window.performance !== undefined &&
-					window.performance.navigation.type === 2 )
-			) {
+			if ( event?.persisted || getNavigationType() === 'back_forward' ) {
 				loadScripts();
 			}
 		}

--- a/assets/js/data/cart/notify-quantity-changes.ts
+++ b/assets/js/data/cart/notify-quantity-changes.ts
@@ -2,8 +2,13 @@
  * External dependencies
  */
 import { Cart, CartItem } from '@woocommerce/types';
-import { dispatch } from '@wordpress/data';
+import { dispatch, select } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { STORE_KEY as CART_STORE_KEY } from './constants';
 
 interface NotifyQuantityChangesArgs {
 	oldCart: Cart;
@@ -216,6 +221,11 @@ export const notifyQuantityChanges = ( {
 	cartItemsPendingQuantity = [],
 	cartItemsPendingDelete = [],
 }: NotifyQuantityChangesArgs ) => {
+	const isResolutionFinished =
+		select( CART_STORE_KEY ).hasFinishedResolution( 'getCartData' );
+	if ( ! isResolutionFinished ) {
+		return;
+	}
 	notifyIfRemoved( oldCart, newCart, cartItemsPendingDelete );
 	notifyIfQuantityLimitsChanged( oldCart, newCart );
 	notifyIfQuantityChanged( oldCart, newCart, cartItemsPendingQuantity );

--- a/assets/js/data/cart/test/notify-quantity-changes.ts
+++ b/assets/js/data/cart/test/notify-quantity-changes.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { dispatch } from '@wordpress/data';
+import { dispatch, select } from '@wordpress/data';
 import { previewCart } from '@woocommerce/resource-previews';
 import { camelCase, cloneDeep, mapKeys } from 'lodash';
 import { Cart, CartResponse } from '@woocommerce/types';
@@ -20,6 +20,14 @@ dispatch.mockImplementation( ( store ) => {
 			createInfoNotice: mockedCreateInfoNotice,
 		};
 	}
+} );
+
+select.mockImplementation( () => {
+	return {
+		hasFinishedResolution() {
+			return true;
+		},
+	};
 } );
 
 /**
@@ -177,5 +185,15 @@ describe( 'notifyQuantityChanges', () => {
 				id: '1-removed',
 			}
 		);
+	} );
+	it( 'does not show notices if the cart has not finished resolving', () => {
+		select.mockImplementation( () => {
+			return {
+				hasFinishedResolution() {
+					return false;
+				},
+			};
+		} );
+		expect( mockedCreateInfoNotice ).not.toHaveBeenCalled();
 	} );
 } );


### PR DESCRIPTION
If you go back to the checkout after placing an order you still see the checkout form and invalid vart data.

This PR implements a fix whereby if the back button usage is detected, the cart is invalidated and pulled again from the API. This results in the following: 

![Screenshot 2023-01-19 at 13 23 16](https://user-images.githubusercontent.com/90977/213454433-74ef8b9f-6d92-46e6-a8eb-130d75c32f9e.png)

Note this did require some deprecated JS code to work because `persisted` is not working reliably in chrome.

Fixes #7233

For the mini cart (#7974), as well as the above code we need to `loadScripts()` when the back button is used. I've implemented the same detection code there also.

Fixes #7974

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. Add items to your cart
2. Go to the checkout block page
3. Place an order
4. Press the browser back button
5. After a short delay you'll see the empty cart notice

For the Mini Cart:

1. Add mini cart to the theme header
2. Add something to your cart
3. Visit a page - note the total in mini cart
4. Visit the shop page and add another item to the cart. Note the new mini cart total
5. Press the browser back button. Without mousing over the mini cart block, confirm the total updates

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Enhancement: Refresh the cart after using the back button to return to checkout.