### PR TITLE
Product SKU: Make the block focusable in editor

### DIFF
--- a/assets/js/atomic/blocks/product-elements/sku/edit.tsx
+++ b/assets/js/atomic/blocks/product-elements/sku/edit.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { useBlockProps } from '@wordpress/block-editor';
 import type { BlockEditProps } from '@wordpress/blocks';
 import EditProductLink from '@woocommerce/editor-components/edit-product-link';
 import { ProductQueryContext as Context } from '@woocommerce/blocks/product-query/types';
@@ -17,6 +18,7 @@ const Edit = ( {
 	setAttributes,
 	context,
 }: BlockEditProps< Attributes > & { context: Context } ): JSX.Element => {
+	const blockProps = useBlockProps();
 	const blockAttrs = {
 		...attributes,
 		...context,
@@ -29,10 +31,10 @@ const Edit = ( {
 	);
 
 	return (
-		<>
+		<div { ...blockProps }>
 			<EditProductLink />
 			<Block { ...blockAttrs } />
-		</>
+		</div>
 	);
 };
 


### PR DESCRIPTION
Product SKU was not focusable, hence not editable. It could be moved around and had no contextual menu etc.

This PR adds this ability.

Fixes partially https://github.com/woocommerce/woocommerce-blocks/issues/8691

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|    <img width="260" alt="image" src="https://user-images.githubusercontent.com/20098064/226637287-abbb037f-72a4-4a9a-ab22-c373a1b6444c.png">    |   <img width="293" alt="image" src="https://user-images.githubusercontent.com/20098064/226637459-81aa5e5e-dbb1-4f07-9005-0c6df80b3058.png">    |

#### User Facing Testing

1. Create a new post
2. Add Products block
3. Add Product SKU block to Products
4. Hover and click on the product
5. **Expected:** Product SKU can be focused on and contextual menu is displayed. Block can be moved up and down to switch places with other blocks.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Product SKU: Make the block focusable in editor
