### PR TITLE
Lockfile Maintenance 2023-03-14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
 	"packages": {
 		"": {
 			"name": "@woocommerce/block-library",
-			"version": "9.8.0-dev",
+			"version": "9.9.0-dev",
 			"hasInstallScript": true,
 			"license": "GPL-3.0+",
 			"dependencies": {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
Irons out lockfile updates to keep a clean working tree on a new `npm install`.

Currently, the lockfile is using the `@woocommerce/block-library` package at version `9.8.0-dev`. This update bumps that dependency version to `9.9.0-dev`.

<!-- Reference any related issues or PRs here -->

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Re-install packages (`npm install`)
2. Confirm `package-lock.json` file does not have any changes after packages are installed.
3. Run environment (`npm run build` and `npm start`) to confirm everything is still working as expected.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental