### PR TITLE
Add link and correct version to deprecated `__experimentalApplyCheckoutFilter` warning

### DIFF
--- a/packages/checkout/filter-registry/index.ts
+++ b/packages/checkout/filter-registry/index.ts
@@ -71,8 +71,8 @@ export const __experimentalRegisterCheckoutFilters = (
 	deprecated( '__experimentalRegisterCheckoutFilters', {
 		alternative: 'registerCheckoutFilters',
 		plugin: 'WooCommerce Blocks',
-		link: '',
-		since: '6.0.0',
+		link: 'https://github.com/woocommerce/woocommerce-blocks/pull/8346',
+		since: '9.6.0',
 		hint: '__experimentalRegisterCheckoutFilters has graduated to stable and this experimental function will be removed.',
 	} );
 	registerCheckoutFilters( namespace, filters );
@@ -279,8 +279,8 @@ export const __experimentalApplyCheckoutFilter = < T >( {
 	deprecated( '__experimentalApplyCheckoutFilter', {
 		alternative: 'applyCheckoutFilter',
 		plugin: 'WooCommerce Blocks',
-		link: '',
-		since: '6.0.0',
+		link: 'https://github.com/woocommerce/woocommerce-blocks/pull/8346',
+		since: '9.6.0',
 		hint: '__experimentalApplyCheckoutFilter has graduated to stable and this experimental function will be removed.',
 	} );
 	return applyCheckoutFilter( {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR updates the link and version number in the deprecated message that was added for `__experimentalRegisterCheckoutFilters` and `__experimentalApplyCheckoutFilters`.

In https://github.com/woocommerce/woocommerce-blocks/pull/8346 these were deprecated but the link was not added.

<img width="644" alt="image" src="https://user-images.githubusercontent.com/5656702/218828385-4abaf18e-41a0-4ea8-b9a5-0aca6488005f.png">

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Follow the testing steps in https://github.com/woocommerce/woocommerce-blocks/pull/8346/ and verify the version number is correct and the PR is linked in the deprecated message.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Skipping
