### PR TITLE
Change the property name of the attribute slug in Products By Attribute

### DIFF
--- a/assets/js/blocks/products-by-attribute/edit-mode.tsx
+++ b/assets/js/blocks/products-by-attribute/edit-mode.tsx
@@ -55,7 +55,7 @@ export const ProductsByAttributeEditMode = (
 					selected={ blockAttributes.attributes }
 					onChange={ ( value = [] ) => {
 						const result = value.map(
-							( { id, attr_slug: attributeSlug } ) => ( {
+							( { id, value: attributeSlug } ) => ( {
 								id,
 								attr_slug: attributeSlug,
 							} )


### PR DESCRIPTION
### Issue
As of 9.8.0 Products by Attribute block renders empty.

### Cause
Due to refactoring done in https://github.com/woocommerce/woocommerce-blocks/pull/8583, the properties returned by SearchListItem changed and didn't match the Products by Attribute interface.

Due to that, `attr_slug` was not sent to the backend and there was an empty response, so the block was rendered empty.

Fixes #8755 

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|   https://user-images.githubusercontent.com/69596988/225275711-08ed4adf-e3a6-4b4d-9b15-273d6a213dd5.gif     | https://user-images.githubusercontent.com/20098064/225292710-aef2075f-87c2-428e-a703-91e32e956b6b.mov |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. Add new Post
2. Add Products by Attribute block
3. Choose some attributes
4. Click Done
5. **Expected:** Block renders correctly and preview the products
6. Publish post and confirm it looks the same in the frontend

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Products by Attributes: Fix the block rendered empty in the Editor
