### PR TITLE
[Experimental] Show condensed version of the billing and shipping address after input

### DIFF
--- a/assets/css/abstracts/_colors.scss
+++ b/assets/css/abstracts/_colors.scss
@@ -4,6 +4,8 @@
 // Bright colors
 $discount-color: $alert-green;
 
+$form-step-border: rgba(0, 0, 0, 0.3);
+$form-step-border-dark: rgba(255, 255, 255, 0.3);
 $input-border-gray: #50575e;
 $input-border-dark: rgba(255, 255, 255, 0.4);
 $controls-border-dark: rgba(255, 255, 255, 0.6);

--- a/assets/js/base/components/cart-checkout/address-form/address-form.tsx
+++ b/assets/js/base/components/cart-checkout/address-form/address-form.tsx
@@ -65,7 +65,7 @@ interface AddressFormProps {
 	// Id for component.
 	id?: string;
 	// Unique id for form.
-	instanceId: string;
+	instanceId?: string | number;
 	// Array of fields in form.
 	fields: ( keyof AddressFields )[];
 	// Field configuration for fields in form.
@@ -87,7 +87,7 @@ const AddressForm = ( {
 		defaultAddressFields
 	) as unknown as ( keyof AddressFields )[],
 	fieldConfig = {} as Record< keyof AddressFields, Partial< AddressField > >,
-	instanceId,
+	instanceId = '',
 	onChange,
 	type = 'shipping',
 	values,
@@ -280,4 +280,4 @@ const AddressForm = ( {
 	);
 };
 
-export default withInstanceId( AddressForm );
+export default withInstanceId( AddressForm ) as typeof AddressForm;

--- a/assets/js/base/components/cart-checkout/form-step/style.scss
+++ b/assets/js/base/components/cart-checkout/form-step/style.scss
@@ -99,11 +99,14 @@
 	.wc-block-components-checkout-step__container::after {
 		content: "";
 		height: 100%;
-		border-left: 1px solid;
-		opacity: 0.3;
+		border-left: 1px solid $form-step-border;
 		position: absolute;
 		left: -$gap-large;
 		top: 0;
+
+		.has-dark-controls & {
+			border-color: $form-step-border-dark;
+		}
 	}
 
 	.is-mobile &,

--- a/assets/js/base/components/cart-checkout/form-step/style.scss
+++ b/assets/js/base/components/cart-checkout/form-step/style.scss
@@ -27,8 +27,7 @@
 	margin-bottom: em($gap);
 }
 .wc-block-components-checkout-step--with-step-number .wc-block-components-checkout-step__content > :last-child {
-	margin-bottom: 0;
-	padding-bottom: em($gap-large);
+	margin-bottom: em($gap-large);
 }
 
 .wc-block-components-checkout-step__heading {
@@ -80,6 +79,8 @@
 		width: $gap-large;
 		left: -$gap-large;
 		top: 0;
+		padding-bottom: em($gap-large);
+		box-sizing: content-box;
 		text-align: center;
 		transform: translateX(-50%);
 		white-space: nowrap;

--- a/assets/js/blocks/checkout/address-card/index.tsx
+++ b/assets/js/blocks/checkout/address-card/index.tsx
@@ -32,9 +32,9 @@ const AddressCard = ( {
 				className="wc-block-components-address-card__icon"
 			/>
 			<address>
-				<strong className="wc-block-components-address-card__address-section">
+				<span className="wc-block-components-address-card__address-section">
 					{ address.first_name + ' ' + address.last_name }
-				</strong>
+				</span>
 				<div className="wc-block-components-address-card__address-section">
 					{ [
 						address.address_1,

--- a/assets/js/blocks/checkout/address-card/index.tsx
+++ b/assets/js/blocks/checkout/address-card/index.tsx
@@ -1,0 +1,83 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Icon } from '@wordpress/icons';
+import { ALLOWED_COUNTRIES } from '@woocommerce/block-settings';
+import type {
+	CartShippingAddress,
+	CartBillingAddress,
+} from '@woocommerce/types';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+const AddressCard = ( {
+	address,
+	onEdit,
+	target,
+	icon: IconComponent,
+}: {
+	address: CartShippingAddress | CartBillingAddress;
+	onEdit: () => void;
+	target: string;
+	icon: JSX.Element;
+} ): JSX.Element | null => {
+	return (
+		<div className="wc-block-components-address-card">
+			<Icon
+				icon={ IconComponent }
+				className="wc-block-components-address-card__icon"
+			/>
+			<address>
+				<strong className="wc-block-components-address-card__address-section">
+					{ address.first_name + ' ' + address.last_name }
+				</strong>
+				<div className="wc-block-components-address-card__address-section">
+					{ [
+						address.address_1,
+						address.address_2,
+						address.city,
+						address.state,
+						address.postcode,
+						ALLOWED_COUNTRIES[ address.country ]
+							? ALLOWED_COUNTRIES[ address.country ]
+							: address.country,
+					]
+						.filter( ( field ) => !! field )
+						.map( ( field, index ) => (
+							<span key={ `address-` + index }>{ field }</span>
+						) ) }
+				</div>
+				{ address.phone ? (
+					<div
+						key={ `address-phone` }
+						className="wc-block-components-address-card__address-section"
+					>
+						{ address.phone }
+					</div>
+				) : (
+					''
+				) }
+			</address>
+			{ onEdit && (
+				<a
+					role="button"
+					href={ '#' + target }
+					className="wc-block-components-address-card__edit"
+					aria-label={ __(
+						'Change address',
+						'woo-gutenberg-products-block'
+					) }
+					onClick={ onEdit }
+				>
+					{ __( 'Change', 'woo-gutenberg-products-block' ) }
+				</a>
+			) }
+		</div>
+	);
+};
+
+export default AddressCard;

--- a/assets/js/blocks/checkout/address-card/style.scss
+++ b/assets/js/blocks/checkout/address-card/style.scss
@@ -1,0 +1,48 @@
+.wc-block-components-address-card {
+	border: 1px solid $input-border-gray;
+	margin: 0;
+	font-size: 0.875em;
+	padding: em($gap-small);
+	margin: 0;
+	border-radius: 4px;
+	display: flex;
+	justify-content: flex-start;
+	align-items: flex-start;
+
+	address {
+		margin: 0;
+		font-style: normal;
+		color: $gray-700;
+
+		strong {
+			color: $input-text-active;
+		}
+		.wc-block-components-address-card__address-section {
+			display: block;
+			margin: 0 0 2px 0;
+			span {
+				display: inline-block;
+				padding: 0 4px 0 0;
+				&::after {
+					content: ", ";
+				}
+				&:last-child::after {
+					content: "";
+				}
+			}
+			&:last-child {
+				margin-bottom: 0;
+			}
+		}
+	}
+}
+.wc-block-components-address-card__icon {
+	width: 1em;
+	font-size: 2em;
+	margin: 0 0.15em 0 -0.1em;
+	position: relative;
+	vertical-align: top;
+}
+.wc-block-components-address-card__edit {
+	margin: 0 0 0 auto;
+}

--- a/assets/js/blocks/checkout/address-card/style.scss
+++ b/assets/js/blocks/checkout/address-card/style.scss
@@ -1,5 +1,5 @@
 .wc-block-components-address-card {
-	border: 1px solid $input-border-gray;
+	border: 1px solid $form-step-border;
 	margin: 0;
 	font-size: 0.875em;
 	padding: em($gap-small);
@@ -9,14 +9,15 @@
 	justify-content: flex-start;
 	align-items: flex-start;
 
+	.has-dark-controls & {
+		border-color: $form-step-border-dark;
+	}
+
 	address {
 		margin: 0;
 		font-style: normal;
 		color: $gray-700;
 
-		strong {
-			color: $input-text-active;
-		}
 		.wc-block-components-address-card__address-section {
 			display: block;
 			margin: 0 0 2px 0;

--- a/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/block.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/block.tsx
@@ -1,17 +1,16 @@
 /**
  * External dependencies
  */
-import { useMemo, useEffect, Fragment, useState } from '@wordpress/element';
+import { useMemo, Fragment } from '@wordpress/element';
+import { useEffectOnce } from 'usehooks-ts';
 import {
 	useCheckoutAddress,
-	useStoreEvents,
 	useEditorContext,
 	noticeContexts,
 } from '@woocommerce/base-context';
-import { AddressForm } from '@woocommerce/base-components/cart-checkout';
 import Noninteractive from '@woocommerce/base-components/noninteractive';
 import type {
-	BillingAddress,
+	ShippingAddress,
 	AddressField,
 	AddressFields,
 } from '@woocommerce/settings';
@@ -20,7 +19,7 @@ import { StoreNoticesContainer } from '@woocommerce/blocks-checkout';
 /**
  * Internal dependencies
  */
-import PhoneNumber from '../../phone-number';
+import CustomerAddress from './customer-address';
 
 const Block = ( {
 	showCompanyField = false,
@@ -35,41 +34,19 @@ const Block = ( {
 	requireCompanyField: boolean;
 	requirePhoneField: boolean;
 } ): JSX.Element => {
-	const {
-		defaultAddressFields,
-		billingAddress,
-		setBillingAddress,
-		setShippingAddress,
-		setBillingPhone,
-		setShippingPhone,
-		useBillingAsShipping,
-	} = useCheckoutAddress();
-	const { dispatchCheckoutEvent } = useStoreEvents();
+	const { billingAddress, setShippingAddress, useBillingAsShipping } =
+		useCheckoutAddress();
 	const { isEditor } = useEditorContext();
-	// Clears data if fields are hidden.
-	useEffect( () => {
-		if ( ! showPhoneField ) {
-			setBillingPhone( '' );
-		}
-	}, [ showPhoneField, setBillingPhone ] );
-
-	const [ addressesSynced, setAddressesSynced ] = useState( false );
 
 	// Syncs shipping address with billing address if "Force shipping to the customer billing address" is enabled.
-	useEffect( () => {
-		if ( addressesSynced ) {
-			return;
-		}
+	useEffectOnce( () => {
 		if ( useBillingAsShipping ) {
-			setShippingAddress( billingAddress );
+			setShippingAddress( {
+				...billingAddress,
+				phone: showPhoneField ? billingAddress.phone : '',
+			} as ShippingAddress );
 		}
-		setAddressesSynced( true );
-	}, [
-		addressesSynced,
-		setShippingAddress,
-		billingAddress,
-		useBillingAsShipping,
-	] );
+	} );
 
 	const addressFieldsConfig = useMemo( () => {
 		return {
@@ -87,54 +64,28 @@ const Block = ( {
 		showApartmentField,
 	] ) as Record< keyof AddressFields, Partial< AddressField > >;
 
-	const AddressFormWrapperComponent = isEditor ? Noninteractive : Fragment;
 	const noticeContext = useBillingAsShipping
 		? [ noticeContexts.BILLING_ADDRESS, noticeContexts.SHIPPING_ADDRESS ]
 		: [ noticeContexts.BILLING_ADDRESS ];
 
+	const WrapperComponent = isEditor ? Noninteractive : Fragment;
+	const hasAddress = !! (
+		billingAddress.address_1 &&
+		( billingAddress.first_name || billingAddress.last_name )
+	);
+
 	return (
-		<AddressFormWrapperComponent>
+		<>
 			<StoreNoticesContainer context={ noticeContext } />
-			<AddressForm
-				id="billing"
-				type="billing"
-				onChange={ ( values: Partial< BillingAddress > ) => {
-					setBillingAddress( values );
-					if ( useBillingAsShipping ) {
-						setShippingAddress( values );
-						dispatchCheckoutEvent( 'set-shipping-address' );
-					}
-					dispatchCheckoutEvent( 'set-billing-address' );
-				} }
-				values={ billingAddress }
-				fields={
-					Object.keys(
-						defaultAddressFields
-					) as ( keyof AddressFields )[]
-				}
-				fieldConfig={ addressFieldsConfig }
-			/>
-			{ showPhoneField && (
-				<PhoneNumber
-					id={ 'billing-phone' }
-					errorId={ 'billing_phone' }
-					isRequired={ requirePhoneField }
-					value={ billingAddress.phone }
-					onChange={ ( value ) => {
-						setBillingPhone( value );
-						dispatchCheckoutEvent( 'set-phone-number', {
-							step: 'billing',
-						} );
-						if ( useBillingAsShipping ) {
-							setShippingPhone( value );
-							dispatchCheckoutEvent( 'set-phone-number', {
-								step: 'shipping',
-							} );
-						}
-					} }
+			<WrapperComponent>
+				<CustomerAddress
+					addressFieldsConfig={ addressFieldsConfig }
+					showPhoneField={ showPhoneField }
+					requirePhoneField={ requirePhoneField }
+					hasAddress={ hasAddress }
 				/>
-			) }
-		</AddressFormWrapperComponent>
+			</WrapperComponent>
+		</>
 	);
 };
 

--- a/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/customer-address.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/customer-address.tsx
@@ -59,8 +59,8 @@ const CustomerAddress = ( {
 			{ ( editing || ! hasAddress ) && (
 				<>
 					<AddressForm
-						id="shipping"
-						type="shipping"
+						id="billing"
+						type="billing"
 						onChange={ ( values: Partial< BillingAddress > ) => {
 							setBillingAddress( values );
 							if ( useBillingAsShipping ) {

--- a/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/customer-address.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/customer-address.tsx
@@ -1,0 +1,101 @@
+/**
+ * External dependencies
+ */
+import { useState } from '@wordpress/element';
+import { AddressForm } from '@woocommerce/base-components/cart-checkout';
+import { useCheckoutAddress, useStoreEvents } from '@woocommerce/base-context';
+import { receipt } from '@wordpress/icons';
+import type {
+	BillingAddress,
+	AddressField,
+	AddressFields,
+} from '@woocommerce/settings';
+
+/**
+ * Internal dependencies
+ */
+import PhoneNumber from '../../phone-number';
+import AddressCard from '../../address-card';
+
+const CustomerAddress = ( {
+	addressFieldsConfig,
+	showPhoneField,
+	requirePhoneField,
+	hasAddress,
+}: {
+	addressFieldsConfig: Record< keyof AddressFields, Partial< AddressField > >;
+	showPhoneField: boolean;
+	requirePhoneField: boolean;
+	hasAddress: boolean;
+} ) => {
+	const {
+		defaultAddressFields,
+		billingAddress,
+		setShippingAddress,
+		setBillingAddress,
+		setBillingPhone,
+		setShippingPhone,
+		useBillingAsShipping,
+	} = useCheckoutAddress();
+	const { dispatchCheckoutEvent } = useStoreEvents();
+
+	const [ editing, setEditing ] = useState( ! hasAddress );
+	const addressFieldKeys = Object.keys(
+		defaultAddressFields
+	) as ( keyof AddressFields )[];
+
+	return (
+		<>
+			{ hasAddress && ! editing && (
+				<AddressCard
+					address={ billingAddress }
+					target="billing"
+					onEdit={ () => {
+						setEditing( true );
+					} }
+					icon={ receipt }
+				/>
+			) }
+			{ ( editing || ! hasAddress ) && (
+				<>
+					<AddressForm
+						id="shipping"
+						type="shipping"
+						onChange={ ( values: Partial< BillingAddress > ) => {
+							setBillingAddress( values );
+							if ( useBillingAsShipping ) {
+								setShippingAddress( values );
+							}
+							dispatchCheckoutEvent( 'set-shipping-address' );
+						} }
+						values={ billingAddress }
+						fields={ addressFieldKeys }
+						fieldConfig={ addressFieldsConfig }
+					/>
+					{ showPhoneField && (
+						<PhoneNumber
+							id="billing-phone"
+							errorId={ 'billing_phone' }
+							isRequired={ requirePhoneField }
+							value={ billingAddress.phone }
+							onChange={ ( value ) => {
+								setBillingPhone( value );
+								dispatchCheckoutEvent( 'set-phone-number', {
+									step: 'shipping',
+								} );
+								if ( useBillingAsShipping ) {
+									setShippingPhone( value );
+									dispatchCheckoutEvent( 'set-phone-number', {
+										step: 'shipping',
+									} );
+								}
+							} }
+						/>
+					) }
+				</>
+			) }
+		</>
+	);
+};
+
+export default CustomerAddress;

--- a/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/customer-address.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/customer-address.tsx
@@ -1,0 +1,94 @@
+/**
+ * External dependencies
+ */
+import { useState } from '@wordpress/element';
+import { AddressForm } from '@woocommerce/base-components/cart-checkout';
+import { useCheckoutAddress, useStoreEvents } from '@woocommerce/base-context';
+import { home } from '@wordpress/icons';
+import type {
+	ShippingAddress,
+	AddressField,
+	AddressFields,
+} from '@woocommerce/settings';
+
+/**
+ * Internal dependencies
+ */
+import PhoneNumber from '../../phone-number';
+import AddressCard from '../../address-card';
+
+const CustomerAddress = ( {
+	addressFieldsConfig,
+	showPhoneField,
+	requirePhoneField,
+	hasAddress,
+}: {
+	addressFieldsConfig: Record< keyof AddressFields, Partial< AddressField > >;
+	showPhoneField: boolean;
+	requirePhoneField: boolean;
+	hasAddress: boolean;
+} ) => {
+	const {
+		defaultAddressFields,
+		shippingAddress,
+		setShippingAddress,
+		setBillingAddress,
+		setShippingPhone,
+		useShippingAsBilling,
+	} = useCheckoutAddress();
+	const { dispatchCheckoutEvent } = useStoreEvents();
+
+	const [ editing, setEditing ] = useState( ! hasAddress );
+	const addressFieldKeys = Object.keys(
+		defaultAddressFields
+	) as ( keyof AddressFields )[];
+
+	return (
+		<>
+			{ hasAddress && ! editing && (
+				<AddressCard
+					address={ shippingAddress }
+					target="shipping"
+					onEdit={ () => {
+						setEditing( true );
+					} }
+					icon={ home }
+				/>
+			) }
+			{ ( editing || ! hasAddress ) && (
+				<>
+					<AddressForm
+						id="shipping"
+						type="shipping"
+						onChange={ ( values: Partial< ShippingAddress > ) => {
+							setShippingAddress( values );
+							if ( useShippingAsBilling ) {
+								setBillingAddress( values );
+							}
+							dispatchCheckoutEvent( 'set-shipping-address' );
+						} }
+						values={ shippingAddress }
+						fields={ addressFieldKeys }
+						fieldConfig={ addressFieldsConfig }
+					/>
+					{ showPhoneField && (
+						<PhoneNumber
+							id="shipping-phone"
+							errorId={ 'shipping_phone' }
+							isRequired={ requirePhoneField }
+							value={ shippingAddress.phone }
+							onChange={ ( value ) => {
+								setShippingPhone( value );
+								dispatchCheckoutEvent( 'set-phone-number', {
+									step: 'shipping',
+								} );
+							} }
+						/>
+					) }
+				</>
+			) }
+		</>
+	);
+};
+
+export default CustomerAddress;

--- a/assets/js/data/utils/index.js
+++ b/assets/js/data/utils/index.js
@@ -1,3 +1,4 @@
 export { default as hasInState } from './has-in-state';
 export { default as updateState } from './update-state';
 export * from './process-error-response';
+export * from './validation';

--- a/assets/js/data/utils/validation.ts
+++ b/assets/js/data/utils/validation.ts
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import { select, dispatch } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { VALIDATION_STORE_KEY } from '../validation';
+
+/**
+ * For a given list of keys, finds the invalid ones and returns them.
+ *
+ * This assumes that error ids are made by of ADDRESS_TYPE_KEY + '_' + KEY e.g. shipping_first_name
+ *
+ * @param  keys
+ * @param  addressType
+ */
+export const getInvalidAddressKeys = (
+	keys: string[],
+	addressType: 'shipping' | 'billing' = 'shipping'
+) => {
+	if ( ! select( VALIDATION_STORE_KEY ).hasValidationErrors() ) {
+		return [];
+	}
+
+	const getValidationError =
+		select( VALIDATION_STORE_KEY ).getValidationError;
+
+	return keys
+		.filter( ( key ) => {
+			return getValidationError( addressType + '_' + key ) !== undefined;
+		} )
+		.filter( Boolean );
+};
+
+/**
+ * For a given list of keys, reveal the validation errors inline.
+ *
+ * @param  keys
+ * @param  addressType
+ */
+export const showValidationErrorsForAddressKeys = (
+	keys: string[],
+	addressType: 'shipping' | 'billing' = 'shipping'
+) => {
+	keys.forEach( ( key ) => {
+		dispatch( VALIDATION_STORE_KEY ).showValidationError(
+			addressType + '_' + key
+		);
+	} );
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
 				"snakecase-keys": "5.4.2",
 				"trim-html": "0.1.9",
 				"use-debounce": "7.0.1",
+				"usehooks-ts": "^2.9.1",
 				"wordpress-components": "npm:@wordpress/components@14.2.0"
 			},
 			"devDependencies": {
@@ -48260,6 +48261,19 @@
 				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
 			}
 		},
+		"node_modules/usehooks-ts": {
+			"version": "2.9.1",
+			"resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-2.9.1.tgz",
+			"integrity": "sha512-2FAuSIGHlY+apM9FVlj8/oNhd+1y+Uwv5QNkMQz1oSfdHk4PXo1qoCw9I5M7j0vpH8CSWFJwXbVPeYDjLCx9PA==",
+			"engines": {
+				"node": ">=16.15.0",
+				"npm": ">=8"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0  || ^17.0.0 || ^18.0.0",
+				"react-dom": "^16.8.0  || ^17.0.0 || ^18.0.0"
+			}
+		},
 		"node_modules/util": {
 			"version": "0.10.4",
 			"dev": true,
@@ -83809,6 +83823,12 @@
 			"version": "1.2.0",
 			"dev": true,
 			"peer": true,
+			"requires": {}
+		},
+		"usehooks-ts": {
+			"version": "2.9.1",
+			"resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-2.9.1.tgz",
+			"integrity": "sha512-2FAuSIGHlY+apM9FVlj8/oNhd+1y+Uwv5QNkMQz1oSfdHk4PXo1qoCw9I5M7j0vpH8CSWFJwXbVPeYDjLCx9PA==",
 			"requires": {}
 		},
 		"util": {

--- a/package.json
+++ b/package.json
@@ -258,6 +258,7 @@
 		"snakecase-keys": "5.4.2",
 		"trim-html": "0.1.9",
 		"use-debounce": "7.0.1",
+		"usehooks-ts": "^2.9.1",
 		"wordpress-components": "npm:@wordpress/components@14.2.0"
 	},
 	"peerDependencies": {


### PR DESCRIPTION
This is a spin off from https://github.com/woocommerce/woocommerce-blocks/pull/8513/files which extracts just the address-card component to show a condensed version of the address if the customer has input one already.

This does not implement any changes to the push system - the form works the same way as before for now. The only difference is to how the address is displayed if populated.

### Screenshots

When an address is already saved (logged in, or refreshing) you'll see:

![address](https://user-images.githubusercontent.com/90977/221626993-d1221167-f720-48fb-bfc5-9cc504af2375.png)

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

e2e will need updating due to the "change" link.

#### User Facing Testing

1. Checkout with a new session as a guest
2. Add your address to the shipping form. 
3. When you see changes are pushed and rates are updated, refresh checkout
4. You should now see the condensed address card.
5. Click "change" and ensure the form is shown again.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Show a condensed version of the address after the address form has been filled out on checkout.
