### PR TITLE
e2e tests: update close modal aria-label to match new versions of GB

### DIFF
--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -128,7 +128,18 @@ export const openWidgetEditor = async () => {
 export const closeModalIfExists = async () => {
 	if (
 		await page.evaluate( () => {
-			return !! document.querySelector( '.components-modal__header' );
+			return !! document.querySelector(
+				'.components-modal__header [aria-label="Close"]'
+			);
+		} )
+	) {
+		await page.click( '.components-modal__header [aria-label="Close"]' );
+	} else if (
+		// Previous versions of Gutenberg/WP used a different aria-label.
+		await page.evaluate( () => {
+			return !! document.querySelector(
+				'.components-modal__header [aria-label="Close dialog"]'
+			);
 		} )
 	) {
 		await page.click(

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -126,25 +126,13 @@ export const openWidgetEditor = async () => {
 };
 
 export const closeModalIfExists = async () => {
-	if (
-		await page.evaluate( () => {
-			return !! document.querySelector(
-				'.components-modal__header [aria-label="Close"]'
-			);
-		} )
-	) {
-		await page.click( '.components-modal__header [aria-label="Close"]' );
-	} else if (
-		// Previous versions of Gutenberg/WP used a different aria-label.
-		await page.evaluate( () => {
-			return !! document.querySelector(
-				'.components-modal__header [aria-label="Close dialog"]'
-			);
-		} )
-	) {
-		await page.click(
-			'.components-modal__header [aria-label="Close dialog"]'
-		);
+	// The modal close button can have different aria-labels, depending on the version of Gutenberg/WP.
+	// Newer versions (WP >=6.2) use `Close`, while older versions (WP <6.1) use `Close dialog`.
+	const closeButton = await page.$(
+		'.components-modal__header [aria-label="Close"], .components-modal__header [aria-label="Close dialog"]'
+	);
+	if ( closeButton ) {
+		await closeButton.click();
 	}
 };
 


### PR DESCRIPTION
Gutenberg changed the `aria-label` of the close button of the Widgets modal:

Before | After
--- | ---
![imatge](https://user-images.githubusercontent.com/3616980/219371771-29006314-c593-42db-88df-2d0d18f7b336.png) | ![imatge](https://user-images.githubusercontent.com/3616980/219371797-2af8ac03-0bc6-4e88-8b29-80f29fdcfae2.png)

so we need to update that in our tests as well.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests

#### User Facing Testing

1. Verify tests in `tests/e2e/specs/backend/mini-cart.test.js` pass.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->
