### PR TITLE
Ensure express payment buttons are visible next to each other

### DIFF
--- a/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment/style.scss
+++ b/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment/style.scss
@@ -88,6 +88,7 @@ $border-radius: 5px;
 
 	.wc-block-components-express-payment__event-buttons {
 		> li {
+			box-sizing: border-box;
 			display: inline-block;
 			width: 50%;
 		}


### PR DESCRIPTION
Fixes woocommerce/woocommerce-blocks#8545 

In p1677282265770279-slack-C02TS23QJ1, @c-shultz reported that the Express Payment buttons are not displayed next to each other when using the Tsubaki theme on a WorcPress.com site (using the eCommerce plan).

### Screenshots

<table>
<tr>
<td>Before:
<br><br>

<img width="698" alt="Screenshot 2023-02-27 at 10 41 26" src="https://user-images.githubusercontent.com/3323310/221471765-b554790e-7611-4274-b2e7-54e73a19e072.png">
</td>
<td>After:
<br><br>

<img width="695" alt="Screenshot 2023-02-27 at 10 41 43" src="https://user-images.githubusercontent.com/3323310/221471762-5a660d56-5fc0-4692-9fa0-1dc8017372cb.png">
</td>
</tr>
</table>

### Testing

#### User Facing Testing

1. Create a WordPress.com site using the eCommerce plan.
2. Install and activate the Tsubaki theme.
3. Install and activate WooCommerce Blocks [using this ZIP file](https://wcblocks.wpcomstaging.com/wp-content/uploads/woocommerce-gutenberg-products-block-8548.zip).
4. Install and activate WooCommerce Payments.
5. Install and activate WooCommerce Stripe Gateway.
6. Activate Express Payment both for WooCommerce Payments and WooCommerce Stripe Gateway.
7. Add a product to the cart and open the checkout page (which should use the Checkout block).
8. Verify that the Express Payment buttons are next to each other.
9. Install and activate the Storefront theme.
10. Verify that the Express Payment buttons are still next to each other and this PR does not introduce a regression.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix: Ensure that Epress Payment buttons are visible next to each other.