### PR TITLE
[WIP] Remove unnecessary shared chunk from Mini Cart translations

### DIFF
--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -588,9 +588,8 @@ class MiniCart extends AbstractBlock {
 
 		$chunks        = $this->get_chunks_paths( $this->chunks_folder );
 		$vendor_chunks = $this->get_chunks_paths( 'vendors--mini-cart-contents-block' );
-		$shared_chunks = [ 'cart-blocks/cart-line-items--mini-cart-contents-block/products-table-frontend' ];
 
-		foreach ( array_merge( $chunks, $vendor_chunks, $shared_chunks ) as $chunk ) {
+		foreach ( array_merge( $chunks, $vendor_chunks ) as $chunk ) {
 			$handle = 'wc-blocks-' . $chunk . '-chunk';
 			$this->asset_api->register_script( $handle, $this->asset_api->get_block_asset_build_path( $chunk ), [], true );
 			$translations[] = $wp_scripts->print_translations( $handle, false );


### PR DESCRIPTION
After moving `CartLineItemsTable` from the Cart block directory to base-components in #8644 (and the translations files for all locales being updated), we are now able to remove the load of a 'shared chunk' that we had in the Mini Cart block.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

Note: this PR doesn't introduce any visible change, so testing is limited to make sure there are no visual regressions.

1. Set your store language to a language with WC Blocks translations, ie: Spanish.
2. Go to the updates page (`/wp-admin/update-core.php`) to make sure translation updates are installed.
3. With a block theme (ie: TT3), go to Appearance > Editor and add the Mini Cart block to the header of your site.
4. In the frontend, add some products to your cart and open the Mini Cart drawer.
5. Verify it shows translated strings.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
