### PR TITLE
Fix noticeContext declaration in the Shipping calculator

### DIFF
--- a/assets/js/base/components/cart-checkout/shipping-calculator/index.tsx
+++ b/assets/js/base/components/cart-checkout/shipping-calculator/index.tsx
@@ -30,9 +30,10 @@ const ShippingCalculator = ( {
 	addressFields = [ 'country', 'state', 'city', 'postcode' ],
 }: ShippingCalculatorProps ): JSX.Element => {
 	const { shippingAddress } = useCustomerData();
+	const noticeContext = 'wc/cart/shipping-calculator';
 	return (
 		<div className="wc-block-components-shipping-calculator">
-			<StoreNoticesContainer context={ 'wc/cart/shipping-calculator' } />
+			<StoreNoticesContainer context={ noticeContext } />
 			<ShippingCalculatorAddress
 				address={ shippingAddress }
 				addressFields={ addressFields }


### PR DESCRIPTION
Declaration of `noticeContext` in [shipping calculator file](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/assets/js/base/components/cart-checkout/shipping-calculator/index.tsx#L35) was missing resulting in console error. 

With this PR, we fix the declaration of `noticeContext` and make error notice appear in the  shipping calculator

## Changes in the PR:

- Added the declaration of noticeContext to make the notice appear in the shipping calculator.


### Screenshots


| Before | After |
| ------ | ----- |
| <img width="1460" alt="image" src="https://user-images.githubusercontent.com/11503784/220375868-807057f0-dd30-4a4b-9912-e45e51f91f34.png"> |<img width="772" alt="image" src="https://user-images.githubusercontent.com/11503784/220375271-3f6b076b-eef1-4e07-96ec-e0d116d289dd.png">|

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1.Add a product to the cart.
2. Go to the Cart block page.
3. Open the shipping calculator.
4. Enter any address with an invalid zip code.
5. Confirm the error notice is getting displayed in the calculator.
6. Confirm there are no errors in the browser console.



* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental



### Changelog

> Fix noticeContext declaration in the Shipping calculator
