### PR TITLE
Style Book: Remove Cart block from Style Book

### DIFF
--- a/assets/js/blocks/cart/index.js
+++ b/assets/js/blocks/cart/index.js
@@ -36,11 +36,6 @@ const settings = {
 		html: false,
 		multiple: false,
 	},
-	example: {
-		attributes: {
-			isPreview: true,
-		},
-	},
 	attributes: blockAttributes,
 	edit: Edit,
 	save: Save,


### PR DESCRIPTION
Currently, the Cart block doesn't fully support Global Styles, so, in orderto avoid providing the users with a confusing or broken experience, we have decided to remove it for the time being, until proper support has been added.

Fixes #8368

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. Go to Appearance → Editor and edit a template.
2. Navigate to Style Book (Select the Styles icon and then the Eye icon).
3. Click on the Woo tab.
4. Confirm the Cart block does not appear in the previews.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental