### PR TITLE
Add a higher z-index than the title for mini cart close button

### DIFF
--- a/assets/js/base/components/drawer/style.scss
+++ b/assets/js/base/components/drawer/style.scss
@@ -119,6 +119,7 @@ $drawer-width-mobile: 100vw;
 		color: inherit;
 		position: absolute;
 		opacity: 0.6;
+		z-index: 2;
 		// The SVG has some white spacing around, thus we have to set this magic number.
 		right: 8px;
 		top: 0;


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/8735

The title of the mini has a higher precedence (z-index) over the close button and thus is covering it. This PR adds a z-index to the close button so it will surface on top of the title so it can be seen and clicked.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
| ![](https://user-images.githubusercontent.com/2132595/225042863-9ad1bcd6-d1c1-4df5-8a77-2e2768f88220.png)       | ![](https://user-images.githubusercontent.com/2132595/225042526-13da907d-472f-4bb0-9fe0-7d17905a7dc4.png)      |

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Use TwentyTwentyThree theme.
2. Go to apperance->editor
3. Add the mini-cart block to the header. Save.
4. In the frontend click on the mini-cart to open up the drawer.
5. Ensure you see the X close button and that you can click on it to close the drawer.


* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix mini-cart block close button not showing