### PR TITLE
No shipping:  Convert error notice to warning notice

### DIFF
--- a/assets/js/base/components/cart-checkout/totals/shipping/shipping-rate-selector.tsx
+++ b/assets/js/base/components/cart-checkout/totals/shipping/shipping-rate-selector.tsx
@@ -37,7 +37,7 @@ export const ShippingRateSelector = ( {
 							<NoticeBanner
 								isDismissible={ false }
 								className="wc-block-components-shipping-rates-control__no-results-notice"
-								status="error"
+								status="warning"
 							>
 								{ __(
 									'There are no shipping options available. Please check your shipping address.',

--- a/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/block.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/block.tsx
@@ -130,7 +130,7 @@ const Block = ( {
 								<NoticeBanner
 									isDismissible={ false }
 									className="wc-block-components-shipping-rates-control__no-results-notice"
-									status="error"
+									status="warning"
 								>
 									{ __(
 										'There are no shipping options available. Please check your shipping address.',


### PR DESCRIPTION
When there are no found shipping rates, we should show a warning rather than an error. The shopper still has an opportunity to change the address and get a valid rate.

### Screenshots

Before:

![Screenshot 2023-04-05 at 16 04 08](https://user-images.githubusercontent.com/90977/230123133-e369b608-c630-4e8d-8448-56446f23c945.png)

After:

![Screenshot 2023-04-05 at 16 04 48](https://user-images.githubusercontent.com/90977/230123152-db3f9b25-6cf9-485f-971e-c9b7a7c3716f.png)

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. WooCommerce > Settings > Shipping
2. Create a shipping zone for the UK with flat rate
3. Remove all rates from "everywhere else"
4. Go to checkout and enter a non-UK address
5. See the notice in the shipping options section

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental