### PR TITLE
Remove Classic Template from Style Book.

### DIFF
--- a/assets/js/blocks/classic-template/index.tsx
+++ b/assets/js/blocks/classic-template/index.tsx
@@ -167,11 +167,6 @@ const registerClassicTemplateBlock = ( {
 			reusable: false,
 			inserter,
 		},
-		example: {
-			attributes: {
-				isPreview: true,
-			},
-		},
 		attributes: {
 			/**
 			 * Template attribute is used to determine which core PHP template gets rendered.


### PR DESCRIPTION
The Classic Template is not style-able, also, removing the example doesn't make us lose much in terms of UX.

Fixes #8370

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. Go to Appearance → Editor and edit the Single Product template.
2. Navigate to Style Book (Select the Styles icon and then the Eye icon).
3. Click on the Woo tab.
4. Confirm the Classic Template block does not appear in the previews.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
