### PR TITLE
Add reset button to all filter blocks

### DIFF
--- a/assets/js/base/components/price-slider/index.tsx
+++ b/assets/js/base/components/price-slider/index.tsx
@@ -77,6 +77,10 @@ export interface PriceSliderProps {
 	 * What step values the slider uses.
 	 */
 	step?: number;
+	/**
+	 * Wheter we're in the editor or not.
+	 */
+	isEditor?: boolean;
 }
 
 const PriceSlider = ( {
@@ -92,6 +96,7 @@ const PriceSlider = ( {
 	inlineInput = true,
 	isLoading = false,
 	isUpdating = false,
+	isEditor = false,
 	onSubmit = () => void 0,
 }: PriceSliderProps ): JSX.Element => {
 	const minRange = useRef< HTMLInputElement >( null );
@@ -473,23 +478,21 @@ const PriceSlider = ( {
 				) }
 			{
 				<div className="wc-block-components-price-slider__actions">
-					{ ! isUpdating &&
-						( minPrice !== minConstraint ||
-							maxPrice !== maxConstraint ) && (
-							<FilterResetButton
-								onClick={ () => {
-									onChange( [
-										minConstraint,
-										maxConstraint,
-									] );
-									debouncedUpdateQuery();
-								} }
-								screenReaderLabel={ __(
-									'Reset price filter',
-									'woo-gutenberg-products-block'
-								) }
-							/>
-						) }
+					{ ( isEditor ||
+						( ! isUpdating &&
+							( minPrice !== minConstraint ||
+								maxPrice !== maxConstraint ) ) ) && (
+						<FilterResetButton
+							onClick={ () => {
+								onChange( [ minConstraint, maxConstraint ] );
+								debouncedUpdateQuery();
+							} }
+							screenReaderLabel={ __(
+								'Reset price filter',
+								'woo-gutenberg-products-block'
+							) }
+						/>
+					) }
 					{ showFilterButton && (
 						<FilterSubmitButton
 							className="wc-block-price-filter__button wc-block-components-price-slider__button"

--- a/assets/js/blocks/price-filter/block.tsx
+++ b/assets/js/blocks/price-filter/block.tsx
@@ -353,6 +353,7 @@ const PriceFilterBlock = ( {
 					onSubmit={ () => onSubmit( minPrice, maxPrice ) }
 					isLoading={ isLoading }
 					isUpdating={ isUpdating }
+					isEditor={ isEditor }
 				/>
 			</div>
 		</>

--- a/assets/js/blocks/rating-filter/block.tsx
+++ b/assets/js/blocks/rating-filter/block.tsx
@@ -489,7 +489,7 @@ const RatingFilterBlock = ( {
 			</div>
 			{
 				<div className="wc-block-rating-filter__actions">
-					{ checked.length > 0 && ! isLoading && (
+					{ ( checked.length > 0 || isEditor ) && ! isLoading && (
 						<FilterResetButton
 							onClick={ () => {
 								setChecked( [] );

--- a/assets/js/blocks/stock-filter/block.tsx
+++ b/assets/js/blocks/stock-filter/block.tsx
@@ -521,7 +521,7 @@ const StockStatusFilterBlock = ( {
 			</div>
 			{
 				<div className="wc-block-stock-filter__actions">
-					{ checked.length > 0 && ! isLoading && (
+					{ ( checked.length > 0 || isEditor ) && ! isLoading && (
 						<FilterResetButton
 							onClick={ () => {
 								setChecked( [] );


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #7826

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Checkout this branch. Run npm run build.
2. Go to your wp-admin dashboard and create a new page. Add the `All products` block.
3. Then add each of these blocks `Filter by Price`, `Filter by Stock` and `Filter by Rating`.
4. Ensure you see the Reset button at the bottom right.
![Reset Button](https://user-images.githubusercontent.com/2132595/216156231-248e509b-33fb-42cb-bd95-5421ade629d1.png)
6. Go to the frontend and ensure you see the Reset button after interacting with the block ( check the checkboxes or move the price slider).

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->


### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Add a reset button for the Filter blocks.