### PR TITLE
Prevent coupon error being removed when blurring the input and fix tests

### DIFF
--- a/packages/checkout/components/text-input/validated-text-input.tsx
+++ b/packages/checkout/components/text-input/validated-text-input.tsx
@@ -101,6 +101,10 @@ const ValidatedTextInput = ( {
 			inputObject.value = inputObject.value.trim();
 			inputObject.setCustomValidity( '' );
 
+			if ( previousValue === inputObject.value ) {
+				return;
+			}
+
 			const inputIsValid = customValidation
 				? inputObject.checkValidity() && customValidation( inputObject )
 				: inputObject.checkValidity();
@@ -120,6 +124,7 @@ const ValidatedTextInput = ( {
 			} );
 		},
 		[
+			previousValue,
 			clearValidationError,
 			customValidation,
 			errorIdString,

--- a/tests/e2e/specs/shopper/cart-checkout/checkout.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/checkout.test.js
@@ -304,7 +304,7 @@ describe( 'Shopper → Checkout', () => {
 			await shopper.block.goToCheckout();
 			await shopper.block.applyCouponFromCheckout( coupon.code );
 			await page.waitForSelector(
-				'.wc-block-components-notices__notice'
+				'.wc-block-components-totals-coupon__form .wc-block-components-validation-error'
 			);
 			await expect( page ).toMatch(
 				'Coupon usage limit has been reached.'

--- a/tests/e2e/specs/shopper/cart-checkout/checkout.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/checkout.test.js
@@ -304,7 +304,7 @@ describe( 'Shopper → Checkout', () => {
 			await shopper.block.goToCheckout();
 			await shopper.block.applyCouponFromCheckout( coupon.code );
 			await page.waitForSelector(
-				'.wc-block-components-totals-coupon__form .wc-block-components-validation-error'
+				'.wc-block-components-totals-coupon__content .wc-block-components-validation-error'
 			);
 			await expect( page ).toMatch(
 				'Coupon usage limit has been reached.'


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR stops the coupon error being removed when the input is blurred and unchanged, this led to a weird UX when I was testing, so I wanted to fix it to improve it.

This PR will add a check to see if the value of the input has changed. If not, then it won't revalidate, and it will keep the error the same until the value actually changes.

It also updates the selector the coupon error message in E2E tests, so they should no longer fail.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Create a single-use coupon in your Marketing -> Coupons dashboard. The usage limit should be set to 1.
2. Add items to your cart, apply the coupon and check out.
3. Once checkout is complete, add a new item to your cart, go to the Cart block and try to reapply the coupon.
4. Ensure you see the error message. Click into the coupon input again and then click out of it without changing the value.
5. Ensure the error remains.
6. Repeat this on the Checkout block.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Prevent errors relating to the coupon input disappearing when focusing/blurring the coupon input and the value of the input field remains unchanged.
