### PR TITLE
Stop notice removal when current notices changes

### DIFF
--- a/assets/js/blocks/cart/inner-blocks/filled-cart-block/frontend.tsx
+++ b/assets/js/blocks/cart/inner-blocks/filled-cart-block/frontend.tsx
@@ -52,12 +52,8 @@ const FrontendBlock = ( {
 				context: 'wc/cart',
 			} );
 		} );
-	}, [
-		createErrorNotice,
-		cartItemErrors,
-		currentlyDisplayedErrorNoticeCodes,
-		removeNotice,
-	] );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ createErrorNotice, cartItemErrors, removeNotice ] );
 
 	if ( cartIsLoading || cartItems.length >= 1 ) {
 		return (

--- a/assets/js/blocks/cart/inner-blocks/filled-cart-block/frontend.tsx
+++ b/assets/js/blocks/cart/inner-blocks/filled-cart-block/frontend.tsx
@@ -6,7 +6,7 @@ import { SidebarLayout } from '@woocommerce/base-components/sidebar-layout';
 import { useStoreCart } from '@woocommerce/base-context/hooks';
 import { useEffect } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { select, useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -24,21 +24,19 @@ const FrontendBlock = ( {
 	const { hasDarkControls } = useCartBlockContext();
 	const { createErrorNotice, removeNotice } = useDispatch( 'core/notices' );
 
-	/*
-	 * The code for removing old notices is also present in the filled-mini-cart-contents-block/frontend.tsx file and
-	 * will take care of removing outdated errors in the Mini Cart block.
-	 */
-	const currentlyDisplayedErrorNoticeCodes = useSelect( ( select ) => {
-		return select( 'core/notices' )
+	useEffect( () => {
+		/*
+		 * The code for removing old notices is also present in the filled-mini-cart-contents-block/frontend.tsx file and
+		 * will take care of removing outdated errors in the Mini Cart block.
+		 */
+		const currentlyDisplayedErrorNoticeCodes = select( 'core/notices' )
 			.getNotices( 'wc/cart' )
 			.filter(
 				( notice ) =>
 					notice.status === 'error' && notice.type === 'default'
 			)
 			.map( ( notice ) => notice.id );
-	} );
 
-	useEffect( () => {
 		// Clear errors out of the store before adding the new ones from the response.
 		currentlyDisplayedErrorNoticeCodes.forEach( ( id ) => {
 			removeNotice( id, 'wc/cart' );
@@ -52,7 +50,6 @@ const FrontendBlock = ( {
 				context: 'wc/cart',
 			} );
 		} );
-		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ createErrorNotice, cartItemErrors, removeNotice ] );
 
 	if ( cartIsLoading || cartItems.length >= 1 ) {

--- a/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/filled-mini-cart-contents-block/frontend.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/filled-mini-cart-contents-block/frontend.tsx
@@ -49,12 +49,8 @@ const FilledMiniCartContentsBlock = ( {
 				context: 'wc/cart',
 			} );
 		} );
-	}, [
-		createErrorNotice,
-		cartItemErrors,
-		currentlyDisplayedErrorNoticeCodes,
-		removeNotice,
-	] );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ createErrorNotice, cartItemErrors, removeNotice ] );
 
 	if ( cartItems.length === 0 ) {
 		return null;

--- a/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/filled-mini-cart-contents-block/frontend.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/filled-mini-cart-contents-block/frontend.tsx
@@ -4,7 +4,7 @@
 import { StoreNoticesContainer } from '@woocommerce/blocks-checkout';
 import { useStoreCart } from '@woocommerce/base-context/hooks';
 
-import { useDispatch, useSelect } from '@wordpress/data';
+import { select, useDispatch } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 
@@ -21,22 +21,25 @@ const FilledMiniCartContentsBlock = ( {
 
 	const { createErrorNotice, removeNotice } = useDispatch( 'core/notices' );
 
-	/*
-	 * The code for removing old notices is also present in the filled-cart-block/frontend.tsx file and will take care
-	 * of removing outdated errors in the Cart block.
-	 */
-	const currentlyDisplayedErrorNoticeCodes = useSelect( ( select ) => {
-		return select( 'core/notices' )
+	// Ensures any cart errors listed in the API response get shown.
+	useEffect( () => {
+		/*
+		 * The code for removing old notices is also present in the filled-mini-cart-contents-block/frontend.tsx file and
+		 * will take care of removing outdated errors in the Mini Cart block.
+		 */
+		const currentlyDisplayedErrorNoticeCodes = select( 'core/notices' )
 			.getNotices( 'wc/cart' )
 			.filter(
 				( notice ) =>
 					notice.status === 'error' && notice.type === 'default'
 			)
 			.map( ( notice ) => notice.id );
-	} );
 
-	// Ensures any cart errors listed in the API response get shown.
-	useEffect( () => {
+		// Clear errors out of the store before adding the new ones from the response.
+		currentlyDisplayedErrorNoticeCodes.forEach( ( id ) => {
+			removeNotice( id, 'wc/cart' );
+		} );
+
 		// Clear errors out of the store before adding the new ones from the response.
 		currentlyDisplayedErrorNoticeCodes.forEach( ( id ) => {
 			removeNotice( id, 'wc/cart' );
@@ -49,7 +52,6 @@ const FilledMiniCartContentsBlock = ( {
 				context: 'wc/cart',
 			} );
 		} );
-		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ createErrorNotice, cartItemErrors, removeNotice ] );
 
 	if ( cartItems.length === 0 ) {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR will change the `useSelect` into a plain `select` and move the selection of `currentlyDisplayedNotices` into the `useEffect` in Cart and Mini cart. This will stop the `useEffect` running every time the notice store changes.

Note that when the cart refreshes, for any reason, notices added to the context that are not contained in the `wc/store/cart` data store will disappear. This is refactored and improved in https://github.com/woocommerce/woocommerce-blocks/pull/8162

<!-- Reference any related issues or PRs here -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Add an item to your cart. Open the same item in the editor.
2. In a new tab go to the Cart block.
3. In the editor set the item to be out of stock.
4. In the Cart block, update the item's quantity, ensure you see a notice.
5. Open the console. Type: `wp.data.dispatch( 'core/notices' ).createNotice( 'error', 'error from console', { context: 'wc/cart', } );`
6. Ensure your error appears alongside the out of stock notice.
7. Repeat for the mini-cart.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Prevent Cart and Checkout notices from disappearing immediately after adding.
