### PR TITLE
[Exploration] Single Product templates by type 

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -71,6 +71,43 @@ class BlockTemplatesController {
 		if ( $this->package->is_experimental_build() ) {
 			add_action( 'after_switch_theme', array( $this, 'check_should_use_blockified_product_grid_templates' ), 10, 2 );
 		}
+
+		add_filter( 'extra_template_types', array( $this, 'add_single_product_templates' ) );
+		add_filter( 'single_template_hierarchy', array( $this, 'update_single_product_template_hierarchy' ), 1, 3 );
+	}
+
+	/**
+	 * Add the single-product-type template to the single template hierarchy.
+	 *
+	 * @param array $templates Template hierarchy.
+	 *
+	 * @return array
+	 */
+	public function update_single_product_template_hierarchy( $templates ) {
+		$product_type = wc_get_product()->get_type();
+		array_splice( $templates, 1, 0, 'single-product-' . $product_type );
+
+		return $templates;
+	}
+
+	/**
+	 * Add a single-product template type for each product type to the list
+	 * of extra template types.
+	 *
+	 * @param array $extra_template_types Array of extra template types.
+	 *
+	 * @return array
+	 */
+	public function add_single_product_templates( $extra_template_types ) {
+		$product_types = array_keys( wc_get_product_types() );
+		foreach ( $product_types as $product_type ) {
+			$extra_template_types[] = array(
+				'slug'  => 'single-product-' . $product_type,
+				'title' => 'Single Product: ' . ucfirst( $product_type ),
+			);
+		}
+
+		return $extra_template_types;
 	}
 
 	/**

--- a/src/BlockTypes/ClassicTemplate.php
+++ b/src/BlockTypes/ClassicTemplate.php
@@ -64,7 +64,7 @@ class ClassicTemplate extends AbstractDynamicBlock {
 
 		$archive_templates = array( 'archive-product', 'taxonomy-product_cat', 'taxonomy-product_tag', ProductAttributeTemplate::SLUG, ProductSearchResultsTemplate::SLUG );
 
-		if ( 'single-product' === $attributes['template'] ) {
+		if ( strpos( $attributes['template'], 'single-product' ) !== false ) {
 			return $this->render_single_product();
 		} elseif ( in_array( $attributes['template'], $archive_templates, true ) ) {
 			// Set this so that our product filters can detect if it's a PHP template.


### PR DESCRIPTION
**⚠️ To try this exploration you need to have this version of Gutenberg 👉 https://github.com/WordPress/gutenberg/pull/46362 in this [commit](https://github.com/WordPress/gutenberg/pull/46362/commits/13d18585d594e033b9af1bc4db59e505d1bb1833) (I just realized the last commit of the PR breaks some things). ⚠️**

Maybe the user experience is not that good because they'll get one menu item per product type.
<img width="266" alt="Screenshot 2023-02-01 at 16 29 48" src="https://user-images.githubusercontent.com/186112/216086833-d0d4d04a-68fc-4d36-9b95-9a5755639b7f.png">
