### PR TITLE
Mini-cart: add setting to not render the block on the cart & checkout pages

### DIFF
--- a/assets/js/blocks/mini-cart/edit.tsx
+++ b/assets/js/blocks/mini-cart/edit.tsx
@@ -14,6 +14,7 @@ import { getSetting } from '@woocommerce/settings';
 import { __ } from '@wordpress/i18n';
 import Noninteractive from '@woocommerce/base-components/noninteractive';
 import type { ReactElement } from 'react';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -37,6 +38,8 @@ const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
 	const blockProps = useBlockProps( {
 		className: `wc-block-mini-cart`,
 	} );
+
+	const isSiteEditor = useSelect( 'core/edit-site' ) !== undefined;
 
 	const templatePartEditUri = getSetting(
 		'templatePartEditUri',
@@ -101,36 +104,40 @@ const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
 							} )
 						}
 					/>
-					<ToggleGroupControl
-						className="wc-block-mini-cart__render-in-cart-and-checkout-toggle"
-						label={ __(
-							'Mini Cart in cart and checkout pages',
-							'woo-gutenberg-products-block'
-						) }
-						value={ renderInCartAndCheckout }
-						onChange={ ( value ) => {
-							setAttributes( { renderInCartAndCheckout: value } );
-						} }
-						help={ __(
-							'Select how the Mini Cart behaves in the Cart and Checkout pages. This might affect the header layout.',
-							'woo-gutenberg-products-block'
-						) }
-					>
-						<ToggleGroupControlOption
-							value={ false }
+					{ isSiteEditor && (
+						<ToggleGroupControl
+							className="wc-block-mini-cart__render-in-cart-and-checkout-toggle"
 							label={ __(
-								'Make invisible',
+								'Mini Cart in cart and checkout pages',
 								'woo-gutenberg-products-block'
 							) }
-						/>
-						<ToggleGroupControlOption
-							value={ true }
-							label={ __(
-								"Don't render",
+							value={ renderInCartAndCheckout }
+							onChange={ ( value ) => {
+								setAttributes( {
+									renderInCartAndCheckout: value,
+								} );
+							} }
+							help={ __(
+								'Select how the Mini Cart behaves in the Cart and Checkout pages. This might affect the header layout.',
 								'woo-gutenberg-products-block'
 							) }
-						/>
-					</ToggleGroupControl>
+						>
+							<ToggleGroupControlOption
+								value={ false }
+								label={ __(
+									'Make invisible',
+									'woo-gutenberg-products-block'
+								) }
+							/>
+							<ToggleGroupControlOption
+								value={ true }
+								label={ __(
+									"Don't render",
+									'woo-gutenberg-products-block'
+								) }
+							/>
+						</ToggleGroupControl>
+					) }
 				</PanelBody>
 				{ templatePartEditUri && (
 					<PanelBody

--- a/assets/js/blocks/mini-cart/edit.tsx
+++ b/assets/js/blocks/mini-cart/edit.tsx
@@ -125,14 +125,14 @@ const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
 							<ToggleGroupControlOption
 								value={ 'hidden' }
 								label={ __(
-									'Make invisible',
+									'Hide',
 									'woo-gutenberg-products-block'
 								) }
 							/>
 							<ToggleGroupControlOption
 								value={ 'removed' }
 								label={ __(
-									"Don't render",
+									'Remove',
 									'woo-gutenberg-products-block'
 								) }
 							/>

--- a/assets/js/blocks/mini-cart/edit.tsx
+++ b/assets/js/blocks/mini-cart/edit.tsx
@@ -24,7 +24,7 @@ import QuantityBadge from './quantity-badge';
 interface Attributes {
 	addToCartBehaviour: string;
 	hasHiddenPrice: boolean;
-	makeInvisibleInCartAndCheckout: boolean;
+	cartAndCheckoutRenderStyle: boolean;
 }
 
 interface Props {
@@ -33,11 +33,8 @@ interface Props {
 }
 
 const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
-	const {
-		addToCartBehaviour,
-		hasHiddenPrice,
-		makeInvisibleInCartAndCheckout,
-	} = attributes;
+	const { addToCartBehaviour, hasHiddenPrice, cartAndCheckoutRenderStyle } =
+		attributes;
 	const blockProps = useBlockProps( {
 		className: `wc-block-mini-cart`,
 	} );
@@ -114,10 +111,10 @@ const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
 								'Mini Cart in cart and checkout pages',
 								'woo-gutenberg-products-block'
 							) }
-							value={ makeInvisibleInCartAndCheckout }
+							value={ cartAndCheckoutRenderStyle }
 							onChange={ ( value ) => {
 								setAttributes( {
-									makeInvisibleInCartAndCheckout: value,
+									cartAndCheckoutRenderStyle: value,
 								} );
 							} }
 							help={ __(
@@ -126,14 +123,14 @@ const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
 							) }
 						>
 							<ToggleGroupControlOption
-								value={ true }
+								value={ 'hidden' }
 								label={ __(
 									'Make invisible',
 									'woo-gutenberg-products-block'
 								) }
 							/>
 							<ToggleGroupControlOption
-								value={ false }
+								value={ 'removed' }
 								label={ __(
 									"Don't render",
 									'woo-gutenberg-products-block'

--- a/assets/js/blocks/mini-cart/edit.tsx
+++ b/assets/js/blocks/mini-cart/edit.tsx
@@ -24,7 +24,7 @@ import QuantityBadge from './quantity-badge';
 interface Attributes {
 	addToCartBehaviour: string;
 	hasHiddenPrice: boolean;
-	renderInCartAndCheckout: boolean;
+	makeInvisibleInCartAndCheckout: boolean;
 }
 
 interface Props {
@@ -33,8 +33,11 @@ interface Props {
 }
 
 const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
-	const { addToCartBehaviour, hasHiddenPrice, renderInCartAndCheckout } =
-		attributes;
+	const {
+		addToCartBehaviour,
+		hasHiddenPrice,
+		makeInvisibleInCartAndCheckout,
+	} = attributes;
 	const blockProps = useBlockProps( {
 		className: `wc-block-mini-cart`,
 	} );
@@ -111,10 +114,10 @@ const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
 								'Mini Cart in cart and checkout pages',
 								'woo-gutenberg-products-block'
 							) }
-							value={ renderInCartAndCheckout }
+							value={ makeInvisibleInCartAndCheckout }
 							onChange={ ( value ) => {
 								setAttributes( {
-									renderInCartAndCheckout: value,
+									makeInvisibleInCartAndCheckout: value,
 								} );
 							} }
 							help={ __(
@@ -123,14 +126,14 @@ const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
 							) }
 						>
 							<ToggleGroupControlOption
-								value={ false }
+								value={ true }
 								label={ __(
 									'Make invisible',
 									'woo-gutenberg-products-block'
 								) }
 							/>
 							<ToggleGroupControlOption
-								value={ true }
+								value={ false }
 								label={ __(
 									"Don't render",
 									'woo-gutenberg-products-block'

--- a/assets/js/blocks/mini-cart/edit.tsx
+++ b/assets/js/blocks/mini-cart/edit.tsx
@@ -23,6 +23,7 @@ import QuantityBadge from './quantity-badge';
 interface Attributes {
 	addToCartBehaviour: string;
 	hasHiddenPrice: boolean;
+	renderInCartAndCheckout: boolean;
 }
 
 interface Props {
@@ -31,7 +32,8 @@ interface Props {
 }
 
 const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
-	const { addToCartBehaviour, hasHiddenPrice } = attributes;
+	const { addToCartBehaviour, hasHiddenPrice, renderInCartAndCheckout } =
+		attributes;
 	const blockProps = useBlockProps( {
 		className: `wc-block-mini-cart`,
 	} );
@@ -54,6 +56,7 @@ const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
 					) }
 				>
 					<ToggleGroupControl
+						className="wc-block-mini-cart__add-to-cart-behaviour-toggle"
 						label={ __(
 							'Add-to-Cart behaviour',
 							'woo-gutenberg-products-block'
@@ -98,6 +101,36 @@ const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
 							} )
 						}
 					/>
+					<ToggleGroupControl
+						className="wc-block-mini-cart__render-in-cart-and-checkout-toggle"
+						label={ __(
+							'Mini Cart in cart and checkout pages',
+							'woo-gutenberg-products-block'
+						) }
+						value={ renderInCartAndCheckout }
+						onChange={ ( value ) => {
+							setAttributes( { renderInCartAndCheckout: value } );
+						} }
+						help={ __(
+							'Select how the Mini Cart behaves in the Cart and Checkout pages. This might affect the header layout.',
+							'woo-gutenberg-products-block'
+						) }
+					>
+						<ToggleGroupControlOption
+							value={ false }
+							label={ __(
+								'Make invisible',
+								'woo-gutenberg-products-block'
+							) }
+						/>
+						<ToggleGroupControlOption
+							value={ true }
+							label={ __(
+								"Don't render",
+								'woo-gutenberg-products-block'
+							) }
+						/>
+					</ToggleGroupControl>
 				</PanelBody>
 				{ templatePartEditUri && (
 					<PanelBody

--- a/assets/js/blocks/mini-cart/index.tsx
+++ b/assets/js/blocks/mini-cart/index.tsx
@@ -61,9 +61,9 @@ const settings: BlockConfiguration = {
 			type: 'boolean',
 			default: false,
 		},
-		renderInCartAndCheckout: {
+		makeInvisibleInCartAndCheckout: {
 			type: 'boolean',
-			default: false,
+			default: true,
 		},
 	},
 

--- a/assets/js/blocks/mini-cart/index.tsx
+++ b/assets/js/blocks/mini-cart/index.tsx
@@ -61,14 +61,12 @@ const settings: BlockConfiguration = {
 			type: 'boolean',
 			default: false,
 		},
-		makeInvisibleInCartAndCheckout: {
-			type: 'boolean',
-			default: true,
+		cartAndCheckoutRenderStyle: {
+			type: 'string',
+			default: 'hidden',
 		},
 	},
-
 	edit,
-
 	save() {
 		return null;
 	},

--- a/assets/js/blocks/mini-cart/index.tsx
+++ b/assets/js/blocks/mini-cart/index.tsx
@@ -61,6 +61,10 @@ const settings: BlockConfiguration = {
 			type: 'boolean',
 			default: false,
 		},
+		renderInCartAndCheckout: {
+			type: 'boolean',
+			default: false,
+		},
 	},
 
 	edit,

--- a/assets/js/blocks/mini-cart/style.scss
+++ b/assets/js/blocks/mini-cart/style.scss
@@ -218,3 +218,8 @@ h2.wc-block-mini-cart__title {
 .admin-bar .wp-block-woocommerce-filled-mini-cart-contents-block {
 	height: calc(100vh - 32px);
 }
+
+.wc-block-mini-cart__add-to-cart-behaviour-toggle,
+.wc-block-mini-cart__render-in-cart-and-checkout-toggle {
+	width: 100%;
+}

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -420,7 +420,7 @@ class MiniCart extends AbstractBlock {
 		</span>';
 
 		if ( is_cart() || is_checkout() ) {
-			if ( $this->shouldNotRenderMiniCart( $attributes ) ) {
+			if ( $this->should_not_render_mini_cart( $attributes ) ) {
 				return '';
 			}
 
@@ -579,7 +579,7 @@ class MiniCart extends AbstractBlock {
 	 *
 	 * @return bool
 	 */
-	public function shouldNotRenderMiniCart( array $attributes ) {
+	public function should_not_render_mini_cart( array $attributes ) {
 		return isset( $attributes['makeInvisibleInCartAndCheckout'] ) && false === $attributes['makeInvisibleInCartAndCheckout'];
 	}
 }

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -580,6 +580,6 @@ class MiniCart extends AbstractBlock {
 	 * @return bool
 	 */
 	public function should_not_render_mini_cart( array $attributes ) {
-		return isset( $attributes['makeInvisibleInCartAndCheckout'] ) && false === $attributes['makeInvisibleInCartAndCheckout'];
+		return isset( $attributes['cartAndCheckoutRenderStyle'] ) && 'hidden' !== $attributes['cartAndCheckoutRenderStyle'];
 	}
 }

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -399,7 +399,7 @@ class MiniCart extends AbstractBlock {
 		</span>';
 
 		if ( is_cart() || is_checkout() ) {
-			if ( isset( $attributes['renderInCartAndCheckout'] ) && false === $attributes['renderInCartAndCheckout'] ) {
+			if ( $this->shouldNotRenderMiniCart( $attributes ) ) {
 				return '';
 			}
 
@@ -543,5 +543,16 @@ class MiniCart extends AbstractBlock {
 				'content'  => '<!-- wp:paragraph {"align":"center"} --><p class="has-text-align-center"><strong>' . __( 'Your cart is currently empty!', 'woo-gutenberg-products-block' ) . '</strong></p><!-- /wp:paragraph -->',
 			)
 		);
+	}
+
+	/**
+	 * Returns whether the mini cart should be rendered or not.
+	 *
+	 * @param array $attributes Block attributes.
+	 *
+	 * @return bool
+	 */
+	public function shouldNotRenderMiniCart( array $attributes ) {
+		return isset( $attributes['makeInvisibleInCartAndCheckout'] ) && false === $attributes['makeInvisibleInCartAndCheckout'];
 	}
 }

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -399,6 +399,10 @@ class MiniCart extends AbstractBlock {
 		</span>';
 
 		if ( is_cart() || is_checkout() ) {
+			if ( isset( $attributes['renderInCartAndCheckout'] ) && false === $attributes['renderInCartAndCheckout'] ) {
+				return '';
+			}
+
 			// It is not necessary to load the Mini Cart Block on Cart and Checkout page.
 			return '<div class="' . $wrapper_classes . '" style="visibility:hidden" aria-hidden="true">
 				<button class="wc-block-mini-cart__button" aria-label="' . esc_attr( $aria_label ) . '" disabled>' . $button_html . '</button>


### PR DESCRIPTION
Currently, the `Mini Cart` is hidden with CSS on the Cart & Checkout pages. As discussed on https://github.com/woocommerce/woocommerce-blocks/issues/7760 we want to give the users the option to not render it at all (not only hide it).
This PR add this setting to the `Mini Cart` block and does not render the block when enabled. The default setting is to render it invisible (same behavior as until now) to not affect existing stores.

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/7760
### Screenshots

### Testing
#### User-Facing Testing

**Site Editor**
1. Go to the Site Editor > Template parts and edit the header template to add the `Mini Cart` block. Save.
2. Edit the block and make sure you see the new setting:

<img width="282" alt="Screenshot 2023-03-13 at 16 27 26" src="https://user-images.githubusercontent.com/186112/224748404-6c02b9ef-2112-405b-9ab5-69abe857a03c.png">

3. Make sure the default option is `Hide`.
4. In the store, go to the Cart page and make sure the `Mini Cart` is rendered but invisible. Repeat but for the Checkout page.
5. Go back to the Site Editor, change the `Mini Cart` setting to `Remove`, and save.
6. In the store, go to the Cart page and make sure the `Mini Cart` markup is not rendered at all. Repeat but for the Checkout page.


**Post/page**
1. Create a new post or page.
2. Insert the `Mini Cart`.
3. Make sure the new `Mini Cart in cart and checkout pages` setting does not appear.

### WooCommerce Visibility
* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog
> Mini Cart: add a new setting to allow not rendering the block on the cart & checkout pages.
