### PR TITLE
Product Rating: Add support for the padding setting

### DIFF
--- a/assets/js/atomic/blocks/product-elements/rating/support.ts
+++ b/assets/js/atomic/blocks/product-elements/rating/support.ts
@@ -9,9 +9,13 @@ export const supports = {
 	...( isFeaturePluginBuild() && {
 		color: {
 			text: true,
-			background: false,
+			background: true,
 			link: false,
 			__experimentalSkipSerialization: true,
+		},
+		spacing: {
+			margin: true,
+			padding: true,
 		},
 		typography: {
 			fontSize: true,
@@ -19,9 +23,10 @@ export const supports = {
 		},
 		__experimentalSelector: '.wc-block-components-product-rating',
 	} ),
-	...( typeof __experimentalGetSpacingClassesAndStyles === 'function' && {
-		spacing: {
-			margin: true,
-		},
-	} ),
+	...( ! isFeaturePluginBuild() &&
+		typeof __experimentalGetSpacingClassesAndStyles === 'function' && {
+			spacing: {
+				margin: true,
+			},
+		} ),
 };

--- a/assets/js/atomic/blocks/product-elements/rating/support.ts
+++ b/assets/js/atomic/blocks/product-elements/rating/support.ts
@@ -9,7 +9,7 @@ export const supports = {
 	...( isFeaturePluginBuild() && {
 		color: {
 			text: true,
-			background: true,
+			background: false,
 			link: false,
 			__experimentalSkipSerialization: true,
 		},

--- a/src/BlockTypes/ProductRating.php
+++ b/src/BlockTypes/ProductRating.php
@@ -32,7 +32,7 @@ class ProductRating extends AbstractBlock {
 			'color'                  =>
 			array(
 				'text'                            => true,
-				'background'                      => true,
+				'background'                      => false,
 				'link'                            => false,
 				'__experimentalSkipSerialization' => true,
 			),

--- a/src/BlockTypes/ProductRating.php
+++ b/src/BlockTypes/ProductRating.php
@@ -32,7 +32,7 @@ class ProductRating extends AbstractBlock {
 			'color'                  =>
 			array(
 				'text'                            => true,
-				'background'                      => false,
+				'background'                      => true,
 				'link'                            => false,
 				'__experimentalSkipSerialization' => true,
 			),
@@ -44,6 +44,7 @@ class ProductRating extends AbstractBlock {
 			'spacing'                =>
 			array(
 				'margin'                          => true,
+				'padding'                         => true,
 				'__experimentalSkipSerialization' => true,
 			),
 			'__experimentalSelector' => '.wc-block-components-product-rating',
@@ -109,7 +110,7 @@ class ProductRating extends AbstractBlock {
 
 		if ( $product ) {
 
-			$styles_and_classes            = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, array( 'font_size', 'margin', 'text_color' ) );
+			$styles_and_classes            = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes );
 			$text_align_styles_and_classes = StyleAttributesUtils::get_text_align_class_and_style( $attributes );
 
 			add_filter(


### PR DESCRIPTION
This PR adds support for the `padding` setting to the **Product Rating** block. 

Part of woocommerce/woocommerce#42489

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|![Edit_Page_“Products”_‹_ratings_—_WordPress-5](https://user-images.githubusercontent.com/905781/215820993-96cd4986-0225-4647-9946-b83b3d596dc6.jpg)|![Edit_Page_“Products”_‹_ratings_—_WordPress-4](https://user-images.githubusercontent.com/905781/215821031-324ff9cb-8f5f-4ecf-953c-9ae322ea7c21.jpg)|

### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Add the **Products** block (and the **Product Rating** block inside of it).
2. Set `padding` and make sure it works correctly both in the editor and frontend.


* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Product Rating: Add support for the Padding setting.
