### PR TITLE
Remove __experimentalDefaultControls from Filter by Stock and Filter by Rating blocks

### DIFF
--- a/assets/js/blocks/rating-filter/block.json
+++ b/assets/js/blocks/rating-filter/block.json
@@ -8,11 +8,7 @@
 	"supports": {
 		"html": false,
 		"multiple": false,
-		"color": {
-		  "__experimentalDefaultControls": {
-			"text": true
-		  }
-		},
+		"color": true,
 		"inserter": false,
 		"lock": false
 	},

--- a/assets/js/blocks/stock-filter/block.json
+++ b/assets/js/blocks/stock-filter/block.json
@@ -8,9 +8,7 @@
 	"supports": {
 		"html": false,
 		"multiple": false,
-		"color": {
-		  "link": true
-		},
+		"color": true,
 		"inserter": false,
 		"lock": false
 	},

--- a/assets/js/blocks/stock-filter/block.json
+++ b/assets/js/blocks/stock-filter/block.json
@@ -9,10 +9,7 @@
 		"html": false,
 		"multiple": false,
 		"color": {
-		  "link": true,
-		  "__experimentalDefaultControls": {
-			"text": true
-		  }
+		  "link": true
 		},
 		"inserter": false,
 		"lock": false


### PR DESCRIPTION
Remove this experimental flag which, if I'm not wrong, was not having any effect.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. Create a post or page and add the Filter by Rating and Filter by Stock blocks.
2. Click on the list of options of the Filter by Rating block to select the Filter by Rating controls block.
3. Open the sidebar and verify you have the options to customize the Text and Background color in the Filter by Rating Controls block.
![imatge](https://user-images.githubusercontent.com/3616980/215499143-4b0574d7-359f-4d1e-a664-13f185d9fa60.png)
4. Select the Filter by Stock controls block and verify you have the options to customize the Text, Background and Link color in the Filter by Stock Controls block. (heads-up that if you change Link color, it's only visible in the frontend when there is at least one option selected)

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental