### PR TITLE
Add `woocommerce_cart_item_permalink` filter to cart item endpoint

### DIFF
--- a/src/StoreApi/Schemas/V1/CartItemSchema.php
+++ b/src/StoreApi/Schemas/V1/CartItemSchema.php
@@ -335,6 +335,20 @@ class CartItemSchema extends ProductSchema {
 	public function get_item_response( $cart_item ) {
 		$product = $cart_item['data'];
 
+		/**
+		 * Filter the product permalink.
+		 *
+		 * This is a hook taken from the legacy cart/mini-cart templates that allows the permalink to be changed for a
+		 * product. This is specific to the cart endpoint.
+		 *
+		 * @since 9.9.0
+		 *
+		 * @param string $product_permalink Product permalink.
+		 * @param array  $cart_item         Cart item array.
+		 * @param string $cart_item_key     Cart item key.
+		 */
+		$product_permalink = apply_filters( 'woocommerce_cart_item_permalink', $product->get_permalink(), $cart_item, $cart_item['key'] );
+
 		return [
 			'key'                  => $cart_item['key'],
 			'id'                   => $product->get_id(),
@@ -348,7 +362,7 @@ class CartItemSchema extends ProductSchema {
 			'backorders_allowed'   => (bool) $product->backorders_allowed(),
 			'show_backorder_badge' => (bool) $product->backorders_require_notification() && $product->is_on_backorder( $cart_item['quantity'] ),
 			'sold_individually'    => $product->is_sold_individually(),
-			'permalink'            => $product->get_permalink(),
+			'permalink'            => $product_permalink,
 			'images'               => $this->get_images( $product ),
 			'variation'            => $this->format_variation_data( $cart_item['variation'], $product ),
 			'item_data'            => $this->get_item_data( $cart_item ),


### PR DESCRIPTION
Applies the `woocommerce_cart_item_permalink` filter from core (cart templates) to the cart item schema in the Store API. This allows the permalink back to product pages from the cart to be modified.

Fixes #8119

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

This is developer facing. You can test this by adding some code:

```php
add_filter( 'woocommerce_cart_item_permalink', function( $permalink ) {
     return add_query_arg( 'test', 'working', $permalink );
} );
```

After which all links back to product pages from the block cart will have `?test=working` after the product URL.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Store API - Apply `woocommerce_cart_item_permalink` filter to cart item permalinks.
