### PR TITLE
Create specific stylesheet for CartLineItemsTable component

### DIFF
--- a/assets/js/base/components/cart-checkout/cart-line-items-table/index.tsx
+++ b/assets/js/base/components/cart-checkout/cart-line-items-table/index.tsx
@@ -11,6 +11,7 @@ import type { RefObject } from 'react';
  * Internal dependencies
  */
 import CartLineItemRow from './cart-line-item-row';
+import './style.scss';
 
 const placeholderRows = [ ...Array( 3 ) ].map( ( _x, i ) => (
 	<CartLineItemRow lineItem={ {} } key={ i } />

--- a/assets/js/base/components/cart-checkout/cart-line-items-table/style.scss
+++ b/assets/js/base/components/cart-checkout/cart-line-items-table/style.scss
@@ -1,0 +1,141 @@
+table.wc-block-cart-items,
+table.wc-block-cart-items th,
+table.wc-block-cart-items td {
+	// Override Storefront theme gray table background.
+	background: none !important;
+	// Remove borders on default themes.
+	border: 0;
+	margin: 0 0 2em;
+}
+
+.editor-styles-wrapper table.wc-block-cart-items,
+table.wc-block-cart-items {
+	width: 100%;
+
+	.wc-block-cart-items__header {
+		@include font-size( smaller );
+		text-transform: uppercase;
+
+		.wc-block-cart-items__header-image {
+			width: 100px;
+		}
+		.wc-block-cart-items__header-product {
+			visibility: hidden;
+		}
+		.wc-block-cart-items__header-total {
+			width: 100px;
+			text-align: right;
+		}
+	}
+	.wc-block-cart-items__row {
+		.wc-block-cart-item__image img {
+			width: 100%;
+			margin: 0;
+		}
+		.wc-block-cart-item__quantity {
+			.wc-block-cart-item__remove-link {
+				@include link-button;
+				@include font-size( smaller );
+
+				text-transform: none;
+				white-space: nowrap;
+			}
+		}
+		.wc-block-components-product-name {
+			display: block;
+			max-width: max-content;
+		}
+		.wc-block-cart-item__total {
+			@include font-size( regular );
+			text-align: right;
+			line-height: inherit;
+		}
+		.wc-block-components-product-metadata {
+			margin-bottom: 0.75em;
+		}
+
+		&.is-disabled {
+			opacity: 0.5;
+			pointer-events: none;
+			transition: opacity 200ms ease;
+		}
+	}
+}
+
+.is-medium,
+.is-small,
+.is-mobile {
+	table.wc-block-cart-items {
+		td {
+			padding: 0;
+		}
+		.wc-block-cart-items__header {
+			display: none;
+		}
+		.wc-block-cart-item__remove-link {
+			display: none;
+		}
+		&:not(.wc-block-mini-cart-items) {
+			.wc-block-cart-items__row {
+				@include with-translucent-border( 0 0 1px );
+			}
+		}
+		.wc-block-cart-items__row {
+			display: grid;
+			grid-template-columns: 80px 132px;
+			padding: $gap 0;
+
+			.wc-block-cart-item__image {
+				grid-column-start: 1;
+				grid-row-start: 1;
+				padding-right: $gap;
+			}
+			.wc-block-cart-item__product {
+				grid-column-start: 2;
+				grid-column-end: 4;
+				grid-row-start: 1;
+				justify-self: stretch;
+				padding: 0 $gap $gap 0;
+			}
+			.wc-block-cart-item__quantity {
+				grid-column-start: 1;
+				grid-row-start: 2;
+				vertical-align: bottom;
+				padding-right: $gap;
+				align-self: end;
+				padding-top: $gap;
+			}
+			.wc-block-cart-item__total {
+				grid-row-start: 1;
+
+				.wc-block-components-formatted-money-amount {
+					display: inline-block;
+				}
+			}
+		}
+	}
+}
+
+.is-large.wc-block-cart {
+	margin-bottom: 3em;
+
+	.wc-block-cart-items {
+		@include with-translucent-border( 0 0 1px );
+
+		th {
+			padding: 0.25rem $gap 0.25rem 0;
+			white-space: nowrap;
+		}
+		td {
+			@include with-translucent-border( 1px 0 0 );
+			padding: $gap 0 $gap $gap;
+			vertical-align: top;
+		}
+		th:last-child {
+			padding-right: 0;
+		}
+		td:last-child {
+			padding-right: $gap;
+		}
+	}
+}

--- a/assets/js/blocks/cart/style.scss
+++ b/assets/js/blocks/cart/style.scss
@@ -14,70 +14,6 @@
 	}
 }
 
-table.wc-block-cart-items,
-table.wc-block-cart-items th,
-table.wc-block-cart-items td {
-	// Override Storefront theme gray table background.
-	background: none !important;
-	// Remove borders on default themes.
-	border: 0;
-	margin: 0 0 2em;
-}
-
-.editor-styles-wrapper table.wc-block-cart-items,
-table.wc-block-cart-items {
-	width: 100%;
-
-	.wc-block-cart-items__header {
-		@include font-size( smaller );
-		text-transform: uppercase;
-
-		.wc-block-cart-items__header-image {
-			width: 100px;
-		}
-		.wc-block-cart-items__header-product {
-			visibility: hidden;
-		}
-		.wc-block-cart-items__header-total {
-			width: 100px;
-			text-align: right;
-		}
-	}
-	.wc-block-cart-items__row {
-		.wc-block-cart-item__image img {
-			width: 100%;
-			margin: 0;
-		}
-		.wc-block-cart-item__quantity {
-			.wc-block-cart-item__remove-link {
-				@include link-button;
-				@include font-size( smaller );
-
-				text-transform: none;
-				white-space: nowrap;
-			}
-		}
-		.wc-block-components-product-name {
-			display: block;
-			max-width: max-content;
-		}
-		.wc-block-cart-item__total {
-			@include font-size( regular );
-			text-align: right;
-			line-height: inherit;
-		}
-		.wc-block-components-product-metadata {
-			margin-bottom: 0.75em;
-		}
-
-		&.is-disabled {
-			opacity: 0.5;
-			pointer-events: none;
-			transition: opacity 200ms ease;
-		}
-	}
-}
-
 .wc-block-cart {
 	.wc-block-components-totals-taxes,
 	.wc-block-components-totals-footer-item {
@@ -168,79 +104,10 @@ table.wc-block-cart-items {
 			}
 		}
 	}
-	table.wc-block-cart-items {
-		td {
-			padding: 0;
-		}
-		.wc-block-cart-items__header {
-			display: none;
-		}
-		.wc-block-cart-item__remove-link {
-			display: none;
-		}
-		&:not(.wc-block-mini-cart-items) {
-			.wc-block-cart-items__row {
-				@include with-translucent-border( 0 0 1px );
-			}
-		}
-		.wc-block-cart-items__row {
-			display: grid;
-			grid-template-columns: 80px 132px;
-			padding: $gap 0;
-
-			.wc-block-cart-item__image {
-				grid-column-start: 1;
-				grid-row-start: 1;
-				padding-right: $gap;
-			}
-			.wc-block-cart-item__product {
-				grid-column-start: 2;
-				grid-column-end: 4;
-				grid-row-start: 1;
-				justify-self: stretch;
-				padding: 0 $gap $gap 0;
-			}
-			.wc-block-cart-item__quantity {
-				grid-column-start: 1;
-				grid-row-start: 2;
-				vertical-align: bottom;
-				padding-right: $gap;
-				align-self: end;
-				padding-top: $gap;
-			}
-			.wc-block-cart-item__total {
-				grid-row-start: 1;
-
-				.wc-block-components-formatted-money-amount {
-					display: inline-block;
-				}
-			}
-		}
-	}
 }
 
 .is-large.wc-block-cart {
 	margin-bottom: 3em;
-
-	.wc-block-cart-items {
-		@include with-translucent-border( 0 0 1px );
-
-		th {
-			padding: 0.25rem $gap 0.25rem 0;
-			white-space: nowrap;
-		}
-		td {
-			@include with-translucent-border( 1px 0 0 );
-			padding: $gap 0 $gap $gap;
-			vertical-align: top;
-		}
-		th:last-child {
-			padding-right: 0;
-		}
-		td:last-child {
-			padding-right: $gap;
-		}
-	}
 
 	.wc-block-components-radio-control__input {
 		left: 0;


### PR DESCRIPTION
The styles of `CartLineItemsTable` were in the Cart block stylesheet. However, that component is used by the Mini Cart block as well. So if some day we created a separated stylesheet per block (ie: https://github.com/woocommerce/woocommerce-blocks/pull/7006), it would break.

This PR creates a specific stylesheet for `CartLineItemsTable`. This also helps keeping the code organized. :slightly_smiling_face: 

Note for the reviewer: this PR doesn't introduce any CSS changes, it's just about moving code from one file to another.

### Testing

#### User Facing Testing

Note: this PR doesn't introduce any visible change, so testing is limited to make sure there are no visual regressions.

0. Add the Mini Cart block to the header of your store (via Appearance > Editor).
1. Add a product to your cart.
2. Open the Mini Cart drawer and verify there are no styling regressions and the list of items looks correctly.
3. Open a page with the Cart block and verify there are no styling regressions and the list of items looks correctly.

Mini Cart | Cart
--- | ---
![imatge](https://user-images.githubusercontent.com/3616980/230092777-ae27c1bd-5e3d-4be6-ab19-5071d32a0f74.png) | ![imatge](https://user-images.githubusercontent.com/3616980/230092656-42225875-c639-4579-aa70-704948c03841.png)

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
