### PR TITLE
Do not mount the coupon form until toggled visible

### DIFF
--- a/assets/js/base/components/cart-checkout/totals/coupon/index.tsx
+++ b/assets/js/base/components/cart-checkout/totals/coupon/index.tsx
@@ -86,7 +86,7 @@ export const TotalsCoupon = ( {
 
 	return (
 		<div className="wc-block-components-totals-coupon">
-			{ isCouponFormHidden && (
+			{ isCouponFormHidden ? (
 				<a
 					role="button"
 					href="#wc-block-components-totals-coupon__form"
@@ -99,52 +99,56 @@ export const TotalsCoupon = ( {
 				>
 					{ __( 'Add a coupon', 'woo-gutenberg-products-block' ) }
 				</a>
-			) }
-			<LoadingMask
-				screenReaderLabel={ __(
-					'Applying coupon…',
-					'woo-gutenberg-products-block'
-				) }
-				isLoading={ isLoading }
-				showSpinner={ false }
-			>
-				<div className={ formWrapperClass }>
-					<form
-						className="wc-block-components-totals-coupon__form"
-						id="wc-block-components-totals-coupon__form"
-					>
-						<ValidatedTextInput
-							id={ textInputId }
-							errorId="coupon"
-							className="wc-block-components-totals-coupon__input"
-							label={ __(
-								'Enter code',
-								'woo-gutenberg-products-block'
-							) }
-							value={ couponValue }
-							ariaDescribedBy={ validationErrorId }
-							onChange={ ( newCouponValue ) => {
-								setCouponValue( newCouponValue );
-							} }
-							focusOnMount={ true }
-							showError={ false }
-						/>
-						<Button
-							className="wc-block-components-totals-coupon__button"
-							disabled={ isLoading || ! couponValue }
-							showSpinner={ isLoading }
-							onClick={ handleCouponSubmit }
-							type="submit"
+			) : (
+				<LoadingMask
+					screenReaderLabel={ __(
+						'Applying coupon…',
+						'woo-gutenberg-products-block'
+					) }
+					isLoading={ isLoading }
+					showSpinner={ false }
+				>
+					<div className={ formWrapperClass }>
+						<form
+							className="wc-block-components-totals-coupon__form"
+							id="wc-block-components-totals-coupon__form"
 						>
-							{ __( 'Apply', 'woo-gutenberg-products-block' ) }
-						</Button>
-					</form>
-					<ValidationInputError
-						propertyName="coupon"
-						elementId={ textInputId }
-					/>
-				</div>
-			</LoadingMask>
+							<ValidatedTextInput
+								id={ textInputId }
+								errorId="coupon"
+								className="wc-block-components-totals-coupon__input"
+								label={ __(
+									'Enter code',
+									'woo-gutenberg-products-block'
+								) }
+								value={ couponValue }
+								ariaDescribedBy={ validationErrorId }
+								onChange={ ( newCouponValue ) => {
+									setCouponValue( newCouponValue );
+								} }
+								focusOnMount={ true }
+								showError={ false }
+							/>
+							<Button
+								className="wc-block-components-totals-coupon__button"
+								disabled={ isLoading || ! couponValue }
+								showSpinner={ isLoading }
+								onClick={ handleCouponSubmit }
+								type="submit"
+							>
+								{ __(
+									'Apply',
+									'woo-gutenberg-products-block'
+								) }
+							</Button>
+						</form>
+						<ValidationInputError
+							propertyName="coupon"
+							elementId={ textInputId }
+						/>
+					</div>
+				</LoadingMask>
+			) }
 		</div>
 	);
 };


### PR DESCRIPTION
The `ValidatedTextInput` component supports focus on mount. We can take advantage of that functionality in the coupon form by only rendering the input when the form is toggled visible via the link.

Fixes #8281

### Testing

#### User Facing Testing

1. Add something to your cart and visit the cart block page.
2. Click the "add a coupon" link
3. The input should focus

### Changelog

> Focus the coupon code input when the form is revealed in the cart.
