### PR TITLE
Fix `renderInnerBlocks` so it doesn't change prop names in the DOM

### DIFF
--- a/assets/js/atomic/utils/render-parent-block.tsx
+++ b/assets/js/atomic/utils/render-parent-block.tsx
@@ -137,7 +137,7 @@ const renderInnerBlocks = ( {
 	children,
 	// Current depth of the children. Used to ensure keys are unique.
 	depth = 1,
-}: renderInnerBlocksProps ): ( JSX.Element | null )[] | null => {
+}: renderInnerBlocksProps ): ( string | JSX.Element | null )[] | null => {
 	if ( ! children || children.length === 0 ) {
 		return null;
 	}
@@ -147,11 +147,10 @@ const renderInnerBlocks = ( {
 		 * convert the HTMLElement to a React component.
 		 */
 		const { blockName = '', ...componentProps } = {
-			key: `${ block }_${ depth }_${ index }`,
 			...( node instanceof HTMLElement ? node.dataset : {} ),
 			className: node instanceof Element ? node?.className : '',
 		};
-
+		const componentKey = `${ block }_${ depth }_${ index }`;
 		const InnerBlockComponent = getBlockComponentFromMap(
 			blockName,
 			blockMap
@@ -190,13 +189,20 @@ const renderInnerBlocks = ( {
 				  } )
 				: undefined;
 
+			// We pass props here rather than componentProps to avoid the data attributes being renamed.
 			return renderedChildren
 				? cloneElement(
 						parsedElement,
-						componentProps,
+						{
+							key: componentKey,
+							...( parsedElement?.props || {} ),
+						},
 						renderedChildren
 				  )
-				: cloneElement( parsedElement, componentProps );
+				: cloneElement( parsedElement, {
+						key: componentKey,
+						...( parsedElement?.props || {} ),
+				  } );
 		}
 
 		// This will wrap inner blocks with the provided wrapper. If no wrapper is provided, we default to Fragment.
@@ -215,7 +221,10 @@ const renderInnerBlocks = ( {
 					showErrorBlock={ CURRENT_USER_IS_ADMIN as boolean }
 				>
 					<InnerBlockComponentWrapper>
-						<InnerBlockComponent { ...componentProps }>
+						<InnerBlockComponent
+							key={ componentKey }
+							{ ...componentProps }
+						>
 							{
 								/**
 								 * Within this Inner Block Component we also need to recursively render it's children. This


### PR DESCRIPTION
`renderInnerBlocks` loops over the DOM and maps DOM nodes to React Components. If there is nothing to map, it clones the element and was previously passing props. These props however were renamed, for example in this case, `data-shipping-text` was transformed to `shippingText`. The fix here is to pass the original props, rather than the transformed props. 

Fixes #8283

### Testing

1. Go to Settings > Shipping > Local Pickup and disable it.
2. View the Checkout on the frontend.
3. Check the browser error console for mentions of invalid props (`shippingText`).
4. Confirm everything else renders correctly and you can place orders.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### Changelog

> Fix potential console warnings when certain Checkout Blocks are disabled.
