### PR TITLE
Update Getting Started Doc

### DIFF
--- a/docs/contributors/contributing/getting-started.md
+++ b/docs/contributors/contributing/getting-started.md
@@ -24,7 +24,7 @@ Before you can start modifying files you'll want to clone this repository locall
 To do so from the command line, ensure you have [`git`](https://git-scm.com) installed on your machine, and run the clone command:
 
 ```sh
-git clone https://github.com/woocommerce/woocommerce-gutenberg-products-block.git
+git clone https://github.com/woocommerce/woocommerce-blocks.git
 ```
 
 ## Configuring your WordPress site
@@ -55,7 +55,7 @@ See [`package.json` `engines`](../../../package.json) for details of required ve
 
 Once you have `node` and `composer` setup, install the dependencies from the command line:
 
--   Change directory to your repo folder, e.g. `$ cd woocommerce-gutenberg-products-block`.
+-   Change directory to your repo folder, e.g. `$ cd woocommerce-blocks`.
 -   Install javascript and php dependencies - `$ npm install && composer install`.
 
 ## Building the plugin files

--- a/docs/contributors/contributing/getting-started.md
+++ b/docs/contributors/contributing/getting-started.md
@@ -57,7 +57,7 @@ See [`package.json` `engines`](../../../package.json) and [`readme.txt`](../../.
 Once you the above setup, install the dependencies from the command line:
 
 -   Change directory to your repo folder, e.g. `$ cd woocommerce-blocks`.
--   Ensure the correct version of Node and NPM are installed - `nvm use`
+-   Ensure the correct version of Node and NPM are installed - `$ nvm use`
 -   Install JavaScript and PHP dependencies - `$ npm install && composer install`.
 
 ## Building the plugin files

--- a/docs/contributors/contributing/getting-started.md
+++ b/docs/contributors/contributing/getting-started.md
@@ -2,18 +2,18 @@
 
 ## Table of contents <!-- omit in toc -->
 
--   [Cloning the Git Repository](#cloning-the-git-repository)
--   [Configuring your WordPress site](#configuring-your-wordpress-site)
--   [Installing dependencies](#installing-dependencies)
--   [Building the plugin files](#building-the-plugin-files)
--   [Create a plugin package in ZIP format](#create-a-plugin-package-in-zip-format)
--   [Linting](#linting)
--   [Running the Blocks plugin](#running-the-blocks-plugin)
--   [Developer Tools (Visual Studio Code)](#developer-tools-visual-studio-code)
-    -   [EditorConfig](#editorconfig)
-    -   [ESLint](#eslint)
-    -   [Prettier](#prettier)
--   [Testing](#testing)
+- [Cloning the Git Repository](#cloning-the-git-repository)
+- [Configuring your WordPress site](#configuring-your-wordpress-site)
+- [Installing dependencies](#installing-dependencies)
+- [Building the plugin files](#building-the-plugin-files)
+- [Create a plugin package in ZIP format](#create-a-plugin-package-in-zip-format)
+- [Linting](#linting)
+- [Running the Blocks plugin](#running-the-blocks-plugin)
+- [Developer Tools (Visual Studio Code)](#developer-tools-visual-studio-code)
+	- [EditorConfig](#editorconfig)
+	- [ESLint](#eslint)
+	- [Prettier](#prettier)
+- [Testing](#testing)
 
 Before you can begin contributing to the Blocks plugin there are several steps and tools required to setup your local development environment.
 
@@ -48,15 +48,17 @@ define( 'SCRIPT_DEBUG', true );
 
 To install dependencies, you will need the following tools installed on your machine:
 
--   [`npm` and `node.js`](https://nodejs.org)
--   [`composer`](https://getcomposer.org)
+* `node` and `npm` via [NVM](https://github.com/nvm-sh/nvm#installing-and-updating): While you can always install Node or NPM through other means, we recommend using NVM to ensure you're aligned with the version used by our development teams. Our repository contains [an `.nvmrc` file](.nvmrc) which helps ensure you are using the correct version of Node.
+* [PHP](https://www.php.net/manual/en/install.php): WooCommerce Blocks requires PHP. It is also needed to run Composer and various project build scripts.
+* [Composer](https://getcomposer.org/doc/00-intro.md): We use Composer to manage all of the dependencies for PHP packages and plugins.
 
-See [`package.json` `engines`](../../../package.json) for details of required versions.
-
-Once you have `node` and `composer` setup, install the dependencies from the command line:
+See [`package.json` `engines`](../../../package.json) and [`readme.txt`](../../../readme.txt#L6) for details on required versions.
+<!--  -->
+Once you the above setup, install the dependencies from the command line:
 
 -   Change directory to your repo folder, e.g. `$ cd woocommerce-blocks`.
--   Install javascript and php dependencies - `$ npm install && composer install`.
+-   Ensure the correct version of Node and NPM are installed - `nvm use`
+-   Install JavaScript and PHP dependencies - `$ npm install && composer install`.
 
 ## Building the plugin files
 

--- a/docs/contributors/contributing/getting-started.md
+++ b/docs/contributors/contributing/getting-started.md
@@ -48,7 +48,7 @@ define( 'SCRIPT_DEBUG', true );
 
 To install dependencies, you will need the following tools installed on your machine:
 
-* `node` and `npm` via [NVM](https://github.com/nvm-sh/nvm#installing-and-updating): While you can always install Node or NPM through other means, we recommend using NVM to ensure you're aligned with the version used by our development teams. Our repository contains [an `.nvmrc` file](.nvmrc) which helps ensure you are using the correct version of Node.
+* `node` and `npm` via [NVM](https://github.com/nvm-sh/nvm#installing-and-updating): While you can always install Node or NPM through other means, we recommend using NVM to ensure you're aligned with the version used by our development teams. Our repository contains [an `.nvmrc` file](../../../.nvmrc) which helps ensure you are using the correct version of Node.
 * [PHP](https://www.php.net/manual/en/install.php): WooCommerce Blocks requires PHP. It is also needed to run Composer and various project build scripts.
 * [Composer](https://getcomposer.org/doc/00-intro.md): We use Composer to manage all of the dependencies for PHP packages and plugins.
 


### PR DESCRIPTION
The doc referenced the old repository name in the `git clone` instructions (and also in directory references). This fixes that.

I'm going to be adding a few other changes to the Getting Started guide as well.

- [x] Improve dependencies install (can use what Woo Core has as a guide)
- [x] Mention use of nvm to make sure the correct version of node and npm is in use.




