### PR TITLE
Ignore shipping address from server when updating shipping methods

### DIFF
--- a/assets/js/data/cart/actions.ts
+++ b/assets/js/data/cart/actions.ts
@@ -417,7 +417,7 @@ export const selectShippingRate =
 				},
 				cache: 'no-store',
 			} );
-			dispatch.receiveCart( response );
+			dispatch.receiveCartContents( response );
 			return response as CartResponse;
 		} catch ( error ) {
 			dispatch.receiveError( error );


### PR DESCRIPTION
Uses `receiveCartContents` to prevent address data overwriting data in the client.

### Testing

#### User Facing Testing

1. Fill out your shipping address. Wait a few moments for it to persist to server.
2. Clear the first name field. There will be a validation error.
3. Select a different shipping method.
4. When the totals are updated, confirm the first name field is still empty.

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Prevent address data being overwritten when changing shipping methods.
