### PR TITLE
Update Local Pickup price display when price is 0 and multiple packages are used

### DIFF
--- a/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/block.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/block.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { _n } from '@wordpress/i18n';
+import { _n, __ } from '@wordpress/i18n';
 import {
 	useState,
 	useEffect,
@@ -75,24 +75,31 @@ const renderPickupLocation = (
 		label: location
 			? decodeEntities( location )
 			: decodeEntities( option.name ),
-		secondaryLabel: createInterpolateElement(
-			/* translators: %1$s name of the product (ie: Sunglasses), %2$d number of units in the current cart package */
-			_n(
-				'<price/>',
-				'<price/> x <packageCount/> packages',
-				packageCount,
-				'woo-gutenberg-products-block'
+		secondaryLabel:
+			parseInt( priceWithTaxes, 10 ) > 0 ? (
+				createInterpolateElement(
+					/* translators: %1$s name of the product (ie: Sunglasses), %2$d number of units in the current cart package */
+					_n(
+						'<price/>',
+						'<price/> x <packageCount/> packages',
+						packageCount,
+						'woo-gutenberg-products-block'
+					),
+					{
+						price: (
+							<FormattedMonetaryAmount
+								currency={ getCurrencyFromPriceResponse(
+									option
+								) }
+								value={ priceWithTaxes }
+							/>
+						),
+						packageCount: <>{ packageCount }</>,
+					}
+				)
+			) : (
+				<em>{ __( 'free', 'woo-gutenberg-products-block' ) }</em>
 			),
-			{
-				price: (
-					<FormattedMonetaryAmount
-						currency={ getCurrencyFromPriceResponse( option ) }
-						value={ priceWithTaxes }
-					/>
-				),
-				packageCount: <>{ packageCount }</>,
-			}
-		),
 		description: decodeEntities( details ),
 		secondaryDescription: address ? (
 			<>

--- a/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/style.scss
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/style.scss
@@ -32,6 +32,12 @@
 			display: block;
 		}
 	}
+	.wc-block-components-radio-control__label-group {
+		em {
+			text-transform: uppercase;
+			font-style: inherit;
+		}
+	}
 	.wc-block-components-radio-control__description-group {
 		width: 100%;
 		box-sizing: border-box;

--- a/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/shared/rate-price.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/shared/rate-price.tsx
@@ -42,7 +42,12 @@ export const RatePrice = ( {
 			{ minRatePrice === maxRatePrice && ! multiple
 				? priceElement
 				: createInterpolateElement(
-						__( 'from <price />', 'woo-gutenberg-products-block' ),
+						minRatePrice === 0 && maxRatePrice === 0
+							? '<price />'
+							: __(
+									'from <price />',
+									'woo-gutenberg-products-block'
+							  ),
 						{
 							price: priceElement,
 						}


### PR DESCRIPTION
Improves how local pickup prices are displayed when there are multiple packages and 0 costs.

Fixes #7999

### Screenshots

Show as "Free" instead of "0 x 3 packages":

![Screenshot 2023-01-19 at 14 19 49](https://user-images.githubusercontent.com/90977/213485625-01b04533-be8d-412c-880d-f8c9fde395a0.png)

Existing logic preserved for pickup with prices:

![Screenshot 2023-01-19 at 14 20 05](https://user-images.githubusercontent.com/90977/213485629-2094404f-22af-4699-ac33-4027ec92b28b.png)

### Testing

#### User Facing Testing

1. Enable the [Multiple Packages for WooCommerce](https://wordpress.org/plugins/multiple-packages-for-woocommerce/) extension and set a price for local pickup.
2. Add multiple products to cart. Confirm you have multiple shipping packages and the price x qty is shown when choosing local pickup.
3. Go to settings and make local pickup free.
4. Go back to checkout and confirm prices for pickup is shown as "FREE".

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Enhancement: Improve free local pickup display during checkout.