### PR TITLE
Change coupon component label to "Apply a coupon code"

### DIFF
--- a/assets/js/base/components/cart-checkout/totals/coupon/index.tsx
+++ b/assets/js/base/components/cart-checkout/totals/coupon/index.tsx
@@ -98,12 +98,15 @@ export const TotalsCoupon = ( {
 					href="#wc-block-components-totals-coupon__form"
 					className="wc-block-components-totals-coupon-link"
 					aria-label={ __(
-						'Add a coupon',
+						'Apply a coupon code',
 						'woo-gutenberg-products-block'
 					) }
 					onClick={ handleCouponAnchorClick }
 				>
-					{ __( 'Add a coupon', 'woo-gutenberg-products-block' ) }
+					{ __(
+						'Apply a coupon code',
+						'woo-gutenberg-products-block'
+					) }
 				</a>
 			) }
 			<LoadingMask

--- a/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-block/test/block.js
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-order-summary-block/test/block.js
@@ -321,7 +321,7 @@ describe( 'Checkout Order Summary', () => {
 		setUseStoreCartReturnValue();
 		const { container } = render( <Block showRateAfterTaxName={ true } /> );
 		expect(
-			await findByText( container, 'Add a coupon' )
+			await findByText( container, 'Apply a coupon code' )
 		).toBeInTheDocument();
 	} );
 

--- a/tests/e2e/specs/shopper/cart-checkout/translations.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/translations.test.js
@@ -48,7 +48,7 @@ describe( 'Shopper → Cart & Checkout → Translations', () => {
 		);
 
 		await expect( orderSummary ).toMatch( 'Subtotaal' );
-		await expect( orderSummary ).toMatch( 'Waardebon code' );
+		await expect( orderSummary ).toMatch( 'Een waardebon code toepassen' );
 		await expect( orderSummary ).toMatch( 'Totaal' );
 	} );
 
@@ -91,7 +91,7 @@ describe( 'Shopper → Cart & Checkout → Translations', () => {
 		);
 		await expect( orderSummary ).toMatch( 'Besteloverzicht' );
 		await expect( orderSummary ).toMatch( 'Subtotaal' );
-		await expect( orderSummary ).toMatch( 'Waardebon code' );
+		await expect( orderSummary ).toMatch( 'Een waardebon code toepassen' );
 		await expect( orderSummary ).toMatch( 'Verzending' );
 		await expect( orderSummary ).toMatch( 'Totaal' );
 	} );


### PR DESCRIPTION
The `Coupon code` text was changed to `Add a coupon`, and it resulted in the [failing of an e2e test](https://github.com/woocommerce/woocommerce-blocks/actions/runs/3958593916/jobs/6780350665#step:12:119) as it couldn't find the translated text for `Coupon code`. 

The translation for  `Add a coupon` is not [available on translate.wordpress.org](https://translate.wordpress.org/projects/wp-plugins/woo-gutenberg-products-block/stable/nl/default/?filters%5Bterm%5D=Add+a+coupon&filters%5Bterm_scope%5D=scope_any&filters%5Bstatus%5D=current_or_waiting_or_fuzzy_or_untranslated&filters%5Buser_login%5D=&filter=Apply+Filters&sort%5Bby%5D=priority&sort%5Bhow%5D=desc), so changing the text to `Apply a coupon code` until the next WC Core release since the translation for the text `Apply a coupon code`  is already [available](https://translate.wordpress.org/projects/wp-plugins/woo-gutenberg-products-block/stable/nl/default/?filters%5Bterm%5D=coupon&filters%5Bterm_scope%5D=scope_any&filters%5Bstatus%5D=current_or_waiting_or_fuzzy_or_untranslated&filters%5Buser_login%5D=&filter=Apply+Filters&sort%5Bby%5D=priority&sort%5Bhow%5D=desc).

Slack: p1674155165351969-slack-C02UBB1EPEF

### Changes in the PR

- Changed the label text from `Add a coupon` to `Apply a coupon code` for the coupon component. 
- Updated the unit and e2e tests

### Testing

#### Automated Tests
* [x] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [x] E2E tests

#### User Facing Testing

1. Checkout this branch
2. Go to the Edit Cart page, remove the Cart block and add it again. 
3. Go to the Edit Checkout page, remove the Checkout block and add it again. 
4. Visit your site front-end and add items to cart
5. Go to the Cart page, and confirm the `Apply a coupon code`  link is visible.
6. Enter the coupon code, and confirm the coupon is getting applied. 
7. Go to the Checkout page, and confirm the `Apply a coupon code`  link is visible.
6. Enter the coupon code, and confirm the coupon is getting applied. 
7. Test around this issue. 


#### Unit tests:

- `npm run test` and ensure the tests pass

#### E2E tests:
 1. Checkout this branch. 
2. Run `npm run build`.
3. Run `npm run test:performance` to run the performance test.
4. Run `npm run test:e2e --  tests/e2e/specs/shopper/cart-checkout/checkout.test.js`and confirm all tests pass. 
5. Run `npm run test:e2e -- translations` and it should pass
6. Run `npm run test:e2e` and confirm all tests pass. 

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
