### PR TITLE
Related Products: fix 404 error

### DIFF
--- a/src/BlockTypes/RelatedProducts.php
+++ b/src/BlockTypes/RelatedProducts.php
@@ -39,6 +39,14 @@ class RelatedProducts extends AbstractBlock {
 	}
 
 	/**
+	 * It isn't necessary register block assets because it is a server side block.
+	 */
+	protected function register_block_type_assets() {
+		return null;
+	}
+
+
+	/**
 	 * Update the query for the product query block.
 	 *
 	 * @param string|null $pre_render   The pre-rendered content. Default null.


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

This PR fixes the 404 error. Since it is a server-side block, it isn't necessary to enqueue any asset.


### Testing
#### User Facing Testing

1. Go to Site Editor.
2. Check the network and see that any 404 error is visible.
3. Open the Single Product template.
4. Add the Related Products.
5. Be sure that it is visible on the front end.


* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

