### PR TITLE
Fix: color setting for Catalog Sorting

### DIFF
--- a/assets/js/blocks/catalog-sorting/edit.tsx
+++ b/assets/js/blocks/catalog-sorting/edit.tsx
@@ -7,7 +7,7 @@ import { __ } from '@wordpress/i18n';
 
 const CatalogSorting = () => {
 	return (
-		<select>
+		<select className="orderby">
 			<option>
 				{ __( 'Default sorting', 'woo-gutenberg-products-block' ) }
 			</option>

--- a/assets/js/blocks/catalog-sorting/style.scss
+++ b/assets/js/blocks/catalog-sorting/style.scss
@@ -5,6 +5,6 @@
 
 	select {
 		font-size: inherit;
-		font-family: inherit;
+		color: inherit;
 	}
 }

--- a/assets/js/blocks/catalog-sorting/style.scss
+++ b/assets/js/blocks/catalog-sorting/style.scss
@@ -3,7 +3,7 @@
 		float: none;
 	}
 
-	select {
+	select.orderby {
 		font-size: inherit;
 		color: inherit;
 	}


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

This is a follow up of #8122 

This PR fixes the issue that the color setting is applied in the editor and on the front end. This also remove the unused style for the Catalog Sorting `select` box.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Go to the Site Editor.
2. Edit the Product Catalog template
3. Add the Catalog Sorting block.
4. Change the color and font size of the block.
5. See the style applied in the Site Editor.
6. Save the template. Go to the Shop page on the front end. See the style applied there too.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental