### PR TITLE
Enable Product Image Gallery only for experimental builds

### DIFF
--- a/assets/js/atomic/blocks/product-elements/product-image-gallery/index.ts
+++ b/assets/js/atomic/blocks/product-elements/product-image-gallery/index.ts
@@ -4,6 +4,7 @@
 import { gallery as icon } from '@wordpress/icons';
 import { registerBlockType, unregisterBlockType } from '@wordpress/blocks';
 import { registerBlockSingleProductTemplate } from '@woocommerce/atomic-utils';
+import { isExperimentalBuild } from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies
@@ -11,16 +12,18 @@ import { registerBlockSingleProductTemplate } from '@woocommerce/atomic-utils';
 import edit from './edit';
 import metadata from './block.json';
 
-registerBlockSingleProductTemplate( {
-	registerBlockFn: () => {
-		// @ts-expect-error: `registerBlockType` is a function that is typed in WordPress core.
-		registerBlockType( metadata, {
-			icon,
-			edit,
-		} );
-	},
-	unregisterBlockFn: () => {
-		unregisterBlockType( metadata.name );
-	},
-	blockName: metadata.name,
-} );
+if ( isExperimentalBuild() ) {
+	registerBlockSingleProductTemplate( {
+		registerBlockFn: () => {
+			// @ts-expect-error: `registerBlockType` is a function that is typed in WordPress core.
+			registerBlockType( metadata, {
+				icon,
+				edit,
+			} );
+		},
+		unregisterBlockFn: () => {
+			unregisterBlockType( metadata.name );
+		},
+		blockName: metadata.name,
+	} );
+}


### PR DESCRIPTION
This PR enables the Product Image Gallery only for the experimental builds.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->


### Testing

#### Automated Tests
#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Run the command `npm run build:deploy`.
2. Edit the Single Product Template.
3. Search the `Product Image Gallery` block. Be sure that it is visible.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental


