### PR TITLE
[Products]: Fix attributes filters that do not update the editor preview correctly

### DIFF
--- a/src/BlockTypes/ProductQuery.php
+++ b/src/BlockTypes/ProductQuery.php
@@ -114,6 +114,22 @@ class ProductQuery extends AbstractBlock {
 	}
 
 	/**
+	 * Merge tax_queries from various queries.
+	 *
+	 * @param array[] ...$queries Query arrays to be merged.
+	 * @return array
+	 */
+	private function merge_tax_queries( ...$queries ) {
+		$tax_query = array();
+		foreach ( $queries as $query ) {
+			if ( ! empty( $query['tax_query'] ) ) {
+				$tax_query = array_merge( $tax_query, $query['tax_query'] );
+			}
+		}
+		return array( 'tax_query' => $tax_query );
+	}
+
+	/**
 	 * Update the query for the product query block in Editor.
 	 *
 	 * @param array           $args    Query args.
@@ -128,8 +144,9 @@ class ProductQuery extends AbstractBlock {
 		$attributes_query = is_array( $woo_attributes ) ? $this->get_product_attributes_query( $woo_attributes ) : array();
 		$stock_query      = is_array( $woo_stock_status ) ? $this->get_stock_status_query( $woo_stock_status ) : array();
 		$visibility_query = $this->get_product_visibility_query( $stock_query );
+		$tax_query        = $this->merge_tax_queries( $attributes_query, $visibility_query );
 
-		return array_merge( $args, $on_sale_query, $orderby_query, $attributes_query, $stock_query, $visibility_query );
+		return array_merge( $args, $on_sale_query, $orderby_query, $stock_query, $tax_query );
 	}
 
 	/**

--- a/src/BlockTypes/ProductQuery.php
+++ b/src/BlockTypes/ProductQuery.php
@@ -116,17 +116,17 @@ class ProductQuery extends AbstractBlock {
 	/**
 	 * Merge tax_queries from various queries.
 	 *
-	 * @param array[] ...$queries Query arrays to be merged.
+	 * @param array ...$queries Query arrays to be merged.
 	 * @return array
 	 */
 	private function merge_tax_queries( ...$queries ) {
-		$tax_query = array();
+		$tax_query = [];
 		foreach ( $queries as $query ) {
 			if ( ! empty( $query['tax_query'] ) ) {
 				$tax_query = array_merge( $tax_query, $query['tax_query'] );
 			}
 		}
-		return array( 'tax_query' => $tax_query );
+		return [ 'tax_query' => $tax_query ];
 	}
 
 	/**

--- a/tests/php/BlockTypes/ProductQuery.php
+++ b/tests/php/BlockTypes/ProductQuery.php
@@ -8,7 +8,7 @@ use Automattic\WooCommerce\Blocks\Tests\Mocks\ProductQueryMock;
  */
 class ProductQuery extends \WP_UnitTestCase {
 	/**
-	 * This variable holds our cart object.
+	 * This variable holds our Product Query object.
 	 *
 	 * @var ProductQueryMock
 	 */
@@ -71,6 +71,23 @@ class ProductQuery extends \WP_UnitTestCase {
 		$query = build_query_vars_from_query_block( $block, 1 );
 
 		return $this->block_instance->build_query( $query );
+	}
+
+	/**
+	 * Build a simplified request for testing.
+	 *
+	 * @param bool  $woocommerce_on_sale WooCommerce on sale.
+	 * @param array $woocommerce_attributes WooCommerce attributes.
+	 * @param array $woocommerce_stock_status WooCommerce stock status.
+	 * @return array
+	 */
+	private function build_request( $woocommerce_on_sale = 'false', $woocommerce_attributes = array(), $woocommerce_stock_status = array() ) {
+		$request = new \WP_REST_Request( 'GET', '/wp/v2/product' );
+		$request->set_param( '__woocommerceOnSale', $woocommerce_on_sale );
+		$request->set_param( '__woocommerceAttributes', $woocommerce_attributes );
+		$request->set_param( '__woocommerceStockStatus', $woocommerce_stock_status );
+
+		return $request;
 	}
 
 	/**
@@ -513,5 +530,80 @@ class ProductQuery extends \WP_UnitTestCase {
 		set_query_var( 'min_price', '' );
 		set_query_var( 'filter_stock_status', '' );
 	}
-}
 
+	/**
+	 * Test merging multiple filter queries.
+	 */
+	public function test_updating_rest_query_without_attributes() {
+		$args    = array();
+		$request = $this->build_request();
+
+		$updated_query = $this->block_instance->update_rest_query( $args, $request );
+
+		$this->assertContainsEquals(
+			array(
+				'key'     => '_stock_status',
+				'value'   => array(),
+				'compare' => 'IN',
+			),
+			$updated_query['meta_query'],
+		);
+
+		$this->assertEquals(
+			array(
+				array(
+					'taxonomy' => 'product_visibility',
+					'field'    => 'term_taxonomy_id',
+					'terms'    => array( 0 ),
+					'operator' => 'NOT IN',
+				),
+			),
+			$updated_query['tax_query'],
+		);
+	}
+
+	/**
+	 * Test merging multiple filter queries.
+	 */
+	public function test_updating_rest_query_with_attributes() {
+		$args         = array();
+		$on_sale      = 'true';
+		$attributes   = array(
+			array(
+				'taxonomy' => 'pa_test',
+				'termId'   => 1,
+			),
+		);
+		$stock_status = array( 'instock', 'outofstock' );
+		$request      = $this->build_request( $on_sale, $attributes, $stock_status );
+
+		$updated_query = $this->block_instance->update_rest_query( $args, $request );
+
+		$this->assertContainsEquals(
+			array(
+				'key'     => '_stock_status',
+				'value'   => array( 'instock', 'outofstock' ),
+				'compare' => 'IN',
+			),
+			$updated_query['meta_query'],
+		);
+
+		$this->assertEquals(
+			array(
+				array(
+					'taxonomy' => 'pa_test',
+					'field'    => 'term_id',
+					'terms'    => array( 1 ),
+					'operator' => 'IN',
+				),
+				array(
+					'taxonomy' => 'product_visibility',
+					'field'    => 'term_taxonomy_id',
+					'terms'    => array( 0 ),
+					'operator' => 'NOT IN',
+				),
+			),
+			$updated_query['tax_query'],
+		);
+	}
+}

--- a/tests/php/BlockTypes/ProductQuery.php
+++ b/tests/php/BlockTypes/ProductQuery.php
@@ -79,7 +79,7 @@ class ProductQuery extends \WP_UnitTestCase {
 	 * @param bool  $woocommerce_on_sale WooCommerce on sale.
 	 * @param array $woocommerce_attributes WooCommerce attributes.
 	 * @param array $woocommerce_stock_status WooCommerce stock status.
-	 * @return array
+	 * @return WP_REST_Request
 	 */
 	private function build_request( $woocommerce_on_sale = 'false', $woocommerce_attributes = array(), $woocommerce_stock_status = array() ) {
 		$request = new \WP_REST_Request( 'GET', '/wp/v2/product' );


### PR DESCRIPTION
## Issue
When changing the attributes filter from the inspector controls, the products shown in the preview of Products block did not change accordingly.

## Cause
The issue was caused by additional query component that extended the Products query: `$visibility_query` ([added here](https://github.com/woocommerce/woocommerce-blocks/pull/7951/files#diff-efb947e345af5e501dfaa2980b055b3b31c308b31e8db23049b6b48fecee33d8R132)).

Both: `$attributes_query` and `$visibility_query` have a shape of:

`array( 'tax_query' => [ ... ])`

so by passing `$visibility_query` to the `merge_arrays` function, the previous `tax_query` (from `$attributes_query`) was overridden by the new one and only the latter was passed further.

## Solution
The solution was to merge both `tax_query` params into a single array.

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/8530

--- 
<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|     https://user-images.githubusercontent.com/20098064/222551633-8761a251-fb8b-4a00-b7d6-63315f2b6198.mov | https://user-images.githubusercontent.com/20098064/222551791-b0d0c617-ed67-4471-bcc1-45d2d6a3a6fb.mov |


### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. Create new post
2. Add _Products_ block
3. Make sure "Inherit query from template" toggle is disabled
4. Add “Product Attributes” filter from “Advanced Filters” in the inspector controls.
5. Add some attributes filter
6. **Expected**: Preview changes according to the applied attribute

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Products block: Fix attributes filters that do not update the editor preview correctly
