### PR TITLE
Remove wc-settings from Mini Cart block dependencies

### DIFF
--- a/assets/js/blocks/mini-cart/frontend.ts
+++ b/assets/js/blocks/mini-cart/frontend.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { getSetting } from '@woocommerce/settings';
 import preloadScript from '@woocommerce/base-utils/preload-script';
 import lazyLoadScript from '@woocommerce/base-utils/lazy-load-script';
 import getNavigationType from '@woocommerce/base-utils/get-navigation-type';
@@ -23,10 +22,10 @@ window.addEventListener( 'load', () => {
 		return;
 	}
 
-	const dependencies = getSetting(
-		'mini_cart_block_frontend_dependencies',
-		{}
-	) as Record< string, dependencyData >;
+	const dependencies = window.wcBlocksMiniCartFrontendDependencies as Record<
+		string,
+		dependencyData
+	>;
 
 	// Preload scripts
 	for ( const dependencyHandle in dependencies ) {

--- a/src/Assets/AssetDataRegistry.php
+++ b/src/Assets/AssetDataRegistry.php
@@ -67,8 +67,8 @@ class AssetDataRegistry {
 	 */
 	protected function init() {
 		add_action( 'init', array( $this, 'register_data_script' ) );
-		add_action( 'wp_print_footer_scripts', array( $this, 'enqueue_asset_data' ), 1 );
-		add_action( 'admin_print_footer_scripts', array( $this, 'enqueue_asset_data' ), 1 );
+		add_action( 'wp_print_footer_scripts', array( $this, 'enqueue_asset_data' ), 2 );
+		add_action( 'admin_print_footer_scripts', array( $this, 'enqueue_asset_data' ), 2 );
 	}
 
 	/**


### PR DESCRIPTION
Part of https://github.com/woocommerce/woocommerce-blocks/issues/7176.

Until now, the Mini Cart block was using `wcSettings` to pass the scripts to lazy load from backend to frontend. That had the issue that we could not lazy-load `wc-settings` and all its dependencies. This PR changes the approach and instead of using `wcSettings`, we directly set a JS variable named `wcBlocksMiniCartFrontendDependencies`.

One side effect from not having `wc-settings` as a dependency is that `wcSettings` variable would be undefined in the frontend. That's because we are only printing it if `wc-settings` is enqueued (see [this code](https://github.com/woocommerce/woocommerce-blocks/blob/01efca15e264a5aa88b1f12a241db37facffbc33/src/Assets/AssetDataRegistry.php#L367)). That was an issue, because we need `wcSettings` to exist when the user interacts with the Mini Cart! To solve it, I used a work-around to enqueue `wc-settings` before `AssetDataRegistry:enqueue_asset_data()` runs, and dequeue it afterwards.

### Testing

#### User Facing Testing

This PR doesn't add any new feature, so testing mostly refers to smoke testing that there are no regressions.

1. Add the Mini Cart block to the header of your store.
2. In the frontend, verify you can open it, interact with its inner blocks (ie: change the quantity of a product, remove a product, etc.).

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

This PR reduces the number of scripts that the Mini Cart block depends on, so it should have a positive impact on stores using it.

### Changelog

> Reduce the number of scripts needed to render a page containing the Mini Cart block
