### PR TITLE
Show JETPACK_AUTOLOAD_DEV notice if it's not set to true

### DIFF
--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -96,7 +96,7 @@ function woocommerce_blocks_is_development_version() {
 /**
  * If development version is detected and the Jetpack constant is not defined, show a notice.
  */
-if ( woocommerce_blocks_is_development_version() && ! defined( 'JETPACK_AUTOLOAD_DEV' ) ) {
+if ( woocommerce_blocks_is_development_version() && ( ! defined( 'JETPACK_AUTOLOAD_DEV' ) || true !== JETPACK_AUTOLOAD_DEV ) ) {
 	add_action(
 		'admin_notices',
 		function () {


### PR DESCRIPTION
I was setting up a new dev install today and by mistake I set `define( 'JETPACK_AUTOLOAD_DEV', '' );` instead of `define( 'JETPACK_AUTOLOAD_DEV', true );`. :man_facepalming:  It took me some time to realize why things weren't working because the notice was not appearing.

### Testing

#### User Facing Testing

1. In your site's `wp-config.php`, remove the `JETPACK_AUTOLOAD_DEV` definition if you have it and instead add `define( 'JETPACK_AUTOLOAD_DEV', '' );`.
2. Go to the Plugins page in the admin.
3. Verify a notice appears saying `JETPACK_AUTOLOAD_DEV` needs to be defined and true:
![imatge](https://user-images.githubusercontent.com/3616980/215071184-8256da9a-0227-472a-ab36-163cd431b81e.png)
4. Set back `JETPACK_AUTOLOAD_DEV` to true: `define( 'JETPACK_AUTOLOAD_DEV', 'true' );`.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [ ] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental
