### PR TITLE
Fix unlinked border widths in WP 6.2

### DIFF
--- a/src/Utils/StyleAttributesUtils.php
+++ b/src/Utils/StyleAttributesUtils.php
@@ -250,7 +250,7 @@ class StyleAttributesUtils {
 
 		$border_width_css = '';
 
-		if ( array_key_exists( 'width', ( $custom_border ) ) ) {
+		if ( array_key_exists( 'width', ( $custom_border ) ) && ! empty( $custom_border['width'] ) ) {
 			// Linked sides.
 			$border_width_css = 'border-width:' . $custom_border['width'] . ';';
 		} else {


### PR DESCRIPTION
Fixes an issue that was not honoring border widths in the frontend if they were 'unlinked' (each side having a different width).

### Testing

#### User Facing Testing

0. With WP 6.2.
1. Add a Featured Item (Featured Category or Featured Product) block to a page or post.
2. Select the border controls and add a border style. Add a color and give it some width.
3. You should see the border you set dynamically display on the featured item.
4. Now click on the `Unlink` button on the border controls and try setting different values for color and width for each of the border sides (top,right,bottom,left).
5. Ensure this is working by visually seeing the changes to the featured item.
6. Save and make sure this is also displaying correctly on the frontend.
7. Test both `Featured Category` and `Featured Product` blocks.

Before | After
--- | ---
![imatge](https://user-images.githubusercontent.com/3616980/228450729-4f3ced5c-75cd-45f1-b7d6-a41b3b23f7ad.png) | ![imatge](https://user-images.githubusercontent.com/3616980/228450761-5f98420f-00a3-4c0d-b5b4-dc3e6793d19c.png)

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix unlinked border widths not being applied correctly in the frontend in WP 6.2 for some blocks
