### PR TITLE
Fix border styles not visible in the editor in Featured Product and Featured Category blocks

### DIFF
--- a/assets/js/base/hooks/use-border-props.ts
+++ b/assets/js/base/hooks/use-border-props.ts
@@ -3,7 +3,6 @@
  * External dependencies
  */
 import { __experimentalUseBorderProps } from '@wordpress/block-editor';
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
 import { isObject } from '@woocommerce/types';
 import { parseStyle } from '@woocommerce/base-utils';
 
@@ -20,13 +19,6 @@ type WithStyle = {
 export const useBorderProps = (
 	attributes: unknown
 ): WithStyle & WithClass => {
-	if ( ! isFeaturePluginBuild() ) {
-		return {
-			className: '',
-			style: {},
-		};
-	}
-
 	const attributesObject = isObject( attributes ) ? attributes : {};
 	const style = parseStyle( attributesObject.style );
 

--- a/assets/js/base/hooks/use-color-props.ts
+++ b/assets/js/base/hooks/use-color-props.ts
@@ -3,7 +3,6 @@
  * External dependencies
  */
 import { __experimentalUseColorProps } from '@wordpress/block-editor';
-import { isFeaturePluginBuild } from '@woocommerce/block-settings';
 import { isObject } from '@woocommerce/types';
 import { parseStyle } from '@woocommerce/base-utils';
 
@@ -18,13 +17,6 @@ type WithStyle = {
 // @todo The @wordpress/block-editor dependency should never be used on the frontend of the store due to excessive side and its dependency on @wordpress/components
 // @see https://github.com/woocommerce/woocommerce-blocks/issues/8071
 export const useColorProps = ( attributes: unknown ): WithStyle & WithClass => {
-	if ( ! isFeaturePluginBuild() ) {
-		return {
-			className: '',
-			style: {},
-		};
-	}
-
 	const attributesObject = isObject( attributes ) ? attributes : {};
 	const style = parseStyle( attributesObject.style );
 


### PR DESCRIPTION
Fixes a bug in WC core that made the border not visible in the editor for the Featured Product and Featured Category blocks. That happened because in #8472 we refactored the code to use `useBorderProps()`, but that function has an extra protection so it returns no styles in WC core.

I removed that extra protection from `useBorderProps()` and `useColorProps()`. IMO, if we want some styling options not to be available in core, we need to gate them in the block metadata, but adding those protections into the `useXProps()` hook is dangeours because we end up with cases like this, where the controls are visible but they take no effect.

### Testing

#### User Facing Testing

0. (If testing the PR directly) build with `WOOCOMMERCE_BLOCKS_PHASE=1 npm run build`, so you simulate a WC core build.
1. Add a Featured Item (Featured Category or Featured Product) block to a page or post.
2. Select the border controls and add a border style. Add a color and give it some width.
3. You should see the border you set dynamically display on the featured item.
4. Now click on the `Unlink` button on the border controls and try setting different values for color and width for each of the border sides (top,right,bottom,left).
5. Ensure this is working by visually seeing the changes to the featured item.
6. Save and make sure this is also displaying correctly on the frontend.
7. Test both `Featured Category` and `Featured Product` blocks.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix border styles not visible in the editor in Featured Product and Featured Category blocks
