### PR TITLE
Mini Cart drawer close button: inherit text color and improve alignment

### DIFF
--- a/assets/js/base/components/drawer/style.scss
+++ b/assets/js/base/components/drawer/style.scss
@@ -118,12 +118,19 @@ $drawer-width-mobile: 100vw;
 		background: transparent;
 		color: inherit;
 		position: absolute;
+		opacity: 0.6;
 		// The SVG has some white spacing around, thus we have to set this magic number.
 		right: 8px;
 		top: 0;
 		// Increase clickable area.
 		padding: 1em;
 		margin: -1em;
+
+		&:hover,
+		&:focus,
+		&:active {
+			opacity: 1;
+		}
 
 		> span {
 			@include visually-hidden();

--- a/assets/js/base/components/drawer/style.scss
+++ b/assets/js/base/components/drawer/style.scss
@@ -118,7 +118,8 @@ $drawer-width-mobile: 100vw;
 		background: transparent;
 		color: inherit;
 		position: absolute;
-		right: 0;
+		// The SVG has some white spacing around, thus we have to set this magic number.
+		right: 8px;
 		top: 0;
 		// Increase clickable area.
 		padding: 1em;

--- a/assets/js/base/components/drawer/style.scss
+++ b/assets/js/base/components/drawer/style.scss
@@ -116,6 +116,7 @@ $drawer-width-mobile: 100vw;
 	.components-button {
 		@include reset-box();
 		background: transparent;
+		color: inherit;
 		position: absolute;
 		right: 0;
 		top: 0;

--- a/assets/js/blocks/mini-cart/style.scss
+++ b/assets/js/blocks/mini-cart/style.scss
@@ -49,11 +49,6 @@
 .wc-block-mini-cart__drawer {
 	font-size: 1rem;
 
-	.components-modal__content .components-modal__header .components-button {
-		padding: unset;
-		margin: unset;
-	}
-
 	.wp-block-woocommerce-mini-cart-contents {
 		.wc-block-components-notices {
 			margin: #{$gap} #{$gap-largest} -#{$gap} #{$gap};
@@ -127,7 +122,7 @@
 
 h2.wc-block-mini-cart__title {
 	@include font-size(larger);
-	margin: $gap-largest $gap 0;
+	margin: $gap $gap 0;
 }
 
 .wc-block-mini-cart__items {
@@ -222,11 +217,4 @@ h2.wc-block-mini-cart__title {
 .admin-bar .wp-block-woocommerce-empty-mini-cart-contents-block,
 .admin-bar .wp-block-woocommerce-filled-mini-cart-contents-block {
 	height: calc(100vh - 32px);
-}
-
-.admin-bar
-.wc-block-components-drawer
-.components-modal__header
-.components-button {
-	top: 32px;
 }


### PR DESCRIPTION
Fixes #8603.

### Testing

#### User Facing Testing

0. Switch to a dark theme (ie: [TT3](https://github.com/WordPress/twentytwentythree/)) and set a dark styling (ie: Appearance > Editor > edit a template > Style > Browse styles > Pilgrimage).
1. Add the Mini Cart block to the header of a template.
2. In the frontend, click on it so it opens the drawer.
3. Verify the close button inherits the text color and on the right it's aligned with the product prices below.

Before | After
--- | ---
![imatge](https://user-images.githubusercontent.com/3616980/222406873-a10639d9-7e3a-4855-a3cf-a2744c9a491e.png) | ![imatge](https://user-images.githubusercontent.com/3616980/222409017-1b2181f2-6f76-4937-8924-ca07a4582c3e.png)

4. Now, to verify the layout still works if there are notices, edit one of the products you have in the cart and set it out of stock.
5. Go back to the frontend, open the drawer and verify the close button is still visible.

Before | After
--- | ---
![imatge](https://user-images.githubusercontent.com/3616980/222406800-2aecec4f-f44f-4f6d-9b64-7d90b489f942.png) | ![imatge](https://user-images.githubusercontent.com/3616980/222408923-b57bf4e2-ecf6-4af3-a0ff-9d745cc906d5.png)

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Improve Mini Cart drawer close button alignment and make it inherit the text color
