### PR TITLE
Add `additionalCartCheckoutInnerBlockTypes` filter to enable additional blocks in the Cart/Checkout blocks.

### DIFF
--- a/assets/js/blocks/cart-checkout-shared/editor-utils.ts
+++ b/assets/js/blocks/cart-checkout-shared/editor-utils.ts
@@ -2,6 +2,9 @@
  * External dependencies
  */
 import { getBlockTypes } from '@wordpress/blocks';
+import { applyCheckoutFilter } from '@woocommerce/blocks-checkout';
+import { CART_STORE_KEY } from '@woocommerce/block-data';
+import { select } from '@wordpress/data';
 
 // List of core block types to allow in inner block areas.
 const coreBlockTypes = [ 'core/paragraph', 'core/image', 'core/separator' ];
@@ -9,11 +12,35 @@ const coreBlockTypes = [ 'core/paragraph', 'core/image', 'core/separator' ];
 /**
  * Gets a list of allowed blocks types under a specific parent block type.
  */
-export const getAllowedBlocks = ( block: string ): string[] => [
-	...getBlockTypes()
-		.filter( ( blockType ) =>
-			( blockType?.parent || [] ).includes( block )
-		)
-		.map( ( { name } ) => name ),
-	...coreBlockTypes,
-];
+export const getAllowedBlocks = ( block: string ): string[] => {
+	const additionalBlockTypes = applyCheckoutFilter( {
+		filterName: 'allowedBlockTypes',
+		defaultValue: [],
+		extensions: select( CART_STORE_KEY ).getCartData().extensions,
+		arg: { block },
+		validation: ( value ) => {
+			if (
+				Array.isArray( value ) &&
+				value.every( ( item ) => typeof item === 'string' )
+			) {
+				return true;
+			}
+			throw new Error(
+				'allowedBlockTypes filters must return an array of strings.'
+			);
+		},
+	} );
+
+	// Convert to set here so that we remove duplicated block types.
+	return Array.from(
+		new Set( [
+			...getBlockTypes()
+				.filter( ( blockType ) =>
+					( blockType?.parent || [] ).includes( block )
+				)
+				.map( ( { name } ) => name ),
+			...coreBlockTypes,
+			...additionalBlockTypes,
+		] )
+	);
+};

--- a/assets/js/blocks/cart-checkout-shared/editor-utils.ts
+++ b/assets/js/blocks/cart-checkout-shared/editor-utils.ts
@@ -13,8 +13,8 @@ const coreBlockTypes = [ 'core/paragraph', 'core/image', 'core/separator' ];
  * Gets a list of allowed blocks types under a specific parent block type.
  */
 export const getAllowedBlocks = ( block: string ): string[] => {
-	const additionalBlockTypes = applyCheckoutFilter( {
-		filterName: 'allowedBlockTypes',
+	const additionalCartCheckoutInnerBlockTypes = applyCheckoutFilter( {
+		filterName: 'additionalCartCheckoutInnerBlockTypes',
 		defaultValue: [],
 		extensions: select( CART_STORE_KEY ).getCartData().extensions,
 		arg: { block },
@@ -40,7 +40,7 @@ export const getAllowedBlocks = ( block: string ): string[] => {
 				)
 				.map( ( { name } ) => name ),
 			...coreBlockTypes,
-			...additionalBlockTypes,
+			...additionalCartCheckoutInnerBlockTypes,
 		] )
 	);
 };

--- a/docs/third-party-developers/extensibility/checkout-block/available-filters.md
+++ b/docs/third-party-developers/extensibility/checkout-block/available-filters.md
@@ -9,11 +9,14 @@
 -   [Proceed to Checkout Button Label](#proceed-to-checkout-button-label)
 -   [Proceed to Checkout Button Link](#proceed-to-checkout-button-link)
 -   [Place Order Button Label](#place-order-button-label)
+-   [Allowed block types](#allowed-block-types)
 -   [Examples](#examples)
-    -   [Changing the wording and the link on the "Proceed to Checkout" button when a specific item is in the Cart](#changing-the-wording-and-the-link-on-the--proceed-to-checkout--button-when-a-specific-item-is-in-the-cart)
+    -   [Changing the wording and the link on the "Proceed to Checkout" button when a specific item is in the Cart](#changing-the-wording-and-the-link-on-the-proceed-to-checkout-button-when-a-specific-item-is-in-the-cart)
+    -   [Allowing blocks in specific areas in the Cart and Checkout blocks](#allowing-blocks-in-specific-areas-in-the-cart-and-checkout-blocks)
     -   [Changing the wording of the Totals label in the Mini Cart, Cart and Checkout](#changing-the-wording-of-the-totals-label-in-the-mini-cart-cart-and-checkout)
     -   [Changing the format of the item's single price](#changing-the-format-of-the-items-single-price)
     -   [Change the name of a coupon](#change-the-name-of-a-coupon)
+    -   [Prevent a snackbar notice from appearing for coupons](#prevent-a-snackbar-notice-from-appearing-for-coupons)
     -   [Hide the "Remove item" link on a cart item](#hide-the-remove-item-link-on-a-cart-item)
     -   [Change the label of the Place Order button](#change-the-label-of-the-place-order-button)
 -   [Troubleshooting](#troubleshooting)
@@ -98,7 +101,7 @@ CartCoupon {
 The Cart block contains a button which is labelled 'Proceed to Checkout' by default. It can be changed using the following filter.
 
 | Filter name                    | Description                                         | Return type |
-|--------------------------------|-----------------------------------------------------| ----------- |
+| ------------------------------ | --------------------------------------------------- | ----------- |
 | `proceedToCheckoutButtonLabel` | The wanted label of the Proceed to Checkout button. | `string`    |
 
 ## Proceed to Checkout Button Link
@@ -106,7 +109,7 @@ The Cart block contains a button which is labelled 'Proceed to Checkout' by defa
 The Cart block contains a button which is labelled 'Proceed to Checkout' and links to the Checkout page by default, but can be changed using the following filter. This filter has the current cart passed to it in the third parameter.
 
 | Filter name                   | Description                                                 | Return type |
-|-------------------------------|-------------------------------------------------------------| ----------- |
+| ----------------------------- | ----------------------------------------------------------- | ----------- |
 | `proceedToCheckoutButtonLink` | The URL that the Proceed to Checkout button should link to. | `string`    |
 
 ## Place Order Button Label
@@ -116,6 +119,18 @@ The Checkout block contains a button which is labelled 'Place Order' by default,
 | Filter name             | Description                                 | Return type |
 | ----------------------- | ------------------------------------------- | ----------- |
 | `placeOrderButtonLabel` | The wanted label of the Place Order button. | `string`    |
+
+## Allowed block types
+
+The Cart and Checkout blocks are made up of inner blocks. These inner blocks areas allow certain block types to be added as children. By default, only `core/paragraph`, `core/image`, and `core/separator` are available to add.
+
+By using the `allowedBlockTypes` filter it is possible to add or remove items from this array to control what the editor can insert into an inner block.
+
+This filter is called once for each inner block area, so it is possible to be very granular when determining what blocks can be added where. See the [Allowing blocks in specific areas in the Cart and Checkout blocks.](#allowing-blocks-in-specific-areas-in-the-cart-and-checkout-blocks) example for more information.
+
+| Filter name         | Description                            | Return type |
+| ------------------- | -------------------------------------- | ----------- |
+| `allowedBlockTypes` | The new array of allowwed block types. | `string[]`  |
 
 ## Examples
 
@@ -154,9 +169,38 @@ registerCheckoutFilters( 'sunglasses-store-extension', {
 } );
 ```
 
-| Before                                                                                                                                    | After |
-|-------------------------------------------------------------------------------------------------------------------------------------------| ----- |
-| <img width="789" alt="image" src="https://user-images.githubusercontent.com/5656702/222575670-a7d1dab8-c93e-477a-b2cc-e463a5de77a6.png">  | <img width="761" alt="image" src="https://user-images.githubusercontent.com/5656702/222572409-de7a6bd6-5a2d-406b-ada9-cc60cc5cca54.png"> |
+| Before                                                                                                                                   | After                                                                                                                                    |
+| ---------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| <img width="789" alt="image" src="https://user-images.githubusercontent.com/5656702/222575670-a7d1dab8-c93e-477a-b2cc-e463a5de77a6.png"> | <img width="761" alt="image" src="https://user-images.githubusercontent.com/5656702/222572409-de7a6bd6-5a2d-406b-ada9-cc60cc5cca54.png"> |
+
+### Allowing blocks in specific areas in the Cart and Checkout blocks
+
+Let's suppose we want to allow the editor to add some blocks in specific places in the Cart and Checkout blocks.
+
+1. Allow `core/table` to be inserted in the Shipping Address block in the Checkout.
+2. Allow `core/quote` to be inserted in every block area in the Cart and Checkout blocks.
+3. Remove the ability to add the `core/separator` block to any inner block in the Cart and Checkout blocks.
+
+In our extension we could register a filter satisfy all three of these conditions like so:
+
+```tsx
+registerCheckoutFilters( 'newsletter-plugin', {
+	allowedBlockTypes: ( value, extensions, { block } ) => {
+		// Remove the ability to add `core/separator`
+		value = value.filter( ( blockName ) => blockName !== 'core/separator' );
+
+		// Add core/quote to any inner block area.
+		value.push( 'core/quote' );
+
+		// If the block we're checking is `woocommerce/checkout-shipping-address-block then allow `core/table`.
+		if ( block === 'woocommerce/checkout-shipping-address-block' ) {
+			value.push( 'core/table' );
+		}
+
+		return value;
+	},
+} );
+```
 
 ### Changing the wording of the Totals label in the Mini Cart, Cart and Checkout
 
@@ -324,4 +368,3 @@ The error will also be shown in your console.
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-blocks/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/third-party-developers/extensibility/checkout-block/available-filters.md)
 
 <!-- /FEEDBACK -->
-

--- a/docs/third-party-developers/extensibility/checkout-block/available-filters.md
+++ b/docs/third-party-developers/extensibility/checkout-block/available-filters.md
@@ -9,7 +9,7 @@
 -   [Proceed to Checkout Button Label](#proceed-to-checkout-button-label)
 -   [Proceed to Checkout Button Link](#proceed-to-checkout-button-link)
 -   [Place Order Button Label](#place-order-button-label)
--   [Allowed block types](#allowed-block-types)
+-   [Additional Cart and Checkout inner block types](#additional-cart-checkout-inner-block-types)
 -   [Examples](#examples)
     -   [Changing the wording and the link on the "Proceed to Checkout" button when a specific item is in the Cart](#changing-the-wording-and-the-link-on-the-proceed-to-checkout-button-when-a-specific-item-is-in-the-cart)
     -   [Allowing blocks in specific areas in the Cart and Checkout blocks](#allowing-blocks-in-specific-areas-in-the-cart-and-checkout-blocks)
@@ -120,17 +120,19 @@ The Checkout block contains a button which is labelled 'Place Order' by default,
 | ----------------------- | ------------------------------------------- | ----------- |
 | `placeOrderButtonLabel` | The wanted label of the Place Order button. | `string`    |
 
-## Allowed block types
+## Additional Cart Checkout inner block types
 
 The Cart and Checkout blocks are made up of inner blocks. These inner blocks areas allow certain block types to be added as children. By default, only `core/paragraph`, `core/image`, and `core/separator` are available to add.
 
-By using the `allowedBlockTypes` filter it is possible to add or remove items from this array to control what the editor can insert into an inner block.
+By using the `additionalCartCheckoutInnerBlockTypes` filter it is possible to add items to this array to control what the editor can insert into an inner block.
 
 This filter is called once for each inner block area, so it is possible to be very granular when determining what blocks can be added where. See the [Allowing blocks in specific areas in the Cart and Checkout blocks.](#allowing-blocks-in-specific-areas-in-the-cart-and-checkout-blocks) example for more information.
 
-| Filter name         | Description                            | Return type |
-| ------------------- | -------------------------------------- | ----------- |
-| `allowedBlockTypes` | The new array of allowwed block types. | `string[]`  |
+| Filter name                             | Description                              | Return type   |
+| --------------------------------------- | ---------------------------------------- | ------------- |
+| `allowedBlockTypes`                     | The new array of allowwed block types.   | `string[]`    |
+| -------------------                     | ---------------------------------------- | ------------- |
+| `additionalCartCheckoutInnerBlockTypes` | The new array of allowwed block types.   | `string[]`    |
 
 ## Examples
 
@@ -179,9 +181,8 @@ Let's suppose we want to allow the editor to add some blocks in specific places 
 
 1. Allow `core/table` to be inserted in the Shipping Address block in the Checkout.
 2. Allow `core/quote` to be inserted in every block area in the Cart and Checkout blocks.
-3. Remove the ability to add the `core/separator` block to any inner block in the Cart and Checkout blocks.
 
-In our extension we could register a filter satisfy all three of these conditions like so:
+In our extension we could register a filter satisfy both of these conditions like so:
 
 ```tsx
 registerCheckoutFilters( 'newsletter-plugin', {

--- a/docs/third-party-developers/extensibility/checkout-block/available-filters.md
+++ b/docs/third-party-developers/extensibility/checkout-block/available-filters.md
@@ -9,7 +9,7 @@
 -   [Proceed to Checkout Button Label](#proceed-to-checkout-button-label)
 -   [Proceed to Checkout Button Link](#proceed-to-checkout-button-link)
 -   [Place Order Button Label](#place-order-button-label)
--   [Additional Cart and Checkout inner block types](#additional-cart-checkout-inner-block-types)
+-   [Additional Cart Checkout inner block types](#additional-cart-checkout-inner-block-types)
 -   [Examples](#examples)
     -   [Changing the wording and the link on the "Proceed to Checkout" button when a specific item is in the Cart](#changing-the-wording-and-the-link-on-the-proceed-to-checkout-button-when-a-specific-item-is-in-the-cart)
     -   [Allowing blocks in specific areas in the Cart and Checkout blocks](#allowing-blocks-in-specific-areas-in-the-cart-and-checkout-blocks)

--- a/tests/e2e/specs/backend/cart.test.js
+++ b/tests/e2e/specs/backend/cart.test.js
@@ -7,6 +7,7 @@ import {
 	switchUserToAdmin,
 	searchForBlock,
 	openGlobalBlockInserter,
+	insertBlock,
 } from '@wordpress/e2e-test-utils';
 import {
 	findLabelWithText,
@@ -65,6 +66,70 @@ describe( `${ block.name } Block`, () => {
 			await page.keyboard.type( block.name );
 			const button = await page.$x( block.selectors.insertButton );
 			expect( button ).toHaveLength( 0 );
+		} );
+
+		it( 'inner blocks can be added/removed by filters', async () => {
+			// Begin by removing the block.
+			await selectBlockByName( block.slug );
+			const options = await page.$x(
+				'//div[@class="block-editor-block-toolbar"]//button[@aria-label="Options"]'
+			);
+			await options[ 0 ].click();
+			const removeButton = await page.$x(
+				'//button[contains(., "Remove Cart")]'
+			);
+			await removeButton[ 0 ].click();
+			// Expect block to have been removed.
+			await expect( page ).not.toMatchElement( block.class );
+
+			// Register a checkout filter to allow `core/table` block in the Checkout block's inner blocks, add
+			// core/audio into the woocommerce/cart-order-summary-block and remove core/paragraph from all Cart inner
+			// blocks.
+			await page.evaluate(
+				"wc.blocksCheckout.registerCheckoutFilters( 'woo-test-namespace'," +
+					'{ additionalCartCheckoutInnerBlockTypes: ( value, extensions, { block } ) => {' +
+					"    value.push('core/table');" +
+					"    if ( block === 'woocommerce/cart-order-summary-block' ) {" +
+					"        value.push( 'core/audio' );" +
+					'    }' +
+					'    return value;' +
+					'}' +
+					'}' +
+					');'
+			);
+
+			await insertBlock( block.name );
+
+			// Select the shipping address block and try to insert a block. Check the Table block is available.
+			await selectBlockByName( 'woocommerce/cart-order-summary-block' );
+			await page.waitForTimeout( 1000 );
+			const addBlockButton = await page.waitForXPath(
+				'//div[@data-type="woocommerce/cart-order-summary-block"]//button[@aria-label="Add block"]'
+			);
+			await addBlockButton.click();
+			const tableButton = await page.waitForXPath(
+				'//*[@role="option" and contains(., "Table")]'
+			);
+			const audioButton = await page.waitForXPath(
+				'//*[@role="option" and contains(., "Audio")]'
+			);
+			expect( tableButton ).not.toBeNull();
+			expect( audioButton ).not.toBeNull();
+
+			// // Now check the filled cart block and expect only the Table block to be available there.
+			await selectBlockByName( 'woocommerce/filled-cart-block' );
+			const filledCartAddBlockButton = await page.waitForXPath(
+				'//div[@data-type="woocommerce/filled-cart-block"]//button[@aria-label="Add block"]'
+			);
+			await filledCartAddBlockButton.click();
+			const filledCartTableButton = await page.waitForXPath(
+				'//*[@role="option" and contains(., "Table")]'
+			);
+			const filledCartAudioButton = await page.$x(
+				'//*[@role="option" and contains(., "Audio")]'
+			);
+			expect( filledCartTableButton ).not.toBeNull();
+			expect( filledCartAudioButton ).toHaveLength( 0 );
 		} );
 
 		it( 'renders without crashing', async () => {

--- a/tests/e2e/specs/backend/checkout.test.js
+++ b/tests/e2e/specs/backend/checkout.test.js
@@ -5,6 +5,7 @@ import {
 	openDocumentSettingsSidebar,
 	switchUserToAdmin,
 	openGlobalBlockInserter,
+	insertBlock,
 } from '@wordpress/e2e-test-utils';
 import {
 	findLabelWithText,
@@ -50,6 +51,72 @@ describe( `${ block.name } Block`, () => {
 			await page.keyboard.type( block.name );
 			const button = await page.$x( block.selectors.insertButton );
 			expect( button ).toHaveLength( 0 );
+		} );
+
+		it( 'inner blocks can be added/removed by filters', async () => {
+			// Begin by removing the block.
+			await selectBlockByName( block.slug );
+			const options = await page.$x(
+				'//div[@class="block-editor-block-toolbar"]//button[@aria-label="Options"]'
+			);
+			await options[ 0 ].click();
+			const removeButton = await page.$x(
+				'//button[contains(., "Remove Checkout")]'
+			);
+			await removeButton[ 0 ].click();
+			// Expect block to have been removed.
+			await expect( page ).not.toMatchElement( block.class );
+
+			// Register a checkout filter to allow `core/table` block in the Checkout block's inner blocks.
+			await page.evaluate(
+				"wc.blocksCheckout.registerCheckoutFilters( 'woo-test-namespace'," +
+					'{ allowedBlockTypes: ( value, extensions, { block } ) => {' +
+					"    value.push('core/table');" +
+					"    if ( block === 'woocommerce/checkout-shipping-address-block' ) {" +
+					"        value.push( 'core/audio' );" +
+					'    }' +
+					'    return value;' +
+					'}' +
+					'}' +
+					');'
+			);
+
+			await insertBlock( block.name );
+
+			// Select the shipping address block and try to insert a block. Check the Table block is available.
+			await selectBlockByName(
+				'woocommerce/checkout-shipping-address-block'
+			);
+			const addBlockButton = await page.waitForXPath(
+				'//div[@data-type="woocommerce/checkout-shipping-address-block"]//button[@aria-label="Add block"]'
+			);
+			expect( addBlockButton ).not.toBeNull();
+			await addBlockButton.click();
+			const tableButton = await page.waitForXPath(
+				'//*[@role="option" and contains(., "Table")]'
+			);
+			const audioButton = await page.waitForXPath(
+				'//*[@role="option" and contains(., "Audio")]'
+			);
+			expect( tableButton ).not.toBeNull();
+			expect( audioButton ).not.toBeNull();
+
+			// Now check the contact information block and expect only the Table block to be available there.
+			await selectBlockByName(
+				'woocommerce/checkout-contact-information-block'
+			);
+			const contactInformationAddBlockButton = await page.waitForXPath(
+				'//div[@data-type="woocommerce/checkout-contact-information-block"]//button[@aria-label="Add block"]'
+			);
+			await contactInformationAddBlockButton.click();
+			const contactInformationTableButton = await page.waitForXPath(
+				'//*[@role="option" and contains(., "Table")]'
+			);
+			const contactInformationAudioButton = await page.$x(
+				'//*[@role="option" and contains(., "Audio")]'
+			);
+			expect( contactInformationTableButton ).not.toBeNull();
+			expect( contactInformationAudioButton ).toHaveLength( 0 );
 		} );
 
 		it( 'renders without crashing', async () => {

--- a/tests/e2e/specs/backend/checkout.test.js
+++ b/tests/e2e/specs/backend/checkout.test.js
@@ -70,7 +70,7 @@ describe( `${ block.name } Block`, () => {
 			// Register a checkout filter to allow `core/table` block in the Checkout block's inner blocks.
 			await page.evaluate(
 				"wc.blocksCheckout.registerCheckoutFilters( 'woo-test-namespace'," +
-					'{ allowedBlockTypes: ( value, extensions, { block } ) => {' +
+					'{ additionalCartCheckoutInnerBlockTypes: ( value, extensions, { block } ) => {' +
 					"    value.push('core/table');" +
 					"    if ( block === 'woocommerce/checkout-shipping-address-block' ) {" +
 					"        value.push( 'core/audio' );" +


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR adds a new filter, `allowedBlockTypes` which can be used to enable additional blocks in the Cart and Checkout blocks. It can also be used to disable blocks that are allowed by default.

It also adds relevant documentation for this filter.

<!-- Reference any related issues or PRs here -->

Fixes #7661

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Add the Cart block to a page in the editor. Click into a few inner blocks and ensure the 'core/paragraph', 'core/image', 'core/separator' blocks are available for each.
2. Repeat for the Checkout block.
3. Ensure the Cart and Checkout blocks work correctly on the front end by placing an order.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

#### Internal developer testing

1. Add this code somewhere it will execute when on the Cart block. If you want a quick plugin to be set up then use [`@woocommerce/extend-cart-checkout-block`](https://www.npmjs.com/package/@woocommerce/extend-cart-checkout-block)

```tsx
registerCheckoutFilters( 'my-store-extension', {
  additionalCartCheckoutInnerBlockTypes: ( value, extensions, { block } ) => {
	  if ( block === 'woocommerce/checkout-shipping-address-block' ) {
		  value.push( 'core/table' );
	  }
	  value.push( 'core/audio' );
	  return value;
  },
} );
```
2. Go to the Checkout Block in the editor, click on the `woocommerce/checkout-shipping-address-block` and add a new block to it.
3. Ensure you can add the `Table` block **and** the `Audio` block.
4. Click onto another inner block, and ensure only the `Audio` block can be added, not the `Table` block.

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

#### Dev note
In this release we added a new filter, `additionalCartCheckoutInnerBlockTypes` which allows additional block types to be added to the Cart and Checkout inner blocks areas. We included an example of how to use it in the [available filters documentation](https://github.com/woocommerce/woocommerce-blocks/blob/65abd2fe57edc76c8d602596081956d98534df86/docs/third-party-developers/extensibility/checkout-block/available-filters.md#additional-cart-checkout-inner-block-types).

### Changelog

> Add `additionalCartCheckoutInnerBlockTypes` checkout filter to allow additional block types to be inserted into the Cart and Checkout blocks in the editor.
