### PR TITLE
Product Image Gallery: not declare the same method twice

### DIFF
--- a/src/BlockTypes/ProductImageGallery.php
+++ b/src/BlockTypes/ProductImageGallery.php
@@ -29,14 +29,6 @@ class ProductImageGallery extends AbstractBlock {
 	}
 
 	/**
-	 * It isn't necessary register block assets because it is a server side block.
-	 */
-	protected function register_block_type_assets() {
-		return null;
-	}
-
-
-	/**
 	 * Include and render the block.
 	 *
 	 * @param array    $attributes Block attributes. Default empty array.


### PR DESCRIPTION
After the merge of #8225, the Product Image Gallery class has the same method declared twice. This PR fixes the issue.
