### PR TITLE
Only print wp.apiFetch.createPreloadingMiddleware() when needed

### DIFF
--- a/src/Assets/AssetDataRegistry.php
+++ b/src/Assets/AssetDataRegistry.php
@@ -368,15 +368,18 @@ class AssetDataRegistry {
 			$this->initialize_core_data();
 			$this->execute_lazy_data();
 
-			$data                   = rawurlencode( wp_json_encode( $this->data ) );
-			$preloaded_api_requests = rawurlencode( wp_json_encode( $this->preloaded_api_requests ) );
+			$data                          = rawurlencode( wp_json_encode( $this->data ) );
+			$wc_settings_script            = "var wcSettings = wcSettings || JSON.parse( decodeURIComponent( '" . esc_js( $data ) . "' ) );";
+			$preloaded_api_requests_script = '';
+
+			if ( count( $this->preloaded_api_requests ) > 0 ) {
+				$preloaded_api_requests        = rawurlencode( wp_json_encode( $this->preloaded_api_requests ) );
+				$preloaded_api_requests_script = "wp.apiFetch.use( wp.apiFetch.createPreloadingMiddleware( JSON.parse( decodeURIComponent( '" . esc_js( $preloaded_api_requests ) . "' ) ) ) );";
+			}
 
 			wp_add_inline_script(
 				$this->handle,
-				"
-				var wcSettings = wcSettings || JSON.parse( decodeURIComponent( '" . esc_js( $data ) . "' ) );
-				wp.apiFetch.use( wp.apiFetch.createPreloadingMiddleware( JSON.parse( decodeURIComponent( '" . esc_js( $preloaded_api_requests ) . "' ) ) ) )
-				",
+				$wc_settings_script . $preloaded_api_requests_script,
 				'before'
 			);
 		}


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-blocks/issues/7176 (this specific PR doesn't reduce the number of requests of the Mini Cart block, but might pave the way to do so in the future).

In some pages, we were printing a script that called `wp.apiFetch.createPreloadingMiddleware()` even if the array of requests to preload was empty. This PR refactors that code so that function is only called if there is something to preload.

@mikejolley I would appreciate your review as well as this PR is closely related to https://github.com/woocommerce/woocommerce-blocks/pull/5022.

### Testing

#### User Facing Testing

This PR shouldn't produce any changes, so testing is focused on making sure there are no regressions:

1. Add the Mini Cart block to a post or page.
2. Create a post or page with the Cart block and another one with the Checkout block.
3. In the frontend, add some products to your cart and open the Mini Cart. Verify you can change the quantity of products and you can remove them.
4. Go to the Cart page and check that there are no extra `fetch` requests to `wc/store/cart` in the _Network_ tab of your browser devtools (you can open them with <kbd>F12</kbd>).
5. Go to the Checkout page and make sure there is no error and you can place an order (checkout works as normal).

Testing stale data:

1. Go to the Cart page.
2. Change cart item quantities. Take note of the amounts.
3. Browse to a different page
4. Use the browser back button.
5. Confirm amounts are still correct and not stale.

Some of these steps have been copied and adapted from https://github.com/woocommerce/woocommerce-blocks/pull/5022.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Only call wp.apiFetch.createPreloadingMiddleware() when necessary.
