### PR TITLE
Add border support to mini cart contents

### DIFF
--- a/assets/js/blocks/mini-cart/mini-cart-contents/index.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/index.tsx
@@ -41,6 +41,10 @@ const settings: BlockConfiguration = {
 			link: true,
 		},
 		lock: false,
+		__experimentalBorder: {
+			color: true,
+			width: true,
+		},
 	},
 	attributes: {
 		isPreview: {

--- a/assets/js/blocks/mini-cart/mini-cart-contents/index.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/index.tsx
@@ -6,6 +6,7 @@ import { cart, filledCart, removeCart } from '@woocommerce/icons';
 import { Icon } from '@wordpress/icons';
 import { registerBlockType } from '@wordpress/blocks';
 import type { BlockConfiguration } from '@wordpress/blocks';
+import { isFeaturePluginBuild } from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies
@@ -41,10 +42,12 @@ const settings: BlockConfiguration = {
 			link: true,
 		},
 		lock: false,
-		__experimentalBorder: {
-			color: true,
-			width: true,
-		},
+		...( isFeaturePluginBuild() && {
+			__experimentalBorder: {
+				color: true,
+				width: true,
+			},
+		} ),
 	},
 	attributes: {
 		isPreview: {

--- a/assets/js/blocks/mini-cart/style.scss
+++ b/assets/js/blocks/mini-cart/style.scss
@@ -99,9 +99,10 @@
 
 .wp-block-woocommerce-empty-mini-cart-contents-block,
 .wp-block-woocommerce-filled-mini-cart-contents-block {
-	height: 100vh;
-	height: 100dvh;
+	height: 100%;
 	max-height: -webkit-fill-available;
+	max-height: -moz-available;
+	max-height: fill-available;
 	display: flex;
 	flex-direction: column;
 }

--- a/assets/js/blocks/mini-cart/style.scss
+++ b/assets/js/blocks/mini-cart/style.scss
@@ -209,9 +209,13 @@ h2.wc-block-mini-cart__title {
 }
 
 .admin-bar .wp-block-woocommerce-mini-cart-contents {
-	margin-top: 32px;
+	margin-top: 46px;
+	height: calc(100dvh - 46px);
 }
 
-.admin-bar .wp-block-woocommerce-mini-cart-contents {
-	height: calc(100vh - 32px);
+@media only screen and (min-width: 783px) {
+	.admin-bar .wp-block-woocommerce-mini-cart-contents {
+		margin-top: 32px;
+		height: calc(100dvh - 32px);
+	}
 }

--- a/assets/js/blocks/mini-cart/style.scss
+++ b/assets/js/blocks/mini-cart/style.scss
@@ -87,9 +87,7 @@
 
 .wp-block-woocommerce-mini-cart-contents {
 	box-sizing: border-box;
-	height: 100vh;
 	height: 100dvh;
-	max-height: -webkit-fill-available;
 	padding: 0;
 	justify-content: center;
 }
@@ -214,8 +212,6 @@ h2.wc-block-mini-cart__title {
 	margin-top: 32px;
 }
 
-.admin-bar .wp-block-woocommerce-mini-cart-contents,
-.admin-bar .wp-block-woocommerce-empty-mini-cart-contents-block,
-.admin-bar .wp-block-woocommerce-filled-mini-cart-contents-block {
+.admin-bar .wp-block-woocommerce-mini-cart-contents {
 	height: calc(100vh - 32px);
 }


### PR DESCRIPTION
This PR adds support for adding border style controls to the Mini Cart overlay via the Mini Cart Contents block.

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/6257

### Screenshots

| Before | After |
| ------ | ----- |
| <img width="291" alt="Screenshot 2023-03-08 at 15 41 35" src="https://user-images.githubusercontent.com/186112/223743115-6f21efd3-d268-4086-ae52-ca94975af484.png">| <img width="288" alt="Screenshot 2023-03-08 at 15 41 09" src="https://user-images.githubusercontent.com/186112/223743151-03acaf76-d09d-4e83-b900-5b444f908bcf.png"> |
| <img width="509" alt="Screenshot 2023-03-08 at 15 40 26" src="https://user-images.githubusercontent.com/186112/223742677-dfc6d5d9-4a18-4fc0-abf8-ba134207feaa.png"> | <img width="509" alt="Screenshot 2023-03-08 at 15 40 14" src="https://user-images.githubusercontent.com/186112/223742736-d6453711-a93b-4806-a173-7ef4af28799a.png"> |

### Testing

#### Automated Tests
#### User Facing Testing

1. Enable a blocks theme, go to Site Editor, and add the `Mini Cart` block to the header.
2. Go to Template Parts and open the `Mini Cart` template.
3. Open the List View, select the `Mini Cart contents` block and check that in the settings sidebar you can see the `Border` controls.
4. Click the `+` button and add a border and save the template.
5. Go to the frontend, click on the `Mini Cart` button, and check you see the same border in the editor and in the frontend.
6. Check that all the buttons in the mini cart modal are correctly displayed.
7. Double check in different browsers and logged in/out of the admin.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility


* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Add border style controls to the Mini Cart block.
