### PR TITLE
Remove mention of newsletter-test repo

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -124,7 +124,6 @@ The WooCommerce Blocks Handbook provides documentation for designers and develop
 ### Tools
 
 -   [@woocommerce/extend-cart-checkout-block](https://www.npmjs.com/package/@woocommerce/extend-cart-checkout-block) This is a template to be used with @wordpress/create-block to create a WooCommerce Blocks extension starting point.
--   [How to integrate with inner blocks in the WooCommerce Blocks Checkout](https://github.com/woocommerce/newsletter-test) A repository with some example code showing how an extension can register an inner block for use in the Checkout Block.
 
 ### Articles
 


### PR DESCRIPTION
This repo has been replaced by the [@woocommerce/extend-cart-checkout-block](https://www.npmjs.com/package/@woocommerce/extend-cart-checkout-block) package so we should remove mention of it from the docs.