### PR TITLE
Fix `isDescendentOfSingleProductTemplate` check

### DIFF
--- a/assets/js/atomic/blocks/product-elements/price/edit.tsx
+++ b/assets/js/atomic/blocks/product-elements/price/edit.tsx
@@ -56,11 +56,10 @@ const PriceEdit = ( {
 	const isDescendentOfSingleProductTemplate = useSelect(
 		( select ) => {
 			const store = select( 'core/edit-site' );
-			const postId = store?.getEditedPostId();
+			const postId = store?.getEditedPostId< string | undefined >();
 
 			return (
-				( postId === 'woocommerce/woocommerce//product-meta' ||
-					postId === 'woocommerce/woocommerce//single-product' ) &&
+				postId?.includes( '//single-product' ) &&
 				! isDescendentOfQueryLoop
 			);
 		},


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

This PR fixes the `isDescendentOfSingleProductTemplate` check.

When the block template has a Single Product Template, the slug is: `${name_template}//single-product`. For this reason, I updated the check. Also, I removed another check because it belonged to an old implementation of the Product Meta template parts (https://github.com/woocommerce/woocommerce-blocks/issues/8465#issuecomment-1453624651).


<!-- Reference any related issues or PRs here -->

Fixes #8743

### Testing

#### Automated Tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Restore the Single Product Template.
2. Enable a theme that has a custom single Product Template defined (eg. Tsubaki theme)
3. Edit the Single Product Template.
4. Edit the template via code and insert [this markup](https://gist.github.com/gigitux/e9323d6d280313f528996e34d62ae626) via the code editor -> check the gif below
5. Ensure the Product Price block doesn't render the product selector.

https://user-images.githubusercontent.com/4463174/224718658-3e506441-486f-4659-8353-fcff3f0c5d7a.mov


* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

