### PR TITLE
Fix e2e tests related to inserting blocks

### DIFF
--- a/tests/e2e/specs/backend/add-to-cart-form.test.js
+++ b/tests/e2e/specs/backend/add-to-cart-form.test.js
@@ -13,7 +13,7 @@ import { searchForBlock } from '@wordpress/e2e-test-utils/build/inserter';
  */
 import {
 	filterCurrentBlocks,
-	insertWCBlock,
+	insertBlockDontWaitForInsertClose,
 	goToSiteEditor,
 	useTheme,
 	waitForCanvas,
@@ -45,15 +45,15 @@ describe( `${ block.name } Block`, () => {
 		} );
 
 		it( 'can be inserted in FSE area', async () => {
-			// We are using here the "insertWCBlock" function because the
+			// We are using here the "insertBlockDontWaitForInsertClose" function because the
 			// tests are flickering when we use the "insertBlock" function.
-			await insertWCBlock( block.name );
+			await insertBlockDontWaitForInsertClose( block.name );
 			await expect( canvas() ).toMatchElement( block.class );
 		} );
 
 		it( 'can be inserted more than once', async () => {
-			await insertWCBlock( block.name );
-			await insertWCBlock( block.name );
+			await insertBlockDontWaitForInsertClose( block.name );
+			await insertBlockDontWaitForInsertClose( block.name );
 			const foo = await filterCurrentBlocks(
 				( b ) => b.name === block.slug
 			);

--- a/tests/e2e/specs/backend/add-to-cart-form.test.js
+++ b/tests/e2e/specs/backend/add-to-cart-form.test.js
@@ -4,7 +4,6 @@
 import {
 	canvas,
 	createNewPost,
-	insertBlock,
 	switchUserToAdmin,
 } from '@wordpress/e2e-test-utils';
 import { searchForBlock } from '@wordpress/e2e-test-utils/build/inserter';
@@ -14,6 +13,7 @@ import { searchForBlock } from '@wordpress/e2e-test-utils/build/inserter';
  */
 import {
 	filterCurrentBlocks,
+	insertWCBlock,
 	goToSiteEditor,
 	useTheme,
 	waitForCanvas,
@@ -45,13 +45,15 @@ describe( `${ block.name } Block`, () => {
 		} );
 
 		it( 'can be inserted in FSE area', async () => {
-			await insertBlock( block.name );
+			// We are using here the "insertWCBlock" function because the
+			// tests are flickering when we use the "insertBlock" function.
+			await insertWCBlock( block.name );
 			await expect( canvas() ).toMatchElement( block.class );
 		} );
 
 		it( 'can be inserted more than once', async () => {
-			await insertBlock( block.name );
-			await insertBlock( block.name );
+			await insertWCBlock( block.name );
+			await insertWCBlock( block.name );
 			const foo = await filterCurrentBlocks(
 				( b ) => b.name === block.slug
 			);

--- a/tests/e2e/specs/backend/all-products.test.js
+++ b/tests/e2e/specs/backend/all-products.test.js
@@ -13,7 +13,6 @@ import {
 	insertBlockDontWaitForInsertClose,
 	openWidgetEditor,
 	closeModalIfExists,
-	openWidgetsEditorBlockInserter,
 } from '../../utils.js';
 
 const block = {
@@ -44,7 +43,6 @@ describe( `${ block.name } Block`, () => {
 			await merchant.login();
 			await openWidgetEditor();
 			await closeModalIfExists();
-			await openWidgetsEditorBlockInserter();
 			await searchForBlock( block.name );
 			const allProductsButton = await page.$x(
 				`//button//span[text()='${ block.name }']`

--- a/tests/e2e/specs/backend/breadcrumbs.test.js
+++ b/tests/e2e/specs/backend/breadcrumbs.test.js
@@ -14,7 +14,7 @@ import { searchForBlock } from '@wordpress/e2e-test-utils/build/inserter';
 import {
 	filterCurrentBlocks,
 	goToSiteEditor,
-	insertWCBlock,
+	insertBlockDontWaitForInsertClose,
 	useTheme,
 	waitForCanvas,
 } from '../../utils.js';
@@ -45,13 +45,13 @@ describe( `${ block.name } Block`, () => {
 		} );
 
 		it( 'can be inserted in FSE area', async () => {
-			await insertWCBlock( block.name );
+			await insertBlockDontWaitForInsertClose( block.name );
 			await expect( canvas() ).toMatchElement( block.class );
 		} );
 
 		it( 'can be inserted more than once', async () => {
-			await insertWCBlock( block.name );
-			await insertWCBlock( block.name );
+			await insertBlockDontWaitForInsertClose( block.name );
+			await insertBlockDontWaitForInsertClose( block.name );
 			const foo = await filterCurrentBlocks(
 				( b ) => b.name === block.slug
 			);

--- a/tests/e2e/specs/backend/breadcrumbs.test.js
+++ b/tests/e2e/specs/backend/breadcrumbs.test.js
@@ -4,7 +4,6 @@
 import {
 	canvas,
 	createNewPost,
-	insertBlock,
 	switchUserToAdmin,
 } from '@wordpress/e2e-test-utils';
 import { searchForBlock } from '@wordpress/e2e-test-utils/build/inserter';
@@ -15,6 +14,7 @@ import { searchForBlock } from '@wordpress/e2e-test-utils/build/inserter';
 import {
 	filterCurrentBlocks,
 	goToSiteEditor,
+	insertWCBlock,
 	useTheme,
 	waitForCanvas,
 } from '../../utils.js';
@@ -45,13 +45,13 @@ describe( `${ block.name } Block`, () => {
 		} );
 
 		it( 'can be inserted in FSE area', async () => {
-			await insertBlock( block.name );
+			await insertWCBlock( block.name );
 			await expect( canvas() ).toMatchElement( block.class );
 		} );
 
 		it( 'can be inserted more than once', async () => {
-			await insertBlock( block.name );
-			await insertBlock( block.name );
+			await insertWCBlock( block.name );
+			await insertWCBlock( block.name );
 			const foo = await filterCurrentBlocks(
 				( b ) => b.name === block.slug
 			);

--- a/tests/e2e/specs/backend/cart.test.js
+++ b/tests/e2e/specs/backend/cart.test.js
@@ -19,11 +19,7 @@ import { merchant } from '@woocommerce/e2e-utils';
 /**
  * Internal dependencies
  */
-import {
-	openWidgetEditor,
-	closeModalIfExists,
-	openWidgetsEditorBlockInserter,
-} from '../../utils.js';
+import { openWidgetEditor, closeModalIfExists } from '../../utils.js';
 
 const block = {
 	name: 'Cart',
@@ -142,7 +138,6 @@ describe( `${ block.name } Block`, () => {
 			await merchant.login();
 			await openWidgetEditor();
 			await closeModalIfExists();
-			await openWidgetsEditorBlockInserter();
 			await searchForBlock( block.name );
 			await page.waitForXPath(
 				`//button//span[text()='${ block.name }']`

--- a/tests/e2e/specs/backend/catalog-sorting.test.js
+++ b/tests/e2e/specs/backend/catalog-sorting.test.js
@@ -14,7 +14,7 @@ import {
 import {
 	filterCurrentBlocks,
 	goToSiteEditor,
-	insertWCBlock,
+	insertBlockDontWaitForInsertClose,
 	useTheme,
 	waitForCanvas,
 } from '../../utils.js';
@@ -45,16 +45,16 @@ describe( `${ block.name } Block`, () => {
 		} );
 
 		it( 'can be inserted in FSE area', async () => {
-			// We are using here the "insertWCBlock" function because the
+			// We are using here the "insertBlockDontWaitForInsertClose" function because the
 			// tests are flickering when we use the "insertBlock" function.
-			await insertWCBlock( block.name );
+			await insertBlockDontWaitForInsertClose( block.name );
 
 			await expect( canvas() ).toMatchElement( block.class );
 		} );
 
 		it( 'can be inserted more than once', async () => {
-			await insertWCBlock( block.name );
-			await insertWCBlock( block.name );
+			await insertBlockDontWaitForInsertClose( block.name );
+			await insertBlockDontWaitForInsertClose( block.name );
 			const catalogStoringBlock = await filterCurrentBlocks(
 				( b ) => b.name === block.slug
 			);

--- a/tests/e2e/specs/backend/catalog-sorting.test.js
+++ b/tests/e2e/specs/backend/catalog-sorting.test.js
@@ -14,6 +14,7 @@ import {
 import {
 	filterCurrentBlocks,
 	goToSiteEditor,
+	insertWCBlock,
 	useTheme,
 	waitForCanvas,
 } from '../../utils.js';
@@ -44,16 +45,16 @@ describe( `${ block.name } Block`, () => {
 		} );
 
 		it( 'can be inserted in FSE area', async () => {
-			// We are using here the "insertCatalogSorting" function because the
+			// We are using here the "insertWCBlock" function because the
 			// tests are flickering when we use the "insertBlock" function.
-			await insertCatalogSorting();
+			await insertWCBlock( block.name );
 
 			await expect( canvas() ).toMatchElement( block.class );
 		} );
 
 		it( 'can be inserted more than once', async () => {
-			await insertCatalogSorting();
-			await insertCatalogSorting();
+			await insertWCBlock( block.name );
+			await insertWCBlock( block.name );
 			const catalogStoringBlock = await filterCurrentBlocks(
 				( b ) => b.name === block.slug
 			);
@@ -61,12 +62,3 @@ describe( `${ block.name } Block`, () => {
 		} );
 	} );
 } );
-
-const insertCatalogSorting = async () => {
-	await searchForBlock( block.name );
-	await page.waitForXPath( `//button//span[text()='${ block.name }']` );
-	const insertButton = (
-		await page.$x( `//button//span[text()='${ block.name }']` )
-	 )[ 0 ];
-	await insertButton.click();
-};

--- a/tests/e2e/specs/backend/checkout.test.js
+++ b/tests/e2e/specs/backend/checkout.test.js
@@ -21,7 +21,6 @@ import {
 	searchForBlock,
 	openWidgetEditor,
 	closeModalIfExists,
-	openWidgetsEditorBlockInserter,
 } from '../../utils.js';
 
 const block = {
@@ -161,7 +160,6 @@ describe( `${ block.name } Block`, () => {
 			await merchant.login();
 			await openWidgetEditor();
 			await closeModalIfExists();
-			await openWidgetsEditorBlockInserter();
 			await searchForBlock( block.name );
 			const checkoutButton = await page.$x(
 				`//button//span[text()='${ block.name }']`

--- a/tests/e2e/specs/backend/mini-cart.test.js
+++ b/tests/e2e/specs/backend/mini-cart.test.js
@@ -11,7 +11,6 @@ import {
  * Internal dependencies
  */
 import {
-	openWidgetsEditorBlockInserter,
 	closeModalIfExists,
 	openWidgetEditor,
 	searchForBlock,
@@ -39,7 +38,6 @@ if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 3 ) {
 
 const addBlockToWidgetsArea = async () => {
 	await closeModalIfExists();
-	await openWidgetsEditorBlockInserter();
 	await searchForBlock( block.name );
 	await page.waitForXPath( block.selectors.insertButton );
 	const miniCartButton = await page.$x( block.selectors.insertButton );

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -93,22 +93,13 @@ export async function searchForBlock( searchTerm ) {
  * @param {string} searchTerm The text to search the inserter for.
  */
 export async function insertBlockDontWaitForInsertClose( searchTerm ) {
-	await insertWCBlock( searchTerm );
-}
-
-/**
- * Searches for the given term and selects the first result that appears.
- *
- * @param {string} searchTerm The text to search the inserter for.
- */
-export const insertWCBlock = async ( searchTerm ) => {
 	await searchForBlock( searchTerm );
 	await page.waitForXPath( `//button//span[text()='${ searchTerm }']` );
 	const insertButton = (
 		await page.$x( `//button//span[text()='${ searchTerm }']` )
 	 )[ 0 ];
 	await insertButton.click();
-};
+}
 
 export const closeInserter = async () => {
 	if (

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -145,15 +145,6 @@ export const closeModalIfExists = async () => {
 	}
 };
 
-export const openWidgetsEditorBlockInserter = async () => {
-	await page.waitForSelector(
-		'.edit-widgets-header [aria-label="Add block"],.edit-widgets-header [aria-label="Toggle block inserter"]'
-	);
-	await page.click(
-		'.edit-widgets-header [aria-label="Add block"],.edit-widgets-header [aria-label="Toggle block inserter"]'
-	);
-};
-
 export const isBlockInsertedInWidgetsArea = async ( blockName ) => {
 	const widgetAreaSelector = '.wp-block-widget-area';
 

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -93,13 +93,22 @@ export async function searchForBlock( searchTerm ) {
  */
 export async function insertBlockDontWaitForInsertClose( searchTerm ) {
 	await openGlobalBlockInserter();
+	await insertWCBlock( searchTerm );
+}
+
+/**
+ * Searches for the given term and selects the first result that appears.
+ *
+ * @param {string} searchTerm The text to search the inserter for.
+ */
+export const insertWCBlock = async ( searchTerm ) => {
 	await searchForBlock( searchTerm );
 	await page.waitForXPath( `//button//span[text()='${ searchTerm }']` );
 	const insertButton = (
 		await page.$x( `//button//span[text()='${ searchTerm }']` )
 	 )[ 0 ];
 	await insertButton.click();
-}
+};
 
 export const closeInserter = async () => {
 	if (

--- a/tests/e2e/utils.js
+++ b/tests/e2e/utils.js
@@ -79,6 +79,7 @@ const SELECTORS = {
  * @param {string} searchTerm The text to search the inserter for.
  */
 export async function searchForBlock( searchTerm ) {
+	await openGlobalBlockInserter();
 	await page.waitForSelector( SELECTORS.inserter.search );
 	await page.focus( SELECTORS.inserter.search );
 	await pressKeyWithModifier( 'primary', 'a' );
@@ -92,7 +93,6 @@ export async function searchForBlock( searchTerm ) {
  * @param {string} searchTerm The text to search the inserter for.
  */
 export async function insertBlockDontWaitForInsertClose( searchTerm ) {
-	await openGlobalBlockInserter();
 	await insertWCBlock( searchTerm );
 }
 

--- a/tests/utils/visit-block-page.js
+++ b/tests/utils/visit-block-page.js
@@ -14,7 +14,7 @@ import kebabCase from 'lodash/kebabCase';
  * Internal dependencies
  */
 import { clickLink } from '.';
-import { insertWCBlock } from '../e2e/utils.js';
+import { insertBlockDontWaitForInsertClose } from '../e2e/utils.js';
 
 /**
  * This will visit a GB page or post, and will hide the welcome guide.
@@ -76,7 +76,9 @@ export async function visitBlockPage( title ) {
 			title,
 			showWelcomeGuide: false,
 		} );
-		await insertWCBlock( title.replace( /block/i, '' ).trim() );
+		await insertBlockDontWaitForInsertClose(
+			title.replace( /block/i, '' ).trim()
+		);
 		const pageContent = await getEditedPostContent();
 		await outputFile(
 			`${ dirname(

--- a/tests/utils/visit-block-page.js
+++ b/tests/utils/visit-block-page.js
@@ -4,7 +4,6 @@
 import {
 	createNewPost,
 	visitAdminPage,
-	insertBlock,
 	getEditedPostContent,
 } from '@wordpress/e2e-test-utils';
 import { outputFile } from 'fs-extra';
@@ -15,6 +14,7 @@ import kebabCase from 'lodash/kebabCase';
  * Internal dependencies
  */
 import { clickLink } from '.';
+import { insertWCBlock } from '../e2e/utils.js';
 
 /**
  * This will visit a GB page or post, and will hide the welcome guide.
@@ -76,7 +76,7 @@ export async function visitBlockPage( title ) {
 			title,
 			showWelcomeGuide: false,
 		} );
-		await insertBlock( title.replace( /block/i, '' ).trim() );
+		await insertWCBlock( title.replace( /block/i, '' ).trim() );
 		const pageContent = await getEditedPostContent();
 		await outputFile(
 			`${ dirname(


### PR DESCRIPTION
This PR:
* Replaces several instances of `insertBlock` with `insertBlockDontWaitForInsertClose`, which seems to be more reliable (these changes are based on #8292).
* Removes `openWidgetsEditorBlockInserter()`, and instead adds a call inside `searchBlock()` to ensure the inserter is open.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests

#### User Facing Testing

1. Verify there are no failing e2e tests related to inserting blocks (besides the ones fixed in https://github.com/woocommerce/woocommerce-blocks/pull/8470).

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
