### PR TITLE
Small cleanup of webpack-helpers

### DIFF
--- a/bin/webpack-helpers.js
+++ b/bin/webpack-helpers.js
@@ -22,7 +22,6 @@ const wcDepMap = {
 const wcHandleMap = {
 	'@woocommerce/blocks-registry': 'wc-blocks-registry',
 	'@woocommerce/settings': 'wc-settings',
-	'@woocommerce/block-settings': 'wc-settings',
 	'@woocommerce/block-data': 'wc-blocks-data-store',
 	'@woocommerce/data': 'wc-store-data',
 	'@woocommerce/shared-context': 'wc-blocks-shared-context',
@@ -78,10 +77,6 @@ const getAlias = ( options = {} ) => {
 		'@woocommerce/block-hocs': path.resolve(
 			__dirname,
 			`../assets/js/${ pathPart }hocs`
-		),
-		'@woocommerce/blocks-registry': path.resolve(
-			__dirname,
-			'../assets/js/blocks-registry'
 		),
 		'@woocommerce/block-settings': path.resolve(
 			__dirname,


### PR DESCRIPTION
Fixes #3658.

This PR:

* Removes `@woocommerce/blocks-registry` from `getAlias()`.
* Removes `@woocommerce/block-settings` from `wcHandleMap`.

### Testing

#### User Facing Testing

1. Run several scripts and verify they still work (`npm run start`, `npm run storybook` and `npm run build`).

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
