### PR TITLE
Add the ability to change the background and text colors of the Mini Cart block "Start shopping" button.

### DIFF
--- a/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-shopping-button-block/block.json
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-shopping-button-block/block.json
@@ -9,7 +9,11 @@
 		"html": false,
 		"multiple": false,
 		"reusable": false,
-		"inserter": true
+		"inserter": true,
+		"color": {
+			"text": true,
+			"background": true
+		}
 	},
 	"attributes": {
 		"lock": {

--- a/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-shopping-button-block/edit.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-shopping-button-block/edit.tsx
@@ -22,22 +22,23 @@ export const Edit = ( {
 	const { startShoppingButtonLabel } = attributes;
 
 	return (
-		<div { ...blockProps }>
-			<div className="wp-block-button aligncenter">
-				<Button className="wc-block-mini-cart__shopping-button">
-					<RichText
-						multiline={ false }
-						allowedFormats={ [] }
-						value={ startShoppingButtonLabel }
-						placeholder={ defaultStartShoppingButtonLabel }
-						onChange={ ( content ) => {
-							setAttributes( {
-								startShoppingButtonLabel: content,
-							} );
-						} }
-					/>
-				</Button>
-			</div>
+		<div className="wp-block-button aligncenter">
+			<Button
+				{ ...blockProps }
+				className="wc-block-mini-cart__shopping-button"
+			>
+				<RichText
+					multiline={ false }
+					allowedFormats={ [] }
+					value={ startShoppingButtonLabel }
+					placeholder={ defaultStartShoppingButtonLabel }
+					onChange={ ( content ) => {
+						setAttributes( {
+							startShoppingButtonLabel: content,
+						} );
+					} }
+				/>
+			</Button>
 		</div>
 	);
 };


### PR DESCRIPTION
This PR adds the ability to add styles to the `Start shopping` button on the empty `Mini cart` block.
It is part of https://github.com/woocommerce/woocommerce-blocks/issues/8736, the `View my cart` and `Go to checkout` buttons will be addressed on a separate PR.

### Testing
#### User-Facing Testing

1. Add the `Mini cart` block to the header template of your site.
2. Go to the `Site Editor` and edit the `Mini cart` template part.
3. Open the `List view` and select the `Empty Mini Cart view`.
4. Click on the `Start shopping` button and check that you can change the background and text colors of the button.
5. Change both of them and save.
6. Go to the frontend and check the button has the colors you just picked on the editor.

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Add the ability to change the background and text colors of the Mini Cart block "Start shopping" button.
