### PR TITLE
Mini-cart buttons: add explanation regarding why we need to check for children

### DIFF
--- a/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-footer-block/block.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-footer-block/block.tsx
@@ -61,7 +61,7 @@ const Block = ( {
 		  parseInt( cartTotals.total_items_tax, 10 )
 		: parseInt( cartTotals.total_items, 10 );
 
-	// The buttons `Cart` and `Checkout` buttons were converted to inner blocks, but we still need to render the buttons
+	// The `Cart` and `Checkout` buttons were converted to inner blocks, but we still need to render the buttons
 	// for themes that have the old `mini-cart.html` template. So we check if there are any inner blocks (buttons) and
 	// if not, render the buttons.
 	const hasButtons = hasChildren( children );

--- a/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-footer-block/block.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-footer-block/block.tsx
@@ -37,6 +37,9 @@ interface Props {
 	checkoutButtonLabel: string;
 }
 
+/**
+ * Checks if there are any children that are blocks.
+ */
 const hasChildren = ( children ): boolean => {
 	return children.some( ( child ) => {
 		if ( Array.isArray( child ) ) {
@@ -58,6 +61,9 @@ const Block = ( {
 		  parseInt( cartTotals.total_items_tax, 10 )
 		: parseInt( cartTotals.total_items, 10 );
 
+	// The buttons `Cart` and `Checkout` buttons were converted to inner blocks, but we still need to render the buttons
+	// for themes that have the old `mini-cart.html` template. So we check if there are any inner blocks (buttons) and
+	// if not, render the buttons.
 	const hasButtons = hasChildren( children );
 
 	return (


### PR DESCRIPTION
Add a comment explaining why we need to check for children on the mini cart footer block.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
