### PR TITLE
Fix Attribute terms sometimes being assigned children

### DIFF
--- a/assets/js/editor-components/search-list-control/types.ts
+++ b/assets/js/editor-components/search-list-control/types.ts
@@ -43,6 +43,9 @@ export type SearchListItem = {
 	parent: number;
 	termId?: string | number;
 	value: string;
+	// This is to avoid a problem with overlapping
+	// ids with terms and their parents.
+	// For more context: https://github.com/woocommerce/woocommerce-blocks/pull/8720
 } & (
 	| { id: string | number; termId?: never }
 	| { id?: never; termId: string | number }

--- a/assets/js/editor-components/search-list-control/types.ts
+++ b/assets/js/editor-components/search-list-control/types.ts
@@ -38,11 +38,15 @@ export type SearchListItem = {
 	breadcrumbs: string[];
 	children?: SearchListItem[];
 	count: number;
-	id: string | number;
+	id?: string | number;
 	name: string;
 	parent: number;
+	termId?: string | number;
 	value: string;
-};
+} & (
+	| { id: string | number; termId?: never }
+	| { id?: never; termId: string | number }
+ );
 
 export interface SearchListItemsContainerProps
 	extends SearchListControlProps,

--- a/assets/js/editor-components/search-list-control/utils.tsx
+++ b/assets/js/editor-components/search-list-control/utils.tsx
@@ -61,6 +61,7 @@ export const buildTermsTree = (
 			// If the object has `termId` property, it is an `AttributeTerm`.
 			// Those can't have children, but sometimes they have the same `id`
 			// as an `AttributeObject`, causing possible overlaps.
+			// For more context: https://github.com/woocommerce/woocommerce-blocks/pull/8720
 			const children = term.termId ? null : termsByParent[ id ];
 			builtParents.push( '' + id );
 			return {

--- a/assets/js/editor-components/search-list-control/utils.tsx
+++ b/assets/js/editor-components/search-list-control/utils.tsx
@@ -57,8 +57,12 @@ export const buildTermsTree = (
 
 	const fillWithChildren = ( terms: SearchListItem[] ): SearchListItem[] => {
 		return terms.map( ( term ) => {
-			const children = termsByParent[ term.id ];
-			builtParents.push( '' + term.id );
+			const id = ( term.id ?? term.termId ) as string | number;
+			// If the object has `termId` property, it is an `AttributeTerm`.
+			// Those can't have children, but sometimes they have the same `id`
+			// as an `AttributeObject`, causing possible overlaps.
+			const children = term.termId ? null : termsByParent[ id ];
+			builtParents.push( '' + id );
 			return {
 				...term,
 				breadcrumbs: getParentsName( listById[ term.parent ] ),

--- a/assets/js/utils/attributes.ts
+++ b/assets/js/utils/attributes.ts
@@ -55,14 +55,20 @@ export const convertAttributeObjectToSearchItem = (
 ): SearchListItem => {
 	const { count, id, name, parent } = attribute;
 
+	const base = isAttributeTerm( attribute )
+		? {
+				termId: id,
+				value: attribute.attr_slug,
+		  }
+		: { id, value: '' };
+
 	return {
+		...base,
 		count,
-		id,
 		name,
 		parent,
 		breadcrumbs: [],
 		children: [],
-		value: isAttributeTerm( attribute ) ? attribute.attr_slug : '',
 	};
 };
 


### PR DESCRIPTION
Attribute terms (e.g. “Blue”, “Yellow”) have their own `id` property which sometimes can overlap with their Taxonomy `id` (e.g. in the test case, “Blue” had the same `id` as the “Size” taxonomy), and the function building the tree representation for the `SearchListControl` would erroneously assign children to it.

To fix this, we do an ugly patch here: we rename the `id` key of `AttributeTerm` when changed to a `SearchListItem` to `termId` instead, so we can differentiate. We do this because other items passed to `SearchListControl` might possibly have several layers of children, but we are sure that in the case of terms, we only have on level deep.

This may need a better refactoring at some point.

Fixes woocommerce/woocommerce#42438

### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

0. Use https://github.com/nielslange/woo-test-environment to spin a new test environment (this is required because it is known to create overlapping ids).
1. Add a Products (Beta) block to your page.
2. Open the Inspector Controls and add a “Product Attributes” advanced filter.
3. Uncollapse “Color”.
4. Make sure “Blue” doesn't appear as a collapsible item.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
