### PR TITLE
Fix issue that prevented spaces being added to Mini Cart, Cart and Checkout buttons

### DIFF
--- a/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/edit.tsx
+++ b/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/edit.tsx
@@ -4,12 +4,8 @@
 import { useRef } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import Button from '@woocommerce/base-components/button';
-import {
-	InspectorControls,
-	RichText,
-	useBlockProps,
-} from '@wordpress/block-editor';
+import EditableButton from '@woocommerce/editor-components/editable-button';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import PageSelector from '@woocommerce/editor-components/page-selector';
 import { CART_PAGE_ID } from '@woocommerce/block-settings';
 
@@ -68,19 +64,16 @@ export const Edit = ( {
 					/>
 				) }
 			</InspectorControls>
-			<Button className="wc-block-cart__submit-button">
-				<RichText
-					multiline={ false }
-					allowedFormats={ [] }
-					value={ buttonLabel }
-					placeholder={ defaultButtonLabel }
-					onChange={ ( content ) => {
-						setAttributes( {
-							buttonLabel: content,
-						} );
-					} }
-				/>
-			</Button>
+			<EditableButton
+				className="wc-block-cart__submit-button"
+				value={ buttonLabel }
+				placeholder={ defaultButtonLabel }
+				onChange={ ( content ) => {
+					setAttributes( {
+						buttonLabel: content,
+					} );
+				} }
+			/>
 		</div>
 	);
 };

--- a/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/edit.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/edit.tsx
@@ -4,17 +4,13 @@
 import { useRef } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import {
-	InspectorControls,
-	useBlockProps,
-	RichText,
-} from '@wordpress/block-editor';
+import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import PageSelector from '@woocommerce/editor-components/page-selector';
 import { PanelBody, ToggleControl } from '@wordpress/components';
 import { CHECKOUT_PAGE_ID } from '@woocommerce/block-settings';
 import { getSetting } from '@woocommerce/settings';
 import { ReturnToCartButton } from '@woocommerce/base-components/cart-checkout';
-import Button from '@woocommerce/base-components/button';
+import EditableButton from '@woocommerce/editor-components/editable-button';
 import Noninteractive from '@woocommerce/base-components/noninteractive';
 
 /**
@@ -104,19 +100,16 @@ export const Edit = ( {
 						/>
 					) }
 				</Noninteractive>
-				<Button className="wc-block-cart__submit-button wc-block-components-checkout-place-order-button">
-					<RichText
-						multiline={ false }
-						allowedFormats={ [] }
-						value={ placeOrderButtonLabel }
-						placeholder={ defaultPlaceOrderButtonLabel }
-						onChange={ ( content ) => {
-							setAttributes( {
-								placeOrderButtonLabel: content,
-							} );
-						} }
-					/>
-				</Button>
+				<EditableButton
+					className="wc-block-cart__submit-button wc-block-components-checkout-place-order-button"
+					value={ placeOrderButtonLabel }
+					placeholder={ defaultPlaceOrderButtonLabel }
+					onChange={ ( content ) => {
+						setAttributes( {
+							placeOrderButtonLabel: content,
+						} );
+					} }
+				/>
 			</div>
 		</div>
 	);

--- a/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-footer-block/edit.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-footer-block/edit.tsx
@@ -3,8 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { TotalsItem } from '@woocommerce/blocks-checkout';
-import Button from '@woocommerce/base-components/button';
-import { useBlockProps, RichText } from '@wordpress/block-editor';
+import EditableButton from '@woocommerce/editor-components/editable-button';
+import { useBlockProps } from '@wordpress/block-editor';
 import { getCurrencyFromPriceResponse } from '@woocommerce/price-format';
 import {
 	usePaymentMethods,
@@ -64,35 +64,27 @@ export const Edit = ( {
 					) }
 				/>
 				<div className="wc-block-mini-cart__footer-actions">
-					<Button
+					<EditableButton
 						className="wc-block-mini-cart__footer-cart"
 						variant="outlined"
-					>
-						<RichText
-							multiline={ false }
-							allowedFormats={ [] }
-							value={ cartButtonLabel }
-							placeholder={ defaultCartButtonLabel }
-							onChange={ ( content ) => {
-								setAttributes( {
-									cartButtonLabel: content,
-								} );
-							} }
-						/>
-					</Button>
-					<Button className="wc-block-mini-cart__footer-checkout">
-						<RichText
-							multiline={ false }
-							allowedFormats={ [] }
-							value={ checkoutButtonLabel }
-							placeholder={ defaultCheckoutButtonLabel }
-							onChange={ ( content ) => {
-								setAttributes( {
-									checkoutButtonLabel: content,
-								} );
-							} }
-						/>
-					</Button>
+						value={ cartButtonLabel }
+						placeholder={ defaultCartButtonLabel }
+						onChange={ ( content ) => {
+							setAttributes( {
+								cartButtonLabel: content,
+							} );
+						} }
+					/>
+					<EditableButton
+						className="wc-block-mini-cart__footer-checkout"
+						value={ checkoutButtonLabel }
+						placeholder={ defaultCheckoutButtonLabel }
+						onChange={ ( content ) => {
+							setAttributes( {
+								checkoutButtonLabel: content,
+							} );
+						} }
+					/>
 				</div>
 				<PaymentEventsProvider>
 					<PaymentMethodIconsElement />

--- a/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-shopping-button-block/edit.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-shopping-button-block/edit.tsx
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
-import { useBlockProps, RichText } from '@wordpress/block-editor';
-import Button from '@woocommerce/base-components/button';
+import { useBlockProps } from '@wordpress/block-editor';
+import EditableButton from '@woocommerce/editor-components/editable-button';
 
 /**
  * Internal dependencies
@@ -23,22 +23,17 @@ export const Edit = ( {
 
 	return (
 		<div className="wp-block-button aligncenter">
-			<Button
+			<EditableButton
 				{ ...blockProps }
 				className="wc-block-mini-cart__shopping-button"
-			>
-				<RichText
-					multiline={ false }
-					allowedFormats={ [] }
-					value={ startShoppingButtonLabel }
-					placeholder={ defaultStartShoppingButtonLabel }
-					onChange={ ( content ) => {
-						setAttributes( {
-							startShoppingButtonLabel: content,
-						} );
-					} }
-				/>
-			</Button>
+				value={ startShoppingButtonLabel }
+				placeholder={ defaultStartShoppingButtonLabel }
+				onChange={ ( content ) => {
+					setAttributes( {
+						startShoppingButtonLabel: content,
+					} );
+				} }
+			/>
 		</div>
 	);
 };

--- a/assets/js/editor-components/editable-button/index.tsx
+++ b/assets/js/editor-components/editable-button/index.tsx
@@ -1,0 +1,88 @@
+/**
+ * External dependencies
+ */
+import { useEffect, useRef } from '@wordpress/element';
+import Button, { ButtonProps } from '@woocommerce/base-components/button';
+import { RichText } from '@wordpress/block-editor';
+import type { RefObject } from 'react';
+
+export interface EditableButtonProps
+	extends Omit< ButtonProps, 'onChange' | 'placeholder' | 'value' > {
+	/**
+	 * Button variant
+	 */
+	onChange: ( value: string ) => void;
+	/**
+	 * The placeholder of the editable button.
+	 */
+	placeholder?: string;
+	/**
+	 * The current value of the editable button.
+	 */
+	value: string;
+}
+
+const EditableButton = ( {
+	onChange,
+	placeholder,
+	value,
+	...props
+}: EditableButtonProps ) => {
+	const button: RefObject< HTMLButtonElement > = useRef( null );
+
+	// Fix a bug in Firefox that didn't allow to type spaces in editable buttons.
+	// @see https://github.com/woocommerce/woocommerce-blocks/issues/8734
+	useEffect( () => {
+		const buttonEl = button?.current;
+
+		if ( ! buttonEl ) {
+			return;
+		}
+
+		const onKeyDown = ( event: KeyboardEvent ) => {
+			// If the user typed something different than space. Abort.
+			if ( event.code !== 'Space' ) {
+				return;
+			}
+			event.preventDefault();
+			const selection = buttonEl.ownerDocument.getSelection();
+			if ( selection && selection.rangeCount > 0 ) {
+				// Get the caret position and insert a space.
+				const range = selection.getRangeAt( 0 );
+				range.deleteContents();
+				const textNode = document.createTextNode( ' ' );
+				range.insertNode( textNode );
+				// Set the caret position after the space.
+				range.setStartAfter( textNode );
+				range.setEndAfter( textNode );
+				selection.removeAllRanges();
+				selection.addRange( range );
+			}
+		};
+
+		buttonEl.addEventListener( 'keydown', onKeyDown );
+
+		return () => {
+			if ( ! buttonEl ) {
+				return;
+			}
+			buttonEl.removeEventListener( 'keydown', onKeyDown );
+		};
+	}, [ onChange, value ] );
+
+	return (
+		<Button { ...props }>
+			<span ref={ button }>
+				<RichText
+					multiline={ false }
+					allowedFormats={ [] }
+					value={ value }
+					placeholder={ placeholder }
+					onChange={ onChange }
+				/>
+			</span>
+		</Button>
+	);
+};
+
+export default EditableButton;

--- a/assets/js/editor-components/editable-button/index.tsx
+++ b/assets/js/editor-components/editable-button/index.tsx
@@ -9,7 +9,7 @@ import type { RefObject } from 'react';
 export interface EditableButtonProps
 	extends Omit< ButtonProps, 'onChange' | 'placeholder' | 'value' > {
 	/**
-	 * Button variant
+	 * On change callback.
 	 */
 	onChange: ( value: string ) => void;
 	/**
@@ -40,7 +40,7 @@ const EditableButton = ( {
 		}
 
 		const onKeyDown = ( event: KeyboardEvent ) => {
-			// If the user typed something different than space. Abort.
+			// If the user typed something different than space, do nothing.
 			if ( event.code !== 'Space' ) {
 				return;
 			}


### PR DESCRIPTION
Fixes #8734.

This PR:
* Creates a new component (`EditableButton`) that can be used to replace buttons containing a `RichText` component. They were used in the editor side of the Mini Cart, Cart and Checkout blocks to customize the text of the buttons.
* Inside this new component, adds a work-around to a Firefox bug that didn't allow to type <kbd>Space</kbd> in `contenteditable` elements inside buttons ([see Firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1822860)). Ideally, when the bug is fixed in Firefox, we should be able to remove this work-around.

### Testing

#### User Facing Testing

1. With Firefox, add the Cart block to a post or page.
2. In the editor, press the _Proceed to Checkout_ button to edit the text to something like: _Go to payment_ (or any string containing spaces).
3. Verify the text is updated correctly and spaces are added as expected.
4. Preview the page in the frontend and verify the button text is correct as well.
5. Repeat steps 1-4 with the Checkout and Mini Cart blocks. (For the Mini Cart, you will need to edit its template part)

* [ ] Do not include in the Testing Notes

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix issue that prevented spaces being added to Mini Cart, Cart and Checkout buttons in Firefox.
