### PR TITLE
Remove wc-blocks-registry from Mini Cart block dependencies so more scripts can be lazy-loaded

### DIFF
--- a/assets/js/base/utils/lazy-load-script.ts
+++ b/assets/js/base/utils/lazy-load-script.ts
@@ -40,7 +40,7 @@ const isScriptTagInDOM = ( scriptId: string, src = '' ): boolean => {
 	// Because of that, we add an extra protection to the wc-blocks-registry-js
 	// script, to avoid ending up with two registries.
 	if ( scriptId === 'wc-blocks-registry-js' ) {
-		if ( typeof window.wc.wcBlocksRegistry !== 'undefined' ) {
+		if ( typeof window?.wc?.wcBlocksRegistry === 'object' ) {
 			return true;
 		}
 	}

--- a/assets/js/base/utils/lazy-load-script.ts
+++ b/assets/js/base/utils/lazy-load-script.ts
@@ -20,6 +20,14 @@ interface AppendScriptAttributesParam {
 	src?: string;
 }
 
+declare global {
+	interface Window {
+		wc: {
+			wcBlocksRegistry: Record< string, unknown >;
+		};
+	}
+}
+
 /**
  * In WP, registered scripts are loaded into the page with an element like this:
  * `<script src='...' id='[SCRIPT_ID]'></script>`
@@ -27,6 +35,16 @@ interface AppendScriptAttributesParam {
  * Useful to know if a script has already been appended to the page.
  */
 const isScriptTagInDOM = ( scriptId: string, src = '' ): boolean => {
+	// If the store is using a plugin to concatenate scripts, we might have some
+	// cases where we don't detect whether a script has already been loaded.
+	// Because of that, we add an extra protection to the wc-blocks-registry-js
+	// script, to avoid ending up with two registries.
+	if ( scriptId === 'wc-blocks-registry-js' ) {
+		if ( typeof window.wc.wcBlocksRegistry !== 'undefined' ) {
+			return true;
+		}
+	}
+
 	const srcParts = src.split( '?' );
 	if ( srcParts?.length > 1 ) {
 		src = srcParts[ 0 ];

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -103,7 +103,7 @@ class MiniCart extends AbstractBlock {
 		$script = [
 			'handle'       => 'wc-' . $this->block_name . '-block-frontend',
 			'path'         => $this->asset_api->get_block_asset_build_path( $this->block_name . '-frontend' ),
-			'dependencies' => [ 'wc-blocks-registry' ],
+			'dependencies' => [],
 		];
 		return $key ? $script[ $key ] : $script;
 	}
@@ -282,7 +282,7 @@ class MiniCart extends AbstractBlock {
 				}
 			}
 		}
-		if ( ! $script->src || 'wc-blocks-registry' === $script->handle ) {
+		if ( ! $script->src ) {
 			return;
 		}
 


### PR DESCRIPTION
Part of #7176.

This is an alternative solution to #7813. It has the benefit that we don't need to declare `wc-blocks-registry` as a dependency of the Mini Cart frontend script, so we don't need to load it (and all its dependencies) on page load.

@gigitux I would appreciate if you can take a look, as we worked on the original fix together. :slightly_smiling_face: 

### Screenshots

The screenshots below show the scripts which are loaded on page load in a page without any other block than the Mini Cart:

Before | After
--- | ---
![imatge](https://user-images.githubusercontent.com/3616980/223483278-9a8a4cba-0df2-402d-aa21-db8104d5d48e.png) | ![imatge](https://user-images.githubusercontent.com/3616980/223483200-5bb93fc8-21f9-44eb-8f8a-cba222b27c45.png)

Keep in mind that the **total** of scripts loaded is the same. We are just deferring some of them after the page has already loaded.

### Testing

#### User Facing Testing

1. Install [Page Optimize](https://wordpress.org/plugins/page-optimize/) and [Product Bundles](https://woocommerce.com/products/product-bundles/).
2. Enable a block theme, like [TT3](https://github.com/WordPress/twentytwentythree/).
3. Go to Appearance > Editor and add the Mini Cart block to the store header.
4. Save the changes.
5. In the frontend, click on the Mini Cart. The drawer should open and show the "empty cart" message. 
6. Go to the shop page and add a product to your cart.
7. Click on the Mini Cart. The drawer should open and show the product you just added.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

This PR makes it so fewer scripts are blocking the page load, so they can be lazy loaded after the page has rendered.

### Changelog

> Reduce the number of scripts needed to render a page containing the Mini Cart block
