### PR TITLE
Remove unnecessary __experimentalDuotone instances

### DIFF
--- a/assets/js/blocks/featured-items/register.tsx
+++ b/assets/js/blocks/featured-items/register.tsx
@@ -25,7 +25,6 @@ interface ExtendedBlockSupports {
 			gradients: boolean;
 			link: boolean;
 			text: string;
-			__experimentalDuotone?: string;
 		};
 		spacing?: {
 			margin: boolean | CSSDirections[];
@@ -73,10 +72,6 @@ export function register(
 			color: {
 				background: metadata.supports?.color?.background,
 				text: metadata.supports?.color?.text,
-				...( isFeaturePluginBuild() && {
-					__experimentalDuotone:
-						metadata.supports?.color?.__experimentalDuotone,
-				} ),
 			},
 			spacing: {
 				padding: metadata.supports?.spacing?.padding,

--- a/src/BlockTypes/FeaturedItem.php
+++ b/src/BlockTypes/FeaturedItem.php
@@ -74,20 +74,6 @@ abstract class FeaturedItem extends AbstractDynamicBlock {
 	abstract protected function render_attributes( $item, $attributes );
 
 	/**
-	 * Get the supports array for this block type.
-	 *
-	 * @return string[][];
-	 * @see $this->register_block_type()
-	 */
-	protected function get_block_type_supports() {
-		return array(
-			'color' => array(
-				'__experimentalDuotone' => '.wc-block-' . $this->block_name . '__background-image',
-			),
-		);
-	}
-
-	/**
 	 * Render the featured item block.
 	 *
 	 * @param array    $attributes Block attributes.


### PR DESCRIPTION
Support for duotone in Featured Product and Featured Category blocks was removed in #7000. However, there were still some calls to `__experimentalDuotone` in the codebase. This PR cleans that up.

### Testing

#### User Facing Testing

1. Install a block theme (ie, [TT3](https://wordpress.org/themes/twentytwentythree/)).
2. Go to Appearance > Editor.
3. Edit a template and add a Featured Product and a Featured Category block.
4. Verify you can still customize the overlay color and opacity (in the editor sidebar).

![imatge](https://user-images.githubusercontent.com/3616980/215512746-8e99dbc1-6d35-423b-bf91-cc265e19afb0.png)

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental