### PR TITLE
Add parsed border props to featured items

### DIFF
--- a/assets/js/blocks/featured-items/with-featured-item.tsx
+++ b/assets/js/blocks/featured-items/with-featured-item.tsx
@@ -17,6 +17,7 @@ import {
 	useState,
 } from 'react';
 import { WP_REST_API_Category } from 'wp-types';
+import { useBorderProps } from '@woocommerce/base-hooks';
 
 /**
  * Internal dependencies
@@ -50,7 +51,6 @@ export interface FeaturedItemRequiredAttributes {
 	overlayGradient: string;
 	showDesc: boolean;
 	showPrice: boolean;
-	borderColor: string;
 }
 
 interface FeaturedCategoryRequiredAttributes
@@ -157,6 +157,8 @@ export const withFeaturedItem =
 			</Placeholder>
 		);
 
+		const borderProps = useBorderProps( attributes );
+
 		const renderItem = () => {
 			const {
 				contentAlign,
@@ -172,7 +174,6 @@ export const withFeaturedItem =
 				showPrice,
 				style,
 				textColor,
-				borderColor,
 			} = attributes;
 
 			const classes = classnames(
@@ -196,10 +197,6 @@ export const withFeaturedItem =
 				color: textColor
 					? `var(--wp--preset--color--${ textColor })`
 					: style?.color?.text,
-				borderColor: borderColor
-					? `var(--wp--preset--color--${ borderColor })`
-					: 'transparent',
-				borderWidth: style?.border?.width,
 				boxSizing: 'border-box',
 			};
 
@@ -231,7 +228,10 @@ export const withFeaturedItem =
 						showHandle={ isSelected }
 						style={ { minHeight } }
 					/>
-					<div className={ classes } style={ containerStyle }>
+					<div
+						className={ classes }
+						style={ { containerStyle, ...borderProps.style } }
+					>
 						<div
 							className={ `${ className }__wrapper` }
 							style={ wrapperStyle }


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/8383

This PR adds in the border props so that featured blocks knows how to parse the border styles in the editor.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Add a Featured Item (Featured Category or Featured Product) block to a page or post.
2. Select the border controls and add a border style. Add a color and give it some width.
3. You should see the border you set dynamically display on the featured item.
4. Now click on the `Unlink` button on the border controls and try setting different values for color and width for each of the border sides (top,right,bottom,left).
5. Ensure this is working by visually seeing the changes to the featured item.
6. Save and make sure this is also displaying correctly on the frontend.
7. Test both `Featured Category` and `Featured Product` blocks.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Fix individual border controls not showing in the editor for Featured Product and Featured Category blocks.
