### PR TITLE
Add `LocalPickupSelect` component

### DIFF
--- a/assets/js/base/components/cart-checkout/local-pickup-select/index.tsx
+++ b/assets/js/base/components/cart-checkout/local-pickup-select/index.tsx
@@ -9,7 +9,7 @@ import { CartShippingPackageShippingRate } from '@woocommerce/types';
 import RadioControl from '../../radio-control';
 
 interface LocalPickupSelectProps {
-	title: string;
+	title?: string | undefined;
 	setSelectedOption: ( value: string ) => void;
 	selectedOption: string;
 	pickupLocations: CartShippingPackageShippingRate[];
@@ -38,7 +38,7 @@ export const LocalPickupSelect = ( {
 		).length > 1;
 	return (
 		<div className="wc-block-components-local-pickup-select">
-			{ multiplePackages && <div>{ title }</div> }
+			{ multiplePackages && title ? <div>{ title }</div> : false }
 			<RadioControl
 				onChange={ ( value ) => {
 					setSelectedOption( value );

--- a/assets/js/base/components/cart-checkout/local-pickup-select/index.tsx
+++ b/assets/js/base/components/cart-checkout/local-pickup-select/index.tsx
@@ -1,0 +1,55 @@
+/**
+ * External dependencies
+ */
+import { RadioControlOption } from '@woocommerce/base-components/radio-control/types';
+import { CartShippingPackageShippingRate } from '@woocommerce/types';
+/**
+ * Internal dependencies
+ */
+import RadioControl from '../../radio-control';
+
+interface LocalPickupSelectProps {
+	title: string;
+	setSelectedOption: ( value: string ) => void;
+	selectedOption: string;
+	pickupLocations: CartShippingPackageShippingRate[];
+	onSelectRate: ( value: string ) => void;
+	renderPickupLocation: (
+		location: CartShippingPackageShippingRate,
+		pickupLocationsCount: number
+	) => RadioControlOption;
+}
+/**
+ * Local pickup select component, used to render a package title and local pickup options.
+ */
+export const LocalPickupSelect = ( {
+	title,
+	setSelectedOption,
+	selectedOption,
+	pickupLocations,
+	onSelectRate,
+	renderPickupLocation,
+}: LocalPickupSelectProps ) => {
+	// Hacky way to check if there are multiple packages, this way is borrowed from  `assets/js/base/components/cart-checkout/shipping-rates-control-package/index.tsx`
+	// We have no built-in way of checking if other extensions have added packages.
+	const multiplePackages =
+		document.querySelectorAll(
+			'.wc-block-components-local-pickup-select .wc-block-components-radio-control'
+		).length > 1;
+	return (
+		<div className="wc-block-components-local-pickup-select">
+			{ multiplePackages && <div>{ title }</div> }
+			<RadioControl
+				onChange={ ( value ) => {
+					setSelectedOption( value );
+					onSelectRate( value );
+				} }
+				selected={ selectedOption }
+				options={ pickupLocations.map( ( location ) =>
+					renderPickupLocation( location, pickupLocations.length )
+				) }
+			/>
+		</div>
+	);
+};
+export default LocalPickupSelect;

--- a/assets/js/base/components/cart-checkout/local-pickup-select/index.tsx
+++ b/assets/js/base/components/cart-checkout/local-pickup-select/index.tsx
@@ -18,7 +18,6 @@ interface LocalPickupSelectProps {
 		location: CartShippingPackageShippingRate,
 		pickupLocationsCount: number
 	) => RadioControlOption;
-	packageCount: number;
 }
 /**
  * Local pickup select component, used to render a package title and local pickup options.
@@ -30,7 +29,6 @@ export const LocalPickupSelect = ( {
 	pickupLocations,
 	onSelectRate,
 	renderPickupLocation,
-	packageCount,
 }: LocalPickupSelectProps ) => {
 	// Hacky way to check if there are multiple packages, this way is borrowed from  `assets/js/base/components/cart-checkout/shipping-rates-control-package/index.tsx`
 	// We have no built-in way of checking if other extensions have added packages.
@@ -48,7 +46,7 @@ export const LocalPickupSelect = ( {
 				} }
 				selected={ selectedOption }
 				options={ pickupLocations.map( ( location ) =>
-					renderPickupLocation( location, packageCount )
+					renderPickupLocation( location, pickupLocations.length )
 				) }
 			/>
 		</div>

--- a/assets/js/base/components/cart-checkout/local-pickup-select/index.tsx
+++ b/assets/js/base/components/cart-checkout/local-pickup-select/index.tsx
@@ -18,6 +18,7 @@ interface LocalPickupSelectProps {
 		location: CartShippingPackageShippingRate,
 		pickupLocationsCount: number
 	) => RadioControlOption;
+	packageCount: number;
 }
 /**
  * Local pickup select component, used to render a package title and local pickup options.
@@ -29,6 +30,7 @@ export const LocalPickupSelect = ( {
 	pickupLocations,
 	onSelectRate,
 	renderPickupLocation,
+	packageCount,
 }: LocalPickupSelectProps ) => {
 	// Hacky way to check if there are multiple packages, this way is borrowed from  `assets/js/base/components/cart-checkout/shipping-rates-control-package/index.tsx`
 	// We have no built-in way of checking if other extensions have added packages.
@@ -46,7 +48,7 @@ export const LocalPickupSelect = ( {
 				} }
 				selected={ selectedOption }
 				options={ pickupLocations.map( ( location ) =>
-					renderPickupLocation( location, pickupLocations.length )
+					renderPickupLocation( location, packageCount )
 				) }
 			/>
 		</div>

--- a/assets/js/base/components/cart-checkout/local-pickup-select/test/index.tsx
+++ b/assets/js/base/components/cart-checkout/local-pickup-select/test/index.tsx
@@ -1,0 +1,121 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+/**
+ * Internal dependencies
+ */
+import LocalPickupSelect from '..';
+
+describe( 'LocalPickupSelect', () => {
+	const TestComponent = ( {
+		selectedOptionOverride = null,
+		onSelectRateOverride = null,
+	}: {
+		selectedOptionOverride?: null | ( ( value: string ) => void );
+		onSelectRateOverride?: null | ( ( value: string ) => void );
+	} ) => (
+		<LocalPickupSelect
+			title="Package 1"
+			setSelectedOption={ selectedOptionOverride || jest.fn() }
+			selectedOption=""
+			pickupLocations={ [
+				{
+					rate_id: '1',
+					currency_code: 'USD',
+					currency_decimal_separator: '.',
+					currency_minor_unit: 2,
+					currency_prefix: '$',
+					currency_suffix: '',
+					currency_thousand_separator: ',',
+					currency_symbol: '$',
+					name: 'Store 1',
+					description: 'Store 1 description',
+					delivery_time: '1 day',
+					price: '0',
+					taxes: '0',
+					instance_id: 1,
+					method_id: 'test_shipping:0',
+					meta_data: [],
+					selected: false,
+				},
+				{
+					rate_id: '2',
+					currency_code: 'USD',
+					currency_decimal_separator: '.',
+					currency_minor_unit: 2,
+					currency_prefix: '$',
+					currency_suffix: '',
+					currency_thousand_separator: ',',
+					currency_symbol: '$',
+					name: 'Store 2',
+					description: 'Store 2 description',
+					delivery_time: '2 days',
+					price: '0',
+					taxes: '0',
+					instance_id: 1,
+					method_id: 'test_shipping:1',
+					meta_data: [],
+					selected: false,
+				},
+			] }
+			onSelectRate={ onSelectRateOverride || jest.fn() }
+			// eslint-disable-next-line @typescript-eslint/no-unused-vars
+			renderPickupLocation={ ( location, pickupLocationsCount ) => {
+				return {
+					value: `${ location.rate_id }`,
+					onChange: jest.fn(),
+					label: `${ location.name }`,
+					description: `${ location.description }`,
+				};
+			} }
+		/>
+	);
+	it( 'Does not render the title if only one package is present on the page', () => {
+		render( <TestComponent /> );
+		expect( screen.queryByText( 'Package 1' ) ).not.toBeInTheDocument();
+	} );
+	it( 'Does render the title if more than one package is present on the page', () => {
+		const { rerender } = render(
+			<div className="wc-block-components-local-pickup-select">
+				<div className="wc-block-components-radio-control"></div>
+			</div>
+		);
+		// Render twice so our component can check the DOM correctly.
+		rerender(
+			<>
+				<div className="wc-block-components-local-pickup-select">
+					<div className="wc-block-components-radio-control"></div>
+				</div>
+				<TestComponent />
+			</>
+		);
+		rerender(
+			<>
+				<div className="wc-block-components-local-pickup-select">
+					<div className="wc-block-components-radio-control"></div>
+				</div>
+				<TestComponent />
+			</>
+		);
+
+		expect( screen.getByText( 'Package 1' ) ).toBeInTheDocument();
+	} );
+	it( 'Calls the correct functions when changing selected option', () => {
+		const setSelectedOption = jest.fn();
+		const onSelectRate = jest.fn();
+		render(
+			<TestComponent
+				selectedOptionOverride={ setSelectedOption }
+				onSelectRateOverride={ onSelectRate }
+			/>
+		);
+		userEvent.click( screen.getByText( 'Store 2' ) );
+		expect( setSelectedOption ).toHaveBeenLastCalledWith( '2' );
+		expect( onSelectRate ).toHaveBeenLastCalledWith( '2' );
+		userEvent.click( screen.getByText( 'Store 1' ) );
+		expect( setSelectedOption ).toHaveBeenLastCalledWith( '1' );
+		expect( onSelectRate ).toHaveBeenLastCalledWith( '1' );
+	} );
+} );

--- a/assets/js/base/components/cart-checkout/local-pickup-select/test/index.tsx
+++ b/assets/js/base/components/cart-checkout/local-pickup-select/test/index.tsx
@@ -61,8 +61,8 @@ describe( 'LocalPickupSelect', () => {
 				},
 			] }
 			onSelectRate={ onSelectRateOverride || jest.fn() }
-			// eslint-disable-next-line @typescript-eslint/no-unused-vars
-			renderPickupLocation={ ( location, pickupLocationsCount ) => {
+			packageCount={ 1 }
+			renderPickupLocation={ ( location ) => {
 				return {
 					value: `${ location.rate_id }`,
 					onChange: jest.fn(),

--- a/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/block.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/block.tsx
@@ -14,10 +14,10 @@ import FormattedMonetaryAmount from '@woocommerce/base-components/formatted-mone
 import { decodeEntities } from '@wordpress/html-entities';
 import { getSetting } from '@woocommerce/settings';
 import { Icon, mapMarker } from '@wordpress/icons';
+import RadioControl from '@woocommerce/base-components/radio-control';
 import type { RadioControlOption } from '@woocommerce/base-components/radio-control/types';
 import { CartShippingPackageShippingRate } from '@woocommerce/types';
 import { isPackageRateCollectable } from '@woocommerce/base-utils';
-import LocalPickupSelect from '@woocommerce/base-components/cart-checkout/local-pickup-select';
 
 /**
  * Internal dependencies
@@ -142,16 +142,15 @@ const Block = (): JSX.Element | null => {
 	}, [ onSelectRate, pickupLocations, selectedOption ] );
 
 	return (
-		<LocalPickupSelect
-			setSelectedOption={ setSelectedOption }
-			selectedOption={ selectedOption }
-			pickupLocations={ pickupLocations }
-			renderPickupLocation={ renderPickupLocation }
-			onSelectRate={ ( value: string ) => {
+		<RadioControl
+			onChange={ ( value: string ) => {
 				setSelectedOption( value );
 				onSelectRate( value );
 			} }
-			packageCount={ shippingRates.length }
+			selected={ selectedOption }
+			options={ pickupLocations.map( ( location ) =>
+				renderPickupLocation( location, shippingRates.length )
+			) }
 		/>
 	);
 };

--- a/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/block.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/block.tsx
@@ -14,10 +14,10 @@ import FormattedMonetaryAmount from '@woocommerce/base-components/formatted-mone
 import { decodeEntities } from '@wordpress/html-entities';
 import { getSetting } from '@woocommerce/settings';
 import { Icon, mapMarker } from '@wordpress/icons';
-import RadioControl from '@woocommerce/base-components/radio-control';
 import type { RadioControlOption } from '@woocommerce/base-components/radio-control/types';
 import { CartShippingPackageShippingRate } from '@woocommerce/types';
 import { isPackageRateCollectable } from '@woocommerce/base-utils';
+import LocalPickupSelect from '@woocommerce/base-components/cart-checkout/local-pickup-select';
 
 /**
  * Internal dependencies
@@ -142,15 +142,16 @@ const Block = (): JSX.Element | null => {
 	}, [ onSelectRate, pickupLocations, selectedOption ] );
 
 	return (
-		<RadioControl
-			onChange={ ( value: string ) => {
+		<LocalPickupSelect
+			setSelectedOption={ setSelectedOption }
+			selectedOption={ selectedOption }
+			pickupLocations={ pickupLocations }
+			renderPickupLocation={ renderPickupLocation }
+			onSelectRate={ ( value: string ) => {
 				setSelectedOption( value );
 				onSelectRate( value );
 			} }
-			selected={ selectedOption }
-			options={ pickupLocations.map( ( location ) =>
-				renderPickupLocation( location, shippingRates.length )
-			) }
+			packageCount={ shippingRates.length }
 		/>
 	);
 };


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR is part of #7998. I am splitting the work up so it is easier to review. There will be a followup where this component is actually used and passed through to Slot/Fill.

This PR adds a new component, `LocalPickupSelect` (and unit tests for it) which incorporates the existing `RadioControl` but wraps it in a div and outputs an optional title (if one is supplied).

This component is required because when showing multiple packages in WC Subscriptions, it is helpful to know the names of the packages.

Without this PR, WC subs would need to render a `RadioControl` and title separately, resulting in a poorer DX. 

This change also allows us to have a focused and dedicated component for displaying pickup rates, which is more explicitly named, making it easier to reason with in future.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. Go to WooCommerce -> Settings -> Shipping -> Local Pickup and activate Local Pickup. Ensure you have added a couple of locations.
2. Add an item to your cart and go to the Checkout block.
3. Select Local Pickup and ensure the options you set up in step 1 are visible.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

#### Internal testing notes
1. Go to `assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/block.tsx` and remove the `RadioControl` rendered by `Block` and replace it with:

```tsx
<LocalPickupSelect
	setSelectedOption={ setSelectedOption }
	selectedOption={ selectedOption }
	pickupLocations={ pickupLocations }
	renderPickupLocation={ renderPickupLocation }
	onSelectRate={ ( value: string ) => {
		setSelectedOption( value );
		onSelectRate( value );
	} }
        packageCount={ shippingRates.length }
/>
```

2. Go to the front-end and ensure the local pickup rates render correctly, and that switching between them works as expected.
3. In `WooCommerce -> Settings -> Shipping -> Local pickup`, add a cost for local pickup on the `Add a price for customers who choose local pickup` option.
4. Check out using a local pickup rate and ensure it is correctly added to the order in the dashboard.
5. Install [Multiple Packages for WooCommerce](https://wordpress.org/plugins/multiple-packages-for-woocommerce/)
6. Go to `WooCommerce -> Settings -> Multiple Packages` and enable it. In the "Group by" option, choose "Product (individual)`. Save the settings.
7. Add multiple items to your cart.
8. Go to the Checkout block and choose local pickup. Ensure the price shown for local pickup says `$5.00 x 5 packages` (the numbers will be different for you depending on what you entered in step 7, and how many items are in your cart).

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Skipping
