### PR TITLE
Make the customer account icon bigger to match the mini-cart one

### DIFF
--- a/assets/js/blocks/customer-account/block.json
+++ b/assets/js/blocks/customer-account/block.json
@@ -23,6 +23,10 @@
 		"iconStyle": {
 			"type": "string",
 			"default": "default"
+		},
+		"iconClass": {
+			"type": "string",
+			"default": "icon"
 		}
 	},
 	"textdomain": "woo-gutenberg-products-block",

--- a/assets/js/blocks/customer-account/block.tsx
+++ b/assets/js/blocks/customer-account/block.tsx
@@ -17,9 +17,11 @@ import { Attributes, DisplayStyle, IconStyle } from './types';
 const AccountIcon = ( {
 	iconStyle,
 	displayStyle,
+	iconClass,
 }: {
 	iconStyle: IconStyle;
 	displayStyle: DisplayStyle;
+	iconClass: string;
 } ) => {
 	const icon =
 		iconStyle === IconStyle.ALT
@@ -27,7 +29,7 @@ const AccountIcon = ( {
 			: customerAccountStyle;
 
 	return displayStyle === DisplayStyle.TEXT_ONLY ? null : (
-		<Icon className="icon" icon={ icon } size={ 18 } />
+		<Icon className={ iconClass } icon={ icon } size={ 18 } />
 	);
 };
 
@@ -52,7 +54,7 @@ export const CustomerAccountBlock = ( {
 }: {
 	attributes: Attributes;
 } ): JSX.Element => {
-	const { displayStyle, iconStyle } = attributes;
+	const { displayStyle, iconStyle, iconClass } = attributes;
 
 	return (
 		<a
@@ -64,6 +66,7 @@ export const CustomerAccountBlock = ( {
 			<AccountIcon
 				iconStyle={ iconStyle }
 				displayStyle={ displayStyle }
+				iconClass={ iconClass }
 			/>
 			<Label displayStyle={ displayStyle } />
 		</a>

--- a/assets/js/blocks/customer-account/index.tsx
+++ b/assets/js/blocks/customer-account/index.tsx
@@ -1,9 +1,10 @@
 /**
  * External dependencies
  */
-import { registerBlockType } from '@wordpress/blocks';
+import { registerBlockType, registerBlockVariation } from '@wordpress/blocks';
 import { Icon } from '@wordpress/icons';
 import { customerAccount } from '@woocommerce/icons';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -26,5 +27,15 @@ registerBlockType( metadata, {
 	edit,
 	save() {
 		return null;
+	},
+} );
+
+registerBlockVariation( 'woocommerce/customer-account', {
+	name: 'woocommerce/customer-account',
+	title: __( 'Customer account', 'woo-gutenberg-products-block' ),
+	isDefault: true,
+	attributes: {
+		...metadata.attributes,
+		iconClass: 'account-icon',
 	},
 } );

--- a/assets/js/blocks/customer-account/index.tsx
+++ b/assets/js/blocks/customer-account/index.tsx
@@ -30,6 +30,11 @@ registerBlockType( metadata, {
 	},
 } );
 
+// We needed to change the size of the icon without affecting already existing blocks.
+// This is why we are registering a new variation with a different icon class instead of changing directly the icon
+// size in the css. By giving it the same name and making it default we are making sure that new blocks will use the
+// new icon size and existing blocks will keep using the old one after updating the plugin.
+// For more context, see https://github.com/woocommerce/woocommerce-blocks/pull/8594
 registerBlockVariation( 'woocommerce/customer-account', {
 	name: 'woocommerce/customer-account',
 	title: __( 'Customer account', 'woo-gutenberg-products-block' ),

--- a/assets/js/blocks/customer-account/index.tsx
+++ b/assets/js/blocks/customer-account/index.tsx
@@ -41,6 +41,8 @@ registerBlockVariation( 'woocommerce/customer-account', {
 	isDefault: true,
 	attributes: {
 		...metadata.attributes,
+		displayStyle: 'icon_and_text',
+		iconStyle: 'default',
 		iconClass: 'wc-block-customer-account__account-icon',
 	},
 } );

--- a/assets/js/blocks/customer-account/index.tsx
+++ b/assets/js/blocks/customer-account/index.tsx
@@ -36,6 +36,6 @@ registerBlockVariation( 'woocommerce/customer-account', {
 	isDefault: true,
 	attributes: {
 		...metadata.attributes,
-		iconClass: 'account-icon',
+		iconClass: 'wc-block-customer-account__account-icon',
 	},
 } );

--- a/assets/js/blocks/customer-account/style.scss
+++ b/assets/js/blocks/customer-account/style.scss
@@ -10,7 +10,7 @@
 		}
 
 		.icon + .label,
-		.account-icon + .label {
+		.wc-block-customer-account__account-icon + .label {
 			margin-left: $gap-smaller;
 		}
 
@@ -19,7 +19,7 @@
 			width: em(16px);
 		}
 
-		.account-icon {
+		.wc-block-customer-account__account-icon {
 			height: em(23px);
 			width: em(23px);
 		}

--- a/assets/js/blocks/customer-account/style.scss
+++ b/assets/js/blocks/customer-account/style.scss
@@ -9,11 +9,17 @@
 			text-decoration: underline !important;
 		}
 
-		.icon + .label {
+		.icon + .label,
+		.account-icon + .label {
 			margin-left: $gap-smaller;
 		}
 
 		.icon {
+			height: em(16px);
+			width: em(16px);
+		}
+
+		.account-icon {
 			height: em(23px);
 			width: em(23px);
 		}

--- a/assets/js/blocks/customer-account/style.scss
+++ b/assets/js/blocks/customer-account/style.scss
@@ -14,8 +14,8 @@
 		}
 
 		.icon {
-			height: em(16px);
-			width: em(16px);
+			height: em(23px);
+			width: em(23px);
 		}
 	}
 }

--- a/assets/js/blocks/customer-account/types.ts
+++ b/assets/js/blocks/customer-account/types.ts
@@ -2,6 +2,7 @@ export interface Attributes {
 	className?: string;
 	displayStyle: DisplayStyle;
 	iconStyle: IconStyle;
+	iconClass: string;
 }
 
 export enum DisplayStyle {

--- a/src/BlockTypes/CustomerAccount.php
+++ b/src/BlockTypes/CustomerAccount.php
@@ -67,7 +67,7 @@ class CustomerAccount extends AbstractBlock {
 		}
 
 		if ( self::DISPLAY_ALT === $attributes['iconStyle'] ) {
-			return '<svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" width="18" height="18">
+			return '<svg class="' . $attributes['iconClass'] . '" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18 18" width="18" height="18">
 				<path
 					d="M9 0C4.03579 0 0 4.03579 0 9C0 13.9642 4.03579 18 9 18C13.9642 18 18 13.9642 18 9C18 4.03579 13.9642 0 9
 					 	0ZM9 4.32C10.5347 4.32 11.7664 5.57056 11.7664 7.08638C11.7664 8.62109 10.5158 9.85277 9 9.85277C7.4653
@@ -79,7 +79,7 @@ class CustomerAccount extends AbstractBlock {
 			</svg>';
 		}
 
-		return '<svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">
+		return '<svg class="' . $attributes['iconClass'] . '" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">
 			<path
 				d="M8.00009 8.34785C10.3096 8.34785 12.1819 6.47909 12.1819 4.17393C12.1819 1.86876 10.3096 0 8.00009 0C5.69055
 				 	0 3.81824 1.86876 3.81824 4.17393C3.81824 6.47909 5.69055 8.34785 8.00009 8.34785ZM0.333496 15.6522C0.333496


### PR DESCRIPTION
The goal of this PR is to increase the size of the `Customer account` icon to make it more similar to the `Mini cart` one.

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/8128

### Testing

#### Check the icon size
1. Go to the Site Editor and edit the Header template.
2. Insert the `Customer account` and `Mini-cart` blocks next to the menu, to look like this 👇 
<img width="359" alt="Screenshot 2023-03-01 at 14 16 48" src="https://user-images.githubusercontent.com/186112/222149887-f19ffb9a-3015-4878-aa8e-33ddcf1eb8ac.png">

3. Check the `Customer account` icon is bigger than before and matches the `Mini cart` icon size.

| Before | After |
| ------ | ----- |
| <img width="312" alt="Screenshot 2023-03-01 at 14 20 35" src="https://user-images.githubusercontent.com/186112/222150649-0974f54b-5bb5-43da-a7e1-5870a860094a.png"> |<img width="311" alt="Screenshot 2023-03-01 at 14 21 42" src="https://user-images.githubusercontent.com/186112/222150932-223dacae-5365-43d8-8831-cd39fc27e247.png"> |

4. Modify the font size on both blocks to M, L, and XL and check the icon sizes also match.

#### Check the icon size of existing blocks does not change
1. Go to `trunk`.
2. Create a new page/post, add a `Customer account` block, and save.
3. Checkout to this branch (`update/8128-account-icon-size`).
4. Reload the page from step 2.
5. Insert another `Customer account` block and save.
6. Check in the editor that the block icon inserted in step 1 keeps its size and the one inserted in step 5 is bigger.
7. Check the same in the frontend.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix: increase the "Customer account" size icon.
