### PR TITLE
[Exploration]: Register product types as post types so they display as templates

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -72,7 +72,7 @@ class BlockTemplatesController {
 			add_action( 'after_switch_theme', array( $this, 'check_should_use_blockified_product_grid_templates' ), 10, 2 );
 		}
 
-		add_single_product_post_types();
+		$this->add_single_product_post_types();
 	}
 
 

--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -71,7 +71,39 @@ class BlockTemplatesController {
 		if ( $this->package->is_experimental_build() ) {
 			add_action( 'after_switch_theme', array( $this, 'check_should_use_blockified_product_grid_templates' ), 10, 2 );
 		}
+
+		add_single_product_post_types();
 	}
+
+
+	/**
+	 * This function is used to register single product post types, so they can be displayed
+	 * as a separate entries in the templates list.
+	 */
+	public function add_single_product_post_types() {
+		$product_types = array_keys( wc_get_product_types() );
+		foreach ( $product_types as $product_type ) {
+			$args = array(
+				/* translators: %s is the product type */
+				'label'               => sprintf( __( 'Product - %s', 'woo-gutenberg-products-block' ), $product_type ),
+				/* translators: %s is the product type */
+				'description'         => sprintf( __( 'Layout your product: %s', 'woo-gutenberg-products-block' ), $product_type ),
+				'public'              => false,
+				'publicly_queryable'  => true,
+				'exclude_from_search' => true,
+				'hierarchical'        => true,
+				'rewrite'             => false,
+				'show_in_rest'        => true,
+				'template'            => array( array( 'core/group', array( 'woocommerce/legacy-template' ) ) ),
+			);
+
+			register_post_type(
+				'product:' . $product_type,
+				$args
+			);
+		}
+	}
+
 
 	/**
 	 * This function is used on the `pre_get_block_template` hook to return the fallback template from the db in case

--- a/src/BlockTypes/ClassicTemplate.php
+++ b/src/BlockTypes/ClassicTemplate.php
@@ -36,6 +36,25 @@ class ClassicTemplate extends AbstractDynamicBlock {
 		add_filter( 'render_block', array( $this, 'add_alignment_class_to_wrapper' ), 10, 2 );
 		add_filter( 'woocommerce_product_query_meta_query', array( $this, 'filter_products_by_stock' ) );
 
+		$product_types = array_keys( wc_get_product_types() );
+		$resp          = register_post_type(
+			'products-simple',
+			array(
+				'label'               => __( 'Products - Simple', 'woo-gutenberg-products-block' ),
+				'description'         => __( 'Layout your simple product', 'woo-gutenberg-products-block' ),
+				'public'              => true,
+				'map_meta_cap'        => true,
+				'publicly_queryable'  => true,
+				'exclude_from_search' => true,
+				'hierarchical'        => true,
+				'rewrite'             => false,
+				'query_var'           => false,
+				'supports'            => array( 'title' ),
+				'show_in_admin_bar'   => true,
+				'template'            => array( 'woocommerce/classic-template' ),
+				'show_in_rest'        => true,
+			)
+		);
 	}
 
 	/**

--- a/src/BlockTypes/ClassicTemplate.php
+++ b/src/BlockTypes/ClassicTemplate.php
@@ -35,26 +35,6 @@ class ClassicTemplate extends AbstractDynamicBlock {
 		parent::initialize();
 		add_filter( 'render_block', array( $this, 'add_alignment_class_to_wrapper' ), 10, 2 );
 		add_filter( 'woocommerce_product_query_meta_query', array( $this, 'filter_products_by_stock' ) );
-
-		$product_types = array_keys( wc_get_product_types() );
-		$resp          = register_post_type(
-			'products-simple',
-			array(
-				'label'               => __( 'Products - Simple', 'woo-gutenberg-products-block' ),
-				'description'         => __( 'Layout your simple product', 'woo-gutenberg-products-block' ),
-				'public'              => true,
-				'map_meta_cap'        => true,
-				'publicly_queryable'  => true,
-				'exclude_from_search' => true,
-				'hierarchical'        => true,
-				'rewrite'             => false,
-				'query_var'           => false,
-				'supports'            => array( 'title' ),
-				'show_in_admin_bar'   => true,
-				'template'            => array( 'woocommerce/classic-template' ),
-				'show_in_rest'        => true,
-			)
-		);
 	}
 
 	/**


### PR DESCRIPTION
End result: post types as a templates are loaded with some delay and are displayed within "Add New Template".

https://user-images.githubusercontent.com/20098064/216616502-e4d93b6f-108a-4a2d-8acb-7486daa0232c.mov

Known problems:
- when clicked wrong template is loaded (post template, not Classic Template)