### PR TITLE
Fix warning when removing the term-description from the archive-product template

### DIFF
--- a/src/Utils/BlockTemplateUtils.php
+++ b/src/Utils/BlockTemplateUtils.php
@@ -122,44 +122,6 @@ class BlockTemplateUtils {
 	}
 
 	/**
-	 * Remove block from parsed template content.
-	 *
-	 * @param string $template_content serialized wp_template content.
-	 * @param string $block_name       Block to be removed.
-	 *
-	 * @return string Updated wp_template content.
-	 */
-	private static function remove_block_from_template( $template_content, $block_name ) {
-		$new_content     = '';
-		$template_blocks = parse_blocks( $template_content );
-
-		self::recursive_remove_block( $template_blocks, $block_name );
-
-		foreach ( $template_blocks as &$block ) {
-			$new_content .= serialize_block( $block );
-		}
-
-		return $new_content;
-	}
-
-	/**
-	 * Remove block recursively from block list.
-	 *
-	 * @param array  $blocks      Parsed blocks array.
-	 * @param string $block_name Block to be removed.
-	 * @return void
-	 */
-	private static function recursive_remove_block( &$blocks, $block_name ) {
-		foreach ( $blocks as $index => &$block ) {
-			if ( $block_name === $block['blockName'] ) {
-				unset( $blocks[ $index ] );
-			} elseif ( ! empty( $block['innerBlocks'] ) ) {
-				self::recursive_remove_block( $block['innerBlocks'], $block_name );
-			}
-		}
-	}
-
-	/**
 	 * Build a unified template object based a post Object.
 	 * Important: This method is an almost identical duplicate from wp-includes/block-template-utils.php as it was not intended for public use. It has been modified to build templates from plugins rather than themes.
 	 *
@@ -239,7 +201,7 @@ class BlockTemplateUtils {
 		// Remove the term description block from the archive-product template
 		// as the Product Catalog/Shop page doesn't have a description.
 		if ( 'archive-product' === $template_file->slug ) {
-			$template->content = self::remove_block_from_template( $template->content, 'core/term-description' );
+			$template->content = str_replace( '<!-- wp:term-description /-->', '', $template->content );
 		}
 		// Plugin was agreed as a valid source value despite existing inline docs at the time of creating: https://github.com/WordPress/gutenberg/issues/36597#issuecomment-976232909.
 		$template->source         = $template_file->source ? $template_file->source : 'plugin';


### PR DESCRIPTION
There was a PHP warning when removing the `term-description` block by parsing and serializing the template blocks.
This PR fixes the warning by removing the block from the template string. We only need to remove this particular block from the template this one time, so this is the most simple and performant way for now.
### Testing

#### Automated Tests
#### User Facing Testing

1. Uncomment [this](https://github.com/woocommerce/woocommerce-blocks/blob/001685f6f89cb43e9341e76ca1124c60db62c110/src/BlockTemplatesController.php#L391) and [these](https://github.com/woocommerce/woocommerce-blocks/blob/001685f6f89cb43e9341e76ca1124c60db62c110/src/BlockTemplatesController.php#L482-L484) lines (don't forget to remove the trailing dot).
2. Go to the Site Editor.
3. Open the `Product by Tag` template and make sure the `term description` block appears.
4. Go back and open the `Product Catalog` template.
5. Make sure the `term description` block is not there and you don't see any PHP warnings or errors.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
