### PR TITLE
Fix Catalog Sorting default color in dark backgrounds

### DIFF
--- a/assets/js/blocks/catalog-sorting/style.scss
+++ b/assets/js/blocks/catalog-sorting/style.scss
@@ -5,7 +5,12 @@
 
 	select.orderby {
 		font-size: inherit;
-		color: inherit;
+	}
+
+	&.has-text-color {
+		select.orderby {
+			color: inherit;
+		}
 	}
 
 	.woocommerce-ordering {


### PR DESCRIPTION
Fixes a regression in #8265 caused by https://github.com/woocommerce/woocommerce-blocks/pull/8372.

### Testing

#### User Facing Testing

1. Install a theme with a dark background (ie: theme TT3 with Auberginie style).
2. Go to Appearance > Editor and edit the Product Catalog template.
3. Add the `Catalog Sorting` block and save the template.
4. Make sure it's legible in the editor and the frontend.
5. Change the text color of the `Catalog Sorting` block.
6. Verify the color is correctly set in the editor and the frontend.

Before | After
--- | ---
<img src="https://user-images.githubusercontent.com/3616980/220139289-8821dbc6-e76b-4aef-8664-dc9055880f5e.png" alt="" width="252" /> | <img src="https://user-images.githubusercontent.com/3616980/220139210-7400a6a7-0066-4d00-a85f-052705091d5a.png" alt="" width="252" />

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix: Adjust `Catalog Sorting` colors in dark themes.
