### PR TITLE
Filter out saved payment methods for payment gateways that are not enabled

### DIFF
--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -313,9 +313,9 @@ class Checkout extends AbstractBlock {
 		}
 
 		if ( $is_block_editor && ! $this->asset_data_registry->exists( 'globalPaymentMethods' ) ) {
-			$payment_methods           = WC()->payment_gateways->payment_gateways();
+			$payment_gateways          = $this->get_enabled_payment_gateways();
 			$formatted_payment_methods = array_reduce(
-				$payment_methods,
+				$payment_gateways,
 				function( $acc, $method ) {
 					if ( 'yes' === $method->enabled ) {
 						$acc[] = [
@@ -340,6 +340,21 @@ class Checkout extends AbstractBlock {
 		 * Fires after checkout block data is registered.
 		 */
 		do_action( 'woocommerce_blocks_checkout_enqueue_data' );
+	}
+
+	/**
+	 * Get payment methods that are enabled in settings.
+	 *
+	 * @return array
+	 */
+	protected function get_enabled_payment_gateways() {
+		$payment_gateways = WC()->payment_gateways->payment_gateways();
+		return array_filter(
+			$payment_gateways,
+			function( $payment_gateway ) {
+				return 'yes' === $payment_gateway->enabled;
+			}
+		);
 	}
 
 	/**
@@ -382,9 +397,23 @@ class Checkout extends AbstractBlock {
 			return;
 		}
 		add_filter( 'woocommerce_payment_methods_list_item', [ $this, 'include_token_id_with_payment_methods' ], 10, 2 );
+
+		$payment_gateways = $this->get_enabled_payment_gateways();
+		$payment_methods  = wc_get_customer_saved_methods_list( get_current_user_id() );
+
+		// Filter out payment methods that are not enabled.
+		foreach ( $payment_methods as $payment_method_group => $saved_payment_methods ) {
+			$payment_methods[ $payment_method_group ] = array_filter(
+				$saved_payment_methods,
+				function( $saved_payment_method ) use ( $payment_gateways ) {
+					return in_array( $saved_payment_method['method']['gateway'], array_keys( $payment_gateways ), true );
+				}
+			);
+		}
+
 		$this->asset_data_registry->add(
 			'customerPaymentMethods',
-			wc_get_customer_saved_methods_list( get_current_user_id() )
+			$payment_methods
 		);
 		remove_filter( 'woocommerce_payment_methods_list_item', [ $this, 'include_token_id_with_payment_methods' ], 10, 2 );
 	}


### PR DESCRIPTION
Prevents saved payment methods from displaying if the gateway that added them is disabled. This is done on the server side (hydration code).

Fixes #8282

### Testing

#### User Facing Testing

1. Install Stripe, enable it, and checkout (save your card to the account)
2. Checkout another order but this time confirm the method you saved in step 1 is displayed as an option.
3. Go to Payment settings  and uncheck the "enabled" checkbox for stripe. Do not disable the actual plugin.
4. Checkout again. Confirm the saved card is not visible.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Prevent saved cards from appearing that belong to gateways that are not enabled.
