### PR TITLE
Set Cart and Checkout blocks to be wide aligned by default

### DIFF
--- a/assets/js/blocks/cart/attributes.js
+++ b/assets/js/blocks/cart/attributes.js
@@ -51,5 +51,6 @@ export const blockAttributes = {
 	},
 	align: {
 		type: 'string',
+		default: 'wide',
 	},
 };

--- a/assets/js/blocks/checkout/block.json
+++ b/assets/js/blocks/checkout/block.json
@@ -41,6 +41,10 @@
 		"requirePhoneField": {
 			"type": "boolean",
 			"default": false
+		},
+		"align": {
+			"type": "string",
+			"default": "wide"
 		}
 	},
 	"textdomain": "woo-gutenberg-products-block",

--- a/tests/e2e/specs/backend/cart.test.js
+++ b/tests/e2e/specs/backend/cart.test.js
@@ -29,6 +29,8 @@ const block = {
 	slug: 'woocommerce/cart',
 	class: '.wp-block-woocommerce-cart',
 	selectors: {
+		disabledInsertButton:
+			"//button[@aria-disabled='true']//span[text()='Cart']",
 		insertButton: "//button//span[text()='Cart']",
 	},
 };
@@ -66,8 +68,10 @@ describe( `${ block.name } Block`, () => {
 		it( 'can only be inserted once', async () => {
 			await openGlobalBlockInserter();
 			await page.keyboard.type( block.name );
-			const button = await page.$x( block.selectors.insertButton );
-			expect( button ).toHaveLength( 0 );
+			const button = await page.$x(
+				block.selectors.disabledInsertButton
+			);
+			expect( button ).toHaveLength( 1 );
 		} );
 
 		it( 'inner blocks can be added/removed by filters', async () => {
@@ -109,14 +113,22 @@ describe( `${ block.name } Block`, () => {
 				'//div[@data-type="woocommerce/cart-order-summary-block"]//button[@aria-label="Add block"]'
 			);
 			await addBlockButton.click();
+			await expect( page ).toFill(
+				'input.components-search-control__input',
+				'Table'
+			);
 			const tableButton = await page.waitForXPath(
 				'//*[@role="option" and contains(., "Table")]'
+			);
+			await expect( tableButton ).not.toBeNull();
+			await expect( page ).toFill(
+				'input.components-search-control__input',
+				'Audio'
 			);
 			const audioButton = await page.waitForXPath(
 				'//*[@role="option" and contains(., "Audio")]'
 			);
-			expect( tableButton ).not.toBeNull();
-			expect( audioButton ).not.toBeNull();
+			await expect( audioButton ).not.toBeNull();
 
 			// // Now check the filled cart block and expect only the Table block to be available there.
 			await selectBlockByName( 'woocommerce/filled-cart-block' );
@@ -124,13 +136,14 @@ describe( `${ block.name } Block`, () => {
 				'//div[@data-type="woocommerce/filled-cart-block"]//button[@aria-label="Add block"]'
 			);
 			await filledCartAddBlockButton.click();
+
 			const filledCartTableButton = await page.waitForXPath(
 				'//*[@role="option" and contains(., "Table")]'
 			);
+			expect( filledCartTableButton ).not.toBeNull();
 			const filledCartAudioButton = await page.$x(
 				'//*[@role="option" and contains(., "Audio")]'
 			);
-			expect( filledCartTableButton ).not.toBeNull();
 			expect( filledCartAudioButton ).toHaveLength( 0 );
 		} );
 

--- a/tests/e2e/specs/backend/cart.test.js
+++ b/tests/e2e/specs/backend/cart.test.js
@@ -68,10 +68,8 @@ describe( `${ block.name } Block`, () => {
 		it( 'can only be inserted once', async () => {
 			await openGlobalBlockInserter();
 			await page.keyboard.type( block.name );
-			const button = await page.$x(
-				block.selectors.disabledInsertButton
-			);
-			expect( button ).toHaveLength( 1 );
+			const button = await page.$x( block.selectors.insertButton );
+			expect( button ).toHaveLength( 0 );
 		} );
 
 		it( 'inner blocks can be added/removed by filters', async () => {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR adds a default value for the `align` attribute on the Cart and Checkout blocks.

This is required to ensure these blocks are rendered at the intended width on all themes, as sometimes they are rendered in a one-column layout.

This will affect existing blocks when opening them in the editor because the `align` attribute will not have a value.

<!-- Reference any related issues or PRs here -->

Fixes #8894

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
| <img width="722" alt="image" src="https://user-images.githubusercontent.com/5656702/228537393-0d7b0d67-b1a7-4d2f-80a1-73b5ad2438ed.png"> | <img width="1265" alt="image" src="https://user-images.githubusercontent.com/5656702/228537476-7eb35b9f-c700-4c89-bc9a-deb20942d6ed.png"> |
| <img width="743" alt="image" src="https://user-images.githubusercontent.com/5656702/228537747-a9e3b17a-f020-496e-8cd0-333aa6dc8c7d.png"> | <img width="1257" alt="image" src="https://user-images.githubusercontent.com/5656702/228537662-84ff0c7b-cbd8-45b8-8825-b07c234d6d39.png"> |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Activate the Twenty Twenty-Three theme
2. Create a new page and insert the Cart block.
3. Ensure it renders in a two-column layout, with the cart items on the left and the order totals on the right.
4. Select the Cart block (you may need to do this from the block list, because you might select inner blocks) and change the alignment to "none".
5. Ensure this changes the layout to a single column.
6. Save the page, go to the front-end and add a product to your Cart.
7. View the page you just saved on the front-end. Ensure the alignment is set correctly and you see the correct width.
8. Go back to the page editor and delete the Cart block. Repeat these steps for the Checkout block.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Release notes
This will affect existing blocks when opening them in the editor because the `align` attribute will not have a value. Merchants who don't want to have the wide alignment by default won't be affected until they edit and save a page containing the Cart or Checkout blocks. If they wish to have no alignment then they should open the page editor and select the Cart/Checkout block and manually set its alignment using the block settings toolbar.

<img width="1245" alt="image" src="https://user-images.githubusercontent.com/5656702/228543812-605a2653-ae90-426a-978f-1f7eeafeccfd.png">



### Changelog

> Set Cart and Checkout blocks to have the wide alignment by default when first added to a page.
