### PR TITLE
Add padding support for `Product Image` block

### DIFF
--- a/assets/js/atomic/blocks/product-elements/image/supports.ts
+++ b/assets/js/atomic/blocks/product-elements/image/supports.ts
@@ -3,7 +3,7 @@
  * External dependencies
  */
 import { isFeaturePluginBuild } from '@woocommerce/block-settings';
-import { __experimentalGetSpacingClassesAndStyles } from '@wordpress/block-editor';
+import { __experimentalGetSpacingClassesAndStyles as getSpacingClassesAndStyles } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -20,9 +20,10 @@ export const supports = {
 			fontSize: true,
 			__experimentalSkipSerialization: true,
 		},
-		...( typeof __experimentalGetSpacingClassesAndStyles === 'function' && {
+		...( typeof getSpacingClassesAndStyles === 'function' && {
 			spacing: {
 				margin: true,
+				padding: true,
 				__experimentalSkipSerialization: true,
 			},
 		} ),

--- a/src/BlockTypes/ProductImage.php
+++ b/src/BlockTypes/ProductImage.php
@@ -188,19 +188,20 @@ class ProductImage extends AbstractBlock {
 		}
 		$parsed_attributes = $this->parse_attributes( $attributes );
 
-		$border_radius = StyleAttributesUtils::get_border_radius_class_and_style( $attributes );
-		$margin        = StyleAttributesUtils::get_margin_class_and_style( $attributes );
+		$border_radius      = StyleAttributesUtils::get_border_radius_class_and_style( $attributes );
+		$margin             = StyleAttributesUtils::get_margin_class_and_style( $attributes );
+		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes );
 
 		$post_id = $block->context['postId'];
 		$product = wc_get_product( $post_id );
 
 		if ( $product ) {
 			return sprintf(
-				'<div class="wc-block-components-product-image wc-block-grid__product-image" style="%1$s %2$s">
+				'<div class="wc-block-components-product-image wc-block-grid__product-image %1$s" style="%2$s">
 					%3$s
 				</div>',
-				isset( $border_radius['style'] ) ? esc_attr( $border_radius['style'] ) : '',
-				isset( $margin['style'] ) ? esc_attr( $margin['style'] ) : '',
+				esc_attr( $classes_and_styles['classes'] ),
+				esc_attr( $classes_and_styles['styles'] ),
 				$this->render_anchor(
 					$product,
 					$this->render_on_sale_badge( $product, $parsed_attributes ),


### PR DESCRIPTION
While working on #7954, I noticed that Product image block supports Margin in Global syles but doesn't support padding. Therefore In this PR, I have added support for padding.

### User Facing Testing

#### Test using Global styles UI

1. Check that padding is visible for `Product Image` in global styles UI

https://user-images.githubusercontent.com/16707866/228507928-f7a9bb3e-8b69-4cf2-b46e-20a72f8e80bb.mov

2. Change the padding & now to verify that this padding change is applied to `Product Image` block:
    1. Go to Editor
    2. Add Products block
    3. Add Product Image block as an inner block if not included already 
    4. Check the Product Image block's padding in both the editor and on the front-end to ensure that the changes made through the Global styles UI are accurately applied:
        - In the editor, select the Product Image block and observe the padding applied around the image. Ensure it matches the value set in the Global styles UI.
        - Save the post or page, and then preview it on the front-end. Confirm that the Product Image block's padding is consistent with the value specified in the Global styles UI.

#### Test using blocks sidebar

1. Navigate to the WordPress admin dashboard and create a new post or page.
2. Add Products block
3. Add Product Image block as an inner block if not included already 
4. Select the image block and open the block settings sidebar.
5. Adjust the margin and padding values for the image block and ensure that the changes are visually reflected in the editor.
6. Save the post or page and preview it on the front-end.
7. Verify that the applied margin and padding values are correctly displayed on the front-end as well.



* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [X] Feature plugin
* [ ] Experimental

### Changelog

> Add padding support for `Product Image` block
