### PR TITLE
Add default currency value for Storybook

### DIFF
--- a/assets/js/base/components/formatted-monetary-amount/index.tsx
+++ b/assets/js/base/components/formatted-monetary-amount/index.tsx
@@ -72,7 +72,7 @@ const FormattedMonetaryAmount = ( {
 		return null;
 	}
 
-	const priceValue = value / 10 ** currency.minorUnit;
+	const priceValue = value / 10 ** ( currency?.minorUnit || 2 );
 
 	if ( ! Number.isFinite( priceValue ) ) {
 		return null;

--- a/assets/js/base/components/formatted-monetary-amount/index.tsx
+++ b/assets/js/base/components/formatted-monetary-amount/index.tsx
@@ -72,10 +72,7 @@ const FormattedMonetaryAmount = ( {
 		return null;
 	}
 
-	const minorUnit =
-		typeof currency?.minorUnit === 'undefined' ? 2 : currency.minorUnit;
-
-	const priceValue = value / 10 ** minorUnit;
+	const priceValue = value / 10 ** currency.minorUnit;
 
 	if ( ! Number.isFinite( priceValue ) ) {
 		return null;
@@ -97,7 +94,7 @@ const FormattedMonetaryAmount = ( {
 	// Wrapper for NumberFormat onValueChange which handles subunit conversion.
 	const onValueChangeWrapper = onValueChange
 		? ( values: NumberFormatValues ) => {
-				const minorUnitValue = +values.value * 10 ** minorUnit;
+				const minorUnitValue = +values.value * 10 ** currency.minorUnit;
 				onValueChange( minorUnitValue );
 		  }
 		: () => void 0;

--- a/storybook/custom-controls/currency.ts
+++ b/storybook/custom-controls/currency.ts
@@ -37,4 +37,5 @@ export const currencyControl = {
 	control: 'select',
 	options: currencies,
 	mapping: Object.keys( currencies ),
+	defaultValue: currencies.USD,
 };


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

This PR fixes the `can't access property "minorUnit", currency is not defined` error on the ProductPrice story.

<!-- Reference any related issues or PRs here -->

Fixes #8145 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Checkout this branch.
2. Run `npm run storybook` and open up the Storybook page.
3. Go to the ProductPrice stories.
4. Ensure you don't see any errors in the console and that the price is correctly displaying on the page.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Fix ProductPrice story in Storybook.
