### PR TITLE
Fix 'Edit Mini Cart template part' link in WP 6.2

### DIFF
--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -201,13 +201,20 @@ class MiniCart extends AbstractBlock {
 			current_user_can( 'edit_theme_options' ) &&
 			wc_current_theme_is_fse_theme()
 		) {
-			$theme_slug      = BlockTemplateUtils::theme_has_template_part( 'mini-cart' ) ? wp_get_theme()->get_stylesheet() : BlockTemplateUtils::PLUGIN_SLUG;
-			$site_editor_uri = admin_url( 'site-editor.php' );
+			$theme_slug = BlockTemplateUtils::theme_has_template_part( 'mini-cart' ) ? wp_get_theme()->get_stylesheet() : BlockTemplateUtils::PLUGIN_SLUG;
 
 			if ( version_compare( get_bloginfo( 'version' ), '5.9', '<' ) ) {
 				$site_editor_uri = add_query_arg(
 					array( 'page' => 'gutenberg-edit-site' ),
 					admin_url( 'themes.php' )
+				);
+			} else {
+				$site_editor_uri = add_query_arg(
+					array(
+						'canvas' => 'edit',
+						'path'   => '/template-parts/single',
+					),
+					admin_url( 'site-editor.php' )
 				);
 			}
 


### PR DESCRIPTION
Fixes #8572.

### Testing

#### User Facing Testing

0. Make sure you use a block theme, like TT3, and install the latest version of Gutenberg.
1. Create a post or page and add the Mini Cart block.
2. In the sidebar, click on the "Edit Mini Cart template part" link.
3. Verify the Site Editor open in a new tab and the Mini Cart template part is opened by default.
4. Repeat the testing steps but having Gutenberg disabled and verify the link keeps working. (This step is to verify no regressions were introduced)

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix 'Edit Mini Cart template part' link in WP 6.2
