### PR TITLE
Change the example of GET products by category from category name to ID

### DIFF
--- a/src/StoreApi/docs/products.md
+++ b/src/StoreApi/docs/products.md
@@ -23,7 +23,7 @@ GET /products?parent_exclude=10
 GET /products?type=simple
 GET /products?sku=sku-1,sku-2
 GET /products?featured=true
-GET /products?category=t-shirts
+GET /products?category=22
 GET /products?product-taxonomy=product-taxonomy-term-id
 GET /products?tag=special-items
 GET /products?attributes[0][attribute]=pa_color&attributes[0][slug]=red


### PR DESCRIPTION
When trying to reproduce the issue https://github.com/woocommerce/woocommerce-blocks/issues/8765 I couldn't get the products by category using Store API because the example was showing to put category slug, while expected is category ID.

### Testing

#### User Facing Testing

1. You can confirm the change makes sense by:
2. Choose some category and check its slug and ID:
3. Run `curl <<STORE DOMAIN>>/wp-json/wc/store/v1/products?category=<<CATEGORY SLUG>>` -> you should get an empty array - no products
4. Run `curl <<STORE DOMAIN>>/wp-json/wc/store/v1/products?category=<<CATEGORY ID>>` -> you should get an array of products from this cateogry

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Store API docs: improve example of products by category query
