### PR TITLE
Product Rating: Normalize the height of icons and the add revew link

### DIFF
--- a/assets/js/atomic/blocks/product-elements/rating/style.scss
+++ b/assets/js/atomic/blocks/product-elements/rating/style.scss
@@ -1,5 +1,6 @@
 .wc-block-components-product-rating {
 	display: block;
+	line-height: 1;
 
 	&__stars {
 		display: inline-block;
@@ -45,6 +46,7 @@
 
 	&__link {
 		display: inline-block;
+		height: 1.618em;
 		width: 100%;
 		text-align: inherit;
 		@include font-size(small);


### PR DESCRIPTION
This PR makes heights of rating star icons and the add review link consistent improving the in-line display of subsequent product elements.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|![before-5](https://user-images.githubusercontent.com/905781/217571875-feb5b7e1-95fb-45d2-af4f-99d151d2196d.jpg)|![after-5](https://user-images.githubusercontent.com/905781/217571891-6f233157-125a-4222-a1a8-8dd7cdac5674.jpg)|

### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Add a new page and the **Products** block.
2. Add the **Product Rating** block.
3. Make sure you have a product that doesn't have any ratings and one that does have at least one.
4. Notice that now the product element below the Rating displays _in line_. 

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Product Rating: Normalize the height of rating icons and the add review link.
