### PR TITLE
Show Cart and Checkout blocks in Style Book

### DIFF
--- a/assets/js/base/context/providers/editor-context.tsx
+++ b/assets/js/base/context/providers/editor-context.tsx
@@ -19,6 +19,9 @@ interface EditorContextType {
 
 	// Get data by name.
 	getPreviewData: ( name: string ) => Record< string, unknown >;
+
+	// Indicates whether in the preview context.
+	isPreview?: boolean;
 }
 
 const EditorContext = createContext( {
@@ -38,11 +41,13 @@ export const EditorProvider = ( {
 	currentPostId = 0,
 	previewData = {},
 	currentView = '',
+	isPreview = false,
 }: {
 	children: React.ReactChildren;
 	currentPostId?: number | undefined;
 	previewData?: Record< string, unknown > | undefined;
 	currentView?: string | undefined;
+	isPreview?: boolean | undefined;
 } ) => {
 	const editingPostId = useSelect(
 		( select ): number =>
@@ -68,6 +73,7 @@ export const EditorProvider = ( {
 		currentView,
 		previewData,
 		getPreviewData,
+		isPreview,
 	};
 
 	return (

--- a/assets/js/blocks/cart-checkout-shared/use-forced-layout/types.ts
+++ b/assets/js/blocks/cart-checkout-shared/use-forced-layout/types.ts
@@ -1,0 +1,18 @@
+/**
+ * External dependencies
+ */
+import type { Block } from '@wordpress/blocks';
+
+export interface LockableBlock extends Block {
+	attributes: {
+		lock?: {
+			type: 'object';
+			remove?: boolean;
+			move: boolean;
+			default?: {
+				remove?: boolean;
+				move?: boolean;
+			};
+		};
+	};
+}

--- a/assets/js/blocks/cart-checkout-shared/use-forced-layout/utils.ts
+++ b/assets/js/blocks/cart-checkout-shared/use-forced-layout/utils.ts
@@ -1,0 +1,80 @@
+/**
+ * External dependencies
+ */
+import type { BlockInstance, TemplateArray } from '@wordpress/blocks';
+import type { MutableRefObject } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import { LockableBlock } from './types';
+
+export const isBlockLocked = ( {
+	attributes,
+}: {
+	attributes: LockableBlock[ 'attributes' ];
+} ) => Boolean( attributes.lock?.remove || attributes.lock?.default?.remove );
+
+/**
+ * This hook is used to determine which blocks are missing from a block. Given the list of inner blocks of a block, we
+ * can check for any registered blocks that:
+ * a) Are locked,
+ * b) Have the parent set as the current block, and
+ * c) Are not present in the list of inner blocks.
+ */
+export const getMissingBlocks = (
+	innerBlocks: BlockInstance[],
+	registeredBlockTypes: ( LockableBlock | undefined )[]
+) => {
+	const lockedBlockTypes = registeredBlockTypes.filter(
+		( block: LockableBlock | undefined ) => block && isBlockLocked( block )
+	);
+	const missingBlocks: LockableBlock[] = [];
+	lockedBlockTypes.forEach( ( lockedBlock ) => {
+		if ( typeof lockedBlock === 'undefined' ) {
+			return;
+		}
+		const existingBlock = innerBlocks.find(
+			( block ) => block.name === lockedBlock.name
+		);
+
+		if ( ! existingBlock ) {
+			missingBlocks.push( lockedBlock );
+		}
+	} );
+	return missingBlocks;
+};
+
+/**
+ * This hook is used to determine the position that a missing block should be inserted at.
+ *
+ * @return The index to insert the missing block at.
+ */
+export const findBlockPosition = ( {
+	defaultTemplatePosition,
+	innerBlocks,
+	currentDefaultTemplate,
+}: {
+	defaultTemplatePosition: number;
+	innerBlocks: BlockInstance[];
+	currentDefaultTemplate: MutableRefObject< TemplateArray >;
+} ) => {
+	switch ( defaultTemplatePosition ) {
+		case -1:
+			// The block is not part of the default template, so we append it to the current layout.
+			return innerBlocks.length;
+		// defaultTemplatePosition defaults to 0, so if this happens we can just return, this is because the block was
+		// the first block in the default layout, so we can prepend it to the current layout.
+		case 0:
+			return 0;
+		default:
+			// The new layout may have extra blocks compared to the default template, so rather than insert
+			// at the default position, we should append it after another default block.
+			const adjacentBlock =
+				currentDefaultTemplate.current[ defaultTemplatePosition - 1 ];
+			const position = innerBlocks.findIndex(
+				( { name: blockName } ) => blockName === adjacentBlock[ 0 ]
+			);
+			return position === -1 ? defaultTemplatePosition : position + 1;
+	}
+};

--- a/assets/js/blocks/cart/edit.js
+++ b/assets/js/blocks/cart/edit.js
@@ -22,7 +22,6 @@ import './editor.scss';
 import {
 	addClassToBody,
 	useBlockPropsWithLocking,
-	useForcedLayout,
 	BlockSettings,
 } from '../cart-checkout-shared';
 import '../cart-checkout-shared/sidebar-notices';
@@ -38,21 +37,16 @@ const ALLOWED_BLOCKS = [
 	'woocommerce/empty-cart-block',
 ];
 
-export const Edit = ( { className, attributes, setAttributes, clientId } ) => {
-	const { hasDarkControls, currentView } = attributes;
+export const Edit = ( { className, attributes, setAttributes } ) => {
+	const { hasDarkControls, currentView, isPreview = false } = attributes;
 	const defaultTemplate = [
 		[ 'woocommerce/filled-cart-block', {}, [] ],
 		[ 'woocommerce/empty-cart-block', {}, [] ],
 	];
 	const blockProps = useBlockPropsWithLocking( {
 		className: classnames( className, 'wp-block-woocommerce-cart', {
-			'is-editor-preview': attributes.isPreview,
+			'is-editor-preview': isPreview,
 		} ),
-	} );
-	useForcedLayout( {
-		clientId,
-		registeredBlocks: ALLOWED_BLOCKS,
-		defaultTemplate,
 	} );
 
 	return (
@@ -81,6 +75,7 @@ export const Edit = ( { className, attributes, setAttributes, clientId } ) => {
 				<EditorProvider
 					previewData={ { previewCart } }
 					currentView={ currentView }
+					isPreview={ isPreview }
 				>
 					<CartBlockContext.Provider
 						value={ {
@@ -92,7 +87,7 @@ export const Edit = ( { className, attributes, setAttributes, clientId } ) => {
 								<InnerBlocks
 									allowedBlocks={ ALLOWED_BLOCKS }
 									template={ defaultTemplate }
-									templateLock={ false }
+									templateLock="insert"
 								/>
 							</CartProvider>
 						</SlotFillProvider>

--- a/assets/js/blocks/cart/index.js
+++ b/assets/js/blocks/cart/index.js
@@ -36,6 +36,12 @@ const settings = {
 		html: false,
 		multiple: false,
 	},
+	example: {
+		attributes: {
+			isPreview: true,
+		},
+		viewportWidth: 800,
+	},
 	attributes: blockAttributes,
 	edit: Edit,
 	save: Save,

--- a/assets/js/blocks/checkout/block.json
+++ b/assets/js/blocks/checkout/block.json
@@ -10,6 +10,12 @@
 		"html": false,
 		"multiple": false
 	},
+	"example": {
+		"attributes": {
+			"isPreview": true
+		},
+		"viewportWidth": 800
+	},
 	"attributes": {
 		"isPreview": {
 			"type": "boolean",

--- a/assets/js/blocks/checkout/edit.tsx
+++ b/assets/js/blocks/checkout/edit.tsx
@@ -64,6 +64,7 @@ export const Edit = ( {
 		showReturnToCart,
 		showRateAfterTaxName,
 		cartPageId,
+		isPreview = false,
 	} = attributes;
 
 	const defaultTemplate = [
@@ -146,6 +147,7 @@ export const Edit = ( {
 				/>
 			</InspectorControls>
 			<EditorProvider
+				isPreview={ isPreview }
 				previewData={ { previewCart, previewSavedPaymentMethods } }
 			>
 				<SlotFillProvider>

--- a/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/edit.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/edit.tsx
@@ -24,6 +24,7 @@ export const Edit = ( {
 	clientId: string;
 	attributes: {
 		className?: string;
+		isPreview?: boolean;
 	};
 } ): JSX.Element => {
 	const blockProps = useBlockProps( {


### PR DESCRIPTION
Reimplements the changes from @nielslange in https://github.com/woocommerce/woocommerce-blocks/pull/8489 but fixes the hover state when previewing due to `useForcedBlocks`. Forcing is disabled when previewing.

Fixes #8433

Gutenberg 14.8 [introduced the Style Book](https://wptavern.com/gutenberg-14-8-overhauls-site-editor-interface-adds-style-book). This PR aims to show the Cart and the Checkout blocks in the Style Book. In a later PR, we'll add support for Global Styles for these two blocks.

### Screenshots

<table>
<tr>
<td valign="top">Cart block:
<br><br>

![cart](https://user-images.githubusercontent.com/3323310/220263306-8431c1d0-0c03-4afc-871f-420009952abc.png)
</td>
<td valign="top">Checkout block:
<br><br>

![checkout](https://user-images.githubusercontent.com/3323310/220263318-07facf38-48eb-470e-afe7-7e8331f4eb73.png)
</td>
</tr>
</table>

### Testing

#### User Facing Testing

1. Ensure that a block theme is installed, e.g. [TT3](https://wordpress.org/themes/twentytwentythree/) and install [Gutenberg v15.1.0](https://github.com/WordPress/gutenberg/releases/download/v15.1.0/gutenberg.zip)
2. Go to `WP Admin » Appearance » Editor`.
3. Click the blue `Edit` button and then click the `Styles` icon in the upper-right corner. 
<img width="273" alt="Screenshot 2023-02-21 at 13 23 00" src="https://user-images.githubusercontent.com/3323310/220263914-44b7013d-c98a-4008-b3ab-a00330d73d22.png">
4. Click on the the `Open Style Book` icon (the one that looks like an eye)
<img width="282" alt="Screenshot 2023-02-21 at 13 23 24" src="https://user-images.githubusercontent.com/3323310/220263978-e0f6e679-a3b4-43be-93a0-c8521b9dea9a.png">
5. Verify that both the Cart and the Checkout blocks are visible.

Kindly note that the Cart and the Checkout blocks will not appear in the blocks sidebar, as they do not support Global Styles yet:
<img width="279" alt="Screenshot 2023-02-21 at 13 24 58" src="https://user-images.githubusercontent.com/3323310/220264263-3ce8a9f2-8302-4b0c-9e3b-6851453ca573.png">

**Testing previews**
Ensure gutenberg plugin is active.

1. Create a new page
2. Click the plus (top left) to open the block inserter
3. Find the cart/checkout blocks. Hover over them to see the preview.
4. Preview should render—no crashing of the editor.

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Add Cart and Checkout blocks to the Style Book.
