### PR TITLE
Product Image Gallery: remove attributes key

### DIFF
--- a/assets/js/atomic/blocks/product-elements/product-image-gallery/block.json
+++ b/assets/js/atomic/blocks/product-elements/product-image-gallery/block.json
@@ -9,7 +9,6 @@
 		"align": true,
 		"multiple": false
 	},
-	"attributes": {},
 	"keywords": [ "WooCommerce" ],
 	"usesContext": [ "postId", "postType", "queryId" ],
 	"textdomain": "woo-gutenberg-products-block",


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR removes the unused attributes key from the block.json file of the Product Image Gallery.
