### PR TITLE
Check if WordPress version is 6.1 and higher to allow for template conversion

### DIFF
--- a/src/Utils/BlockTemplateUtils.php
+++ b/src/Utils/BlockTemplateUtils.php
@@ -641,7 +641,7 @@ class BlockTemplateUtils {
 	 * @return boolean
 	 */
 	public static function should_use_blockified_product_grid_templates() {
-		$minimum_wp_version = '6.1.1';
+		$minimum_wp_version = '6.1';
 
 		if ( version_compare( $GLOBALS['wp_version'], $minimum_wp_version, '<' ) ) {
 			return false;

--- a/src/Utils/BlockTemplateUtils.php
+++ b/src/Utils/BlockTemplateUtils.php
@@ -635,11 +635,18 @@ class BlockTemplateUtils {
 
 	/**
 	 * Returns whether the blockified templates should be used or not.
-	 * If the option is not stored on the db, we need to check if the current theme is a block one or not.
+	 * First, we need to make sure WordPress version is higher than 6.1 (lowest that supports Products block).
+	 * Then, if the option is not stored on the db, we need to check if the current theme is a block one or not.
 	 *
 	 * @return boolean
 	 */
 	public static function should_use_blockified_product_grid_templates() {
+		$minimum_wp_version = '6.1.1';
+
+		if ( version_compare( $GLOBALS['wp_version'], $minimum_wp_version, '<' ) ) {
+			return false;
+		}
+
 		$use_blockified_templates = get_option( Options::WC_BLOCK_USE_BLOCKIFIED_PRODUCT_GRID_BLOCK_AS_TEMPLATE );
 
 		if ( false === $use_blockified_templates ) {


### PR DESCRIPTION
Recently the blockified Archive Template has been added: [PR](https://github.com/woocommerce/woocommerce-blocks/pull/8308). 

This PR adds additional condition to check if WordPress version is at least 6.1. This is necessary, since Products block is not available in the lower versions.

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

| 6.1.1 | Lower than 6.1 |
| ------ | ----- |
|    <img width="1024" alt="image" src="https://user-images.githubusercontent.com/20098064/222102231-90c8da84-877b-4784-ad64-c8e8ce383202.png">    |    <img width="985" alt="image" src="https://user-images.githubusercontent.com/20098064/222100194-8e2c1cde-0e42-4144-bc33-3ec62709b24a.png">   |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. [Prerequisite] WordPress version 6.1.1
2. [Prerequisite] Reset customization made to Product Catalog and Product Search Results templates.
Uncomment [this](https://github.com/woocommerce/woocommerce-blocks/blob/001685f6f89cb43e9341e76ca1124c60db62c110/src/BlockTemplatesController.php#L391) and [these](https://github.com/woocommerce/woocommerce-blocks/blob/001685f6f89cb43e9341e76ca1124c60db62c110/src/BlockTemplatesController.php#L482-L484) lines (don't forget to remove the trailing dot)
3. Go to Editor to Product Catalog
4. See new templates work in the Site Editor and on the front end.
5. Lower the WordPress version to 6.0 or 5.9
6. Go to Editor to Product Catalog

**Expected:** You should see the old Classic Template view

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental