### PR TITLE
Fix Interactivity API setup

### DIFF
--- a/src/Interactivity/directives/wp-html.php
+++ b/src/Interactivity/directives/wp-html.php
@@ -1,8 +1,0 @@
-<?php
-
-if ( ! class_exists( 'WP_HTML_Tag_Processor' ) ) {
-	require __DIR__ . '/../../../../gutenberg/lib/compat/wordpress-6.2/html-api/class-wp-html-attribute-token.php';
-	require __DIR__ . '/../../../../gutenberg/lib/compat/wordpress-6.2/html-api/class-wp-html-span.php';
-	require __DIR__ . '/../../../../gutenberg/lib/compat/wordpress-6.2/html-api/class-wp-html-text-replacement.php';
-	require __DIR__ . '/../../../../gutenberg/lib/compat/wordpress-6.2/html-api/class-wp-html-tag-processor.php';
-}

--- a/src/Interactivity/directives/wp-html.php
+++ b/src/Interactivity/directives/wp-html.php
@@ -1,8 +1,8 @@
 <?php
 
 if ( ! class_exists( 'WP_HTML_Tag_Processor' ) ) {
-	include __DIR__ . '/../../../../gutenberg/lib/compat/wordpress-6.2/html-api/class-wp-html-attribute-token.php';
-	include __DIR__ . '/../../../../gutenberg/lib/compat/wordpress-6.2/html-api/class-wp-html-span.php';
-	include __DIR__ . '/../../../../gutenberg/lib/compat/wordpress-6.2/html-api/class-wp-html-text-replacement.php';
-	include __DIR__ . '/../../../../gutenberg/lib/compat/wordpress-6.2/html-api/class-wp-html-tag-processor.php';
+	require __DIR__ . '/../../../../gutenberg/lib/compat/wordpress-6.2/html-api/class-wp-html-attribute-token.php';
+	require __DIR__ . '/../../../../gutenberg/lib/compat/wordpress-6.2/html-api/class-wp-html-span.php';
+	require __DIR__ . '/../../../../gutenberg/lib/compat/wordpress-6.2/html-api/class-wp-html-text-replacement.php';
+	require __DIR__ . '/../../../../gutenberg/lib/compat/wordpress-6.2/html-api/class-wp-html-tag-processor.php';
 }

--- a/src/Interactivity/woo-directives.php
+++ b/src/Interactivity/woo-directives.php
@@ -1,6 +1,4 @@
 <?php
-require_once __DIR__ . '/directives/wp-html.php';
-
 require_once __DIR__ . '/directives/class-woo-directive-context.php';
 require_once __DIR__ . '/directives/class-woo-directive-store.php';
 require_once __DIR__ . '/directives/woo-process-directives.php';

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -287,6 +287,37 @@ function woocommerce_blocks_plugin_outdated_notice() {
 
 add_action( 'admin_notices', 'woocommerce_blocks_plugin_outdated_notice' );
 
-// Include the Interactivity API.
-require_once __DIR__ . '/src/Interactivity/woo-directives.php';
+/**
+ * Check if Guntenberg plugin is enabled (required by the Interactivity API).
+ *
+ * This is a temporary fix until `WP_HTML_Tag_Processor` is released in WP 6.2.
+ *
+ * @param bool $enabled True if the Interactivity API is manually enabled.
+ * @return bool True if _also_ the Gutenberg plugin is enabled.
+ */
+function woocommerce_blocks_is_gutenberg_enabled( $enabled ) {
+	if ( ! function_exists( 'is_plugin_active' ) ) {
+		include_once ABSPATH . 'wp-admin/includes/plugin.php';
+	}
+	return $enabled && is_plugin_active( 'gutenberg/gutenberg.php' );
+}
+add_filter(
+	'woocommerce_blocks_enable_interactivity_api',
+	'woocommerce_blocks_is_gutenberg_enabled',
+	999
+);
 
+/**
+ * Load and setup the Interactivity API if enabled.
+ */
+function woocommerce_blocks_interactivity_setup() {
+	$is_enabled = apply_filters(
+		'woocommerce_blocks_enable_interactivity_api',
+		false
+	);
+
+	if ( $is_enabled ) {
+		require_once __DIR__ . '/src/Interactivity/woo-directives.php';
+	}
+}
+add_action( 'plugins_loaded', 'woocommerce_blocks_interactivity_setup' );

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -288,22 +288,18 @@ function woocommerce_blocks_plugin_outdated_notice() {
 add_action( 'admin_notices', 'woocommerce_blocks_plugin_outdated_notice' );
 
 /**
- * Check if Guntenberg plugin is enabled (required by the Interactivity API).
+ * Disable the Interactivity API if the required `WP_HTML_Tag_Processor` class
+ * doesn't exist, regardless of whether it was enabled manually.
  *
- * This is a temporary fix until `WP_HTML_Tag_Processor` is released in WP 6.2.
- *
- * @param bool $enabled True if the Interactivity API is manually enabled.
- * @return bool True if _also_ the Gutenberg plugin is enabled.
+ * @param bool $enabled Current filter value.
+ * @return bool True if _also_ the `WP_HTML_Tag_Processor` class was found.
  */
-function woocommerce_blocks_is_gutenberg_enabled( $enabled ) {
-	if ( ! function_exists( 'is_plugin_active' ) ) {
-		include_once ABSPATH . 'wp-admin/includes/plugin.php';
-	}
-	return $enabled && is_plugin_active( 'gutenberg/gutenberg.php' );
+function woocommerce_blocks_has_wp_html_tag_processor( $enabled ) {
+	return $enabled && class_exists( 'WP_HTML_Tag_Processor' );
 }
 add_filter(
 	'woocommerce_blocks_enable_interactivity_api',
-	'woocommerce_blocks_is_gutenberg_enabled',
+	'woocommerce_blocks_has_wp_html_tag_processor',
 	999
 );
 


### PR DESCRIPTION
## What

Fixes how the Interactivity API files are loaded, which now requires two conditions to be true:

1. The filter `woocommerce_blocks_enable_interactivity_api` should be explicitly set to `true`
2. The `WP_HTML_Tag_Processor` class, either included by WP core or the Gutenberg plugin, should be defined.

## Why

All e2e tests were recently failing due to a 500 response error from the server.

It was a bug introduced in #8447, that was causing the Interactivity API files to be unnecessarily loaded, and also requiring missing files from the Gutenberg plugin.

## How

Only requiring `/src/Interactivity/woo-directives.php` when those two conditions are true.

* [x] Do not include in the Testing Notes