### PR TITLE
Enable the compatibility layer when Product Meta, Product Price and Breadcrumbs blocks are added

### DIFF
--- a/src/Templates/SingleProductTemplateCompatibility.php
+++ b/src/Templates/SingleProductTemplateCompatibility.php
@@ -287,8 +287,7 @@ class SingleProductTemplateCompatibility extends AbstractTemplateCompatibility {
 		$parsed_blocks  = parse_blocks( $template_content );
 		$grouped_blocks = self::group_blocks( $parsed_blocks );
 
-		// @todo Check this list before terminating the Blockfied Single Product Template project.
-		$single_product_template_blocks = array( 'woocommerce/product-image-gallery', 'woocommerce/product-details', 'woocommerce/add-to-cart-form' );
+		$single_product_template_blocks = array( 'woocommerce/product-image-gallery', 'woocommerce/product-details', 'woocommerce/add-to-cart-form', 'woocommerce/product-meta', 'woocommerce/product-price', 'woocommerce/breadcrumbs' );
 
 		$wrapped_blocks = array_map(
 			function( $blocks ) use ( $single_product_template_blocks ) {


### PR DESCRIPTION
This PR enables the Compatibility layer when Product Meta, Product Price and Breadcrumbs blocks are added.

This is necessary because the compatibility layer removes the default hooks that prevent the rendering of these blocks.

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Switch to the TT3 theme.
2. Go to the Site Editor, and edit the Single Product Template.
3. Add the Product Meta, Product Price and Breadcrumbs blocks **inside** the group block.
4. Add the Product Meta, Product Price and Breadcrumbs blocks **outside** the group block.
5. Save.
6. Go to the frontend and check that all the blocks are visible.

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental


