### PR TITLE
Fix Local pickup e2e tests

### DIFF
--- a/tests/e2e/specs/merchant/local-pickup.test.ts
+++ b/tests/e2e/specs/merchant/local-pickup.test.ts
@@ -254,12 +254,8 @@ describe( `Local Pickup Settings`, () => {
 				'New City'
 			);
 			await page.select(
-				'.components-modal__content select[name="location_country"]',
+				'.components-modal__content select[name="location_country_state"]',
 				'United Kingdom (UK)'
-			);
-			await expect( page ).toFill(
-				'.components-modal__content input[name="location_state"]',
-				'New State'
 			);
 			await expect( page ).toFill(
 				'.components-modal__content input[name="location_postcode"]',

--- a/tests/e2e/specs/merchant/local-pickup.test.ts
+++ b/tests/e2e/specs/merchant/local-pickup.test.ts
@@ -253,6 +253,7 @@ describe( `Local Pickup Settings`, () => {
 				'.components-modal__content input[name="location_city"]',
 				'New City'
 			);
+			// We merged the Country and State fields into the same field in the local pickup modal.
 			await page.select(
 				'.components-modal__content select[name="location_country_state"]',
 				'United Kingdom (UK)'

--- a/tests/utils/merchant.ts
+++ b/tests/utils/merchant.ts
@@ -101,7 +101,7 @@ export const merchant = {
 		);
 		await expect( page ).toSelect(
 			'select[name="location_country_state"]',
-			'US'
+			'United States (US) — California'
 		);
 		await expect( page ).toClick( 'button', { text: 'Done' } );
 		await merchant.saveLocalPickupSettingsPageWithRefresh();

--- a/tests/utils/merchant.ts
+++ b/tests/utils/merchant.ts
@@ -100,10 +100,9 @@ export const merchant = {
 			'Collect from store'
 		);
 		await expect( page ).toSelect(
-			'select[name="location_country"]',
+			'select[name="location_country_state"]',
 			'US'
 		);
-		await expect( page ).toSelect( 'select[name="location_state"]', 'CA' );
 		await expect( page ).toClick( 'button', { text: 'Done' } );
 		await merchant.saveLocalPickupSettingsPageWithRefresh();
 	},


### PR DESCRIPTION
This PR fixes the following failed e2e tests:
- User does not see shipping rates until full address is entered
- Local Pickup Settings › Location Settings › can add a new location
- Local Pickup Settings › Location Settings › can delete a location

We removed the `location_state` select input and changed `location_country` to `location_country_state` select input in #8408 that was causing the e2e to fail. 

## Changes in the PR
- Change `location_country` select input to `location_country_state` select input in e2e tests.
- Remove `location_state` select input in e2e tests.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.



### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests

#### Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->


1. Run `npm run test:e2e -- tests/e2e/specs/merchant/local-pickup.test.ts`
2. Confirm all the tests are getting passed. 
3. Run `npm run test:e2e -- tests/e2e/specs/shopper/cart-checkout/checkout.test.js`
2. Confirm all the tests are getting passed. 

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->
