### PR TITLE
Add permission_callback filter for the Store API

### DIFF
--- a/src/StoreApi/Routes/V1/AbstractRoute.php
+++ b/src/StoreApi/Routes/V1/AbstractRoute.php
@@ -323,4 +323,35 @@ abstract class AbstractRoute implements RouteInterface {
 			'context' => $this->get_context_param(),
 		);
 	}
+
+	/**
+	 * Determines whether the current user can make the request. By default the Store API allows all
+	 * requests--its a public API.
+	 */
+	public function permission_callback() {
+		/**
+		 * Filter the permission callback for the Store API either globally, or for specific endpoints.
+		 *
+		 * Example:
+		 *
+		 *  add_filter(
+		 *      'woocommerce_store_api_permission_callback',
+		 *      function( $permission, $namespace, $path ) {
+		 *          if ( $path === '/checkout' ) {
+		 *              return false;
+		 *          }
+		 *          return $permission;
+		 *      },
+		 *      10,
+		 *      3
+		 *  );
+		 *
+		 * @since 10.0.0
+		 * @param bool $permission_callback Whether the request has permission. Default true.
+		 * @param string $namespace The namespace for the route.
+		 * @param string $path The route path.
+		 * @param AbstractRoute $route_instance The route instance.
+		 */
+		return apply_filters( 'woocommerce_store_api_permission_callback', true, $this->get_namespace(), $this->get_path(), $this );
+	}
 }

--- a/src/StoreApi/Routes/V1/Batch.php
+++ b/src/StoreApi/Routes/V1/Batch.php
@@ -42,7 +42,7 @@ class Batch extends AbstractRoute implements RouteInterface {
 		return array(
 			'callback'            => [ $this, 'get_response' ],
 			'methods'             => 'POST',
-			'permission_callback' => '__return_true',
+			'permission_callback' => [ $this, 'permission_callback' ],
 			'args'                => array(
 				'validation' => array(
 					'type'    => 'string',

--- a/src/StoreApi/Routes/V1/Cart.php
+++ b/src/StoreApi/Routes/V1/Cart.php
@@ -31,7 +31,7 @@ class Cart extends AbstractCartRoute {
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'get_response' ],
-				'permission_callback' => '__return_true',
+				'permission_callback' => [ $this, 'permission_callback' ],
 				'args'                => [
 					'context' => $this->get_context_param( [ 'default' => 'view' ] ),
 				],

--- a/src/StoreApi/Routes/V1/CartAddItem.php
+++ b/src/StoreApi/Routes/V1/CartAddItem.php
@@ -33,7 +33,7 @@ class CartAddItem extends AbstractCartRoute {
 			[
 				'methods'             => \WP_REST_Server::CREATABLE,
 				'callback'            => [ $this, 'get_response' ],
-				'permission_callback' => '__return_true',
+				'permission_callback' => [ $this, 'permission_callback' ],
 				'args'                => [
 					'id'        => [
 						'description'       => __( 'The cart item product or variation ID.', 'woo-gutenberg-products-block' ),

--- a/src/StoreApi/Routes/V1/CartApplyCoupon.php
+++ b/src/StoreApi/Routes/V1/CartApplyCoupon.php
@@ -33,7 +33,7 @@ class CartApplyCoupon extends AbstractCartRoute {
 			[
 				'methods'             => \WP_REST_Server::CREATABLE,
 				'callback'            => [ $this, 'get_response' ],
-				'permission_callback' => '__return_true',
+				'permission_callback' => [ $this, 'permission_callback' ],
 				'args'                => [
 					'code' => [
 						'description' => __( 'Unique identifier for the coupon within the cart.', 'woo-gutenberg-products-block' ),

--- a/src/StoreApi/Routes/V1/CartCoupons.php
+++ b/src/StoreApi/Routes/V1/CartCoupons.php
@@ -40,7 +40,7 @@ class CartCoupons extends AbstractCartRoute {
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'get_response' ],
-				'permission_callback' => '__return_true',
+				'permission_callback' => [ $this, 'permission_callback' ],
 				'args'                => [
 					'context' => $this->get_context_param( [ 'default' => 'view' ] ),
 				],
@@ -48,12 +48,12 @@ class CartCoupons extends AbstractCartRoute {
 			[
 				'methods'             => \WP_REST_Server::CREATABLE,
 				'callback'            => [ $this, 'get_response' ],
-				'permission_callback' => '__return_true',
+				'permission_callback' => [ $this, 'permission_callback' ],
 				'args'                => $this->schema->get_endpoint_args_for_item_schema( \WP_REST_Server::CREATABLE ),
 			],
 			[
 				'methods'             => \WP_REST_Server::DELETABLE,
-				'permission_callback' => '__return_true',
+				'permission_callback' => [ $this, 'permission_callback' ],
 				'callback'            => [ $this, 'get_response' ],
 			],
 			'schema'      => [ $this->schema, 'get_public_item_schema' ],

--- a/src/StoreApi/Routes/V1/CartCouponsByCode.php
+++ b/src/StoreApi/Routes/V1/CartCouponsByCode.php
@@ -46,7 +46,7 @@ class CartCouponsByCode extends AbstractCartRoute {
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'get_response' ],
-				'permission_callback' => '__return_true',
+				'permission_callback' => [ $this, 'permission_callback' ],
 				'args'                => [
 					'context' => $this->get_context_param( [ 'default' => 'view' ] ),
 				],
@@ -54,7 +54,7 @@ class CartCouponsByCode extends AbstractCartRoute {
 			[
 				'methods'             => \WP_REST_Server::DELETABLE,
 				'callback'            => [ $this, 'get_response' ],
-				'permission_callback' => '__return_true',
+				'permission_callback' => [ $this, 'permission_callback' ],
 			],
 			'schema'      => [ $this->schema, 'get_public_item_schema' ],
 			'allow_batch' => [ 'v1' => true ],

--- a/src/StoreApi/Routes/V1/CartExtensions.php
+++ b/src/StoreApi/Routes/V1/CartExtensions.php
@@ -40,7 +40,7 @@ class CartExtensions extends AbstractCartRoute {
 			[
 				'methods'             => \WP_REST_Server::CREATABLE,
 				'callback'            => [ $this, 'get_response' ],
-				'permission_callback' => '__return_true',
+				'permission_callback' => [ $this, 'permission_callback' ],
 				'args'                => [
 					'namespace' => [
 						'description' => __( 'Extension\'s name - this will be used to ensure the data in the request is routed appropriately.', 'woo-gutenberg-products-block' ),

--- a/src/StoreApi/Routes/V1/CartItems.php
+++ b/src/StoreApi/Routes/V1/CartItems.php
@@ -40,7 +40,7 @@ class CartItems extends AbstractCartRoute {
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'get_response' ],
-				'permission_callback' => '__return_true',
+				'permission_callback' => [ $this, 'permission_callback' ],
 				'args'                => [
 					'context' => $this->get_context_param( [ 'default' => 'view' ] ),
 				],
@@ -48,13 +48,13 @@ class CartItems extends AbstractCartRoute {
 			[
 				'methods'             => \WP_REST_Server::CREATABLE,
 				'callback'            => array( $this, 'get_response' ),
-				'permission_callback' => '__return_true',
+				'permission_callback' => [ $this, 'permission_callback' ],
 				'args'                => $this->schema->get_endpoint_args_for_item_schema( \WP_REST_Server::CREATABLE ),
 			],
 			[
 				'methods'             => \WP_REST_Server::DELETABLE,
 				'callback'            => [ $this, 'get_response' ],
-				'permission_callback' => '__return_true',
+				'permission_callback' => [ $this, 'permission_callback' ],
 			],
 			'schema'      => [ $this->schema, 'get_public_item_schema' ],
 			'allow_batch' => [ 'v1' => true ],

--- a/src/StoreApi/Routes/V1/CartItemsByKey.php
+++ b/src/StoreApi/Routes/V1/CartItemsByKey.php
@@ -46,7 +46,7 @@ class CartItemsByKey extends AbstractCartRoute {
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'get_response' ],
-				'permission_callback' => '__return_true',
+				'permission_callback' => [ $this, 'permission_callback' ],
 				'args'                => [
 					'context' => $this->get_context_param( [ 'default' => 'view' ] ),
 				],
@@ -54,13 +54,13 @@ class CartItemsByKey extends AbstractCartRoute {
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
 				'callback'            => array( $this, 'get_response' ),
-				'permission_callback' => '__return_true',
+				'permission_callback' => [ $this, 'permission_callback' ],
 				'args'                => $this->schema->get_endpoint_args_for_item_schema( \WP_REST_Server::EDITABLE ),
 			],
 			[
 				'methods'             => \WP_REST_Server::DELETABLE,
 				'callback'            => [ $this, 'get_response' ],
-				'permission_callback' => '__return_true',
+				'permission_callback' => [ $this, 'permission_callback' ],
 			],
 			'schema'      => [ $this->schema, 'get_public_item_schema' ],
 			'allow_batch' => [ 'v1' => true ],

--- a/src/StoreApi/Routes/V1/CartRemoveCoupon.php
+++ b/src/StoreApi/Routes/V1/CartRemoveCoupon.php
@@ -33,7 +33,7 @@ class CartRemoveCoupon extends AbstractCartRoute {
 			[
 				'methods'             => \WP_REST_Server::CREATABLE,
 				'callback'            => [ $this, 'get_response' ],
-				'permission_callback' => '__return_true',
+				'permission_callback' => [ $this, 'permission_callback' ],
 				'args'                => [
 					'code' => [
 						'description' => __( 'Unique identifier for the coupon within the cart.', 'woo-gutenberg-products-block' ),

--- a/src/StoreApi/Routes/V1/CartRemoveItem.php
+++ b/src/StoreApi/Routes/V1/CartRemoveItem.php
@@ -36,7 +36,7 @@ class CartRemoveItem extends AbstractCartRoute {
 			[
 				'methods'             => \WP_REST_Server::CREATABLE,
 				'callback'            => [ $this, 'get_response' ],
-				'permission_callback' => '__return_true',
+				'permission_callback' => [ $this, 'permission_callback' ],
 				'args'                => [
 					'key' => [
 						'description' => __( 'Unique identifier (key) for the cart item.', 'woo-gutenberg-products-block' ),

--- a/src/StoreApi/Routes/V1/CartSelectShippingRate.php
+++ b/src/StoreApi/Routes/V1/CartSelectShippingRate.php
@@ -33,7 +33,7 @@ class CartSelectShippingRate extends AbstractCartRoute {
 			[
 				'methods'             => \WP_REST_Server::CREATABLE,
 				'callback'            => [ $this, 'get_response' ],
-				'permission_callback' => '__return_true',
+				'permission_callback' => [ $this, 'permission_callback' ],
 				'args'                => [
 					'package_id' => array(
 						'description' => __( 'The ID of the package being shipped. Leave blank to apply to all packages.', 'woo-gutenberg-products-block' ),

--- a/src/StoreApi/Routes/V1/CartUpdateCustomer.php
+++ b/src/StoreApi/Routes/V1/CartUpdateCustomer.php
@@ -38,7 +38,7 @@ class CartUpdateCustomer extends AbstractCartRoute {
 			[
 				'methods'             => \WP_REST_Server::CREATABLE,
 				'callback'            => [ $this, 'get_response' ],
-				'permission_callback' => '__return_true',
+				'permission_callback' => [ $this, 'permission_callback' ],
 				'args'                => [
 					'billing_address'  => [
 						'description'       => __( 'Billing address.', 'woo-gutenberg-products-block' ),

--- a/src/StoreApi/Routes/V1/CartUpdateItem.php
+++ b/src/StoreApi/Routes/V1/CartUpdateItem.php
@@ -31,7 +31,7 @@ class CartUpdateItem extends AbstractCartRoute {
 			[
 				'methods'             => \WP_REST_Server::CREATABLE,
 				'callback'            => [ $this, 'get_response' ],
-				'permission_callback' => '__return_true',
+				'permission_callback' => [ $this, 'permission_callback' ],
 				'args'                => [
 					'key'      => [
 						'description' => __( 'Unique identifier (key) for the cart item to update.', 'woo-gutenberg-products-block' ),

--- a/src/StoreApi/Routes/V1/Checkout.php
+++ b/src/StoreApi/Routes/V1/Checkout.php
@@ -66,7 +66,7 @@ class Checkout extends AbstractCartRoute {
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'get_response' ],
-				'permission_callback' => '__return_true',
+				'permission_callback' => [ $this, 'permission_callback' ],
 				'args'                => [
 					'context' => $this->get_context_param( [ 'default' => 'view' ] ),
 				],
@@ -74,7 +74,7 @@ class Checkout extends AbstractCartRoute {
 			[
 				'methods'             => \WP_REST_Server::CREATABLE,
 				'callback'            => [ $this, 'get_response' ],
-				'permission_callback' => '__return_true',
+				'permission_callback' => [ $this, 'permission_callback' ],
 				'args'                => array_merge(
 					[
 						'payment_data' => [

--- a/src/StoreApi/Routes/V1/ProductAttributeTerms.php
+++ b/src/StoreApi/Routes/V1/ProductAttributeTerms.php
@@ -39,7 +39,7 @@ class ProductAttributeTerms extends AbstractTermsRoute {
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'get_response' ],
-				'permission_callback' => '__return_true',
+				'permission_callback' => [ $this, 'permission_callback' ],
 				'args'                => $this->get_collection_params(),
 			],
 			'schema' => [ $this->schema, 'get_public_item_schema' ],

--- a/src/StoreApi/Routes/V1/ProductAttributes.php
+++ b/src/StoreApi/Routes/V1/ProductAttributes.php
@@ -38,7 +38,7 @@ class ProductAttributes extends AbstractRoute {
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'get_response' ],
-				'permission_callback' => '__return_true',
+				'permission_callback' => [ $this, 'permission_callback' ],
 				'args'                => $this->get_collection_params(),
 			],
 			'schema' => [ $this->schema, 'get_public_item_schema' ],

--- a/src/StoreApi/Routes/V1/ProductAttributesById.php
+++ b/src/StoreApi/Routes/V1/ProductAttributesById.php
@@ -46,7 +46,7 @@ class ProductAttributesById extends AbstractRoute {
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'get_response' ],
-				'permission_callback' => '__return_true',
+				'permission_callback' => [ $this, 'permission_callback' ],
 				'args'                => array(
 					'context' => $this->get_context_param(
 						array(

--- a/src/StoreApi/Routes/V1/ProductCategories.php
+++ b/src/StoreApi/Routes/V1/ProductCategories.php
@@ -38,7 +38,7 @@ class ProductCategories extends AbstractTermsRoute {
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'get_response' ],
-				'permission_callback' => '__return_true',
+				'permission_callback' => [ $this, 'permission_callback' ],
 				'args'                => $this->get_collection_params(),
 			],
 			'schema' => [ $this->schema, 'get_public_item_schema' ],

--- a/src/StoreApi/Routes/V1/ProductCategoriesById.php
+++ b/src/StoreApi/Routes/V1/ProductCategoriesById.php
@@ -46,7 +46,7 @@ class ProductCategoriesById extends AbstractRoute {
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'get_response' ],
-				'permission_callback' => '__return_true',
+				'permission_callback' => [ $this, 'permission_callback' ],
 				'args'                => array(
 					'context' => $this->get_context_param(
 						array(

--- a/src/StoreApi/Routes/V1/ProductCollectionData.php
+++ b/src/StoreApi/Routes/V1/ProductCollectionData.php
@@ -43,7 +43,7 @@ class ProductCollectionData extends AbstractRoute {
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'get_response' ],
-				'permission_callback' => '__return_true',
+				'permission_callback' => [ $this, 'permission_callback' ],
 				'args'                => $this->get_collection_params(),
 			],
 			'schema' => [ $this->schema, 'get_public_item_schema' ],

--- a/src/StoreApi/Routes/V1/ProductReviews.php
+++ b/src/StoreApi/Routes/V1/ProductReviews.php
@@ -41,7 +41,7 @@ class ProductReviews extends AbstractRoute {
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'get_response' ],
-				'permission_callback' => '__return_true',
+				'permission_callback' => [ $this, 'permission_callback' ],
 				'args'                => $this->get_collection_params(),
 			],
 			'schema' => [ $this->schema, 'get_public_item_schema' ],

--- a/src/StoreApi/Routes/V1/ProductTags.php
+++ b/src/StoreApi/Routes/V1/ProductTags.php
@@ -31,7 +31,7 @@ class ProductTags extends AbstractTermsRoute {
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'get_response' ],
-				'permission_callback' => '__return_true',
+				'permission_callback' => [ $this, 'permission_callback' ],
 				'args'                => $this->get_collection_params(),
 			],
 			'schema' => [ $this->schema, 'get_public_item_schema' ],

--- a/src/StoreApi/Routes/V1/Products.php
+++ b/src/StoreApi/Routes/V1/Products.php
@@ -41,7 +41,7 @@ class Products extends AbstractRoute {
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'get_response' ],
-				'permission_callback' => '__return_true',
+				'permission_callback' => [ $this, 'permission_callback' ],
 				'args'                => $this->get_collection_params(),
 			],
 			'schema' => [ $this->schema, 'get_public_item_schema' ],

--- a/src/StoreApi/Routes/V1/ProductsById.php
+++ b/src/StoreApi/Routes/V1/ProductsById.php
@@ -46,7 +46,7 @@ class ProductsById extends AbstractRoute {
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'get_response' ],
-				'permission_callback' => '__return_true',
+				'permission_callback' => [ $this, 'permission_callback' ],
 				'args'                => array(
 					'context' => $this->get_context_param(
 						array(


### PR DESCRIPTION
This PR makes it possible to disable API endpoints using a permission filter. For example:

```
add_filter(
     'woocommerce_store_api_permission_callback',
          function( $permission, $namespace, $path ) {
               if ( $path === '/checkout' ) {
                    return false;
               }
               return $permission;
          },
          10,
          3
);
```

The hook gets context of the request path and API namespace, and you simply return a boolean. It defaults to `true` (all endpoints are public).

Due to the nature of the filter, this would be use at your own risk, because you would be preventing access to checkout or other important endpoints. But its there if needed.

Fixes #7409

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Implement the above example code somewhere, for example the main plugin file.
2. Make a request to the checkout endpoint.
3. You should be locked out with a permission error.
4. Other endpoints should continue to function e.g. cart

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Introduce `woocommerce_store_api_permission_callback` filter for the store API.
