### PR TITLE
Add validation error to prevent checkout when there is no shipping method available

### DIFF
--- a/assets/js/base/context/providers/cart-checkout/checkout-processor.ts
+++ b/assets/js/base/context/providers/cart-checkout/checkout-processor.ts
@@ -14,7 +14,7 @@ import {
 	emptyHiddenAddressFields,
 	removeAllNotices,
 } from '@woocommerce/base-utils';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useSelect, select as selectStore } from '@wordpress/data';
 import {
 	CHECKOUT_STORE_KEY,
 	PAYMENT_STORE_KEY,
@@ -160,6 +160,19 @@ const CheckoutProcessor = () => {
 
 	const checkValidation = useCallback( () => {
 		if ( hasValidationErrors() ) {
+			// If there is a shipping rates validation error, return the error message to be displayed.
+			if (
+				selectStore( VALIDATION_STORE_KEY ).getValidationError(
+					'shipping-rates-error'
+				) !== undefined
+			) {
+				return {
+					errorMessage: __(
+						'Sorry, this order requires a shipping option.',
+						'woo-gutenberg-products-block'
+					),
+				};
+			}
 			return false;
 		}
 		if ( hasPaymentError ) {

--- a/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/block.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/block.tsx
@@ -9,6 +9,9 @@ import {
 } from 'wordpress-components';
 import classnames from 'classnames';
 import { Icon, store, shipping } from '@wordpress/icons';
+import { useEffect } from '@wordpress/element';
+import { VALIDATION_STORE_KEY } from '@woocommerce/block-data';
+import { useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -18,6 +21,14 @@ import { RatePrice, getLocalPickupPrices, getShippingPrices } from './shared';
 import type { minMaxPrices } from './shared';
 import { defaultLocalPickupText, defaultShippingText } from './constants';
 import { shippingAddressHasValidationErrors } from '../../../../data/cart/utils';
+
+const SHIPPING_RATE_ERROR = {
+	hidden: true,
+	message: __(
+		'Shipping options are not available',
+		'woo-gutenberg-products-block'
+	),
+};
 
 const LocalPickupSelector = ( {
 	checked,
@@ -83,6 +94,23 @@ const ShippingSelector = ( {
 } ) => {
 	const rateShouldBeHidden =
 		shippingCostRequiresAddress && shippingAddressHasValidationErrors();
+	const hasShippingPrices = rate.min !== undefined && rate.max !== undefined;
+	const { setValidationErrors, clearValidationError } =
+		useDispatch( VALIDATION_STORE_KEY );
+	useEffect( () => {
+		if ( checked === 'shipping' && ! hasShippingPrices ) {
+			setValidationErrors( {
+				'shipping-rates-error': SHIPPING_RATE_ERROR,
+			} );
+		} else {
+			clearValidationError( 'shipping-rates-error' );
+		}
+	}, [
+		checked,
+		clearValidationError,
+		hasShippingPrices,
+		setValidationErrors,
+	] );
 	const Price =
 		rate.min === undefined || rateShouldBeHidden ? (
 			<span className="wc-block-checkout__shipping-method-option-price">

--- a/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/shared/rate-price.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/shared/rate-price.tsx
@@ -16,7 +16,7 @@ export const RatePrice = ( {
 }: {
 	minRate: CartShippingPackageShippingRate | undefined;
 	maxRate: CartShippingPackageShippingRate | undefined;
-	multiple: boolean;
+	multiple?: boolean;
 } ) => {
 	if ( minRate === undefined || maxRate === undefined ) {
 		return null;


### PR DESCRIPTION
With this PR, we're preventing checkout if no shipping methods are available. 

Fixes #8348

## Changes in the PR:
- Add the validation error in ShippingSelector to prevent checkout when no shipping rates are available.
- Add a notice to the checkout processor so that notice appears after clicking on the place order button.

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|![image](https://user-images.githubusercontent.com/11503784/216732422-d263b199-9701-4174-981e-9f555d2bca6d.png)|![image](https://user-images.githubusercontent.com/11503784/221024165-bb27a4b5-a46b-4d4a-a39f-734a048900c7.png)|




### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. Enable local pickup with pickup price.
2. Remove the shipping methods from the WC settings.
3. Go to the Checkout block and select the shipping option.
4. Confirm error notice is being displayed at the top.
5. Confirm you're not able to place the order.
6. Select local pickup.
7. Confirm you're able to place an order

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Add validation error to prevent checkout when there is no shipping method available