### PR TITLE
Stop displaying decimals in Filter by Price

### DIFF
--- a/assets/js/base/components/formatted-monetary-amount/index.tsx
+++ b/assets/js/base/components/formatted-monetary-amount/index.tsx
@@ -37,7 +37,6 @@ const currencyToNumberFormat = (
 	return {
 		thousandSeparator: currency?.thousandSeparator,
 		decimalSeparator: currency?.decimalSeparator,
-		decimalScale: currency?.minorUnit,
 		fixedDecimalScale: true,
 		prefix: currency?.prefix,
 		suffix: currency?.suffix,
@@ -83,9 +82,11 @@ const FormattedMonetaryAmount = ( {
 		'wc-block-components-formatted-money-amount',
 		className
 	);
+	const decimalScale = props.decimalScale ?? currency?.minorUnit;
 	const numberFormatProps = {
 		...props,
 		...currencyToNumberFormat( currency ),
+		decimalScale,
 		value: undefined,
 		currency: undefined,
 		onValueChange: undefined,

--- a/assets/js/base/components/price-slider/index.tsx
+++ b/assets/js/base/components/price-slider/index.tsx
@@ -396,6 +396,22 @@ const PriceSlider = ( {
 		</div>
 	);
 
+	const getInputClassName = ( type: 'min' | 'max' ) =>
+		`wc-block-price-filter__amount wc-block-price-filter__amount--${ type } wc-block-form-text-input wc-block-components-price-slider__amount wc-block-components-price-slider__amount--${ type }`;
+
+	const commonFormattedMonetaryAmountProps = {
+		currency,
+		decimalScale: 0,
+	};
+
+	const commonFormattedMonetaryAmountInputProps = {
+		...commonFormattedMonetaryAmountProps,
+		displayType: 'input',
+		allowNegative: false,
+		disabled: isLoading || ! hasValidConstraints,
+		onBlur: priceInputOnBlur,
+	};
+
 	return (
 		<div className={ classes } ref={ wrapper }>
 			{ ( ! inlineInputAvailable || ! showInputFields ) && slider }
@@ -403,14 +419,12 @@ const PriceSlider = ( {
 				<div className="wc-block-price-filter__controls wc-block-components-price-slider__controls">
 					{ ! isUpdating ? (
 						<FormattedMonetaryAmount
-							currency={ currency }
-							displayType="input"
-							className="wc-block-price-filter__amount wc-block-price-filter__amount--min wc-block-form-text-input wc-block-components-price-slider__amount wc-block-components-price-slider__amount--min"
+							{ ...commonFormattedMonetaryAmountInputProps }
+							className={ getInputClassName( 'min' ) }
 							aria-label={ __(
 								'Filter products by minimum price',
 								'woo-gutenberg-products-block'
 							) }
-							allowNegative={ false }
 							isAllowed={ isValidMinValue( {
 								minConstraint,
 								minorUnit: currency.minorUnit,
@@ -422,10 +436,7 @@ const PriceSlider = ( {
 								}
 								setMinPriceInput( value );
 							} }
-							onBlur={ priceInputOnBlur }
-							disabled={ isLoading || ! hasValidConstraints }
 							value={ minPriceInput }
-							decimalScale={ 0 }
 						/>
 					) : (
 						<div className="input-loading"></div>
@@ -433,9 +444,8 @@ const PriceSlider = ( {
 					{ inlineInputAvailable && slider }
 					{ ! isUpdating ? (
 						<FormattedMonetaryAmount
-							currency={ currency }
-							displayType="input"
-							className="wc-block-price-filter__amount wc-block-price-filter__amount--max wc-block-form-text-input wc-block-components-price-slider__amount wc-block-components-price-slider__amount--max"
+							{ ...commonFormattedMonetaryAmountInputProps }
+							className={ getInputClassName( 'max' ) }
 							aria-label={ __(
 								'Filter products by maximum price',
 								'woo-gutenberg-products-block'
@@ -450,10 +460,7 @@ const PriceSlider = ( {
 								}
 								setMaxPriceInput( value );
 							} }
-							onBlur={ priceInputOnBlur }
-							disabled={ isLoading || ! hasValidConstraints }
 							value={ maxPriceInput }
-							decimalScale={ 0 }
 						/>
 					) : (
 						<div className="input-loading"></div>
@@ -467,14 +474,12 @@ const PriceSlider = ( {
 				Number.isFinite( maxPrice ) && (
 					<div className="wc-block-price-filter__range-text wc-block-components-price-slider__range-text">
 						<FormattedMonetaryAmount
-							currency={ currency }
+							{ ...commonFormattedMonetaryAmountProps }
 							value={ minPrice }
-							decimalScale={ 0 }
 						/>
 						<FormattedMonetaryAmount
-							currency={ currency }
+							{ ...commonFormattedMonetaryAmountProps }
 							value={ maxPrice }
-							decimalScale={ 0 }
 						/>
 					</div>
 				) }

--- a/assets/js/base/components/price-slider/index.tsx
+++ b/assets/js/base/components/price-slider/index.tsx
@@ -425,6 +425,7 @@ const PriceSlider = ( {
 							onBlur={ priceInputOnBlur }
 							disabled={ isLoading || ! hasValidConstraints }
 							value={ minPriceInput }
+							decimalScale={ 0 }
 						/>
 					) : (
 						<div className="input-loading"></div>
@@ -452,6 +453,7 @@ const PriceSlider = ( {
 							onBlur={ priceInputOnBlur }
 							disabled={ isLoading || ! hasValidConstraints }
 							value={ maxPriceInput }
+							decimalScale={ 0 }
 						/>
 					) : (
 						<div className="input-loading"></div>
@@ -467,10 +469,12 @@ const PriceSlider = ( {
 						<FormattedMonetaryAmount
 							currency={ currency }
 							value={ minPrice }
+							decimalScale={ 0 }
 						/>
 						<FormattedMonetaryAmount
 							currency={ currency }
 							value={ maxPrice }
+							decimalScale={ 0 }
 						/>
 					</div>
 				) }


### PR DESCRIPTION
Currently, Filter by Price displays decimals even though the current smallest step for a slider is `1`:

To improve usability and simplify the filter this PR removes the decimals and displays just whole numbers.
- [commit 1](https://github.com/woocommerce/woocommerce-blocks/commit/b80fb67e8839464e72f2e078a3681169f092da05) - this commit does actual removal
- [commit 2](https://github.com/woocommerce/woocommerce-blocks/commit/3c3c18ece9b88ad06b435f540f7ed71bb3506fd2) - this commit is just a refactor, so these changes are not required for an enhancement

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/8974

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|    <img width="330" alt="image" src="https://user-images.githubusercontent.com/20098064/230318622-8fddf45b-f697-4c4d-96b0-779f465ab32c.png">    |    <img width="331" alt="image" src="https://user-images.githubusercontent.com/20098064/230318206-272f24f4-7591-4985-8265-8e481de89e76.png">   |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. Edit Product Catalog template in Editor
2. Add Filter by Price and Products block
3. Save 
4. **Expected:** Filter by Price displays ONLY whole numbers, skipping decimals in both Editor and Frontend
5. **Expected:** Smoke test the inputs and sliders - check that input and slider values are synchronized
6. Change Filter by Price "PRICE RANGE SELECTOR" setting from "Editable" to "Text" and repeat the above
7. Verify that other prices (e.g. in Products block) display full price with decimals. Remember the number of decimals may depend on the currency, but for the majority of currencies, you should see two minor units, e.g. $19.99.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Filter by Price: Simplify the interface by removing the decimals 
