### PR TITLE
Store breadcrumbs block > Ensure experimental global styles are limited to the Feature plugin

### DIFF
--- a/assets/js/blocks/breadcrumbs/block.json
+++ b/assets/js/blocks/breadcrumbs/block.json
@@ -23,23 +23,12 @@
 		"align": [ "wide", "full" ],
 		"color": {
 			"background": false,
-			"link": true,
-			"__experimentalDefaultControls": {
-				"text": true,
-				"link": true
-			}
+			"link": true
 		},
 		"html": false,
 		"typography": {
 			"fontSize": true,
-			"lineHeight": true,
-			"__experimentalFontFamily": true,
-			"__experimentalFontStyle": true,
-			"__experimentalFontWeight": true,
-			"__experimentalTextTransform": true,
-			"__experimentalDefaultControls": {
-				"fontSize": true
-			}
+			"lineHeight": true
 		}
 	},
 	"apiVersion": 2,

--- a/assets/js/blocks/breadcrumbs/index.tsx
+++ b/assets/js/blocks/breadcrumbs/index.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
-import type { BlockConfiguration } from '@wordpress/blocks';
 import { isFeaturePluginBuild } from '@woocommerce/block-settings';
 import { Icon, queryPagination } from '@wordpress/icons';
 
@@ -12,26 +11,24 @@ import { Icon, queryPagination } from '@wordpress/icons';
 import metadata from './block.json';
 import edit from './edit';
 
-const blockConfig: BlockConfiguration = {
-	...metadata,
-	supports: {
-		...( isFeaturePluginBuild() && {
-			typography: {
+const featurePluginSupport = {
+	...metadata.supports,
+	...( isFeaturePluginBuild() && {
+		typography: {
+			fontSize: true,
+			lineHeight: true,
+			__experimentalFontFamily: true,
+			__experimentalFontStyle: true,
+			__experimentalFontWeight: true,
+			__experimentalTextTransform: true,
+			__experimentalDefaultControls: {
 				fontSize: true,
-				lineHeight: true,
-				__experimentalFontFamily: true,
-				__experimentalFontStyle: true,
-				__experimentalFontWeight: true,
-				__experimentalTextTransform: true,
-				__experimentalDefaultControls: {
-					fontSize: true,
-				},
 			},
-		} ),
-	},
+		},
+	} ),
 };
 
-registerBlockType( blockConfig, {
+registerBlockType( metadata, {
 	icon: {
 		src: (
 			<Icon
@@ -42,6 +39,9 @@ registerBlockType( blockConfig, {
 	},
 	attributes: {
 		...metadata.attributes,
+	},
+	supports: {
+		...featurePluginSupport,
 	},
 	edit,
 	save() {

--- a/assets/js/blocks/breadcrumbs/index.tsx
+++ b/assets/js/blocks/breadcrumbs/index.tsx
@@ -15,8 +15,7 @@ const featurePluginSupport = {
 	...metadata.supports,
 	...( isFeaturePluginBuild() && {
 		typography: {
-			fontSize: true,
-			lineHeight: true,
+			...metadata.supports.typography,
 			__experimentalFontFamily: true,
 			__experimentalFontStyle: true,
 			__experimentalFontWeight: true,

--- a/assets/js/blocks/breadcrumbs/index.tsx
+++ b/assets/js/blocks/breadcrumbs/index.tsx
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
+import type { BlockConfiguration } from '@wordpress/blocks';
+import { isFeaturePluginBuild } from '@woocommerce/block-settings';
 import { Icon, queryPagination } from '@wordpress/icons';
 
 /**
@@ -10,7 +12,26 @@ import { Icon, queryPagination } from '@wordpress/icons';
 import metadata from './block.json';
 import edit from './edit';
 
-registerBlockType( metadata, {
+const blockConfig: BlockConfiguration = {
+	...metadata,
+	supports: {
+		...( isFeaturePluginBuild() && {
+			typography: {
+				fontSize: true,
+				lineHeight: true,
+				__experimentalFontFamily: true,
+				__experimentalFontStyle: true,
+				__experimentalFontWeight: true,
+				__experimentalTextTransform: true,
+				__experimentalDefaultControls: {
+					fontSize: true,
+				},
+			},
+		} ),
+	},
+};
+
+registerBlockType( blockConfig, {
 	icon: {
 		src: (
 			<Icon


### PR DESCRIPTION
This PR addresses [the feedback](https://github.com/woocommerce/woocommerce-blocks/pull/8222#discussion_r1090684222) given by @Aljullu on #8222 and ensures the typography experimental styles are restricted to the feature plugin. I've also removed the `__experimentalDefaultControls` for the color as it is not affecting the block controls.

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### User Facing Testing

1. Make sure you are using a block theme.
2. Edit the Single Product Template ( e.g. wp-admin/site-editor.php?postType=wp_template&postId=woocommerce%2Fwoocommerce%2F%2Fsingle-product&canvas=edit&sidebar=%2Ftemplates).
3. Insert the new Store Breadcrumbs block.
4. Style the breadcrumbs (update the colors for the link and text and typography) and ensure the changes are also visible on the FrontEnd.

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Fix: The experimental typography styles for the Store Breadcrumbs block are now restricted to the feature plugin.
