### PR TITLE
Disable buttons and show spinner when mini cart quantity is updating

### DIFF
--- a/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-cart-button-block/block.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-cart-button-block/block.tsx
@@ -5,6 +5,8 @@ import { CART_URL } from '@woocommerce/block-settings';
 import Button from '@woocommerce/base-components/button';
 import classNames from 'classnames';
 import { useColorProps } from '@woocommerce/base-hooks';
+import { useSelect } from '@wordpress/data';
+import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
 
 /**
  * Internal dependencies
@@ -19,11 +21,15 @@ type MiniCartCartButtonBlockProps = {
 };
 
 const Block = ( {
-	className,
 	cartButtonLabel,
+	className,
 	style,
 }: MiniCartCartButtonBlockProps ): JSX.Element | null => {
 	const colorProps = useColorProps( { style } );
+
+	const isCalculating = useSelect( ( select ) =>
+		select( CHECKOUT_STORE_KEY ).isCalculating()
+	);
 
 	if ( ! CART_URL ) {
 		return null;
@@ -39,6 +45,8 @@ const Block = ( {
 			style={ { ...colorProps.style } }
 			href={ CART_URL }
 			variant={ getVariant( className, 'outlined' ) }
+			showSpinner={ isCalculating }
+			disabled={ isCalculating }
 		>
 			{ cartButtonLabel || defaultCartButtonLabel }
 		</Button>

--- a/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-checkout-button-block/block.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-checkout-button-block/block.tsx
@@ -5,6 +5,8 @@ import { CHECKOUT_URL } from '@woocommerce/block-settings';
 import Button from '@woocommerce/base-components/button';
 import classNames from 'classnames';
 import { useColorProps } from '@woocommerce/base-hooks';
+import { useSelect } from '@wordpress/data';
+import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
 
 /**
  * Internal dependencies
@@ -19,11 +21,15 @@ type MiniCartCheckoutButtonBlockProps = {
 };
 
 const Block = ( {
-	className,
 	checkoutButtonLabel,
+	className,
 	style,
 }: MiniCartCheckoutButtonBlockProps ): JSX.Element | null => {
 	const colorProps = useColorProps( { style } );
+
+	const isCalculating = useSelect( ( select ) =>
+		select( CHECKOUT_STORE_KEY ).isCalculating()
+	);
 
 	if ( ! CHECKOUT_URL ) {
 		return null;
@@ -39,6 +45,8 @@ const Block = ( {
 			variant={ getVariant( className, 'contained' ) }
 			style={ { ...colorProps.style } }
 			href={ CHECKOUT_URL }
+			showSpinner={ isCalculating }
+			disabled={ isCalculating }
 		>
 			{ checkoutButtonLabel || defaultCheckoutButtonLabel }
 		</Button>

--- a/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-footer-block/block.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-footer-block/block.tsx
@@ -13,6 +13,7 @@ import { getIconsFromPaymentMethods } from '@woocommerce/base-utils';
 import { getSetting } from '@woocommerce/settings';
 import { PaymentEventsProvider } from '@woocommerce/base-context';
 import classNames from 'classnames';
+import { select } from '@wordpress/data';
 import { isObject } from '@woocommerce/types';
 
 /**
@@ -37,6 +38,11 @@ interface Props {
 	checkoutButtonLabel: string;
 }
 
+const isCartItemUpdating = () => {
+	const store = select( 'wc/store/cart' );
+	return store.getItemsPendingQuantityUpdate()?.length !== 0;
+};
+
 const hasChildren = ( children ): boolean => {
 	return children.some( ( child ) => {
 		if ( Array.isArray( child ) ) {
@@ -58,6 +64,7 @@ const Block = ( {
 		  parseInt( cartTotals.total_items_tax, 10 )
 		: parseInt( cartTotals.total_items, 10 );
 
+	const cartItemUpdating = isCartItemUpdating();
 	const hasButtons = hasChildren( children );
 
 	return (
@@ -79,9 +86,15 @@ const Block = ( {
 					children
 				) : (
 					<>
-						<CartButton cartButtonLabel={ cartButtonLabel } />
+						<CartButton
+							cartButtonLabel={ cartButtonLabel }
+							disabled={ cartItemUpdating }
+							showSpinner={ cartItemUpdating }
+						/>
 						<CheckoutButton
 							checkoutButtonLabel={ checkoutButtonLabel }
+							disabled={ cartItemUpdating }
+							showSpinner={ cartItemUpdating }
 						/>
 					</>
 				) }

--- a/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-footer-block/block.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-footer-block/block.tsx
@@ -13,8 +13,9 @@ import { getIconsFromPaymentMethods } from '@woocommerce/base-utils';
 import { getSetting } from '@woocommerce/settings';
 import { PaymentEventsProvider } from '@woocommerce/base-context';
 import classNames from 'classnames';
-import { select } from '@wordpress/data';
+import { useSelect, select } from '@wordpress/data';
 import { isObject } from '@woocommerce/types';
+import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
 
 /**
  * Internal dependencies
@@ -64,7 +65,10 @@ const Block = ( {
 		  parseInt( cartTotals.total_items_tax, 10 )
 		: parseInt( cartTotals.total_items, 10 );
 
-	const cartItemUpdating = isCartItemUpdating();
+	const isCalculating = useSelect( ( select ) =>
+		select( CHECKOUT_STORE_KEY ).isCalculating()
+	);
+
 	const hasButtons = hasChildren( children );
 
 	return (
@@ -88,13 +92,13 @@ const Block = ( {
 					<>
 						<CartButton
 							cartButtonLabel={ cartButtonLabel }
-							disabled={ cartItemUpdating }
-							showSpinner={ cartItemUpdating }
+							disabled={ isCalculating }
+							showSpinner={ isCalculating }
 						/>
 						<CheckoutButton
 							checkoutButtonLabel={ checkoutButtonLabel }
-							disabled={ cartItemUpdating }
-							showSpinner={ cartItemUpdating }
+							disabled={ isCalculating }
+							showSpinner={ isCalculating }
 						/>
 					</>
 				) }

--- a/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-footer-block/block.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-footer-block/block.tsx
@@ -13,9 +13,7 @@ import { getIconsFromPaymentMethods } from '@woocommerce/base-utils';
 import { getSetting } from '@woocommerce/settings';
 import { PaymentEventsProvider } from '@woocommerce/base-context';
 import classNames from 'classnames';
-import { useSelect, select } from '@wordpress/data';
 import { isObject } from '@woocommerce/types';
-import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
 
 /**
  * Internal dependencies
@@ -39,11 +37,6 @@ interface Props {
 	checkoutButtonLabel: string;
 }
 
-const isCartItemUpdating = () => {
-	const store = select( 'wc/store/cart' );
-	return store.getItemsPendingQuantityUpdate()?.length !== 0;
-};
-
 const hasChildren = ( children ): boolean => {
 	return children.some( ( child ) => {
 		if ( Array.isArray( child ) ) {
@@ -64,10 +57,6 @@ const Block = ( {
 		? parseInt( cartTotals.total_items, 10 ) +
 		  parseInt( cartTotals.total_items_tax, 10 )
 		: parseInt( cartTotals.total_items, 10 );
-
-	const isCalculating = useSelect( ( select ) =>
-		select( CHECKOUT_STORE_KEY ).isCalculating()
-	);
 
 	const hasButtons = hasChildren( children );
 
@@ -90,15 +79,9 @@ const Block = ( {
 					children
 				) : (
 					<>
-						<CartButton
-							cartButtonLabel={ cartButtonLabel }
-							disabled={ isCalculating }
-							showSpinner={ isCalculating }
-						/>
+						<CartButton cartButtonLabel={ cartButtonLabel } />
 						<CheckoutButton
 							checkoutButtonLabel={ checkoutButtonLabel }
-							disabled={ isCalculating }
-							showSpinner={ isCalculating }
 						/>
 					</>
 				) }

--- a/assets/js/blocks/mini-cart/style.scss
+++ b/assets/js/blocks/mini-cart/style.scss
@@ -180,6 +180,12 @@ h2.wc-block-mini-cart__title {
 		.wp-block-button {
 			flex-grow: 1;
 			display: inline-flex;
+
+			&:disabled {
+				padding: $gap-large;
+				opacity: 0.6;
+				cursor: auto;
+			}
 		}
 
 		.wc-block-components-button.outlined {


### PR DESCRIPTION
This PR makes the buttons on the `Mini cart` disabled and with a spinner instead of the text when any item quantity is updated.

Fixes https://github.com/woocommerce/woocommerce/issues/42480

### Testing
#### User-Facing Testing

1. Create a new page, add the `Mini cart`, and save.
2. Go to the frontend and add some products to the cart. 
3. Click the `Mini cart` button to open the sidebar.
4. Increase or decrease the quantity of the product with the `+` or `-` buttons.
5. Check the buttons become disabled and with a spinner while the request to update the quantity is happening.

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix: disable the Mini Cart buttons while updating the product quantities.
