### PR TITLE
Add support for woocommerce_loop_add_to_cart_args filter in Products block

### DIFF
--- a/src/BlockTypes/ProductButton.php
+++ b/src/BlockTypes/ProductButton.php
@@ -89,26 +89,49 @@ class ProductButton extends AbstractBlock {
 			$html_element                  = ( ! $product->has_options() && $product->is_purchasable() && $product->is_in_stock() && ! $cart_redirect_after_add ) ? 'button' : 'a';
 			$styles_and_classes            = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, array( 'border_radius', 'font_size', 'font_weight', 'margin', 'padding', 'text_color' ) );
 			$text_align_styles_and_classes = StyleAttributesUtils::get_text_align_class_and_style( $attributes );
+			$html_classes                  = implode(
+				' ',
+				array_filter(
+					array(
+						'wp-block-button__link',
+						'wc-block-components-product-button__button',
+						$product->is_purchasable() && ! $product->has_options() ? 'ajax_add_to_cart add_to_cart_button' : '',
+						'product_type_' . $product->get_type(),
+						$styles_and_classes['classes'],
+					)
+				)
+			);
+
+			$args = apply_filters(
+				'woocommerce_loop_add_to_cart_args',
+				array(
+					'class'      => $html_classes,
+					'attributes' => array(
+						'data-product_id'  => $product->get_id(),
+						'data-product_sku' => $product->get_sku(),
+						'rel'              => 'nofollow',
+					),
+				),
+				$product
+			);
 
 			return apply_filters(
 				'woocommerce_loop_add_to_cart_link',
 				sprintf(
 					'<div class="wp-block-button wc-block-components-product-button wc-block-grid__product-add-to-cart %1$s">
-					<%2$s href="%3$s" rel="nofollow" data-product_id="%4$s" data-product_sku="%5$s" class="wp-block-button__link %6$s wc-block-components-product-button__button product_type_%7$s %8$s" style="%9$s">%10$s</%11$s>
+					<%2$s href="%3$s" class="%4$s" style="%5$s" %6$s>%7$s</%8$s>
 				</div>',
 					esc_attr( $text_align_styles_and_classes['class'] ?? '' ),
 					$html_element,
 					esc_url( $product->add_to_cart_url() ),
-					esc_attr( $product->get_id() ),
-					esc_attr( $product->get_sku() ),
-					$product->is_purchasable() && ! $product->has_options() ? 'ajax_add_to_cart add_to_cart_button' : '',
-					esc_attr( $product->get_type() ),
-					esc_attr( $styles_and_classes['classes'] ),
+					esc_attr( array_key_exists( 'class', $args ) ? $args['class'] : '' ),
 					esc_attr( $styles_and_classes['styles'] ),
+					isset( $args['attributes'] ) ? wc_implode_html_attributes( $args['attributes'] ) : '',
 					esc_html( $product->add_to_cart_text() ),
 					$html_element
 				),
-				$product
+				$product,
+				$args
 			);
 		}
 	}

--- a/src/BlockTypes/ProductButton.php
+++ b/src/BlockTypes/ProductButton.php
@@ -119,7 +119,7 @@ class ProductButton extends AbstractBlock {
 				'woocommerce_loop_add_to_cart_link',
 				sprintf(
 					'<div class="wp-block-button wc-block-components-product-button wc-block-grid__product-add-to-cart %1$s">
-					<%2$s href="%3$s" class="%4$s" style="%5$s" %6$s>%7$s</%8$s>
+					<%2$s href="%3$s" class="%4$s" style="%5$s" %6$s>%7$s</%2$s>
 				</div>',
 					esc_attr( $text_align_styles_and_classes['class'] ?? '' ),
 					$html_element,
@@ -127,8 +127,7 @@ class ProductButton extends AbstractBlock {
 					esc_attr( array_key_exists( 'class', $args ) ? $args['class'] : '' ),
 					esc_attr( $styles_and_classes['styles'] ),
 					isset( $args['attributes'] ) ? wc_implode_html_attributes( $args['attributes'] ) : '',
-					esc_html( $product->add_to_cart_text() ),
-					$html_element
+					esc_html( $product->add_to_cart_text() )
 				),
 				$product,
 				$args

--- a/src/BlockTypes/ProductButton.php
+++ b/src/BlockTypes/ProductButton.php
@@ -109,11 +109,16 @@ class ProductButton extends AbstractBlock {
 					'attributes' => array(
 						'data-product_id'  => $product->get_id(),
 						'data-product_sku' => $product->get_sku(),
+						'aria-label'       => $product->add_to_cart_description(),
 						'rel'              => 'nofollow',
 					),
 				),
 				$product
 			);
+
+			if ( isset( $args['attributes']['aria-label'] ) ) {
+				$args['attributes']['aria-label'] = wp_strip_all_tags( $args['attributes']['aria-label'] );
+			}
 
 			return apply_filters(
 				'woocommerce_loop_add_to_cart_link',

--- a/src/BlockTypes/ProductButton.php
+++ b/src/BlockTypes/ProductButton.php
@@ -124,7 +124,7 @@ class ProductButton extends AbstractBlock {
 					esc_attr( $text_align_styles_and_classes['class'] ?? '' ),
 					$html_element,
 					esc_url( $product->add_to_cart_url() ),
-					esc_attr( array_key_exists( 'class', $args ) ? $args['class'] : '' ),
+					isset( $args['class'] ) ? esc_attr( $args['class'] ) : '',
 					esc_attr( $styles_and_classes['styles'] ),
 					isset( $args['attributes'] ) ? wc_implode_html_attributes( $args['attributes'] ) : '',
 					esc_html( $product->add_to_cart_text() )


### PR DESCRIPTION
Fixes #8020.

Some of this code is based on similar code found in WC core:
* https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/templates/loop/add-to-cart.php#L24
* https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/includes/wc-template-functions.php#L1343

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. Add the Products (Beta) block to a post or page.
2. In any PHP file (ie: in `woocommerce-gutenberg-products-block.php`), add these two filters:

```PHP
add_filter(
	'woocommerce_loop_add_to_cart_args',
	function ( $args, $product ) {
		return array(
			// Add `custom-class` to the class list.
			'class'      => $args['class'] . ' custom-class',
			// Remove all other attributes and only leave `data-foo`.
			'attributes' => array(
				'data-foo' => 'bar',
			),
		);
	},
	10,
	2
);
add_filter(
	'woocommerce_loop_add_to_cart_link',
	function ( $link, $product, $args ) {
		// Verify $args is available in this filter.
		echo '<pre>';
		print_r( $args );
		echo '</pre>';
		// Add a Lorem ipsum header.
		return '<h1>Lorem ipsum</h1>' . $link;
	},
	10,
	3
);
```
3. Visit the page with the Products block in the frontend and verify:
3.1. `$args` is correctly printed in the screen and includes the args returned in the `woocommerce_loop_add_to_cart_args` filter.
3.2. Each _Add to cart_ button has the `custom-class` alongside all other classes.
3.3. Each _Add to cart_ button has the `data-foo="bar"` attribute.
3.4. A `Lorem ipsum` header is added before each _Add to cart_ button.
<img src="https://user-images.githubusercontent.com/3616980/218762558-3b142f12-747f-4d29-9a57-2ace8758f5bb.png" alt="" width="240" />

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Add support for the `woocommerce_loop_add_to_cart_args` filter in the Products block
