### PR TITLE
Product Image Gallery: Prevent image placeholder from going outside its wrapper

### DIFF
--- a/assets/js/atomic/blocks/product-elements/product-image-gallery/editor.scss
+++ b/assets/js/atomic/blocks/product-elements/product-image-gallery/editor.scss
@@ -1,7 +1,8 @@
 .wc-block-editor-product-gallery {
 	img {
-		width: 500px;
-		height: 500px;
+		max-width: 500px;
+		width: 100%;
+		height: auto;
 	}
 	.wc-block-editor-product-gallery__other-images {
 		img {


### PR DESCRIPTION
When the users resize the window or access smaller screen sizes, the placeholder image is not resized to fit the wrapper component. This PR solves that by removing the fixed `width` of the placeholder and allowing it to adjust itself accordingly to its container.

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #8742  

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/20469356/228633672-5a987adb-5e49-480e-941c-0514ad955c58.png) | ![image](https://user-images.githubusercontent.com/20469356/228633979-f6ba3b61-77d3-4d7b-a71e-83813f230e7e.png) |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->


1. Log in to your WordPress dashboard;
2. Go to Appearance > Themes, and select a block theme (for example: Twenty-twenty three);
3. Go to Appearance < Site Editor (Beta);
4. Go to Templates > Single Product;
5. Click the Edit button;
6. Click on the "+" icon to add a new block and search for "Product Image Gallery" block in the search bar;
7. Click on the "Product Image Gallery" block, and add it to the editor;
9. Resize the window and make sure that the placeholder image adjusts itself to the block wrapping it


* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Fix image placeholder for the Product Image Gallery block that was not fitting inside its wrapper component
