### PR TITLE
Capture and disregard sibling notices

### DIFF
--- a/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/block.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/block.tsx
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import { useMemo, useEffect, Fragment, useState } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
+import { STORE_NOTICES_STORE_KEY } from '@woocommerce/block-data';
 import {
 	useCheckoutAddress,
 	useStoreEvents,
@@ -45,6 +47,9 @@ const Block = ( {
 		useBillingAsShipping,
 	} = useCheckoutAddress();
 	const { dispatchCheckoutEvent } = useStoreEvents();
+	const { registerContainer, unregisterContainer } = useDispatch(
+		STORE_NOTICES_STORE_KEY
+	);
 	const { isEditor } = useEditorContext();
 	// Clears data if fields are hidden.
 	useEffect( () => {
@@ -70,6 +75,18 @@ const Block = ( {
 		billingAddress,
 		useBillingAsShipping,
 	] );
+
+	// Capture sibling block notices
+	useEffect( () => {
+		if ( useBillingAsShipping ) {
+			registerContainer( noticeContexts.SHIPPING_ADDRESS );
+		}
+		return () => {
+			if ( useBillingAsShipping ) {
+				unregisterContainer( noticeContexts.SHIPPING_ADDRESS );
+			}
+		};
+	}, [ registerContainer, unregisterContainer, useBillingAsShipping ] );
 
 	const addressFieldsConfig = useMemo( () => {
 		return {

--- a/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/block.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/block.tsx
@@ -3,6 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useMemo, useEffect, Fragment, useState } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
+import { STORE_NOTICES_STORE_KEY } from '@woocommerce/block-data';
 import { AddressForm } from '@woocommerce/base-components/cart-checkout';
 import {
 	useCheckoutAddress,
@@ -50,6 +52,9 @@ const Block = ( {
 		setUseShippingAsBilling,
 	} = useCheckoutAddress();
 	const { dispatchCheckoutEvent } = useStoreEvents();
+	const { registerContainer, unregisterContainer } = useDispatch(
+		STORE_NOTICES_STORE_KEY
+	);
 	const { isEditor } = useEditorContext();
 
 	// This is used to track whether the "Use shipping as billing" checkbox was checked on first load and if we synced
@@ -79,6 +84,18 @@ const Block = ( {
 		shippingAddress,
 		useShippingAsBilling,
 	] );
+
+	// Capture sibling block notices
+	useEffect( () => {
+		if ( useShippingAsBilling ) {
+			registerContainer( noticeContexts.BILLING_ADDRESS );
+		}
+		return () => {
+			if ( useShippingAsBilling ) {
+				unregisterContainer( noticeContexts.BILLING_ADDRESS );
+			}
+		};
+	}, [ registerContainer, unregisterContainer, useShippingAsBilling ] );
 
 	const addressFieldsConfig = useMemo( () => {
 		return {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
Recently in https://github.com/woocommerce/woocommerce-blocks/pull/8182 we introduced more controlled notice handling, this included showing notices in the correct places when needed and surfacing notices up to the main block when it makes sense.

However, this introduced a problem in sibling blocks (Shipping address billing address, payment and express payment) in which an error might be returned for both, but is rendered on one of them only while the other bubbles).

This PR adds extra logic in the block to register (capture) sibling notices, however, this prevents the notice from bubbling, however, it disregards the notice instead instead of rendering it.

<!-- Reference any related issues or PRs here -->

Alternative to https://github.com/woocommerce/woocommerce-blocks/pull/8390
Fixes https://github.com/woocommerce/woocommerce-blocks/issues/8387


### Testing

1. In Checkout, have billing as shipping.
2. Cause a bug in the zip code for example (wrong zipcode)
3. See that Checkout block will only show an error once, not in 2 places.


### Changelog

> Fix bug in which errors would be shown twice in Checkout block.
