### PR TITLE
Revert "Show Cart and Checkout blocks in Style Book"

### DIFF
--- a/assets/js/blocks/cart/index.js
+++ b/assets/js/blocks/cart/index.js
@@ -36,11 +36,6 @@ const settings = {
 		html: false,
 		multiple: false,
 	},
-	example: {
-		attributes: {
-			isPreview: true,
-		},
-	},
 	attributes: blockAttributes,
 	edit: Edit,
 	save: Save,

--- a/assets/js/blocks/checkout/block.json
+++ b/assets/js/blocks/checkout/block.json
@@ -10,11 +10,6 @@
 		"html": false,
 		"multiple": false
 	},
-	"example": {
-		"attributes": {
-			"isPreview": true
-		}
-	},
 	"attributes": {
 		"isPreview": {
 			"type": "boolean",


### PR DESCRIPTION
Reverts woocommerce/woocommerce-blocks#8489

In p1677701598203669-slack-C8X6Q7XQU, @ralucaStan reported that the editor freezes when hovering over the Cart and Checkout blocks in the [block inserter](https://wordpress.org/documentation/article/adding-a-new-block/). This problem was caused by #8489. This PR aims to revert that PR.

## Screenshot

<img width="973" alt="Screenshot 2023-03-01 at 21 10 51" src="https://user-images.githubusercontent.com/3323310/222373424-abee3359-9148-4be3-8550-47b913370888.png">

## Steps to test

1. Create a new page or post and open the [block inserter](https://wordpress.org/documentation/article/adding-a-new-block/).
2. Hover over the Cart and Checkout blocks.
3. Verify that the editor no longer freezes.