### PR TITLE
Add `ExperimentalOrderLocalPickupPackages` Slot/Fill

### DIFF
--- a/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/block.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/block.tsx
@@ -14,11 +14,11 @@ import FormattedMonetaryAmount from '@woocommerce/base-components/formatted-mone
 import { decodeEntities } from '@wordpress/html-entities';
 import { getSetting } from '@woocommerce/settings';
 import { Icon, mapMarker } from '@wordpress/icons';
-import RadioControl from '@woocommerce/base-components/radio-control';
 import type { RadioControlOption } from '@woocommerce/base-components/radio-control/types';
 import { CartShippingPackageShippingRate } from '@woocommerce/types';
 import { isPackageRateCollectable } from '@woocommerce/base-utils';
 import { ExperimentalOrderLocalPickupPackages } from '@woocommerce/blocks-checkout';
+import { LocalPickupSelect } from '@woocommerce/base-components/cart-checkout/local-pickup-select';
 
 /**
  * Internal dependencies
@@ -144,7 +144,7 @@ const Block = (): JSX.Element | null => {
 		cart,
 		components: {
 			ShippingRatesControlPackage,
-			RadioControl,
+			LocalPickupSelect,
 		},
 		renderPickupLocation,
 	};
@@ -161,15 +161,13 @@ const Block = (): JSX.Element | null => {
 		<>
 			<ExperimentalOrderLocalPickupPackages.Slot { ...slotFillProps } />
 			<ExperimentalOrderLocalPickupPackages>
-				<RadioControl
-					onChange={ ( value: string ) => {
-						setSelectedOption( value );
-						onSelectRate( value );
-					} }
-					selected={ selectedOption }
-					options={ pickupLocations.map( ( location ) =>
-						renderPickupLocation( location, shippingRates.length )
-					) }
+				<LocalPickupSelect
+					title={ shippingRates[ 0 ].name }
+					setSelectedOption={ setSelectedOption }
+					onSelectRate={ onSelectRate }
+					selectedOption={ selectedOption }
+					renderPickupLocation={ renderPickupLocation }
+					pickupLocations={ pickupLocations }
 				/>
 			</ExperimentalOrderLocalPickupPackages>
 		</>

--- a/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/block.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/block.tsx
@@ -8,7 +8,7 @@ import {
 	useCallback,
 	createInterpolateElement,
 } from '@wordpress/element';
-import { useShippingData } from '@woocommerce/base-context/hooks';
+import { useShippingData, useStoreCart } from '@woocommerce/base-context/hooks';
 import { getCurrencyFromPriceResponse } from '@woocommerce/price-format';
 import FormattedMonetaryAmount from '@woocommerce/base-components/formatted-monetary-amount';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -18,11 +18,13 @@ import RadioControl from '@woocommerce/base-components/radio-control';
 import type { RadioControlOption } from '@woocommerce/base-components/radio-control/types';
 import { CartShippingPackageShippingRate } from '@woocommerce/types';
 import { isPackageRateCollectable } from '@woocommerce/base-utils';
+import { ExperimentalOrderLocalPickupPackages } from '@woocommerce/blocks-checkout';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
+import ShippingRatesControlPackage from '../../../../base/components/cart-checkout/shipping-rates-control-package';
 
 const getPickupLocation = (
 	option: CartShippingPackageShippingRate
@@ -133,6 +135,20 @@ const Block = (): JSX.Element | null => {
 		[ selectShippingRate ]
 	);
 
+	// Prepare props to pass to the ExperimentalOrderLocalPickupPackages slot fill.
+	// We need to pluck out receiveCart.
+	// eslint-disable-next-line no-unused-vars
+	const { extensions, receiveCart, ...cart } = useStoreCart();
+	const slotFillProps = {
+		extensions,
+		cart,
+		components: {
+			ShippingRatesControlPackage,
+			RadioControl,
+		},
+		renderPickupLocation,
+	};
+
 	// Update the selected option if there is no rate selected on mount.
 	useEffect( () => {
 		if ( ! selectedOption && pickupLocations[ 0 ] ) {
@@ -142,16 +158,21 @@ const Block = (): JSX.Element | null => {
 	}, [ onSelectRate, pickupLocations, selectedOption ] );
 
 	return (
-		<RadioControl
-			onChange={ ( value: string ) => {
-				setSelectedOption( value );
-				onSelectRate( value );
-			} }
-			selected={ selectedOption }
-			options={ pickupLocations.map( ( location ) =>
-				renderPickupLocation( location, shippingRates.length )
-			) }
-		/>
+		<>
+			<ExperimentalOrderLocalPickupPackages.Slot { ...slotFillProps } />
+			<ExperimentalOrderLocalPickupPackages>
+				<RadioControl
+					onChange={ ( value: string ) => {
+						setSelectedOption( value );
+						onSelectRate( value );
+					} }
+					selected={ selectedOption }
+					options={ pickupLocations.map( ( location ) =>
+						renderPickupLocation( location, shippingRates.length )
+					) }
+				/>
+			</ExperimentalOrderLocalPickupPackages>
+		</>
 	);
 };
 

--- a/docs/third-party-developers/extensibility/checkout-block/available-slot-fills.md
+++ b/docs/third-party-developers/extensibility/checkout-block/available-slot-fills.md
@@ -57,6 +57,21 @@ Checkout:
 -   `components`: an object containing components you can use to render your own shipping rates, it contains `ShippingRatesControlPackage`.
 -   `context`, equal to the name of the Block in which the fill is rendered: `woocommerce/cart` or `woocommerce/checkout`
 
+## ExperimentalOrderLocalPickupPackages
+
+This slot renders inside the Checkout Pickup Options block in the Checkout block. It does not render in the Cart block.
+
+Checkout:
+
+![Example of ExperimentalOrderLocalPickupPackages in the Checkout block](https://user-images.githubusercontent.com/5656702/222814945-a449d016-0621-4a70-b0f4-2ae1ce6487f1.png)
+
+### Passed parameters
+
+-   `renderPickupLocation`: a render function that renders the address details of a local pickup option.
+-   `cart`: `wc/store/cart` data but in `camelCase` instead of `snake_case`. [Object breakdown.](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/c00da597efe4c16fcf5481c213d8052ec5df3766/assets/js/type-defs/cart.ts#L172-L188)
+-   `extensions`: external data registered by third-party developers using `ExtendSchema`, if you used `ExtendSchema` on `wc/store/cart` you would find your data under your namespace here.
+-   `components`: an object containing components you can use to render your own pickup rates, it contains `ShippingRatesControlPackage` and `RadioControl`.
+
 ## ExperimentalDiscountsMeta
 
 This slot renders below the `CouponCode` input.

--- a/packages/checkout/components/index.js
+++ b/packages/checkout/components/index.js
@@ -3,6 +3,7 @@ export { default as TotalsWrapper } from './totals-wrapper';
 export { default as ExperimentalOrderMeta } from './order-meta';
 export { default as ExperimentalDiscountsMeta } from './discounts-meta';
 export { default as ExperimentalOrderShippingPackages } from './order-shipping-packages';
+export { default as ExperimentalOrderLocalPickupPackages } from './order-local-pickup-packages';
 export { default as Panel } from './panel';
 export { default as Button } from './button';
 export { default as Label } from './label';

--- a/packages/checkout/components/order-local-pickup-packages/index.tsx
+++ b/packages/checkout/components/order-local-pickup-packages/index.tsx
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import {
+	Cart,
+	CartShippingPackageShippingRate,
+} from '@woocommerce/type-defs/cart';
+import { Component } from '@wordpress/element';
+import { RadioControlOption } from '@woocommerce/base-components/radio-control/types';
+
+/**
+ * Internal dependencies
+ */
+import { createSlotFill } from '../../slot';
+
+const slotName = '__experimentalOrderLocalPickupPackages';
+const {
+	Fill: ExperimentalOrderLocalPickupPackages,
+	Slot: OrderLocalPickupPackagesSlot,
+	// eslint-disable-next-line @typescript-eslint/naming-convention
+} = createSlotFill( slotName );
+
+interface ExperimentalOrderLocalPickupPackagesProps {
+	extensions: Record< string, unknown >;
+	cart: Cart;
+	components: Record< string, Component >;
+	renderPickupLocation: (
+		option: CartShippingPackageShippingRate,
+		packageCount: number
+	) => RadioControlOption;
+}
+const Slot = ( {
+	extensions,
+	cart,
+	components,
+	renderPickupLocation,
+}: ExperimentalOrderLocalPickupPackagesProps ) => {
+	return (
+		<OrderLocalPickupPackagesSlot
+			className={ classnames(
+				'wc-block-components-local-pickup-rates-control'
+			) }
+			fillProps={ {
+				extensions,
+				cart,
+				components,
+				renderPickupLocation,
+			} }
+		/>
+	);
+};
+
+ExperimentalOrderLocalPickupPackages.Slot = Slot;
+
+export default ExperimentalOrderLocalPickupPackages;


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR is based on `add/local-pickup-select`

It adds a Slot/Fill in the `checkout-pickup-options-block` block which can be used to render content below **our** pickup options.

It also changes the existing `RadioControl` in the `CheckoutPickupOptionsBlock` to a `LocalPickupSelect` - this is required because when WC Subs renders multiple packages, we need to show a title for the package.

Follow up issue: woocommerce/woocommerce#42461

<!-- Reference any related issues or PRs here -->

Fixes woocommerce/woocommerce-blocks#7998

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [x] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Go to WooCommerce -> Settings -> Shipping -> Local Pickup and activate Local Pickup. Ensure you have added a couple of locations.
2. Add an item to your cart and go to the Checkout block.
3. Select Local Pickup and ensure the options you set up in step 1 are visible.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### Internal developer testing

1. From your `plugins` directory run `npx @wordpress/create-block -t @woocommerce/extend-cart-checkout-block my-test-plugin` - this will create a plugin called `My test plugin`. Activate this.
2. Edit `my-test-plugin/src/js/index.js` and change the `render` function on/around line 17 to this:
```ts
const render = () => {
	return (
		<>
			<ExperimentalOrderLocalPickupPackages>
				<div
					style={{
						border: '1px solid grey',
						marginTop: 20,
						padding: 20,
						borderRadius: 2,
					}}
				>
					By using our convenient local pickup option, you can come to
					our store and pick up your order. We will send you an email
					when your order is ready for pickup.
				</div>
			</ExperimentalOrderLocalPickupPackages>
		</>
	);
};
```
3. Go to WooCommerce -> Settings -> Shipping -> Local Pickup and activate Local Pickup. Ensure you have added a couple of locations.
4. Add an item to your cart and go to the Checkout block.
5. Select Local Pickup and ensure the options you set up in step 1 are visible.
6. Ensure you can see the `By using our convenient local pickup option, you can come to our store and pick up your order. We will send you an email when your order is ready for pickup.` text below the pickup options.
7. <img width="689" alt="image" src="https://user-images.githubusercontent.com/5656702/222863926-70832477-dd8f-46ac-abcc-139e2b01ba5a.png">


### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Dev note

In this release we added a new Slot/Fill to the Local Pickup area. The Slot/Fill is named `ExperimentalOrderLocalPickupPackages` and it can be used to output content below our local pickup options. To find out more about this Slot/Fill please refer to our [available slot fills documentation](https://github.com/woocommerce/woocommerce-blocks/blob/dfea41a11425e05da50bf50af0235eeba4b45e1b/docs/third-party-developers/extensibility/checkout-block/available-slot-fills.md).
 
### Changelog

> Add new ExperimentalOrderLocalPickupPackages Slot/Fill.
