### PR TITLE
Style Book: Hide Filter blocks and Product Search block 

### DIFF
--- a/assets/js/blocks/attribute-filter/block.json
+++ b/assets/js/blocks/attribute-filter/block.json
@@ -14,11 +14,6 @@
 		"inserter": false,
 		"lock": false
 	},
-	"example": {
-		"attributes": {
-			"isPreview": true
-		}
-	},
 	"attributes": {
 		"className": {
 			"type": "string",

--- a/assets/js/blocks/price-filter/block.json
+++ b/assets/js/blocks/price-filter/block.json
@@ -15,11 +15,6 @@
 		"inserter": false,
 		"lock": false
 	},
-	"example": {
-		"attributes": {
-			"isPreview": true
-		}
-	},
 	"attributes": {
 		"className": {
 			"type": "string",

--- a/assets/js/blocks/product-search/index.tsx
+++ b/assets/js/blocks/product-search/index.tsx
@@ -135,11 +135,6 @@ registerBlockType( 'woocommerce/product-search', {
 		align: [ 'wide', 'full' ],
 		inserter: ! isBlockVariationAvailable,
 	},
-	example: {
-		attributes: {
-			hasLabel: true,
-		},
-	},
 	attributes,
 	transforms: {
 		from: [

--- a/assets/js/blocks/rating-filter/block.json
+++ b/assets/js/blocks/rating-filter/block.json
@@ -16,11 +16,6 @@
 		"inserter": false,
 		"lock": false
 	},
-	"example": {
-		"attributes": {
-			"isPreview": true
-		}
-	},
 	"attributes": {
 		"className": {
 			"type": "string",

--- a/assets/js/blocks/stock-filter/block.json
+++ b/assets/js/blocks/stock-filter/block.json
@@ -17,11 +17,6 @@
 		"inserter": false,
 		"lock": false
 	},
-	"example": {
-		"attributes": {
-			"isPreview": true
-		}
-	},
 	"attributes": {
 		"className": {
 			"type": "string",


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR hides:
- Filter Blocks.
- Deprecated Product Search block.

### Filter Blocks

Regarding the Filter Blocks, I explored another approach (#8295), but we realized that Style Book rendered the old version of those blocks with that approach. To fix this issue, we should wait that [ #47443](https://github.com/WordPress/gutenberg/issues/47443) is fixed. 

If we agree with this approach, we should create another issue to keep in mind that we are blocked by #47443.

### Deprecated Product Search block

It is fine that we hide the Product Search Block. It is a deprecated block and is no longer visible in the editor inserter.


<!-- Reference any related issues or PRs here -->

Fixes #8175 
Fixes #8180 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Testing



#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. With Gutenberg installed and a block theme like [Twenty Twenty-Three](https://wordpress.org/themes/twentytwentythree/) enabled.
2. Go to Appearance > Editor and edit a template.
3. In the toolbar, select Styles (black and white circle) and then, Open Style Book (eye icon).
4. Go to the WooCommerce tab.
5. Be sure that the `Attribute Filter`, `Stock Filter`, `Price Filter`, `Rating filter`, and `Product Search` blocks aren't visible.

cc @nefeline @Aljullu 

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix: Hide filter blocks and _Product Search_ block for Style Book.