### PR TITLE
Release: 9.7.2

### DIFF
--- a/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment/style.scss
+++ b/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment/style.scss
@@ -7,9 +7,10 @@ $border-radius: 5px;
 
 	.wc-block-components-express-payment__event-buttons {
 		list-style: none;
-		display: flex;
-		flex-direction: row;
-		flex-wrap: wrap;
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(calc(33% - 10px), 1fr));
+		grid-gap: 10px;
+		box-sizing: border-box;
 		width: 100%;
 		padding: 0;
 		margin: 0;
@@ -18,11 +19,18 @@ $border-radius: 5px;
 
 		> li {
 			margin: 0;
+			width: 100%;
 
 			> img {
 				width: 100%;
 				height: 48px;
 			}
+		}
+	}
+
+	@include breakpoint("<782px") {
+		.wc-block-components-express-payment__event-buttons {
+			grid-template-columns: 1fr;
 		}
 	}
 }
@@ -83,28 +91,6 @@ $border-radius: 5px;
 
 		> p {
 			margin-bottom: em($gap);
-		}
-	}
-
-	.wc-block-components-express-payment__event-buttons {
-		> li {
-			box-sizing: border-box;
-			display: inline-block;
-			width: 50%;
-		}
-
-		> li:nth-child(even) {
-			padding-left: $gap-smaller;
-		}
-
-		> li:nth-child(odd) {
-			padding-right: $gap-smaller;
-		}
-
-		> li:only-child {
-			display: block;
-			width: 100%;
-			padding: 0;
 		}
 	}
 }

--- a/docs/internal-developers/testing/releases/971.md
+++ b/docs/internal-developers/testing/releases/971.md
@@ -1,0 +1,3 @@
+# Testing notes and ZIP for release 9.7.1
+
+No User Facing Testing required with this patch release.

--- a/docs/internal-developers/testing/releases/972.md
+++ b/docs/internal-developers/testing/releases/972.md
@@ -4,4 +4,4 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 
 ## WooCommerce Core
 
-Install WC Blocks in a site with WP 6.1 (or lower) and Gutenberg disabled and verify there is no PHP fatal error.
+Install WC Blocks in a site with WP 6.1.1 and Gutenberg disabled and verify there is no PHP fatal error.

--- a/docs/internal-developers/testing/releases/972.md
+++ b/docs/internal-developers/testing/releases/972.md
@@ -1,0 +1,7 @@
+# Testing notes and ZIP for release 9.7.2
+
+Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.com/woocommerce/woocommerce-blocks/files/10881589/woocommerce-gutenberg-products-block.zip)
+
+## WooCommerce Core
+
+Install WC Blocks in a site with WP 6.1 (or lower) and Gutenberg disabled and verify there is no PHP fatal error.

--- a/docs/internal-developers/testing/releases/README.md
+++ b/docs/internal-developers/testing/releases/README.md
@@ -125,6 +125,7 @@ Every release includes specific testing instructions for new features and bug fi
     -   [9.6.2](./962.md)
     -   [9.6.3](./963.md)
 -   [9.7.0](./970.md)
+    -   [9.7.1](./971.md)
 
 
 <!-- FEEDBACK -->

--- a/docs/internal-developers/testing/releases/README.md
+++ b/docs/internal-developers/testing/releases/README.md
@@ -126,6 +126,7 @@ Every release includes specific testing instructions for new features and bug fi
     -   [9.6.3](./963.md)
 -   [9.7.0](./970.md)
     -   [9.7.1](./971.md)
+    -   [9.7.2](./972.md)
 
 
 <!-- FEEDBACK -->

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "@woocommerce/block-library",
 	"title": "WooCommerce Blocks",
 	"author": "Automattic",
-	"version": "9.7.0",
+	"version": "9.7.2",
 	"description": "WooCommerce blocks for the Gutenberg editor.",
 	"homepage": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/",
 	"keywords": [

--- a/readme.txt
+++ b/readme.txt
@@ -80,6 +80,13 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 
 == Changelog ==
 
+= 9.7.1 - 2023-03-03 =
+
+#### Bug Fixes
+
+- Fix: Show up to three Express Payments buttons next to each other. ([8601](https://github.com/woocommerce/woocommerce-blocks/pull/8601))
+
+
 = 9.7.0 - 2023-02-28 =
 
 #### Enhancements

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: gutenberg, woocommerce, woo commerce, products, blocks, woocommerce blocks
 Requires at least: 6.1.1
 Tested up to: 6.1.1
 Requires PHP: 7.2
-Stable tag: 9.7.0
+Stable tag: 9.7.2
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/src/Package.php
+++ b/src/Package.php
@@ -109,7 +109,7 @@ class Package {
 				NewPackage::class,
 				function ( $container ) {
 					// leave for automated version bumping.
-					$version = '9.7.0';
+					$version = '9.7.2';
 					return new NewPackage(
 						$version,
 						dirname( __DIR__ ),

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Blocks
  * Plugin URI: https://github.com/woocommerce/woocommerce-gutenberg-products-block
  * Description: WooCommerce blocks for the Gutenberg editor.
- * Version: 9.7.0
+ * Version: 9.7.2
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain:  woo-gutenberg-products-block


### PR DESCRIPTION
# Patch release

This is the patch release pull request for WooCommerce Blocks plugin `9.7.2`.

## Changelog

---

```md
#### Bug Fixes

- Fix: Show up to three Express Payments buttons next to each other. ([8601](https://github.com/woocommerce/woocommerce-blocks/pull/8601))

```

---

## Communication

### Prepared Updates

Please leave a comment on this PR with links to the following:

-   [ ] Release announcement (announcement post on developer.woocommerce.com published after release).
-   [ ] Happiness engineering or Happiness/Support (if special instructions needed).
-   [ ] Relevant developer documentation (if applicable).

## Quality

> This section is for things related to quality around the release.

-   [x] Testing Instructions are included in this PR: https://github.com/woocommerce/woocommerce-blocks/blob/release/9.7.2/docs/internal-developers/testing/releases/972.md

-   [ ] Any performance impacts are documented.

---