### PR TITLE
Fix fatal error when extensions use `woocommerce_customer_taxable_address` outside of the Checkout context

### DIFF
--- a/src/Shipping/ShippingController.php
+++ b/src/Shipping/ShippingController.php
@@ -257,6 +257,11 @@ class ShippingController {
 	 * @return array
 	 */
 	public function filter_taxable_address( $address ) {
+
+		if ( null === WC()->session ) {
+			return $address;
+		}
+
 		// We only need to select from the first package, since pickup_location only supports a single package.
 		$chosen_method          = current( WC()->session->get( 'chosen_shipping_methods', array() ) ) ?? '';
 		$chosen_method_id       = explode( ':', $chosen_method )[0];

--- a/src/Shipping/ShippingController.php
+++ b/src/Shipping/ShippingController.php
@@ -49,7 +49,7 @@ class ShippingController {
 				true
 			);
 		}
-		$this->asset_data_registry->add( 'collectableMethodIds', array( $this, 'get_local_pickup_method_ids' ), true );
+		$this->asset_data_registry->add( 'collectableMethodIds', array( 'Automattic\WooCommerce\StoreApi\Utilities\LocalPickupUtils', 'get_local_pickup_method_ids' ), true );
 		add_action( 'rest_api_init', [ $this, 'register_settings' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'admin_scripts' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'hydrate_client_settings' ] );
@@ -59,32 +59,6 @@ class ShippingController {
 		add_filter( 'woocommerce_shipping_packages', array( $this, 'filter_shipping_packages' ) );
 		add_filter( 'pre_update_option_woocommerce_pickup_location_settings', array( $this, 'flush_cache' ) );
 		add_filter( 'pre_update_option_pickup_location_pickup_locations', array( $this, 'flush_cache' ) );
-	}
-
-	/**
-	 * Gets a list of payment method ids that support the 'local-pickup' feature.
-	 *
-	 * @return string[] List of payment method ids that support the 'local-pickup' feature.
-	 */
-	public function get_local_pickup_method_ids() {
-		$all_methods_supporting_local_pickup = array_reduce(
-			WC()->shipping()->get_shipping_methods(),
-			function( $methods, $method ) {
-				if ( $method->supports( 'local-pickup' ) ) {
-					$methods[] = $method->id;
-				}
-				return $methods;
-			},
-			array()
-		);
-
-		// We use array_values because this will be used in JS, so we don't need the (numerical) keys.
-		return array_values(
-			// This array_unique is necessary because WC()->shipping()->get_shipping_methods() can return duplicates.
-			array_unique(
-				$all_methods_supporting_local_pickup
-			)
-		);
 	}
 
 	/**

--- a/src/StoreApi/Utilities/LocalPickupUtils.php
+++ b/src/StoreApi/Utilities/LocalPickupUtils.php
@@ -1,0 +1,34 @@
+<?php
+namespace Automattic\WooCommerce\StoreApi\Utilities;
+
+/**
+ * Util class for local pickup related functionality, this contains methods that need to be accessed from places besides
+ * the ShippingController, i.e. the OrderController.
+ */
+class LocalPickupUtils {
+	/**
+	 * Gets a list of payment method ids that support the 'local-pickup' feature.
+	 *
+	 * @return string[] List of payment method ids that support the 'local-pickup' feature.
+	 */
+	public static function get_local_pickup_method_ids() {
+		$all_methods_supporting_local_pickup = array_reduce(
+			WC()->shipping()->get_shipping_methods(),
+			function( $methods, $method ) {
+				if ( $method->supports( 'local-pickup' ) ) {
+					$methods[] = $method->id;
+				}
+				return $methods;
+			},
+			array()
+		);
+
+		// We use array_values because this will be used in JS, so we don't need the (numerical) keys.
+		return array_values(
+		// This array_unique is necessary because WC()->shipping()->get_shipping_methods() can return duplicates.
+			array_unique(
+				$all_methods_supporting_local_pickup
+			)
+		);
+	}
+}


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
An extension may use the `woocommerce_customer_taxable_address` hook outside of the Checkout context, e.g. when processing subscription renewals, and therefore the `WC()->session` won't be available. 

In our `ShippingController` we rely on this session to check if the order is using local pickup so we set the correct tax rates for that.

This PR introduces some changes to stop this error:

- Move `get_local_pickup_method_ids` out of the `ShippingController` and into a new class called `LocalPickupUtils`.
  - this is required because places that don't have access to a `ShippingController` sometimes need to get the local pickup method IDs.
- Update the `update_addresses_from_cart` method in `OrderController` so that if the shopper has selected local pickup, the order's shipping address is set to the local pickup method's address. This will allow tax to be calculated based on the shipping address.
- Check for the existence of the session before proceeding with the `woocommerce_customer_taxable_address` filter, if that fails, then return the same address without applying filters.

#### Why update the shipping address?

We decided to set the local pickup location's address to the shipping address of the order so that tax can be calculated based on that. Reason one: UX. Having the shipping address set to the user's billing address in the order screen could have been confusing to merchants, it didn't make sense for them to have to scroll down to see the local pickup method's metadata to work out where to send it. Reason two: calculating taxes based on address, the reason we can't rely on the address in the shipping method's metadata is because this is a single formatted address, we cannot reliably parse it into individual address parts to calculate tax correctly. We could have approached this from another angle and stored the individual address parts in the metadata, but this would have made the shipping section of the order busy and visually distracting.

#### Caveat

Important note for HEs responding to bug reports on this - unfortunately, any subscription orders placed before this change was released (hopefully this will go out in 9.7.0) will NOT have the correct tax applied. In the case that this happens, the merchant will need to manually update the shipping address to be the one where tax should be applied. There is no way for us to retroactively fix this.

<!-- Reference any related issues or PRs here -->

Fixes #8473

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. Add a Local Pickup location to your site via `WooCommerce -> Shipping -> Local Pickup` (WC blocks will need to be the default checkout for this to show up). Please ensure you enter a fully valid address.
2. Add items to your cart and check out using this local pickup method.
3. Check the order in the back end and ensure the shipping address is set to the local pickup address you created earlier.

#### Internal Developer Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Install [AvaTax](https://woocommerce.com/products/woocommerce-avatax/) (credentials in secret 7715) and set it up so taxes are applied to your orders. I used a store in the USA and used USA addresses.
4. Install WooCommerce Subscriptions
5. Create a Subscription product and add it to your cart. Then check out.
6. Open the **subscription** in the WP dashboard and from the subscription actions box choose "Process renewal"
7. <img width="319" alt="image" src="https://user-images.githubusercontent.com/5656702/219742801-c2d87718-ddad-4622-a2b2-b9f7eb3befdf.png">
8. Verify this completes successfully.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix an issue where subscription renewals would not work when using AvaTax
