### PR TITLE
Check for null session before going setting up tax address

### DIFF
--- a/src/Shipping/ShippingController.php
+++ b/src/Shipping/ShippingController.php
@@ -283,6 +283,10 @@ class ShippingController {
 	 * @return array
 	 */
 	public function filter_taxable_address( $address ) {
+
+		if ( null === WC()->session ) {
+			return $address;
+		}
 		// We only need to select from the first package, since pickup_location only supports a single package.
 		$chosen_method          = current( WC()->session->get( 'chosen_shipping_methods', array() ) ) ?? '';
 		$chosen_method_id       = explode( ':', $chosen_method )[0];


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request and the reason for such changes. -->
This PR is pulled from https://github.com/woocommerce/woocommerce-blocks/pull/8529 The original PR does too much, and we prefer to commit to that solution yet. This change alone is enough to fix Avatax's issue.

Avatax seems to duplicate WC_Customer->get_taxable_address to avoid the session issue in order context, they still trigger the `woocommerce_customer_taxable_address` filter, which we hook into and use session.

Another fix would be to change Avatax code, and instead of rebuilding `get_taxable_address`, just use WC_Abstract_Order->get_tax_location, for now, that function is protected, the plan is to make it public in WooCommerce core and switch Avatax to it.

If we can't make it public, instead of having Avatax copy `WC_Customer->get_taxable_address`, they just [copy](https://gist.github.com/senadir/c9b5fa31b13075dbf45293df16de9157) `WC_Abstract_Order->get_tax_location`.


This doesn't fix the issue of Avatax using the wrong tax address when checking out a Checkout Block + new Local Pickup + Renewal order, they will end up using the store address, but that's an acceptable tradeoff for now.
<!-- Reference any related issues or PRs here -->

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/8473

### Testing


1. Install [AvaTax](https://woocommerce.com/products/woocommerce-avatax/) (credentials in secret 7715) and set it up so taxes are applied to your orders. I used a store in the USA and used USA addresses.
2. Install WooCommerce Subscriptions and  go to WooCommerce > Settings > Subscriptions and enable "Accept Manual Renewals"
3. Enable Cash on Delivery and Stripe as payment methods
4. Create a Subscription product, add it to your cart, and check out twice, once with Cash on Delivery, and once with Stripe.
5. Open both **subscription** orders in the WP dashboard, and from each of the subscriptions actions box, choose "Process renewal"
6. <img width="319" alt="image" src="https://user-images.githubusercontent.com/5656702/219742801-c2d87718-ddad-4622-a2b2-b9f7eb3befdf.png">
7. For both renewals, ensure there is no error displayed and the sum is correct

### Changelog

> Check if the session is set before returning the updated customer address
