### PR TITLE
Add `validateOnMount` prop to `ValidatedTextInput`

### DIFF
--- a/assets/js/base/components/cart-checkout/totals/coupon/index.tsx
+++ b/assets/js/base/components/cart-checkout/totals/coupon/index.tsx
@@ -128,6 +128,7 @@ export const TotalsCoupon = ( {
 									setCouponValue( newCouponValue );
 								} }
 								focusOnMount={ true }
+								validateOnMount={ false }
 								showError={ false }
 							/>
 							<Button

--- a/assets/js/base/components/cart-checkout/totals/coupon/test/index.tsx
+++ b/assets/js/base/components/cart-checkout/totals/coupon/test/index.tsx
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { dispatch } from '@wordpress/data';
+import { VALIDATION_STORE_KEY } from '@woocommerce/block-data';
+
+/**
+ * Internal dependencies
+ */
+import { TotalsCoupon } from '..';
+
+describe( 'TotalsCoupon', () => {
+	it( "Shows a validation error when one is in the wc/store/validation data store and doesn't show one when there isn't", () => {
+		const { rerender } = render( <TotalsCoupon instanceId={ 'coupon' } /> );
+		const openCouponFormButton = screen.getByText( 'Add a coupon' );
+		expect( openCouponFormButton ).toBeInTheDocument();
+		userEvent.click( openCouponFormButton );
+		expect(
+			screen.queryByText( 'Invalid coupon code' )
+		).not.toBeInTheDocument();
+
+		const { setValidationErrors } = dispatch( VALIDATION_STORE_KEY );
+		act( () => {
+			setValidationErrors( {
+				coupon: {
+					hidden: false,
+					message: 'Invalid coupon code',
+				},
+			} );
+		} );
+		rerender( <TotalsCoupon instanceId={ 'coupon' } /> );
+		expect( screen.getByText( 'Invalid coupon code' ) ).toBeInTheDocument();
+	} );
+} );

--- a/packages/checkout/components/text-input/test/validated-text-input.tsx
+++ b/packages/checkout/components/text-input/test/validated-text-input.tsx
@@ -6,11 +6,20 @@ import { VALIDATION_STORE_KEY } from '@woocommerce/block-data';
 import { dispatch, select } from '@wordpress/data';
 import userEvent from '@testing-library/user-event';
 import { useState } from '@wordpress/element';
+import * as wpData from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import { __ValidatedTexInputWithoutId as ValidatedTextInput } from '../validated-text-input';
+
+jest.mock( '@wordpress/data', () => ( {
+	__esModule: true,
+	...jest.requireActual( '@wordpress/data' ),
+	useDispatch: jest.fn().mockImplementation( ( args ) => {
+		return jest.requireActual( '@wordpress/data' ).useDispatch( args );
+	} ),
+} ) );
 
 describe( 'ValidatedTextInput', () => {
 	it( 'Removes related validation error on change', async () => {
@@ -170,5 +179,129 @@ describe( 'ValidatedTextInput', () => {
 		await expect(
 			screen.queryByText( 'Please enter a valid test input' )
 		).not.toBeNull();
+	} );
+	describe( 'correctly validates on mount', () => {
+		it( 'validates when focusOnMount is true and validateOnMount is not set', async () => {
+			const setValidationErrors = jest.fn();
+			wpData.useDispatch.mockImplementation( ( storeName: string ) => {
+				if ( storeName === VALIDATION_STORE_KEY ) {
+					return {
+						...jest
+							.requireActual( '@wordpress/data' )
+							.useDispatch( storeName ),
+						setValidationErrors,
+					};
+				}
+				return jest
+					.requireActual( '@wordpress/data' )
+					.useDispatch( storeName );
+			} );
+
+			const TestComponent = () => {
+				const [ inputValue, setInputValue ] = useState( '' );
+				return (
+					<ValidatedTextInput
+						instanceId={ '6' }
+						id={ 'test-input' }
+						onChange={ ( value ) => setInputValue( value ) }
+						value={ inputValue }
+						label={ 'Test Input' }
+						required={ true }
+						focusOnMount={ true }
+					/>
+				);
+			};
+			await render( <TestComponent /> );
+			const textInputElement = await screen.getByLabelText(
+				'Test Input'
+			);
+			await expect( textInputElement ).toHaveFocus();
+			await expect( setValidationErrors ).toHaveBeenCalledWith( {
+				'test-input': {
+					message: 'Please enter a valid test input',
+					hidden: true,
+				},
+			} );
+		} );
+		it( 'validates when focusOnMount is false, regardless of validateOnMount value', async () => {
+			const setValidationErrors = jest.fn();
+			wpData.useDispatch.mockImplementation( ( storeName: string ) => {
+				if ( storeName === VALIDATION_STORE_KEY ) {
+					return {
+						...jest
+							.requireActual( '@wordpress/data' )
+							.useDispatch( storeName ),
+						setValidationErrors,
+					};
+				}
+				return jest
+					.requireActual( '@wordpress/data' )
+					.useDispatch( storeName );
+			} );
+
+			const TestComponent = ( { validateOnMount = false } ) => {
+				const [ inputValue, setInputValue ] = useState( '' );
+				return (
+					<ValidatedTextInput
+						instanceId={ '6' }
+						id={ 'test-input' }
+						onChange={ ( value ) => setInputValue( value ) }
+						value={ inputValue }
+						label={ 'Test Input' }
+						required={ true }
+						focusOnMount={ true }
+						validateOnMount={ validateOnMount }
+					/>
+				);
+			};
+			const { rerender } = await render( <TestComponent /> );
+			const textInputElement = await screen.getByLabelText(
+				'Test Input'
+			);
+			await expect( textInputElement ).toHaveFocus();
+			await expect( setValidationErrors ).not.toHaveBeenCalled();
+
+			await rerender( <TestComponent validateOnMount={ true } /> );
+			await expect( textInputElement ).toHaveFocus();
+			await expect( setValidationErrors ).not.toHaveBeenCalled();
+		} );
+		it( 'does not validate when validateOnMount is false and focusOnMount is true', async () => {
+			const setValidationErrors = jest.fn();
+			wpData.useDispatch.mockImplementation( ( storeName: string ) => {
+				if ( storeName === VALIDATION_STORE_KEY ) {
+					return {
+						...jest
+							.requireActual( '@wordpress/data' )
+							.useDispatch( storeName ),
+						setValidationErrors,
+					};
+				}
+				return jest
+					.requireActual( '@wordpress/data' )
+					.useDispatch( storeName );
+			} );
+
+			const TestComponent = () => {
+				const [ inputValue, setInputValue ] = useState( '' );
+				return (
+					<ValidatedTextInput
+						instanceId={ '6' }
+						id={ 'test-input' }
+						onChange={ ( value ) => setInputValue( value ) }
+						value={ inputValue }
+						label={ 'Test Input' }
+						required={ true }
+						focusOnMount={ true }
+						validateOnMount={ false }
+					/>
+				);
+			};
+			await render( <TestComponent /> );
+			const textInputElement = await screen.getByLabelText(
+				'Test Input'
+			);
+			await expect( textInputElement ).toHaveFocus();
+			await expect( setValidationErrors ).not.toHaveBeenCalled();
+		} );
 	} );
 } );

--- a/packages/checkout/components/text-input/test/validated-text-input.tsx
+++ b/packages/checkout/components/text-input/test/validated-text-input.tsx
@@ -158,14 +158,17 @@ describe( 'ValidatedTextInput', () => {
 					onChange={ ( value ) => setInputValue( value ) }
 					value={ inputValue }
 					label={ 'Test Input' }
+					required={ true }
 				/>
 			);
 		};
 		render( <TestComponent /> );
 		const textInputElement = await screen.getByLabelText( 'Test Input' );
+		await userEvent.type( textInputElement, 'test' );
 		await userEvent.type( textInputElement, '{selectall}{del}' );
+		await textInputElement.blur();
 		await expect(
-			select( VALIDATION_STORE_KEY ).getValidationError( 'test-input' )
-		).not.toBe( 'Please enter a valid test input' );
+			screen.queryByText( 'Please enter a valid test input' )
+		).not.toBeNull();
 	} );
 } );

--- a/packages/checkout/components/text-input/validated-text-input.tsx
+++ b/packages/checkout/components/text-input/validated-text-input.tsx
@@ -168,12 +168,11 @@ const ValidatedTextInput = ( {
 			inputRef.current?.focus();
 		}
 
-		// Skip validation only if validateOnMount is false and focusOnMount is true.
-		if ( ! validateOnMount && focusOnMount ) {
-			setIsPristine( false );
-			return;
+		// if validateOnMount is false, only validate input if focusOnMount is also false
+		if ( validateOnMount || ! focusOnMount ) {
+			validateInput( true );
 		}
-		validateInput( true );
+
 		setIsPristine( false );
 	}, [
 		validateOnMount,

--- a/packages/checkout/components/text-input/validated-text-input.tsx
+++ b/packages/checkout/components/text-input/validated-text-input.tsx
@@ -50,7 +50,7 @@ interface ValidatedTextInputProps
 		| ( ( inputObject: HTMLInputElement ) => boolean )
 		| undefined;
 	// Whether validation should run when focused - only has an effect when focusOnMount is also true.
-	validateOnFirstFocus?: boolean | undefined;
+	validateOnMount?: boolean | undefined;
 }
 
 const ValidatedTextInput = ( {
@@ -66,7 +66,7 @@ const ValidatedTextInput = ( {
 	value = '',
 	customValidation,
 	label,
-	validateOnFirstFocus = true,
+	validateOnMount = true,
 	...rest
 }: ValidatedTextInputProps ): JSX.Element => {
 	const [ isPristine, setIsPristine ] = useState( true );
@@ -168,15 +168,15 @@ const ValidatedTextInput = ( {
 			inputRef.current?.focus();
 		}
 
-		// Skip validation only if validateOnFirstFocus is false and focusOnMount is true.
-		if ( ! validateOnFirstFocus && focusOnMount ) {
+		// Skip validation only if validateOnMount is false and focusOnMount is true.
+		if ( ! validateOnMount && focusOnMount ) {
 			setIsPristine( false );
 			return;
 		}
 		validateInput( true );
 		setIsPristine( false );
 	}, [
-		validateOnFirstFocus,
+		validateOnMount,
 		focusOnMount,
 		isPristine,
 		setIsPristine,

--- a/packages/checkout/components/text-input/validated-text-input.tsx
+++ b/packages/checkout/components/text-input/validated-text-input.tsx
@@ -167,9 +167,21 @@ const ValidatedTextInput = ( {
 		if ( focusOnMount ) {
 			inputRef.current?.focus();
 		}
+
+		// Skip validation only if validateOnFirstFocus is false and focusOnMount is true.
+		if ( ! validateOnFirstFocus && focusOnMount ) {
+			setIsPristine( false );
+			return;
+		}
 		validateInput( true );
 		setIsPristine( false );
-	}, [ focusOnMount, isPristine, setIsPristine, validateInput ] );
+	}, [
+		validateOnFirstFocus,
+		focusOnMount,
+		isPristine,
+		setIsPristine,
+		validateInput,
+	] );
 
 	// Remove validation errors when unmounted.
 	useEffect( () => {

--- a/packages/checkout/components/text-input/validated-text-input.tsx
+++ b/packages/checkout/components/text-input/validated-text-input.tsx
@@ -49,6 +49,8 @@ interface ValidatedTextInputProps
 	customValidation?:
 		| ( ( inputObject: HTMLInputElement ) => boolean )
 		| undefined;
+	// Whether validation should run when focused - only has an effect when focusOnMount is also true.
+	validateOnFirstFocus?: boolean | undefined;
 }
 
 const ValidatedTextInput = ( {
@@ -64,6 +66,7 @@ const ValidatedTextInput = ( {
 	value = '',
 	customValidation,
 	label,
+	validateOnFirstFocus = true,
 	...rest
 }: ValidatedTextInputProps ): JSX.Element => {
 	const [ isPristine, setIsPristine ] = useState( true );


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR updates `ValidatedTextInput` to have a new prop, `validateOnMount`. This is necessary to prevent the validation running when opening the coupon input on the Checkout block.

The prop defaults to `true` which is the current behaviour so nothing else should be affected.

It also adds a unit test for this functionality, though this is tested via `TotalsCoupon`.
<!-- Reference any related issues or PRs here -->

Fixes #8118

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
| <img width="869" alt="image" src="https://user-images.githubusercontent.com/5656702/228319127-d26b3d81-11d6-454b-8329-66e144dd2c69.png"> | <img width="864" alt="image" src="https://user-images.githubusercontent.com/5656702/228319249-548a519f-69d3-408c-ab9a-9528c88382f9.png"> |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Ensure coupons are enabled on your site (WooCommerce -> Settings -> General -> Enable the use of coupon codes)
2. In your dashboard, go to Marketing -> Coupons and add a coupon to your site.
3. Add an item to your cart and go to the Checkout block.
4. Click "Add a coupon" then enter a completely wrong code. Ensure you see an error!
5. Enter the coupon code you made in step 2 and submit, the error should disappear.
6. Ensure the coupon applies correctly and that you can check out.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

#### Internal testing
1. Run `npm run storybook`
2. Go to `cart-checkout > Totals > Coupon > Error state` 
3. Click `Add a coupon` and ensure the error is visible.

<img width="876" alt="image" src="https://user-images.githubusercontent.com/5656702/228318370-80d024c1-14ea-4372-9ed2-ecccb5de86a6.png">


### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Skipping
