### PR TITLE
Adjust response method in checkout route to prevent coupon breakage

### DIFF
--- a/src/StoreApi/Routes/V1/AbstractRoute.php
+++ b/src/StoreApi/Routes/V1/AbstractRoute.php
@@ -93,22 +93,9 @@ abstract class AbstractRoute implements RouteInterface {
 	 */
 	public function get_response( \WP_REST_Request $request ) {
 		$response = null;
+
 		try {
-			switch ( $request->get_method() ) {
-				case 'POST':
-					$response = $this->get_route_post_response( $request );
-					break;
-				case 'PUT':
-				case 'PATCH':
-					$response = $this->get_route_update_response( $request );
-					break;
-				case 'DELETE':
-					$response = $this->get_route_delete_response( $request );
-					break;
-				default:
-					$response = $this->get_route_response( $request );
-					break;
-			}
+			$response = $this->get_response_by_request_method( $request );
 		} catch ( RouteException $error ) {
 			$response = $this->get_route_error_response( $error->getErrorCode(), $error->getMessage(), $error->getCode(), $error->getAdditionalData() );
 		} catch ( InvalidCartException $error ) {
@@ -117,11 +104,26 @@ abstract class AbstractRoute implements RouteInterface {
 			$response = $this->get_route_error_response( 'woocommerce_rest_unknown_server_error', $error->getMessage(), 500 );
 		}
 
-		if ( is_wp_error( $response ) ) {
-			$response = $this->error_to_response( $response );
-		}
+		return is_wp_error( $response ) ? $this->error_to_response( $response ) : $response;
+	}
 
-		return $response;
+	/**
+	 * Get the route response based on the type of request.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 * @return \WP_REST_Response
+	 */
+	protected function get_response_by_request_method( \WP_REST_Request $request ) {
+		switch ( $request->get_method() ) {
+			case 'POST':
+				return $this->get_route_post_response( $request );
+			case 'PUT':
+			case 'PATCH':
+				return $this->get_route_update_response( $request );
+			case 'DELETE':
+				return $this->get_route_delete_response( $request );
+		}
+		return $this->get_route_response( $request );
 	}
 
 	/**


### PR DESCRIPTION
Store API updates draft orders on cart routes because it assumes the cart was modified. This breaks the checkout endpoint when single use coupons are applied because coupons are removed and reapplied, without freeing up usage limits.

We can adjust the checkout route to avoid updates to the cart to prevent this issue occurring.

Fixes #8446

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Testing

Use this to enable PayPal standard:

```php
add_filter( 'woocommerce_should_load_paypal_standard', '__return_true' );
```

1. Create a new coupon with any value, but set the per-user usage limit to 1
2. Add an item to the cart
3. Place an order via PayPal. Once you hit paypal you can close the window-don't pay
4. Edit the order in WP Admin
5. See if the coupons are still applied.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fixed an issue where single use coupons would not apply when checking out via the Checkout Block and Store API.
