### PR TITLE
Avoid changing the markup of all ratings when the Product Rating block is present in the page

### DIFF
--- a/assets/js/atomic/blocks/product-elements/rating/style.scss
+++ b/assets/js/atomic/blocks/product-elements/rating/style.scss
@@ -71,10 +71,3 @@
 		}
 	}
 }
-
-// Fix applied specifically to Classic Template
-.woocommerce-loop-product__link {
-	.wc-block-components-product-rating__stars {
-		display: block;
-	}
-}

--- a/src/BlockTypes/ProductRating.php
+++ b/src/BlockTypes/ProductRating.php
@@ -107,16 +107,25 @@ class ProductRating extends AbstractBlock {
 		$post_id = $block->context['postId'];
 		$product = wc_get_product( $post_id );
 
-		add_filter(
-			'woocommerce_product_get_rating_html',
-			[ $this, 'filter_rating_html' ],
-			10,
-			3
-		);
-
 		if ( $product ) {
+
 			$styles_and_classes            = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, array( 'font_size', 'margin', 'text_color' ) );
 			$text_align_styles_and_classes = StyleAttributesUtils::get_text_align_class_and_style( $attributes );
+
+			add_filter(
+				'woocommerce_product_get_rating_html',
+				[ $this, 'filter_rating_html' ],
+				10,
+				3
+			);
+
+			$rating_html = wc_get_rating_html( $product->get_average_rating() );
+
+			remove_filter(
+				'woocommerce_product_get_rating_html',
+				[ $this, 'filter_rating_html' ],
+				10
+			);
 
 			return sprintf(
 				'<div class="wc-block-components-product-rating wc-block-grid__product-rating %1$s %2$s" style="%3$s">
@@ -125,7 +134,7 @@ class ProductRating extends AbstractBlock {
 				esc_attr( $text_align_styles_and_classes['class'] ?? '' ),
 				esc_attr( $styles_and_classes['classes'] ),
 				esc_attr( $styles_and_classes['styles'] ?? '' ),
-				wc_get_rating_html( $product->get_average_rating() )
+				$rating_html
 			);
 		}
 	}


### PR DESCRIPTION
See previous discussion in https://github.com/woocommerce/woocommerce-blocks/pull/8202#discussion_r1082315817.

### Testing

#### User Facing Testing

0. Make sure a product has an average rating of 4 or less.
1. With [TT3](https://wordpress.org/themes/twentytwentythree/), go to Appearance > Editor.
2. Edit the Product Catalog template, adding the Products block above the WooCommerce Product Grid Block:
<img src="https://user-images.githubusercontent.com/3616980/213691713-5649be46-1c3c-4e2b-a54b-be501bc1c787.png" alt="" width="346" />
3. You might want to add a title above each of those blocks to help you distinguish them in the frontend.
4. Go to the frontend and verify the rating markup of the WooCommerce Product Grid block is not filtered. To verify it, scroll down to the WooCommerce Product Grid block and check that the "empty" star in the rating is outlined instead of dimmed:

Before | After
--- | ---
![imatge](https://user-images.githubusercontent.com/3616980/213691993-b96360a0-4afb-4e0d-b8be-46f9f9bbf710.png) | ![imatge](https://user-images.githubusercontent.com/3616980/213691932-cac4ccb7-c272-4909-abf1-93fbf89e8ce9.png)

Note: the Products block is expected to have dimmed stars instead of outlined ones. This testing steps refers to the WooCommerce Product Grid block.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Enhancement: Prevent an edge case where adding the _Product_ blocks above the Classic Template block would cause its ratings to change the markup.