### PR TITLE
Fix Mini Cart missing translations

### DIFF
--- a/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/empty-mini-cart-contents-block/index.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/empty-mini-cart-contents-block/index.tsx
@@ -9,9 +9,11 @@ import { registerBlockType } from '@wordpress/blocks';
  * Internal dependencies
  */
 import { Edit, Save } from './edit';
-import metadata from './block.json';
 
-registerBlockType( metadata, {
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore -- TypeScript expects some required properties which we already
+// registered in PHP.
+registerBlockType( 'woocommerce/empty-mini-cart-contents-block', {
 	icon: {
 		src: (
 			<Icon

--- a/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/filled-mini-cart-contents-block/index.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/filled-mini-cart-contents-block/index.tsx
@@ -9,9 +9,11 @@ import { registerBlockType } from '@wordpress/blocks';
  * Internal dependencies
  */
 import { Edit, Save } from './edit';
-import metadata from './block.json';
 
-registerBlockType( metadata, {
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore -- TypeScript expects some required properties which we already
+// registered in PHP.
+registerBlockType( 'woocommerce/filled-mini-cart-contents-block', {
 	icon: {
 		src: (
 			<Icon

--- a/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-footer-block/index.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-footer-block/index.tsx
@@ -8,10 +8,12 @@ import { registerBlockType } from '@wordpress/blocks';
  * Internal dependencies
  */
 import { Edit, Save } from './edit';
-import metadata from './block.json';
 import attributes from './attributes';
 
-registerBlockType( metadata, {
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore -- TypeScript expects some required properties which we already
+// registered in PHP.
+registerBlockType( 'woocommerce/mini-cart-footer-block', {
 	icon: {
 		src: (
 			<Icon

--- a/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-items-block/index.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-items-block/index.tsx
@@ -8,9 +8,11 @@ import { registerBlockType } from '@wordpress/blocks';
  * Internal dependencies
  */
 import { Edit, Save } from './edit';
-import metadata from './block.json';
 
-registerBlockType( metadata, {
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore -- TypeScript expects some required properties which we already
+// registered in PHP.
+registerBlockType( 'woocommerce/mini-cart-items-block', {
 	icon: {
 		src: (
 			<Icon

--- a/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-products-table-block/index.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-products-table-block/index.tsx
@@ -8,9 +8,11 @@ import { registerBlockType } from '@wordpress/blocks';
  * Internal dependencies
  */
 import { Edit, Save } from './edit';
-import metadata from './block.json';
 
-registerBlockType( metadata, {
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore -- TypeScript expects some required properties which we already
+// registered in PHP.
+registerBlockType( 'woocommerce/mini-cart-products-table-block', {
 	icon: (
 		<Icon icon={ list } className="wc-block-editor-components-block-icon" />
 	),

--- a/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-shopping-button-block/index.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-shopping-button-block/index.tsx
@@ -8,10 +8,12 @@ import { registerBlockType } from '@wordpress/blocks';
  * Internal dependencies
  */
 import { Edit, Save } from './edit';
-import metadata from './block.json';
 import attributes from './attributes';
 
-registerBlockType( metadata, {
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore -- TypeScript expects some required properties which we already
+// registered in PHP.
+registerBlockType( 'woocommerce/mini-cart-shopping-button-block', {
 	icon: {
 		src: (
 			<Icon

--- a/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-title-block/index.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-title-block/index.tsx
@@ -8,9 +8,11 @@ import { registerBlockType } from '@wordpress/blocks';
  * Internal dependencies
  */
 import { Edit, Save } from './edit';
-import metadata from './block.json';
 
-registerBlockType( metadata, {
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore -- TypeScript expects some required properties which we already
+// registered in PHP.
+registerBlockType( 'woocommerce/mini-cart-title-block', {
 	icon: {
 		src: (
 			<Icon

--- a/src/BlockTypes/EmptyMiniCartContentsBlock.php
+++ b/src/BlockTypes/EmptyMiniCartContentsBlock.php
@@ -1,0 +1,14 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\BlockTypes;
+
+/**
+ * EmptyMiniCartContentsBlock class.
+ */
+class EmptyMiniCartContentsBlock extends AbstractInnerBlock {
+	/**
+	 * Block name.
+	 *
+	 * @var string
+	 */
+	protected $block_name = 'empty-mini-cart-contents-block';
+}

--- a/src/BlockTypes/FilledMiniCartContentsBlock.php
+++ b/src/BlockTypes/FilledMiniCartContentsBlock.php
@@ -1,0 +1,14 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\BlockTypes;
+
+/**
+ * FilledMiniCartContentsBlock class.
+ */
+class FilledMiniCartContentsBlock extends AbstractInnerBlock {
+	/**
+	 * Block name.
+	 *
+	 * @var string
+	 */
+	protected $block_name = 'filled-mini-cart-contents-block';
+}

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -363,7 +363,6 @@ class MiniCart extends AbstractBlock {
 		$cart_controller     = $this->get_cart_controller();
 		$cart                = $cart_controller->get_cart_instance();
 		$cart_contents_count = $cart->get_cart_contents_count();
-		$cart_contents       = $cart->get_cart();
 		$cart_contents_total = $cart->get_subtotal();
 
 		if ( $cart->display_prices_including_tax() ) {
@@ -378,7 +377,7 @@ class MiniCart extends AbstractBlock {
 		$wrapper_styles = $classes_styles['styles'];
 
 		$aria_label = sprintf(
-		/* translators: %1$d is the number of products in the cart. %2$s is the cart total */
+			/* translators: %1$d is the number of products in the cart. %2$s is the cart total */
 			_n(
 				'%1$d item in cart, total price of %2$s',
 				'%1$d items in cart, total price of %2$s',
@@ -401,7 +400,7 @@ class MiniCart extends AbstractBlock {
 
 		if ( is_cart() || is_checkout() ) {
 			// It is not necessary to load the Mini Cart Block on Cart and Checkout page.
-				return '<div class="' . $wrapper_classes . '" style="visibility:hidden" aria-hidden="true">
+			return '<div class="' . $wrapper_classes . '" style="visibility:hidden" aria-hidden="true">
 				<button class="wc-block-mini-cart__button" aria-label="' . esc_attr( $aria_label ) . '" disabled>' . $button_html . '</button>
 			</div>';
 		}

--- a/src/BlockTypes/MiniCartContents.php
+++ b/src/BlockTypes/MiniCartContents.php
@@ -1,10 +1,6 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
-use Automattic\WooCommerce\Blocks\Package;
-use Automattic\WooCommerce\Blocks\Assets;
-use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
-use Automattic\WooCommerce\StoreApi\Utilities\CartController;
 use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
 
 /**
@@ -140,4 +136,25 @@ class MiniCartContents extends AbstractBlock {
 			$parsed_style
 		);
 	}
+
+	/**
+	 * Get list of Mini Cart block & its inner-block types.
+	 *
+	 * @return array;
+	 */
+	public static function get_mini_cart_block_types() {
+		$block_types = [];
+
+		$block_types[] = 'MiniCartContents';
+		$block_types[] = 'EmptyMiniCartContentsBlock';
+		$block_types[] = 'FilledMiniCartContentsBlock';
+		$block_types[] = 'MiniCartFooterBlock';
+		$block_types[] = 'MiniCartItemsBlock';
+		$block_types[] = 'MiniCartProductsTableBlock';
+		$block_types[] = 'MiniCartShoppingButtonBlock';
+		$block_types[] = 'MiniCartTitleBlock';
+
+		return $block_types;
+	}
+
 }

--- a/src/BlockTypes/MiniCartFooterBlock.php
+++ b/src/BlockTypes/MiniCartFooterBlock.php
@@ -1,0 +1,14 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\BlockTypes;
+
+/**
+ * MiniCartFooterBlock class.
+ */
+class MiniCartFooterBlock extends AbstractInnerBlock {
+	/**
+	 * Block name.
+	 *
+	 * @var string
+	 */
+	protected $block_name = 'mini-cart-footer-block';
+}

--- a/src/BlockTypes/MiniCartItemsBlock.php
+++ b/src/BlockTypes/MiniCartItemsBlock.php
@@ -1,0 +1,14 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\BlockTypes;
+
+/**
+ * MiniCartItemsBlock class.
+ */
+class MiniCartItemsBlock extends AbstractInnerBlock {
+	/**
+	 * Block name.
+	 *
+	 * @var string
+	 */
+	protected $block_name = 'mini-cart-items-block';
+}

--- a/src/BlockTypes/MiniCartProductsTableBlock.php
+++ b/src/BlockTypes/MiniCartProductsTableBlock.php
@@ -1,0 +1,14 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\BlockTypes;
+
+/**
+ * MiniCartProductsTableBlock class.
+ */
+class MiniCartProductsTableBlock extends AbstractInnerBlock {
+	/**
+	 * Block name.
+	 *
+	 * @var string
+	 */
+	protected $block_name = 'mini-cart-products-table-block';
+}

--- a/src/BlockTypes/MiniCartShoppingButtonBlock.php
+++ b/src/BlockTypes/MiniCartShoppingButtonBlock.php
@@ -1,0 +1,14 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\BlockTypes;
+
+/**
+ * MiniCartShoppingButtonBlock class.
+ */
+class MiniCartShoppingButtonBlock extends AbstractInnerBlock {
+	/**
+	 * Block name.
+	 *
+	 * @var string
+	 */
+	protected $block_name = 'mini-cart-shopping-button-block';
+}

--- a/src/BlockTypes/MiniCartTitleBlock.php
+++ b/src/BlockTypes/MiniCartTitleBlock.php
@@ -1,0 +1,14 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\BlockTypes;
+
+/**
+ * MiniCartTitleBlock class.
+ */
+class MiniCartTitleBlock extends AbstractInnerBlock {
+	/**
+	 * Block name.
+	 *
+	 * @var string
+	 */
+	protected $block_name = 'mini-cart-title-block';
+}

--- a/src/BlockTypesController.php
+++ b/src/BlockTypesController.php
@@ -8,6 +8,7 @@ use Automattic\WooCommerce\Blocks\Assets\Api as AssetApi;
 use Automattic\WooCommerce\Blocks\Integrations\IntegrationRegistry;
 use Automattic\WooCommerce\Blocks\BlockTypes\Cart;
 use Automattic\WooCommerce\Blocks\BlockTypes\Checkout;
+use Automattic\WooCommerce\Blocks\BlockTypes\MiniCartContents;
 
 /**
  * BlockTypesController class.
@@ -182,7 +183,6 @@ final class BlockTypesController {
 			'FilterWrapper',
 			'HandpickedProducts',
 			'MiniCart',
-			'MiniCartContents',
 			'StoreNotices',
 			'PriceFilter',
 			'ProductAddToCart',
@@ -217,7 +217,12 @@ final class BlockTypesController {
 			'StockFilter',
 		];
 
-		$block_types = array_merge( $block_types, Cart::get_cart_block_types(), Checkout::get_checkout_block_types() );
+		$block_types = array_merge(
+			$block_types,
+			Cart::get_cart_block_types(),
+			Checkout::get_checkout_block_types(),
+			MiniCartContents::get_mini_cart_block_types()
+		);
 
 		if ( Package::feature()->is_experimental_build() ) {
 			$block_types[] = 'SingleProduct';


### PR DESCRIPTION
Fixes #8302.

This PR is inspired by #6737.

Note: if testing in the feature plugin, this PR doesn't fix missing translations for languages which don't have WC Blocks translations. In those cases, we fall back to WC core translations for PHP and JS text but it doesn't work for block.json strings.

### Testing

#### User Facing Testing

1. Set your store language to a language with WC Blocks translations, ie: Spanish.
2. With a block theme (ie: TT3), go to Appearance > Editor > Template Parts and edit the Mini Cart block template part.
3. Open the sidebar list view and navigate to the `Tabla de productos del mini carrito` block. Verify the block name is correctly translated.

Before | After
--- | ---
![imatge](https://user-images.githubusercontent.com/3616980/222114778-7d88f8ec-0694-4d7b-8c9c-48e885895f22.png) | ![imatge](https://user-images.githubusercontent.com/3616980/222114836-bb895da0-fc50-4a96-a47b-35194d900266.png)

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix Mini Cart block having some translations missing in the editor.
