### PR TITLE
Fix E2E tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,7 @@
 				"@wordpress/data-controls": "2.2.7",
 				"@wordpress/dependency-extraction-webpack-plugin": "3.2.1",
 				"@wordpress/dom": "3.16.0",
-				"@wordpress/e2e-test-utils": "9.0.0",
+				"@wordpress/e2e-test-utils": "9.2.0",
 				"@wordpress/e2e-tests": "4.6.0",
 				"@wordpress/element": "4.20.0",
 				"@wordpress/env": "^4.9.0",
@@ -13803,15 +13803,15 @@
 			}
 		},
 		"node_modules/@wordpress/e2e-test-utils": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils/-/e2e-test-utils-9.0.0.tgz",
-			"integrity": "sha512-ERu7Ze/3hzHIbU/3CU8RwsWvHADUVMMJkGE3KBSPT7mCPVvbk42/2RbqUiQwcwWgM2tY0zfhY7JAg7F9WmnbEw==",
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils/-/e2e-test-utils-9.2.0.tgz",
+			"integrity": "sha512-kfnIwgoo4fd1+h85btWFyoMcPBqYA4szwWI3GmrBny8ybyFljRed1XVleZ/oD6MaFgid4uB6V4+OKTlsw5mg/Q==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/api-fetch": "^6.20.0",
-				"@wordpress/keycodes": "^3.23.0",
-				"@wordpress/url": "^3.24.0",
+				"@wordpress/api-fetch": "^6.22.0",
+				"@wordpress/keycodes": "^3.25.0",
+				"@wordpress/url": "^3.26.0",
 				"change-case": "^4.1.2",
 				"form-data": "^4.0.0",
 				"node-fetch": "^2.6.0"
@@ -13824,10 +13824,44 @@
 				"puppeteer-core": ">=11"
 			}
 		},
+		"node_modules/@wordpress/e2e-test-utils/node_modules/@wordpress/api-fetch": {
+			"version": "6.22.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.22.0.tgz",
+			"integrity": "sha512-IO7Shv1Qz93bo/Rq20beAV+p1qSOCs4uUi98rzhhih7U0SF88Jo69mlNmQbpALWcG040a2DRQR8E18Mj7JwViQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/i18n": "^4.25.0",
+				"@wordpress/url": "^3.26.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@wordpress/e2e-test-utils/node_modules/@wordpress/i18n": {
+			"version": "4.25.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.25.0.tgz",
+			"integrity": "sha512-cKU5Ox1DKa3WShRu+QrCU+QzNvyoQhrNtS6kcvw17DfMBjPe7AsYjd7ZBb7Io327jP97Oqh5BtaYdUq/4S1cIw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/hooks": "^3.25.0",
+				"gettext-parser": "^1.3.1",
+				"memize": "^1.1.0",
+				"sprintf-js": "^1.1.1",
+				"tannin": "^1.2.0"
+			},
+			"bin": {
+				"pot-to-php": "tools/pot-to-php.js"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/@wordpress/e2e-test-utils/node_modules/@wordpress/url": {
-			"version": "3.24.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.24.0.tgz",
-			"integrity": "sha512-NFDz2rCe+ubt6UfXoB0dWhCgQHF9LbuW7ug8C0hCggAVYhI3Dhs1oLyqElLWT4t16s3fovxFIASGoTqB4i01JQ==",
+			"version": "3.26.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.26.0.tgz",
+			"integrity": "sha512-oqIYWqUo1sr1qU4jxbRhzusSqMClSHn4bNtlR835VcqZoBnTM7/RwfrmTo6aCWDcSAd7LQVV1vykTjJsAYdxsA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
@@ -15980,9 +16014,9 @@
 			}
 		},
 		"node_modules/@wordpress/hooks": {
-			"version": "3.24.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.24.0.tgz",
-			"integrity": "sha512-Nm8Y+IdahS2dg4fSMVZmb7FDqxTHJu9jTQ8BgCFKuX0b4M1brZatvg8VMMj5ZbDm2XMai+07lsFBrxWHpNm18Q==",
+			"version": "3.25.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.25.0.tgz",
+			"integrity": "sha512-xdSUsyStn6b5Ts4vaMuCDsxy4D9hWPUkCItF3q16Zh6DgPAXeRvGozVt6Y+kW8xZ3dHI3t6uzP0VXSiVWkK8Gw==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0"
 			},
@@ -16138,14 +16172,33 @@
 			"license": "MIT"
 		},
 		"node_modules/@wordpress/keycodes": {
-			"version": "3.23.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.23.0.tgz",
-			"integrity": "sha512-CfvxhqwgVU2c3f2B1F09i8E+1/HMkgf4gmmf+0dyKFMmYesByY4GKuvOvKw5dklFWp96qECz6Jf+L2F4vw7//w==",
+			"version": "3.25.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.25.0.tgz",
+			"integrity": "sha512-y55wL9bj/XrW7Uyvg6kyQeVjPQOezG7HTI+L3nzI12waL50eGhqM1DSOv6PhMrcoHG4CN5Lg8bXNUF6TrAntfA==",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/i18n": "^4.23.0",
+				"@wordpress/i18n": "^4.25.0",
 				"change-case": "^4.1.2",
 				"lodash": "^4.17.21"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@wordpress/keycodes/node_modules/@wordpress/i18n": {
+			"version": "4.25.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.25.0.tgz",
+			"integrity": "sha512-cKU5Ox1DKa3WShRu+QrCU+QzNvyoQhrNtS6kcvw17DfMBjPe7AsYjd7ZBb7Io327jP97Oqh5BtaYdUq/4S1cIw==",
+			"dependencies": {
+				"@babel/runtime": "^7.16.0",
+				"@wordpress/hooks": "^3.25.0",
+				"gettext-parser": "^1.3.1",
+				"memize": "^1.1.0",
+				"sprintf-js": "^1.1.1",
+				"tannin": "^1.2.0"
+			},
+			"bin": {
+				"pot-to-php": "tools/pot-to-php.js"
 			},
 			"engines": {
 				"node": ">=12"
@@ -60203,24 +60256,49 @@
 			}
 		},
 		"@wordpress/e2e-test-utils": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils/-/e2e-test-utils-9.0.0.tgz",
-			"integrity": "sha512-ERu7Ze/3hzHIbU/3CU8RwsWvHADUVMMJkGE3KBSPT7mCPVvbk42/2RbqUiQwcwWgM2tY0zfhY7JAg7F9WmnbEw==",
+			"version": "9.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils/-/e2e-test-utils-9.2.0.tgz",
+			"integrity": "sha512-kfnIwgoo4fd1+h85btWFyoMcPBqYA4szwWI3GmrBny8ybyFljRed1XVleZ/oD6MaFgid4uB6V4+OKTlsw5mg/Q==",
 			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/api-fetch": "^6.20.0",
-				"@wordpress/keycodes": "^3.23.0",
-				"@wordpress/url": "^3.24.0",
+				"@wordpress/api-fetch": "^6.22.0",
+				"@wordpress/keycodes": "^3.25.0",
+				"@wordpress/url": "^3.26.0",
 				"change-case": "^4.1.2",
 				"form-data": "^4.0.0",
 				"node-fetch": "^2.6.0"
 			},
 			"dependencies": {
+				"@wordpress/api-fetch": {
+					"version": "6.22.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.22.0.tgz",
+					"integrity": "sha512-IO7Shv1Qz93bo/Rq20beAV+p1qSOCs4uUi98rzhhih7U0SF88Jo69mlNmQbpALWcG040a2DRQR8E18Mj7JwViQ==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.16.0",
+						"@wordpress/i18n": "^4.25.0",
+						"@wordpress/url": "^3.26.0"
+					}
+				},
+				"@wordpress/i18n": {
+					"version": "4.25.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.25.0.tgz",
+					"integrity": "sha512-cKU5Ox1DKa3WShRu+QrCU+QzNvyoQhrNtS6kcvw17DfMBjPe7AsYjd7ZBb7Io327jP97Oqh5BtaYdUq/4S1cIw==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.16.0",
+						"@wordpress/hooks": "^3.25.0",
+						"gettext-parser": "^1.3.1",
+						"memize": "^1.1.0",
+						"sprintf-js": "^1.1.1",
+						"tannin": "^1.2.0"
+					}
+				},
 				"@wordpress/url": {
-					"version": "3.24.0",
-					"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.24.0.tgz",
-					"integrity": "sha512-NFDz2rCe+ubt6UfXoB0dWhCgQHF9LbuW7ug8C0hCggAVYhI3Dhs1oLyqElLWT4t16s3fovxFIASGoTqB4i01JQ==",
+					"version": "3.26.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.26.0.tgz",
+					"integrity": "sha512-oqIYWqUo1sr1qU4jxbRhzusSqMClSHn4bNtlR835VcqZoBnTM7/RwfrmTo6aCWDcSAd7LQVV1vykTjJsAYdxsA==",
 					"dev": true,
 					"requires": {
 						"@babel/runtime": "^7.16.0",
@@ -61693,9 +61771,9 @@
 			}
 		},
 		"@wordpress/hooks": {
-			"version": "3.24.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.24.0.tgz",
-			"integrity": "sha512-Nm8Y+IdahS2dg4fSMVZmb7FDqxTHJu9jTQ8BgCFKuX0b4M1brZatvg8VMMj5ZbDm2XMai+07lsFBrxWHpNm18Q==",
+			"version": "3.25.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.25.0.tgz",
+			"integrity": "sha512-xdSUsyStn6b5Ts4vaMuCDsxy4D9hWPUkCItF3q16Zh6DgPAXeRvGozVt6Y+kW8xZ3dHI3t6uzP0VXSiVWkK8Gw==",
 			"requires": {
 				"@babel/runtime": "^7.16.0"
 			}
@@ -61791,16 +61869,29 @@
 			}
 		},
 		"@wordpress/keycodes": {
-			"version": "3.23.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.23.0.tgz",
-			"integrity": "sha512-CfvxhqwgVU2c3f2B1F09i8E+1/HMkgf4gmmf+0dyKFMmYesByY4GKuvOvKw5dklFWp96qECz6Jf+L2F4vw7//w==",
+			"version": "3.25.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.25.0.tgz",
+			"integrity": "sha512-y55wL9bj/XrW7Uyvg6kyQeVjPQOezG7HTI+L3nzI12waL50eGhqM1DSOv6PhMrcoHG4CN5Lg8bXNUF6TrAntfA==",
 			"requires": {
 				"@babel/runtime": "^7.16.0",
-				"@wordpress/i18n": "^4.23.0",
+				"@wordpress/i18n": "^4.25.0",
 				"change-case": "^4.1.2",
 				"lodash": "^4.17.21"
 			},
 			"dependencies": {
+				"@wordpress/i18n": {
+					"version": "4.25.0",
+					"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-4.25.0.tgz",
+					"integrity": "sha512-cKU5Ox1DKa3WShRu+QrCU+QzNvyoQhrNtS6kcvw17DfMBjPe7AsYjd7ZBb7Io327jP97Oqh5BtaYdUq/4S1cIw==",
+					"requires": {
+						"@babel/runtime": "^7.16.0",
+						"@wordpress/hooks": "^3.25.0",
+						"gettext-parser": "^1.3.1",
+						"memize": "^1.1.0",
+						"sprintf-js": "^1.1.1",
+						"tannin": "^1.2.0"
+					}
+				},
 				"change-case": {
 					"version": "4.1.2",
 					"requires": {

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
 		"@wordpress/data-controls": "2.2.7",
 		"@wordpress/dependency-extraction-webpack-plugin": "3.2.1",
 		"@wordpress/dom": "3.16.0",
-		"@wordpress/e2e-test-utils": "9.0.0",
+		"@wordpress/e2e-test-utils": "9.2.0",
 		"@wordpress/e2e-tests": "4.6.0",
 		"@wordpress/element": "4.20.0",
 		"@wordpress/env": "^4.9.0",

--- a/tests/e2e/specs/backend/active-filters.test.js
+++ b/tests/e2e/specs/backend/active-filters.test.js
@@ -9,6 +9,7 @@ import {
 import {
 	visitBlockPage,
 	selectBlockByName,
+	switchBlockInspectorTabWhenGutenbergIsInstalled,
 } from '@woocommerce/blocks-test-utils';
 
 const block = {
@@ -31,6 +32,7 @@ describe( `${ block.name } Block`, () => {
 	describe( 'attributes', () => {
 		beforeEach( async () => {
 			await openDocumentSettingsSidebar();
+			await switchBlockInspectorTabWhenGutenbergIsInstalled( 'Settings' );
 			await selectBlockByName( block.slug );
 		} );
 

--- a/tests/e2e/specs/backend/attribute-filter.test.js
+++ b/tests/e2e/specs/backend/attribute-filter.test.js
@@ -10,6 +10,7 @@ import {
 	visitBlockPage,
 	saveOrPublish,
 	selectBlockByName,
+	switchBlockInspectorTabWhenGutenbergIsInstalled,
 } from '@woocommerce/blocks-test-utils';
 
 const block = {
@@ -64,6 +65,7 @@ describe( `${ block.name } Block`, () => {
 		beforeEach( async () => {
 			await openDocumentSettingsSidebar();
 			await selectBlockByName( block.slug );
+			await switchBlockInspectorTabWhenGutenbergIsInstalled( 'Settings' );
 		} );
 
 		it( "allows changing the block's title", async () => {

--- a/tests/e2e/specs/backend/cart.test.js
+++ b/tests/e2e/specs/backend/cart.test.js
@@ -5,12 +5,14 @@ import {
 	clickBlockToolbarButton,
 	openDocumentSettingsSidebar,
 	switchUserToAdmin,
-	getAllBlocks,
+	searchForBlock,
+	openGlobalBlockInserter,
 } from '@wordpress/e2e-test-utils';
 import {
 	findLabelWithText,
 	visitBlockPage,
 	selectBlockByName,
+	switchBlockInspectorTabWhenGutenbergIsInstalled,
 } from '@woocommerce/blocks-test-utils';
 import { merchant } from '@woocommerce/e2e-utils';
 
@@ -18,8 +20,6 @@ import { merchant } from '@woocommerce/e2e-utils';
  * Internal dependencies
  */
 import {
-	searchForBlock,
-	insertBlockDontWaitForInsertClose,
 	openWidgetEditor,
 	closeModalIfExists,
 	openWidgetsEditorBlockInserter,
@@ -29,6 +29,9 @@ const block = {
 	name: 'Cart',
 	slug: 'woocommerce/cart',
 	class: '.wp-block-woocommerce-cart',
+	selectors: {
+		insertButton: "//button//span[text()='Cart']",
+	},
 };
 
 const filledCartBlock = {
@@ -62,8 +65,10 @@ describe( `${ block.name } Block`, () => {
 		} );
 
 		it( 'can only be inserted once', async () => {
-			await insertBlockDontWaitForInsertClose( block.name );
-			expect( await getAllBlocks() ).toHaveLength( 1 );
+			await openGlobalBlockInserter();
+			await page.keyboard.type( block.name );
+			const button = await page.$x( block.selectors.insertButton );
+			expect( button ).toHaveLength( 0 );
 		} );
 
 		it( 'renders without crashing', async () => {
@@ -114,6 +119,9 @@ describe( `${ block.name } Block`, () => {
 		describe( 'attributes', () => {
 			beforeEach( async () => {
 				await openDocumentSettingsSidebar();
+				await switchBlockInspectorTabWhenGutenbergIsInstalled(
+					'Settings'
+				);
 				await selectBlockByName(
 					'woocommerce/cart-order-summary-shipping-block'
 				);

--- a/tests/e2e/specs/backend/catalog-sorting.test.js
+++ b/tests/e2e/specs/backend/catalog-sorting.test.js
@@ -41,7 +41,7 @@ describe( `${ block.name } Block`, () => {
 		} );
 	} );
 
-	describe( 'in FSE editor', () => {
+	describe.skip( 'in FSE editor', () => {
 		useTheme( 'emptytheme' );
 
 		beforeEach( async () => {

--- a/tests/e2e/specs/backend/catalog-sorting.test.js
+++ b/tests/e2e/specs/backend/catalog-sorting.test.js
@@ -6,8 +6,8 @@ import {
 	createNewPost,
 	insertBlock,
 	switchUserToAdmin,
+	searchForBlock,
 } from '@wordpress/e2e-test-utils';
-import { searchForBlock } from '@wordpress/e2e-test-utils/build/inserter';
 
 /**
  * Internal dependencies

--- a/tests/e2e/specs/backend/checkout.test.js
+++ b/tests/e2e/specs/backend/checkout.test.js
@@ -2,14 +2,15 @@
  * External dependencies
  */
 import {
-	getAllBlocks,
 	openDocumentSettingsSidebar,
 	switchUserToAdmin,
+	openGlobalBlockInserter,
 } from '@wordpress/e2e-test-utils';
 import {
 	findLabelWithText,
 	visitBlockPage,
 	selectBlockByName,
+	switchBlockInspectorTabWhenGutenbergIsInstalled,
 } from '@woocommerce/blocks-test-utils';
 import { merchant } from '@woocommerce/e2e-utils';
 
@@ -18,17 +19,18 @@ import { merchant } from '@woocommerce/e2e-utils';
  */
 import {
 	searchForBlock,
-	insertBlockDontWaitForInsertClose,
 	openWidgetEditor,
 	closeModalIfExists,
 	openWidgetsEditorBlockInserter,
-	closeInserter,
 } from '../../utils.js';
 
 const block = {
 	name: 'Checkout',
 	slug: 'woocommerce/checkout',
 	class: '.wp-block-woocommerce-checkout',
+	selectors: {
+		insertButton: "//button//span[text()='Checkout']",
+	},
 };
 
 if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 ) {
@@ -44,9 +46,10 @@ describe( `${ block.name } Block`, () => {
 		} );
 
 		it( 'can only be inserted once', async () => {
-			await insertBlockDontWaitForInsertClose( block.name );
-			await closeInserter();
-			expect( await getAllBlocks() ).toHaveLength( 1 );
+			await openGlobalBlockInserter();
+			await page.keyboard.type( block.name );
+			const button = await page.$x( block.selectors.insertButton );
+			expect( button ).toHaveLength( 0 );
 		} );
 
 		it( 'renders without crashing', async () => {
@@ -56,6 +59,9 @@ describe( `${ block.name } Block`, () => {
 		describe( 'attributes', () => {
 			beforeEach( async () => {
 				await openDocumentSettingsSidebar();
+				await switchBlockInspectorTabWhenGutenbergIsInstalled(
+					'Settings'
+				);
 				await selectBlockByName( block.slug );
 			} );
 
@@ -80,6 +86,9 @@ describe( `${ block.name } Block`, () => {
 		describe( 'shipping address block attributes', () => {
 			beforeEach( async () => {
 				await openDocumentSettingsSidebar();
+				await switchBlockInspectorTabWhenGutenbergIsInstalled(
+					'Settings'
+				);
 				await selectBlockByName(
 					'woocommerce/checkout-shipping-address-block'
 				);
@@ -129,6 +138,9 @@ describe( `${ block.name } Block`, () => {
 		describe( 'action block attributes', () => {
 			beforeEach( async () => {
 				await openDocumentSettingsSidebar();
+				await switchBlockInspectorTabWhenGutenbergIsInstalled(
+					'Settings'
+				);
 				await selectBlockByName( 'woocommerce/checkout-actions-block' );
 			} );
 

--- a/tests/e2e/specs/backend/customer-account.test.js
+++ b/tests/e2e/specs/backend/customer-account.test.js
@@ -5,7 +5,10 @@ import {
 	switchUserToAdmin,
 	openDocumentSettingsSidebar,
 } from '@wordpress/e2e-test-utils';
-import { visitBlockPage } from '@woocommerce/blocks-test-utils';
+import {
+	visitBlockPage,
+	switchBlockInspectorTabWhenGutenbergIsInstalled,
+} from '@woocommerce/blocks-test-utils';
 
 const block = {
 	name: 'Customer account',
@@ -33,6 +36,7 @@ describe( `${ block.name } Block`, () => {
 	describe( 'attributes', () => {
 		beforeEach( async () => {
 			await openDocumentSettingsSidebar();
+			await switchBlockInspectorTabWhenGutenbergIsInstalled( 'Settings' );
 			await page.click( block.class );
 		} );
 

--- a/tests/e2e/specs/backend/price-filter.test.js
+++ b/tests/e2e/specs/backend/price-filter.test.js
@@ -8,6 +8,7 @@ import {
 import {
 	visitBlockPage,
 	selectBlockByName,
+	switchBlockInspectorTabWhenGutenbergIsInstalled,
 } from '@woocommerce/blocks-test-utils';
 
 const block = {
@@ -30,6 +31,9 @@ describe( `${ block.name } Block`, () => {
 		describe( 'Attributes', () => {
 			beforeEach( async () => {
 				await openDocumentSettingsSidebar();
+				await switchBlockInspectorTabWhenGutenbergIsInstalled(
+					'Settings'
+				);
 				await selectBlockByName( block.slug );
 			} );
 

--- a/tests/e2e/specs/backend/product-query.test.ts
+++ b/tests/e2e/specs/backend/product-query.test.ts
@@ -8,7 +8,10 @@ import {
 	openDocumentSettingsSidebar,
 	openListView,
 } from '@wordpress/e2e-test-utils';
-import { visitBlockPage } from '@woocommerce/blocks-test-utils';
+import {
+	visitBlockPage,
+	switchBlockInspectorTabWhenGutenbergIsInstalled,
+} from '@woocommerce/blocks-test-utils';
 
 /**
  * Internal dependencies
@@ -51,6 +54,7 @@ describeOrSkip( GUTENBERG_EDITOR_CONTEXT === 'gutenberg' )(
 			await visitBlockPage( `${ block.name } Block` );
 			const canvasEl = canvas();
 			await openDocumentSettingsSidebar();
+			await switchBlockInspectorTabWhenGutenbergIsInstalled( 'Settings' );
 			await openListView();
 			await page.click(
 				'.block-editor-list-view-block__contents-container a.components-button'

--- a/tests/e2e/specs/backend/product-query/advanced-filters.test.ts
+++ b/tests/e2e/specs/backend/product-query/advanced-filters.test.ts
@@ -8,6 +8,7 @@ import {
 	getFixtureProductsData,
 	shopper,
 	getToggleIdByLabel,
+	switchBlockInspectorTabWhenGutenbergIsInstalled,
 } from '@woocommerce/blocks-test-utils';
 import { ElementHandle } from 'puppeteer';
 import { setCheckbox } from '@woocommerce/e2e-utils';
@@ -47,6 +48,7 @@ describeOrSkip( GUTENBERG_EDITOR_CONTEXT === 'gutenberg' )(
 			await resetProductQueryBlockPage();
 			await ensureSidebarOpened();
 			await selectBlockByName( block.slug );
+			await switchBlockInspectorTabWhenGutenbergIsInstalled( 'Settings' );
 			$productFiltersPanel = await findToolsPanelWithTitle(
 				'Advanced Filters'
 			);

--- a/tests/e2e/specs/backend/product-query/popular-filters.test.ts
+++ b/tests/e2e/specs/backend/product-query/popular-filters.test.ts
@@ -11,6 +11,7 @@ import {
 	selectBlockByName,
 	visitBlockPage,
 	saveOrPublish,
+	switchBlockInspectorTabWhenGutenbergIsInstalled,
 } from '@woocommerce/blocks-test-utils';
 
 /**
@@ -28,6 +29,7 @@ import {
 const getPopularFilterPanel = async () => {
 	await ensureSidebarOpened();
 	await selectBlockByName( block.slug );
+	await switchBlockInspectorTabWhenGutenbergIsInstalled( 'Settings' );
 	return await findSidebarPanelWithTitle( 'Popular Filters' );
 };
 

--- a/tests/e2e/specs/backend/rating-filter.test.js
+++ b/tests/e2e/specs/backend/rating-filter.test.js
@@ -5,7 +5,10 @@ import {
 	switchUserToAdmin,
 	openDocumentSettingsSidebar,
 } from '@wordpress/e2e-test-utils';
-import { visitBlockPage } from '@woocommerce/blocks-test-utils';
+import {
+	visitBlockPage,
+	switchBlockInspectorTabWhenGutenbergIsInstalled,
+} from '@woocommerce/blocks-test-utils';
 
 /**
  * Internal dependencies
@@ -30,6 +33,7 @@ describe( `${ block.name } Block`, () => {
 	describe( 'attributes', () => {
 		beforeEach( async () => {
 			await openDocumentSettingsSidebar();
+			await switchBlockInspectorTabWhenGutenbergIsInstalled( 'Settings' );
 			await page.click( block.class );
 		} );
 

--- a/tests/e2e/specs/backend/stock-filter.test.js
+++ b/tests/e2e/specs/backend/stock-filter.test.js
@@ -5,7 +5,10 @@ import {
 	switchUserToAdmin,
 	openDocumentSettingsSidebar,
 } from '@wordpress/e2e-test-utils';
-import { visitBlockPage } from '@woocommerce/blocks-test-utils';
+import {
+	visitBlockPage,
+	switchBlockInspectorTabWhenGutenbergIsInstalled,
+} from '@woocommerce/blocks-test-utils';
 
 /**
  * Internal dependencies
@@ -31,6 +34,7 @@ describe( `${ block.name } Block`, () => {
 	describe( 'attributes', () => {
 		beforeEach( async () => {
 			await openDocumentSettingsSidebar();
+			await switchBlockInspectorTabWhenGutenbergIsInstalled( 'Settings' );
 			await page.click( block.class );
 		} );
 

--- a/tests/e2e/specs/merchant/checkout-terms.test.js
+++ b/tests/e2e/specs/merchant/checkout-terms.test.js
@@ -11,6 +11,7 @@ import {
 	visitBlockPage,
 	selectBlockByName,
 	saveOrPublish,
+	switchBlockInspectorTabWhenGutenbergIsInstalled,
 } from '@woocommerce/blocks-test-utils';
 
 /**
@@ -65,6 +66,7 @@ describe( 'Merchant → Checkout → Can adjust T&S and Privacy Policy options',
 		await merchant.login();
 		await visitBlockPage( 'Checkout Block' );
 		await openDocumentSettingsSidebar();
+		await switchBlockInspectorTabWhenGutenbergIsInstalled( 'Settings' );
 		await selectBlockByName( 'woocommerce/checkout-terms-block' );
 		const [ termsCheckboxLabel ] = await page.$x(
 			`//label[contains(text(), "Require checkbox") and contains(@class, "components-toggle-control__label")]`
@@ -99,6 +101,7 @@ describe( 'Merchant → Checkout → Can adjust T&S and Privacy Policy options',
 		// Deactivate checkboxes for T&S and Privacy Policy links.
 		await visitBlockPage( 'Checkout Block' );
 		await openDocumentSettingsSidebar();
+		await switchBlockInspectorTabWhenGutenbergIsInstalled( 'Settings' );
 		await selectBlockByName( 'woocommerce/checkout-terms-block' );
 		await unsetCheckbox( termsCheckboxId );
 		await saveOrPublish();

--- a/tests/e2e/specs/shopper/cart-checkout/checkout.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/checkout.test.js
@@ -13,6 +13,7 @@ import {
 	selectBlockByName,
 	saveOrPublish,
 	getToggleIdByLabel,
+	switchBlockInspectorTabWhenGutenbergIsInstalled,
 } from '@woocommerce/blocks-test-utils';
 
 /**
@@ -70,6 +71,7 @@ describe( 'Shopper → Checkout', () => {
 			await merchant.login();
 			await visitBlockPage( 'Checkout Block' );
 			await openDocumentSettingsSidebar();
+			await switchBlockInspectorTabWhenGutenbergIsInstalled( 'Settings' );
 			await selectBlockByName(
 				'woocommerce/checkout-shipping-address-block'
 			);
@@ -83,6 +85,7 @@ describe( 'Shopper → Checkout', () => {
 			await shopper.block.emptyCart();
 			await visitBlockPage( 'Checkout Block' );
 			await openDocumentSettingsSidebar();
+			await switchBlockInspectorTabWhenGutenbergIsInstalled( 'Settings' );
 			await selectBlockByName(
 				'woocommerce/checkout-shipping-address-block'
 			);
@@ -301,7 +304,7 @@ describe( 'Shopper → Checkout', () => {
 			await shopper.block.goToCheckout();
 			await shopper.block.applyCouponFromCheckout( coupon.code );
 			await page.waitForSelector(
-				'.wc-block-components-validation-error'
+				'.wc-block-components-notices__notice'
 			);
 			await expect( page ).toMatch(
 				'Coupon usage limit has been reached.'

--- a/tests/e2e/specs/shopper/cart-checkout/translations.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/translations.test.js
@@ -52,7 +52,6 @@ describe( 'Shopper → Cart & Checkout → Translations', () => {
 		await expect( orderSummary ).toMatch( 'Totaal' );
 	} );
 
-	// The translation of WooCommerce Core is taking over translations of WC Blocks. We have to fix this issue https://github.com/woocommerce/woocommerce-blocks/issues/7775 before we can enable this test.
 	it( 'User can view translated Checkout block', async () => {
 		await shopper.block.goToCheckout();
 

--- a/tests/e2e/specs/shopper/filter-products-by-attribute.test.ts
+++ b/tests/e2e/specs/shopper/filter-products-by-attribute.test.ts
@@ -13,6 +13,7 @@ import {
 import {
 	selectBlockByName,
 	insertBlockUsingSlash,
+	switchBlockInspectorTabWhenGutenbergIsInstalled,
 } from '@woocommerce/blocks-test-utils';
 
 /**
@@ -189,8 +190,10 @@ describe( `${ block.name } Block`, () => {
 				postId: productCatalogTemplateId,
 			} );
 
-			await selectBlockByName( block.slug );
 			await ensureSidebarOpened();
+			await selectBlockByName( block.slug );
+			await switchBlockInspectorTabWhenGutenbergIsInstalled( 'Settings' );
+
 			const [ filterButtonToggle ] = await page.$x(
 				block.selectors.editor.filterButtonToggle
 			);
@@ -308,6 +311,8 @@ describe( `${ block.name } Block`, () => {
 			await page.goto( editorPageUrl );
 			await ensureSidebarOpened();
 			await selectBlockByName( block.slug );
+			await switchBlockInspectorTabWhenGutenbergIsInstalled( 'Settings' );
+
 			const [ filterButtonToggle ] = await page.$x(
 				block.selectors.editor.filterButtonToggle
 			);

--- a/tests/e2e/specs/shopper/filter-products-by-price.test.ts
+++ b/tests/e2e/specs/shopper/filter-products-by-price.test.ts
@@ -12,6 +12,7 @@ import {
 import {
 	selectBlockByName,
 	insertBlockUsingSlash,
+	switchBlockInspectorTabWhenGutenbergIsInstalled,
 } from '@woocommerce/blocks-test-utils';
 
 /**
@@ -187,6 +188,8 @@ describe( `${ block.name } Block`, () => {
 
 			await selectBlockByName( block.slug );
 			await ensureSidebarOpened();
+			await switchBlockInspectorTabWhenGutenbergIsInstalled( 'Settings' );
+
 			await page.waitForXPath(
 				block.selectors.editor.filterButtonToggle
 			);
@@ -297,6 +300,7 @@ describe( `${ block.name } Block`, () => {
 
 			await ensureSidebarOpened();
 			await selectBlockByName( block.slug );
+			await switchBlockInspectorTabWhenGutenbergIsInstalled( 'Settings' );
 			await page.waitForXPath(
 				block.selectors.editor.filterButtonToggle
 			);

--- a/tests/e2e/specs/shopper/filter-products-by-rating.test.ts
+++ b/tests/e2e/specs/shopper/filter-products-by-rating.test.ts
@@ -14,6 +14,7 @@ import {
 	insertBlockUsingSlash,
 	saveOrPublish,
 	getToggleIdByLabel,
+	switchBlockInspectorTabWhenGutenbergIsInstalled,
 } from '@woocommerce/blocks-test-utils';
 import { setCheckbox } from '@woocommerce/e2e-utils';
 
@@ -162,6 +163,8 @@ describe( `${ block.name } Block`, () => {
 			await waitForCanvas();
 			await selectBlockByName( block.slug );
 			await ensureSidebarOpened();
+			await switchBlockInspectorTabWhenGutenbergIsInstalled( 'Settings' );
+
 			await page.waitForXPath(
 				block.selectors.editor.filterButtonToggle
 			);
@@ -268,6 +271,7 @@ describe( `${ block.name } Block`, () => {
 			await waitForCanvas();
 			await ensureSidebarOpened();
 			await selectBlockByName( block.slug );
+			await switchBlockInspectorTabWhenGutenbergIsInstalled( 'Settings' );
 			await setCheckbox(
 				await getToggleIdByLabel( "Show 'Apply filters' button", 1 )
 			);

--- a/tests/e2e/specs/shopper/filter-products-by-stock.test.ts
+++ b/tests/e2e/specs/shopper/filter-products-by-stock.test.ts
@@ -14,6 +14,7 @@ import {
 	insertBlockUsingSlash,
 	getToggleIdByLabel,
 	saveOrPublish,
+	switchBlockInspectorTabWhenGutenbergIsInstalled,
 } from '@woocommerce/blocks-test-utils';
 import { setCheckbox } from '@woocommerce/e2e-utils';
 
@@ -168,6 +169,7 @@ describe( `${ block.name } Block`, () => {
 			await waitForCanvas();
 			await selectBlockByName( block.slug );
 			await ensureSidebarOpened();
+			await switchBlockInspectorTabWhenGutenbergIsInstalled( 'Settings' );
 			await page.waitForXPath(
 				block.selectors.editor.filterButtonToggle
 			);
@@ -274,6 +276,7 @@ describe( `${ block.name } Block`, () => {
 			await waitForCanvas();
 			await ensureSidebarOpened();
 			await selectBlockByName( block.slug );
+			await switchBlockInspectorTabWhenGutenbergIsInstalled( 'Settings' );
 			await setCheckbox(
 				await getToggleIdByLabel( "Show 'Apply filters' button" )
 			);

--- a/tests/e2e/specs/shopper/product-query/product-query-with-templates.test.ts
+++ b/tests/e2e/specs/shopper/product-query/product-query-with-templates.test.ts
@@ -6,6 +6,8 @@ import {
 	ensureSidebarOpened,
 } from '@wordpress/e2e-test-utils';
 
+import { switchBlockInspectorTabWhenGutenbergIsInstalled } from '@woocommerce/blocks-test-utils';
+
 /**
  * Internal dependencies
  */
@@ -36,6 +38,7 @@ describe( `${ block.name } Block`, () => {
 			} );
 			await ensureSidebarOpened();
 			await addProductQueryBlock();
+			await switchBlockInspectorTabWhenGutenbergIsInstalled( 'Settings' );
 		} );
 
 		it( 'when Inherit Query from template is disabled all the settings that customize the query should be hide', async () => {

--- a/tests/e2e/specs/shopper/product-query/utils.ts
+++ b/tests/e2e/specs/shopper/product-query/utils.ts
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import { insertBlock, ensureSidebarOpened } from '@wordpress/e2e-test-utils';
+import { switchBlockInspectorTabWhenGutenbergIsInstalled } from '@woocommerce/blocks-test-utils';
+
 /**
  * Internal dependencies
  */
@@ -39,6 +41,7 @@ const enableInheritQueryFromTemplateSetting = async () => {
 
 export const configurateProductQueryBlock = async () => {
 	await ensureSidebarOpened();
+	await switchBlockInspectorTabWhenGutenbergIsInstalled( 'Settings' );
 	await enableInheritQueryFromTemplateSetting();
 };
 

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -10,6 +10,7 @@ import {
 	visitAdminPage,
 	pressKeyWithModifier,
 	searchForBlock as searchForFSEBlock,
+	enterEditMode,
 } from '@wordpress/e2e-test-utils';
 import { addQueryArgs } from '@wordpress/url';
 import { WP_ADMIN_DASHBOARD } from '@woocommerce/e2e-utils';
@@ -172,8 +173,7 @@ export async function goToSiteEditor( params = {} ) {
 		GUTENBERG_EDITOR_CONTEXT === 'gutenberg' &&
 		( params?.postId || Object.keys( params ).length === 0 )
 	) {
-		await page.waitForSelector( SELECTORS.templateEditor.editButton );
-		await page.click( SELECTORS.templateEditor.editButton );
+		await enterEditMode();
 	}
 }
 

--- a/tests/utils/index.js
+++ b/tests/utils/index.js
@@ -24,3 +24,4 @@ export { getToggleIdByLabel } from './get-toggle-id-by-label';
 export { insertBlockUsingQuickInserter } from './insert-block-using-quick-inserter';
 export { insertBlockUsingSlash } from './insert-block-using-slash';
 export { insertShortcodeBlock } from './insert-shortcode-block';
+export { switchBlockInspectorTabWhenGutenbergIsInstalled } from './switch-block-inspector-tab-when-gutenberg-is-installed';

--- a/tests/utils/switch-block-inspector-tab-when-gutenberg-is-installed.ts
+++ b/tests/utils/switch-block-inspector-tab-when-gutenberg-is-installed.ts
@@ -1,0 +1,19 @@
+/**
+ * External dependencies
+ */
+import { switchBlockInspectorTab } from '@wordpress/e2e-test-utils';
+
+/**
+ * Internal dependencies
+ */
+import { GUTENBERG_EDITOR_CONTEXT } from '../e2e/utils';
+
+// @todo Remove this function when WP 6.2 is released. We can use the "switchBlockInspectorTab" function directly.
+export const switchBlockInspectorTabWhenGutenbergIsInstalled = async (
+	tabName: string
+) => {
+	if ( GUTENBERG_EDITOR_CONTEXT === 'core' ) {
+		return;
+	}
+	await switchBlockInspectorTab( tabName );
+};


### PR DESCRIPTION
This PR fixes E2E tests. All test fails when Gutenberg is installed because Gutenberg changed the UI regarding the block settings (https://github.com/WordPress/gutenberg/pull/45005):

![image](https://user-images.githubusercontent.com/4463174/214257437-c23d4dee-440b-4963-9841-1eddc6417d01.png)

To fix this issue I upgrade the package `@wordpress/e2e-test-utils` that contains a new util `switchBlockInspectorTab` to switch the tab. Also, I fixed some failure tests for some updates that we did in our codebase.

 
I disabled the test regarding the `Catalog Sorting` block. Even if they are straightforward, they failed but I don't understand why. Could you take a look, @albarin?

Some tests are still flaky. 😢 

 
### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests

#### User Facing Testing
- Be sure that CI is green



* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental


