### PR TITLE
Add minimum height to Mini Cart Contents block in the Style Book

### DIFF
--- a/assets/js/blocks/mini-cart/mini-cart-contents/editor.scss
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/editor.scss
@@ -79,3 +79,9 @@
 		color: currentColor;
 	}
 }
+
+.editor-styles-wrapper .wp-block-woocommerce-mini-cart-contents,
+.editor-styles-wrapper .wp-block-woocommerce-filled-mini-cart-contents-block {
+	height: auto;
+	min-height: 500px;
+}


### PR DESCRIPTION
The Mini Cart Contents block was not visible in the Style Book because it was getting a height of `0px`. This PR adds a `500px` minimum height and sets `height` back to `auto`, which is required because the [dynamic viewport size](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/assets/js/blocks/mini-cart/style.scss#L90-L91) we use doesn't seem to play well inside an `<iframe>`, like in the Style Book.

### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. With Gutenberg installed and a block theme like [Twenty Twenty-Three](https://wordpress.org/themes/twentytwentythree/) enabled.
2. Go to Appearance > Editor and edit a template.
3. In the toolbar, select Styles (black and white circle) and then, Open Style Book (eye icon).
4. Go to the WooCommerce tab.
5. Ensure the Mini Cart Contents block is visible.

| Before | After |
| ------ | ----- |
| ![imatge](https://user-images.githubusercontent.com/3616980/219356399-cd2c16c1-4256-42e4-a59b-0a77d273ebc7.png) | ![imatge](https://user-images.githubusercontent.com/3616980/219356269-9cc6ece5-5f5f-4df9-8e57-dc158bcace8d.png) |

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Make Mini Cart Contents block visible in the Style Book.
