### PR TITLE
Related Products: Move Notice block to the Inspector Control section

### DIFF
--- a/assets/js/atomic/blocks/product-elements/related-products/edit.tsx
+++ b/assets/js/atomic/blocks/product-elements/related-products/edit.tsx
@@ -5,9 +5,13 @@ import {
 	BLOCK_ATTRIBUTES,
 	INNER_BLOCKS_TEMPLATE,
 } from '@woocommerce/blocks/product-query/variations';
-import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
+import {
+	InnerBlocks,
+	InspectorControls,
+	useBlockProps,
+} from '@wordpress/block-editor';
 import { InnerBlockTemplate } from '@wordpress/blocks';
-import { Disabled, Notice } from '@wordpress/components';
+import { Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -23,7 +27,7 @@ const Edit = () => {
 
 	return (
 		<div { ...blockProps }>
-			<Disabled>
+			<InspectorControls>
 				<Notice
 					className={ 'wc-block-editor-related-products__notice' }
 					status={ 'warning' }
@@ -36,7 +40,7 @@ const Edit = () => {
 						) }
 					</p>
 				</Notice>
-			</Disabled>
+			</InspectorControls>
 			<InnerBlocks template={ TEMPLATE } />
 		</div>
 	);

--- a/assets/js/atomic/blocks/product-elements/related-products/editor.scss
+++ b/assets/js/atomic/blocks/product-elements/related-products/editor.scss
@@ -1,5 +1,4 @@
 .wc-block-editor-related-products__notice {
-	margin: auto $gap;
-	margin-bottom: $gap;
+	margin: auto $gap $gap;
 	max-width: max-content;
 }

--- a/assets/js/atomic/blocks/product-elements/related-products/editor.scss
+++ b/assets/js/atomic/blocks/product-elements/related-products/editor.scss
@@ -1,4 +1,5 @@
 .wc-block-editor-related-products__notice {
-	margin: 10px auto;
+	margin: auto $gap;
+	margin-bottom: $gap;
 	max-width: max-content;
 }


### PR DESCRIPTION
This PR moves the Notice block that existed inside the Related Products to the Inspector Control section (on the sidebar).

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #8817 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
| <img width="1644" alt="image" src="https://user-images.githubusercontent.com/20469356/227358037-a753a748-7033-4d30-878b-9d218157156b.png"> | <img width="1647" alt="image" src="https://user-images.githubusercontent.com/20469356/227357464-4720cf26-bfc8-42a2-8db7-7b1979e2518f.png"> |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Go to Appearance > Themes and activate a Blockfied theme, such as: Twenty-twenty Three;
2. After the theme is activated, go to Appearance > Editor (Beta);
3. Inside the Design section, click on Templates;
4. Select the Single Product template;
5. On the top left of the page, click on the Edit button;
6. Using the Block Inserter, type: Related Products, and add the block to the Editor;
7. Click on the Save button;
8. Check that the Skeleton component appears above the Add To Cart button

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Move Related Products's notice component to the Inspector Control section
