### PR TITLE
Fix a circular dependency in CartLineItemRow

### DIFF
--- a/assets/js/base/components/cart-checkout/cart-line-items-table/cart-line-item-row.tsx
+++ b/assets/js/base/components/cart-checkout/cart-line-items-table/cart-line-item-row.tsx
@@ -12,13 +12,6 @@ import {
 	useStoreEvents,
 	useStoreCart,
 } from '@woocommerce/base-context/hooks';
-import {
-	ProductBackorderBadge,
-	ProductImage,
-	ProductLowStockBadge,
-	ProductMetadata,
-	ProductSaleBadge,
-} from '@woocommerce/base-components/cart-checkout';
 import { getCurrencyFromPriceResponse } from '@woocommerce/price-format';
 import { applyCheckoutFilter, mustContain } from '@woocommerce/blocks-checkout';
 import Dinero from 'dinero.js';
@@ -26,6 +19,15 @@ import { forwardRef, useMemo } from '@wordpress/element';
 import type { CartItem } from '@woocommerce/types';
 import { objectHasProp, Currency } from '@woocommerce/types';
 import { getSetting } from '@woocommerce/settings';
+
+/**
+ * Internal dependencies
+ */
+import ProductBackorderBadge from '../product-backorder-badge';
+import ProductImage from '../product-image';
+import ProductLowStockBadge from '../product-low-stock-badge';
+import ProductMetadata from '../product-metadata';
+import ProductSaleBadge from '../product-sale-badge';
 
 /**
  * Convert a Dinero object with precision to store currency minor unit.


### PR DESCRIPTION
In #8644 I introduced a circular dependency as `@woocommerce/base-components/cart-checkout` was importing itself. This PR fixes it. Thanks @gigitux for noticing it!

### Testing

#### User Facing Testing

Make sure the circular dependency is fixed:
1. Run `npm run start` and verify there isn't a `ERROR in Circular dependency detected`.

Make sure there are no regressions in the Mini Cart and Cart blocks:

1. Add the Cart block to a post or page and add the Mini Cart block to the header of your page.
2. In the frontend, add some products to the Cart and verify the Mini Cart block renders properly and you can use it to change the quantity of products in the cart.
3. Go to the Cart page and verify it also renders correctly and you can change the quantity of products.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
