### PR TITLE
Display pickup location details in order confirmations

### DIFF
--- a/src/Shipping/ShippingController.php
+++ b/src/Shipping/ShippingController.php
@@ -59,6 +59,7 @@ class ShippingController {
 		add_action( 'admin_enqueue_scripts', [ $this, 'hydrate_client_settings' ] );
 		add_action( 'woocommerce_load_shipping_methods', array( $this, 'register_local_pickup' ) );
 		add_filter( 'woocommerce_local_pickup_methods', array( $this, 'register_local_pickup_method' ) );
+		add_filter( 'woocommerce_order_hide_shipping_address', array( $this, 'hide_shipping_address_for_local_pickup' ), 10 );
 		add_filter( 'woocommerce_customer_taxable_address', array( $this, 'filter_taxable_address' ) );
 		add_filter( 'woocommerce_shipping_packages', array( $this, 'filter_shipping_packages' ) );
 		add_filter( 'pre_update_option_woocommerce_pickup_location_settings', array( $this, 'flush_cache' ) );
@@ -339,6 +340,16 @@ class ShippingController {
 	public function register_local_pickup_method( $methods ) {
 		$methods[] = 'pickup_location';
 		return $methods;
+	}
+
+	/**
+	 * Hides the shipping address on the order confirmation page when local pickup is selected.
+	 *
+	 * @param array $pickup_methods Method ids.
+	 * @return array
+	 */
+	public function hide_shipping_address_for_local_pickup( $pickup_methods ) {
+		return array_merge( $pickup_methods, LocalPickupUtils::get_local_pickup_method_ids() );
 	}
 
 	/**

--- a/src/Shipping/ShippingController.php
+++ b/src/Shipping/ShippingController.php
@@ -107,22 +107,29 @@ class ShippingController {
 	 * @return string
 	 */
 	public function show_local_pickup_details( $return, $order ) {
+		// Confirm order is valid before proceeding further.
+		if ( ! $order instanceof \WC_Order ) {
+			return $return;
+		}
+
 		$shipping_method_ids = ArrayUtil::select( $order->get_shipping_methods(), 'get_method_id', ArrayUtil::SELECT_BY_OBJECT_METHOD );
 		$shipping_method_id  = current( $shipping_method_ids );
 
-		if ( 'pickup_location' === $shipping_method_id ) {
-			$shipping_method = current( $order->get_shipping_methods() );
-			$details         = $shipping_method->get_meta( 'pickup_details' );
-			$location        = $shipping_method->get_meta( 'pickup_location' );
-			$address         = $shipping_method->get_meta( 'pickup_address' );
-			$return          = sprintf(
-				// Translators: %s location name.
-				__( 'Pickup from <strong>%s</strong>:', 'woo-gutenberg-products-block' ),
-				$location
-			) . '<br/><address>' . str_replace( ',', ',<br/>', $address ) . '</address><br/>' . $details;
+		// Ensure order used pickup location method, otherwise bail.
+		if ( 'pickup_location' !== $shipping_method_id ) {
+			return $return;
 		}
 
-		return $return;
+		$shipping_method = current( $order->get_shipping_methods() );
+		$details         = $shipping_method->get_meta( 'pickup_details' );
+		$location        = $shipping_method->get_meta( 'pickup_location' );
+		$address         = $shipping_method->get_meta( 'pickup_address' );
+
+		return sprintf(
+			// Translators: %s location name.
+			__( 'Pickup from <strong>%s</strong>:', 'woo-gutenberg-products-block' ),
+			$location
+		) . '<br/><address>' . str_replace( ',', ',<br/>', $address ) . '</address><br/>' . $details;
 	}
 
 	/**

--- a/tests/e2e/specs/shopper/cart-checkout/checkout.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/checkout.test.js
@@ -118,7 +118,10 @@ describe( 'Shopper → Checkout', () => {
 			expect( page ).toMatch( 'Woo Collection' );
 			await shopper.block.fillBillingDetails( BILLING_DETAILS );
 			await shopper.block.placeOrder();
-			await shopper.block.verifyBillingDetails( BILLING_DETAILS );
+			await shopper.block.verifyBillingDetails(
+				BILLING_DETAILS,
+				'.woocommerce-customer-details address'
+			);
 		} );
 	} );
 

--- a/tests/e2e/specs/shopper/cart-checkout/checkout.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/checkout.test.js
@@ -147,6 +147,9 @@ describe( 'Shopper → Checkout', () => {
 	} );
 
 	describe( 'Shipping and Billing Addresses', () => {
+		const NORMAL_SHIPPING_NAME = 'Normal Shipping';
+		const NORMAL_SHIPPING_PRICE = '$20.00';
+
 		beforeAll( async () => {
 			await preventCompatibilityNotice();
 			await merchant.login();
@@ -189,6 +192,10 @@ describe( 'Shopper → Checkout', () => {
 			);
 			await shopper.block.fillShippingDetails( SHIPPING_DETAILS );
 			await shopper.block.fillBillingDetails( BILLING_DETAILS );
+			await shopper.block.selectAndVerifyShippingOption(
+				NORMAL_SHIPPING_NAME,
+				NORMAL_SHIPPING_PRICE
+			);
 			await shopper.block.placeOrder();
 			await shopper.block.verifyShippingDetails( SHIPPING_DETAILS );
 			await shopper.block.verifyBillingDetails( BILLING_DETAILS );

--- a/tests/utils/shopper.js
+++ b/tests/utils/shopper.js
@@ -323,7 +323,7 @@ export const shopper = {
 
 		// prettier-ignore
 		verifyBillingDetails: async ( customerBillingDetails ) => {
-			await page.waitForSelector( '.woocommerce-customer-details' );
+			await page.waitForSelector( '.woocommerce-customer-details address' );
 			await Promise.all( [
 				expect( page ).toMatch(
 					customerBillingDetails.firstname
@@ -347,7 +347,7 @@ export const shopper = {
 		// prettier-ignore
 		verifyShippingDetails: async ( customerShippingDetails ) => {
 			await page.waitForSelector(
-				'.woocommerce-customer-details'
+				'.woocommerce-customer-details address'
 			);
 			await Promise.all( [
 				expect( page ).toMatch(

--- a/tests/utils/shopper.js
+++ b/tests/utils/shopper.js
@@ -322,8 +322,8 @@ export const shopper = {
 		},
 
 		// prettier-ignore
-		verifyBillingDetails: async ( customerBillingDetails ) => {
-			await page.waitForSelector( '.woocommerce-customer-details address' );
+		verifyBillingDetails: async ( customerBillingDetails, selector = '.woocommerce-column--billing-address' ) => {
+			await page.waitForSelector( selector );
 			await Promise.all( [
 				expect( page ).toMatch(
 					customerBillingDetails.firstname
@@ -347,7 +347,7 @@ export const shopper = {
 		// prettier-ignore
 		verifyShippingDetails: async ( customerShippingDetails ) => {
 			await page.waitForSelector(
-				'.woocommerce-customer-details address'
+				'.woocommerce-column--shipping-address'
 			);
 			await Promise.all( [
 				expect( page ).toMatch(

--- a/tests/utils/shopper.js
+++ b/tests/utils/shopper.js
@@ -323,7 +323,7 @@ export const shopper = {
 
 		// prettier-ignore
 		verifyBillingDetails: async ( customerBillingDetails ) => {
-			await page.waitForSelector( '.woocommerce-column--billing-address' );
+			await page.waitForSelector( '.woocommerce-customer-details' );
 			await Promise.all( [
 				expect( page ).toMatch(
 					customerBillingDetails.firstname
@@ -347,7 +347,7 @@ export const shopper = {
 		// prettier-ignore
 		verifyShippingDetails: async ( customerShippingDetails ) => {
 			await page.waitForSelector(
-				'.woocommerce-column--shipping-address'
+				'.woocommerce-customer-details'
 			);
 			await Promise.all( [
 				expect( page ).toMatch(


### PR DESCRIPTION
This PR enhances the order confirmation page and emails with some extra details about pickup when using the Local Pickup shipping method. Since the filters are used by both emails and the page, we only need a single solution.

Fixes #8246
Fixes #8245

### Screenshots

![Screenshot 2023-03-14 at 12 09 54](https://user-images.githubusercontent.com/90977/224999426-4b72ee18-2a86-4dbb-a764-7995022065ff.png)

![Screenshot 2023-03-14 at 12 09 47](https://user-images.githubusercontent.com/90977/224999438-6a914f5d-6196-4d93-aa50-f4af6c018d61.png)

### Testing

#### User Facing Testing

1. Place an order using the checkout block, selecting Local Pickup as your shipping method.

![Screenshot 2023-03-14 at 12 22 05](https://user-images.githubusercontent.com/90977/224999661-9fda7cbe-fa46-4094-a8b3-f12cd2564382.png)

2. Check the order confirmation page shows pickup details.
3. Confirm the order confirmation page hides the "shipping address".
4. Check the order email confirmation shows the same pickup details.

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Display pickup location details in order confirmations
