### PR TITLE
Fix Product Price and Product Rating alignment

### DIFF
--- a/assets/js/atomic/blocks/product-elements/price/attributes.ts
+++ b/assets/js/atomic/blocks/product-elements/price/attributes.ts
@@ -14,7 +14,7 @@ export const blockAttributes: BlockAttributes = {
 	},
 	textAlign: {
 		type: 'string',
-		default: 'center',
+		default: '',
 	},
 };
 

--- a/assets/js/atomic/blocks/product-elements/rating/attributes.ts
+++ b/assets/js/atomic/blocks/product-elements/rating/attributes.ts
@@ -14,7 +14,7 @@ export const blockAttributes: BlockAttributes = {
 	},
 	textAlign: {
 		type: 'string',
-		default: 'center',
+		default: '',
 	},
 };
 

--- a/src/Utils/StyleAttributesUtils.php
+++ b/src/Utils/StyleAttributesUtils.php
@@ -525,29 +525,9 @@ class StyleAttributesUtils {
 	 */
 	public static function get_text_align_class_and_style( $attributes ) {
 
-		$text_align_attribute = $attributes['textAlign'] ?? null;
-
-		if ( ! $text_align_attribute ) {
-			return null;
-		}
-
-		if ( 'left' === $text_align_attribute ) {
+		if ( isset( $attributes['textAlign'] ) ) {
 			return array(
-				'class' => 'has-text-align-left',
-				'style' => null,
-			);
-		}
-
-		if ( 'center' === $text_align_attribute ) {
-			return array(
-				'class' => 'has-text-align-center',
-				'style' => null,
-			);
-		}
-
-		if ( 'right' === $text_align_attribute ) {
-			return array(
-				'class' => 'has-text-align-right',
+				'class' => 'has-text-align-' . $attributes['textAlign'],
 				'style' => null,
 			);
 		}


### PR DESCRIPTION
Fixes #8521.

This PR fixes the alignment of the Product Price and Product Rating blocks. What happened was that we defined `center` as the default alignment, so when center-alignment was defined, the necessary class was not being added (as it was the default state). This can be fixed easily by removing `center` from the default value.

In practice, I reverted the last commit from #8264 (cc @tjcafferkey). That causes that in the All Products block, Product Price and Product Rating blocks are centered-aligned by default but the alignment button in the toolbar default state is "left aligned". I think it's worth the trade-off, but wanted to mention it anyway.

I think it's also worth highlighting that the issue in the All Products block is caused by the center styling being forced by CSS, that's why the toolbar button doesn't match the end result. In the Products block we don't have that custom CSS so it doesn't cause the same issue.

This PR also refactors `get_text_align_class_and_style()` in `StyleAttributesUtils.php` making the code simpler and more similar to [some GB blocks](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/post-title/index.php#L40-L42).

I added the `skip-changelog` label because this PR is fixing a regression that was never released.

### Testing

#### User Facing Testing

1. Create a post or page.
2. Add a Products block.
3. Confirm the Product Price is centered by default in the editor.
4. Save and go to the frontend.
5. Confirm the Product Price is centered there.
6. Go back to the editor and add another Product Price and a Product Rating block.
7. Toggle their alignment (left, center, right) and verify whatever setting you choose is applied in the editor and the frontend.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
