### PR TITLE
Fixes CSS spacing and availability issues for breadcrumb, catalog sort, and result count blocks.

### DIFF
--- a/assets/js/blocks/breadcrumbs/style.scss
+++ b/assets/js/blocks/breadcrumbs/style.scss
@@ -1,3 +1,9 @@
 .woocommerce.wc-block-breadcrumbs {
 	font-size: inherit;
 }
+.woocommerce.woocommerce-shop .wc-block-breadcrumbs {
+	.woocommerce-breadcrumb {
+		margin: auto;
+		display: block;
+	}
+}

--- a/assets/js/blocks/catalog-sorting/style.scss
+++ b/assets/js/blocks/catalog-sorting/style.scss
@@ -7,4 +7,8 @@
 		font-size: inherit;
 		color: inherit;
 	}
+
+	.woocommerce-ordering {
+		margin: auto;
+	}
 }

--- a/assets/js/blocks/product-results-count/style.scss
+++ b/assets/js/blocks/product-results-count/style.scss
@@ -10,16 +10,3 @@
 	}
 }
 
-.woocommerce .wc-block-catalog-sorting {
-	.woocommerce-ordering {
-		margin: auto;
-	}
-}
-
-.woocommerce.woocommerce-shop .wc-block-breadcrumbs {
-	.woocommerce-breadcrumb {
-		margin: auto;
-		display: block;
-	}
-}
-

--- a/assets/js/blocks/product-results-count/style.scss
+++ b/assets/js/blocks/product-results-count/style.scss
@@ -9,3 +9,9 @@
 		margin: auto;
 	}
 }
+
+.woocommerce .wc-block-catalog-sorting {
+	.woocommerce-ordering {
+		margin: auto;
+	}
+}

--- a/assets/js/blocks/product-results-count/style.scss
+++ b/assets/js/blocks/product-results-count/style.scss
@@ -15,3 +15,11 @@
 		margin: auto;
 	}
 }
+
+.woocommerce.woocommerce-shop .wc-block-breadcrumbs {
+	.woocommerce-breadcrumb {
+		margin: auto;
+		display: block;
+	}
+}
+

--- a/assets/js/blocks/product-results-count/style.scss
+++ b/assets/js/blocks/product-results-count/style.scss
@@ -5,5 +5,7 @@
 	.woocommerce-result-count {
 		float: none;
 		font-size: inherit;
+		// reset for margin
+		margin: auto;
 	}
 }


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

While testing the implementations of the Store Breadcrumbs, Catalog Sorting and Product Result Counts block, I noticed that on some themes the margins were causing some spacing alignment issues. I also noticed that the Store Breadcrumbs block was not even showing on some pages (Shop page) because of some [theme specific rules shipped with WooCommerce core](https://github.com/Automattic/theme-tsubaki/blob/6135086b08dd13ac625e973a067e730edecb04a5/functions.php#L61-L66).

Below screenshots are on the Twenty Twenty Two theme.

### Store Breadcrumbs

### Misaligned Margin

| Before | After |
|-------| ----- |
| <img width="1372" alt="CleanShot 2023-02-07 at 07 57 57@2x" src="https://user-images.githubusercontent.com/1429108/217170772-cc744548-3a4e-4dc0-9572-26a7bbbb57e3.png"> | <img width="1359" alt="CleanShot 2023-02-07 at 07 58 58@2x" src="https://user-images.githubusercontent.com/1429108/217170974-ce17659b-95aa-49a6-9211-4b7d26f12cb5.png"> |

### Breadcrumbs not even displaying for shop page.

While it appears okay when editing the Product Catalog template, it is not shown on the frontend for certain themes. It surfaced with Twenty Twenty Two (or derivatives of that theme) for me. 

| Before | After |
|-------|--------|
| <img width="1362" alt="CleanShot 2023-02-07 at 08 01 49@2x" src="https://user-images.githubusercontent.com/1429108/217171425-48704f27-e0ec-47f7-ab50-b30745a13701.png"> | <img width="1339" alt="CleanShot 2023-02-07 at 08 02 29@2x" src="https://user-images.githubusercontent.com/1429108/217171552-c9f18564-6266-4aa8-92e9-11b0b9eaf05d.png"> |

## Catalog Sorting Block

| Before | After |
| ------ | ----- |
| <img width="1358" alt="CleanShot 2023-02-07 at 08 03 42@2x" src="https://user-images.githubusercontent.com/1429108/217171772-e8cadea6-2398-4a6b-809b-ae8996dd1521.png"> | <img width="1360" alt="CleanShot 2023-02-07 at 08 04 20@2x" src="https://user-images.githubusercontent.com/1429108/217171870-60940c0d-b484-4ea3-a187-040879eb234f.png"> |

## Product Results Count

| Before | After |
| ------ | ------ |
| <img width="1359" alt="CleanShot 2023-02-07 at 08 05 19@2x" src="https://user-images.githubusercontent.com/1429108/217172067-5304961f-b515-489c-bb2a-232faaec15ce.png"> | <img width="1365" alt="CleanShot 2023-02-07 at 08 05 54@2x" src="https://user-images.githubusercontent.com/1429108/217172178-7b4e1664-1fd0-4a00-99e7-5478db86ba84.png">

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

The issues are primarily visible with the Twenty Twenty Two theme. However, testing should be done against some other themes to make sure this doesn't introduce significant issues with those themes. In theory, it _shouldn't_ because the CSS for the blocks should appropriately inherit what the theme provides for default margins and spacing in the container around the blocks.

1. Go to the "Product Catalog" Template in the Site Editor (`Appearance` -> `Editor`).
2. Paste the following after the header in the template:

```
<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
<div class="wp-block-group"><!-- wp:woocommerce/breadcrumbs {"textColor":"pale-pink","style":{"elements":{"link":{"color":{"text":"var:preset|color|light-green-cyan"}}}}} /-->

<!-- wp:woocommerce/catalog-sorting /-->

<!-- wp:woocommerce/product-results-count {"textColor":"vivid-green-cyan"} /--></div>
<!-- /wp:group -->
```
3. Make sure that in the editor view the alignment for the blocks appears as in the above screenshots.
4. Make sure that the shop catalog on the frontend (default is `sitedomain.com/shop` on most WP installs) shows all blocks aligned as in the above screenshots.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Fix spacing and display issues for Store Breadcrumbs, Catalog Sorting and Product Result Counts blocks.
