### PR TITLE
Switch to `select` instead of `resolveSelector` in data store.

### DIFF
--- a/assets/js/data/cart/actions.ts
+++ b/assets/js/data/cart/actions.ts
@@ -22,7 +22,7 @@ import {
 import { ACTION_TYPES as types } from './action-types';
 import { apiFetchWithHeaders } from '../shared-controls';
 import { ReturnOrGeneratorYieldUnion } from '../mapped-types';
-import { CartDispatchFromMap, CartResolveSelectFromMap } from './index';
+import { CartDispatchFromMap, CartSelectFromMap } from './index';
 import type { Thunks } from './thunks';
 
 // Thunks are functions that can be dispatched, similar to actions creators
@@ -188,7 +188,7 @@ export const shippingRatesBeingSelected = ( isResolving: boolean ) =>
  */
 export const applyExtensionCartUpdate =
 	( args: ExtensionCartUpdateArgs ) =>
-	async ( { dispatch } ) => {
+	async ( { dispatch }: { dispatch: CartDispatchFromMap } ) => {
 		try {
 			const { response } = await apiFetchWithHeaders( {
 				path: '/wc/store/v1/cart/extensions',
@@ -213,7 +213,7 @@ export const applyExtensionCartUpdate =
  */
 export const applyCoupon =
 	( couponCode: string ) =>
-	async ( { dispatch } ) => {
+	async ( { dispatch }: { dispatch: CartDispatchFromMap } ) => {
 		try {
 			dispatch.receiveApplyingCoupon( couponCode );
 			const { response } = await apiFetchWithHeaders( {
@@ -243,7 +243,7 @@ export const applyCoupon =
  */
 export const removeCoupon =
 	( couponCode: string ) =>
-	async ( { dispatch } ) => {
+	async ( { dispatch }: { dispatch: CartDispatchFromMap } ) => {
 		try {
 			dispatch.receiveRemovingCoupon( couponCode );
 			const { response } = await apiFetchWithHeaders( {
@@ -276,7 +276,7 @@ export const removeCoupon =
  */
 export const addItemToCart =
 	( productId: number, quantity = 1 ) =>
-	async ( { dispatch } ) => {
+	async ( { dispatch }: { dispatch: CartDispatchFromMap } ) => {
 		try {
 			triggerAddingToCartEvent();
 			const { response } = await apiFetchWithHeaders( {
@@ -346,12 +346,12 @@ export const changeCartItemQuantity =
 	) =>
 	async ( {
 		dispatch,
-		resolveSelect,
+		select,
 	}: {
 		dispatch: CartDispatchFromMap;
-		resolveSelect: CartResolveSelectFromMap;
+		select: CartSelectFromMap;
 	} ) => {
-		const cartItem = await resolveSelect.getCartItem( cartItemKey );
+		const cartItem = select.getCartItem( cartItemKey );
 		if ( cartItem?.quantity === quantity ) {
 			return;
 		}


### PR DESCRIPTION
`resolveSelector` along other stuff introduced in WP 5.9.0 allowed us to switch to using thunks, unfortunately, `resolveSelector` had a bug in which a selector without a resolver would never resolve and halt the execution, this was fixed in https://github.com/WordPress/gutenberg/pull/39976/ but landed in 6.0.

For our use case, we switched to using `select` instead which resolves.

### Testing steps

1. In WordPress 5.9.x, go to Cart block.
2. Try increasing the quantity, it should work.

### Changelog

> Fix a bug in WordPress 5.9 in which changing quantity doesn't work inside Cart and Mini Cart blocks.