### PR TITLE
Skip `generate-zip-file` action when `skip-zip` label is present on the PR

### DIFF
--- a/.github/workflows/generate-zip.yml
+++ b/.github/workflows/generate-zip.yml
@@ -4,6 +4,7 @@ on: [pull_request]
 
 jobs:
   generate-zip-file:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-zip') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
This PR adds a condition to the `generate-zip-file` GH action to be skipped if the PR has the `skip-zip` label.

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/6909

### Testing
1. Create a test PR and check the `generate-zip-file` runs.
2. Add the `skip-zip` label and push again.
3. Make sure now the `generate-zip-file` action is skipped.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
