### PR TITLE
Show three Express Payments buttons in-line

### DIFF
--- a/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment/style.scss
+++ b/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment/style.scss
@@ -7,9 +7,10 @@ $border-radius: 5px;
 
 	.wc-block-components-express-payment__event-buttons {
 		list-style: none;
-		display: flex;
-		flex-direction: row;
-		flex-wrap: wrap;
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(calc(33% - 10px), 1fr));
+		grid-gap: 10px;
+		box-sizing: border-box;
 		width: 100%;
 		padding: 0;
 		margin: 0;
@@ -18,11 +19,18 @@ $border-radius: 5px;
 
 		> li {
 			margin: 0;
+			width: 100%;
 
 			> img {
 				width: 100%;
 				height: 48px;
 			}
+		}
+	}
+
+	@include breakpoint("<782px") {
+		.wc-block-components-express-payment__event-buttons {
+			grid-template-columns: 1fr;
 		}
 	}
 }
@@ -83,28 +91,6 @@ $border-radius: 5px;
 
 		> p {
 			margin-bottom: em($gap);
-		}
-	}
-
-	.wc-block-components-express-payment__event-buttons {
-		> li {
-			box-sizing: border-box;
-			display: inline-block;
-			width: 50%;
-		}
-
-		> li:nth-child(even) {
-			padding-left: $gap-smaller;
-		}
-
-		> li:nth-child(odd) {
-			padding-right: $gap-smaller;
-		}
-
-		> li:only-child {
-			display: block;
-			width: 100%;
-			padding: 0;
 		}
 	}
 }


### PR DESCRIPTION
Fixes woocommerce/woocommerce-blocks#8600 

In p1677558681155729/1677282265.770279-slack-C02TS23QJ1X, @pierorocca suggested focusing on displaying 3 to 4 buttons in one line for now. In https://github.com/woocommerce/woocommerce/issues/42464, @stephendharmadi shared designs that show that maximum three Express Payment buttons should be shown next to each other.

### Screenshots

<table>
<tr>
<td valign="top">Before:
<br><br>

<img width="687" alt="Screenshot 2023-03-02 at 14 26 14" src="https://user-images.githubusercontent.com/3323310/222359640-6a503a19-0d71-4b4d-aa80-00803781bfba.png">
</td>
<td valign="top">After:
<br><br>

<img width="689" alt="Screenshot 2023-03-02 at 14 38 36" src="https://user-images.githubusercontent.com/3323310/222362346-616ed25f-f58a-4777-a9eb-16a4642f5de6.png">
</td>
</tr>
</table>

This PR also introduces spacing between the Express Payment buttons. In case a merchant shows more than three Express Payment buttons, they now contain spacing:

<table>
<tr>
<td valign="top">Before:
<br><br>

<img width="687" alt="Screenshot 2023-03-02 at 14 26 14" src="https://user-images.githubusercontent.com/3323310/222359640-6a503a19-0d71-4b4d-aa80-00803781bfba.png">
</td>
<td valign="top">After:
<br><br>

<img width="691" alt="Screenshot 2023-03-02 at 15 03 59" src="https://user-images.githubusercontent.com/3323310/222367924-a8d80823-45d8-4080-ba93-7e0ef6f09530.png">
</td>
</tr>
</table>

### Testing

#### User Facing Testing

1. Create a WordPress.com site using the eCommerce plan.
2. Install and activate the Tsubaki theme.
3. Install and activate WooCommerce Blocks [using this ZIP file](https://wcblocks.wpcomstaging.com/wp-content/uploads/woocommerce-gutenberg-products-block-8601.zip).
4. Install and activate WooCommerce Payments.
5. Install and activate WooCommerce Stripe Gateway.
6. Activate Express Payment both for WooCommerce Payments and WooCommerce Stripe Gateway.
7. Add a product to the cart and open the checkout page (which should use the Checkout block).
8. Verify that up to three Express Payment buttons are next to each other.
9. Simulate viewing the page with a mobile device by making the page smaller and verify that the three Express Payment buttons appear stacked.
10. Install and activate the Storefront theme.
11. Repeat steps 8. and 9. to verify that this change did not introduce a regression.

* [x] Do not include in the Testing Notes

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix: Show up to three Express Payments buttons next to each other.

cc: @pierorocca 