### PR TITLE
Fix the incorrect position of the after_shop_loop_item_title hook

### DIFF
--- a/src/Templates/ArchiveProductTemplatesCompatibility.php
+++ b/src/Templates/ArchiveProductTemplatesCompatibility.php
@@ -188,7 +188,7 @@ class ArchiveProductTemplatesCompatibility extends AbstractTemplateCompatibility
 			),
 			'woocommerce_after_shop_loop_item_title'  => array(
 				'block_name' => 'core/post-title',
-				'position'   => 'before',
+				'position'   => 'after',
 				'hooked'     => array(
 					'woocommerce_template_loop_rating' => 5,
 					'woocommerce_template_loop_price'  => 10,


### PR DESCRIPTION
One of the hooks in the blockified Product Archive compatibility layer had incorrect position:

`woocommerce_after_shop_loop_item_title` was placed `before` the title.

This PR fixes this problem.

### Screenshots

| Before | After |
| ------ | ----- |
|    <img width="418" alt="image" src="https://user-images.githubusercontent.com/20098064/229038034-8bca36c7-f450-4525-88a5-2e949c68b4f5.png"> | <img width="420" alt="image" src="https://user-images.githubusercontent.com/20098064/229038149-0a3af317-e81e-42c2-bbd2-161c2c1ef1cf.png">
 | 

#### User Facing Testing
1. In your `functions.php` file add a custom hook:

```
function after_title_action( $html ) {
	echo '<p>After title content</p>';
}
add_action( 'woocommerce_after_shop_loop_item_title', 'after_title_action');
```

2. Go to Editor
3. Open Product Catalog template
4. Remove the Classic Template if it's there
5. Add a Products block
6. Save and go to frontend
7. **Expected:** "After title content" is displayed AFTER the Product title
8. Go back to Editor and change the place of Product Title within the Product Template block (e.g. move it above the Product Image), save and go to frontend
9. **Expected:** "After title content" is still displayed exactly AFTER the Product Title

**KNOWN ISSUE: Note the content is duplicated and it's a known issue that will be fixed separately! 
https://github.com/woocommerce/woocommerce-blocks/issues/8912**

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental

### Changelog

> Product Archive compatibility layer: Fix the `woocommerce_after_shop_loop_item_title` hook positioning
