### PR TITLE
Single Product Block: Fix Product SKU preview

### DIFF
--- a/assets/js/atomic/blocks/product-elements/product-meta/edit.tsx
+++ b/assets/js/atomic/blocks/product-elements/product-meta/edit.tsx
@@ -3,6 +3,7 @@
  */
 import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 import { InnerBlockTemplate } from '@wordpress/blocks';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -10,6 +11,13 @@ import { InnerBlockTemplate } from '@wordpress/blocks';
 import './editor.scss';
 
 const Edit = () => {
+	const isDescendentOfSingleProductTemplate = useSelect( ( select ) => {
+		const store = select( 'core/edit-site' );
+		const postId = store?.getEditedPostId< string | undefined >();
+
+		return postId?.includes( '//single-product' );
+	}, [] );
+
 	const TEMPLATE: InnerBlockTemplate[] = [
 		[
 			'core/group',
@@ -18,7 +26,7 @@ const Edit = () => {
 				[
 					'woocommerce/product-sku',
 					{
-						isDescendentOfSingleProductTemplate: true,
+						isDescendentOfSingleProductTemplate,
 					},
 				],
 				[


### PR DESCRIPTION
⚠️ This PR is blocked by #8610.

Currently, the Product SKU preview is wrong when it is used inside the Single Product Block. This PR fixes this behavior.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|![image](https://user-images.githubusercontent.com/4463174/226673199-ee10eedd-0cb8-4b2e-8492-8888deff5e2f.png)|![image](https://user-images.githubusercontent.com/4463174/226673533-2044b527-035c-4402-b4d7-330677670fb2.png)|

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Add a post/page.
2. Add the Single Product Block.
3. Select a product.
4. Be sure that the Product SKU preview matches to the selected product.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
