### PR TITLE
[WIP] Add margin support to Mini Cart contents block

### DIFF
--- a/assets/js/base/components/drawer/style.scss
+++ b/assets/js/base/components/drawer/style.scss
@@ -54,8 +54,6 @@ $drawer-animation-duration: 0.3s;
 }
 
 .wc-block-components-drawer {
-	@include with-translucent-border(0 0 0 1px);
-	background: #fff;
 	display: block;
 	height: 100%;
 	left: 100%;

--- a/assets/js/blocks/mini-cart/frontend.ts
+++ b/assets/js/blocks/mini-cart/frontend.ts
@@ -175,10 +175,27 @@ window.addEventListener( 'load', () => {
 	const style = document.createElement( 'style' );
 	const backgroundColor = getComputedStyle( document.body ).backgroundColor;
 
+	/**
+	 * Prevent the Mini Cart drawer overflowing the viewport if it has top or
+	 * bottom margins.
+	 */
+	const miniCartContents = document.querySelector(
+		'.wp-block-woocommerce-mini-cart-contents'
+	);
+	let miniCartContentsMarginTop = '0';
+	let miniCartContentsMarginBottom = '0';
+	if ( miniCartContents ) {
+		miniCartContentsMarginTop =
+			getComputedStyle( miniCartContents ).marginTop;
+		miniCartContentsMarginBottom =
+			getComputedStyle( miniCartContents ).marginBottom;
+	}
+
 	style.appendChild(
 		document.createTextNode(
 			`:where(.wp-block-woocommerce-mini-cart-contents) {
 				background-color: ${ backgroundColor };
+				max-height: calc(100% - ${ miniCartContentsMarginTop } - ${ miniCartContentsMarginBottom });
 			}`
 		)
 	);

--- a/assets/js/blocks/mini-cart/frontend.ts
+++ b/assets/js/blocks/mini-cart/frontend.ts
@@ -175,27 +175,10 @@ window.addEventListener( 'load', () => {
 	const style = document.createElement( 'style' );
 	const backgroundColor = getComputedStyle( document.body ).backgroundColor;
 
-	/**
-	 * Prevent the Mini Cart drawer overflowing the viewport if it has top or
-	 * bottom margins.
-	 */
-	const miniCartContents = document.querySelector(
-		'.wp-block-woocommerce-mini-cart-contents'
-	);
-	let miniCartContentsMarginTop = '0';
-	let miniCartContentsMarginBottom = '0';
-	if ( miniCartContents ) {
-		miniCartContentsMarginTop =
-			getComputedStyle( miniCartContents ).marginTop;
-		miniCartContentsMarginBottom =
-			getComputedStyle( miniCartContents ).marginBottom;
-	}
-
 	style.appendChild(
 		document.createTextNode(
 			`:where(.wp-block-woocommerce-mini-cart-contents) {
 				background-color: ${ backgroundColor };
-				max-height: calc(100% - ${ miniCartContentsMarginTop } - ${ miniCartContentsMarginBottom });
 			}`
 		)
 	);

--- a/assets/js/blocks/mini-cart/mini-cart-contents/index.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/index.tsx
@@ -48,6 +48,9 @@ const settings: BlockConfiguration = {
 				width: true,
 			},
 		} ),
+		spacing: {
+			margin: true,
+		},
 	},
 	attributes,
 	example: {

--- a/assets/js/blocks/mini-cart/style.scss
+++ b/assets/js/blocks/mini-cart/style.scss
@@ -85,11 +85,16 @@
 	}
 }
 
+.wc-block-mini-cart__template-part {
+	display: flex;
+	flex-direction: column;
+	height: 100dvh;
+}
 .wp-block-woocommerce-mini-cart-contents {
 	box-sizing: border-box;
-	height: 100dvh;
+	flex-grow: 1;
+	overflow: hidden;
 	padding: 0;
-	justify-content: center;
 }
 :where(.wp-block-woocommerce-mini-cart-contents) {
 	background: #fff;
@@ -222,13 +227,13 @@ h2.wc-block-mini-cart__title {
 	}
 }
 
-.admin-bar .wp-block-woocommerce-mini-cart-contents {
+.admin-bar .wc-block-mini-cart__template-part {
 	margin-top: 46px;
 	height: calc(100dvh - 46px);
 }
 
 @media only screen and (min-width: 783px) {
-	.admin-bar .wp-block-woocommerce-mini-cart-contents {
+	.admin-bar .wc-block-mini-cart__template-part {
 		margin-top: 32px;
 		height: calc(100dvh - 32px);
 	}

--- a/assets/js/blocks/mini-cart/style.scss
+++ b/assets/js/blocks/mini-cart/style.scss
@@ -228,14 +228,12 @@ h2.wc-block-mini-cart__title {
 }
 
 .admin-bar .wc-block-mini-cart__template-part {
-	margin-top: 46px;
-	height: calc(100dvh - 46px);
+	padding-top: 46px;
 }
 
 @media only screen and (min-width: 783px) {
 	.admin-bar .wc-block-mini-cart__template-part {
-		margin-top: 32px;
-		height: calc(100dvh - 32px);
+		padding-top: 32px;
 	}
 }
 


### PR DESCRIPTION
This PR adds support for adding margin style controls to the Mini Cart overlay via the Mini Cart Contents block.

Fixes woocommerce/woocommerce#42431.

### Testing

#### User Facing Testing

1. Enable a blocks theme, go to Site Editor, and add the `Mini Cart` block to the header.
2. Go to Template Parts and open the `Mini Cart` template.
3. Open the List View, select the `Mini Cart Contents` block and check that in the settings sidebar you can see the `Dimensions` controls.
4. Click the `+` button and add a margin and save the template.
5. Go to the frontend, click on the `Mini Cart` button, and check you see the margin around the drawer.
6. Double check with empty cart, having one product and having many products.

![imatge](https://user-images.githubusercontent.com/3616980/226605586-c3341cf6-bb69-45af-81f0-90275cd8da67.png)

**Known issues**

- This PR is affected by https://github.com/woocommerce/woocommerce-blocks/issues/8716 as well. So when adding a margin, the close button might appear outside of the drawer.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Add margin style controls to the Mini Cart Contents block.
