### PR TITLE
Preload Mini Cart inner blocks frontend scripts

### DIFF
--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -2,7 +2,6 @@
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
 use Automattic\WooCommerce\Blocks\Package;
-use Automattic\WooCommerce\StoreApi\Utilities\CartController;
 use Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry;
 use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
 use Automattic\WooCommerce\Blocks\Assets\Api as AssetApi;
@@ -120,8 +119,6 @@ class MiniCart extends AbstractBlock {
 			return;
 		}
 
-		$cart = WC()->cart;
-
 		parent::enqueue_data( $attributes );
 
 		// Hydrate the following data depending on admin or frontend context.
@@ -185,17 +182,21 @@ class MiniCart extends AbstractBlock {
 			'translations' => $this->get_inner_blocks_translations(),
 		);
 
-		// Preload inner blocks frontend scripts.
-		$inner_blocks_frontend_scripts = $cart->is_empty() ? array(
-			'empty-cart-frontend',
-			'shopping-button-frontend',
-		) : array(
-			'filled-cart-frontend',
-			'title-frontend',
-			'items-frontend',
-			'footer-frontend',
-			'products-table-frontend',
-		);
+		$inner_blocks_frontend_scripts = array();
+		$cart                          = $this->get_cart_instance();
+		if ( $cart ) {
+			// Preload inner blocks frontend scripts.
+			$inner_blocks_frontend_scripts = $cart->is_empty() ? array(
+				'empty-cart-frontend',
+				'shopping-button-frontend',
+			) : array(
+				'filled-cart-frontend',
+				'title-frontend',
+				'items-frontend',
+				'footer-frontend',
+				'products-table-frontend',
+			);
+		}
 		foreach ( $inner_blocks_frontend_scripts as $inner_block_frontend_script ) {
 			$script_data = $this->asset_api->get_script_data( 'build/mini-cart-contents-block/' . $inner_block_frontend_script . '.js' );
 			$this->scripts_to_lazy_load[ 'wc-block-' . $inner_block_frontend_script ] = array(
@@ -330,8 +331,7 @@ class MiniCart extends AbstractBlock {
 			return;
 		}
 
-		$cart_controller     = $this->get_cart_controller();
-		$cart                = $cart_controller->get_cart_instance();
+		$cart                = $this->get_cart_instance();
 		$cart_contents_total = $cart->get_subtotal();
 
 		if ( $cart->display_prices_including_tax() ) {
@@ -348,8 +348,7 @@ class MiniCart extends AbstractBlock {
 	 * @return string
 	 */
 	protected function get_include_tax_label_markup() {
-		$cart_controller     = $this->get_cart_controller();
-		$cart                = $cart_controller->get_cart_instance();
+		$cart                = $this->get_cart_instance();
 		$cart_contents_total = $cart->get_subtotal();
 
 		return ( ! empty( $this->tax_label ) && 0 !== $cart_contents_total ) ? ( "<small class='wc-block-mini-cart__tax-label'>" . esc_html( $this->tax_label ) . '</small>' ) : '';
@@ -381,8 +380,7 @@ class MiniCart extends AbstractBlock {
 			return '';
 		}
 
-		$cart_controller     = $this->get_cart_controller();
-		$cart                = $cart_controller->get_cart_instance();
+		$cart                = $this->get_cart_instance();
 		$cart_contents_count = $cart->get_cart_contents_count();
 		$cart_contents_total = $cart->get_subtotal();
 
@@ -462,12 +460,18 @@ class MiniCart extends AbstractBlock {
 	}
 
 	/**
-	 * Return an instace of the CartController class.
+	 * Return the main instance of WC_Cart class.
 	 *
-	 * @return CartController CartController class instance.
+	 * @return \WC_Cart CartController class instance.
 	 */
-	protected function get_cart_controller() {
-		return new CartController();
+	protected function get_cart_instance() {
+		$cart = WC()->cart;
+
+		if ( $cart && $cart instanceof \WC_Cart ) {
+			return $cart;
+		}
+
+		return null;
 	}
 
 	/**
@@ -478,9 +482,9 @@ class MiniCart extends AbstractBlock {
 	 * @return array;
 	 */
 	protected function get_tax_label() {
-		$cart = WC()->cart;
+		$cart = $this->get_cart_instance();
 
-		if ( $cart->display_prices_including_tax() ) {
+		if ( $cart && $cart->display_prices_including_tax() ) {
 			if ( ! wc_prices_include_tax() ) {
 				$tax_label                         = WC()->countries->inc_tax_or_vat();
 				$display_cart_prices_including_tax = true;

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -188,8 +188,10 @@ class MiniCart extends AbstractBlock {
 			// Preload inner blocks frontend scripts.
 			$inner_blocks_frontend_scripts = $cart->is_empty() ? array(
 				'empty-cart-frontend',
+				'filled-cart-frontend',
 				'shopping-button-frontend',
 			) : array(
+				'empty-cart-frontend',
 				'filled-cart-frontend',
 				'title-frontend',
 				'items-frontend',

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -120,6 +120,8 @@ class MiniCart extends AbstractBlock {
 			return;
 		}
 
+		$cart = WC()->cart;
+
 		parent::enqueue_data( $attributes );
 
 		// Hydrate the following data depending on admin or frontend context.
@@ -182,6 +184,25 @@ class MiniCart extends AbstractBlock {
 			'version'      => $script_data['version'],
 			'translations' => $this->get_inner_blocks_translations(),
 		);
+
+		// Preload inner blocks frontend scripts.
+		$inner_blocks_frontend_scripts = $cart->is_empty() ? array(
+			'empty-cart-frontend',
+			'shopping-button-frontend',
+		) : array(
+			'filled-cart-frontend',
+			'title-frontend',
+			'items-frontend',
+			'footer-frontend',
+			'products-table-frontend',
+		);
+		foreach ( $inner_blocks_frontend_scripts as $inner_block_frontend_script ) {
+			$script_data = $this->asset_api->get_script_data( 'build/mini-cart-contents-block/' . $inner_block_frontend_script . '.js' );
+			$this->scripts_to_lazy_load[ 'wc-block-' . $inner_block_frontend_script ] = array(
+				'src'     => $script_data['src'],
+				'version' => $script_data['version'],
+			);
+		}
 
 		$this->asset_data_registry->add(
 			'mini_cart_block_frontend_dependencies',


### PR DESCRIPTION
Part of #7176.

To improve Mini Cart block performance, we can preload the scripts that will be needed to render the inner blocks. Currently, we are preloading many other scripts, so we have the logic in place, this PR is simply adding the inner blocks scripts to the list of blocks to lazy load.

### Testing

#### User Facing Testing

Testing this PR is about making sure there are no regressions in the Mini Cart block:

1. Add the Mini Cart block to your site's header.
2. In the frontend, open the _Network_ tab of your browser devtools and verify the Mini Cart inner blocks are being preloaded (you can search for `empty-cart-frontend` or `filled-cart-frontend`).
3. Interact with the Mini Cart and verify there are no regressions.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Preload Mini Cart inner blocks frontend scripts to improve performance
