### PR TITLE
Remove construct method from Product Archive Compatiblity Layer

### DIFF
--- a/src/Templates/ArchiveProductTemplatesCompatibility.php
+++ b/src/Templates/ArchiveProductTemplatesCompatibility.php
@@ -24,14 +24,6 @@ class ArchiveProductTemplatesCompatibility extends AbstractTemplateCompatibility
 	protected $hook_data;
 
 	/**
-	 * Constructor.
-	 */
-	public function __construct() {
-		$this->set_hook_data();
-		$this->init();
-	}
-
-	/**
 	 * Update the render block data to inject our custom attribute needed to
 	 * determine which blocks belong to an inherited Products block.
 	 *


### PR DESCRIPTION
### Problem
There's a compatibility layer for blockified Product Archive. Hooks are fired twice and content is duplicated

### Solution
`init` method is called already when class is registered [in Bootstrap.php here](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/src/Domain/Bootstrap.php#L134). Hence it's not needed in the `ArchiveProductTemplatesCompatibility` class. Also, `set_hook_data` is called within `init` method [here](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/src/Templates/AbstractTemplateCompatibility.php#L28).

Methods invoked in the constructor were already called when registering a class, so it duplicated the hooks

Fixes: https://github.com/woocommerce/woocommerce-blocks/issues/8912 

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|     <img width="420" alt="image" src="https://user-images.githubusercontent.com/20098064/229070643-688a8158-603f-4076-847c-bddef5b58ac4.png">   |   <img width="418" alt="image" src="https://user-images.githubusercontent.com/20098064/229070561-9d958fc1-4dc7-43e4-9600-f8aa25210b1b.png">    |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

### Prerequisites:
1. Install [WooCommerce Pre-Orders ](https://woocommerce.com/products/woocommerce-pre-orders/) plugin
2. Go to WooCommerce -> Settings -> Pre-Order
3. Provide some text in "Shop loop product message" section, e.g. "Available soon"
4. Make some product a Pre-Order: edit product, go to Pre-Orders, tick "Enable pre-orders for this product."
5. Alternatively - the equivalent of the above - add the following code to your functions.php

```
function before_title_action( $html ) {
	echo '<p>Before title content</p>';
}
add_action( 'woocommerce_before_shop_loop_item_title', 'before_title_action' );
```

### Steps to reproduce
1. Go to Editor
2. Open Product Catalog template
7. Remove the Classic Template if it's there
8. Add a Products block
9. Save and go to frontend
10. **Expected:** "Available soon" content is displayed below the product title **ONCE**, not twice

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental

### Changelog

> Product Archive Compatibility Layer: Fix duplicated content
