### PR TITLE
Fix "Add to cart form" test

### DIFF
--- a/tests/e2e/specs/backend/add-to-cart-form.test.js
+++ b/tests/e2e/specs/backend/add-to-cart-form.test.js
@@ -14,9 +14,9 @@ import { searchForBlock } from '@wordpress/e2e-test-utils/build/inserter';
 import {
 	filterCurrentBlocks,
 	insertBlockDontWaitForInsertClose,
-	goToSiteEditor,
 	useTheme,
 	waitForCanvas,
+	goToTemplateEditor,
 } from '../../utils.js';
 
 const block = {
@@ -40,7 +40,9 @@ describe( `${ block.name } Block`, () => {
 		useTheme( 'emptytheme' );
 
 		beforeEach( async () => {
-			await goToSiteEditor();
+			await goToTemplateEditor( {
+				postId: 'woocommerce/woocommerce//single-product',
+			} );
 			await waitForCanvas();
 		} );
 


### PR DESCRIPTION
In this PR https://github.com/woocommerce/woocommerce-blocks/pull/8482 the `Add to cart form` block was made available only on the `Single Product Template` in the Site Editor. But the test was trying to insert it in the `Home` template and failing, this PR fixes that test by going directly to the `Single Product Template` on the Site Editor.

### Testing
#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests

Make sure the `add-to-cart-form.test.js` are passing on CI.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
