### PR TITLE
Add "Collection from..." in Checkout sidebar when selecting local pickup

### DIFF
--- a/assets/js/base/components/cart-checkout/pickup-location/index.tsx
+++ b/assets/js/base/components/cart-checkout/pickup-location/index.tsx
@@ -2,19 +2,14 @@
  * External dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { getSetting } from '@woocommerce/settings';
 import { useSelect } from '@wordpress/data';
 import { isObject, objectHasProp } from '@woocommerce/types';
+import { isPackageRateCollectable } from '@woocommerce/base-utils';
 
 /**
  * Shows a formatted pickup location.
  */
 const PickupLocation = (): JSX.Element | null => {
-	const collectibleMethodIds = getSetting< string[] >(
-		'collectibleMethodIds',
-		[]
-	);
-
 	const { pickupAddress, pickupMethod } = useSelect( ( select ) => {
 		const cartShippingRates = select( 'wc/store/cart' ).getShippingRates();
 
@@ -22,8 +17,7 @@ const PickupLocation = (): JSX.Element | null => {
 			( cartShippingRate ) => cartShippingRate.shipping_rates
 		);
 		const selectedCollectibleRate = flattenedRates.find(
-			( rate ) =>
-				rate.selected && collectibleMethodIds.includes( rate.method_id )
+			( rate ) => rate.selected && isPackageRateCollectable( rate )
 		);
 
 		// If the rate has an address specified in its metadata.

--- a/assets/js/base/components/cart-checkout/pickup-location/index.tsx
+++ b/assets/js/base/components/cart-checkout/pickup-location/index.tsx
@@ -36,7 +36,8 @@ const PickupLocation = (): JSX.Element | null => {
 			);
 			if (
 				isObject( selectedRateMetaData ) &&
-				objectHasProp( selectedRateMetaData, 'value' )
+				objectHasProp( selectedRateMetaData, 'value' ) &&
+				selectedRateMetaData.value
 			) {
 				const selectedRatePickupAddress = selectedRateMetaData.value;
 				return {

--- a/assets/js/base/components/cart-checkout/pickup-location/index.tsx
+++ b/assets/js/base/components/cart-checkout/pickup-location/index.tsx
@@ -16,16 +16,16 @@ const PickupLocation = (): JSX.Element | null => {
 		const flattenedRates = cartShippingRates.flatMap(
 			( cartShippingRate ) => cartShippingRate.shipping_rates
 		);
-		const selectedCollectibleRate = flattenedRates.find(
+		const selectedCollectableRate = flattenedRates.find(
 			( rate ) => rate.selected && isPackageRateCollectable( rate )
 		);
 
 		// If the rate has an address specified in its metadata.
 		if (
-			isObject( selectedCollectibleRate ) &&
-			objectHasProp( selectedCollectibleRate, 'meta_data' )
+			isObject( selectedCollectableRate ) &&
+			objectHasProp( selectedCollectableRate, 'meta_data' )
 		) {
-			const selectedRateMetaData = selectedCollectibleRate.meta_data.find(
+			const selectedRateMetaData = selectedCollectableRate.meta_data.find(
 				( meta ) => meta.key === 'pickup_address'
 			);
 			if (
@@ -36,15 +36,15 @@ const PickupLocation = (): JSX.Element | null => {
 				const selectedRatePickupAddress = selectedRateMetaData.value;
 				return {
 					pickupAddress: selectedRatePickupAddress,
-					pickupMethod: selectedCollectibleRate.name,
+					pickupMethod: selectedCollectableRate.name,
 				};
 			}
 		}
 
-		if ( isObject( selectedCollectibleRate ) ) {
+		if ( isObject( selectedCollectableRate ) ) {
 			return {
 				pickupAddress: undefined,
-				pickupMethod: selectedCollectibleRate.name,
+				pickupMethod: selectedCollectableRate.name,
 			};
 		}
 		return {

--- a/assets/js/base/components/cart-checkout/pickup-location/index.tsx
+++ b/assets/js/base/components/cart-checkout/pickup-location/index.tsx
@@ -1,0 +1,83 @@
+/**
+ * External dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { getSetting } from '@woocommerce/settings';
+import { useSelect } from '@wordpress/data';
+import { isObject, objectHasProp } from '@woocommerce/types';
+
+/**
+ * Shows a formatted pickup location.
+ */
+const PickupLocation = (): JSX.Element | null => {
+	const collectibleMethodIds = [
+		...getSetting< string[] >( 'collectibleMethodIds', [] ),
+		'pickup_location',
+	];
+
+	const { pickupAddress, pickupMethod } = useSelect( ( select ) => {
+		const cartShippingRates = select( 'wc/store/cart' ).getShippingRates();
+
+		const flattenedRates = cartShippingRates.flatMap(
+			( cartShippingRate ) => cartShippingRate.shipping_rates
+		);
+		const selectedCollectibleRate = flattenedRates.find(
+			( rate ) =>
+				rate.selected && collectibleMethodIds.includes( rate.method_id )
+		);
+
+		// If the rate has an address specified in its metadata.
+		if (
+			isObject( selectedCollectibleRate ) &&
+			objectHasProp( selectedCollectibleRate, 'meta_data' )
+		) {
+			const selectedRateMetaData = selectedCollectibleRate.meta_data.find(
+				( meta ) => meta.key === 'pickup_address'
+			);
+			if (
+				isObject( selectedRateMetaData ) &&
+				objectHasProp( selectedRateMetaData, 'value' )
+			) {
+				const selectedRatePickupAddress = selectedRateMetaData.value;
+				return {
+					pickupAddress: selectedRatePickupAddress,
+					pickupMethod: selectedCollectibleRate.name,
+				};
+			}
+		}
+
+		if ( isObject( selectedCollectibleRate ) ) {
+			return {
+				pickupAddress: undefined,
+				pickupMethod: selectedCollectibleRate.name,
+			};
+		}
+		return {
+			pickupAddress: undefined,
+			pickupMethod: undefined,
+		};
+	} );
+
+	// If the method does not contain an address, or the method supporting collection was not found, return early.
+	if (
+		typeof pickupAddress === 'undefined' &&
+		typeof pickupMethod === 'undefined'
+	) {
+		return null;
+	}
+
+	// Show the pickup method's name if we don't have an address to show.
+	return (
+		<span className="wc-block-components-shipping-address">
+			{ sprintf(
+				/* translators: %s: shipping method name, e.g. "Amazon Locker" */
+				__( 'Collection from %s', 'woo-gutenberg-products-block' ),
+				typeof pickupAddress === 'undefined'
+					? pickupMethod
+					: pickupAddress
+			) + ' ' }
+		</span>
+	);
+};
+
+export default PickupLocation;

--- a/assets/js/base/components/cart-checkout/pickup-location/index.tsx
+++ b/assets/js/base/components/cart-checkout/pickup-location/index.tsx
@@ -10,10 +10,10 @@ import { isObject, objectHasProp } from '@woocommerce/types';
  * Shows a formatted pickup location.
  */
 const PickupLocation = (): JSX.Element | null => {
-	const collectibleMethodIds = [
-		...getSetting< string[] >( 'collectibleMethodIds', [] ),
-		'pickup_location',
-	];
+	const collectibleMethodIds = getSetting< string[] >(
+		'collectibleMethodIds',
+		[]
+	);
 
 	const { pickupAddress, pickupMethod } = useSelect( ( select ) => {
 		const cartShippingRates = select( 'wc/store/cart' ).getShippingRates();

--- a/assets/js/base/components/cart-checkout/pickup-location/test/index.tsx
+++ b/assets/js/base/components/cart-checkout/pickup-location/test/index.tsx
@@ -18,7 +18,7 @@ jest.mock( '@woocommerce/settings', () => {
 			if ( setting === 'localPickupEnabled' ) {
 				return true;
 			}
-			if ( setting === 'collectibleMethodIds' ) {
+			if ( setting === 'collectableMethodIds' ) {
 				return [ 'pickup_location' ];
 			}
 			return originalModule.getSetting( setting, ...rest );

--- a/assets/js/base/components/cart-checkout/pickup-location/test/index.tsx
+++ b/assets/js/base/components/cart-checkout/pickup-location/test/index.tsx
@@ -2,10 +2,10 @@
  * External dependencies
  */
 import { render, screen } from '@testing-library/react';
-import ShippingAddress from '@woocommerce/base-components/cart-checkout/totals/shipping/shipping-address';
 import { CART_STORE_KEY, CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
 import { dispatch } from '@wordpress/data';
 import { previewCart } from '@woocommerce/resource-previews';
+import PickupLocation from '@woocommerce/base-components/cart-checkout/pickup-location';
 
 jest.mock( '@woocommerce/settings', () => {
 	const originalModule = jest.requireActual( '@woocommerce/settings' );
@@ -25,35 +25,8 @@ jest.mock( '@woocommerce/settings', () => {
 		},
 	};
 } );
-describe( 'ShippingAddress', () => {
-	const testShippingAddress = {
-		first_name: 'John',
-		last_name: 'Doe',
-		company: 'Automattic',
-		address_1: '123 Main St',
-		address_2: '',
-		city: 'San Francisco',
-		state: 'CA',
-		postcode: '94107',
-		country: 'US',
-		phone: '555-555-5555',
-	};
-
-	it( 'renders ShippingLocation if user does not prefer collection', () => {
-		render(
-			<ShippingAddress
-				showCalculator={ false }
-				isShippingCalculatorOpen={ false }
-				setIsShippingCalculatorOpen={ jest.fn() }
-				shippingAddress={ testShippingAddress }
-			/>
-		);
-		expect( screen.getByText( /Shipping to 94107/ ) ).toBeInTheDocument();
-		expect(
-			screen.queryByText( /Collection from/ )
-		).not.toBeInTheDocument();
-	} );
-	it( 'renders PickupLocation if shopper prefers collection', async () => {
+describe( 'PickupLocation', () => {
+	it( `renders an address if one is set in the method's metadata`, async () => {
 		dispatch( CHECKOUT_STORE_KEY ).setPrefersCollection( true );
 
 		// Deselect the default selected rate and select pickup_location:1 rate.
@@ -74,18 +47,47 @@ describe( 'ShippingAddress', () => {
 
 		dispatch( CART_STORE_KEY ).receiveCart( previewCart );
 
-		render(
-			<ShippingAddress
-				showCalculator={ false }
-				isShippingCalculatorOpen={ false }
-				setIsShippingCalculatorOpen={ jest.fn() }
-				shippingAddress={ testShippingAddress }
-			/>
-		);
+		render( <PickupLocation /> );
 		expect(
 			screen.getByText(
 				/Collection from 123 Easy Street, New York, 12345/
 			)
+		).toBeInTheDocument();
+	} );
+	it( 'renders the method name if address is not in metadata', async () => {
+		dispatch( CHECKOUT_STORE_KEY ).setPrefersCollection( true );
+
+		// Deselect the default selected rate and select pickup_location:1 rate.
+		const currentlySelectedIndex =
+			previewCart.shipping_rates[ 0 ].shipping_rates.findIndex(
+				( rate ) => rate.selected
+			);
+		previewCart.shipping_rates[ 0 ].shipping_rates[
+			currentlySelectedIndex
+		].selected = false;
+		const pickupRateIndex =
+			previewCart.shipping_rates[ 0 ].shipping_rates.findIndex(
+				( rate ) => rate.rate_id === 'pickup_location:2'
+			);
+		previewCart.shipping_rates[ 0 ].shipping_rates[
+			pickupRateIndex
+		].selected = true;
+
+		// Set the pickup_location metadata value to an empty string in the selected pickup rate.
+		const addressKeyIndex = previewCart.shipping_rates[ 0 ].shipping_rates[
+			pickupRateIndex
+		].meta_data.findIndex(
+			( metaData ) => metaData.key === 'pickup_address'
+		);
+		previewCart.shipping_rates[ 0 ].shipping_rates[
+			pickupRateIndex
+		].meta_data[ addressKeyIndex ].value = '';
+
+		dispatch( CART_STORE_KEY ).receiveCart( previewCart );
+
+		render( <PickupLocation /> );
+		expect(
+			screen.getByText( /Collection from Local pickup/ )
 		).toBeInTheDocument();
 	} );
 } );

--- a/assets/js/base/components/cart-checkout/totals/shipping/index.tsx
+++ b/assets/js/base/components/cart-checkout/totals/shipping/index.tsx
@@ -104,18 +104,17 @@ export const TotalsShipping = ( {
 							<ShippingVia
 								selectedShippingRates={ selectedShippingRates }
 							/>
-							{ ! prefersCollection && (
-								<ShippingAddress
-									shippingAddress={ shippingAddress }
-									showCalculator={ showCalculator }
-									isShippingCalculatorOpen={
-										isShippingCalculatorOpen
-									}
-									setIsShippingCalculatorOpen={
-										setIsShippingCalculatorOpen
-									}
-								/>
-							) }
+							<ShippingAddress
+								shippingAddress={ shippingAddress }
+								showCalculator={ showCalculator }
+								isShippingCalculatorOpen={
+									isShippingCalculatorOpen
+								}
+								setIsShippingCalculatorOpen={
+									setIsShippingCalculatorOpen
+								}
+								prefersCollection={ prefersCollection }
+							/>
 						</>
 					) : null
 				}

--- a/assets/js/base/components/cart-checkout/totals/shipping/index.tsx
+++ b/assets/js/base/components/cart-checkout/totals/shipping/index.tsx
@@ -8,10 +8,12 @@ import { useStoreCart } from '@woocommerce/base-context/hooks';
 import { TotalsItem } from '@woocommerce/blocks-checkout';
 import type { Currency } from '@woocommerce/price-format';
 import { ShippingVia } from '@woocommerce/base-components/cart-checkout/totals/shipping/shipping-via';
-import { isAddressComplete } from '@woocommerce/base-utils';
+import {
+	isAddressComplete,
+	isPackageRateCollectable,
+} from '@woocommerce/base-utils';
 import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
 import { useSelect } from '@wordpress/data';
-import { isPackageRateCollectable } from '@woocommerce/base-utils';
 
 /**
  * Internal dependencies

--- a/assets/js/base/components/cart-checkout/totals/shipping/index.tsx
+++ b/assets/js/base/components/cart-checkout/totals/shipping/index.tsx
@@ -8,8 +8,6 @@ import { useStoreCart } from '@woocommerce/base-context/hooks';
 import { TotalsItem } from '@woocommerce/blocks-checkout';
 import type { Currency } from '@woocommerce/price-format';
 import { ShippingVia } from '@woocommerce/base-components/cart-checkout/totals/shipping/shipping-via';
-import { useSelect } from '@wordpress/data';
-import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
 import { isAddressComplete } from '@woocommerce/base-utils';
 
 /**
@@ -50,12 +48,6 @@ export const TotalsShipping = ( {
 		shippingRates,
 		isLoadingRates,
 	} = useStoreCart();
-	const { prefersCollection } = useSelect( ( select ) => {
-		const checkoutStore = select( CHECKOUT_STORE_KEY );
-		return {
-			prefersCollection: checkoutStore.prefersCollection(),
-		};
-	} );
 	const totalShippingValue = getTotalShippingValue( values );
 	const hasRates = hasShippingRate( shippingRates ) || totalShippingValue > 0;
 	const showShippingCalculatorForm =
@@ -113,7 +105,6 @@ export const TotalsShipping = ( {
 								setIsShippingCalculatorOpen={
 									setIsShippingCalculatorOpen
 								}
-								prefersCollection={ prefersCollection }
 							/>
 						</>
 					) : null

--- a/assets/js/base/components/cart-checkout/totals/shipping/index.tsx
+++ b/assets/js/base/components/cart-checkout/totals/shipping/index.tsx
@@ -11,7 +11,7 @@ import { ShippingVia } from '@woocommerce/base-components/cart-checkout/totals/s
 import { isAddressComplete } from '@woocommerce/base-utils';
 import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
 import { useSelect } from '@wordpress/data';
-import { getSetting } from '@woocommerce/settings';
+import { isPackageRateCollectable } from '@woocommerce/base-utils';
 
 /**
  * Internal dependencies
@@ -34,11 +34,6 @@ export interface TotalShippingProps {
 	className?: string;
 	isCheckout?: boolean;
 }
-
-const collectibleMethodIds = getSetting< string[] >(
-	'collectibleMethodIds',
-	[]
-);
 export const TotalsShipping = ( {
 	currency,
 	values,
@@ -67,9 +62,9 @@ export const TotalsShipping = ( {
 			return shippingPackage.shipping_rates
 				.filter(
 					( rate ) =>
-						// If the shopper prefers collection, the rate is collectible AND selected.
+						// If the shopper prefers collection, the rate is collectable AND selected.
 						( prefersCollection &&
-							collectibleMethodIds.includes( rate.method_id ) &&
+							isPackageRateCollectable( rate ) &&
 							rate.selected ) ||
 						// Or the shopper does not prefer collection and the rate is selected
 						( ! prefersCollection && rate.selected )

--- a/assets/js/base/components/cart-checkout/totals/shipping/shipping-address.tsx
+++ b/assets/js/base/components/cart-checkout/totals/shipping/shipping-address.tsx
@@ -2,12 +2,13 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { EnteredAddress } from '@woocommerce/settings';
 import {
 	formatShippingAddress,
 	isAddressComplete,
 } from '@woocommerce/base-utils';
 import { useEditorContext } from '@woocommerce/base-context';
+import { ShippingAddress as ShippingAddressType } from '@woocommerce/settings';
+import PickupLocation from '@woocommerce/base-components/cart-checkout/pickup-location';
 
 /**
  * Internal dependencies
@@ -19,7 +20,8 @@ export interface ShippingAddressProps {
 	showCalculator: boolean;
 	isShippingCalculatorOpen: boolean;
 	setIsShippingCalculatorOpen: CalculatorButtonProps[ 'setIsShippingCalculatorOpen' ];
-	shippingAddress: EnteredAddress;
+	shippingAddress: ShippingAddressType;
+	prefersCollection?: boolean | undefined;
 }
 
 export const ShippingAddress = ( {
@@ -27,6 +29,7 @@ export const ShippingAddress = ( {
 	isShippingCalculatorOpen,
 	setIsShippingCalculatorOpen,
 	shippingAddress,
+	prefersCollection = false,
 }: ShippingAddressProps ): JSX.Element | null => {
 	const addressComplete = isAddressComplete( shippingAddress );
 	const { isEditor } = useEditorContext();
@@ -38,7 +41,11 @@ export const ShippingAddress = ( {
 	const formattedLocation = formatShippingAddress( shippingAddress );
 	return (
 		<>
-			<ShippingLocation formattedLocation={ formattedLocation } />
+			{ prefersCollection ? (
+				<PickupLocation />
+			) : (
+				<ShippingLocation formattedLocation={ formattedLocation } />
+			) }
 			{ showCalculator && (
 				<CalculatorButton
 					label={ __(

--- a/assets/js/base/components/cart-checkout/totals/shipping/shipping-address.tsx
+++ b/assets/js/base/components/cart-checkout/totals/shipping/shipping-address.tsx
@@ -48,7 +48,7 @@ export const ShippingAddress = ( {
 			) : (
 				<ShippingLocation formattedLocation={ formattedLocation } />
 			) }
-			{ showCalculator && (
+			{ showCalculator && ! prefersCollection ? (
 				<CalculatorButton
 					label={ __(
 						'Change address',
@@ -57,7 +57,7 @@ export const ShippingAddress = ( {
 					isShippingCalculatorOpen={ isShippingCalculatorOpen }
 					setIsShippingCalculatorOpen={ setIsShippingCalculatorOpen }
 				/>
-			) }
+			) : null }
 		</>
 	);
 };

--- a/assets/js/base/components/cart-checkout/totals/shipping/shipping-address.tsx
+++ b/assets/js/base/components/cart-checkout/totals/shipping/shipping-address.tsx
@@ -9,6 +9,8 @@ import {
 import { useEditorContext } from '@woocommerce/base-context';
 import { ShippingAddress as ShippingAddressType } from '@woocommerce/settings';
 import PickupLocation from '@woocommerce/base-components/cart-checkout/pickup-location';
+import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -21,7 +23,6 @@ export interface ShippingAddressProps {
 	isShippingCalculatorOpen: boolean;
 	setIsShippingCalculatorOpen: CalculatorButtonProps[ 'setIsShippingCalculatorOpen' ];
 	shippingAddress: ShippingAddressType;
-	prefersCollection?: boolean | undefined;
 }
 
 export const ShippingAddress = ( {
@@ -29,11 +30,12 @@ export const ShippingAddress = ( {
 	isShippingCalculatorOpen,
 	setIsShippingCalculatorOpen,
 	shippingAddress,
-	prefersCollection = false,
 }: ShippingAddressProps ): JSX.Element | null => {
 	const addressComplete = isAddressComplete( shippingAddress );
 	const { isEditor } = useEditorContext();
-
+	const prefersCollection = useSelect( ( select ) =>
+		select( CHECKOUT_STORE_KEY ).prefersCollection()
+	);
 	// If the address is incomplete, and we're not in the editor, don't show anything.
 	if ( ! addressComplete && ! isEditor ) {
 		return null;

--- a/assets/js/base/components/cart-checkout/totals/shipping/test/index.tsx
+++ b/assets/js/base/components/cart-checkout/totals/shipping/test/index.tsx
@@ -18,9 +18,24 @@ jest.mock( '@wordpress/data', () => ( {
 	useSelect: jest.fn(),
 } ) );
 
-wpData.useSelect.mockImplementation( () => {
-	return { prefersCollection: false };
-} );
+// Mock use select so we can override it when wc/store/checkout is accessed, but return the original select function if any other store is accessed.
+wpData.useSelect.mockImplementation(
+	jest.fn().mockImplementation( ( passedMapSelect ) => {
+		const mockedSelect = jest.fn().mockImplementation( ( storeName ) => {
+			if ( storeName === 'wc/store/checkout' ) {
+				return {
+					prefersCollection() {
+						return false;
+					},
+				};
+			}
+			return jest.requireActual( '@wordpress/data' ).select( storeName );
+		} );
+		passedMapSelect( mockedSelect, {
+			dispatch: jest.requireActual( '@wordpress/data' ).dispatch,
+		} );
+	} )
+);
 
 const shippingAddress = {
 	first_name: 'John',

--- a/assets/js/base/components/cart-checkout/totals/shipping/test/shipping-address.tsx
+++ b/assets/js/base/components/cart-checkout/totals/shipping/test/shipping-address.tsx
@@ -18,7 +18,7 @@ jest.mock( '@woocommerce/settings', () => {
 			if ( setting === 'localPickupEnabled' ) {
 				return true;
 			}
-			if ( setting === 'collectibleMethodIds' ) {
+			if ( setting === 'collectableMethodIds' ) {
 				return [ 'pickup_location' ];
 			}
 			return originalModule.getSetting( setting, ...rest );

--- a/assets/js/base/components/cart-checkout/totals/shipping/test/shipping-address.tsx
+++ b/assets/js/base/components/cart-checkout/totals/shipping/test/shipping-address.tsx
@@ -1,0 +1,134 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import ShippingAddress from '@woocommerce/base-components/cart-checkout/totals/shipping/shipping-address';
+import { CART_STORE_KEY, CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
+import { dispatch } from '@wordpress/data';
+import { previewCart } from '@woocommerce/resource-previews';
+
+jest.mock( '@woocommerce/settings', () => {
+	const originalModule = jest.requireActual( '@woocommerce/settings' );
+
+	return {
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore We know @woocommerce/settings is an object.
+		...originalModule,
+		getSetting: ( setting: string, ...rest: unknown[] ) => {
+			if ( setting === 'localPickupEnabled' ) {
+				return true;
+			}
+			if ( setting === 'collectibleMethodIds' ) {
+				return [ 'pickup_location' ];
+			}
+			return originalModule.getSetting( setting, ...rest );
+		},
+	};
+} );
+describe( 'ShippingAddress', () => {
+	const testShippingAddress = {
+		first_name: 'John',
+		last_name: 'Doe',
+		company: 'Automattic',
+		address_1: '123 Main St',
+		address_2: '',
+		city: 'San Francisco',
+		state: 'CA',
+		postcode: '94107',
+		country: 'US',
+		phone: '555-555-5555',
+	};
+
+	it( 'renders ShippingLocation if user does not prefer collection', () => {
+		render(
+			<ShippingAddress
+				showCalculator={ false }
+				isShippingCalculatorOpen={ false }
+				setIsShippingCalculatorOpen={ jest.fn() }
+				shippingAddress={ testShippingAddress }
+			/>
+		);
+		expect( screen.getByText( /Shipping to 94107/ ) ).toBeInTheDocument();
+		expect(
+			screen.queryByText( /Collection from/ )
+		).not.toBeInTheDocument();
+	} );
+	it( 'renders PickupLocation if shopper prefers collection and shows address if set', async () => {
+		dispatch( CHECKOUT_STORE_KEY ).setPrefersCollection( true );
+
+		// Deselect the default selected rate and select pickup_location:1 rate.
+		const currentlySelectedIndex =
+			previewCart.shipping_rates[ 0 ].shipping_rates.findIndex(
+				( rate ) => rate.selected
+			);
+		previewCart.shipping_rates[ 0 ].shipping_rates[
+			currentlySelectedIndex
+		].selected = false;
+		const pickupRateIndex =
+			previewCart.shipping_rates[ 0 ].shipping_rates.findIndex(
+				( rate ) => rate.method_id === 'pickup_location'
+			);
+		previewCart.shipping_rates[ 0 ].shipping_rates[
+			pickupRateIndex
+		].selected = true;
+
+		dispatch( CART_STORE_KEY ).receiveCart( previewCart );
+
+		render(
+			<ShippingAddress
+				showCalculator={ false }
+				isShippingCalculatorOpen={ false }
+				setIsShippingCalculatorOpen={ jest.fn() }
+				shippingAddress={ testShippingAddress }
+			/>
+		);
+		expect(
+			screen.getByText(
+				/Collection from 123 Easy Street, New York, 12345/
+			)
+		).toBeInTheDocument();
+	} );
+	it( 'renders PickupLocation if shopper prefers collection and only shows name if address is not set', async () => {
+		dispatch( CHECKOUT_STORE_KEY ).setPrefersCollection( true );
+
+		// Deselect the default selected rate and select pickup_location:1 rate.
+		const currentlySelectedIndex =
+			previewCart.shipping_rates[ 0 ].shipping_rates.findIndex(
+				( rate ) => rate.selected
+			);
+		previewCart.shipping_rates[ 0 ].shipping_rates[
+			currentlySelectedIndex
+		].selected = false;
+		const pickupRateIndex =
+			previewCart.shipping_rates[ 0 ].shipping_rates.findIndex(
+				( rate ) => rate.rate_id === 'pickup_location:2'
+			);
+		previewCart.shipping_rates[ 0 ].shipping_rates[
+			pickupRateIndex
+		].selected = true;
+
+		// Set the pickup_location metadata value to an empty string in the selected pickup rate.
+		const addressKeyIndex = previewCart.shipping_rates[ 0 ].shipping_rates[
+			pickupRateIndex
+		].meta_data.findIndex(
+			( metaData ) => metaData.key === 'pickup_address'
+		);
+		previewCart.shipping_rates[ 0 ].shipping_rates[
+			pickupRateIndex
+		].meta_data[ addressKeyIndex ].value = '';
+
+		dispatch( CART_STORE_KEY ).receiveCart( previewCart );
+
+		render(
+			<ShippingAddress
+				showCalculator={ false }
+				isShippingCalculatorOpen={ false }
+				setIsShippingCalculatorOpen={ jest.fn() }
+				shippingAddress={ testShippingAddress }
+			/>
+		);
+		expect(
+			screen.getByText( /Collection from Local pickup/ )
+		).toBeInTheDocument();
+	} );
+} );

--- a/assets/js/base/context/hooks/shipping/types.ts
+++ b/assets/js/base/context/hooks/shipping/types.ts
@@ -18,6 +18,6 @@ export interface ShippingData {
 	isCollectable: boolean;
 	// True when a rate is currently being selected and persisted to the server.
 	isSelectingRate: boolean;
-
+	// True when the user has chosen a local pickup method.
 	hasSelectedLocalPickup: boolean;
 }

--- a/assets/js/base/context/hooks/shipping/use-shipping-data.ts
+++ b/assets/js/base/context/hooks/shipping/use-shipping-data.ts
@@ -85,7 +85,6 @@ export const useShippingData = (): ShippingData => {
 			( rate ) => rate.split( ':' )[ 0 ]
 		)
 	);
-
 	// Selects a shipping rate, fires an event, and catch any errors.
 	const { dispatchCheckoutEvent } = useStoreEvents();
 	const selectShippingRate = useCallback(

--- a/assets/js/data/checkout/selectors.ts
+++ b/assets/js/data/checkout/selectors.ts
@@ -77,7 +77,7 @@ export const isCalculating = ( state: CheckoutState ) => {
 };
 
 export const prefersCollection = ( state: CheckoutState ) => {
-	if ( state.prefersCollection === undefined ) {
+	if ( typeof state.prefersCollection === 'undefined' ) {
 		const shippingRates = select( cartStoreKey ).getShippingRates();
 		if ( ! shippingRates || ! shippingRates.length ) {
 			return false;

--- a/assets/js/data/checkout/selectors.ts
+++ b/assets/js/data/checkout/selectors.ts
@@ -85,6 +85,7 @@ export const prefersCollection = ( state: CheckoutState ) => {
 		const selectedRate = shippingRates[ 0 ].shipping_rates.find(
 			( rate ) => rate.selected
 		);
+
 		if (
 			objectHasProp( selectedRate, 'method_id' ) &&
 			isString( selectedRate.method_id )

--- a/src/Shipping/ShippingController.php
+++ b/src/Shipping/ShippingController.php
@@ -51,6 +51,7 @@ class ShippingController {
 				true
 			);
 		}
+
 		$this->asset_data_registry->add( 'collectableMethodIds', array( 'Automattic\WooCommerce\StoreApi\Utilities\LocalPickupUtils', 'get_local_pickup_method_ids' ), true );
 		$this->asset_data_registry->add( 'shippingCostRequiresAddress', get_option( 'woocommerce_shipping_cost_requires_address', false ) === 'yes' );
 		add_action( 'rest_api_init', [ $this, 'register_settings' ] );

--- a/src/Shipping/ShippingController.php
+++ b/src/Shipping/ShippingController.php
@@ -205,17 +205,19 @@ class ShippingController {
 	 * @return string[] List of payment method ids that support the 'collectible' feature.
 	 */
 	public function get_collectible_method_ids() {
-		return array_keys(
-			wp_list_pluck(
-				array_filter(
-					WC()->shipping()->get_shipping_methods(),
-					function( $method ) {
-						return in_array( 'collectible', $method->supports, true );
-					}
-				),
-				'id'
+		$collectible_method_ids = array_keys(
+			array_filter(
+				WC()->shipping()->get_shipping_methods(),
+				function( $method ) {
+					return $method->supports( 'collectible' );
+				},
+				true
 			)
 		);
+		// `pickup_location` will always be collectible. Adding it here means we can avoid hard coding it elsewhere on
+		// the client.
+		$collectible_method_ids[] = 'pickup_location';
+		return $collectible_method_ids;
 	}
 
 	/**

--- a/src/Shipping/ShippingController.php
+++ b/src/Shipping/ShippingController.php
@@ -199,6 +199,25 @@ class ShippingController {
 	}
 
 	/**
+	 * Gets a list of payment method ids that support the 'collectible' feature.
+	 *
+	 * @return string[] List of payment method ids that support the 'collectible' feature.
+	 */
+	public function get_collectible_method_ids() {
+		return array_keys(
+			wp_list_pluck(
+				array_filter(
+					WC()->shipping()->get_shipping_methods(),
+					function( $method ) {
+						return in_array( 'collectible', $method->supports, true );
+					}
+				),
+				'id'
+			)
+		);
+	}
+
+	/**
 	 * Register Local Pickup settings for rest api.
 	 */
 	public function register_settings() {

--- a/src/Shipping/ShippingController.php
+++ b/src/Shipping/ShippingController.php
@@ -200,27 +200,6 @@ class ShippingController {
 	}
 
 	/**
-	 * Gets a list of payment method ids that support the 'collectible' feature.
-	 *
-	 * @return string[] List of payment method ids that support the 'collectible' feature.
-	 */
-	public function get_collectible_method_ids() {
-		$collectible_method_ids = array_keys(
-			array_filter(
-				WC()->shipping()->get_shipping_methods(),
-				function( $method ) {
-					return $method->supports( 'collectible' );
-				},
-				true
-			)
-		);
-		// `pickup_location` will always be collectible. Adding it here means we can avoid hard coding it elsewhere on
-		// the client.
-		$collectible_method_ids[] = 'pickup_location';
-		return $collectible_method_ids;
-	}
-
-	/**
 	 * Register Local Pickup settings for rest api.
 	 */
 	public function register_settings() {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR is based on `add/local-pickup-methods` which has a PR here: https://github.com/woocommerce/woocommerce-blocks/pull/8256

In this PR I made the following changes:
- Add a `PickupLocation` component. This will render when the user has chosen "Local pickup" as their shipping method.
- Move `areRatesCollectible` function outside of the `useShippingData` hook. It made more sense not to create new functions every time the hook is called. For reference, this function which will check whether the selected rate is a collectible one (collectible methods are saved in the site setting `collectibleMethodIds`) - this is required to know whether we should be dispatching the rate change to all packages (if collectible, yes) or just to a single package (if not collectible this is OK).
- Update the `wc/store/checkout` data store's `prefersCollection` selector to check all collectible methods, not just `local_pickup`
- Add tests for `ShippingAddress` component, but only ones that cover this PR, new tests should be added to cover some address scenarios (these could be added within `ShippingLocation` actually)
- Add tests for `PickupLocation`
- Ensure only the local pickup method name appears in the shipping totals if using multiple packages


<!-- Reference any related issues or PRs here -->

Fixes #7997

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before (Note the multiple package names & no pickup address) | After |
| ------ | ----- |
| <img width="307" alt="image" src="https://user-images.githubusercontent.com/5656702/214911310-74954e53-cf54-411d-b924-f9436294819f.png"> | <img width="303" alt="image" src="https://user-images.githubusercontent.com/5656702/214911198-67243d18-8b4a-415c-81aa-46a7434e42dd.png"> |

### Testing

#### Automated Tests
* [x] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [ ] E2E tests

#### Internal developer Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->


<details>
<summary>Expand for example shipping method</summary>

```php
function amazon_locker_shipping_init() {
	class Amazon_Locker_Shipping_Method extends WC_Shipping_Method {

		/**
		 * Min amount to be valid.
		 *
		 * @var integer
		 */
		public $min_amount = 0;

		/**
		 * Requires option.
		 *
		 * @var string
		 */
		public $requires = '';

		/**
		 * Constructor.
		 *
		 * @param int $instance_id Shipping method instance.
		 */
		public function __construct( $instance_id = 0 ) {
			$this->id                 = 'amazon_locker_shipping';
			$this->instance_id        = absint( $instance_id );
                        $this->title              = 'Amazon locker';
			$this->method_title       = __( 'Amazon locker', 'woocommerce' );
			$this->method_description = __( 'Get your order shipped to an amazon locker.', 'woocommerce' );
			$this->supports           = array(
				'instance-settings',
				'instance-settings-modal',
				'local-pickup',
			);

			$this->init();
		}

		/**
		 * Initialize Amazon Locker shipping.
		 */
		public function init() {
		}

		/**
		 * See if Amazon locker shipping is available based on the package and cart.
		 *
		 * @param array $package Shipping package.
		 * @return bool
		 */
		public function is_available( $package ) {
			return true;
		}

		/**
		 * Called to calculate shipping rates for this method. Rates can be added using the add_rate() method.
		 *
		 * @param array $package Shipping package.
		 * @uses WC_Shipping_Method::add_rate()
		 */
		public function calculate_shipping( $package = array() ) {
			$this->add_rate(
				array(
					'label'   => $this->title,
					'cost'    => 0,
					'taxes'   => false,
					'package' => $package,
				)
			);
		}
	}
}

add_action( 'woocommerce_shipping_init', 'amazon_locker_shipping_init' ); // use this hook to initialize your new custom method

function add_amazon_locker_shipping( $methods ) {
	$methods['amazon_locker_shipping'] = 'Amazon_Locker_Shipping_Method';

	return $methods;
}
add_filter( 'woocommerce_shipping_methods', 'add_amazon_locker_shipping' );
```
</details>

2. Enable this method for one of your shipping zones. Note, the settings UI doesn't work properly for this method but that is OK.
3. Enable the built-in local pickup too (WooCommerce -> Settings -> Shipping -> Local pickup) and add a location. Please ensure you set an address for this location. **Set up two of these!**
4. Enable some regular methods (flat rate, free) for your zone too.
5. Enable the [Multiple Packages for WooCommerce](https://wordpress.org/plugins/multiple-packages-for-woocommerce/) plugin, go to its settings page (WooCommerce -> Settings -> Multiple packages) and change the `Group By` option to be `Product (individual)`.
6. Add some items to your cart (at least 2) go to the Checkout page.
7. For the `Shipping method`, select `Shipping` and then select a different rate for each package. It should look like this.
<img width="598" alt="image" src="https://user-images.githubusercontent.com/5656702/214912610-c8b25807-215f-46ea-8918-28285db7c7ab.png">
8. In the sidebar, ensure you see the shipping total correctly and that it lists both methods for shipping like so:
<img width="312" alt="image" src="https://user-images.githubusercontent.com/5656702/214912768-c6332b8d-ba5a-4afd-bb86-688ed9ef982d.png">
9. Change shipping method back to `Local Pickup` and ensure that the sidebar updates to only show **one** shipping method name.
10. Select the Amazon locker option and check the sidebar, only one method name should show, and it should also say "Collection from Amazon locker"
11. Choose one of the built-in local pickup rates you set up in step 3.
12. Ensure the sidebar updates and shows the correct method name and shows "Collection from <address>"

### User facing testing

1. Enable the built-in local pickup method (WooCommerce -> Settings -> Shipping -> Local pickup) and add two locations. Please ensure you set a different address for both of these locations.
2. Enable some different regular shipping methods (flat rate, free) for your zone too.
3. Add at least two items to your cart and go to the Checkout page.
4. For the `Shipping Method` option, select "Shipping"
5. Fill in your address and ensure the rates you set up in step 2 are shown. Select one.
6. In the Checkout sidebar, ensure you see the correct rate, and your entered address.
7. Return to the `Shipping Method` option, select "Local pickup"
8. Check the sidebar and ensure the sidebar shows local pickup, and shows the address for the pickup location you have chosen.
9. Change the location and ensure the sidebar updates.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Show the collection address in the shipping section of the Checkout sidebar when using a Local Pickup method.
