### PR TITLE
Add settings as a supports prop for local pickup

### DIFF
--- a/src/Shipping/PickupLocation.php
+++ b/src/Shipping/PickupLocation.php
@@ -26,7 +26,7 @@ class PickupLocation extends WC_Shipping_Method {
 		$this->title            = $this->get_option( 'title' );
 		$this->tax_status       = $this->get_option( 'tax_status' );
 		$this->cost             = $this->get_option( 'cost' );
-		$this->supports         = [ 'local-pickup' ];
+		$this->supports         = [ 'settings', 'local-pickup' ];
 		$this->pickup_locations = get_option( $this->id . '_pickup_locations', [] );
 		add_filter( 'woocommerce_attribute_label', array( $this, 'translate_meta_data' ), 10, 3 );
 	}


### PR DESCRIPTION
When https://github.com/woocommerce/woocommerce-blocks/pull/8256 was merged, Local Pickup's `supports` prop was switched from the default one `[ 'settings' ]` to `[ 'local-pickup' ]`, this ended up omitting settings and removing local pickup from the settings page, this PR reverts it.

### Testing steps

1. Have Checkout block as your default checkout.
2. Go to WooCommerce -> Settings -> Shipping and you should see local pickup.