### PR TITLE
Add filter to change proceed to checkout button text and URL

### DIFF
--- a/assets/js/base/components/button/index.tsx
+++ b/assets/js/base/components/button/index.tsx
@@ -12,7 +12,7 @@ import Spinner from '@woocommerce/base-components/spinner';
 import './style.scss';
 
 export interface ButtonProps
-	extends Omit< WPButtonType.ButtonProps, 'variant' > {
+	extends Omit< WPButtonType.ButtonProps, 'variant' | 'href' > {
 	/**
 	 * Show spinner
 	 *
@@ -23,6 +23,10 @@ export interface ButtonProps
 	 * Button variant
 	 */
 	variant?: 'text' | 'contained' | 'outlined';
+	/**
+	 * The URL the button should link to.
+	 */
+	href?: string | undefined;
 }
 
 export interface AnchorProps extends Omit< ButtonProps, 'href' > {

--- a/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/block.tsx
+++ b/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/block.tsx
@@ -8,7 +8,7 @@ import { CHECKOUT_URL } from '@woocommerce/block-settings';
 import { usePositionRelativeToViewport } from '@woocommerce/base-hooks';
 import { getSetting } from '@woocommerce/settings';
 import { useSelect } from '@wordpress/data';
-import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
+import { CART_STORE_KEY, CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
 import { applyCheckoutFilter } from '@woocommerce/blocks-checkout';
 
 /**
@@ -33,6 +33,7 @@ const Block = ( {
 	const isCalculating = useSelect( ( select ) =>
 		select( CHECKOUT_STORE_KEY ).isCalculating()
 	);
+
 	const [ positionReferenceElement, positionRelativeToViewport ] =
 		usePositionRelativeToViewport();
 	const [ showSpinner, setShowSpinner ] = useState( false );
@@ -58,15 +59,19 @@ const Block = ( {
 			global.removeEventListener( 'pageshow', hideSpinner );
 		};
 	}, [] );
-
+	const cart = useSelect( ( select ) => {
+		return select( CART_STORE_KEY ).getCartData();
+	} );
 	const label = applyCheckoutFilter< string >( {
 		filterName: 'proceedToCheckoutButtonLabel',
 		defaultValue: buttonLabel || defaultButtonLabel,
+		arg: { cart },
 	} );
 
 	const filteredLink = applyCheckoutFilter< string >( {
 		filterName: 'proceedToCheckoutButtonLink',
 		defaultValue: link || CHECKOUT_URL,
+		arg: { cart },
 	} );
 
 	const submitContainerContents = (

--- a/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/block.tsx
+++ b/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/block.tsx
@@ -9,6 +9,7 @@ import { usePositionRelativeToViewport } from '@woocommerce/base-hooks';
 import { getSetting } from '@woocommerce/settings';
 import { useSelect } from '@wordpress/data';
 import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
+import { applyCheckoutFilter } from '@woocommerce/blocks-checkout';
 
 /**
  * Internal dependencies
@@ -58,15 +59,25 @@ const Block = ( {
 		};
 	}, [] );
 
+	const label = applyCheckoutFilter< string >( {
+		filterName: 'proceedToCheckoutButtonLabel',
+		defaultValue: buttonLabel || defaultButtonLabel,
+	} );
+
+	const filteredLink = applyCheckoutFilter< string >( {
+		filterName: 'proceedToCheckoutButtonLink',
+		defaultValue: link || CHECKOUT_URL,
+	} );
+
 	const submitContainerContents = (
 		<Button
 			className="wc-block-cart__submit-button"
-			href={ link || CHECKOUT_URL }
+			href={ filteredLink }
 			disabled={ isCalculating }
 			onClick={ () => setShowSpinner( true ) }
 			showSpinner={ showSpinner }
 		>
-			{ buttonLabel || defaultButtonLabel }
+			{ label }
 		</Button>
 	);
 

--- a/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/block.tsx
+++ b/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/block.tsx
@@ -28,7 +28,7 @@ const Block = ( {
 	className: string;
 	buttonLabel: string;
 } ): JSX.Element => {
-	const link = getSetting( 'page-' + checkoutPageId, false );
+	const link = getSetting< string >( 'page-' + checkoutPageId, false );
 	const isCalculating = useSelect( ( select ) =>
 		select( CHECKOUT_STORE_KEY ).isCalculating()
 	);

--- a/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/test/block.tsx
+++ b/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/test/block.tsx
@@ -9,8 +9,8 @@ import { registerCheckoutFilters } from '@woocommerce/blocks-checkout';
  */
 import Block from '../block';
 
-describe( 'proceed to checkout block', () => {
-	it( 'Allows the text to be filtered', () => {
+describe( 'Proceed to checkout block', () => {
+	it( 'allows the text to be filtered', () => {
 		registerCheckoutFilters( 'test-extension', {
 			proceedToCheckoutButtonLabel: () => {
 				return 'Proceed to step two';
@@ -21,7 +21,7 @@ describe( 'proceed to checkout block', () => {
 		);
 		expect( screen.getByText( 'Proceed to step two' ) ).toBeInTheDocument();
 	} );
-	it( 'Allows the link to be filtered', () => {
+	it( 'allows the link to be filtered', () => {
 		registerCheckoutFilters( 'test-extension', {
 			proceedToCheckoutButtonLink: () => {
 				return 'https://woocommerce.com';

--- a/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/test/block.tsx
+++ b/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/test/block.tsx
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import { registerCheckoutFilters } from '@woocommerce/blocks-checkout';
+
+/**
+ * Internal dependencies
+ */
+import Block from '../block';
+
+describe( 'proceed to checkout block', () => {
+	it( 'Allows the text to be filtered', () => {
+		registerCheckoutFilters( 'test-extension', {
+			proceedToCheckoutButtonLabel: () => {
+				return 'Proceed to step two';
+			},
+		} );
+		render(
+			<Block checkoutPageId={ 0 } buttonLabel={ '' } className={ '' } />
+		);
+		expect( screen.getByText( 'Proceed to step two' ) ).toBeInTheDocument();
+	} );
+	it( 'Allows the link to be filtered', () => {
+		registerCheckoutFilters( 'test-extension', {
+			proceedToCheckoutButtonLink: () => {
+				return 'https://woocommerce.com';
+			},
+		} );
+		render(
+			<Block checkoutPageId={ 0 } buttonLabel={ '' } className={ '' } />
+		);
+		const button = screen.getByText( 'Proceed to Checkout' );
+		const link = button.closest( 'a' );
+		expect( link?.href ).toBe( 'https://woocommerce.com/' );
+	} );
+	it( 'does not allow incorrect types to be applied to either button label or button link', () => {
+		registerCheckoutFilters( 'test-extension', {
+			proceedToCheckoutButtonLabel: () => {
+				return 123;
+			},
+			proceedToCheckoutButtonLink: () => {
+				return 123;
+			},
+		} );
+		render(
+			<Block checkoutPageId={ 0 } buttonLabel={ '' } className={ '' } />
+		);
+		//@todo When https://github.com/WordPress/gutenberg/issues/22850 is complete use that new matcher here for more specific error message assertion.
+		expect( console ).toHaveErrored();
+	} );
+} );

--- a/assets/js/types/type-defs/cart.ts
+++ b/assets/js/types/type-defs/cart.ts
@@ -185,7 +185,7 @@ export interface CartErrorItem {
 	message: string;
 }
 
-export interface Cart {
+export interface Cart extends Record< string, unknown > {
 	coupons: Array< CartCouponItem >;
 	shippingRates: Array< CartShippingRate >;
 	shippingAddress: CartShippingAddress;

--- a/docs/third-party-developers/extensibility/checkout-block/available-filters.md
+++ b/docs/third-party-developers/extensibility/checkout-block/available-filters.md
@@ -95,7 +95,7 @@ CartCoupon {
 
 ## Proceed to Checkout Button Label
 
-The Cart block contains a button which is labelled 'Proceed to Checkout' by default, but can be changed using the following filter.
+The Cart block contains a button which is labelled 'Proceed to Checkout' by default. It can be changed using the following filter.
 
 | Filter name                    | Description                                         | Return type |
 |--------------------------------|-----------------------------------------------------| ----------- |

--- a/docs/third-party-developers/extensibility/checkout-block/available-filters.md
+++ b/docs/third-party-developers/extensibility/checkout-block/available-filters.md
@@ -6,8 +6,11 @@
 -   [Order Summary Items](#order-summary-items)
 -   [Totals footer item (in Mini Cart, Cart and Checkout)](#totals-footer-item-in-mini-cart-cart-and-checkout)
 -   [Coupons](#coupons)
+-   [Proceed to Checkout Button Label](#proceed-to-checkout-button-label)
+-   [Proceed to Checkout Button Link](#proceed-to-checkout-button-link)
 -   [Place Order Button Label](#place-order-button-label)
 -   [Examples](#examples)
+    -   [Changing the wording and the link on the "Proceed to Checkout" button when a specific item is in the Cart](#changing-the-wording-and-the-link-on-the--proceed-to-checkout--button-when-a-specific-item-is-in-the-cart)
     -   [Changing the wording of the Totals label in the Mini Cart, Cart and Checkout](#changing-the-wording-of-the-totals-label-in-the-mini-cart-cart-and-checkout)
     -   [Changing the format of the item's single price](#changing-the-format-of-the-items-single-price)
     -   [Change the name of a coupon](#change-the-name-of-a-coupon)
@@ -90,15 +93,70 @@ CartCoupon {
 }
 ```
 
+## Proceed to Checkout Button Label
+
+The Cart block contains a button which is labelled 'Proceed to Checkout' by default, but can be changed using the following filter.
+
+| Filter name                    | Description                                         | Return type |
+|--------------------------------|-----------------------------------------------------| ----------- |
+| `proceedToCheckoutButtonLabel` | The wanted label of the Proceed to Checkout button. | `string`    |
+
+## Proceed to Checkout Button Link
+
+The Cart block contains a button which is labelled 'Proceed to Checkout' and links to the Checkout page by default, but can be changed using the following filter. This filter has the current cart passed to it in the third parameter.
+
+| Filter name                   | Description                                                 | Return type |
+|-------------------------------|-------------------------------------------------------------| ----------- |
+| `proceedToCheckoutButtonLink` | The URL that the Proceed to Checkout button should link to. | `string`    |
+
 ## Place Order Button Label
 
-The Checkout block contains a button which is labelled 'Place Order' by default, but can be changed using the following filter.
+The Checkout block contains a button which is labelled 'Place Order' by default, but can be changed using the following filter. This filter has the current cart passed to it in the third parameter.
 
 | Filter name             | Description                                 | Return type |
 | ----------------------- | ------------------------------------------- | ----------- |
 | `placeOrderButtonLabel` | The wanted label of the Place Order button. | `string`    |
 
 ## Examples
+
+### Changing the wording and the link on the "Proceed to Checkout" button when a specific item is in the Cart
+
+For this example, let's say our store has a checkout page for regular items, and one set up specifically for users purchasing sunglasses. We will use the `wc/store/cart` data store to check whether a specific item (Sunglasses) is in the cart, and if it is, we will change the URL and text on the "Proceed to Checkout" button in the Cart block.
+
+```ts
+registerCheckoutFilters( 'sunglasses-store-extension', {
+	proceedToCheckoutButtonLabel: ( value, extensions, { cart } ) => {
+		if ( ! cart.items ) {
+			return value;
+		}
+		const isSunglassesInCart = cart.items.some(
+			( item ) => item.name === 'Sunglasses'
+		);
+		// Return the default value if sunglasses is not in the cart.
+		if ( ! isSunglassesInCart ) {
+			return value;
+		}
+		return 'Proceed to 😎 checkout';
+	},
+	proceedToCheckoutButtonLink: ( value, extensions, { cart } ) => {
+		if ( ! cart.items ) {
+			return value;
+		}
+		const isSunglassesInCart = cart.items.some(
+			( item ) => item.name === 'Sunglasses'
+		);
+		// Return the default value if sunglasses is not in the cart.
+		if ( ! isSunglassesInCart ) {
+			return value;
+		}
+		return '/sunglasses-checkout';
+	},
+} );
+```
+
+| Before                                                                                                                                    | After |
+|-------------------------------------------------------------------------------------------------------------------------------------------| ----- |
+| <img width="789" alt="image" src="https://user-images.githubusercontent.com/5656702/222575670-a7d1dab8-c93e-477a-b2cc-e463a5de77a6.png">  | <img width="761" alt="image" src="https://user-images.githubusercontent.com/5656702/222572409-de7a6bd6-5a2d-406b-ada9-cc60cc5cca54.png"> |
 
 ### Changing the wording of the Totals label in the Mini Cart, Cart and Checkout
 

--- a/packages/checkout/filter-registry/index.ts
+++ b/packages/checkout/filter-registry/index.ts
@@ -32,7 +32,7 @@ let checkoutFilters: Record<
 	Record< string, CheckoutFilterFunction >
 > = {};
 
-const cachedValues: Record< string, unknown > = {};
+let cachedValues: Record< string, unknown > = {};
 
 /**
  * Register filters for a specific extension.
@@ -53,7 +53,8 @@ export const registerCheckoutFilters = (
 			link: 'https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/bb921d21f42e21f38df2b1c87b48e07aa4cb0538/docs/extensibility/available-filters.md#coupons',
 		} );
 	}
-
+	// Clear cached values when registering new filters because otherwise we get outdated results when applying them.
+	cachedValues = {};
 	checkoutFilters = {
 		...checkoutFilters,
 		[ namespace ]: filters,

--- a/packages/checkout/filter-registry/index.ts
+++ b/packages/checkout/filter-registry/index.ts
@@ -15,11 +15,11 @@ import { isNull, isObject, objectHasProp } from '@woocommerce/types';
  */
 const returnTrue = (): true => true;
 
-type CheckoutFilterFunction = < T >(
-	value: T,
+type CheckoutFilterFunction< U = unknown > = < T >(
+	value: T | U,
 	extensions: Record< string, unknown >,
 	args?: CheckoutFilterArguments
-) => T;
+) => T | U;
 
 type CheckoutFilterArguments =
 	| ( Record< string, unknown > & {
@@ -32,7 +32,7 @@ let checkoutFilters: Record<
 	Record< string, CheckoutFilterFunction >
 > = {};
 
-const cachedValues: Record< string, T > = {};
+const cachedValues: Record< string, unknown > = {};
 
 /**
  * Register filters for a specific extension.
@@ -220,13 +220,13 @@ export const applyCheckoutFilter = < T >( {
 		! shouldReRunFilters( filterName, arg, extensions, defaultValue ) &&
 		cachedValues[ filterName ] !== undefined
 	) {
-		return cachedValues[ filterName ];
+		return cachedValues[ filterName ] as T;
 	}
 	const filters = getCheckoutFilters( filterName );
 	let value = defaultValue;
 	filters.forEach( ( filter ) => {
 		try {
-			const newValue = filter( value, extensions || {}, arg );
+			const newValue = filter( value, extensions || {}, arg ) as T;
 			if ( typeof newValue !== typeof value ) {
 				throw new Error(
 					sprintf(

--- a/packages/checkout/filter-registry/test/index.js
+++ b/packages/checkout/filter-registry/test/index.js
@@ -82,4 +82,38 @@ describe( 'Checkout registry', () => {
 		expect( newValue.current ).toBe( value );
 		spy.console.mockRestore();
 	} );
+
+	it( 'should allow filters to be registered multiple times and return the correct value each time', () => {
+		const value = 'Hello World';
+		registerCheckoutFilters( filterName, {
+			[ filterName ]: ( val, extensions, args ) =>
+				val.toUpperCase() + args?.punctuationSign,
+		} );
+		const { result: newValue } = renderHook( () =>
+			applyCheckoutFilter( {
+				filterName,
+				defaultValue: value,
+				arg: {
+					punctuationSign: '!',
+				},
+			} )
+		);
+		expect( newValue.current ).toBe( 'HELLO WORLD!' );
+		registerCheckoutFilters( filterName, {
+			[ filterName ]: ( val, extensions, args ) =>
+				args?.punctuationSign +
+				val.toUpperCase() +
+				args?.punctuationSign,
+		} );
+		const { result: newValue2 } = renderHook( () =>
+			applyCheckoutFilter( {
+				filterName,
+				defaultValue: value,
+				arg: {
+					punctuationSign: '!',
+				},
+			} )
+		);
+		expect( newValue2.current ).toBe( '!HELLO WORLD!' );
+	} );
 } );


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
During an extensibility monthly chat session in the WooCommerce Community Slack a user suggested that a filter for changing the URL and text on the "Proceed to checkout" button would be useful.

This PR adds such filters, they enable extensions to change the text on the "Proceed to checkout" button in the Cart block and allow them to change the URL the button links to.

The current cart is passed in the `arg` (third) parameter when applying the filter.

The PR also makes a couple of other tweaks, they are:

- Make the `Cart` type extend a plain object, this is required to prevent a TS error when passing something that isn't a `Record< string, unknown >` to the filter args.
- Allow `href` on the `WPButton` type imported from `wordpress-components` - this is required to prevent a TypeScript error when trying to add a link to the button.
- Clear `cachedValues` when applying filters. This was required because if filters ran once then new ones were registered, or existing ones were changed, the new functions would not be available due to caching. (Unit tests have also been added for this).

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

Fixes #8614

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
| <img width="789" alt="image" src="https://user-images.githubusercontent.com/5656702/222575670-a7d1dab8-c93e-477a-b2cc-e463a5de77a6.png"> | <img width="761" alt="image" src="https://user-images.githubusercontent.com/5656702/222572409-de7a6bd6-5a2d-406b-ada9-cc60cc5cca54.png"> |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Add items to your cart, go to the Cart block and ensure the button to proceed to checkout works and looks normal.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### Internal developer testing

1. Add an item to your shop called `Sunglasses` - if you used the default store data it should exist already.
2. Add this code somewhere it will execute when on the Cart block. If you want a quick plugin to be set up then use [`@woocommerce/extend-cart-checkout-block`](https://www.npmjs.com/package/@woocommerce/extend-cart-checkout-block)
```ts
import { registerCheckoutFilters } from '@woocommerce/blocks-checkout';

registerCheckoutFilters( 'sunglasses-store-extension', {
	proceedToCheckoutButtonLabel: ( value, extensions, { cart } ) => {
		if ( ! cart.items ) {
			return value;
		}
		const isSunglassesInCart = cart.items.some(
			( item ) => item.name === 'Sunglasses'
		);
		// Return the default value if sunglasses is not in the cart.
		if ( ! isSunglassesInCart ) {
			return value;
		}
		return 'Proceed to 😎 checkout';
	},
	proceedToCheckoutButtonLink: ( value, extensions, { cart } ) => {
		if ( ! cart.items ) {
			return value;
		}
		const isSunglassesInCart = cart.items.some(
			( item ) => item.name === 'Sunglasses'
		);
		// Return the default value if sunglasses is not in the cart.
		if ( ! isSunglassesInCart ) {
			return value;
		}
		return '/sunglasses-checkout';
	},
} );
```
3. Add `Sunglasses` to your cart along with another item
4. Go to the Cart block, ensure the "Proceed to checkout" button has an sunglasses emoji in it and that the URL it links to is `/sunglasses-checkout`.
5. Without reloading, remove `Sunglasses` from your cart. Ensure the button returns to normal and that the URL links to the correct checkout page.

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Dev note

In this release we are adding two new filters for the Cart block, they are: `proceedToCheckoutButtonLabel` and `proceedToCheckoutButtonLink`.

By using these filters, developers can alter the text and link of the "Proceed to checkout" button in the Cart. Our documentation has more information on these filters and an example of how to use them.

### Changelog

> Add `proceedToCheckoutButtonLabel` and `proceedToCheckoutButtonLink` filters and delete cached filters when registering new ones.