### PR TITLE
Remove code that disabled attribute lookup in e2e tests

### DIFF
--- a/tests/e2e/config/setup.js
+++ b/tests/e2e/config/setup.js
@@ -20,7 +20,6 @@ import {
 	createBlockPages,
 	enablePaymentGateways,
 	createProductAttributes,
-	disableAttributeLookup,
 } from '../fixtures/fixture-loaders';
 import { PERFORMANCE_REPORT_FILENAME } from '../../utils/constants';
 
@@ -61,9 +60,6 @@ module.exports = async ( globalConfig ) => {
 		products.forEach( async ( productId ) => {
 			await createReviews( productId );
 		} );
-
-		// This is necessary for avoid this bug https://github.com/woocommerce/woocommerce/issues/32065
-		await disableAttributeLookup();
 
 		// Wipe the performance e2e file at the start of every run
 		if ( existsSync( PERFORMANCE_REPORT_FILENAME ) ) {

--- a/tests/e2e/fixtures/fixture-loaders.js
+++ b/tests/e2e/fixtures/fixture-loaders.js
@@ -481,11 +481,6 @@ const deleteProductAttributes = ( ids ) => {
 	return WooCommerce.post( 'products/attributes/batch', { delete: ids } );
 };
 
-const disableAttributeLookup = () =>
-	WooCommerce.put( 'settings/products/woocommerce_attribute_lookup_enabled', {
-		value: 'no',
-	} );
-
 module.exports = {
 	createProductAttributes,
 	deleteProductAttributes,
@@ -507,5 +502,4 @@ module.exports = {
 	deleteShippingZones,
 	createBlockPages,
 	deleteBlockPages,
-	disableAttributeLookup,
 };


### PR DESCRIPTION
This PR removes the code that disabled attribute lookup in e2e tests. That was introduced in https://github.com/woocommerce/woocommerce-blocks/pull/6355 (cc @gigitux), to work around this issue: https://github.com/woocommerce/woocommerce/issues/32065. However, that issue has been fixed since then and that code was producing a 404 error, causing the jest setup not to complete and, consequently, the tear down script to fail.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests

#### User Facing Testing

1. Make sure e2e tests pass.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
