### PR TITLE
Remove `isExperimentalBuild` Checks in Classic Template Block

### DIFF
--- a/assets/js/blocks/classic-template/index.tsx
+++ b/assets/js/blocks/classic-template/index.tsx
@@ -7,7 +7,10 @@ import {
 	unregisterBlockType,
 } from '@wordpress/blocks';
 import type { BlockEditProps } from '@wordpress/blocks';
-import { WC_BLOCKS_IMAGE_URL } from '@woocommerce/block-settings';
+import {
+	isExperimentalBuild,
+	WC_BLOCKS_IMAGE_URL,
+} from '@woocommerce/block-settings';
 import { useBlockProps } from '@wordpress/block-editor';
 import { Button, Placeholder } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -207,46 +210,55 @@ const registerClassicTemplateBlock = ( {
 
 let currentTemplateId: string | undefined;
 
-subscribe( () => {
-	const previousTemplateId = currentTemplateId;
-	const store = select( 'core/edit-site' );
-	currentTemplateId = store?.getEditedPostId() as string | undefined;
+if ( isExperimentalBuild() ) {
+	subscribe( () => {
+		const previousTemplateId = currentTemplateId;
+		const store = select( 'core/edit-site' );
+		currentTemplateId = store?.getEditedPostId() as string | undefined;
 
-	if ( previousTemplateId === currentTemplateId ) {
-		return;
-	}
+		if ( previousTemplateId === currentTemplateId ) {
+			return;
+		}
 
-	const parsedTemplate = currentTemplateId?.split( '//' )[ 1 ];
+		const parsedTemplate = currentTemplateId?.split( '//' )[ 1 ];
 
-	if ( parsedTemplate === null || parsedTemplate === undefined ) {
-		return;
-	}
+		if ( parsedTemplate === null || parsedTemplate === undefined ) {
+			return;
+		}
 
-	const block = getBlockType( BLOCK_SLUG );
+		const block = getBlockType( BLOCK_SLUG );
 
-	if (
-		block !== undefined &&
-		( ! hasTemplateSupportForClassicTemplateBlock(
-			parsedTemplate,
-			TEMPLATES
-		) ||
-			isClassicTemplateBlockRegisteredWithAnotherTitle(
-				block,
-				parsedTemplate
-			) )
-	) {
-		unregisterBlockType( BLOCK_SLUG );
-		currentTemplateId = undefined;
-		return;
-	}
+		if (
+			block !== undefined &&
+			( ! hasTemplateSupportForClassicTemplateBlock(
+				parsedTemplate,
+				TEMPLATES
+			) ||
+				isClassicTemplateBlockRegisteredWithAnotherTitle(
+					block,
+					parsedTemplate
+				) )
+		) {
+			unregisterBlockType( BLOCK_SLUG );
+			currentTemplateId = undefined;
+			return;
+		}
 
-	if (
-		block === undefined &&
-		hasTemplateSupportForClassicTemplateBlock( parsedTemplate, TEMPLATES )
-	) {
-		registerClassicTemplateBlock( {
-			template: parsedTemplate,
-			inserter: true,
-		} );
-	}
-} );
+		if (
+			block === undefined &&
+			hasTemplateSupportForClassicTemplateBlock(
+				parsedTemplate,
+				TEMPLATES
+			)
+		) {
+			registerClassicTemplateBlock( {
+				template: parsedTemplate,
+				inserter: true,
+			} );
+		}
+	} );
+} else {
+	registerClassicTemplateBlock( {
+		inserter: false,
+	} );
+}

--- a/assets/js/blocks/classic-template/index.tsx
+++ b/assets/js/blocks/classic-template/index.tsx
@@ -7,10 +7,7 @@ import {
 	unregisterBlockType,
 } from '@wordpress/blocks';
 import type { BlockEditProps } from '@wordpress/blocks';
-import {
-	isExperimentalBuild,
-	WC_BLOCKS_IMAGE_URL,
-} from '@woocommerce/block-settings';
+import { WC_BLOCKS_IMAGE_URL } from '@woocommerce/block-settings';
 import { useBlockProps } from '@wordpress/block-editor';
 import { Button, Placeholder } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -89,7 +86,7 @@ const Edit = ( {
 		getButtonLabel,
 	} = conversionConfig[ templateType ];
 
-	const canConvert = isExperimentalBuild() && isConversionPossible();
+	const canConvert = isConversionPossible();
 	const placeholderDescription = getDescription( templateTitle, canConvert );
 
 	return (
@@ -210,55 +207,46 @@ const registerClassicTemplateBlock = ( {
 
 let currentTemplateId: string | undefined;
 
-if ( isExperimentalBuild() ) {
-	subscribe( () => {
-		const previousTemplateId = currentTemplateId;
-		const store = select( 'core/edit-site' );
-		currentTemplateId = store?.getEditedPostId() as string | undefined;
+subscribe( () => {
+	const previousTemplateId = currentTemplateId;
+	const store = select( 'core/edit-site' );
+	currentTemplateId = store?.getEditedPostId() as string | undefined;
 
-		if ( previousTemplateId === currentTemplateId ) {
-			return;
-		}
+	if ( previousTemplateId === currentTemplateId ) {
+		return;
+	}
 
-		const parsedTemplate = currentTemplateId?.split( '//' )[ 1 ];
+	const parsedTemplate = currentTemplateId?.split( '//' )[ 1 ];
 
-		if ( parsedTemplate === null || parsedTemplate === undefined ) {
-			return;
-		}
+	if ( parsedTemplate === null || parsedTemplate === undefined ) {
+		return;
+	}
 
-		const block = getBlockType( BLOCK_SLUG );
+	const block = getBlockType( BLOCK_SLUG );
 
-		if (
-			block !== undefined &&
-			( ! hasTemplateSupportForClassicTemplateBlock(
-				parsedTemplate,
-				TEMPLATES
-			) ||
-				isClassicTemplateBlockRegisteredWithAnotherTitle(
-					block,
-					parsedTemplate
-				) )
-		) {
-			unregisterBlockType( BLOCK_SLUG );
-			currentTemplateId = undefined;
-			return;
-		}
+	if (
+		block !== undefined &&
+		( ! hasTemplateSupportForClassicTemplateBlock(
+			parsedTemplate,
+			TEMPLATES
+		) ||
+			isClassicTemplateBlockRegisteredWithAnotherTitle(
+				block,
+				parsedTemplate
+			) )
+	) {
+		unregisterBlockType( BLOCK_SLUG );
+		currentTemplateId = undefined;
+		return;
+	}
 
-		if (
-			block === undefined &&
-			hasTemplateSupportForClassicTemplateBlock(
-				parsedTemplate,
-				TEMPLATES
-			)
-		) {
-			registerClassicTemplateBlock( {
-				template: parsedTemplate,
-				inserter: true,
-			} );
-		}
-	} );
-} else {
-	registerClassicTemplateBlock( {
-		inserter: false,
-	} );
-}
+	if (
+		block === undefined &&
+		hasTemplateSupportForClassicTemplateBlock( parsedTemplate, TEMPLATES )
+	) {
+		registerClassicTemplateBlock( {
+			template: parsedTemplate,
+			inserter: true,
+		} );
+	}
+} );


### PR DESCRIPTION
By removing the `isExperimentalBuild` conditional checks in the Classic Template block, we ensure that the capability of switching to the blockified Single Product Template will land in WooCommerce Core and not be limited to the feature plugin.

This is an adjustment from #8324. The test plan is the mainly the same, with some minor adjustments.

See p1680000654295729-slack-C02UBB1EPEF for additional context.

### Screenshots
| Before | After |
| ------ | ----- |
| <img width="1043" alt="Screenshot 2023-01-30 at 12 41 58" src="https://user-images.githubusercontent.com/186112/215467611-b77d7564-920f-4c05-87af-32e9ed5e6a9b.png"> |<video src=https://user-images.githubusercontent.com/4463174/227149851-235b6685-0955-48e8-91d5-37f2ad7f9b87.mp4/>|

### Testing

##### Prerequisites:
WordPress: >=6.1
Make sure `Single Product` template customizations are reset to the default state:
1. Go to (`/wp-admin/site-editor.php?postType=wp_template`)
1. Click three dots next to the template and click `Clear customizations`

##### Steps
1. Build a release version of the plugin (via `npm run build:deploy`).
1. Enter the `Single Product` template.
1. Check that the placeholder description says "This block serves as a placeholder for your WooCommerce Single Product Block. We recommend upgrading to the Single Products block for more features to edit your products visually. Don't worry, you can always revert back.".
1. Click the `Upgrade to Blockified Single Product Template` button.
1. See new templates work in the Site Editor and on the front end.
1. Ensure there are no side-effects to this change and everything functions as-expected.
1. Ensure there are no lingering dependencies that are flagged as experimental.

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Enable users to migrate to the blockified Single Product template.