### PR TITLE
Update release steps mentioning the version on the WooCommerce.com plugin page takes some hours to update

### DIFF
--- a/.github/patch-initial-checklist.md
+++ b/.github/patch-initial-checklist.md
@@ -57,7 +57,7 @@ Each porter is responsible for testing the PRs that fall under the focus of thei
 -   [ ] After the wp.org workflow completes, confirm the following
     -   [ ] Changelog, Version, and Last Updated on [WP.org plugin page](https://wordpress.org/plugins/woo-gutenberg-products-block/) is correct.
     -   [ ] Confirm svn tag is correct, e.g. [{{version}}](https://plugins.svn.wordpress.org/woo-gutenberg-products-block/tags/{{version}}/)
-    -   [ ] Confirm [WooCommerce.com plugin page](https://woocommerce.com/products/woocommerce-gutenberg-products-block/) is updated. Note: this can take several hours, feel free to check it tomorrow.
+    -   [ ] Confirm [WooCommerce.com plugin page](https://woocommerce.com/products/woocommerce-gutenberg-products-block/) is updated. Note: this can take several hours, feel free to check it the following day.
     -   [ ] Download zip and smoke test.
     -   [ ] Test updating plugin from previous version.
 

--- a/.github/patch-initial-checklist.md
+++ b/.github/patch-initial-checklist.md
@@ -57,7 +57,7 @@ Each porter is responsible for testing the PRs that fall under the focus of thei
 -   [ ] After the wp.org workflow completes, confirm the following
     -   [ ] Changelog, Version, and Last Updated on [WP.org plugin page](https://wordpress.org/plugins/woo-gutenberg-products-block/) is correct.
     -   [ ] Confirm svn tag is correct, e.g. [{{version}}](https://plugins.svn.wordpress.org/woo-gutenberg-products-block/tags/{{version}}/)
-    -   [ ] Confirm [WooCommerce.com plugin page](https://woocommerce.com/products/woocommerce-gutenberg-products-block/) is updated.
+    -   [ ] Confirm [WooCommerce.com plugin page](https://woocommerce.com/products/woocommerce-gutenberg-products-block/) is updated. Note: this can take several hours, feel free to check it tomorrow.
     -   [ ] Download zip and smoke test.
     -   [ ] Test updating plugin from previous version.
 

--- a/.github/release-initial-checklist.md
+++ b/.github/release-initial-checklist.md
@@ -76,7 +76,7 @@ Each porter is responsible for testing the PRs that fall under the focus of thei
 -   [ ] After the wp.org workflow completes, confirm the following
     -   [ ] Changelog, Version, and Last Updated on [WP.org plugin page](https://wordpress.org/plugins/woo-gutenberg-products-block/) is correct.
     -   [ ] Confirm svn tag is correct, e.g. [{{version}}](https://plugins.svn.wordpress.org/woo-gutenberg-products-block/tags/{{version}}/)
-    -   [ ] Confirm [WooCommerce.com plugin page](https://woocommerce.com/products/woocommerce-gutenberg-products-block/) is updated.
+    -   [ ] Confirm [WooCommerce.com plugin page](https://woocommerce.com/products/woocommerce-gutenberg-products-block/) is updated. Note: this can take several hours, feel free to check it tomorrow.
     -   [ ] Download zip and smoke test.
     -   [ ] Test updating plugin from previous version.
 

--- a/.github/release-initial-checklist.md
+++ b/.github/release-initial-checklist.md
@@ -76,7 +76,7 @@ Each porter is responsible for testing the PRs that fall under the focus of thei
 -   [ ] After the wp.org workflow completes, confirm the following
     -   [ ] Changelog, Version, and Last Updated on [WP.org plugin page](https://wordpress.org/plugins/woo-gutenberg-products-block/) is correct.
     -   [ ] Confirm svn tag is correct, e.g. [{{version}}](https://plugins.svn.wordpress.org/woo-gutenberg-products-block/tags/{{version}}/)
-    -   [ ] Confirm [WooCommerce.com plugin page](https://woocommerce.com/products/woocommerce-gutenberg-products-block/) is updated. Note: this can take several hours, feel free to check it tomorrow.
+    -   [ ] Confirm [WooCommerce.com plugin page](https://woocommerce.com/products/woocommerce-gutenberg-products-block/) is updated. Note: this can take several hours, feel free to check it the following day.
     -   [ ] Download zip and smoke test.
     -   [ ] Test updating plugin from previous version.
 


### PR DESCRIPTION
When doing a release, the new version number in WooCommerce.com takes some hours to update. This PR updates the release steps mentioning it to avoid confusion.

### Testing

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->