### PR TITLE
Fix E2E tests - Wait for the Checkout to push changes before proceeding with tests

### DIFF
--- a/tests/e2e/specs/merchant/checkout-terms.test.js
+++ b/tests/e2e/specs/merchant/checkout-terms.test.js
@@ -56,6 +56,7 @@ describe( 'Merchant → Checkout → Can adjust T&S and Privacy Policy options',
 		await expect( page ).toMatch(
 			'By proceeding with your purchase you agree to our Terms and Conditions and Privacy Policy'
 		);
+		await shopper.block.fillInCheckoutWithTestData();
 		await shopper.block.placeOrder();
 		await expect( page ).toMatch( 'Order received' );
 	} );

--- a/tests/e2e/specs/shopper/cart-checkout/account.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/account.test.js
@@ -59,8 +59,7 @@ describe( 'Shopper → Checkout → Account', () => {
 		} );
 		//Create random email to place an order.
 		const testEmail = `test${ Math.random() * 10 }@example.com`;
-		await shopper.block.fillInCheckoutWithTestData();
-		await expect( page ).toFill( `#email`, testEmail );
+		await shopper.block.fillInCheckoutWithTestData( { email: testEmail } );
 		await shopper.block.placeOrder();
 		await expect( page ).toMatch( 'Order received' );
 		await merchant.login();

--- a/tests/e2e/specs/shopper/cart-checkout/checkout.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/checkout.test.js
@@ -31,12 +31,6 @@ import {
 
 import { createCoupon } from '../../../utils';
 
-if ( process.env.WOOCOMMERCE_BLOCKS_PHASE < 2 ) {
-	// Skips all the tests if it's a WooCommerce Core process environment.
-	// eslint-disable-next-line jest/no-focused-tests, jest/expect-expect
-	test.only( 'Skipping Cart & Checkout tests', () => {} );
-}
-
 let coupon;
 
 describe( 'Shopper → Checkout', () => {

--- a/tests/utils/shopper.js
+++ b/tests/utils/shopper.js
@@ -206,7 +206,7 @@ export const shopper = {
 		},
 		// prettier-ignore
 		fillBillingDetails: async ( customerBillingDetails ) => {
-			await page.waitForSelector("#billing-fields");
+			await page.waitForSelector( '#billing-fields' );
 			const companyInputField = await page.$( '#billing-company' );
 
 			if ( companyInputField ) {

--- a/tests/utils/shopper.js
+++ b/tests/utils/shopper.js
@@ -188,15 +188,16 @@ export const shopper = {
 				? 'shipping'
 				: 'billing';
 			const testData = {
-				first_name: 'John',
-				last_name: 'Doe',
-				address_1: '123 Easy Street',
-				address_2: 'Testville',
+				firstname: 'John',
+				lastname: 'Doe',
+				addressfirstline: '123 Easy Street',
+				addresssecondline: 'Testville',
 				country: 'United States (US)',
 				city: 'New York',
 				state: 'New York',
 				postcode: '90210',
 				email: 'john.doe@test.com',
+				phone: '01234567890',
 			};
 			await expect( page ).toFill( `#email`, testData.email );
 			if ( shippingOrBilling === 'shipping' ) {
@@ -204,6 +205,14 @@ export const shopper = {
 			} else {
 				await shopper.block.fillBillingDetails( testData );
 			}
+			// Blur active field to trigger shipping rates update, then wait for requests to finish.
+			await page.evaluate( 'document.activeElement.blur()' );
+			await page.waitForRequest( ( request ) =>
+				request.url().includes( '/wp-json/wc/store/v1/batch' )
+			);
+			await page.waitForResponse( ( response ) =>
+				response.url().includes( '/wp-json/wc/store/v1/batch' )
+			);
 		},
 		// prettier-ignore
 		fillBillingDetails: async ( customerBillingDetails ) => {
@@ -214,11 +223,11 @@ export const shopper = {
 				await expect( page ).toFill( '#billing-company', customerBillingDetails.company );
 			}
 
-			await expect( page ).toFill( '#billing-first_name', customerBillingDetails.first_name );
+			await expect( page ).toFill( '#billing-first_name', customerBillingDetails.firstname );
 			await expect( page ).toFill( '#billing-last_name', customerBillingDetails.lastname );
 			await expect( page ).toFill( '#billing-country input', customerBillingDetails.country );
-			await expect( page ).toFill( '#billing-address_1', customerBillingDetails.address_1 );
-			await expect( page ).toFill( '#billing-address_2', customerBillingDetails.address_2 );
+			await expect( page ).toFill( '#billing-address_1', customerBillingDetails.addressfirstline );
+			await expect( page ).toFill( '#billing-address_2', customerBillingDetails.addresssecondline );
 			await expect( page ).toFill( '#billing-city', customerBillingDetails.city );
 			await expect( page ).toFill( '#billing-state input', customerBillingDetails.state );
 			await expect( page ).toFill( '#billing-postcode', customerBillingDetails.postcode );
@@ -239,11 +248,11 @@ export const shopper = {
 				await expect( page ).toFill( '#shipping-company', customerShippingDetails.company );
 			}
 
-			await expect( page ).toFill( '#shipping-first_name', customerShippingDetails.first_name );
-			await expect( page ).toFill( '#shipping-last_name', customerShippingDetails.last_name );
+			await expect( page ).toFill( '#shipping-first_name', customerShippingDetails.firstname );
+			await expect( page ).toFill( '#shipping-last_name', customerShippingDetails.lastname );
 			await expect( page ).toFill( '#shipping-country input', customerShippingDetails.country );
-			await expect( page ).toFill( '#shipping-address_1', customerShippingDetails.address_1 );
-			await expect( page ).toFill( '#shipping-address_2', customerShippingDetails.address_2 );
+			await expect( page ).toFill( '#shipping-address_1', customerShippingDetails.addressfirstline );
+			await expect( page ).toFill( '#shipping-address_2', customerShippingDetails.addresssecondline );
 			await expect( page ).toFill( '#shipping-city', customerShippingDetails.city );
 			await expect( page ).toFill( '#shipping-state input', customerShippingDetails.state );
 			await expect( page ).toFill( '#shipping-postcode', customerShippingDetails.postcode );

--- a/tests/utils/shopper.js
+++ b/tests/utils/shopper.js
@@ -230,8 +230,20 @@ export const shopper = {
 
 			// Blur #email field to trigger shipping rates update, then wait for requests to finish.
 			await page.evaluate('document.activeElement.blur()' );
-			await page.waitForRequest( ( request ) => request.url().includes( '/wp-json/wc/store/v1/batch' ) );
-			await page.waitForResponse( ( response ) => response.url().includes( '/wp-json/wc/store/v1/batch' ) );
+			await page.waitForRequest( ( request ) => {
+				const isBatch = request.url().includes( '/wp-json/wc/store/v1/batch' );
+				const parsedPostData = JSON.parse( request.postData() );
+				const isAddressPush = parsedPostData?.requests?.[ 0 ]?.path?.includes( '/wc/store/v1/cart/update-customer' );
+				return isBatch && isAddressPush;
+			} );
+			await page.waitForResponse( async ( response ) => {
+				const isBatch = response.url().includes( '/wp-json/wc/store/v1/batch' );
+				const responseJson = await response.text();
+				const parsedResponse = JSON.parse( responseJson );
+				const responseContainsShippingPostcode = parsedResponse?.responses[0]?.body.billing_address.postcode === customerBillingDetails.postcode;
+				return isBatch&& responseContainsShippingPostcode;
+			} );
+			await page.waitForTimeout( 1500 );
 		},
 
 		// prettier-ignore
@@ -254,8 +266,20 @@ export const shopper = {
 
 			// Blur #shipping-phone field to trigger shipping rates update, then wait for requests to finish.
 			await page.evaluate('document.activeElement.blur()' );
-			await page.waitForRequest( ( request ) => request.url().includes( '/wp-json/wc/store/v1/batch' ) );
-			await page.waitForResponse( ( response ) => response.url().includes( '/wp-json/wc/store/v1/batch' ) );
+			await page.waitForRequest( ( request ) => {
+				const isBatch = request.url().includes( '/wp-json/wc/store/v1/batch' );
+				const parsedPostData = JSON.parse( request.postData() );
+				const isAddressPush = parsedPostData?.requests?.[ 0 ]?.path?.includes( '/wc/store/v1/cart/update-customer' );
+				return isBatch && isAddressPush;
+			} );
+			await page.waitForResponse( async ( response ) => {
+				const isBatch = response.url().includes( '/wp-json/wc/store/v1/batch' );
+				const responseJson = await response.text();
+				const parsedResponse = JSON.parse( responseJson );
+				const responseContainsShippingPostcode = parsedResponse?.responses[0]?.body.shipping_address.postcode === customerShippingDetails.postcode;
+				return isBatch&& responseContainsShippingPostcode;
+			} );
+			await page.waitForTimeout( 1500 );
 		},
 
 		// prettier-ignore

--- a/tests/utils/shopper.js
+++ b/tests/utils/shopper.js
@@ -190,7 +190,7 @@ export const shopper = {
 			const testData = {
 				first_name: 'John',
 				last_name: 'Doe',
-				shipping_address_1: '123 Easy Street',
+				address_1: '123 Easy Street',
 				address_2: 'Testville',
 				country: 'United States (US)',
 				city: 'New York',
@@ -214,11 +214,11 @@ export const shopper = {
 				await expect( page ).toFill( '#billing-company', customerBillingDetails.company );
 			}
 
-			await expect( page ).toFill( '#billing-first_name', customerBillingDetails.firstname );
+			await expect( page ).toFill( '#billing-first_name', customerBillingDetails.first_name );
 			await expect( page ).toFill( '#billing-last_name', customerBillingDetails.lastname );
 			await expect( page ).toFill( '#billing-country input', customerBillingDetails.country );
-			await expect( page ).toFill( '#billing-address_1', customerBillingDetails.addressfirstline );
-			await expect( page ).toFill( '#billing-address_2', customerBillingDetails.addresssecondline );
+			await expect( page ).toFill( '#billing-address_1', customerBillingDetails.address_1 );
+			await expect( page ).toFill( '#billing-address_2', customerBillingDetails.address_2 );
 			await expect( page ).toFill( '#billing-city', customerBillingDetails.city );
 			await expect( page ).toFill( '#billing-state input', customerBillingDetails.state );
 			await expect( page ).toFill( '#billing-postcode', customerBillingDetails.postcode );
@@ -239,11 +239,11 @@ export const shopper = {
 				await expect( page ).toFill( '#shipping-company', customerShippingDetails.company );
 			}
 
-			await expect( page ).toFill( '#shipping-first_name', customerShippingDetails.firstname );
-			await expect( page ).toFill( '#shipping-last_name', customerShippingDetails.lastname );
+			await expect( page ).toFill( '#shipping-first_name', customerShippingDetails.first_name );
+			await expect( page ).toFill( '#shipping-last_name', customerShippingDetails.last_name );
 			await expect( page ).toFill( '#shipping-country input', customerShippingDetails.country );
-			await expect( page ).toFill( '#shipping-address_1', customerShippingDetails.addressfirstline );
-			await expect( page ).toFill( '#shipping-address_2', customerShippingDetails.addresssecondline );
+			await expect( page ).toFill( '#shipping-address_1', customerShippingDetails.address_1 );
+			await expect( page ).toFill( '#shipping-address_2', customerShippingDetails.address_2 );
 			await expect( page ).toFill( '#shipping-city', customerShippingDetails.city );
 			await expect( page ).toFill( '#shipping-state input', customerShippingDetails.state );
 			await expect( page ).toFill( '#shipping-postcode', customerShippingDetails.postcode );

--- a/tests/utils/shopper.js
+++ b/tests/utils/shopper.js
@@ -225,7 +225,7 @@ export const shopper = {
 			await expect( page ).toFill( '#billing-phone', customerBillingDetails.phone );
 			await expect( page ).toFill( '#email', customerBillingDetails.email );
 
-			// blur #email field to trigger shipping rates update, then wait for requests to finish
+			// Blur #email field to trigger shipping rates update, then wait for requests to finish.
 			await page.evaluate('document.activeElement.blur()' );
 			await page.waitForRequest( ( request ) => request.url().includes( '/wp-json/wc/store/v1/batch' ) );
 			await page.waitForResponse( ( response ) => response.url().includes( '/wp-json/wc/store/v1/batch' ) );
@@ -249,7 +249,7 @@ export const shopper = {
 			await expect( page ).toFill( '#shipping-postcode', customerShippingDetails.postcode );
 			await expect( page ).toFill( '#shipping-phone', customerShippingDetails.phone );
 
-			// blur #shipping-phone field to trigger shipping rates update, then wait for requests to finish
+			// Blur #shipping-phone field to trigger shipping rates update, then wait for requests to finish.
 			await page.evaluate('document.activeElement.blur()' );
 			await page.waitForRequest( ( request ) => request.url().includes( '/wp-json/wc/store/v1/batch' ) );
 			await page.waitForResponse( ( response ) => response.url().includes( '/wp-json/wc/store/v1/batch' ) );

--- a/tests/utils/shopper.js
+++ b/tests/utils/shopper.js
@@ -360,6 +360,7 @@ export const shopper = {
 			shippingName,
 			shippingPrice
 		) => {
+			await page.waitForNetworkIdle( { idleTime: 1000 } );
 			await page.waitForSelector(
 				'.wc-block-components-radio-control__label'
 			);

--- a/tests/utils/shopper.js
+++ b/tests/utils/shopper.js
@@ -207,12 +207,6 @@ export const shopper = {
 			}
 			// Blur active field to trigger shipping rates update, then wait for requests to finish.
 			await page.evaluate( 'document.activeElement.blur()' );
-			await page.waitForRequest( ( request ) =>
-				request.url().includes( '/wp-json/wc/store/v1/batch' )
-			);
-			await page.waitForResponse( ( response ) =>
-				response.url().includes( '/wp-json/wc/store/v1/batch' )
-			);
 		},
 		// prettier-ignore
 		fillBillingDetails: async ( customerBillingDetails ) => {

--- a/tests/utils/shopper.js
+++ b/tests/utils/shopper.js
@@ -191,6 +191,7 @@ export const shopper = {
 				first_name: 'John',
 				last_name: 'Doe',
 				shipping_address_1: '123 Easy Street',
+				address_2: 'Testville',
 				country: 'United States (US)',
 				city: 'New York',
 				state: 'New York',

--- a/tests/utils/shopper.js
+++ b/tests/utils/shopper.js
@@ -224,7 +224,10 @@ export const shopper = {
 			await expect( page ).toFill( '#billing-phone', customerBillingDetails.phone );
 			await expect( page ).toFill( '#email', customerBillingDetails.email );
 
-			await page.waitForTimeout(1500);
+			// blur #email field to trigger shipping rates update, then wait for requests to finish
+			await page.evaluate('document.activeElement.blur()' );
+			await page.waitForRequest( ( request ) => request.url().includes( '/wp-json/wc/store/v1/batch' ) );
+			await page.waitForResponse( ( response ) => response.url().includes( '/wp-json/wc/store/v1/batch' ) );
 		},
 
 		// prettier-ignore
@@ -245,7 +248,10 @@ export const shopper = {
 			await expect( page ).toFill( '#shipping-postcode', customerShippingDetails.postcode );
 			await expect( page ).toFill( '#shipping-phone', customerShippingDetails.phone );
 
-			await page.waitForTimeout(1500);
+			// blur #shipping-phone field to trigger shipping rates update, then wait for requests to finish
+			await page.evaluate('document.activeElement.blur()' );
+			await page.waitForRequest( ( request ) => request.url().includes( '/wp-json/wc/store/v1/batch' ) );
+			await page.waitForResponse( ( response ) => response.url().includes( '/wp-json/wc/store/v1/batch' ) );
 		},
 
 		// prettier-ignore

--- a/tests/utils/shopper.js
+++ b/tests/utils/shopper.js
@@ -294,6 +294,8 @@ export const shopper = {
 			await expect( page ).toFill( '#billing-postcode', customerBillingDetails.postcode );
 			await expect( page ).toFill( '#billing-phone', customerBillingDetails.phone );
 			await expect( page ).toFill( '#email', customerBillingDetails.email );
+			// Blur active field to trigger customer address update, then wait for requests to finish.
+			await page.evaluate( 'document.activeElement.blur()' );
 			await checkCustomerPushCompleted( 'billing', customerBillingDetails );
 		},
 
@@ -314,6 +316,8 @@ export const shopper = {
 			await expect( page ).toFill( '#shipping-state input', customerShippingDetails.state );
 			await expect( page ).toFill( '#shipping-postcode', customerShippingDetails.postcode );
 			await expect( page ).toFill( '#shipping-phone', customerShippingDetails.phone );
+			// Blur active field to customer address update, then wait for requests to finish.
+			await page.evaluate( 'document.activeElement.blur()' );
 			await checkCustomerPushCompleted( 'shipping', customerShippingDetails );
 		},
 

--- a/tests/utils/shopper.js
+++ b/tests/utils/shopper.js
@@ -198,27 +198,12 @@ export const shopper = {
 				email: 'john.doe@test.com',
 			};
 			await expect( page ).toFill( `#email`, testData.email );
-			await shopper.block.fillInCheckoutAddress(
-				testData,
-				shippingOrBilling
-			);
+			if ( shippingOrBilling === 'shipping' ) {
+				await shopper.block.fillShippingDetails( testData );
+			} else {
+				await shopper.block.fillBillingDetails( testData );
+			}
 		},
-
-		// prettier-ignore
-		fillInCheckoutAddress: async (
-			address,
-			shippingOrBilling = 'shipping'
-		) => {
-			await expect( page ).toFill( `#${ shippingOrBilling }-first_name`, address.first_name );
-			await expect( page ).toFill( `#${ shippingOrBilling }-first_name`, address.first_name );
-			await expect( page ).toFill( `#${ shippingOrBilling }-last_name`, address.last_name );
-			await expect( page ).toFill( `#${ shippingOrBilling }-address_1`, address.shipping_address_1 );
-			await expect( page ).toFill( `#${ shippingOrBilling }-country input`, address.country );
-			await expect( page ).toFill( `#${ shippingOrBilling }-city`, address.city );
-			await expect( page ).toFill( `#${ shippingOrBilling }-state input`, address.state );
-			await expect( page ).toFill( `#${ shippingOrBilling }-postcode`, address.postcode );
-		},
-
 		// prettier-ignore
 		fillBillingDetails: async ( customerBillingDetails ) => {
 			await page.waitForSelector("#billing-fields");
@@ -238,6 +223,8 @@ export const shopper = {
 			await expect( page ).toFill( '#billing-postcode', customerBillingDetails.postcode );
 			await expect( page ).toFill( '#billing-phone', customerBillingDetails.phone );
 			await expect( page ).toFill( '#email', customerBillingDetails.email );
+
+			await page.waitForTimeout(1500);
 		},
 
 		// prettier-ignore
@@ -257,6 +244,8 @@ export const shopper = {
 			await expect( page ).toFill( '#shipping-state input', customerShippingDetails.state );
 			await expect( page ).toFill( '#shipping-postcode', customerShippingDetails.postcode );
 			await expect( page ).toFill( '#shipping-phone', customerShippingDetails.phone );
+
+			await page.waitForTimeout(1500);
 		},
 
 		// prettier-ignore


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR adds some extra checks to the checkout E2E tests which will wait for the server response to contain the full address before continuing with the tests. This is required because sometimes the tests would try to continue executing before the address had been synced with the server.

I added a new function `checkCustomerPushCompleted` which blurs the active field then waits and checks the server responses until one matches the test address.

Then I added an argument to `fillInCheckoutWithTestData` which allows the test data passed to `checkCustomerPushCompleted` to be overridden with custom values. (needed in the `user can can create an account` test in `account.test.js` when a custom email is passed).

Finally, when checking out without a terms and conditions checkbox, I ensured the checkout data was filled before proceeding with checkout.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Check the E2E tests, ensure no Cart/Checkout failures.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental


### Changelog

> Skipping