### PR TITLE
fix: disable compatibility layer for block themes that have a default block template

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -538,9 +538,7 @@ class BlockTemplatesController {
 		}
 
 		if (
-			is_singular( 'product' ) &&
-			! BlockTemplateUtils::theme_has_template( 'single-product' ) &&
-			$this->block_template_is_available( 'single-product' )
+			is_singular( 'product' ) && $this->block_template_is_available( 'single-product' )
 		) {
 			$templates = get_block_templates( array( 'slug__in' => array( 'single-product' ) ) );
 
@@ -548,11 +546,11 @@ class BlockTemplatesController {
 				add_filter( 'woocommerce_disable_compatibility_layer', '__return_true' );
 			}
 
-			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
+			if ( ! BlockTemplateUtils::theme_has_template( 'single-product' ) ) {
+				add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
+			}
 		} elseif (
-			( is_product_taxonomy() && is_tax( 'product_cat' ) ) &&
-			! BlockTemplateUtils::theme_has_template( 'taxonomy-product_cat' ) &&
-			$this->block_template_is_available( 'taxonomy-product_cat' )
+			( is_product_taxonomy() && is_tax( 'product_cat' ) ) && $this->block_template_is_available( 'taxonomy-product_cat' )
 		) {
 			$templates = get_block_templates( array( 'slug__in' => array( 'taxonomy-product_cat' ) ) );
 
@@ -560,11 +558,11 @@ class BlockTemplatesController {
 				add_filter( 'woocommerce_disable_compatibility_layer', '__return_true' );
 			}
 
-			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
+			if ( ! BlockTemplateUtils::theme_has_template( 'taxonomy-product_cat' ) ) {
+				add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
+			}
 		} elseif (
-			( is_product_taxonomy() && is_tax( 'product_tag' ) ) &&
-			! BlockTemplateUtils::theme_has_template( 'taxonomy-product_tag' ) &&
-			$this->block_template_is_available( 'taxonomy-product_tag' )
+			( is_product_taxonomy() && is_tax( 'product_tag' ) ) && $this->block_template_is_available( 'taxonomy-product_tag' )
 		) {
 			$templates = get_block_templates( array( 'slug__in' => array( 'taxonomy-product_tag' ) ) );
 
@@ -572,11 +570,11 @@ class BlockTemplatesController {
 				add_filter( 'woocommerce_disable_compatibility_layer', '__return_true' );
 			}
 
-			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
+			if ( ! BlockTemplateUtils::theme_has_template( 'taxonomy-product_tag' ) ) {
+				add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
+			}
 		} elseif (
-			( is_post_type_archive( 'product' ) || is_page( wc_get_page_id( 'shop' ) ) ) &&
-			! BlockTemplateUtils::theme_has_template( 'archive-product' ) &&
-			$this->block_template_is_available( 'archive-product' )
+			( is_post_type_archive( 'product' ) || is_page( wc_get_page_id( 'shop' ) ) ) && $this->block_template_is_available( 'archive-product' )
 		) {
 			$templates = get_block_templates( array( 'slug__in' => array( 'archive-product' ) ) );
 
@@ -584,16 +582,16 @@ class BlockTemplatesController {
 				add_filter( 'woocommerce_disable_compatibility_layer', '__return_true' );
 			}
 
-			add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
+			if ( ! BlockTemplateUtils::theme_has_template( 'archive-product' ) ) {
+				add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
+			}
 		} else {
 			$queried_object = get_queried_object();
 			if ( is_null( $queried_object ) ) {
 				return;
 			}
 
-			if ( isset( $queried_object->taxonomy ) && taxonomy_is_product_attribute( $queried_object->taxonomy ) &&
-				! BlockTemplateUtils::theme_has_template( ProductAttributeTemplate::SLUG ) &&
-				$this->block_template_is_available( ProductAttributeTemplate::SLUG )
+			if ( isset( $queried_object->taxonomy ) && taxonomy_is_product_attribute( $queried_object->taxonomy ) && $this->block_template_is_available( ProductAttributeTemplate::SLUG )
 			) {
 				$templates = get_block_templates( array( 'slug__in' => array( ProductAttributeTemplate::SLUG ) ) );
 
@@ -601,7 +599,9 @@ class BlockTemplatesController {
 					add_filter( 'woocommerce_disable_compatibility_layer', '__return_true' );
 				}
 
-				add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
+				if ( ! BlockTemplateUtils::theme_has_template( ProductAttributeTemplate::SLUG ) ) {
+					add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This PR disables the compatibility layer for all block themes. Before, we disabled the compatibility layer only for the theme that didn't have a default block template.

The Classic Product Template isn't rendered because we override all the "default" actions when the compatibility layer is enabled.


<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #8753


### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Active TT3.
2. Be sure that the Single Product Template has no custom change.
3. Go on a product and ensure the Single Product Template is loaded.
4. Active Tsubaki theme (or a theme that has the Single Product Template defined) 
5. Be sure that the Single Product Template has no custom change.
6. Go on a product and ensure the Single Product Template is loaded.



* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix Single Product page not visible in block themes that provided a custom template.