### PR TITLE
Rename JS translation function name

### DIFF
--- a/docs/internal-developers/translations/translation-loading.md
+++ b/docs/internal-developers/translations/translation-loading.md
@@ -248,7 +248,7 @@ The following function handles the loading of fallback translations for JS/TS fi
  *
  * @return string|false        Path to the translation file to load. False if there isn't one.
  */
-function load_woocommerce_core_json_translation( $file, $handle, $domain ) {
+function load_woocommerce_core_js_translation( $file, $handle, $domain ) {
 	if ( 'woo-gutenberg-products-block' !== $domain ) {
 		return $file;
 	}
@@ -294,5 +294,5 @@ function load_woocommerce_core_json_translation( $file, $handle, $domain ) {
 	return $lang_dir . '/woocommerce-' . $locale . '-' . $core_path_md5 . '.json';
 }
 
-add_filter( 'load_script_translation_file', 'load_woocommerce_core_json_translation', 10, 3 );
+add_filter( 'load_script_translation_file', 'load_woocommerce_core_js_translation', 10, 3 );
 ```

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -178,7 +178,7 @@ add_action( 'plugins_loaded', array( '\Automattic\WooCommerce\Blocks\Package', '
  *
  * @return string|false        Path to the translation file to load. False if there isn't one.
  */
-function load_woocommerce_core_json_translation( $file, $handle, $domain ) {
+function load_woocommerce_core_js_translation( $file, $handle, $domain ) {
 	if ( 'woo-gutenberg-products-block' !== $domain ) {
 		return $file;
 	}
@@ -224,7 +224,7 @@ function load_woocommerce_core_json_translation( $file, $handle, $domain ) {
 	return $lang_dir . '/woocommerce-' . $locale . '-' . $core_path_md5 . '.json';
 }
 
-add_filter( 'load_script_translation_file', 'load_woocommerce_core_json_translation', 10, 3 );
+add_filter( 'load_script_translation_file', 'load_woocommerce_core_js_translation', 10, 3 );
 
 /**
  * Filter translations so we can retrieve translations from Core when the original and the translated
@@ -307,6 +307,7 @@ add_filter(
  * Load and setup the Interactivity API if enabled.
  */
 function woocommerce_blocks_interactivity_setup() {
+	// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 	$is_enabled = apply_filters(
 		'woocommerce_blocks_enable_interactivity_api',
 		false


### PR DESCRIPTION
While having in internal discussion about translation handling of JS and JSON files in p1678281263182499-slack-C02UBB1EPEF, we noticed that https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/translations/translation-loading.md#loading-fallback-translations-for-jsts-files refers to a JS function called `load_woocommerce_core_json_translation`. This function is located at https://github.com/woocommerce/woocommerce-blocks/blob/24d368d13b71f80a94557ab7cfcd8bb61f837b1a/woocommerce-gutenberg-products-block.php#L181-L227

Given that this function acts as a fallback mechanism to load JS translations, but not to load JSON translations, the function name is misleading. This PR aims to improve the function name, to avoid confusion.

### Testing

#### User Facing Testing

1. Check out this PR.
2. Run a global search for `load_woocommerce_core_json_translation` to verify that this function name no longer appears.
3. Then, check the changed files to verify that all appearances of `load_woocommerce_core_json_translation` have been changed to `load_woocommerce_core_js_translation`.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental