### PR TITLE
Handle InvalidCartException in checkout route

### DIFF
--- a/src/StoreApi/Routes/V1/Checkout.php
+++ b/src/StoreApi/Routes/V1/Checkout.php
@@ -4,6 +4,7 @@ namespace Automattic\WooCommerce\StoreApi\Routes\V1;
 use Automattic\WooCommerce\StoreApi\Payments\PaymentContext;
 use Automattic\WooCommerce\StoreApi\Payments\PaymentResult;
 use Automattic\WooCommerce\StoreApi\Exceptions\InvalidStockLevelsInCartException;
+use Automattic\WooCommerce\StoreApi\Exceptions\InvalidCartException;
 use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
 use Automattic\WooCommerce\StoreApi\Utilities\DraftOrderTrait;
 use Automattic\WooCommerce\Checkout\Helpers\ReserveStock;
@@ -121,6 +122,8 @@ class Checkout extends AbstractCartRoute {
 		if ( ! $response ) {
 			try {
 				$response = $this->get_response_by_request_method( $request );
+			} catch ( InvalidCartException $error ) {
+				$response = $this->get_route_error_response_from_object( $error->getError(), $error->getCode(), $error->getAdditionalData() );
 			} catch ( RouteException $error ) {
 				$response = $this->get_route_error_response( $error->getErrorCode(), $error->getMessage(), $error->getCode(), $error->getAdditionalData() );
 			} catch ( \Exception $error ) {


### PR DESCRIPTION
In https://github.com/woocommerce/woocommerce-blocks/pull/8822/files we refactored some of the error handling logic in the checkout endpoint, but forgot to handle `InvalidCartException`. This fixes the issue.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. Install Conditional Shipping and Payments + WooCommerce Blocks nightly.
2. Navigate to WooCommerce > Settings > Restrictions and create a Payment Gateways Restriction like so: ![bfbmsu.png](https://user-images.githubusercontent.com/90977/228513268-b10b65f6-c64b-4bcd-99b8-e4fa83b2db31.png)
3. Add a product to the cart, navigate to the checkout block and fill in your details.
4. Select the excluded Payment Gateway and click the Place Order button.
5. You should see an error message from conditional shipping and payments rather than something generic.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
