### PR TITLE
Add spacing between Mini Cart title and products list when scrolled

### DIFF
--- a/assets/js/blocks/mini-cart/style.scss
+++ b/assets/js/blocks/mini-cart/style.scss
@@ -97,6 +97,7 @@
 
 .wp-block-woocommerce-empty-mini-cart-contents-block,
 .wp-block-woocommerce-filled-mini-cart-contents-block {
+	background: inherit;
 	height: 100%;
 	max-height: -webkit-fill-available;
 	max-height: -moz-available;
@@ -121,7 +122,11 @@
 
 h2.wc-block-mini-cart__title {
 	@include font-size(larger);
-	margin: $gap $gap 0;
+	background: inherit;
+	margin: $gap $gap $gap * -2;
+	padding-bottom: $gap * 2;
+	mask-image: linear-gradient(#000 calc(100% - #{$gap * 1.5}), transparent);
+	z-index: 1;
 }
 
 .wc-block-mini-cart__items {


### PR DESCRIPTION
Fixes #8666.

This PR adds some spacing under the Mini Cart title, so when scrolling the list of products, there is some space between the title and the product list. I added it as a gradient as it makes it easier to understand that it's a scrollable area.

### Testing

#### User Facing Testing

1. With a block theme, add the Mini Cart block to the header of your site.
2. Add many products to your cart.
3. Click on the Mini Cart button to open the drawer.
4. Scroll down the list of products in the Mini Cart drawer and verify there is some space between the title and product list.
5. Go to Appearance > Editor > Template parts and edit the Mini Cart template part.
6. Change the background color to something different.
7. Repeat steps 3 and 4 and verify the space between the Mini Cart title and the products list honors that color.

Before | After | After (with custom background color)
--- | --- | ---
![imatge](https://user-images.githubusercontent.com/3616980/223775624-f4b1b78e-d6bd-4698-a2a8-096083a0e8ba.png) | ![imatge](https://user-images.githubusercontent.com/3616980/223775552-b3255fbe-b4de-435a-81e4-913b2b7e92e7.png) | ![imatge](https://user-images.githubusercontent.com/3616980/223775429-e55069e8-5007-44bd-a4d3-1dc43a2fdfef.png)


* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Add spacing between Mini Cart title and products list when scrolled
