### PR TITLE
Remove font family styling support from Catalog Sorting and Product Results Count blocks

### DIFF
--- a/assets/js/blocks/catalog-sorting/block.json
+++ b/assets/js/blocks/catalog-sorting/block.json
@@ -11,8 +11,7 @@
 			"background": false
 		},
 		"typography": {
-			"fontSize": true,
-			"__experimentalFontFamily": true
+			"fontSize": true
 		}
 	},
 	"attributes": {

--- a/assets/js/blocks/product-results-count/block.json
+++ b/assets/js/blocks/product-results-count/block.json
@@ -11,8 +11,7 @@
 			"background": false
 		},
 		"typography": {
-			"fontSize": true,
-			"__experimentalFontFamily": true
+			"fontSize": true
 		}
 	},
 	"attributes": {},


### PR DESCRIPTION
I think we should remove support for font family styling in these two blocks. It's currently using an experimental flag and we don't have font family styling in most other blocks. 

If not, at least we should only enable it in the feature plugin builds.

cc @dinhtungdu as the DRI of the project. Do you agree with this?

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. With a block theme (ie [TT3](https://wordpress.org/themes/twentytwentythree/)) go to Appearance > Editor and edit one of the templates.
2. Add the Catalog Sorting and Product Results Count.
3. Verify in the sidebar it's not possible to change the font family (you might need to click the plus icon next to the _Typography_ panel title).

Before | After
--- | ---
![imatge](https://user-images.githubusercontent.com/3616980/215068121-cb15abcd-617f-47af-9a36-c09461729c10.png) | ![imatge](https://user-images.githubusercontent.com/3616980/215069205-26d57ef6-691d-4047-b109-fbb935a300e0.png)

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
