### PR TITLE
Move testing steps #8438 to experimental section

### DIFF
--- a/docs/internal-developers/testing/releases/970.md
+++ b/docs/internal-developers/testing/releases/970.md
@@ -641,3 +641,34 @@ Make sure Product Catalog template is cleared out to the default state. To achie
 Video presents the replacement of a Classic Template on two templates: Product Catalog and Products by Category
 
 <video src="https://user-images.githubusercontent.com/20098064/214537418-51c74d39-7e00-4e26-9c2c-fe2e0f245390.mov" />
+
+### Simplify unused Add to Cart button form placeholder for grouped product ([8438](https://github.com/woocommerce/woocommerce-blocks/pull/8438))
+
+1. Go to Editor
+2. Edit the Product Catalog template
+3. Add All Products block
+4. Enter the "edit" mode of All Products block by clicking a pencil button
+5. Remove "Add to Cart Button" block
+6. Add "Add to Cart" block - THESE ARE TWO SEPARATE BLOCKS. IT'S ABOUT "ADD TO CART" BLOCK!
+7. By default the "Display form elements" toggle should be disabled
+**Expected**: Button looks like on a pictures above
+8. Save the changes and check the frontend as well
+
+9. Enter the edit mode of "Add to Cart" button (there's a [bug that block cannot be clicked](https://github.com/woocommerce/woocommerce-blocks/issues/8439). To enter the edit mode, please open a "list view" of blocks and choose "Add to Cart" from there)
+10. Enable "Display form elements" toggle
+**Expected**: Button looks like on a pictures above (while it changes to form for other types of products: simple, variable)
+11. Save the changes and check the frontend as well
+
+#### Editor - Grouped product is the middle one on each image. Other products are included for comparison
+
+| Case | Before | After |
+| ------ | ----- |----- |
+|    Display form elements: disabled    |   <img width="620" alt="image" src="https://user-images.githubusercontent.com/20098064/219035374-59f7e3d5-cf88-4450-8052-b1e7bcde275b.png">    |   <img width="637" alt="image" src="https://user-images.githubusercontent.com/20098064/219033902-bc991786-e9cc-41c6-9ae8-1f33cda4378c.png">   |
+|    Display form elements: enabled    |    <img width="630" alt="image" src="https://user-images.githubusercontent.com/20098064/219035240-8e943b7d-5422-4acf-9cda-f610be2f3fb8.png">   |    <img width="628" alt="image" src="https://user-images.githubusercontent.com/20098064/219034539-606de553-f664-4e45-b252-a903001a455b.png">  |
+
+#### Frontend - Grouped product is the middle one on each image. Other products are included for comparison
+
+| Case | Before | After |
+| ------ | ----- |----- |
+|    Display form elements: disabled    |   <img width="671" alt="image" src="https://user-images.githubusercontent.com/20098064/219035426-a0032999-2d10-4389-9945-0ba2fb7accc7.png">    |   <img width="658" alt="image" src="https://user-images.githubusercontent.com/20098064/219034371-c2ab137a-1c38-4907-91c3-a5c69db8fed3.png">   |
+|    Display form elements: enabled    |   <img width="665" alt="image" src="https://user-images.githubusercontent.com/20098064/219035271-97621392-9299-4cde-9628-fa750f805faf.png">    |   <img width="659" alt="image" src="https://user-images.githubusercontent.com/20098064/219034622-44db616a-5a7e-4359-bac7-537c404f1add.png">   |

--- a/docs/internal-developers/testing/releases/970.md
+++ b/docs/internal-developers/testing/releases/970.md
@@ -162,37 +162,6 @@ The content displayed on the frontend is dynamically changed depending on the pr
 
 ![Untitled-2023-02-02-2008](https://user-images.githubusercontent.com/3966773/217264284-03f0254e-7981-4c5f-a368-270d52995245.png)
 
-### Simplify unused Add to Cart button form placeholder for grouped product ([8438](https://github.com/woocommerce/woocommerce-blocks/pull/8438))
-
-1. Go to Editor
-2. Edit the Product Catalog template
-3. Add All Products block
-4. Enter the "edit" mode of All Products block by clicking a pencil button
-5. Remove "Add to Cart Button" block
-6. Add "Add to Cart" block - THESE ARE TWO SEPARATE BLOCKS. IT'S ABOUT "ADD TO CART" BLOCK!
-7. By default the "Display form elements" toggle should be disabled
-**Expected**: Button looks like on a pictures above
-8. Save the changes and check the frontend as well
-
-9. Enter the edit mode of "Add to Cart" button (there's a [bug that block cannot be clicked](https://github.com/woocommerce/woocommerce-blocks/issues/8439). To enter the edit mode, please open a "list view" of blocks and choose "Add to Cart" from there)
-10. Enable "Display form elements" toggle
-**Expected**: Button looks like on a pictures above (while it changes to form for other types of products: simple, variable)
-11. Save the changes and check the frontend as well
-
-#### Editor - Grouped product is the middle one on each image. Other products are included for comparison
-
-| Case | Before | After |
-| ------ | ----- |----- |
-|    Display form elements: disabled    |   <img width="620" alt="image" src="https://user-images.githubusercontent.com/20098064/219035374-59f7e3d5-cf88-4450-8052-b1e7bcde275b.png">    |   <img width="637" alt="image" src="https://user-images.githubusercontent.com/20098064/219033902-bc991786-e9cc-41c6-9ae8-1f33cda4378c.png">   |
-|    Display form elements: enabled    |    <img width="630" alt="image" src="https://user-images.githubusercontent.com/20098064/219035240-8e943b7d-5422-4acf-9cda-f610be2f3fb8.png">   |    <img width="628" alt="image" src="https://user-images.githubusercontent.com/20098064/219034539-606de553-f664-4e45-b252-a903001a455b.png">  |
-
-#### Frontend - Grouped product is the middle one on each image. Other products are included for comparison
-
-| Case | Before | After |
-| ------ | ----- |----- |
-|    Display form elements: disabled    |   <img width="671" alt="image" src="https://user-images.githubusercontent.com/20098064/219035426-a0032999-2d10-4389-9945-0ba2fb7accc7.png">    |   <img width="658" alt="image" src="https://user-images.githubusercontent.com/20098064/219034371-c2ab137a-1c38-4907-91c3-a5c69db8fed3.png">   |
-|    Display form elements: enabled    |   <img width="665" alt="image" src="https://user-images.githubusercontent.com/20098064/219035271-97621392-9299-4cde-9628-fa750f805faf.png">    |   <img width="659" alt="image" src="https://user-images.githubusercontent.com/20098064/219034622-44db616a-5a7e-4359-bac7-537c404f1add.png">   |
-
 ### Use the @wordpress/components instead of wordpress-components while in editor ([8432](https://github.com/woocommerce/woocommerce-blocks/pull/8432))
 
 Prerequisites:


### PR DESCRIPTION
PR should be marked as Experimental, not Core.

During testing, `Add to Cart` block wouldn't appear in the inserter.`Add to Cart` is an experimental block that I didn’t realize earlier. So it’s expected that the block won’t show up in the production build.

It’s listed in [the docs](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md#experimental-flag) and [here’s the flag](https://github.com/woocommerce/woocommerce-blocks/blob/b3a9753d8b7dae18b36025d09fbff835b8365de0/assets/js/atomic/blocks/product-elements/add-to-cart/index.js#L29).