### PR TITLE
Fix Products block Feedback prompt display

### DIFF
--- a/assets/js/blocks/product-query/inspector-controls.tsx
+++ b/assets/js/blocks/product-query/inspector-controls.tsx
@@ -208,13 +208,6 @@ const ProductQueryControls = ( props: ProductQueryBlock ) => {
 					) }
 				</ToolsPanel>
 			</InspectorControls>
-			{
-				// Hacky temporary solution to display the feedback prompt
-				// at the bottom of the inspector controls
-			 }
-			<InspectorControls __experimentalGroup="color">
-				<ProductQueryFeedbackPrompt />
-			</InspectorControls>
 		</>
 	);
 };
@@ -226,6 +219,9 @@ export const withProductQueryControls =
 			<>
 				<ProductQueryControls { ...props } />
 				<BlockEdit { ...props } />
+				<InspectorControls>
+					<ProductQueryFeedbackPrompt />
+				</InspectorControls>
 			</>
 		) : (
 			<BlockEdit { ...props } />


### PR DESCRIPTION
With WordPress 6.2, the inspector controls are going to be tabbed into a “Styles” and “Setting” section (where applicable). Previously, in order to display our Feedback Prompt at the bottom of the controls, we had hooked it into the “Colors” section as a temporary/hacky solution to the problem.

Now that the styles sections are all moved, the problem doesn't really exist anymore, and we can just place it at the bottom of the controls.

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #8298

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
| <img src="https://user-images.githubusercontent.com/1847066/216691478-f66341cb-b72c-414c-9733-a923fd5b3549.png" width="300" /> | ![Screenshot 2023-02-03 at 20 32 46](https://user-images.githubusercontent.com/1847066/216691441-83647627-f1b1-4c5c-ade8-a4d5d6df5102.png)      |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Install the latest Gutenberg development plugin.
2. Add a Products block to a page or post.
3. Open the inspector controls.
4. Verify that the “Styles” tab is not available and that the “Feedback prompt” appears at the bottom of the inspector controls, above the “Advanced” section.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
