### PR TITLE
Fix styles of the Add to Cart form and Product Image Gallery block

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -2,6 +2,7 @@
 namespace Automattic\WooCommerce\Blocks;
 
 use Automattic\WooCommerce\Blocks\Domain\Package;
+use Automattic\WooCommerce\Blocks\Templates\BlockTemplatesCompatibility;
 use Automattic\WooCommerce\Blocks\Templates\ProductAttributeTemplate;
 use Automattic\WooCommerce\Blocks\Utils\BlockTemplateUtils;
 
@@ -322,6 +323,14 @@ class BlockTemplatesController {
 				}
 				if ( ! $template->description ) {
 					$template->description = BlockTemplateUtils::get_block_template_description( $template->slug );
+				}
+
+				if ( 'single-product' === $template->slug ) {
+					if ( ! is_admin() ) {
+						$new_content       = BlockTemplatesCompatibility::wrap_single_product_template( $template->content );
+						$template->content = $new_content;
+					}
+					return $template;
 				}
 
 				return $template;


### PR DESCRIPTION
Reintroduces the logic to wrap the Single Product template in the frontend. Kudos to @gigitux for suggesting this fix.

This regression was introduced by #8507, which disabled the compatibility layer.

### Testing

#### User Facing Testing

* Make sure you are using a block theme, like TT3.
* Go to Appearance > Editor.
* Edit the Single Product template.
* Add the Add to Cart form and Product Image Gallery blocks.
* Make sure they render correctly.

Before | After
--- | ---
![imatge](https://user-images.githubusercontent.com/3616980/221873455-da39e46d-f00c-4b0c-b793-11a71d7104e8.png) | ![imatge](https://user-images.githubusercontent.com/3616980/221873341-8e80ca20-3226-4a96-9a16-c1b1c80d5fb9.png)

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [ ] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental