### PR TITLE
Comment out the integration with Airtable

### DIFF
--- a/.github/monitor-typescript-errors/index.js
+++ b/.github/monitor-typescript-errors/index.js
@@ -58,7 +58,8 @@ const runner = async () => {
 	}
 
 	/**
-	 * TODO: Airtable integration is failing auth, so we're disabling it for now.
+	 * @todo: Airtable integration is failing auth, so we're disabling it for now.
+	 * Issue opened: https://github.com/woocommerce/woocommerce-blocks/issues/8961
 	 */
 	// if ( process.env[ 'CURRENT_BRANCH' ] === 'trunk' ) {
 	// 	try {

--- a/.github/monitor-typescript-errors/index.js
+++ b/.github/monitor-typescript-errors/index.js
@@ -1,9 +1,8 @@
 const fs = require( 'fs' );
 const { getOctokit, context } = require( '@actions/github' );
-const { setFailed, getInput, setOutput } = require( '@actions/core' );
+const { getInput, setOutput } = require( '@actions/core' );
 const { parseXml, getFilesWithNewErrors } = require( './utils/xml' );
 const { generateMarkdownMessage } = require( './utils/markdown' );
-const { addRecord } = require( './utils/airtable' );
 const { addComment } = require( './utils/github' );
 
 const runner = async () => {
@@ -58,13 +57,16 @@ const runner = async () => {
 		}
 	}
 
-	if ( process.env[ 'CURRENT_BRANCH' ] === 'trunk' ) {
-		try {
-			await addRecord( currentCheckStyleFileContentParsed.totalErrors );
-		} catch ( error ) {
-			setFailed( error );
-		}
-	}
+	/**
+	 * TODO: Airtable integration is failing auth, so we're disabling it for now.
+	 */
+	// if ( process.env[ 'CURRENT_BRANCH' ] === 'trunk' ) {
+	// 	try {
+	// 		await addRecord( currentCheckStyleFileContentParsed.totalErrors );
+	// 	} catch ( error ) {
+	// 		setFailed( error );
+	// 	}
+	// }
 };
 
 runner();


### PR DESCRIPTION
Comment out the integration with Airtable as it's failing on `trunk` since March 30th 2023.

Let's keep in mind API Keys which we use for integration [are being deprecated by Airtable](https://community.airtable.com/t5/announcements/new-api-capabilities-now-in-ga-and-upcoming-api-keys-deprecation/ba-p/141824), so the proper fix means following [the new guidelines of integration](https://community.airtable.com/t5/announcements/new-beta-new-api-authentication-methods-endpoints-and-public-api/ba-p/38823).

This is temporary, so the integration can be either fixed or removed completely (issue regarding proper fix [created here](https://github.com/woocommerce/woocommerce/issues/42418)).