### PR TITLE
Product Price: Transition from using CSS margin to Global Styles

### DIFF
--- a/assets/js/atomic/blocks/product-elements/price/supports.ts
+++ b/assets/js/atomic/blocks/product-elements/price/supports.ts
@@ -24,12 +24,11 @@ export const supports = {
 			__experimentalFontStyle: true,
 			__experimentalSkipSerialization: true,
 		},
-		...( typeof __experimentalGetSpacingClassesAndStyles === 'function' && {
-			spacing: {
-				margin: true,
-				__experimentalSkipSerialization: true,
-			},
-		} ),
 		__experimentalSelector: '.wc-block-components-product-price',
+	} ),
+	...( typeof __experimentalGetSpacingClassesAndStyles === 'function' && {
+		spacing: {
+			margin: true,
+		},
 	} ),
 };


### PR DESCRIPTION
As we are moving product element margins from CSS to global styles, we need to make sure margin styles are available in WC core. This PR updates the Product Price block so styles are no longer gated to the feature plugin.

@danieldudzic if this PR is approved, I guess we will need to do the same change with Product Rating and Product Button?

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Add a **Products** block on a new page.
2. Ensure the **Product Price** `margin` is displaying correctly (and is present in the Dimensions > Margin setting).
3. Now add an **All Products** block on another page.
4. Click on the pencil icon to edit the layout and change the Product Price block margin.
5. Verify the margin is applied in the editor. Save the layout, save the page and check the changes in the frontend, verify the margin is applied there as well.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Enhancement: Graduate margin styling for _Product Price block_ to WooCommerce core.