### PR TITLE
Fix Customer Account block doing a 404 request in the frontend

### DIFF
--- a/src/BlockTypes/AbstractBlock.php
+++ b/src/BlockTypes/AbstractBlock.php
@@ -286,7 +286,7 @@ abstract class AbstractBlock {
 	 *
 	 * @see $this->register_block_type()
 	 * @param string $key Data to get, or default to everything.
-	 * @return array|string
+	 * @return array|string|null
 	 */
 	protected function get_block_type_script( $key = null ) {
 		$script = [

--- a/src/BlockTypes/CustomerAccount.php
+++ b/src/BlockTypes/CustomerAccount.php
@@ -95,7 +95,7 @@ class CustomerAccount extends AbstractBlock {
 	 *
 	 * @param array $attributes Block attributes.
 	 *
-	 * @return string Label to render on the block
+	 * @return string Label to render on the block.
 	 */
 	private function render_label( $attributes ) {
 		if ( self::ICON_ONLY === $attributes['displayStyle'] ) {
@@ -105,5 +105,16 @@ class CustomerAccount extends AbstractBlock {
 		return get_current_user_id()
 			? __( 'My Account', 'woo-gutenberg-products-block' )
 			: __( 'Login', 'woo-gutenberg-products-block' );
+	}
+
+	/**
+	 * Get the frontend script handle for this block type.
+	 *
+	 * @param string $key Data to get, or default to everything.
+	 *
+	 * @return null This block has no frontend script.
+	 */
+	protected function get_block_type_script( $key = null ) {
+		return null;
 	}
 }


### PR DESCRIPTION
Fixes #8643.

### Testing

#### User Facing Testing

1. With a block theme like [TT3](https://wordpress.org/themes/twentytwentythree/), add the Customer Account block to the header of your site.
2. Go to the frontend and open the _Network_ tab in the browser devtools (<kbd>F12</kbd>).
3. Verify there is no request to `build/customer-account-frontend.js` which returns 404.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix Customer Account block doing a 404 request in the frontend.
