### PR TITLE
Add E2E test for third-party local pickup methods

### DIFF
--- a/assets/js/base/utils/shipping-rates.ts
+++ b/assets/js/base/utils/shipping-rates.ts
@@ -6,6 +6,7 @@ import {
 	CartShippingRate,
 } from '@woocommerce/type-defs/cart';
 import { getSetting } from '@woocommerce/settings';
+import { LOCAL_PICKUP_ENABLED } from '@woocommerce/block-settings';
 
 /**
  * Get the number of packages in a shippingRates array.
@@ -36,7 +37,7 @@ export const isPackageRateCollectable = (
 export const hasCollectableRate = (
 	chosenRates: string[] | string
 ): boolean => {
-	if ( ! getSetting< boolean >( 'localPickupEnabled', false ) ) {
+	if ( ! LOCAL_PICKUP_ENABLED ) {
 		return false;
 	}
 	if ( Array.isArray( chosenRates ) ) {

--- a/assets/js/base/utils/shipping-rates.ts
+++ b/assets/js/base/utils/shipping-rates.ts
@@ -36,6 +36,9 @@ export const isPackageRateCollectable = (
 export const hasCollectableRate = (
 	chosenRates: string[] | string
 ): boolean => {
+	if ( ! getSetting< boolean >( 'localPickupEnabled', false ) ) {
+		return false;
+	}
 	if ( Array.isArray( chosenRates ) ) {
 		return !! chosenRates.find( ( rate ) =>
 			collectableMethodIds.includes( rate )

--- a/assets/js/base/utils/test/shipping-rates.ts
+++ b/assets/js/base/utils/test/shipping-rates.ts
@@ -6,7 +6,7 @@ import {
 	isPackageRateCollectable,
 } from '@woocommerce/base-utils';
 import { CartShippingRate } from '@woocommerce/type-defs/cart';
-import { getSetting } from '@woocommerce/settings';
+import * as blockSettings from '@woocommerce/block-settings';
 
 jest.mock( '@woocommerce/settings', () => {
 	return {
@@ -16,16 +16,17 @@ jest.mock( '@woocommerce/settings', () => {
 			if ( setting === 'collectableMethodIds' ) {
 				return [ 'local_pickup' ];
 			}
-			if ( setting === 'localPickupEnabled' ) {
-				return true;
-			}
 			return jest
 				.requireActual( '@woocommerce/settings' )
 				.getSetting( setting );
 		} ),
 	};
 } );
-
+jest.mock( '@woocommerce/block-settings', () => ( {
+	__esModule: true,
+	...jest.requireActual( '@woocommerce/block-settings' ),
+	LOCAL_PICKUP_ENABLED: true,
+} ) );
 describe( 'hasCollectableRate', () => {
 	it( 'correctly identifies if an array contains a collectable rate', () => {
 		const ratesToTest = [ 'flat_rate', 'local_pickup' ];
@@ -34,17 +35,8 @@ describe( 'hasCollectableRate', () => {
 		expect( hasCollectableRate( ratesToTest2 ) ).toBe( false );
 	} );
 	it( 'returns false for all rates if local pickup is disabled', () => {
-		getSetting.mockImplementation( ( setting: string ) => {
-			if ( setting === 'collectableMethodIds' ) {
-				return [ 'local_pickup' ];
-			}
-			if ( setting === 'localPickupEnabled' ) {
-				return false;
-			}
-			return jest
-				.requireActual( '@woocommerce/settings' )
-				.getSetting( setting );
-		} );
+		// Attempt to assign to const or readonly variable error on next line is OK because it is mocked by jest
+		blockSettings.LOCAL_PICKUP_ENABLED = false;
 		const ratesToTest = [ 'flat_rate', 'local_pickup' ];
 		expect( hasCollectableRate( ratesToTest ) ).toBe( false );
 	} );

--- a/tests/e2e/specs/shopper/cart-checkout/checkout.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/checkout.test.js
@@ -118,6 +118,7 @@ describe( 'Shopper → Checkout', () => {
 			expect( page ).toMatch( 'Woo Collection' );
 			await shopper.block.fillBillingDetails( BILLING_DETAILS );
 			await shopper.block.placeOrder();
+			await shopper.block.verifyBillingDetails( BILLING_DETAILS );
 		} );
 	} );
 

--- a/tests/e2e/specs/shopper/cart-checkout/checkout.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/checkout.test.js
@@ -48,10 +48,53 @@ describe( 'Shopper → Checkout', () => {
 
 	describe( 'Local pickup', () => {
 		beforeAll( async () => {
+			// Enable local pickup.
 			await visitAdminPage(
 				'admin.php',
 				'page=wc-settings&tab=shipping&section=pickup_location'
 			);
+
+			const localPickupCheckbox = await page.waitForXPath(
+				'//input[@name="local_pickup_enabled"]'
+			);
+			const isCheckboxChecked = await page.evaluate(
+				( checkbox ) => checkbox.checked,
+				localPickupCheckbox
+			);
+
+			if ( isCheckboxChecked === true ) {
+				return;
+			}
+
+			// eslint-disable-next-line jest/no-standalone-expect
+			await expect( page ).toClick( 'label', {
+				text: 'Enable local pickup',
+			} );
+			// eslint-disable-next-line jest/no-standalone-expect
+			await expect( page ).toClick( 'button', {
+				text: 'Save changes',
+			} );
+		} );
+		afterAll( async () => {
+			// Disable local pickup.
+			await visitAdminPage(
+				'admin.php',
+				'page=wc-settings&tab=shipping&section=pickup_location'
+			);
+
+			const localPickupCheckbox = await page.waitForXPath(
+				'//input[@name="local_pickup_enabled"]'
+			);
+			const isCheckboxChecked = await page.evaluate(
+				( checkbox ) => checkbox.checked,
+				localPickupCheckbox
+			);
+
+			// Skip this if it's already unchecked.
+			if ( isCheckboxChecked === false ) {
+				return;
+			}
+
 			// eslint-disable-next-line jest/no-standalone-expect
 			await expect( page ).toClick( 'label', {
 				text: 'Enable local pickup',

--- a/tests/e2e/specs/shopper/cart-checkout/checkout.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/checkout.test.js
@@ -109,7 +109,7 @@ describe( 'Shopper → Checkout', () => {
 			await shopper.block.goToShop();
 			await shopper.addToCartFromShopPage( SIMPLE_PHYSICAL_PRODUCT_NAME );
 			await shopper.block.goToCheckout();
-			expect( page ).toClick(
+			await expect( page ).toClick(
 				'.wc-block-checkout__shipping-method-option-title',
 				{
 					text: 'Local Pickup',
@@ -177,8 +177,12 @@ describe( 'Shopper → Checkout', () => {
 			await shopper.block.goToShop();
 			await shopper.addToCartFromShopPage( SIMPLE_PHYSICAL_PRODUCT_NAME );
 			await shopper.block.goToCheckout();
-			await page.waitForSelector( '#checkbox-control-0' );
-			await unsetCheckbox( '#checkbox-control-0' );
+			await page.waitForSelector(
+				'.wc-block-checkout__use-address-for-billing input[type="checkbox"]'
+			);
+			await unsetCheckbox(
+				'.wc-block-checkout__use-address-for-billing input[type="checkbox"]'
+			);
 			await shopper.block.fillShippingDetails( SHIPPING_DETAILS );
 			await shopper.block.fillBillingDetails( BILLING_DETAILS );
 			await shopper.block.placeOrder();


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR is based on #8542 (`fix/hardcoded-pickup-location`) and adds an E2E test to check for third party local pickup methods.

In the test, we enable local pickup and then check we can click it, and that we can see the third party method on the page when local pickup is selected.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests

#### User Facing Testing

1. Check tests pass in CI

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Skipping
