### PR TITLE
Check for `address` on `shippingData`

### DIFF
--- a/assets/js/data/payment/thunks.ts
+++ b/assets/js/data/payment/thunks.ts
@@ -109,10 +109,13 @@ export const __internalEmitPaymentProcessingEvent: emitProcessingEventType = (
 					);
 				}
 
-				if ( shippingDataFromResponse ) {
+				if (
+					objectHasProp( shippingDataFromResponse, 'address' ) &&
+					shippingDataFromResponse.address
+				) {
 					// Set this here so that old extensions still using shippingData can set the shippingAddress.
 					shippingAddress =
-						shippingDataFromResponse as ShippingAddress;
+						shippingDataFromResponse.address as ShippingAddress;
 					deprecated(
 						'returning shippingData from an onPaymentProcessing observer in WooCommerce Blocks',
 						{


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR fixes an issue where observers returning `address` in the `shippingData` object would not get the address applied to the order.

In #8163 we added checks to see if `shippingData` was used, rather than `shippingAddress`, and if so we would extract the address from there and use that, however we did not correctly identify that the address was stored in a property on `shippingData`.
<!-- Reference any related issues or PRs here -->

Fixes #8785

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### ~~User~~ Internal Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Clone the [Stripe plugin](https://github.com/woocommerce/woocommerce-gateway-stripe) into your plugins directory and set it up. You will need to enter Stripe keys on the plugin's settings page to get it working.
2. Go to this line of code: https://github.com/woocommerce/woocommerce-gateway-stripe/blob/8ffd22aff3b06eda02a1ae2fd8368b71450b36a9/client/blocks/credit-card/use-payment-processing.js#L136
3. Modify the object returned by this function to include `shippingData` with an address property, like so:
4.
```js
return {
	type: emitResponse.responseTypes.SUCCESS,
	meta: {
		paymentMethodData: {
			stripe_source: response.source.id,
			// The billing information here is relevant to properly create the
			// Stripe Customer object.
			billing_email: ownerInfo.email,
			billing_first_name: billingData?.first_name ?? '',
			billing_last_name: billingData?.last_name ?? '',
			paymentMethod: PAYMENT_METHOD_NAME,
			paymentRequestType: 'cc',
		},
		billingData,
		shippingData: {
			address: {
				...billingData,
				first_name: 'Set by',
				last_name: 'Stripe plugin',
			},
		},
	},
};
```
5. Make an order using Stripe.
6. When it is complete, check the order in the back end. The shipping address name should be `Set by Stripe plugin`.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Dev note

In [Check for address on shippingData (#8878)](https://github.com/woocommerce/woocommerce-blocks/pull/8878) we fixed a regression with our payment processing observers. Previously, payment processing observers that returned a `shippingData` object with an `address` property would overwrite the customer's shipping address with the supplied address, however in [#8163](https://github.com/woocommerce/woocommerce-blocks/pull/8163) this was inadvertently removed.

This has now been changed so that these extensions work as they did (but passing the address via `shippingData.address` is still deprecated, and the preferred method is to pass it via `shippingAddress` which should be a flat address object).

To migrate away from the deprecated `shippingData` property to using the new `shippingAddress` property, you will need to update your observer's return value. The address, previously stored the in `shippingData.address` should be moved into `shippingAddress` which will be a **flat object** containing only the address data.

**Old observer response value**
```js
return {
  shippingData: {
    address: {
      first_name: 'John',
      last_name: 'Doe',
    }
}
```

**New observer response value - note the `shippingAddress` value is a flat object**
```js
return {
  shippingAddress: {
    first_name: 'John',
    last_name: 'Doe',
  }
}
```

### Changelog

> Fixed an issue where extensions were unable to programatically set the shipping address during payment processing.
