### PR TITLE
Update Product Details block so it inherits more styles from the theme

### DIFF
--- a/assets/js/atomic/blocks/product-elements/product-details/block.tsx
+++ b/assets/js/atomic/blocks/product-elements/product-details/block.tsx
@@ -84,7 +84,7 @@ export const SingleProductDetails = () => {
 
 	return (
 		<div { ...blockProps }>
-			<ul className="tabs" role="tablist">
+			<ul className="wc-tabs tabs" role="tablist">
 				{ tabsTitle }
 			</ul>
 			{ tabsContent }

--- a/assets/js/atomic/blocks/product-elements/product-details/style.scss
+++ b/assets/js/atomic/blocks/product-elements/product-details/style.scss
@@ -1,5 +1,5 @@
 .wp-block-woocommerce-product-details {
-	ul.tabs {
+	ul.wc-tabs {
 		list-style: none;
 		padding: 0 0 0 1em;
 		margin: 0 0 1.618em;

--- a/assets/js/atomic/blocks/product-elements/product-details/style.scss
+++ b/assets/js/atomic/blocks/product-elements/product-details/style.scss
@@ -9,35 +9,27 @@
 
 		li {
 			border: 1px solid $gray-200;
-			background-color: $white;
 			display: inline-block;
 			position: relative;
 			z-index: 0;
 			border-radius: 4px 4px 0 0;
 			margin: 0;
 			padding: 0.5em 1em;
-			opacity: 0.5;
 
 			a {
 				display: inline-block;
 				font-weight: 700;
-				color: $black;
 				text-decoration: none;
 
 				&:hover {
 					text-decoration: none;
-					color: color.adjust($black, $lightness: 10%);
 				}
 			}
 
 			&.active {
-				background: $gray-100;
 				z-index: 2;
-				border-bottom-color: $gray-200;
-				opacity: 1;
 
 				a {
-					color: inherit;
 					text-shadow: inherit;
 				}
 			}


### PR DESCRIPTION
Fixes #8490.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

Repeat these testing steps with at least three themes: [TT2](https://wordpress.org/themes/twentytwentytwo/), [TT3](https://wordpress.org/themes/twentytwentythree/) and any other block theme which is not a child theme of TT2/TT3 (ie, [Pixl](https://wordpress.org/themes/pixl/)).
1. Go to Appearance > Editor and edit the Single Product template.
2. Add the Product Details block after the Classic Template block.
3. Verify the styling of the tabs of the Classic Template and Single Product block look the same in the frontend.

Theme | Before | After
--- | --- | ---
TT2 | ![imatge](https://user-images.githubusercontent.com/3616980/220280107-bfa5496b-4a25-4097-9c82-06b0adbf9343.png) | ![imatge](https://user-images.githubusercontent.com/3616980/220279896-33e3f81c-5360-4264-ba04-00ef9cac683c.png)
TT3 (Auberginie) | ![imatge](https://user-images.githubusercontent.com/3616980/220279202-67582490-9116-4d16-9a63-9f2cfde32d60.png) | ![imatge](https://user-images.githubusercontent.com/3616980/220279289-614c402e-441d-4848-9d81-757e4f01f549.png)
TT3 (Whisper) | ![imatge](https://user-images.githubusercontent.com/3616980/220278797-3091a82f-1335-4fb2-857b-fa406c5d5267.png) | ![imatge](https://user-images.githubusercontent.com/3616980/220278925-d2dace37-cfe6-4d8e-b004-a2510245a67f.png)
Pixl |![imatge](https://user-images.githubusercontent.com/3616980/220354959-784b5618-eee5-46c6-9c4d-e5655e094b0d.png) |  ![imatge](https://user-images.githubusercontent.com/3616980/220354867-363f3c95-b163-4ad5-bd4f-6678b5fa81b0.png)

**Testing the editor view:**

It's possible to test the editor view as well if you build WC core from this branch: `fix/load-theme-specific-stylesheet-in-site-editor` (see related PR: https://github.com/woocommerce/woocommerce/pull/36911).

Then, follow the same steps:
1. Go to Appearance > Editor and edit the Single Product template.
2. Add the Product Details block after the Classic Template block.
3. Verify the styling of the tabs of the Classic Template and Single Product block look the same in the editor.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Update Product Details block so it inherits more styles from the theme.
