### PR TITLE
Add to cart form > Reintroduce the .product and .product-type classes

### DIFF
--- a/src/BlockTypes/AddToCartForm.php
+++ b/src/BlockTypes/AddToCartForm.php
@@ -48,7 +48,7 @@ class AddToCartForm extends AbstractBlock {
 		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes );
 
 		return sprintf(
-			'<div class="wp-block-add-to-cart-form %1$s %2$s" style="%3$s">%4$s</div>',
+			'<div class="wp-block-add-to-cart-form %1$s %2$s" style="%3$s"><div class="product type-product">%4$s</div></div>',
 			esc_attr( $classes_and_styles['classes'] ),
 			esc_attr( $classname ),
 			esc_attr( $classes_and_styles['styles'] ),


### PR DESCRIPTION
This is a proposal for temporarily reintroducing the `.product` and `.product-type` classes to the Add to Cart Form button until the compatibility layer is released to ensure the correct styles are in place.

Context: this selector was removed as part of [this discussion](https://github.com/woocommerce/woocommerce-blocks/pull/8482#discussion_r1112109400), but since the compatibility layer is not ready to be released just yet, we can re-add the class for now so users can use the block without any styling inconsistencies.

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
### Testing

#### User Facing Testing

The test instructions are exactly the same as described on #8284 

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> N/A
