### PR TITLE
Filter by Stock and Filter by Rating: Fix the potential endless redirection loop when used on a search results page

### DIFF
--- a/assets/js/blocks/rating-filter/block.tsx
+++ b/assets/js/blocks/rating-filter/block.tsx
@@ -139,10 +139,17 @@ const RatingFilterBlock = ( {
 		}
 
 		if ( checkedRatings.length === 0 ) {
+			/**
+			 * .replace() was added as removeQueryArgs() function uses decodeURIcomponent method
+			 * which doesn't encode single quotes (') while it was still encoded in the original URL (%27).
+			 * So when the single quote was in a query param, for example as a search term, it caused
+			 * endless redirection loop.
+			 * More context: https://github.com/woocommerce/woocommerce-blocks/issues/8707
+			 */
 			const url = removeQueryArgs(
 				window.location.href,
 				QUERY_PARAM_KEY
-			);
+			).replace( /'/g, '%27' );
 
 			if ( url !== window.location.href ) {
 				changeUrl( url );

--- a/assets/js/blocks/rating-filter/block.tsx
+++ b/assets/js/blocks/rating-filter/block.tsx
@@ -26,7 +26,7 @@ import FilterSubmitButton from '@woocommerce/base-components/filter-submit-butto
 import FilterResetButton from '@woocommerce/base-components/filter-reset-button';
 import FormTokenField from '@woocommerce/base-components/form-token-field';
 import { addQueryArgs, removeQueryArgs } from '@wordpress/url';
-import { changeUrl, encodeSearchTerm } from '@woocommerce/utils';
+import { changeUrl, normalizeQueryParams } from '@woocommerce/utils';
 import classnames from 'classnames';
 import { difference } from 'lodash';
 import type { ReactElement } from 'react';
@@ -144,7 +144,7 @@ const RatingFilterBlock = ( {
 				QUERY_PARAM_KEY
 			);
 
-			if ( url !== encodeSearchTerm( window.location.href ) ) {
+			if ( url !== normalizeQueryParams( window.location.href ) ) {
 				changeUrl( url );
 			}
 
@@ -155,7 +155,7 @@ const RatingFilterBlock = ( {
 			[ QUERY_PARAM_KEY ]: checkedRatings.join( ',' ),
 		} );
 
-		if ( newUrl === encodeSearchTerm( window.location.href ) ) {
+		if ( newUrl === normalizeQueryParams( window.location.href ) ) {
 			return;
 		}
 

--- a/assets/js/blocks/rating-filter/block.tsx
+++ b/assets/js/blocks/rating-filter/block.tsx
@@ -26,7 +26,7 @@ import FilterSubmitButton from '@woocommerce/base-components/filter-submit-butto
 import FilterResetButton from '@woocommerce/base-components/filter-reset-button';
 import FormTokenField from '@woocommerce/base-components/form-token-field';
 import { addQueryArgs, removeQueryArgs } from '@wordpress/url';
-import { changeUrl } from '@woocommerce/utils';
+import { changeUrl, encodeSearchTerm } from '@woocommerce/utils';
 import classnames from 'classnames';
 import { difference } from 'lodash';
 import type { ReactElement } from 'react';
@@ -139,19 +139,12 @@ const RatingFilterBlock = ( {
 		}
 
 		if ( checkedRatings.length === 0 ) {
-			/**
-			 * .replace() was added as removeQueryArgs() function uses decodeURIcomponent method
-			 * which doesn't encode single quotes (') while it was still encoded in the original URL (%27).
-			 * So when the single quote was in a query param, for example as a search term, it caused
-			 * endless redirection loop.
-			 * More context: https://github.com/woocommerce/woocommerce-blocks/issues/8707
-			 */
 			const url = removeQueryArgs(
 				window.location.href,
 				QUERY_PARAM_KEY
-			).replace( /'/g, '%27' );
+			);
 
-			if ( url !== window.location.href ) {
+			if ( url !== encodeSearchTerm( window.location.href ) ) {
 				changeUrl( url );
 			}
 
@@ -162,7 +155,7 @@ const RatingFilterBlock = ( {
 			[ QUERY_PARAM_KEY ]: checkedRatings.join( ',' ),
 		} );
 
-		if ( newUrl === window.location.href ) {
+		if ( newUrl === encodeSearchTerm( window.location.href ) ) {
 			return;
 		}
 

--- a/assets/js/blocks/stock-filter/block.tsx
+++ b/assets/js/blocks/stock-filter/block.tsx
@@ -35,7 +35,7 @@ import { addQueryArgs, removeQueryArgs } from '@wordpress/url';
 import {
 	changeUrl,
 	PREFIX_QUERY_ARG_FILTER_TYPE,
-	encodeSearchTerm,
+	normalizeQueryParams,
 } from '@woocommerce/utils';
 import { difference } from 'lodash';
 import classnames from 'classnames';
@@ -228,7 +228,7 @@ const StockStatusFilterBlock = ( {
 				QUERY_PARAM_KEY
 			);
 
-			if ( url !== encodeSearchTerm( window.location.href ) ) {
+			if ( url !== normalizeQueryParams( window.location.href ) ) {
 				changeUrl( url );
 			}
 
@@ -239,7 +239,7 @@ const StockStatusFilterBlock = ( {
 			[ QUERY_PARAM_KEY ]: checkedOptions.join( ',' ),
 		} );
 
-		if ( newUrl === encodeSearchTerm( window.location.href ) ) {
+		if ( newUrl === normalizeQueryParams( window.location.href ) ) {
 			return;
 		}
 

--- a/assets/js/blocks/stock-filter/block.tsx
+++ b/assets/js/blocks/stock-filter/block.tsx
@@ -32,7 +32,11 @@ import isShallowEqual from '@wordpress/is-shallow-equal';
 import { decodeEntities } from '@wordpress/html-entities';
 import { isBoolean, objectHasProp } from '@woocommerce/types';
 import { addQueryArgs, removeQueryArgs } from '@wordpress/url';
-import { changeUrl, PREFIX_QUERY_ARG_FILTER_TYPE } from '@woocommerce/utils';
+import {
+	changeUrl,
+	PREFIX_QUERY_ARG_FILTER_TYPE,
+	encodeSearchTerm,
+} from '@woocommerce/utils';
 import { difference } from 'lodash';
 import classnames from 'classnames';
 
@@ -219,19 +223,12 @@ const StockStatusFilterBlock = ( {
 			return;
 		}
 		if ( checkedOptions.length === 0 ) {
-			/**
-			 * .replace() was added as removeQueryArgs() function uses decodeURIcomponent method
-			 * which doesn't encode single quotes (') while it was still encoded in the original URL (%27).
-			 * So when the single quote was in a query param, for example as a search term, it caused
-			 * endless redirection loop.
-			 * More context: https://github.com/woocommerce/woocommerce-blocks/issues/8707
-			 */
 			const url = removeQueryArgs(
 				window.location.href,
 				QUERY_PARAM_KEY
-			).replace( /'/g, '%27' );
+			);
 
-			if ( url !== window.location.href ) {
+			if ( url !== encodeSearchTerm( window.location.href ) ) {
 				changeUrl( url );
 			}
 
@@ -242,7 +239,7 @@ const StockStatusFilterBlock = ( {
 			[ QUERY_PARAM_KEY ]: checkedOptions.join( ',' ),
 		} );
 
-		if ( newUrl === window.location.href ) {
+		if ( newUrl === encodeSearchTerm( window.location.href ) ) {
 			return;
 		}
 

--- a/assets/js/blocks/stock-filter/block.tsx
+++ b/assets/js/blocks/stock-filter/block.tsx
@@ -219,10 +219,17 @@ const StockStatusFilterBlock = ( {
 			return;
 		}
 		if ( checkedOptions.length === 0 ) {
+			/**
+			 * .replace() was added as removeQueryArgs() function uses decodeURIcomponent method
+			 * which doesn't encode single quotes (') while it was still encoded in the original URL (%27).
+			 * So when the single quote was in a query param, for example as a search term, it caused
+			 * endless redirection loop.
+			 * More context: https://github.com/woocommerce/woocommerce-blocks/issues/8707
+			 */
 			const url = removeQueryArgs(
 				window.location.href,
 				QUERY_PARAM_KEY
-			);
+			).replace( /'/g, '%27' );
 
 			if ( url !== window.location.href ) {
 				changeUrl( url );

--- a/assets/js/utils/filters.ts
+++ b/assets/js/utils/filters.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { getQueryArg, addQueryArgs } from '@wordpress/url';
+import { getQueryArg, getQueryArgs, addQueryArgs } from '@wordpress/url';
 import { getSettingWithCoercion } from '@woocommerce/settings';
 import { isBoolean } from '@woocommerce/types';
 
@@ -41,16 +41,11 @@ export function changeUrl( newUrl: string ) {
 }
 
 /**
- * Extract the search term from query params and encode it.
+ * Run the query params through buildQueryString to normalise the params.
  *
  * @param {string} url URL to encode the search param from.
  */
-export const encodeSearchTerm = ( url: string ) => {
-	const searchTerm = getQueryArg( url, 's' );
-	if ( searchTerm ) {
-		return addQueryArgs( url, {
-			s: searchTerm,
-		} );
-	}
-	return url;
+export const normalizeQueryParams = ( url: string ) => {
+	const queryArgs = getQueryArgs( url );
+	return addQueryArgs( url, queryArgs );
 };

--- a/assets/js/utils/filters.ts
+++ b/assets/js/utils/filters.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { getQueryArg } from '@wordpress/url';
+import { getQueryArg, addQueryArgs } from '@wordpress/url';
 import { getSettingWithCoercion } from '@woocommerce/settings';
 import { isBoolean } from '@woocommerce/types';
 
@@ -39,3 +39,18 @@ export function changeUrl( newUrl: string ) {
 		window.history.replaceState( {}, '', newUrl );
 	}
 }
+
+/**
+ * Extract the search term from query params and encode it.
+ *
+ * @param {string} url URL to encode the search param from.
+ */
+export const encodeSearchTerm = ( url: string ) => {
+	const searchTerm = getQueryArg( url, 's' );
+	if ( searchTerm ) {
+		return addQueryArgs( url, {
+			s: searchTerm,
+		} );
+	}
+	return url;
+};

--- a/assets/js/utils/test/filters.js
+++ b/assets/js/utils/test/filters.js
@@ -1,0 +1,27 @@
+/**
+ * Internal dependencies
+ */
+import { normalizeQueryParams } from '../filters';
+
+describe( 'normalizeQueryParams', () => {
+	test( 'does not change url if there is no query params', () => {
+		const input = 'https://example.com';
+		const expected = 'https://example.com';
+
+		expect( normalizeQueryParams( input ) ).toBe( expected );
+	} );
+
+	test( 'does not change search term if there is no special character', () => {
+		const input = 'https://example.com?foo=bar&s=asdf1234&baz=qux';
+		const expected = 'https://example.com?foo=bar&s=asdf1234&baz=qux';
+
+		expect( normalizeQueryParams( input ) ).toBe( expected );
+	} );
+
+	test( 'decodes single quote characters', () => {
+		const input = 'https://example.com?foo=bar%27&s=asd%27f1234&baz=qux%27';
+		const expected = "https://example.com?foo=bar'&s=asd'f1234&baz=qux'";
+
+		expect( normalizeQueryParams( input ) ).toBe( expected );
+	} );
+} );


### PR DESCRIPTION
Issue: https://github.com/woocommerce/woocommerce-blocks/issues/8707

### Problem statement
If we have the widget 'Filter Products by Stock' enabled (), when we search products and the string contains the single quote character `'`, the page gets in an infinite reloading loop.

### Explanation
Single quote character `'`  is not encoded by `componentURIComponents` method ([docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent#description)), while it is encoded in the URL (`%27`). So in the Filter by Stock and Filter by Rating, when there's a comparison of URL after augmenting the query params, the search param was never matching (`s='` vs `s=%27`).

### Solution
The search term is encoded/normalized using `addQueryArgs` which does the encoding under the hood. It's used ONLY for comparison purposes.
One caveat is that calling `addQueryArgs` from `@wordpress/url` runs encoding on each of the query param, not only the one that's added.

### Review
When reviewing please focus on possible security concerns.

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/8707

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|     https://user-images.githubusercontent.com/20098064/226333224-f54927c0-7ed4-4cd8-9bf3-490e45c74ec7.mov  | https://user-images.githubusercontent.com/20098064/226333413-b8aef6b3-dca3-4b23-ac8b-00e9cf6d1070.mov   |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. Enable TT1 theme
2. Go to Appearance -> Widgets 
3. Add there Filter by Stock, Filter by Rating, Active Filters and Product Search blocks
4. Save and go to your store's shop
5. Your blocks should be available in the footer
6. Input in the search term: `'` and then some other random terms including letters, numbers, white space, special characters
7. **Expected:** there's no endless redirections
8. Click on some filters to Filter by Stock and Filter by Rating and confirm there's no redirection loop


* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Filter by Stock and Filter by Rating: Fix the potential endless redirection loop when used on a search results page
