### PR TITLE
Product Image Gallery: fix 404 error

### DIFF
--- a/src/BlockTypes/ProductImageGallery.php
+++ b/src/BlockTypes/ProductImageGallery.php
@@ -1,9 +1,6 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
-use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
-
-
 /**
  * ProductImageGallery class.
  */
@@ -14,6 +11,13 @@ class ProductImageGallery extends AbstractBlock {
 	 * @var string
 	 */
 	protected $block_name = 'product-image-gallery';
+
+	/**
+	 * It isn't necessary register block assets because it is a server side block.
+	 */
+	protected function register_block_type_assets() {
+		return null;
+	}
 
 	/**
 	 *  Register the context


### PR DESCRIPTION
This PR fixes the 404 error. Since it is a server-side block, it isn't necessary to enqueue any asset.

Fixes #8436 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Testing


#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Go to Site Editor.
2. Check the network and see that any 404 error is visible.
3. Open the Single Product template.
4. Add the Product Image Gallery.
5. Be sure that it is visible on the front end.


* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

