### PR TITLE
Trigger the set-billing-address when editing Shipping and useShippingAsBilling is true

### DIFF
--- a/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/block.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/block.tsx
@@ -119,6 +119,7 @@ const Block = ( {
 						setShippingAddress( values );
 						if ( useShippingAsBilling ) {
 							setBillingAddress( { ...values, email } );
+							dispatchCheckoutEvent( 'set-billing-address' );
 						}
 						dispatchCheckoutEvent( 'set-shipping-address' );
 					} }


### PR DESCRIPTION
I found this problem as part of working on the Klaviyo integration, we have a couple of events, set-billing-address and set-shipping-address, we trigger those whenever shipping or billing address changes, we didn't trigger the billing event in the shipping form, but we did the reverse, this fixes it.

### Testing

1. Add a shippable product to cart, go to checkout.
2. Make sure only the shipping step is visible and the billing one is not visible (marked with useShippingAsBilling)
3. Type this into the console
```
wp.hooks.addAction(
	"experimental__woocommerce_blocks-checkout-set-billing-address",
	"test-plugin",
	({storeCart}) => {
		console.log("set-billing-address", storeCart);
	}
);
```
4. Type into the shipping form, you should see the cart printed in console.
5. Unsync the form by unchecking `Use same address for billing`
6. Type into the shipping form, you should see nothing in the console.
7. Type into the billing form, you should see the storeCart in the console.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental


### Changelog

> Trigger the set-billing-address from the shipping step.
