### PR TITLE
Fix Customer account sidebar link incorrect margin in WP 6.2

### DIFF
--- a/assets/js/blocks/customer-account/editor.scss
+++ b/assets/js/blocks/customer-account/editor.scss
@@ -2,6 +2,11 @@
 	width: 100%;
 }
 
-.account-link {
+/* In sidebar without tabs (WP <=6.1) */
+.block-editor-block-card + div > .account-link {
 	padding: 0 $gap $gap 52px;
+}
+/* In tabbed sidebar (ie: WP >=6.2) */
+.account-link {
+	padding: $gap;
 }

--- a/assets/js/blocks/customer-account/editor.scss
+++ b/assets/js/blocks/customer-account/editor.scss
@@ -3,10 +3,10 @@
 }
 
 /* In sidebar without tabs (WP <=6.1) */
-.block-editor-block-card + div > .account-link {
+.block-editor-block-card + div > .wc-block-editor-customer-account__link {
 	padding: 0 $gap $gap 52px;
 }
 /* In tabbed sidebar (ie: WP >=6.2) */
-.account-link {
+.wc-block-editor-customer-account__link {
 	padding: $gap;
 }

--- a/assets/js/blocks/customer-account/sidebar-settings.tsx
+++ b/assets/js/blocks/customer-account/sidebar-settings.tsx
@@ -47,7 +47,11 @@ const AccountSettingsLink = () => {
 		}
 	);
 
-	return <div className="account-link">{ linkText }</div>;
+	return (
+		<div className="wc-block-editor-customer-account__link">
+			{ linkText }
+		</div>
+	);
 };
 
 export const BlockSettings = ( {


### PR DESCRIPTION
Fixes #8435.

In 40e7d31be012ee614ec699ac5d6871ba707393f8 I also updated the class name to match [the guidelines](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/contributors/contributing/coding-guidelines.md#naming).

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. In WP 6.1 without Gutenberg installed, verify there are no regressions:
1.1. Add the Customer account block to a post or page.
1.2. In the editor, open the sidebar and verify the Manage account settings link is displayed below the product description.
2. In WP 6.2 or WP 6.1 with Gutenberg installed, verify the link has correct margins:
2.1. Add the Customer account block to a post or page.
1.2. In the editor, open the sidebar and verify the Manage account settings link has correct margins.

· | WP 6.1 without GB enabled | WP 6.1 with GB enabled |
--- | --- | --- |
Before | ![imatge](https://user-images.githubusercontent.com/3616980/219014857-6071a40e-8770-4f1f-b37c-91e5bf7451b5.png) | ![imatge](https://user-images.githubusercontent.com/3616980/219015103-982b2663-a15a-4101-9f24-83478b0e6eea.png) |
After | ![imatge](https://user-images.githubusercontent.com/3616980/219014857-6071a40e-8770-4f1f-b37c-91e5bf7451b5.png) | ![imatge](https://user-images.githubusercontent.com/3616980/219014964-505597f7-2f52-42c8-91ad-04c130bfff78.png) | 

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix Customer account sidebar link incorrect margin in WP 6.2.
