### PR TITLE
Allow themes to remove the Mini Cart title on overridden template parts

### DIFF
--- a/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/filled-mini-cart-contents-block/block.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/filled-mini-cart-contents-block/block.tsx
@@ -1,5 +1,0 @@
-const Block = ( { children }: { children: JSX.Element } ): JSX.Element => {
-	return <>{ children }</>;
-};
-
-export default Block;

--- a/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/register-components.ts
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/register-components.ts
@@ -41,6 +41,7 @@ registerCheckoutBlock( {
 
 registerCheckoutBlock( {
 	metadata: miniCartTitleMetadata,
+	force: false,
 	component: lazy(
 		() =>
 			import(

--- a/packages/checkout/blocks-registry/register-checkout-block.ts
+++ b/packages/checkout/blocks-registry/register-checkout-block.ts
@@ -6,7 +6,6 @@ import { registerBlockComponent } from '@woocommerce/blocks-registry';
 /**
  * Internal dependencies
  */
-import type { CheckoutBlockOptions } from './types';
 import {
 	assertBlockName,
 	assertBlockParent,
@@ -14,6 +13,7 @@ import {
 	assertBlockComponent,
 } from './utils';
 import { registeredBlocks } from './registered-blocks';
+import type { CheckoutBlockOptions } from './types';
 
 /**
  * Main API for registering a new checkout block within areas.
@@ -34,6 +34,13 @@ export const registerCheckoutBlock = (
 		component: options.component,
 	} );
 
+	// Infer the `force` value from whether the block is locked or not. But
+	// allow overriding it on block registration.
+	const force =
+		typeof options.force === 'boolean'
+			? options.force
+			: Boolean( options.metadata?.attributes?.lock?.default?.remove );
+
 	/**
 	 * Store block metadata for later lookup.
 	 */
@@ -41,6 +48,6 @@ export const registerCheckoutBlock = (
 		blockName: options.metadata.name,
 		metadata: options.metadata,
 		component: options.component,
-		force: !! options.metadata?.attributes?.lock?.default?.remove,
+		force,
 	};
 };

--- a/packages/checkout/blocks-registry/types.ts
+++ b/packages/checkout/blocks-registry/types.ts
@@ -46,6 +46,7 @@ export type RegisteredBlocks = Record< string, RegisteredBlock >;
 
 export type CheckoutBlockOptions = {
 	metadata: CheckoutBlockOptionsMetadata;
+	force?: boolean;
 	component:
 		| LazyExoticComponent< React.ComponentType< unknown > >
 		| ( () => JSX.Element | null )


### PR DESCRIPTION
This PR allows themes to have a Mini Cart template part that doesn't contain the Mini Cart Title block (issue reported by @dinhtungdu).

### Testing

#### User Facing Testing

1. With a block theme, add a `mini-cart.html` file under `/parts` directory with these contents:
```HTML
<!-- wp:woocommerce/mini-cart-contents -->
<div class="wp-block-woocommerce-mini-cart-contents">
	<!-- wp:woocommerce/filled-mini-cart-contents-block -->
	<div class="wp-block-woocommerce-filled-mini-cart-contents-block">
		<!-- wp:woocommerce/mini-cart-items-block -->
		<div class="wp-block-woocommerce-mini-cart-items-block">
			<!-- wp:woocommerce/mini-cart-products-table-block -->
			<div class="wp-block-woocommerce-mini-cart-products-table-block">
			</div>
			<!-- /wp:woocommerce/mini-cart-products-table-block -->
		</div>
		<!-- /wp:woocommerce/mini-cart-items-block -->
		<!-- wp:woocommerce/mini-cart-footer-block -->
		<div class="wp-block-woocommerce-mini-cart-footer-block">
		</div>
		<!-- /wp:woocommerce/mini-cart-footer-block -->
	</div>
	<!-- /wp:woocommerce/filled-mini-cart-contents-block -->

	<!-- wp:woocommerce/empty-mini-cart-contents-block -->
	<div class="wp-block-woocommerce-empty-mini-cart-contents-block">
		<!-- wp:pattern {"slug":"woocommerce/mini-cart-empty-cart-message"} /-->

		<!-- wp:woocommerce/mini-cart-shopping-button-block -->
		<div class="wp-block-woocommerce-mini-cart-shopping-button-block"></div>
		<!-- /wp:woocommerce/mini-cart-shopping-button-block -->
	</div>
	<!-- /wp:woocommerce/empty-mini-cart-contents-block -->
</div>
<!-- /wp:woocommerce/mini-cart-contents -->
```
2. Go to Appearance > Editor > Template Parts > Mini Cart and verify the Mini Cart Title block is not there.
3. Add the Mini Cart block to the header of your store (if you don't have it yet).
4. Go to the frontend and add some products to your cart.
5. Open the Mini Cart and verify the Mini Cart Title is not rendered.

Before | After
--- | ---
![imatge](https://user-images.githubusercontent.com/3616980/225932894-70dbc939-2e3a-497a-b280-96482842963d.png) | ![imatge](https://user-images.githubusercontent.com/3616980/225932820-2a012252-91e1-46f6-807a-48e0f1e64c1d.png)

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Allow themes to remove the Mini Cart title on overridden template parts.
