### PR TITLE
Make a Single Product conversion enabled in Core, but keep the Produc…

### DIFF
--- a/assets/js/blocks/classic-template/archive-product.ts
+++ b/assets/js/blocks/classic-template/archive-product.ts
@@ -7,6 +7,7 @@ import {
 	type BlockInstance,
 } from '@wordpress/blocks';
 import { isWpVersion } from '@woocommerce/settings';
+import { isExperimentalBuild } from '@woocommerce/block-settings';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -74,7 +75,7 @@ const getBlockifiedTemplateWithTermDescription = (
 const isConversionPossible = () => {
 	// Blockification is possible for the WP version 6.1 and above,
 	// which are the versions the Products block supports.
-	return isWpVersion( '6.1', '>=' );
+	return isExperimentalBuild() && isWpVersion( '6.1', '>=' );
 };
 
 const getDescriptionAllowingConversion = ( templateTitle: string ) =>

--- a/assets/js/blocks/classic-template/index.tsx
+++ b/assets/js/blocks/classic-template/index.tsx
@@ -89,7 +89,7 @@ const Edit = ( {
 		getButtonLabel,
 	} = conversionConfig[ templateType ];
 
-	const canConvert = isExperimentalBuild() && isConversionPossible();
+	const canConvert = isConversionPossible();
 	const placeholderDescription = getDescription( templateTitle, canConvert );
 
 	return (

--- a/assets/js/blocks/classic-template/product-search-results.ts
+++ b/assets/js/blocks/classic-template/product-search-results.ts
@@ -8,6 +8,7 @@ import {
 	type InnerBlockTemplate,
 } from '@wordpress/blocks';
 import { isWpVersion } from '@woocommerce/settings';
+import { isExperimentalBuild } from '@woocommerce/block-settings';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -122,7 +123,7 @@ const getBlockifiedTemplate = ( inheritedAttributes: InheritedAttributes ) => {
 const isConversionPossible = () => {
 	// Blockification is possible for the WP version 6.1 and above,
 	// which are the versions the Products block supports.
-	return isWpVersion( '6.1', '>=' );
+	return isExperimentalBuild() && isWpVersion( '6.1', '>=' );
 };
 
 const getDescriptionAllowingConversion = ( templateTitle: string ) =>


### PR DESCRIPTION
Expose the conversion of Single Product from classic to blockified version to Core, but keep the Product Archive behind a experimental flag.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing
Prerequisite:
- use a non-experimental build, e.g. running `npm run build:deploy` (that prerequisite is already satisfied when testing using ZIP file. In such case, ignore this point)

1. Make sure Product Catalog / Product Search Results / Single Product templates are cleared out to the default state. To achieve that:
    - Go to (/wp-admin/site-editor.php?postType=wp_template)
    - Click three dots next to template and click "Clear customizations"
2. Go to Product Catalog template
3. **Expected:** There's a placeholder for Classic Template and **there's NO** "Upgrade to Products block" button
4. Go to Product Search Result template
5. **Expected:** There's a placeholder for Classic Template and **there's NO** "Upgrade to Products block" button
6. Go to Single Product template
7. **Expected:** There's a placeholder for Classic Template and **there IS** "Upgrade to Products block" button

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental

