### PR TITLE
Checkout/Store API - Allow partial pushes without country

### DIFF
--- a/assets/js/data/cart/index.ts
+++ b/assets/js/data/cart/index.ts
@@ -13,7 +13,7 @@ import * as actions from './actions';
 import * as resolvers from './resolvers';
 import reducer, { State } from './reducers';
 import type { SelectFromMap, DispatchFromMap } from '../mapped-types';
-import { pushChanges } from './push-changes';
+import { pushChanges, flushChanges } from './push-changes';
 import {
 	updatePaymentMethods,
 	debouncedUpdatePaymentMethods,
@@ -33,6 +33,11 @@ const registeredStore = registerStore< State >( STORE_KEY, {
 } );
 
 registeredStore.subscribe( pushChanges );
+
+// This will skip the debounce and immediately push changes to the server when a field is blurred.
+document.body.addEventListener( 'focusout', () => {
+	flushChanges();
+} );
 
 // First we will run the updatePaymentMethods function without any debounce to ensure payment methods are ready as soon
 // as the cart is loaded. After that, we will unsubscribe this function and instead run the

--- a/assets/js/data/cart/index.ts
+++ b/assets/js/data/cart/index.ts
@@ -35,8 +35,14 @@ const registeredStore = registerStore< State >( STORE_KEY, {
 registeredStore.subscribe( pushChanges );
 
 // This will skip the debounce and immediately push changes to the server when a field is blurred.
-document.body.addEventListener( 'focusout', () => {
-	flushChanges();
+document.body.addEventListener( 'focusout', ( event: FocusEvent ) => {
+	if (
+		event.target &&
+		event.target instanceof Element &&
+		event.target.tagName.toLowerCase() === 'input'
+	) {
+		flushChanges();
+	}
 } );
 
 // First we will run the updatePaymentMethods function without any debounce to ensure payment methods are ready as soon

--- a/assets/js/data/cart/push-changes.ts
+++ b/assets/js/data/cart/push-changes.ts
@@ -176,7 +176,7 @@ const updateCustomerData = debounce( (): void => {
 				processErrorResponse( response );
 			} );
 	}
-}, 3000 );
+}, 5000 );
 
 /**
  * After cart has fully initialized, pushes changes to the server when data in the store is changed. Updates to the
@@ -240,4 +240,8 @@ export const pushChanges = (): void => {
 	) {
 		updateCustomerData();
 	}
+};
+
+export const flushChanges = (): void => {
+	updateCustomerData.flush();
 };

--- a/assets/js/data/cart/push-changes.ts
+++ b/assets/js/data/cart/push-changes.ts
@@ -176,7 +176,7 @@ const updateCustomerData = debounce( (): void => {
 				processErrorResponse( response );
 			} );
 	}
-}, 5000 );
+}, 1000 );
 
 /**
  * After cart has fully initialized, pushes changes to the server when data in the store is changed. Updates to the

--- a/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -167,15 +167,7 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 		$errors  = new \WP_Error();
 		$address = $this->sanitize_callback( $address, $request, $param );
 
-		if ( empty( $address['country'] ) ) {
-			$errors->add(
-				'missing_country',
-				__( 'Country is required', 'woo-gutenberg-products-block' )
-			);
-			return $errors;
-		}
-
-		if ( ! in_array( $address['country'], array_keys( wc()->countries->get_countries() ), true ) ) {
+		if ( ! empty( $address['country'] ) && ! in_array( $address['country'], array_keys( wc()->countries->get_countries() ), true ) ) {
 			$errors->add(
 				'invalid_country',
 				sprintf(


### PR DESCRIPTION
Continuing on from https://github.com/woocommerce/woocommerce-blocks/pull/8400, this PR ensures the push logic works if the country field is blank or not included with the request. Previously, if you were a guest without an address the pushes would fail if you left out country. This meant that performing certain actions, such as applying a coupon, would reset fields because the server is not in sync with client.

### Testing

#### User Facing Testing

1. WooCommerce > Settings > General, set "Default customer location" to no address.
2. Logged out, in a new browser window/incognito mode, add something to the cart and go to checkout.
3. Enter your email address, a first name, and a last name.
4. Apply a coupon.
5. When the coupon has applied, ensure the address fields you entered were not removed.
6. Successfully place an order.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

I increased the debounce from 1 second to 3, since we're pushing more fields now and don't want to push excessively. 

### Changelog

> Checkout - Allow partial pushes of address data to work before a country is provided.
