### PR TITLE
Temporarily disable E2E tests running latest version of Gutenberg.

### DIFF
--- a/.github/workflows/php-js-e2e-tests.yml
+++ b/.github/workflows/php-js-e2e-tests.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
     JSE2EWithGutenberg:
+        if: ${{ false }}  # disable until we've fixed failing tests.
         strategy:
             fail-fast: false
             matrix:


### PR DESCRIPTION
E2E tests are consistently failing with the latest version of Gutenberg and blocking PRs. Whilst we look into these failing tests we have decided to disable/skip E2E tests running on the latest version of Gutenberg until they've been resolved.