### PR TITLE
Remove feature flag from Element variations

### DIFF
--- a/assets/js/blocks/product-query/variations/elements/product-summary.tsx
+++ b/assets/js/blocks/product-query/variations/elements/product-summary.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
 import { Icon } from '@wordpress/components';
 import {
 	BLOCK_DESCRIPTION,
@@ -17,11 +16,9 @@ import { registerElementVariation } from './utils';
 export const CORE_NAME = 'core/post-excerpt';
 export const VARIATION_NAME = 'woocommerce/product-query/product-summary';
 
-if ( isFeaturePluginBuild() ) {
-	registerElementVariation( CORE_NAME, {
-		blockDescription: BLOCK_DESCRIPTION,
-		blockIcon: <Icon icon={ page } />,
-		blockTitle: BLOCK_TITLE,
-		variationName: VARIATION_NAME,
-	} );
-}
+registerElementVariation( CORE_NAME, {
+	blockDescription: BLOCK_DESCRIPTION,
+	blockIcon: <Icon icon={ page } />,
+	blockTitle: BLOCK_TITLE,
+	variationName: VARIATION_NAME,
+} );

--- a/assets/js/blocks/product-query/variations/elements/product-template.tsx
+++ b/assets/js/blocks/product-query/variations/elements/product-template.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
 import { Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { layout } from '@wordpress/icons';
@@ -14,14 +13,12 @@ import { registerElementVariation } from './utils';
 export const CORE_NAME = 'core/post-template';
 export const VARIATION_NAME = 'woocommerce/product-query/product-template';
 
-if ( isFeaturePluginBuild() ) {
-	registerElementVariation( CORE_NAME, {
-		blockDescription: __(
-			'Contains the block elements used to render a product, like its name, featured image, rating, and more.',
-			'woo-gutenberg-products-block'
-		),
-		blockIcon: <Icon icon={ layout } />,
-		blockTitle: __( 'Product template', 'woo-gutenberg-products-block' ),
-		variationName: VARIATION_NAME,
-	} );
-}
+registerElementVariation( CORE_NAME, {
+	blockDescription: __(
+		'Contains the block elements used to render a product, like its name, featured image, rating, and more.',
+		'woo-gutenberg-products-block'
+	),
+	blockIcon: <Icon icon={ layout } />,
+	blockTitle: __( 'Product template', 'woo-gutenberg-products-block' ),
+	variationName: VARIATION_NAME,
+} );

--- a/assets/js/blocks/product-query/variations/elements/product-title.tsx
+++ b/assets/js/blocks/product-query/variations/elements/product-title.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
 import { Icon } from '@wordpress/components';
 import {
 	BLOCK_DESCRIPTION,
@@ -17,11 +16,9 @@ import { registerElementVariation } from './utils';
 export const CORE_NAME = 'core/post-title';
 export const VARIATION_NAME = 'woocommerce/product-query/product-title';
 
-if ( isFeaturePluginBuild() ) {
-	registerElementVariation( CORE_NAME, {
-		blockDescription: BLOCK_DESCRIPTION,
-		blockIcon: <Icon icon={ heading } />,
-		blockTitle: BLOCK_TITLE,
-		variationName: VARIATION_NAME,
-	} );
-}
+registerElementVariation( CORE_NAME, {
+	blockDescription: BLOCK_DESCRIPTION,
+	blockIcon: <Icon icon={ heading } />,
+	blockTitle: BLOCK_TITLE,
+	variationName: VARIATION_NAME,
+} );


### PR DESCRIPTION
We removed the featured plugin flag from the “Products (Beta)” block in https://github.com/woocommerce/woocommerce-blocks/pull/8001. Alas, we forgot to remove the flag on the elements, and they are not accessible without the plugin.

This PR removes feature flag from:

* Product Summary
* Product Template
* Product Title

Fixes #8296

#### Other Checks

- [x] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).

This PR does remove feature flags, but these feature flags were not added to the document in the first place.

- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Testing

#### User Facing Testing

1. Build the package for production using the env variable `WOOCOMMERCE_BLOCKS_PHASE` set to `1`.
2. Check that the “Products (Beta)” block has the inner blocks described above available for addition.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Product Elements: remove feature plugin flag from Product Title, Product Summary and Product Template block.