### PR TITLE
Prevent Cart hydration in the editor due to the All Products block

### DIFF
--- a/src/BlockTypes/AllProducts.php
+++ b/src/BlockTypes/AllProducts.php
@@ -30,11 +30,16 @@ class AllProducts extends AbstractBlock {
 		$this->asset_data_registry->add( 'min_rows', wc_get_theme_support( 'product_blocks::min_rows', 1 ), true );
 		$this->asset_data_registry->add( 'max_rows', wc_get_theme_support( 'product_blocks::max_rows', 6 ), true );
 		$this->asset_data_registry->add( 'default_rows', wc_get_theme_support( 'product_blocks::default_rows', 3 ), true );
-		$this->hydrate_from_api();
+
+		// Hydrate the following data depending on admin or frontend context.
+		if ( ! is_admin() && ! WC()->is_rest_api_request() ) {
+			$this->hydrate_from_api();
+		}
 	}
 
 	/**
-	 * Hydrate the All Product block with data from the API.
+	 * Hydrate the All Product block with data from the API. This is for the add to cart buttons which show current
+	 * quantity in cart, and events.
 	 */
 	protected function hydrate_from_api() {
 		$this->asset_data_registry->hydrate_api_request( '/wc/store/v1/cart' );


### PR DESCRIPTION
This PR prevents cart API requests in the editor due to the hydration of the All Products Block not being gated to the frontend.

Fixes #8244

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

```php
function thing_happens_in_editor() {
  die( 'Why' );
}
add_action( 'woocommerce_check_cart_items', 'thing_happens_in_editor', 1 );
```

Add this to the main plugin file to test.

1. Edit a page.
2. Confirm the page does not `die`

Remove the code and do the following:

1. Add the all products block to a page.
2. Save and view the page.
3. Open network inspector and confirm there were no extra requests made to the `cart` endpoint.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### Performance Impact

Reduces data sent along with requests in admin.

### Changelog

> Performance - Prevent extra API hydration in the editor when using All Products block
