### PR TITLE
Fix Filter by Rating reset button

### DIFF
--- a/assets/js/blocks/rating-filter/block.tsx
+++ b/assets/js/blocks/rating-filter/block.tsx
@@ -493,7 +493,7 @@ const RatingFilterBlock = ( {
 						<FilterResetButton
 							onClick={ () => {
 								setChecked( [] );
-								setProductRatings( [] );
+								setProductRatingsQuery( [] );
 								onSubmit( [] );
 							} }
 							screenReaderLabel={ __(


### PR DESCRIPTION
The block was attempting to use `setProductRatings` which is an undefined function, instead of `setProductRatingsQuery` when resetting the filters using the "Reset" button.

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/8373

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Ensure products have ratings
2. Add Filter by Rating to your page which also uses the All Products block, and enable the Apply button in the filter block settings
3. On the frontend, apply some filters for this block and then attempt to reset them by clicking the "Reset" button
4. Go to Appearance > Site Editor and add the block to the Product Catalog page making sure you again enable the Apply filter button in the block settings.
5. On the frontend, apply some filters for this block and then attempt to reset them by clicking the "Reset" button (in this scenario the page will refresh.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Filter by Rating: Fix functionality to for resetting filters using the Reset button.
