### PR TITLE
Checkout: Fix state validation after changing countries when there are error notices (push-changes fix)

### DIFF
--- a/assets/js/data/cart/push-changes.ts
+++ b/assets/js/data/cart/push-changes.ts
@@ -126,7 +126,6 @@ const dirtyProps = <
 const updateCustomerData = debounce( (): void => {
 	const { billingAddress, shippingAddress } = customerData;
 	const validationStore = select( VALIDATION_STORE_KEY );
-	const customerDataToUpdate = {} as Partial< BillingAddressShippingAddress >;
 
 	// Before we push anything, we need to ensure that the data we're pushing (dirty fields) are valid, otherwise we will
 	// abort and wait for the validation issues to be resolved.
@@ -150,6 +149,8 @@ const updateCustomerData = debounce( (): void => {
 	}
 
 	// Find valid data from the list of dirtyProps and prepare to push to the server.
+	const customerDataToUpdate = {} as Partial< BillingAddressShippingAddress >;
+
 	if ( dirtyProps.billingAddress.length ) {
 		customerDataToUpdate.billing_address = pick(
 			billingAddress,
@@ -166,14 +167,31 @@ const updateCustomerData = debounce( (): void => {
 		dirtyProps.shippingAddress = [];
 	}
 
+	// If there is customer data to update, push it to the server.
 	if ( Object.keys( customerDataToUpdate ).length ) {
 		dispatch( STORE_KEY )
 			.updateCustomerData( customerDataToUpdate )
-			.then( () => {
-				removeAllNotices();
-			} )
+			.then( removeAllNotices )
 			.catch( ( response ) => {
 				processErrorResponse( response );
+
+				// Data did not persist due to an error. Make the props dirty again so they get pushed to the server.
+				if ( customerDataToUpdate.billing_address ) {
+					dirtyProps.billingAddress = [
+						...dirtyProps.billingAddress,
+						...( Object.keys(
+							customerDataToUpdate.billing_address
+						) as BaseAddressKey[] ),
+					];
+				}
+				if ( customerDataToUpdate.shipping_address ) {
+					dirtyProps.shippingAddress = [
+						...dirtyProps.shippingAddress,
+						...( Object.keys(
+							customerDataToUpdate.shipping_address
+						) as BaseAddressKey[] ),
+					];
+				}
 			} );
 	}
 }, 1000 );


### PR DESCRIPTION
When pushing data to the server, we store a list of `dirtyProps` that need to be sent to the server since they were edited. One pushed, the list of props is cleared. The problem here is that if the API request fails (validation error), the data does not persist, so we need to ensure it is sent with the next request after other data gets edited by the customer.

Fixes #8631

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. With a default valid US shipping address set, add an item to the cart and proceed to checkout.
2. Change the shipping address country to India. You will see an error about the incorrect postcode.
3. Select an India state from the dropdown. You will see an error about the incorrect postcode.
4. Enter a valid postcode `411014`. All errors should go away. 

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Checkout: Fix state validation after changing shipping country.
