### PR TITLE
Fix link padding in TT3

### DIFF
--- a/assets/js/base/components/sidebar-layout/style.scss
+++ b/assets/js/base/components/sidebar-layout/style.scss
@@ -49,10 +49,13 @@
 .is-large {
 	.wc-block-components-sidebar {
 		.wc-block-components-totals-item,
-		.wc-block-components-totals-coupon-link,
 		.wc-block-components-panel {
 			padding-left: $gap;
 			padding-right: $gap;
+		}
+		.wc-block-components-totals-coupon-link {
+			margin-left: $gap;
+			margin-right: $gap;
 		}
 
 		.wc-block-components-panel {

--- a/assets/js/blocks/checkout/styles/style.scss
+++ b/assets/js/blocks/checkout/styles/style.scss
@@ -58,10 +58,13 @@
 			}
 		}
 		.wc-block-components-totals-item,
-		.wc-block-components-totals-coupon-link,
 		.wc-block-components-panel {
 			padding-left: $gap;
 			padding-right: $gap;
+		}
+		.wc-block-components-totals-coupon-link {
+			margin-left: $gap;
+			margin-right: $gap;
 		}
 	}
 }
@@ -79,10 +82,13 @@
 			padding: 0;
 			width: 100%;
 			.wc-block-components-totals-item,
-			.wc-block-components-totals-coupon-link,
 			.wc-block-components-panel {
 				padding-left: 0;
 				padding-right: 0;
+			}
+			.wc-block-components-totals-coupon-link {
+				margin-left: 0;
+				margin-right: 0;
 			}
 		}
 	}


### PR DESCRIPTION
I've verified that link colors are correct across block themes, with the exception of [TT3 which has a bug](https://github.com/woocommerce/woocommerce-blocks/issues/8807#issuecomment-1479091387). But links within TT3 are still consistent.

This does however fix a padding issue:

![Screenshot 2023-03-30 at 11 18 33](https://user-images.githubusercontent.com/90977/228806064-cdaaec76-9b0d-4750-b88e-e89e019c1f9f.png)

After:
 
![Screenshot 2023-03-30 at 11 15 59](https://user-images.githubusercontent.com/90977/228806097-2be36671-8598-4dd8-897b-cf8f911fcbc9.png)

Fixes #8807
Fixes #8750

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->
