### PR TITLE
Fix Payment Options settings crash in the editor

### DIFF
--- a/assets/js/editor-components/external-link-card/index.tsx
+++ b/assets/js/editor-components/external-link-card/index.tsx
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { Icon, external } from '@wordpress/icons';
 import { VisuallyHidden } from '@wordpress/components';
 import { sanitizeHTML } from '@woocommerce/utils';
-import { alert } from '@woocommerce/icons';
+import { Alert } from '@woocommerce/icons';
 
 /**
  * Internal dependencies
@@ -50,7 +50,7 @@ const ExternalLinkCard = ( {
 				) }
 				{ warning ? (
 					<span className="wc-block-editor-components-external-link-card__warning">
-						<Icon icon={ alert } />
+						<Icon icon={ <Alert status="error" /> } />
 						<span>{ warning }</span>
 					</span>
 				) : null }


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
We introduced a bug in this PR #8365 that caused the 'Payment Options' settings to crash on the editor page of the Checkout Block. The source of this problem was missing updating a reference of the custom `Alert` icon in the `assets/js/editor-components/external-link-card/index.tsx` file after refactoring.
<!-- Reference any related issues or PRs here -->

Fixes bug discussed here: p1677229171369329-slack-C8X6Q7XQU

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|     <img width="1874" alt="image" src="https://user-images.githubusercontent.com/14235870/221171831-6245b687-a377-4730-92ab-8710360ee060.png">   |    <img width="1208" alt="image" src="https://user-images.githubusercontent.com/14235870/221178227-e4e12f08-dd88-4aac-824c-3990bde13a89.png">   |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Install and enable an incompatible payment gateway plugin with the `Cart` & `Checkout` Blocks. (e.g., [IDPay Payment Gateway for Woocommerce](https://wordpress.org/plugins/woo-idpay-gateway/))
2. Create a new page and add the `Checkout` Block
3. Select the Checkout Block or any of its Inner Blocks (except for the `Payment Options` Inner Block). Ensure our incompatible payment gateway (e.g., IDPay) is listed under the incompatible gateways notice:

<img width="567" alt="image" src="https://user-images.githubusercontent.com/14235870/221174704-1d12e2bc-6c6c-4089-a2d2-a7bedc7f55c3.png">

4. Select the `Payment Options` Inner Block. Ensure its settings are correctly displayed, the incompatible gateways notice is showing and our incompatible payment Gateway is highlighted under `Settings -> Block -> Methods`

<img width="1208" alt="image" src="https://user-images.githubusercontent.com/14235870/221178227-e4e12f08-dd88-4aac-824c-3990bde13a89.png">

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Fix the Checkout Blocks "Payment Options" settings crash in the editor