### PR TITLE
Remove patch version from Requires at least

### DIFF
--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -7,7 +7,7 @@
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain:  woo-gutenberg-products-block
- * Requires at least: 6.1.1
+ * Requires at least: 6.1
  * Requires PHP: 7.2
  * WC requires at least: 7.3
  * WC tested up to: 7.4
@@ -18,7 +18,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-$minimum_wp_version = '6.1.1';
+$minimum_wp_version = '6.1';
 
 if ( ! defined( 'WC_BLOCKS_IS_FEATURE_PLUGIN' ) ) {
 	define( 'WC_BLOCKS_IS_FEATURE_PLUGIN', true );


### PR DESCRIPTION
As discussed in p1677844988315309/1677844415.071149-slack-C02UBB1EPEF, we don't want to specify the patch version in the `Requires at least` rule.

### Testing


#### User Facing Testing

1. Change your WP site version to 6.1.0 (you can use the plugin [WP Downgrade | Specific Core Version](https://wordpress.org/plugins/wp-downgrade/) to downgrade). Make sure you choose `6.1` and not `6.1.0` neither `6.1.1`.
2. Verify WC Blocks can be enabled.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [ ] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental

### Changelog

> Change the required minimum version from 6.1.1 to 6.1.0.