### PR TITLE
Prevent `withSidebarNotices` breaking the rules of hooks

### DIFF
--- a/assets/js/blocks/cart-checkout-shared/sidebar-notices/index.tsx
+++ b/assets/js/blocks/cart-checkout-shared/sidebar-notices/index.tsx
@@ -34,11 +34,6 @@ const withSidebarNotices = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
 		const { name: blockName, isSelected: isBlockSelected } = props;
 
-		// Show sidebar notices only when a WooCommerce block is selected.
-		if ( ! blockName.startsWith( 'woocommerce/' ) || ! isBlockSelected ) {
-			return <BlockEdit key="edit" { ...props } />;
-		}
-
 		const [
 			isIncompatiblePaymentGatewaysNoticeDismissed,
 			setIsIncompatiblePaymentGatewaysNoticeDismissed,
@@ -89,6 +84,11 @@ const withSidebarNotices = createHigherOrderComponent(
 				) }
 			</>
 		);
+
+		// Show sidebar notices only when a WooCommerce block is selected.
+		if ( ! blockName.startsWith( 'woocommerce/' ) || ! isBlockSelected ) {
+			return <BlockEdit key="edit" { ...props } />;
+		}
 
 		return (
 			<>


### PR DESCRIPTION
Fixes the following console warning:

```
react-dom.js?ver=18.2.0:73 Warning: Internal React error: Expected static flag was missing. Please notify the React team.
    at https://woo.test/wp-content/plugins/woo-blocks/build/cart.js?ver=3b7459a31f63baa6781a01facc45f831:35:2204
    at https://woo.test/wp-content/plugins/woo-blocks/build/cart.js?ver=3b7459a31f63baa6781a01facc45f831:43:12712
    at FilteredComponentRenderer (https://woo.test/wp-includes/js/dist/components.js?ver=44a078ed77cc03c99918:67352:9)
    at BlockEdit (https://woo.test/wp-includes/js/dist/block-editor.js?ver=9f16435421d8488f0b7a:16298:5)
    at BlockCrashBoundary (https://woo.test/wp-includes/js/dist/block-editor.js?ver=9f16435421d8488f0b7a:16657:5)
    at BlockListBlock (https://woo.test/wp-includes/js/dist/block-editor.js?ver=9f16435421d8488f0b7a:17820:12)
```

This is because we are breaking the rules of hooks by returning before they have been executed.

**Steps to reproduce:**

- Activate WP 6.2 RC using the WordPress Beta Tester plugin
- Install [WooCommerce 7.4.1](https://href.li/?https://github.com/woocommerce/woocommerce/releases/tag/7.4.1)
- Activate the latest trunk of WooCommerce blocks.
- Activate any FSE theme.
- Go to Appearance -> Editor
- Add Cart block to the template.
- Open the browser console and select the Cart block on the editor.

### Testing

Repeat the above steps and ensure the console is free of warnings.

### Changelog

> Fix react 18 error in the editor when using cart/checkout blocks.
