### PR TITLE
Reinstate "Hide shipping costs until an address is entered" but disable it when using local pickup

### DIFF
--- a/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/block.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/block.tsx
@@ -2,7 +2,10 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useShippingData } from '@woocommerce/base-context/hooks';
+import {
+	useCustomerData,
+	useShippingData,
+} from '@woocommerce/base-context/hooks';
 import { ShippingRatesControl } from '@woocommerce/base-components/cart-checkout';
 import {
 	getShippingRatesPackageCount,
@@ -19,8 +22,6 @@ import type {
 	PackageRateOption,
 	CartShippingPackageShippingRate,
 } from '@woocommerce/types';
-import { CART_STORE_KEY } from '@woocommerce/block-data';
-import { useSelect } from '@wordpress/data';
 import NoticeBanner from '@woocommerce/base-components/notice-banner';
 import type { ReactElement } from 'react';
 
@@ -65,9 +66,7 @@ const Block = ( { noShippingPlaceholder = null } ): ReactElement | null => {
 		isCollectable,
 	} = useShippingData();
 
-	const shippingAddress = useSelect( ( select ) => {
-		return select( CART_STORE_KEY ).getCustomerData().shippingAddress;
-	} );
+	const { shippingAddress } = useCustomerData();
 
 	const filteredShippingRates = isCollectable
 		? shippingRates.map( ( shippingRatesPackage ) => {

--- a/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/block.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/block.tsx
@@ -27,7 +27,6 @@ import NoticeBanner from '@woocommerce/base-components/notice-banner';
  * Internal dependencies
  */
 import './style.scss';
-import { shippingAddressHasValidationErrors } from '../../../../data/cart/utils';
 
 /**
  * Renders a shipping rate control option.
@@ -56,7 +55,6 @@ const renderShippingRatesControlOption = (
 
 const Block = ( {
 	noShippingPlaceholder = null,
-	shippingCostRequiresAddress = false,
 } ): React.ReactElement | null => {
 	const { isEditor } = useEditorContext();
 
@@ -68,8 +66,8 @@ const Block = ( {
 		isCollectable,
 	} = useShippingData();
 
-	const shippingAddressPushed = useSelect( ( select ) => {
-		return select( CART_STORE_KEY ).getFullShippingAddressPushed();
+	const shippingAddress = useSelect( ( select ) => {
+		return select( CART_STORE_KEY ).getCustomerData().shippingAddress;
 	} );
 
 	const filteredShippingRates = isCollectable
@@ -86,25 +84,14 @@ const Block = ( {
 		  } )
 		: shippingRates;
 
-	const shippingAddress = useSelect( ( select ) => {
-		return select( CART_STORE_KEY ).getCustomerData()?.shippingAddress;
-	} );
-
 	if ( ! needsShipping ) {
 		return null;
 	}
 
-	const shippingAddressHasErrors = ! shippingAddressHasValidationErrors();
-	const addressComplete = isAddressComplete( shippingAddress );
-
 	const shippingRatesPackageCount =
 		getShippingRatesPackageCount( shippingRates );
 
-	if (
-		( ! hasCalculatedShipping && ! shippingRatesPackageCount ) ||
-		( shippingCostRequiresAddress &&
-			( ! shippingAddressPushed || ! shippingAddressHasErrors ) )
-	) {
+	if ( ! hasCalculatedShipping && ! shippingRatesPackageCount ) {
 		return (
 			<p>
 				{ __(
@@ -114,6 +101,7 @@ const Block = ( {
 			</p>
 		);
 	}
+	const addressComplete = isAddressComplete( shippingAddress );
 
 	return (
 		<>

--- a/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/block.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/block.tsx
@@ -22,6 +22,7 @@ import type {
 import { CART_STORE_KEY } from '@woocommerce/block-data';
 import { useSelect } from '@wordpress/data';
 import NoticeBanner from '@woocommerce/base-components/notice-banner';
+import type { ReactElement } from 'react';
 
 /**
  * Internal dependencies
@@ -53,9 +54,7 @@ const renderShippingRatesControlOption = (
 	};
 };
 
-const Block = ( {
-	noShippingPlaceholder = null,
-} ): React.ReactElement | null => {
+const Block = ( { noShippingPlaceholder = null } ): ReactElement | null => {
 	const { isEditor } = useEditorContext();
 
 	const {

--- a/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/frontend.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/frontend.tsx
@@ -20,7 +20,6 @@ const FrontendBlock = ( {
 	showStepNumber,
 	children,
 	className,
-	shippingCostRequiresAddress = false,
 }: {
 	title: string;
 	description: string;
@@ -32,7 +31,6 @@ const FrontendBlock = ( {
 	showStepNumber: boolean;
 	children: JSX.Element;
 	className?: string;
-	shippingCostRequiresAddress: boolean;
 } ) => {
 	const checkoutIsProcessing = useSelect( ( select ) =>
 		select( CHECKOUT_STORE_KEY ).isProcessing()
@@ -55,9 +53,7 @@ const FrontendBlock = ( {
 			description={ description }
 			showStepNumber={ showStepNumber }
 		>
-			<Block
-				shippingCostRequiresAddress={ shippingCostRequiresAddress }
-			/>
+			<Block />
 			{ children }
 		</FormStep>
 	);

--- a/assets/js/extensions/shipping-methods/pickup-location/general-settings.tsx
+++ b/assets/js/extensions/shipping-methods/pickup-location/general-settings.tsx
@@ -79,7 +79,7 @@ const GeneralSettings = () => {
 						'woo-gutenberg-products-block'
 					) }
 					help={
-						<div>
+						<span>
 							{ __(
 								'When enabled, local pickup will appear as an option on the block based checkout.',
 								'woo-gutenberg-products-block'
@@ -89,7 +89,7 @@ const GeneralSettings = () => {
 								'If local pickup is enabled, the "Hide shipping costs until an address is entered" setting will be ignored.',
 								'woo-gutenberg-products-block'
 							) }
-						</div>
+						</span>
 					}
 				/>
 				<TextControl

--- a/assets/js/extensions/shipping-methods/pickup-location/general-settings.tsx
+++ b/assets/js/extensions/shipping-methods/pickup-location/general-settings.tsx
@@ -78,10 +78,19 @@ const GeneralSettings = () => {
 						'Enable local pickup',
 						'woo-gutenberg-products-block'
 					) }
-					help={ __(
-						'When enabled, local pickup will appear as an option on the block based checkout.',
-						'woo-gutenberg-products-block'
-					) }
+					help={
+						<div>
+							{ __(
+								'When enabled, local pickup will appear as an option on the block based checkout.',
+								'woo-gutenberg-products-block'
+							) }
+							<br />
+							{ __(
+								'If local pickup is enabled, the "Hide shipping costs until an address is entered" setting will be ignored.',
+								'woo-gutenberg-products-block'
+							) }
+						</div>
+					}
 				/>
 				<TextControl
 					label={ __( 'Title', 'woo-gutenberg-products-block' ) }

--- a/assets/js/extensions/shipping-methods/pickup-location/general-settings.tsx
+++ b/assets/js/extensions/shipping-methods/pickup-location/general-settings.tsx
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { createInterpolateElement, useState } from '@wordpress/element';
-import { ADMIN_URL } from '@woocommerce/settings';
+import { ADMIN_URL, getSetting } from '@woocommerce/settings';
 import { CHECKOUT_PAGE_ID } from '@woocommerce/block-settings';
 import {
 	CheckboxControl,
@@ -47,6 +47,11 @@ const GeneralSettings = () => {
 		useSettingsContext();
 	const [ showCosts, setShowCosts ] = useState( !! settings.cost );
 
+	const shippingCostRequiresAddress = getSetting< boolean >(
+		'shippingCostRequiresAddress',
+		false
+	);
+
 	return (
 		<SettingsSection Description={ GeneralSettingsDescription }>
 			<SettingsCard>
@@ -84,11 +89,15 @@ const GeneralSettings = () => {
 								'When enabled, local pickup will appear as an option on the block based checkout.',
 								'woo-gutenberg-products-block'
 							) }
-							<br />
-							{ __(
-								'If local pickup is enabled, the "Hide shipping costs until an address is entered" setting will be ignored.',
-								'woo-gutenberg-products-block'
-							) }
+							{ shippingCostRequiresAddress ? (
+								<>
+									<br />
+									{ __(
+										'If local pickup is enabled, the "Hide shipping costs until an address is entered" setting will be ignored.',
+										'woo-gutenberg-products-block'
+									) }
+								</>
+							) : null }
 						</span>
 					}
 				/>

--- a/src/Shipping/ShippingController.php
+++ b/src/Shipping/ShippingController.php
@@ -28,6 +28,13 @@ class ShippingController {
 	protected $asset_data_registry;
 
 	/**
+	 * Whether local pickup is enabled.
+	 *
+	 * @var bool
+	 */
+	private $local_pickup_enabled;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param AssetApi          $asset_api Instance of the asset API.
@@ -36,6 +43,9 @@ class ShippingController {
 	public function __construct( AssetApi $asset_api, AssetDataRegistry $asset_data_registry ) {
 		$this->asset_api           = $asset_api;
 		$this->asset_data_registry = $asset_data_registry;
+
+		$pickup_location_settings   = get_option( 'woocommerce_pickup_location_settings', [] );
+		$this->local_pickup_enabled = wc_string_to_bool( $pickup_location_settings['enabled'] ?? 'no' );
 	}
 
 	/**

--- a/src/Shipping/ShippingController.php
+++ b/src/Shipping/ShippingController.php
@@ -90,7 +90,7 @@ class ShippingController {
 	 * @return boolean Whether shipping cost calculation should require an address to be entered before calculating.
 	 */
 	public function override_cost_requires_address_option( $value ) {
-		if ( CartCheckoutUtils::is_checkout_block_default() ) {
+		if ( CartCheckoutUtils::is_checkout_block_default() && $this->local_pickup_enabled ) {
 			return 'no';
 		}
 		return $value;

--- a/src/Shipping/ShippingController.php
+++ b/src/Shipping/ShippingController.php
@@ -77,24 +77,6 @@ class ShippingController {
 		add_filter( 'woocommerce_shipping_settings', array( $this, 'remove_shipping_settings' ) );
 		add_filter( 'wc_shipping_enabled', array( $this, 'force_shipping_enabled' ), 100, 1 );
 		add_filter( 'woocommerce_order_shipping_to_display', array( $this, 'show_local_pickup_details' ), 10, 2 );
-
-		// This is required to short circuit `show_shipping` from class-wc-cart.php - without it, that function
-		// returns based on the option's value in the DB and we can't override it any other way.
-		add_filter( 'option_woocommerce_shipping_cost_requires_address', array( $this, 'override_cost_requires_address_option' ) );
-	}
-
-	/**
-	 * Overrides the option to force shipping calculations NOT to wait until an address is entered, but only if the
-	 * Checkout page contains the Checkout Block.
-	 *
-	 * @param boolean $value Whether shipping cost calculation requires address to be entered.
-	 * @return boolean Whether shipping cost calculation should require an address to be entered before calculating.
-	 */
-	public function override_cost_requires_address_option( $value ) {
-		if ( CartCheckoutUtils::is_checkout_block_default() ) {
-			return 'no';
-		}
-		return $value;
 	}
 
 	/**

--- a/src/Shipping/ShippingController.php
+++ b/src/Shipping/ShippingController.php
@@ -44,8 +44,7 @@ class ShippingController {
 		$this->asset_api           = $asset_api;
 		$this->asset_data_registry = $asset_data_registry;
 
-		$pickup_location_settings   = get_option( 'woocommerce_pickup_location_settings', [] );
-		$this->local_pickup_enabled = wc_string_to_bool( $pickup_location_settings['enabled'] ?? 'no' );
+		$this->local_pickup_enabled = LocalPickupUtils::is_local_pickup_enabled();
 	}
 
 	/**

--- a/src/Shipping/ShippingController.php
+++ b/src/Shipping/ShippingController.php
@@ -133,48 +133,31 @@ class ShippingController {
 	 */
 	public function remove_shipping_settings( $settings ) {
 
-		// Do not add the "Hide shipping costs until an address is entered" setting if the Checkout block is not used on the WC checkout page.
-		if ( CartCheckoutUtils::is_checkout_block_default() ) {
-			$settings = array_filter(
-				$settings,
-				function( $setting ) {
-					return ! in_array(
-						$setting['id'],
-						array(
-							'woocommerce_shipping_cost_requires_address',
-						),
-						true
-					);
-				}
-			);
-		}
-
 		// Do not add the shipping calculator setting if the Cart block is not used on the WC cart page.
 		if ( CartCheckoutUtils::is_cart_block_default() ) {
 
-			// If the Cart is default, but not the checkout, we should ensure the 'Calculations' title is added to the
-			// `woocommerce_shipping_cost_requires_address` options group, since it is attached to the
-			// `woocommerce_enable_shipping_calc` option that we're going to remove later.
-			if ( ! CartCheckoutUtils::is_checkout_block_default() ) {
-				$calculations_title = '';
+			// Ensure the 'Calculations' title is added to the `woocommerce_shipping_cost_requires_address` options
+			// group, since it is attached to the `woocommerce_enable_shipping_calc` option that gets removed if the
+			// Cart block is in use.
+			$calculations_title = '';
 
-				// Get Calculations title so we can add it to 'Hide shipping costs until an address is entered' option.
-				foreach ( $settings as $setting ) {
-					if ( 'woocommerce_enable_shipping_calc' === $setting['id'] ) {
-						$calculations_title = $setting['title'];
-						break;
-					}
-				}
-
-				// Add Calculations title to 'Hide shipping costs until an address is entered' option.
-				foreach ( $settings as $index => $setting ) {
-					if ( 'woocommerce_shipping_cost_requires_address' === $setting['id'] ) {
-						$settings[ $index ]['title']         = $calculations_title;
-						$settings[ $index ]['checkboxgroup'] = 'start';
-						break;
-					}
+			// Get Calculations title so we can add it to 'Hide shipping costs until an address is entered' option.
+			foreach ( $settings as $setting ) {
+				if ( 'woocommerce_enable_shipping_calc' === $setting['id'] ) {
+					$calculations_title = $setting['title'];
+					break;
 				}
 			}
+
+			// Add Calculations title to 'Hide shipping costs until an address is entered' option.
+			foreach ( $settings as $index => $setting ) {
+				if ( 'woocommerce_shipping_cost_requires_address' === $setting['id'] ) {
+					$settings[ $index ]['title']         = $calculations_title;
+					$settings[ $index ]['checkboxgroup'] = 'start';
+					break;
+				}
+			}
+
 			$settings = array_filter(
 				$settings,
 				function( $setting ) {

--- a/src/Shipping/ShippingController.php
+++ b/src/Shipping/ShippingController.php
@@ -76,6 +76,24 @@ class ShippingController {
 		add_filter( 'woocommerce_shipping_settings', array( $this, 'remove_shipping_settings' ) );
 		add_filter( 'wc_shipping_enabled', array( $this, 'force_shipping_enabled' ), 100, 1 );
 		add_filter( 'woocommerce_order_shipping_to_display', array( $this, 'show_local_pickup_details' ), 10, 2 );
+
+		// This is required to short circuit `show_shipping` from class-wc-cart.php - without it, that function
+		// returns based on the option's value in the DB and we can't override it any other way.
+		add_filter( 'option_woocommerce_shipping_cost_requires_address', array( $this, 'override_cost_requires_address_option' ) );
+	}
+
+	/**
+	 * Overrides the option to force shipping calculations NOT to wait until an address is entered, but only if the
+	 * Checkout page contains the Checkout Block.
+	 *
+	 * @param boolean $value Whether shipping cost calculation requires address to be entered.
+	 * @return boolean Whether shipping cost calculation should require an address to be entered before calculating.
+	 */
+	public function override_cost_requires_address_option( $value ) {
+		if ( CartCheckoutUtils::is_checkout_block_default() ) {
+			return 'no';
+		}
+		return $value;
 	}
 
 	/**

--- a/src/Shipping/ShippingController.php
+++ b/src/Shipping/ShippingController.php
@@ -104,7 +104,7 @@ class ShippingController {
 	 * @return boolean Whether shipping should continue to be enabled/disabled.
 	 */
 	public function force_shipping_enabled( $enabled ) {
-		if ( CartCheckoutUtils::is_checkout_block_default() ) {
+		if ( CartCheckoutUtils::is_checkout_block_default() && $this->local_pickup_enabled ) {
 			return true;
 		}
 		return $enabled;

--- a/src/Shipping/ShippingController.php
+++ b/src/Shipping/ShippingController.php
@@ -206,6 +206,18 @@ class ShippingController {
 				}
 			);
 		}
+
+		if ( CartCheckoutUtils::is_checkout_block_default() && $this->local_pickup_enabled ) {
+			foreach ( $settings as $index => $setting ) {
+				if ( 'woocommerce_shipping_cost_requires_address' === $setting['id'] ) {
+					$settings[ $index ]['desc']    .= ' (' . __( 'Not available when using WooCommerce Blocks Local Pickup', 'woo-gutenberg-products-block' ) . ')';
+					$settings[ $index ]['disabled'] = true;
+					$settings[ $index ]['value']    = 'no';
+					break;
+				}
+			}
+		}
+
 		return $settings;
 	}
 

--- a/src/StoreApi/Utilities/LocalPickupUtils.php
+++ b/src/StoreApi/Utilities/LocalPickupUtils.php
@@ -6,6 +6,16 @@ namespace Automattic\WooCommerce\StoreApi\Utilities;
  * the ShippingController, i.e. the OrderController.
  */
 class LocalPickupUtils {
+
+	/**
+	 * Checks if WC Blocks local pickup is enabled.
+	 *
+	 * @return bool True if local pickup is enabled.
+	 */
+	public static function is_local_pickup_enabled() {
+		$pickup_location_settings = get_option( 'woocommerce_pickup_location_settings', [] );
+		return wc_string_to_bool( $pickup_location_settings['enabled'] ?? 'no' );
+	}
 	/**
 	 * Gets a list of payment method ids that support the 'local-pickup' feature.
 	 *

--- a/tests/e2e/specs/backend/checkout.test.js
+++ b/tests/e2e/specs/backend/checkout.test.js
@@ -22,7 +22,6 @@ import {
 	openWidgetEditor,
 	closeModalIfExists,
 } from '../../utils.js';
-import { merchant as merchantUtils } from '../../../utils/merchant';
 
 const block = {
 	name: 'Checkout',
@@ -126,79 +125,6 @@ describe( `${ block.name } Block`, () => {
 			beforeEach( async () => {
 				await openSettingsSidebar();
 				await selectBlockByName( block.slug );
-			} );
-
-			it( 'can toggle "hide shipping costs until an address is entered"', async () => {
-				await selectBlockByName(
-					'woocommerce/checkout-shipping-methods-block'
-				);
-				const toggleLabel = await findLabelWithText(
-					'Hide shipping costs until an address is entered'
-				);
-				await toggleLabel.click();
-				const shippingOptionsRequireAddressText = await page.$x(
-					'//p[contains(text(), "Shipping options will be displayed here after entering your full shipping address.")]'
-				);
-				await expect( shippingOptionsRequireAddressText ).toHaveLength(
-					1
-				);
-
-				await toggleLabel.click();
-				await expect( page ).toMatchElement(
-					'.wc-block-components-shipping-rates-control'
-				);
-			} );
-
-			it( 'toggles the same setting in shipping method and shipping methods blocks', async () => {
-				await merchantUtils.goToLocalPickupSettingsPage();
-				await merchantUtils.enableLocalPickup();
-				await merchantUtils.saveLocalPickupSettingsPageWithRefresh();
-
-				await visitBlockPage( `${ block.name } Block` );
-				await expect( page ).toClick(
-					'.wc-block-checkout__shipping-method button',
-					{ text: 'Shipping' }
-				);
-				await openSettingsSidebar();
-				const toggleLabel = await findLabelWithText(
-					'Hide shipping costs until an address is entered'
-				);
-				await toggleLabel.click();
-				const [ label ] = await page.$x(
-					'//label[contains(., "Hide shipping costs until an address is entered")]'
-				);
-				const shippingMethodForValue = await page.evaluate(
-					( passedLabel ) => passedLabel.getAttribute( 'for' ),
-					label
-				);
-				const shippingMethodSettingIsChecked = await page.evaluate(
-					( passedShippingMethodForValue ) =>
-						document.getElementById( passedShippingMethodForValue )
-							.checked,
-					shippingMethodForValue
-				);
-				await expect( shippingMethodSettingIsChecked ).toBe( true );
-				await selectBlockByName(
-					'woocommerce/checkout-shipping-methods-block'
-				);
-				const [ shippingMethodsLabel ] = await page.$x(
-					'//label[contains(., "Hide shipping costs until an address is entered")]'
-				);
-				const shippingMethodsLabelForValue = await page.evaluate(
-					( passedShippingMethodsLabel ) =>
-						passedShippingMethodsLabel.getAttribute( 'for' ),
-					shippingMethodsLabel
-				);
-				const shippingMethodLabelIsChecked = await page.evaluate(
-					( passedShippingMethodsLabelForValue ) =>
-						document.getElementById(
-							passedShippingMethodsLabelForValue
-						).checked,
-					shippingMethodsLabelForValue
-				);
-				expect( shippingMethodSettingIsChecked ).toBe(
-					shippingMethodLabelIsChecked
-				);
 			} );
 
 			it( 'can enable dark mode inputs', async () => {

--- a/tests/e2e/specs/merchant/local-pickup.test.ts
+++ b/tests/e2e/specs/merchant/local-pickup.test.ts
@@ -106,32 +106,8 @@ describe( `Local Pickup Settings`, () => {
 				checkoutSlug: 'checkout-block',
 			} );
 		} );
-		it( 'hides the correct shipping options if Checkout block is the default', async () => {
-			await visitAdminPage(
-				'admin.php',
-				'page=wc-settings&tab=shipping&section=options'
-			);
-			const hideShippingLabel = await findLabelWithText(
-				'Hide shipping costs until an address is entered'
-			);
-			expect( hideShippingLabel ).toBeUndefined();
-
-			const shippingCalculatorLabel = await findLabelWithText(
-				'Enable the shipping calculator on the cart page'
-			);
-			expect( shippingCalculatorLabel ).toBeUndefined();
-		} );
-
-		it( 'does not hide the relevant setting if Cart or Checkout block is not the default', async () => {
-			await setCartCheckoutPages( {
-				cartSlug: 'cart',
-				checkoutSlug: 'checkout',
-			} );
-
-			await visitAdminPage(
-				'admin.php',
-				'page=wc-settings&tab=advanced'
-			);
+		it( 'shows the correct shipping options depending on whether Local Pickup is enabled', async () => {
+			await merchant.disableLocalPickup();
 			await visitAdminPage(
 				'admin.php',
 				'page=wc-settings&tab=shipping&section=options'
@@ -141,10 +117,15 @@ describe( `Local Pickup Settings`, () => {
 			);
 			await expect( hideShippingLabel ).toHaveLength( 1 );
 
-			const shippingCalculatorLabel = await page.$x(
-				'//label[contains(., "Enable the shipping calculator on the cart page")]'
+			await merchant.enableLocalPickup();
+			await visitAdminPage(
+				'admin.php',
+				'page=wc-settings&tab=shipping&section=options'
 			);
-			await expect( shippingCalculatorLabel ).toHaveLength( 1 );
+			const modifiedHideShippingLabel = await page.$x(
+				'//label[contains(., "Hide shipping costs until an address is entered (Not available when using WooCommerce Blocks Local Pickup)")]'
+			);
+			await expect( modifiedHideShippingLabel ).toHaveLength( 1 );
 		} );
 	} );
 

--- a/tests/e2e/specs/shopper/cart-checkout/checkout.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/checkout.test.js
@@ -336,38 +336,6 @@ describe( 'Shopper → Checkout', () => {
 
 		afterAll( async () => {
 			await merchant.login();
-			await visitBlockPage( 'Checkout Block' );
-			await openSettingsSidebar();
-			await selectBlockByName(
-				'woocommerce/checkout-shipping-methods-block'
-			);
-			const [ label ] = await page.$x(
-				'//label[contains(., "Hide shipping costs until an address is entered")]'
-			);
-			const shippingMethodForValue = await page.evaluate(
-				( passedLabel ) => passedLabel.getAttribute( 'for' ),
-				label
-			);
-			let shippingMethodSettingIsChecked = await page.evaluate(
-				( passedShippingMethodForValue ) =>
-					document.getElementById( passedShippingMethodForValue )
-						.checked,
-				shippingMethodForValue
-			);
-			if ( ! shippingMethodSettingIsChecked ) {
-				await setCheckbox(
-					await getToggleIdByLabel(
-						'Hide shipping costs until an address is entered'
-					)
-				);
-			}
-			shippingMethodSettingIsChecked = await page.evaluate(
-				( passedShippingMethodForValue ) =>
-					document.getElementById( passedShippingMethodForValue )
-						.checked,
-				shippingMethodForValue
-			);
-
 			await merchantUtils.disableLocalPickup();
 		} );
 
@@ -401,158 +369,67 @@ describe( 'Shopper → Checkout', () => {
 			await expect( page ).toMatch( NORMAL_SHIPPING_NAME );
 		} );
 
-		it( 'User sees the correct shipping options based on block settings', async () => {
-			await preventCompatibilityNotice();
-			await merchant.login();
-			await visitBlockPage( 'Checkout Block' );
-			await openSettingsSidebar();
-			await selectBlockByName(
-				'woocommerce/checkout-shipping-methods-block'
-			);
-
-			const [ label ] = await page.$x(
-				'//label[contains(., "Hide shipping costs until an address is entered")]'
-			);
-			const shippingMethodForValue = await page.evaluate(
-				( passedLabel ) => passedLabel.getAttribute( 'for' ),
-				label
-			);
-			let shippingMethodSettingIsChecked = await page.evaluate(
-				( passedShippingMethodForValue ) =>
-					document.getElementById( passedShippingMethodForValue )
-						.checked,
-				shippingMethodForValue
-			);
-			if ( ! shippingMethodSettingIsChecked ) {
-				await setCheckbox(
-					await getToggleIdByLabel(
-						'Hide shipping costs until an address is entered'
-					)
-				);
-			}
-			shippingMethodSettingIsChecked = await page.evaluate(
-				( passedShippingMethodForValue ) =>
-					document.getElementById( passedShippingMethodForValue )
-						.checked,
-				shippingMethodForValue
-			);
-			await expect( shippingMethodSettingIsChecked ).toBe( true );
-			await saveOrPublish();
-			await shopper.block.emptyCart();
-			// Log out to have a fresh empty cart.
-			await shopper.logout();
-			await shopper.block.goToShop();
-			await shopper.addToCartFromShopPage( SIMPLE_PHYSICAL_PRODUCT_NAME );
-			await shopper.block.goToCheckout();
-			// Expect no shipping options to be shown, but with a friendly message.
-			const shippingOptionsRequireAddressText = await page.$x(
-				'//p[contains(text(), "Shipping options will be displayed here after entering your full shipping address.")]'
-			);
-			expect( shippingOptionsRequireAddressText ).toHaveLength( 1 );
-
-			// Enter the address and expect shipping options to be shown.
-			await shopper.block.fillInCheckoutWithTestData();
-			await expect( page ).toMatchElement(
-				'.wc-block-components-shipping-rates-control'
-			);
-
-			// This sequence will reset the checkout form.
-			await shopper.login();
-			await shopper.logout();
-
-			await preventCompatibilityNotice();
-			await merchant.login();
-			await visitBlockPage( 'Checkout Block' );
-			await openSettingsSidebar();
-			await selectBlockByName(
-				'woocommerce/checkout-shipping-methods-block'
-			);
-
-			await unsetCheckbox(
-				await getToggleIdByLabel(
-					'Hide shipping costs until an address is entered'
-				)
-			);
-			await saveOrPublish();
-			await shopper.block.emptyCart();
-
-			await shopper.block.goToShop();
-			await shopper.addToCartFromShopPage( SIMPLE_PHYSICAL_PRODUCT_NAME );
-			await shopper.block.goToCheckout();
-
-			// Expect the shipping options to be displayed without entering an address.
-			await expect( page ).toMatchElement(
-				'.wc-block-components-shipping-rates-control'
-			);
-		} );
-
 		it( 'User does not see shipping rates until full address is entered', async () => {
 			await preventCompatibilityNotice();
 			await merchant.login();
 
-			await merchantUtils.enableLocalPickup();
-			await merchantUtils.addLocalPickupLocation();
-			await visitBlockPage( 'Checkout Block' );
-			await openSettingsSidebar();
-			await selectBlockByName(
-				'woocommerce/checkout-shipping-methods-block'
+			await merchantUtils.disableLocalPickup();
+			await visitAdminPage(
+				'admin.php',
+				'page=wc-settings&tab=shipping&section=options'
 			);
+			const hideShippingLabel = await page.$x(
+				'//label[contains(., "Hide shipping costs until an address is entered")]'
+			);
+			await hideShippingLabel[ 0 ].click();
 
-			await setCheckbox(
-				await getToggleIdByLabel(
-					'Hide shipping costs until an address is entered'
-				)
+			const saveButton = await page.$x(
+				'//button[contains(., "Save changes")]'
 			);
-			await saveOrPublish();
+			await saveButton[ 0 ].click();
+
+			await page.waitForXPath(
+				'//strong[contains(., "Your settings have been saved.")]'
+			);
+			await merchant.logout();
+
 			await shopper.block.emptyCart();
-			// Log out to have a fresh empty cart.
-			await shopper.logout();
 			await shopper.block.goToShop();
 			await shopper.addToCartFromShopPage( SIMPLE_PHYSICAL_PRODUCT_NAME );
 			await shopper.block.goToCheckout();
 
-			// Expect no shipping options to be shown, but with a friendly message.
+			// // Expect no shipping options to be shown, but with a friendly message.
 			const shippingOptionsRequireAddressText = await page.$x(
 				'//p[contains(text(), "Shipping options will be displayed here after entering your full shipping address.")]'
 			);
 
-			expect( shippingOptionsRequireAddressText ).toHaveLength( 1 );
-
-			await expect( page ).toClick(
-				'.wc-block-checkout__shipping-method button',
-				{ text: 'Shipping' }
-			);
+			await expect( shippingOptionsRequireAddressText ).toHaveLength( 1 );
 
 			// Enter the address but not city and expect shipping options not to be shown.
-			await shopper.block.fillInCheckoutWithTestData( { city: '' } );
+			await shopper.block.fillInCheckoutWithTestData( { postcode: '' } );
 
 			await expect( page ).not.toMatchElement(
 				'.wc-block-components-shipping-rates-control'
 			);
 
+			await merchant.login();
+			await merchantUtils.enableLocalPickup();
+			await merchantUtils.addLocalPickupLocation();
+			await merchant.logout();
+
 			// This sequence will reset the checkout form.
 			await shopper.login();
 			await shopper.logout();
 
-			await preventCompatibilityNotice();
-			await merchant.login();
-			await visitBlockPage( 'Checkout Block' );
-			await openSettingsSidebar();
-			await selectBlockByName(
-				'woocommerce/checkout-shipping-methods-block'
-			);
-
-			await unsetCheckbox(
-				await getToggleIdByLabel(
-					'Hide shipping costs until an address is entered'
-				)
-			);
-			await saveOrPublish();
 			await shopper.block.emptyCart();
-
 			await shopper.block.goToShop();
 			await shopper.addToCartFromShopPage( SIMPLE_PHYSICAL_PRODUCT_NAME );
 			await shopper.block.goToCheckout();
+
+			await expect( page ).toClick(
+				'.wc-block-checkout__shipping-method button',
+				{ text: 'Shipping' }
+			);
 
 			// Expect the shipping options to be displayed without entering an address.
 			await expect( page ).toMatchElement(

--- a/tests/e2e/specs/shopper/cart-checkout/checkout.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/checkout.test.js
@@ -334,7 +334,7 @@ describe( 'Shopper → Checkout', () => {
 		const NORMAL_SHIPPING_NAME = 'Normal Shipping';
 		const NORMAL_SHIPPING_PRICE = '$20.00';
 
-		afterAll( async () => {
+		afterEach( async () => {
 			await merchant.login();
 			await merchantUtils.disableLocalPickup();
 		} );

--- a/tests/utils/shopper.js
+++ b/tests/utils/shopper.js
@@ -432,7 +432,7 @@ export const shopper = {
 			};
 
 			// We need to wait for the shipping total to update before we assert.
-			// As no dom elements are being added or removed, we cannot use `await page.waitForSelectot()`
+			// As no dom elements are being added or removed, we cannot use `await page.waitForSelector()`
 			// so instead we check when the `via <Shipping Method>` text changes
 			await page.$eval(
 				'.wc-block-components-totals-shipping .wc-block-components-totals-shipping__via',


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR partially reverts #8679 and makes a couple of changes to the "Hide shipping costs until an address is entered" option in WC Core shipping settings.

- When `Local pickup` from WC Blocks is enabled, the "Hide shipping costs until an address is entered" in setting in WooCommerce > Shipping > Shipping options is set to false, the checkbox is disabled, and there is additional text explaining why the option is disabled.

<!-- Reference any related issues or PRs here -->

Fixes #8660
Fixes #8919
Fixes #7895

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Ensure you have some shipping rates set up in your store.
2. Disable WC Blocks local pickup (WooCommerce -> Shipping -> Local pickup). 
3. Go to WooCommerce -> Shipping -> Shipping options, ensure you see the option "Hide shipping costs until an address is entered" with no additional text.
4. Check this box.
5. In an incognito window, add an item to your cart.
6. Go to the Cart block. Ensure you don't see any shipping rates shown.
7. Go to the Checkout block, ensure the shipping rate selector says "Shipping options will be displayed here after entering your full shipping address."
8. Enable WC Blocks local pickup and add a location (WooCommerce -> Shipping -> Local pickup)
9. Go to WooCommerce -> Shipping -> Shipping options, ensure you see the option "Hide shipping costs until an address is entered (Not available when using WooCommerce Blocks Local Pickup)" exactly as written.
10. Enter your address and ensure shipping rates show up.
11. Ensure this option is disabled, and turned off, ensure you cannot activate it by clicking the checkbox.
12. Close the incognito window from earlier and open a new one. Add an item to your cart.
13. Go to the Cart block. Ensure rates show up in the sidebar.
14. Go to the Checkout block, ensure the method selector (Shipping / Local Pickup) shows.
15. Ensure shipping rates show up when the "Shipping" method has been selected, even when no address is entered.
16. Place two orders, one using local pickup, the other using regular shipping.
17. Ensure these both appear correctly in the confirmation email and in the orders dashboard.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Release post note

When using Local Pickup with WooCommerce Blocks, the option to "Hide shipping costs until an address is entered" will no longer be available.

We also removed the "Hide shipping costs until an address is entered" block setting from the Cart and Checkout blocks, which was added in WooCommerce Blocks 9.9.0, if you used this option, you will now need to go to the WooCommerce Settings (WooCommerce -> Settings -> Shipping -> Shipping Options) and check that the option is set correctly.

### Changelog

> Disable "Hide shipping costs until an address is entered" option when Local Pickup is in use.
