### PR TITLE
Update testing instructions on 9.2.0 release

### DIFF
--- a/docs/internal-developers/testing/releases/920.md
+++ b/docs/internal-developers/testing/releases/920.md
@@ -6,17 +6,19 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 
 ### Fix overriding archive-product when saving a fallback template ([7975](https://github.com/woocommerce/woocommerce-blocks/pull/7975))
 
-1. On the `Site Editor` (`/wp-admin/site-editor.php?postType=wp_template`), make sure you have no customizations on any template.
-2. Edit the `Product Catalog` template, add some customization and save.
-3. On the front end, go to `/shop` and make sure you see the customization you just did.
-4. On the front end, go also to a category, a tag, and an attribute page (like `product-category/clothing/`, `/product-tag/music`, `color/red`, depending on your store configuration).
-5. Check that all 3 pages are using the `Product Catalog` template, meaning you see exactly the same customization you did on the `Product Catalog`.
-6. Go back to the `Site Editor`, click on one of the templates using the Catalog fallback (either `Products by Category`, `Products by Tag`, or `Products by Attribute`).
-7. Make some customization and save it.
-8. Go back to the `Site Editor` and make sure `Product Catalog` still has its original customization.
-9. Make sure the other two templates still fall back to `Product Catalog`.
-10. On the front end, go to `/shop` and make sure you see the `Product Catalog` customization.
-11. On the front end, go also to a category, a tag, and an attribute page and make sure you see the expected customizations.
+1. Go to `Products` > `Attribute` (`/wp-admin/edit.php?post_type=product&page=product_attributes`).
+2. Edit one of the attributes (like `color`), check the `Enable archives?` checkbox, and save.
+3. On the `Site Editor` (`/wp-admin/site-editor.php?postType=wp_template`), make sure you have no customizations on any template.
+4. Edit the `Product Catalog` template, add some customization and save.
+5. On the front end, go to `/shop` and make sure you see the customization you just did.
+6. On the front end, go also to a category, a tag, and an attribute page (like `product-category/clothing/`, `/product-tag/music`, `color/red`, depending on your store configuration).
+7. Check that all 3 pages are using the `Product Catalog` template, meaning you see exactly the same customization you did on the `Product Catalog`.
+8. Go back to the `Site Editor`, click on one of the templates using the Catalog fallback (either `Products by Category`, `Products by Tag`, or `Products by Attribute`).
+9. Make some customization and save it.
+10. Go back to the `Site Editor` and make sure `Product Catalog` still has its original customization.
+11. Make sure the other two templates still fall back to `Product Catalog`.
+12. On the front end, go to `/shop` and make sure you see the `Product Catalog` customization.
+13. On the front end, go also to a category, a tag, and an attribute page and make sure you see the expected customizations.
 
 ### Fix: Add non-ASCII terms support to Filter by Attribute block. ([7906](https://github.com/woocommerce/woocommerce-blocks/pull/7906))
 


### PR DESCRIPTION
Update testing instructions on 9.2.0 release to include instructions on how to enable archives on a product attribute.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->