### PR TITLE
Check if property exists before accessing

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -295,7 +295,7 @@ class BlockTemplatesController {
 			$fits_slug_query =
 				! isset( $query['slug__in'] ) || in_array( $template_file->slug, $query['slug__in'], true );
 			$fits_area_query =
-				! isset( $query['area'] ) || $template_file->area === $query['area'];
+				! isset( $query['area'] ) || ( property_exists( $template_file, 'area' ) && $template_file->area === $query['area'] );
 			$should_include  = $is_not_custom && $fits_slug_query && $fits_area_query;
 			if ( $should_include ) {
 				$query_result[] = $template;


### PR DESCRIPTION
This PR fixes the error: ```Notice: Undefined property: stdClass::$area in BlockTemplatesController.php```
Check whether the property `area` exists before accessing it.

This PR https://github.com/woocommerce/woocommerce-blocks/pull/7341 was created in October last year by an external contributor, but they've been unresponsive since then, so I've recreated it because some of the checks were failing and this way we have more control.

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/7299

### Testing
#### User-Facing Testing
1. Use `get_block_templates` like this
```
add_action( 'wp', function(){
	$header_template_parts = get_block_templates( array( 'area' => 'header' ), 'wp_template_part');
});
```
2. Go to the store homepage and check there error does not appear anymore.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix error: "Undefined property $area" error on the BlockTemplatesController.
