### PR TITLE
Rename BlockTemplatesCompatibility class to ArchiveProductTemplatesCompatibility

### DIFF
--- a/src/Domain/Bootstrap.php
+++ b/src/Domain/Bootstrap.php
@@ -29,7 +29,7 @@ use Automattic\WooCommerce\StoreApi\SchemaController;
 use Automattic\WooCommerce\StoreApi\StoreApi;
 use Automattic\WooCommerce\Blocks\Shipping\ShippingController;
 use Automattic\WooCommerce\Blocks\Templates\SingleProductTemplateCompatibility;
-use Automattic\WooCommerce\Blocks\Templates\BlockTemplatesCompatibility;
+use Automattic\WooCommerce\Blocks\Templates\ArchiveProductTemplatesCompatibility;
 
 /**
  * Takes care of bootstrapping the plugin.
@@ -131,7 +131,7 @@ class Bootstrap {
 		$this->container->get( ProductSearchResultsTemplate::class );
 		$this->container->get( ProductAttributeTemplate::class );
 		$this->container->get( ClassicTemplatesCompatibility::class );
-		$this->container->get( BlockTemplatesCompatibility::class )->init();
+		$this->container->get( ArchiveProductTemplatesCompatibility::class )->init();
 		$this->container->get( SingleProductTemplateCompatibility::class )->init();
 		$this->container->get( BlockPatterns::class );
 		$this->container->get( PaymentsApi::class );
@@ -279,9 +279,9 @@ class Bootstrap {
 			}
 		);
 		$this->container->register(
-			BlockTemplatesCompatibility::class,
+			ArchiveProductTemplatesCompatibility::class,
 			function () {
-				return new BlockTemplatesCompatibility();
+				return new ArchiveProductTemplatesCompatibility();
 			}
 		);
 

--- a/src/Templates/AbstractTemplateCompatibility.php
+++ b/src/Templates/AbstractTemplateCompatibility.php
@@ -2,7 +2,7 @@
 namespace Automattic\WooCommerce\Blocks\Templates;
 
 /**
- * BlockTemplatesCompatibility class.
+ * AbstractTemplateCompatibility class.
  *
  * To bridge the gap on compatibility with PHP hooks and blockified templates.
  *

--- a/src/Templates/ArchiveProductTemplatesCompatibility.php
+++ b/src/Templates/ArchiveProductTemplatesCompatibility.php
@@ -2,13 +2,13 @@
 namespace Automattic\WooCommerce\Blocks\Templates;
 
 /**
- * BlockTemplatesCompatibility class.
+ * ArchiveProductTemplatesCompatibility class.
  *
- * To bridge the gap on compatibility with PHP hooks and blockified templates.
+ * To bridge the gap on compatibility with PHP hooks and Product Archive blockified templates.
  *
  * @internal
  */
-class BlockTemplatesCompatibility extends AbstractTemplateCompatibility {
+class ArchiveProductTemplatesCompatibility extends AbstractTemplateCompatibility {
 
 	/**
 	 * The custom ID of the loop item block as the replacement of the core/null block.


### PR DESCRIPTION
This PR is a follow-up of [this discussion](https://github.com/woocommerce/woocommerce-blocks/pull/8442/files#r1110029429).
With #8442, the `BlockTemplatesCompatibility` class handles the compatibility layer only with the Archive Product templates. For this reason, we decided to rename it to `ArchiveProductTemplatesCompatibility`.

### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Check out this branch.
2. Search inside the project for the text `BlockTemplatesCompatibility`. 
3. Be sure that there are 0 results.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

