### PR TITLE
Add to Cart Form Block > Ensure the editor preview is properly displayed with the Gutenberg plugin disabled

### DIFF
--- a/assets/js/atomic/blocks/product-elements/add-to-cart-form/edit.tsx
+++ b/assets/js/atomic/blocks/product-elements/add-to-cart-form/edit.tsx
@@ -14,7 +14,7 @@ export interface Attributes {
 
 const Edit = () => {
 	const blockProps = useBlockProps( {
-		className: 'woocommerce wc-block-add-to-cart-form',
+		className: 'wc-block-add-to-cart-form',
 	} );
 
 	return (

--- a/assets/js/atomic/blocks/product-elements/add-to-cart-form/editor.scss
+++ b/assets/js/atomic/blocks/product-elements/add-to-cart-form/editor.scss
@@ -3,24 +3,25 @@
 	flex-direction: row;
 }
 
-.wc-block-add-to-cart-form__notice {
+.wc-block-add-to-cart-form__notice.components-notice {
 	margin: 10px 0;
 	color: $black;
 	max-width: 60%;
 }
+
 input.wc-block-add-to-cart-form__quantity {
-	width: 35px;
+	max-width: 55px;
 	float: left;
 	padding: 10px 6px 10px 12px;
 	margin-right: 10px;
-	height: 15px;
+	font-size: 13px;
 }
 
 input[type="number"]::-webkit-inner-spin-button {
 	opacity: 1;
 }
 
-.wc-block-add-to-cart-form__button {
+button.components-button.wc-block-add-to-cart-form__button {
 	float: left;
 	padding: 20px 30px;
 	border-radius: 0;

--- a/assets/js/atomic/blocks/product-elements/add-to-cart-form/editor.scss
+++ b/assets/js/atomic/blocks/product-elements/add-to-cart-form/editor.scss
@@ -9,12 +9,14 @@
 	max-width: 60%;
 }
 
-input.wc-block-add-to-cart-form__quantity {
-	max-width: 55px;
+input.wc-block-add-to-cart-form__quantity[type="number"] {
+	max-width: 50px;
+	min-height: 22px;
 	float: left;
-	padding: 10px 6px 10px 12px;
+	padding: 6px 6px 6px 12px;
 	margin-right: 10px;
 	font-size: 13px;
+	height: inherit;
 }
 
 input[type="number"]::-webkit-inner-spin-button {

--- a/assets/js/atomic/blocks/product-elements/add-to-cart-form/editor.scss
+++ b/assets/js/atomic/blocks/product-elements/add-to-cart-form/editor.scss
@@ -11,7 +11,7 @@
 
 input.wc-block-add-to-cart-form__quantity[type="number"] {
 	max-width: 50px;
-	min-height: 22px;
+	min-height: 23px;
 	float: left;
 	padding: 6px 6px 6px 12px;
 	margin-right: 10px;


### PR DESCRIPTION
This change ensures the editor preview for the Add to Cart Button form is displayed correctly while having the Gutenberg plugin disabled: in this particular case, as it turns out, some CSS selectors differ depending on the version of Gutenberg we are on.

Props to @Aljullu for identifying this inconsistency and @imanish003 for the initial flag!

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
| <img width="428" alt="Screenshot 2023-02-28 at 21 59 39" src="https://user-images.githubusercontent.com/15730971/221978504-dba6ce15-90d0-449f-b629-52b0bdcfbdac.png"> | <img width="418" alt="Screenshot 2023-02-28 at 23 30 34" src="https://user-images.githubusercontent.com/15730971/221996438-e247a4a4-281b-4f47-acbb-771bbc5d0658.png"> |

### Testing

#### User Facing Testing

1. Ensure you have the Gutenberg plugin disabled.
2. With a block theme enabled, head over to Edit site > Templates > Single Product and click on Edit.
3. Add the "Add to Cart Form" block to this template.
4. Ensure the input is displayed correctly, as demonstrated in the screenshot.
5. Enable the Gutenberg plugin.
6. Ensure the input is displayed correctly as well.

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
