### PR TITLE
Make a product titles in Products block a link

### DIFF
--- a/assets/js/blocks/product-query/constants.ts
+++ b/assets/js/blocks/product-query/constants.ts
@@ -84,6 +84,7 @@ export const INNER_BLOCKS_TEMPLATE: InnerBlockTemplate[] = [
 					textAlign: 'center',
 					level: 3,
 					fontSize: 'medium',
+					isLink: true,
 					__woocommerceNamespace: PRODUCT_TITLE_ID,
 				},
 				[],


### PR DESCRIPTION
As pointed out in a [comment](https://github.com/woocommerce/woocommerce-blocks/pull/8248#pullrequestreview-1309487895) in a PR related to the conversion of Classic Template to the blockified template, it may be worth making a product title a link by default.

This PR makes the product titles in a Products block a link by default.

Let's keep in mind there was an option to make the product title a link, but it was disabled by default (this PR doesn't add a feature, just changes the default state).

### Screenshots

| Before | After |
| ------ | ----- |
|   <img width="683" alt="image" src="https://user-images.githubusercontent.com/20098064/220889529-1d791b2d-7648-471d-a598-2f0a0878ff93.png">     |     <img width="689" alt="image" src="https://user-images.githubusercontent.com/20098064/220889702-e0e5ae96-ff29-46f7-be60-f46c0b24e278.png">  |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. Go to the Editor
2. Add a _Products_ block
3. Focus on the Product Title block

Expected: "Make title a link" in Link Settings is enabled by default

 <img width="400" alt="image" src="https://user-images.githubusercontent.com/20098064/220889702-e0e5ae96-ff29-46f7-be60-f46c0b24e278.png">

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Products block: set the Product Title as a link by default.
