### PR TITLE
Add unit tests for shipping rate calculator

### DIFF
--- a/assets/js/base/components/cart-checkout/totals/shipping/test/index.tsx
+++ b/assets/js/base/components/cart-checkout/totals/shipping/test/index.tsx
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import { screen, render } from '@testing-library/react';
-require( '@wordpress/data' );
+import { SlotFillProvider } from '@woocommerce/blocks-checkout';
+import { previewCart as mockPreviewCart } from '@woocommerce/resource-previews';
 
 /**
  * Internal dependencies
@@ -124,26 +125,39 @@ jest.mock( '@woocommerce/base-context/hooks', () => ( {
 			},
 		],
 	} ),
+	useStoreCart: jest.fn().mockReturnValue( {
+		cartItems: mockPreviewCart.items,
+		cartTotals: mockPreviewCart.totals,
+		cartCoupons: mockPreviewCart.coupons,
+		cartFees: mockPreviewCart.fees,
+		cartNeedsShipping: mockPreviewCart.needs_shipping,
+		shippingRates: mockPreviewCart.shipping_rates,
+		shippingAddress: mockPreviewCart.shipping_address,
+		billingAddress: mockPreviewCart.billing_address,
+		cartHasCalculatedShipping: mockPreviewCart.has_calculated_shipping,
+	} ),
 } ) );
 describe( 'TotalsShipping', () => {
 	it( 'should show correct calculator button label if address is complete', () => {
 		const { rerender } = render(
-			<TotalsShipping
-				currency={ {
-					code: 'USD',
-					symbol: '$',
-					position: 'left',
-					precision: 2,
-				} }
-				values={ {
-					total_shipping: '10',
-					total_shipping_tax: '0',
-				} }
-				showCalculator={ true }
-				showRateSelector={ true }
-				isCheckout={ true }
-				className={ '' }
-			/>
+			<SlotFillProvider>
+				<TotalsShipping
+					currency={ {
+						code: 'USD',
+						symbol: '$',
+						position: 'left',
+						precision: 2,
+					} }
+					values={ {
+						total_shipping: '10',
+						total_shipping_tax: '0',
+					} }
+					showCalculator={ true }
+					showRateSelector={ true }
+					isCheckout={ true }
+					className={ '' }
+				/>
+			</SlotFillProvider>
 		);
 		expect( screen.getByText( 'Calculate' ) ).toBeInTheDocument();
 	} );

--- a/assets/js/base/components/cart-checkout/totals/shipping/test/index.tsx
+++ b/assets/js/base/components/cart-checkout/totals/shipping/test/index.tsx
@@ -4,6 +4,8 @@
 import { screen, render } from '@testing-library/react';
 import { SlotFillProvider } from '@woocommerce/blocks-checkout';
 import { previewCart as mockPreviewCart } from '@woocommerce/resource-previews';
+import * as wpData from '@wordpress/data';
+import * as baseContextHooks from '@woocommerce/base-context/hooks';
 
 /**
  * Internal dependencies
@@ -15,131 +17,154 @@ jest.mock( '@wordpress/data', () => ( {
 	...jest.requireActual( '@wordpress/data' ),
 	AsyncModeProvider:
 		jest.requireActual( '@wordpress/data' ).AsyncModeProvider,
-	useSelect: jest.fn().mockImplementation( ( selector ) => {
-		return { prefersCollection: true };
-	} ),
+	useSelect: jest.fn(),
 } ) );
 
-jest.mock( '@woocommerce/base-context/hooks', () => ( {
-	...jest.requireActual( '@woocommerce/base-context/hooks' ),
-	useShippingData: jest.fn().mockReturnValue( {
-		needsShipping: true,
-		shippingRates: [
-			{
-				package_id: 0,
-				name: 'Shipping method',
-				destination: {
-					address_1: '',
-					address_2: '',
-					city: '',
-					state: '',
-					postcode: '',
-					country: '',
-				},
-				items: [
-					{
-						key: 'fb0c0a746719a7596f296344b80cb2b6',
-						name: 'Hoodie - Blue, Yes',
-						quantity: 1,
-					},
-					{
-						key: '1f0e3dad99908345f7439f8ffabdffc4',
-						name: 'Beanie',
-						quantity: 1,
-					},
-				],
-				shipping_rates: [
-					{
-						rate_id: 'flat_rate:1',
-						name: 'Flat rate',
-						description: '',
-						delivery_time: '',
-						price: '500',
-						taxes: '0',
-						instance_id: 1,
-						method_id: 'flat_rate',
-						meta_data: [
-							{
-								key: 'Items',
-								value: 'Hoodie - Blue, Yes &times; 1, Beanie &times; 1',
-							},
-						],
-						selected: false,
-						currency_code: 'USD',
-						currency_symbol: '$',
-						currency_minor_unit: 2,
-						currency_decimal_separator: '.',
-						currency_thousand_separator: ',',
-						currency_prefix: '$',
-						currency_suffix: '',
-					},
-					{
-						rate_id: 'local_pickup:2',
-						name: 'Local pickup',
-						description: '',
-						delivery_time: '',
-						price: '0',
-						taxes: '0',
-						instance_id: 2,
-						method_id: 'local_pickup',
-						meta_data: [
-							{
-								key: 'Items',
-								value: 'Hoodie - Blue, Yes &times; 1, Beanie &times; 1',
-							},
-						],
-						selected: false,
-						currency_code: 'USD',
-						currency_symbol: '$',
-						currency_minor_unit: 2,
-						currency_decimal_separator: '.',
-						currency_thousand_separator: ',',
-						currency_prefix: '$',
-						currency_suffix: '',
-					},
-					{
-						rate_id: 'free_shipping:5',
-						name: 'Free shipping',
-						description: '',
-						delivery_time: '',
-						price: '0',
-						taxes: '0',
-						instance_id: 5,
-						method_id: 'free_shipping',
-						meta_data: [
-							{
-								key: 'Items',
-								value: 'Hoodie - Blue, Yes &times; 1, Beanie &times; 1',
-							},
-						],
-						selected: true,
-						currency_code: 'USD',
-						currency_symbol: '$',
-						currency_minor_unit: 2,
-						currency_decimal_separator: '.',
-						currency_thousand_separator: ',',
-						currency_prefix: '$',
-						currency_suffix: '',
-					},
-				],
+wpData.useSelect.mockImplementation( () => {
+	return { prefersCollection: false };
+} );
+
+const shippingAddress = {
+	first_name: 'John',
+	last_name: 'Doe',
+	company: 'Company',
+	address_1: '409 Main Street',
+	address_2: 'Apt 1',
+	city: 'London',
+	postcode: 'W1T 4JG',
+	country: 'GB',
+	state: '',
+	email: 'john.doe@company',
+	phone: '+1234567890',
+};
+
+jest.mock( '@woocommerce/base-context/hooks', () => {
+	return {
+		__esModule: true,
+		...jest.requireActual( '@woocommerce/base-context/hooks' ),
+		useShippingData: jest.fn(),
+		useStoreCart: jest.fn(),
+	};
+} );
+baseContextHooks.useShippingData.mockReturnValue( {
+	needsShipping: true,
+	shippingRates: [
+		{
+			package_id: 0,
+			name: 'Shipping method',
+			destination: {
+				address_1: '',
+				address_2: '',
+				city: '',
+				state: '',
+				postcode: '',
+				country: '',
 			},
-		],
-	} ),
-	useStoreCart: jest.fn().mockReturnValue( {
-		cartItems: mockPreviewCart.items,
-		cartTotals: mockPreviewCart.totals,
-		cartCoupons: mockPreviewCart.coupons,
-		cartFees: mockPreviewCart.fees,
-		cartNeedsShipping: mockPreviewCart.needs_shipping,
-		shippingRates: mockPreviewCart.shipping_rates,
-		shippingAddress: mockPreviewCart.shipping_address,
-		billingAddress: mockPreviewCart.billing_address,
-		cartHasCalculatedShipping: mockPreviewCart.has_calculated_shipping,
-	} ),
-} ) );
+			items: [
+				{
+					key: 'fb0c0a746719a7596f296344b80cb2b6',
+					name: 'Hoodie - Blue, Yes',
+					quantity: 1,
+				},
+				{
+					key: '1f0e3dad99908345f7439f8ffabdffc4',
+					name: 'Beanie',
+					quantity: 1,
+				},
+			],
+			shipping_rates: [
+				{
+					rate_id: 'flat_rate:1',
+					name: 'Flat rate',
+					description: '',
+					delivery_time: '',
+					price: '500',
+					taxes: '0',
+					instance_id: 1,
+					method_id: 'flat_rate',
+					meta_data: [
+						{
+							key: 'Items',
+							value: 'Hoodie - Blue, Yes &times; 1, Beanie &times; 1',
+						},
+					],
+					selected: false,
+					currency_code: 'USD',
+					currency_symbol: '$',
+					currency_minor_unit: 2,
+					currency_decimal_separator: '.',
+					currency_thousand_separator: ',',
+					currency_prefix: '$',
+					currency_suffix: '',
+				},
+				{
+					rate_id: 'local_pickup:2',
+					name: 'Local pickup',
+					description: '',
+					delivery_time: '',
+					price: '0',
+					taxes: '0',
+					instance_id: 2,
+					method_id: 'local_pickup',
+					meta_data: [
+						{
+							key: 'Items',
+							value: 'Hoodie - Blue, Yes &times; 1, Beanie &times; 1',
+						},
+					],
+					selected: false,
+					currency_code: 'USD',
+					currency_symbol: '$',
+					currency_minor_unit: 2,
+					currency_decimal_separator: '.',
+					currency_thousand_separator: ',',
+					currency_prefix: '$',
+					currency_suffix: '',
+				},
+				{
+					rate_id: 'free_shipping:5',
+					name: 'Free shipping',
+					description: '',
+					delivery_time: '',
+					price: '0',
+					taxes: '0',
+					instance_id: 5,
+					method_id: 'free_shipping',
+					meta_data: [
+						{
+							key: 'Items',
+							value: 'Hoodie - Blue, Yes &times; 1, Beanie &times; 1',
+						},
+					],
+					selected: true,
+					currency_code: 'USD',
+					currency_symbol: '$',
+					currency_minor_unit: 2,
+					currency_decimal_separator: '.',
+					currency_thousand_separator: ',',
+					currency_prefix: '$',
+					currency_suffix: '',
+				},
+			],
+		},
+	],
+} );
+baseContextHooks.useStoreCart.mockReturnValue( {
+	cartItems: mockPreviewCart.items,
+	cartTotals: [ mockPreviewCart.totals ],
+	cartCoupons: mockPreviewCart.coupons,
+	cartFees: mockPreviewCart.fees,
+	cartNeedsShipping: mockPreviewCart.needs_shipping,
+	shippingRates: [],
+	shippingAddress,
+	billingAddress: mockPreviewCart.billing_address,
+	cartHasCalculatedShipping: mockPreviewCart.has_calculated_shipping,
+	isLoadingRates: false,
+} );
+
 describe( 'TotalsShipping', () => {
 	it( 'should show correct calculator button label if address is complete', () => {
-		const { rerender } = render(
+		render(
 			<SlotFillProvider>
 				<TotalsShipping
 					currency={ {
@@ -149,7 +174,7 @@ describe( 'TotalsShipping', () => {
 						precision: 2,
 					} }
 					values={ {
-						total_shipping: '10',
+						total_shipping: '0',
 						total_shipping_tax: '0',
 					} }
 					showCalculator={ true }
@@ -159,6 +184,101 @@ describe( 'TotalsShipping', () => {
 				/>
 			</SlotFillProvider>
 		);
-		expect( screen.getByText( 'Calculate' ) ).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				'Shipping to W1T 4JG, London, United Kingdom (UK)'
+			)
+		).toBeInTheDocument();
+		expect( screen.getByText( 'Change address' ) ).toBeInTheDocument();
+	} );
+	it( 'should show correct calculator button label if address is incomplete', () => {
+		baseContextHooks.useStoreCart.mockReturnValue( {
+			cartItems: mockPreviewCart.items,
+			cartTotals: [ mockPreviewCart.totals ],
+			cartCoupons: mockPreviewCart.coupons,
+			cartFees: mockPreviewCart.fees,
+			cartNeedsShipping: mockPreviewCart.needs_shipping,
+			shippingRates: [],
+			shippingAddress: {
+				...shippingAddress,
+				city: '',
+				country: '',
+				postcode: '',
+			},
+			billingAddress: mockPreviewCart.billing_address,
+			cartHasCalculatedShipping: mockPreviewCart.has_calculated_shipping,
+			isLoadingRates: false,
+		} );
+		render(
+			<SlotFillProvider>
+				<TotalsShipping
+					currency={ {
+						code: 'USD',
+						symbol: '$',
+						position: 'left',
+						precision: 2,
+					} }
+					values={ {
+						total_shipping: '0',
+						total_shipping_tax: '0',
+					} }
+					showCalculator={ true }
+					showRateSelector={ true }
+					isCheckout={ true }
+					className={ '' }
+				/>
+			</SlotFillProvider>
+		);
+		expect(
+			screen.queryByText( 'Change address' )
+		).not.toBeInTheDocument();
+		expect(
+			screen.getByText( 'Add an address for shipping options' )
+		).toBeInTheDocument();
+	} );
+	it( 'does not show the calculator button when default rates are available and no address has been entered', () => {
+		baseContextHooks.useStoreCart.mockReturnValue( {
+			cartItems: mockPreviewCart.items,
+			cartTotals: [ mockPreviewCart.totals ],
+			cartCoupons: mockPreviewCart.coupons,
+			cartFees: mockPreviewCart.fees,
+			cartNeedsShipping: mockPreviewCart.needs_shipping,
+			shippingRates: mockPreviewCart.shipping_rates,
+			shippingAddress: {
+				...shippingAddress,
+				city: '',
+				country: '',
+				postcode: '',
+			},
+			billingAddress: mockPreviewCart.billing_address,
+			cartHasCalculatedShipping: mockPreviewCart.has_calculated_shipping,
+			isLoadingRates: false,
+		} );
+		render(
+			<SlotFillProvider>
+				<TotalsShipping
+					currency={ {
+						code: 'USD',
+						symbol: '$',
+						position: 'left',
+						precision: 2,
+					} }
+					values={ {
+						total_shipping: '0',
+						total_shipping_tax: '0',
+					} }
+					showCalculator={ true }
+					showRateSelector={ true }
+					isCheckout={ true }
+					className={ '' }
+				/>
+			</SlotFillProvider>
+		);
+		expect(
+			screen.queryByText( 'Change address' )
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByText( 'Add an address for shipping options' )
+		).not.toBeInTheDocument();
 	} );
 } );

--- a/assets/js/base/components/cart-checkout/totals/shipping/test/index.tsx
+++ b/assets/js/base/components/cart-checkout/totals/shipping/test/index.tsx
@@ -1,0 +1,150 @@
+/**
+ * External dependencies
+ */
+import { screen, render } from '@testing-library/react';
+require( '@wordpress/data' );
+
+/**
+ * Internal dependencies
+ */
+import { TotalsShipping } from '../index';
+
+jest.mock( '@wordpress/data', () => ( {
+	__esModule: true,
+	...jest.requireActual( '@wordpress/data' ),
+	AsyncModeProvider:
+		jest.requireActual( '@wordpress/data' ).AsyncModeProvider,
+	useSelect: jest.fn().mockImplementation( ( selector ) => {
+		return { prefersCollection: true };
+	} ),
+} ) );
+
+jest.mock( '@woocommerce/base-context/hooks', () => ( {
+	...jest.requireActual( '@woocommerce/base-context/hooks' ),
+	useShippingData: jest.fn().mockReturnValue( {
+		needsShipping: true,
+		shippingRates: [
+			{
+				package_id: 0,
+				name: 'Shipping method',
+				destination: {
+					address_1: '',
+					address_2: '',
+					city: '',
+					state: '',
+					postcode: '',
+					country: '',
+				},
+				items: [
+					{
+						key: 'fb0c0a746719a7596f296344b80cb2b6',
+						name: 'Hoodie - Blue, Yes',
+						quantity: 1,
+					},
+					{
+						key: '1f0e3dad99908345f7439f8ffabdffc4',
+						name: 'Beanie',
+						quantity: 1,
+					},
+				],
+				shipping_rates: [
+					{
+						rate_id: 'flat_rate:1',
+						name: 'Flat rate',
+						description: '',
+						delivery_time: '',
+						price: '500',
+						taxes: '0',
+						instance_id: 1,
+						method_id: 'flat_rate',
+						meta_data: [
+							{
+								key: 'Items',
+								value: 'Hoodie - Blue, Yes &times; 1, Beanie &times; 1',
+							},
+						],
+						selected: false,
+						currency_code: 'USD',
+						currency_symbol: '$',
+						currency_minor_unit: 2,
+						currency_decimal_separator: '.',
+						currency_thousand_separator: ',',
+						currency_prefix: '$',
+						currency_suffix: '',
+					},
+					{
+						rate_id: 'local_pickup:2',
+						name: 'Local pickup',
+						description: '',
+						delivery_time: '',
+						price: '0',
+						taxes: '0',
+						instance_id: 2,
+						method_id: 'local_pickup',
+						meta_data: [
+							{
+								key: 'Items',
+								value: 'Hoodie - Blue, Yes &times; 1, Beanie &times; 1',
+							},
+						],
+						selected: false,
+						currency_code: 'USD',
+						currency_symbol: '$',
+						currency_minor_unit: 2,
+						currency_decimal_separator: '.',
+						currency_thousand_separator: ',',
+						currency_prefix: '$',
+						currency_suffix: '',
+					},
+					{
+						rate_id: 'free_shipping:5',
+						name: 'Free shipping',
+						description: '',
+						delivery_time: '',
+						price: '0',
+						taxes: '0',
+						instance_id: 5,
+						method_id: 'free_shipping',
+						meta_data: [
+							{
+								key: 'Items',
+								value: 'Hoodie - Blue, Yes &times; 1, Beanie &times; 1',
+							},
+						],
+						selected: true,
+						currency_code: 'USD',
+						currency_symbol: '$',
+						currency_minor_unit: 2,
+						currency_decimal_separator: '.',
+						currency_thousand_separator: ',',
+						currency_prefix: '$',
+						currency_suffix: '',
+					},
+				],
+			},
+		],
+	} ),
+} ) );
+describe( 'TotalsShipping', () => {
+	it( 'should show correct calculator button label if address is complete', () => {
+		const { rerender } = render(
+			<TotalsShipping
+				currency={ {
+					code: 'USD',
+					symbol: '$',
+					position: 'left',
+					precision: 2,
+				} }
+				values={ {
+					total_shipping: '10',
+					total_shipping_tax: '0',
+				} }
+				showCalculator={ true }
+				showRateSelector={ true }
+				isCheckout={ true }
+				className={ '' }
+			/>
+		);
+		expect( screen.getByText( 'Calculate' ) ).toBeInTheDocument();
+	} );
+} );

--- a/assets/js/base/components/cart-checkout/totals/shipping/test/index.tsx
+++ b/assets/js/base/components/cart-checkout/totals/shipping/test/index.tsx
@@ -15,8 +15,6 @@ import { TotalsShipping } from '../index';
 jest.mock( '@wordpress/data', () => ( {
 	__esModule: true,
 	...jest.requireActual( '@wordpress/data' ),
-	AsyncModeProvider:
-		jest.requireActual( '@wordpress/data' ).AsyncModeProvider,
 	useSelect: jest.fn(),
 } ) );
 

--- a/assets/js/base/components/cart-checkout/totals/shipping/test/shipping-placeholder.tsx
+++ b/assets/js/base/components/cart-checkout/totals/shipping/test/shipping-placeholder.tsx
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import { screen, render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import ShippingPlaceholder from '../shipping-placeholder';
+
+describe( 'ShippingPlaceholder', () => {
+	it( 'should show correct text if showCalculator is false', () => {
+		const { rerender } = render(
+			<ShippingPlaceholder
+				showCalculator={ false }
+				isCheckout={ true }
+				isShippingCalculatorOpen={ false }
+				setIsShippingCalculatorOpen={ jest.fn() }
+			/>
+		);
+		expect(
+			screen.getByText( 'No shipping options available' )
+		).toBeInTheDocument();
+		rerender(
+			<ShippingPlaceholder
+				showCalculator={ false }
+				isCheckout={ false }
+				isShippingCalculatorOpen={ false }
+				setIsShippingCalculatorOpen={ jest.fn() }
+			/>
+		);
+		expect(
+			screen.getByText( 'Calculated during checkout' )
+		).toBeInTheDocument();
+	} );
+} );

--- a/tests/js/setup-globals.js
+++ b/tests/js/setup-globals.js
@@ -1,5 +1,6 @@
 // Set up `wp.*` aliases.  Doing this because any tests importing wp stuff will likely run into this.
 global.wp = {};
+require( '@wordpress/data' );
 
 // wcSettings is required by @woocommerce/* packages
 global.wcSettings = {


### PR DESCRIPTION
In PR #8141, we're displaying a link to add the shipping address in the shipping calculator on the cart page when the shipping address is unavailable. We're also hiding the option to change the shipping address when default shipping rates are defined. 

In this PR, we're adding some more unit tests for #8141. 

Fixes #8027 and  #7730

## Changes in the PR

- Add unit test to check correct button is getting displayed. 


### Testing

#### Automated Tests
* [x] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Run 'npm run test -- assets/js/base/components/cart-checkout/totals/shipping/test/' in the terminal. 
2. Confirm all unit tests pass. 


* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
