### PR TITLE
Remove newsletter repo example from the docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -123,8 +123,7 @@ The WooCommerce Blocks Handbook provides documentation for designers and develop
 
 ### Tools
 
--   [@woocommerce/extend-cart-checkout-block](https://www.npmjs.com/package/@woocommerce/extend-cart-checkout-block) This is a template to be used with @wordpress/create-block to create a WooCommerce Blocks extension starting point.
--   [How to integrate with inner blocks in the WooCommerce Blocks Checkout](https://github.com/woocommerce/newsletter-test) A repository with some example code showing how an extension can register an inner block for use in the Checkout Block.
+-   [@woocommerce/extend-cart-checkout-block](https://www.npmjs.com/package/@woocommerce/extend-cart-checkout-block) This is a template to be used with @wordpress/create-block to create a WooCommerce Blocks extension starting point. It also showcases how to use some extensibility points, like registering an inner block in the Checkout Block.
 
 ### Articles
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -123,7 +123,7 @@ The WooCommerce Blocks Handbook provides documentation for designers and develop
 
 ### Tools
 
--   [@woocommerce/extend-cart-checkout-block](https://www.npmjs.com/package/@woocommerce/extend-cart-checkout-block) This is a template to be used with @wordpress/create-block to create a WooCommerce Blocks extension starting point. It also showcases how to use some extensibility points, like registering an inner block in the Checkout Block.
+-   [@woocommerce/extend-cart-checkout-block](https://www.npmjs.com/package/@woocommerce/extend-cart-checkout-block) This is a template to be used with @wordpress/create-block to create a WooCommerce Blocks extension starting point. It also showcases how to use some extensibility points, e.g. registering an inner block in the Checkout Block, applying filters to certain texts such as the place order button, using Slot/Fill and how to change the behaviour of the Store API.
 
 ### Articles
 


### PR DESCRIPTION
The newsletter is not maintained anymore and we use the @woocommerce/extend-cart-checkout-block to showcase our extensibility points

