### PR TITLE
Fix/extension data conflicts

### DIFF
--- a/assets/js/base/context/hooks/use-checkout-extension-data.ts
+++ b/assets/js/base/context/hooks/use-checkout-extension-data.ts
@@ -22,8 +22,8 @@ export const useCheckoutExtensionData = (): {
 	) => void;
 } => {
 	const { __internalSetExtensionData } = useDispatch( CHECKOUT_STORE_KEY );
-	const extensionData = useSelect( ( selectData ) =>
-		selectData( CHECKOUT_STORE_KEY ).getExtensionData()
+	const extensionData = useSelect( ( select ) =>
+		select( CHECKOUT_STORE_KEY ).getExtensionData()
 	);
 	const extensionDataRef = useRef( extensionData );
 

--- a/assets/js/base/context/hooks/use-checkout-extension-data.ts
+++ b/assets/js/base/context/hooks/use-checkout-extension-data.ts
@@ -2,8 +2,7 @@
  * External dependencies
  */
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useCallback, useEffect, useRef } from '@wordpress/element';
-import isShallowEqual from '@wordpress/is-shallow-equal';
+import { useCallback, useRef } from '@wordpress/element';
 import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
 
 /**
@@ -23,26 +22,15 @@ export const useCheckoutExtensionData = (): {
 	) => void;
 } => {
 	const { __internalSetExtensionData } = useDispatch( CHECKOUT_STORE_KEY );
-	const extensionData = useSelect( ( select ) =>
-		select( CHECKOUT_STORE_KEY ).getExtensionData()
+	const extensionData = useSelect( ( selectData ) =>
+		selectData( CHECKOUT_STORE_KEY ).getExtensionData()
 	);
 	const extensionDataRef = useRef( extensionData );
 
-	useEffect( () => {
-		if ( ! isShallowEqual( extensionData, extensionDataRef.current ) ) {
-			extensionDataRef.current = extensionData;
-		}
-	}, [ extensionData ] );
-
-	const setExtensionDataWithNamespace = useCallback(
+	const setExtensionData = useCallback(
 		( namespace, key, value ) => {
-			const currentData = extensionDataRef.current[ namespace ] || {};
-			__internalSetExtensionData( {
-				...extensionDataRef.current,
-				[ namespace ]: {
-					...currentData,
-					[ key ]: value,
-				},
+			__internalSetExtensionData( namespace, {
+				[ key ]: value,
 			} );
 		},
 		[ __internalSetExtensionData ]
@@ -50,6 +38,6 @@ export const useCheckoutExtensionData = (): {
 
 	return {
 		extensionData: extensionDataRef.current,
-		setExtensionData: setExtensionDataWithNamespace,
+		setExtensionData,
 	};
 };

--- a/assets/js/data/checkout/actions.ts
+++ b/assets/js/data/checkout/actions.ts
@@ -131,15 +131,20 @@ export const setPrefersCollection = ( prefersCollection: boolean ) => ( {
 } );
 
 /**
- * Register some extra data for an extension. This works with the
- *
- * @param  extensionData An object containing the data to register for an extension
+ * Registers additional data under an extension namespace.
  */
 export const __internalSetExtensionData = (
-	extensionData: Record< string, Record< string, unknown > >
+	// The namespace for the extension. Defaults to 'default'. Must be unique to prevent conflicts.
+	namespace: string,
+	// Data to register under the namespace.
+	extensionData: Record< string, unknown >,
+	// If true, all data under the current extension namespace is replaced. If false, data is appended.
+	replace = false
 ) => ( {
 	type: types.SET_EXTENSION_DATA,
 	extensionData,
+	namespace,
+	replace,
 } );
 
 export type CheckoutAction =

--- a/assets/js/data/checkout/reducers.ts
+++ b/assets/js/data/checkout/reducers.ts
@@ -149,11 +149,19 @@ const reducer = ( state = defaultState, action: CheckoutAction ) => {
 		case types.SET_EXTENSION_DATA:
 			if (
 				action.extensionData !== undefined &&
-				state.extensionData !== action.extensionData
+				action.namespace !== undefined
 			) {
 				newState = {
 					...state,
-					extensionData: action.extensionData,
+					extensionData: {
+						...state.extensionData,
+						[ action.namespace ]: action.replace
+							? action.extensionData
+							: {
+									...state.extensionData[ action.namespace ],
+									...action.extensionData,
+							  },
+					},
 				};
 			}
 			break;

--- a/assets/js/data/checkout/test/reducer.ts
+++ b/assets/js/data/checkout/test/reducer.ts
@@ -215,21 +215,81 @@ describe.only( 'Checkout Store Reducer', () => {
 		).toEqual( expectedState );
 	} );
 
-	it( 'should handle SET_EXTENSION_DATA', () => {
-		const mockExtensionData = {
-			testExtension: { key: 'test', value: 'test2' },
-		};
-		const expectedState = {
-			...defaultState,
-			status: STATUS.IDLE,
-			extensionData: mockExtensionData,
-		};
-
-		expect(
-			reducer(
+	describe( 'should handle SET_EXTENSION_DATA', () => {
+		it( 'should set data under a namespace', () => {
+			const mockExtensionData = {
+				extensionNamespace: {
+					testKey: 'test-value',
+					testKey2: 'test-value-2',
+				},
+			};
+			const expectedState = {
+				...defaultState,
+				status: STATUS.IDLE,
+				extensionData: mockExtensionData,
+			};
+			expect(
+				reducer(
+					defaultState,
+					actions.__internalSetExtensionData(
+						'extensionNamespace',
+						mockExtensionData.extensionNamespace
+					)
+				)
+			).toEqual( expectedState );
+		} );
+		it( 'should append data under a namespace', () => {
+			const mockExtensionData = {
+				extensionNamespace: {
+					testKey: 'test-value',
+					testKey2: 'test-value-2',
+				},
+			};
+			const expectedState = {
+				...defaultState,
+				status: STATUS.IDLE,
+				extensionData: mockExtensionData,
+			};
+			const firstState = reducer(
 				defaultState,
-				actions.__internalSetExtensionData( mockExtensionData )
-			)
-		).toEqual( expectedState );
+				actions.__internalSetExtensionData( 'extensionNamespace', {
+					testKey: 'test-value',
+				} )
+			);
+			const secondState = reducer(
+				firstState,
+				actions.__internalSetExtensionData( 'extensionNamespace', {
+					testKey2: 'test-value-2',
+				} )
+			);
+			expect( secondState ).toEqual( expectedState );
+		} );
+		it( 'support replacing data under a namespace', () => {
+			const mockExtensionData = {
+				extensionNamespace: {
+					testKey: 'test-value',
+				},
+			};
+			const expectedState = {
+				...defaultState,
+				status: STATUS.IDLE,
+				extensionData: mockExtensionData,
+			};
+			const firstState = reducer(
+				defaultState,
+				actions.__internalSetExtensionData( 'extensionNamespace', {
+					testKeyOld: 'test-value',
+				} )
+			);
+			const secondState = reducer(
+				firstState,
+				actions.__internalSetExtensionData(
+					'extensionNamespace',
+					{ testKey: 'test-value' },
+					true
+				)
+			);
+			expect( secondState ).toEqual( expectedState );
+		} );
 	} );
 } );

--- a/docs/internal-developers/block-client-apis/checkout/checkout-api.md
+++ b/docs/internal-developers/block-client-apis/checkout/checkout-api.md
@@ -71,7 +71,7 @@ The following actions can be dispatched from the Checkout data store:
 -   `__internalSetUseShippingAsBilling( useShippingAsBilling: boolean )`: Set `state.useShippingAsBilling` to `useShippingAsBilling`
 -   `__internalSetShouldCreateAccount( shouldCreateAccount: boolean )`: Set `state.shouldCreateAccount` to `shouldCreateAccount`
 -   `__internalSetOrderNotes( orderNotes: string )`: Set `state.orderNotes` to `orderNotes`
--   `__internalSetExtensionData( extensionData: Record< string, Record< string, unknown > > )`: Set `state.extensionData` to `extensionData`
+-   `__internalSetExtensionData( namespace: string, extensionData: Record< string, unknown > )`: Set `state.extensionData` to `extensionData`
 
 ### Contexts
 


### PR DESCRIPTION
When multiple extensions interact with `extensionData` [there may be race conditions due to how the `useCheckoutExtensionData` hook selects and merges data to the store](https://github.com/woocommerce/woocommerce-blocks/issues/8333).

To avoid this, this PR changes the shape of `__internalSetExtensionData` so that it is passed a namespace, and any merging happens in the data store reducer. This means the `setExtensionData` callback no longer needs to be aware what is currently living inside the data store, and conflicts are avoided.

I've updated test coverage to test these changes.

Fixes #8333

### Testing

#### Automated Tests
* [x] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [ ] E2E tests

#### User Facing Testing

These are steps from #8333.

1. Install and activate MailPoet and AutomateWoo extensions.
2. Edit the checkout block and ensure `AutomateWoo` newsletter opt-in field is first.
3. Add something to your cart and go to the checkout.
4. Do not interact with the opt-in checkboxes, just place the order.
5. Before this PR you'd see an error notice stating extension data is missing. After this PR the order will go through without error.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Fix potential conflict between newsletter extensions on the checkout page.
