### PR TITLE
Pipeline: Fix JavaScript, CSS and Markdown Linting / Lint MD step

### DIFF
--- a/docs/contributors/contributing/getting-started.md
+++ b/docs/contributors/contributing/getting-started.md
@@ -10,9 +10,9 @@
 - [Linting](#linting)
 - [Running the Blocks plugin](#running-the-blocks-plugin)
 - [Developer Tools (Visual Studio Code)](#developer-tools-visual-studio-code)
-	- [EditorConfig](#editorconfig)
-	- [ESLint](#eslint)
-	- [Prettier](#prettier)
+    - [EditorConfig](#editorconfig)
+    - [ESLint](#eslint)
+    - [Prettier](#prettier)
 - [Testing](#testing)
 
 Before you can begin contributing to the Blocks plugin there are several steps and tools required to setup your local development environment.
@@ -48,9 +48,9 @@ define( 'SCRIPT_DEBUG', true );
 
 To install dependencies, you will need the following tools installed on your machine:
 
-* `node` and `npm` via [NVM](https://github.com/nvm-sh/nvm#installing-and-updating): While you can always install Node or NPM through other means, we recommend using NVM to ensure you're aligned with the version used by our development teams. Our repository contains [an `.nvmrc` file](../../../.nvmrc) which helps ensure you are using the correct version of Node.
-* [PHP](https://www.php.net/manual/en/install.php): WooCommerce Blocks requires PHP. It is also needed to run Composer and various project build scripts.
-* [Composer](https://getcomposer.org/doc/00-intro.md): We use Composer to manage all of the dependencies for PHP packages and plugins.
+- `node` and `npm` via [NVM](https://github.com/nvm-sh/nvm#installing-and-updating): While you can always install Node or NPM through other means, we recommend using NVM to ensure you're aligned with the version used by our development teams. Our repository contains [an `.nvmrc` file](../../../.nvmrc) which helps ensure you are using the correct version of Node.
+- [PHP](https://www.php.net/manual/en/install.php): WooCommerce Blocks requires PHP. It is also needed to run Composer and various project build scripts.
+- [Composer](https://getcomposer.org/doc/00-intro.md): We use Composer to manage all of the dependencies for PHP packages and plugins.
 
 See [`package.json` `engines`](../../../package.json) and [`readme.txt`](../../../readme.txt#L6) for details on required versions.
 <!--  -->


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
There are some lint errors appearing when running `npm run lint:md:docs` in the project:

```
npm run lint:md:docs

> @woocommerce/block-library@10.0.0-dev lint:md:docs
> wp-scripts lint-md-docs

docs/contributors/contributing/getting-started.md:13:1 MD007/ul-indent Unordered list indentation [Expected: 4; Actual: 1]
docs/contributors/contributing/getting-started.md:14:1 MD007/ul-indent Unordered list indentation [Expected: 4; Actual: 1]
docs/contributors/contributing/getting-started.md:15:1 MD007/ul-indent Unordered list indentation [Expected: 4; Actual: 1]
docs/contributors/contributing/getting-started.md:51:1 MD004/ul-style Unordered list style [Expected: dash; Actual: asterisk]
docs/contributors/contributing/getting-started.md:52:1 MD004/ul-style Unordered list style [Expected: dash; Actual: asterisk]
docs/contributors/contributing/getting-started.md:53:1 MD004/ul-style Unordered list style [Expected: dash; Actual: asterisk]
```

This PR solves those errors by replacing the Tab with `4 spaces` and the `asterisk` with a `dash` as requested by the lint rules.

<!-- Reference any related issues or PRs here -->

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Check that the JavaScript, CSS and Markdown Linting / Lint MD (pull_request) step is passing

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->
