### PR TITLE
Prevent cart from breaking when item_data contains an array

### DIFF
--- a/src/StoreApi/Schemas/V1/CartItemSchema.php
+++ b/src/StoreApi/Schemas/V1/CartItemSchema.php
@@ -480,7 +480,7 @@ class CartItemSchema extends ProductSchema {
 			$item_data_element['hidden'] = $item_data_element['__experimental_woocommerce_blocks_hidden'];
 		}
 
-		foreach ( $item_data_element as $key => $item ) {
+		foreach ( $item_data_element as $item ) {
 			if ( ! is_scalar( $item ) ) {
 				return [];
 			}

--- a/src/StoreApi/Schemas/V1/CartItemSchema.php
+++ b/src/StoreApi/Schemas/V1/CartItemSchema.php
@@ -459,7 +459,14 @@ class CartItemSchema extends ProductSchema {
 		 * @return array
 		 */
 		$item_data = apply_filters( 'woocommerce_get_item_data', array(), $cart_item );
-		return array_map( [ $this, 'format_item_data_element' ], $item_data );
+		return array_values(
+			array_filter(
+				array_map( [ $this, 'format_item_data_element' ], $item_data ),
+				function ( $item ) {
+						return ! empty( $item );
+				}
+			)
+		);
 	}
 
 	/**
@@ -471,6 +478,12 @@ class CartItemSchema extends ProductSchema {
 	protected function format_item_data_element( $item_data_element ) {
 		if ( array_key_exists( '__experimental_woocommerce_blocks_hidden', $item_data_element ) ) {
 			$item_data_element['hidden'] = $item_data_element['__experimental_woocommerce_blocks_hidden'];
+		}
+
+		foreach ( $item_data_element as $key => $item ) {
+			if ( ! is_scalar( $item ) ) {
+				return [];
+			}
 		}
 		return array_map( 'wp_strip_all_tags', $item_data_element );
 	}

--- a/src/StoreApi/Schemas/V1/CartItemSchema.php
+++ b/src/StoreApi/Schemas/V1/CartItemSchema.php
@@ -465,7 +465,7 @@ class CartItemSchema extends ProductSchema {
 		$valid_item_data = array_filter(
 			$formatted_item_data,
 			function ( $item ) {
-				return ! empty( $item );
+				return null !== $item;
 			}
 		);
 
@@ -489,7 +489,7 @@ class CartItemSchema extends ProductSchema {
 		// which will be filtered out in get_item_data (after this function has run).
 		foreach ( $item_data_element as $item ) {
 			if ( ! is_scalar( $item ) ) {
-				return [];
+				return null;
 			}
 		}
 		return array_map( 'wp_strip_all_tags', $item_data_element );


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
It was reported in p1676459035348189-slack-C01DT6U03HC that some users were seeing fatal errors relating to the wrong type being passed to `wp_strip_all_tags`, this can occur when an extension adds item data, but one of the values is an array, rather than a scalar.

<!-- Reference any related issues or PRs here -->

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [x] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact. @senadir tagging you too, because this touches near `wp_strip_all_tags` I would like us to be super sure this change has no security impact. Note, I don't think it does because we are simply returning an empty array, so the untrusted data is entirely removed OR passed through `wp_strip_all_tags`.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Add this code somewhere it will execute.
```php
add_filter(
    'woocommerce_get_item_data',
    function( $item ) {
        return array_merge( $item, [
            [
                'name' => 'data_1',
                'value' => [ 'breaking' => '<script>alert("data!")</script>' ]
            ],
            [
                'name' => 'Other data',
                'value' => 'Should show <script>alert("but this shouldnt")</script>',
            ]
        ] );
    }
);
```
3. Add items to your cart and open the Cart block, ensure you see `Other data: Should show` on the cart items. Ensure the script is not rendered or executed!
4. If you have WC Subscriptions installed, create a subscription item and add a sign-up fee and free trial to it.
5. Add this item to your cart and load the Cart block. Ensure the signup and free trial information shows up ok.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Fixed an issue where cart item data could cause fatal errors if it was an array.