### PR TITLE
Product SKU Block: don't render the prefix when the SKU isn't defined

### DIFF
--- a/src/BlockTypes/ProductSKU.php
+++ b/src/BlockTypes/ProductSKU.php
@@ -55,14 +55,22 @@ class ProductSKU extends AbstractBlock {
 		$post_id = $block->context['postId'];
 		$product = wc_get_product( $post_id );
 
-		if ( $product ) {
-			return sprintf(
-				'<div class="wc-block-components-product-sku wc-block-grid__product-sku">
-					SKU:
-					<strong>%s</strong>
-				</div>',
-				$product->get_sku()
-			);
+		if ( ! $product ) {
+			return '';
 		}
+
+		$product_sku = $product->get_sku();
+
+		if ( ! $product_sku ) {
+			return '';
+		}
+
+		return sprintf(
+			'<div class="wc-block-components-product-sku wc-block-grid__product-sku">
+				SKU:
+				<strong>%s</strong>
+			</div>',
+			$product_sku
+		);
 	}
 }


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

When the Product SKU isn't defined, it isn't necessary display the prefix SKU.

<!-- Reference any related issues or PRs here -->

Fixes #8834 

### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Create a post/page.
2. Add the `Products` block.
3. Inside the `Products` block, add the Product SKU block.
4. Save the post/page.
5. Edit a Product that will be visible in `Products` block.
6. Scroll down until you see the “Inventory” section. In that section, it is visible a field labeled “SKU.” Remove the SKU in that field, and then click on the “Update” button at the bottom of the page.
7. On the front end, visit the saved post/page and check the `Products` block.
8. Ensure that the edited product doesn't have the SKU prefix visible.


* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

## Screenshots

| Before | After |
|--------|--------|
|![image](https://user-images.githubusercontent.com/4463174/227186842-d7f4a673-d943-4f40-a897-901139e92cd9.png)|![image](https://user-images.githubusercontent.com/4463174/227193368-f7f0db7e-115d-4590-a9e3-b16af1b2538e.png)| 





### Changelog

> Product SKU Block: don't render the prefix when the SKU isn't defined.

