### PR TITLE
Product Price block: add support to the Single Product Template

### DIFF
--- a/assets/js/atomic/blocks/product-elements/price/attributes.ts
+++ b/assets/js/atomic/blocks/product-elements/price/attributes.ts
@@ -16,6 +16,10 @@ export const blockAttributes: BlockAttributes = {
 		type: 'string',
 		default: '',
 	},
+	isDescendentOfSingleProductTemplate: {
+		type: 'boolean',
+		default: false,
+	},
 };
 
 export default blockAttributes;

--- a/assets/js/atomic/blocks/product-elements/price/block.tsx
+++ b/assets/js/atomic/blocks/product-elements/price/block.tsx
@@ -102,7 +102,7 @@ export const Block = ( props: Props ): JSX.Element | null => {
 			regularPrice={
 				isDescendentOfSingleProductTemplate
 					? pricePreview
-					: prices.price
+					: prices.regular_price
 			}
 			regularPriceClassName={ classnames( {
 				[ `${ parentClassName }__product-price__regular` ]:
@@ -114,6 +114,12 @@ export const Block = ( props: Props ): JSX.Element | null => {
 };
 
 export default ( props: Props ) => {
+	// It is necessary because this block has to support serveral context:
+	// 	-	 Inside `All Products Block` -> `withProductDataContext` HOC
+	// - Inside `Products Block` -> Gutenberg Context
+	// - Inside `Single Product Template` -> Gutenberg Context
+	// - Without any parent -> `WithSelector` and `withProductDataContext` HOCs
+	// For more details, check https://github.com/woocommerce/woocommerce-blocks/pull/8609
 	if ( props.isDescendentOfSingleProductTemplate ) {
 		return <Block { ...props } />;
 	}

--- a/assets/js/atomic/blocks/product-elements/price/block.tsx
+++ b/assets/js/atomic/blocks/product-elements/price/block.tsx
@@ -114,8 +114,8 @@ export const Block = ( props: Props ): JSX.Element | null => {
 };
 
 export default ( props: Props ) => {
-	// It is necessary because this block has to support serveral context:
-	// 	-	 Inside `All Products Block` -> `withProductDataContext` HOC
+	// It is necessary because this block has to support serveral contexts:
+	// - Inside `All Products Block` -> `withProductDataContext` HOC
 	// - Inside `Products Block` -> Gutenberg Context
 	// - Inside `Single Product Template` -> Gutenberg Context
 	// - Without any parent -> `WithSelector` and `withProductDataContext` HOCs

--- a/assets/js/atomic/blocks/product-elements/price/block.tsx
+++ b/assets/js/atomic/blocks/product-elements/price/block.tsx
@@ -40,7 +40,7 @@ interface PriceProps {
 }
 
 export const Block = ( props: Props ): JSX.Element | null => {
-	const { className, textAlign } = props;
+	const { className, textAlign, isDescendentOfSingleProductTemplate } = props;
 	const { parentClassName } = useInnerBlockLayoutContext();
 	const { product } = useProductDataContext();
 
@@ -57,7 +57,7 @@ export const Block = ( props: Props ): JSX.Element | null => {
 		}
 	);
 
-	if ( ! product.id ) {
+	if ( ! product.id && ! isDescendentOfSingleProductTemplate ) {
 		return (
 			<ProductPrice align={ textAlign } className={ wrapperClassName } />
 		);
@@ -71,7 +71,11 @@ export const Block = ( props: Props ): JSX.Element | null => {
 		...spacingProps.style,
 	};
 	const prices: PriceProps = product.prices;
-	const currency = getCurrencyFromPriceResponse( prices );
+	const currency = isDescendentOfSingleProductTemplate
+		? getCurrencyFromPriceResponse()
+		: getCurrencyFromPriceResponse( prices );
+
+	const pricePreview = '5000';
 	const isOnSale = prices.price !== prices.regular_price;
 	const priceClassName = classnames( {
 		[ `${ parentClassName }__product-price__value` ]: parentClassName,
@@ -86,12 +90,20 @@ export const Block = ( props: Props ): JSX.Element | null => {
 			priceStyle={ style }
 			priceClassName={ priceClassName }
 			currency={ currency }
-			price={ prices.price }
+			price={
+				isDescendentOfSingleProductTemplate
+					? pricePreview
+					: prices.price
+			}
 			// Range price props
 			minPrice={ prices?.price_range?.min_amount }
 			maxPrice={ prices?.price_range?.max_amount }
 			// This is the regular or original price when the `price` value is a sale price.
-			regularPrice={ prices.regular_price }
+			regularPrice={
+				isDescendentOfSingleProductTemplate
+					? pricePreview
+					: prices.price
+			}
 			regularPriceClassName={ classnames( {
 				[ `${ parentClassName }__product-price__regular` ]:
 					parentClassName,
@@ -101,4 +113,9 @@ export const Block = ( props: Props ): JSX.Element | null => {
 	);
 };
 
-export default withProductDataContext( Block );
+export default ( props: Props ) => {
+	if ( props.isDescendentOfSingleProductTemplate ) {
+		return <Block { ...props } />;
+	}
+	return withProductDataContext( Block )( props );
+};

--- a/assets/js/atomic/blocks/product-elements/price/edit.tsx
+++ b/assets/js/atomic/blocks/product-elements/price/edit.tsx
@@ -9,6 +9,7 @@ import {
 import { useEffect } from '@wordpress/element';
 import type { BlockAlignment } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -110,7 +111,7 @@ const PriceEdit = ( {
 				icon={ BLOCK_ICON }
 				label={ BLOCK_TITLE }
 				description={ __(
-					'Choose a product to display its SKU.',
+					'Choose a product to display its price.',
 					'woo-gutenberg-products-block'
 				) }
 			>

--- a/assets/js/atomic/blocks/product-elements/price/edit.tsx
+++ b/assets/js/atomic/blocks/product-elements/price/edit.tsx
@@ -8,13 +8,14 @@ import {
 } from '@wordpress/block-editor';
 import { useEffect } from '@wordpress/element';
 import type { BlockAlignment } from '@wordpress/blocks';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import Block from './block';
-import withProductSelector from '../shared/with-product-selector';
-import { BLOCK_TITLE as label, BLOCK_ICON as icon } from './constants';
+import { BLOCK_TITLE, BLOCK_ICON } from './constants';
+import { ProductSelector } from '../shared/product-selector';
 
 type UnsupportedAligments = 'wide' | 'full';
 type AllowedAlignments = Exclude< BlockAlignment, UnsupportedAligments >;
@@ -51,26 +52,80 @@ const PriceEdit = ( {
 	};
 	const isDescendentOfQueryLoop = Number.isFinite( context.queryId );
 
-	useEffect(
-		() => setAttributes( { isDescendentOfQueryLoop } ),
-		[ setAttributes, isDescendentOfQueryLoop ]
+	const { isDescendentOfSingleProductTemplate } = useSelect(
+		( select ) => {
+			const store = select( 'core/edit-site' );
+			const postId = store?.getEditedPostId();
+
+			return {
+				isDescendentOfSingleProductTemplate:
+					( postId === 'woocommerce/woocommerce//product-meta' ||
+						postId ===
+							'woocommerce/woocommerce//single-product' ) &&
+					! isDescendentOfQueryLoop,
+			};
+		},
+		[ isDescendentOfQueryLoop ]
 	);
 
+	useEffect(
+		() =>
+			setAttributes( {
+				isDescendentOfQueryLoop,
+				isDescendentOfSingleProductTemplate,
+			} ),
+		[
+			isDescendentOfQueryLoop,
+			isDescendentOfSingleProductTemplate,
+			setAttributes,
+		]
+	);
+
+	const showProductSelector =
+		! isDescendentOfQueryLoop && ! isDescendentOfSingleProductTemplate;
+
+	if ( ! showProductSelector ) {
+		return (
+			<>
+				<BlockControls>
+					<AlignmentToolbar
+						value={ attributes.textAlign }
+						onChange={ ( textAlign: AllowedAlignments ) => {
+							setAttributes( { textAlign } );
+						} }
+					/>
+				</BlockControls>
+				<div { ...blockProps }>
+					<Block { ...blockAttrs } />
+				</div>
+			</>
+		);
+	}
+
 	return (
-		<>
-			<BlockControls>
-				<AlignmentToolbar
-					value={ attributes.textAlign }
-					onChange={ ( textAlign: AllowedAlignments ) => {
-						setAttributes( { textAlign } );
-					} }
-				/>
-			</BlockControls>
-			<div { ...blockProps }>
+		<div { ...blockProps }>
+			<ProductSelector
+				productId={ attributes.productId }
+				setAttributes={ setAttributes }
+				icon={ BLOCK_ICON }
+				label={ BLOCK_TITLE }
+				description={ __(
+					'Choose a product to display its SKU.',
+					'woo-gutenberg-products-block'
+				) }
+			>
+				<BlockControls>
+					<AlignmentToolbar
+						value={ attributes.textAlign }
+						onChange={ ( textAlign: AllowedAlignments ) => {
+							setAttributes( { textAlign } );
+						} }
+					/>
+				</BlockControls>
 				<Block { ...blockAttrs } />
-			</div>
-		</>
+			</ProductSelector>
+		</div>
 	);
 };
 
-export default withProductSelector( { icon, label } )( PriceEdit );
+export default PriceEdit;

--- a/assets/js/atomic/blocks/product-elements/price/edit.tsx
+++ b/assets/js/atomic/blocks/product-elements/price/edit.tsx
@@ -53,18 +53,16 @@ const PriceEdit = ( {
 	};
 	const isDescendentOfQueryLoop = Number.isFinite( context.queryId );
 
-	const { isDescendentOfSingleProductTemplate } = useSelect(
+	const isDescendentOfSingleProductTemplate = useSelect(
 		( select ) => {
 			const store = select( 'core/edit-site' );
 			const postId = store?.getEditedPostId();
 
-			return {
-				isDescendentOfSingleProductTemplate:
-					( postId === 'woocommerce/woocommerce//product-meta' ||
-						postId ===
-							'woocommerce/woocommerce//single-product' ) &&
-					! isDescendentOfQueryLoop,
-			};
+			return (
+				( postId === 'woocommerce/woocommerce//product-meta' ||
+					postId === 'woocommerce/woocommerce//single-product' ) &&
+				! isDescendentOfQueryLoop
+			);
 		},
 		[ isDescendentOfQueryLoop ]
 	);

--- a/assets/js/atomic/blocks/product-elements/price/index.tsx
+++ b/assets/js/atomic/blocks/product-elements/price/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
-import type { BlockConfiguration } from '@wordpress/blocks';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -17,25 +17,32 @@ import {
 	BLOCK_DESCRIPTION as description,
 } from './constants';
 
-type CustomBlockConfiguration = BlockConfiguration & {
-	ancestor: string[];
-};
+const { ancestor, ...configuration } = sharedConfig;
 
-const blockConfig: CustomBlockConfiguration = {
-	...sharedConfig,
+const blockConfig = {
+	...configuration,
 	apiVersion: 2,
 	title,
 	description,
-	ancestor: [
-		'woocommerce/all-products',
-		'woocommerce/single-product',
-		'core/post-template',
-	],
 	usesContext: [ 'query', 'queryId', 'postId' ],
 	icon: { src: icon },
 	attributes,
 	supports,
 	edit,
+	save: () => {
+		if (
+			attributes.isDescendentOfQueryLoop ||
+			attributes.isDescendentOfSingleProductTemplate
+		) {
+			return null;
+		}
+
+		return (
+			<div
+				className={ classnames( 'is-loading', attributes.className ) }
+			/>
+		);
+	},
 };
 
 registerBlockType( 'woocommerce/product-price', blockConfig );

--- a/assets/js/atomic/blocks/product-elements/price/types.ts
+++ b/assets/js/atomic/blocks/product-elements/price/types.ts
@@ -3,4 +3,5 @@ export interface BlockAttributes {
 	className?: string;
 	textAlign?: 'left' | 'center' | 'right';
 	isDescendentOfQueryLoop?: boolean;
+	isDescendentOfSingleProductTemplate?: boolean;
 }

--- a/assets/js/atomic/blocks/product-elements/shared/config.tsx
+++ b/assets/js/atomic/blocks/product-elements/shared/config.tsx
@@ -14,7 +14,9 @@ import save from '../save';
  * Holds default config for this collection of blocks.
  * attributes and title are omitted here as these are added on an individual block level.
  */
-const sharedConfig: Omit< BlockConfiguration, 'attributes' | 'title' > = {
+const sharedConfig: Omit< BlockConfiguration, 'attributes' | 'title' > & {
+	ancestor: string[];
+} = {
 	category: 'woocommerce-product-elements',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
 	icon: {

--- a/assets/js/atomic/blocks/product-elements/shared/product-selector.tsx
+++ b/assets/js/atomic/blocks/product-elements/shared/product-selector.tsx
@@ -1,0 +1,77 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import ProductControl from '@woocommerce/editor-components/product-control';
+import { Placeholder, Button, ToolbarGroup } from '@wordpress/components';
+import { BlockControls } from '@wordpress/block-editor';
+import TextToolbarButton from '@woocommerce/editor-components/text-toolbar-button';
+import { useState } from 'react';
+
+export const ProductSelector = ( {
+	productId,
+	icon,
+	label,
+	description,
+	setAttributes,
+	children,
+}: {
+	productId: string;
+	icon: string;
+	label: string;
+	description: string;
+	setAttributes: ( obj: Record< string, string > ) => void;
+	children: React.ReactNode;
+} ) => {
+	const [ isEditing, setIsEditing ] = useState( ! productId );
+
+	return (
+		<>
+			{ isEditing ? (
+				<Placeholder
+					icon={ icon || '' }
+					label={ label || '' }
+					className="wc-atomic-blocks-product"
+				>
+					{ !! description && <div>{ description }</div> }
+					<div className="wc-atomic-blocks-product__selection">
+						<ProductControl
+							selected={ productId || 0 }
+							showVariations
+							onChange={ ( value = [] ) => {
+								setAttributes( {
+									productId: value[ 0 ] ? value[ 0 ].id : 0,
+								} );
+							} }
+						/>
+						<Button
+							isSecondary
+							disabled={ ! productId }
+							onClick={ () => {
+								setIsEditing( false );
+							} }
+						>
+							{ __( 'Done', 'woo-gutenberg-products-block' ) }
+						</Button>
+					</div>
+				</Placeholder>
+			) : (
+				<>
+					<BlockControls>
+						<ToolbarGroup>
+							<TextToolbarButton
+								onClick={ () => setIsEditing( true ) }
+							>
+								{ __(
+									'Switch product…',
+									'woo-gutenberg-products-block'
+								) }
+							</TextToolbarButton>
+						</ToolbarGroup>
+					</BlockControls>
+					{ children }
+				</>
+			) }
+		</>
+	);
+};

--- a/assets/js/atomic/blocks/product-elements/shared/product-selector.tsx
+++ b/assets/js/atomic/blocks/product-elements/shared/product-selector.tsx
@@ -6,7 +6,7 @@ import ProductControl from '@woocommerce/editor-components/product-control';
 import { Placeholder, Button, ToolbarGroup } from '@wordpress/components';
 import { BlockControls } from '@wordpress/block-editor';
 import TextToolbarButton from '@woocommerce/editor-components/text-toolbar-button';
-import { useState } from 'react';
+import { useState } from '@wordpress/element';
 
 export const ProductSelector = ( {
 	productId,


### PR DESCRIPTION
This PR added support to the Product Price block to Single Product Template.

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/8479


On the implementation level, the main issue is that the atomic blocks support several contexts: 

- Inside `All Products Block` -> `withProductDataContext` HOC
- Inside `Products Block` -> Gutenberg Context
- Inside `Single Product Template` -> Gutenberg Context
- Without any parent -> `WithSelector` and `withProductDataContext` HOCs

#### withProductDataContext
The HOC withProductDataContext servers pass the select product object to the block.

#### With Selector
The HOC withSelector, when the `ProductDataContext` isn't defined, renders a modal for selecting the product and setting the product id in the context. In this way, the block can fetch the right data.

We added the support to different contexts at different times, so the code isn't in the best shape, which influenced the work for this PR.


It was necessary to create a component identical to the ´WithSelector` HOC. There is no need to show the selector product modal when the block is inside the Single Product template. Using a component, we can easily distinguish the two cases.

In any case, we should refactor all the atomic blocks and create a common logic easily to check and with great type safety: should we put it as a cooldown task? 

![image](https://user-images.githubusercontent.com/4463174/222519855-047667d0-61d2-4a0d-b7cc-ae5d131c076d.png)


### Testing
#### User Facing Testing

1. Switch to the TT3 theme.
2. Go to the Site Editor, and edit the Single Product Template.
3. Add the Product Price. It should have a price of 50.00 with the currency set in WC options. Save.
4. On the front end, click a product and check that the block shows the right price.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Product Price block: add support to the Single Product Template.
