### PR TITLE
Upgrade @types/wordpress__blocks package

### DIFF
--- a/assets/js/atomic/blocks/product-elements/button/index.ts
+++ b/assets/js/atomic/blocks/product-elements/button/index.ts
@@ -17,11 +17,7 @@ import {
 	BLOCK_DESCRIPTION as description,
 } from './constants';
 
-type CustomBlockConfiguration = BlockConfiguration & {
-	ancestor: string[];
-};
-
-const blockConfig: CustomBlockConfiguration = {
+const blockConfig: BlockConfiguration = {
 	...sharedConfig,
 	apiVersion: 2,
 	title,

--- a/assets/js/atomic/blocks/product-elements/image/index.ts
+++ b/assets/js/atomic/blocks/product-elements/image/index.ts
@@ -18,11 +18,7 @@ import {
 	BLOCK_DESCRIPTION as description,
 } from './constants';
 
-type CustomBlockConfiguration = BlockConfiguration & {
-	ancestor: string[];
-};
-
-const blockConfig: CustomBlockConfiguration = {
+const blockConfig: BlockConfiguration = {
 	...sharedConfig,
 	apiVersion: 2,
 	name: 'woocommerce/product-image',

--- a/assets/js/atomic/blocks/product-elements/price/index.ts
+++ b/assets/js/atomic/blocks/product-elements/price/index.ts
@@ -17,11 +17,7 @@ import {
 	BLOCK_DESCRIPTION as description,
 } from './constants';
 
-type CustomBlockConfiguration = BlockConfiguration & {
-	ancestor: string[];
-};
-
-const blockConfig: CustomBlockConfiguration = {
+const blockConfig: BlockConfiguration = {
 	...sharedConfig,
 	apiVersion: 2,
 	title,

--- a/assets/js/atomic/blocks/product-elements/rating/index.ts
+++ b/assets/js/atomic/blocks/product-elements/rating/index.ts
@@ -17,11 +17,7 @@ import {
 } from './constants';
 import { supports } from './support';
 
-type CustomBlockConfiguration = BlockConfiguration & {
-	ancestor: string[];
-};
-
-const blockConfig: CustomBlockConfiguration = {
+const blockConfig: BlockConfiguration = {
 	...sharedConfig,
 	apiVersion: 2,
 	title,

--- a/assets/js/atomic/blocks/product-elements/sale-badge/index.ts
+++ b/assets/js/atomic/blocks/product-elements/sale-badge/index.ts
@@ -17,11 +17,7 @@ import {
 } from './constants';
 import { supports } from './support';
 
-type CustomBlockConfiguration = BlockConfiguration & {
-	ancestor: string[];
-};
-
-const blockConfig: CustomBlockConfiguration = {
+const blockConfig: BlockConfiguration = {
 	...sharedConfig,
 	title,
 	description,

--- a/assets/js/atomic/blocks/product-elements/sku/index.ts
+++ b/assets/js/atomic/blocks/product-elements/sku/index.ts
@@ -16,11 +16,7 @@ import {
 	BLOCK_DESCRIPTION as description,
 } from './constants';
 
-type CustomBlockConfiguration = BlockConfiguration & {
-	ancestor: string[];
-};
-
-const blockConfig: CustomBlockConfiguration = {
+const blockConfig: BlockConfiguration = {
 	...sharedConfig,
 	apiVersion: 2,
 	title,

--- a/assets/js/atomic/blocks/product-elements/stock-indicator/index.ts
+++ b/assets/js/atomic/blocks/product-elements/stock-indicator/index.ts
@@ -18,11 +18,7 @@ import {
 	BLOCK_DESCRIPTION as description,
 } from './constants';
 
-type CustomBlockConfiguration = BlockConfiguration & {
-	ancestor: string[];
-};
-
-const blockConfig: CustomBlockConfiguration = {
+const blockConfig: BlockConfiguration = {
 	...sharedConfig,
 	apiVersion: 2,
 	title,

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,7 @@
 				"@types/react": "17.0.47",
 				"@types/react-dom": "18.0.10",
 				"@types/wordpress__block-editor": "6.0.6",
-				"@types/wordpress__blocks": "11.0.7",
+				"@types/wordpress__blocks": "11.0.9",
 				"@types/wordpress__components": "^23.0.0",
 				"@types/wordpress__core-data": "^2.4.5",
 				"@types/wordpress__data": "^6.0.2",
@@ -11495,9 +11495,9 @@
 			}
 		},
 		"node_modules/@types/wordpress__blocks": {
-			"version": "11.0.7",
-			"resolved": "https://registry.npmjs.org/@types/wordpress__blocks/-/wordpress__blocks-11.0.7.tgz",
-			"integrity": "sha512-8BcT3CUxHt73CepaLtQHAhA7uBhDOK9x5HJOAxzV+Bl37W04u4jSNulXxwX/6tI7t7Knux5lnN9bvKf/1sg+Rw==",
+			"version": "11.0.9",
+			"resolved": "https://registry.npmjs.org/@types/wordpress__blocks/-/wordpress__blocks-11.0.9.tgz",
+			"integrity": "sha512-TyM5LfBJxAHwf+MJ21f3ex+xpNtEooMLFazSalfMxyUM2pWNI4eGSptuP3VpSYaQKhlgUOeJAXKOYp3ZKtEiGQ==",
 			"dev": true,
 			"dependencies": {
 				"@types/react": "*",
@@ -58558,9 +58558,9 @@
 			}
 		},
 		"@types/wordpress__blocks": {
-			"version": "11.0.7",
-			"resolved": "https://registry.npmjs.org/@types/wordpress__blocks/-/wordpress__blocks-11.0.7.tgz",
-			"integrity": "sha512-8BcT3CUxHt73CepaLtQHAhA7uBhDOK9x5HJOAxzV+Bl37W04u4jSNulXxwX/6tI7t7Knux5lnN9bvKf/1sg+Rw==",
+			"version": "11.0.9",
+			"resolved": "https://registry.npmjs.org/@types/wordpress__blocks/-/wordpress__blocks-11.0.9.tgz",
+			"integrity": "sha512-TyM5LfBJxAHwf+MJ21f3ex+xpNtEooMLFazSalfMxyUM2pWNI4eGSptuP3VpSYaQKhlgUOeJAXKOYp3ZKtEiGQ==",
 			"dev": true,
 			"requires": {
 				"@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
 		"@types/react": "17.0.47",
 		"@types/react-dom": "18.0.10",
 		"@types/wordpress__block-editor": "6.0.6",
-		"@types/wordpress__blocks": "11.0.7",
+		"@types/wordpress__blocks": "11.0.9",
 		"@types/wordpress__components": "^23.0.0",
 		"@types/wordpress__core-data": "^2.4.5",
 		"@types/wordpress__data": "^6.0.2",


### PR DESCRIPTION
This PR updates the `@types/wordpress__blocks`. During the review of #8609, @imanish003 [noticed that declaring the `ancestor` key in our codebase is avoidable](https://github.com/woocommerce/woocommerce-blocks/pull/8609#discussion_r1124103609). 

Nice catch! 