### PR TITLE
[POC] Added custom fields to the checkout blocks

### DIFF
--- a/assets/js/blocks/checkout/form-step/custom-fields.tsx
+++ b/assets/js/blocks/checkout/form-step/custom-fields.tsx
@@ -5,6 +5,8 @@ import { __ } from '@wordpress/i18n';
 import { InspectorControls } from '@wordpress/block-editor';
 import { Button, PanelBody, TextControl } from '@wordpress/components';
 import { useState } from '@wordpress/element';
+import { useEffect } from 'react';
+const { dispatch } = wp.data;
 
 /**
  * Internal dependencies
@@ -21,11 +23,18 @@ export interface FormStepBlockProps {
  * Custom Fields list for use in the editor.
  */
 export const CustomFields = (): JSX.Element => {
-	const [ fields, setFields ] = useState( [] );
+	const post = wp.data.select( 'core/editor' ).getCurrentPost();
+	const [ fields, setFields ] = useState( post.checkout_custom_fields );
 
 	const addField = () => {
 		setFields( [ ...fields, { name: 'test-field' } ] );
 	};
+
+	useEffect( () => {
+		dispatch( 'core/editor' ).editPost( {
+			checkout_custom_fields: fields,
+		} );
+	}, [ fields ] );
 
 	return (
 		<InspectorControls>
@@ -51,9 +60,6 @@ export const CustomFields = (): JSX.Element => {
 				>
 					{ __( 'Add Custom Field', 'woo-gutenberg-products-block' ) }
 				</Button>
-				<p className="wc-block-checkout__controls-text">
-					{ __( 'Test.', 'woo-gutenberg-products-block' ) }
-				</p>
 			</PanelBody>
 		</InspectorControls>
 	);

--- a/assets/js/blocks/checkout/form-step/custom-fields.tsx
+++ b/assets/js/blocks/checkout/form-step/custom-fields.tsx
@@ -1,0 +1,60 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { InspectorControls } from '@wordpress/block-editor';
+import { Button, PanelBody, TextControl } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+export interface FormStepBlockProps {
+	attributes: { title: string; description: string; showStepNumber: boolean };
+	setAttributes: ( attributes: Record< string, unknown > ) => void;
+	className?: string;
+	children?: React.ReactNode;
+	lock?: { move: boolean; remove: boolean };
+}
+
+/**
+ * Custom Fields list for use in the editor.
+ */
+export const CustomFields = (): JSX.Element => {
+	const [ fields, setFields ] = useState( [] );
+
+	const addField = () => {
+		setFields( [ ...fields, { name: 'test-field' } ] );
+	};
+
+	return (
+		<InspectorControls>
+			<PanelBody
+				title={ __( 'Custom Fields', 'woo-gutenberg-products-block' ) }
+			>
+				{ fields.map( ( field, index ) => (
+					<TextControl
+						label={ __(
+							'Field Name:',
+							'woo-gutenberg-products-block'
+						) }
+						key={ index }
+						value={ field.name }
+						onChange={ () => void 0 }
+					/>
+				) ) }
+				<Button
+					variant="secondary"
+					isBusy={ false }
+					aria-disabled={ false }
+					onClick={ addField }
+				>
+					{ __( 'Add Custom Field', 'woo-gutenberg-products-block' ) }
+				</Button>
+				<p className="wc-block-checkout__controls-text">
+					{ __( 'Test.', 'woo-gutenberg-products-block' ) }
+				</p>
+			</PanelBody>
+		</InspectorControls>
+	);
+};

--- a/assets/js/blocks/checkout/form-step/form-step-block.tsx
+++ b/assets/js/blocks/checkout/form-step/form-step-block.tsx
@@ -14,6 +14,7 @@ import { PanelBody, ToggleControl } from '@wordpress/components';
  * Internal dependencies
  */
 import FormStepHeading from './form-step-heading';
+import { CustomFields } from './custom-fields';
 export interface FormStepBlockProps {
 	attributes: { title: string; description: string; showStepNumber: boolean };
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
@@ -53,11 +54,11 @@ export const FormStepBlock = ( {
 							'woo-gutenberg-products-block'
 						) }
 						checked={ showStepNumber }
-						onChange={ () =>
+						onChange={ () => {
 							setAttributes( {
 								showStepNumber: ! showStepNumber,
-							} )
-						}
+							} );
+						} }
 					/>
 				</PanelBody>
 			</InspectorControls>
@@ -69,6 +70,7 @@ export const FormStepBlock = ( {
 					style={ { backgroundColor: 'transparent' } }
 				/>
 			</FormStepHeading>
+			<CustomFields />
 			<div className="wc-block-components-checkout-step__container">
 				<p className="wc-block-components-checkout-step__description">
 					<PlainText

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -318,3 +318,85 @@ function woocommerce_blocks_interactivity_setup() {
 	}
 }
 add_action( 'plugins_loaded', 'woocommerce_blocks_interactivity_setup' );
+
+
+add_action( 'rest_api_init', 'add_checkout_custom_fields' );
+
+/**
+ * Adds custom checkout fields to the checkout page rest api.
+ */
+function add_checkout_custom_fields() {
+	// Field name to register.
+	$field = 'checkout_custom_fields';
+	register_rest_field(
+		'page',
+		$field,
+		array(
+			'get_callback'    => function ( $object ) use ( $field ) {
+				// Get field as single value from post meta.
+				return get_option( $field, [] );
+			},
+			'update_callback' => function ( $value, $object ) use ( $field ) {
+				// Update the field/meta value.
+				update_option( $field, $value );
+			},
+			'schema'          => array(
+				'type'       => 'object',
+				'properties' => array(
+					'billing'    => array(
+						'type'     => 'array',
+						'elements' => array(
+							'type'       => 'object',
+							'properties' => array(
+								'id'       => 'integer',
+								'label'    => 'string',
+								'required' => 'boolean',
+								'type'     => 'string',
+								'size'     => 'string', //half|full
+								// 'priority' => 'integer',
+							),
+						),
+					),
+					'shipping'   => array(
+						'type'     => 'array',
+						'elements' => array(
+							'type'       => 'object',
+							'properties' => array(
+								'id'       => 'integer',
+								'label'    => 'string',
+								'required' => 'boolean',
+								'type'     => 'string',
+								'size'     => 'string', //half|full
+								// 'priority' => 'integer',
+							),
+						),
+					),
+					'additional' => array(
+						'type'     => 'array',
+						'elements' => array(
+							'type'       => 'object',
+							'properties' => array(
+								'id'       => 'integer',
+								'label'    => 'string',
+								'required' => 'boolean',
+								'type'     => 'string',
+								'size'     => 'string', //half|full
+								// 'priority' => 'integer',
+							),
+						),
+					),
+				),
+				// 'arg_options' => array(
+				// 	'sanitize_callback' => function ( $value ) {
+				// 		// Make the value safe for storage.
+				// 		return sanitize_text_field( $value );
+				// 	},
+				// 	'validate_callback' => function ( $value ) {
+				// 		// Valid if it contains exactly 10 English letters.
+				// 		return (bool) preg_match( '/\A[a-z]{10}\Z/', $value );
+				// 	},
+				// ),
+			),
+		)
+	);
+}


### PR DESCRIPTION
This PR is only a POC so we can test different approaches to create a way of adding custom fields in the checkout page.

To test it
- Checkout to this branch
- Edit your blocks checkout page
- Click the contact Information block
- Expand the Custom Fields accordion in the blocks settings
- Click the Add Custom Field button
- The post Update button will be available
- Save the post
- Reload the page
- The custom field should still show up in the block settings
- If you try to edit the field name it won't work yet
- It's not possible to delete fields yet

<img width="275" alt="Screenshot 2023-04-04 at 3 53 18 PM" src="https://user-images.githubusercontent.com/6342964/229891864-b4444125-5d22-459b-95ca-f8c766f647fd.png">

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|        |       |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1.
2.
3.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Add suggested changelog entry here.
