### PR TITLE
[WIP] Add filters to add compatibility with WC Payments plugin

### DIFF
--- a/src/StoreApi/Routes/V1/ProductCollectionData.php
+++ b/src/StoreApi/Routes/V1/ProductCollectionData.php
@@ -72,8 +72,8 @@ class ProductCollectionData extends AbstractRoute {
 			$filter_request->set_param( 'max_price', null );
 
 			$price_results     = $filters->get_filtered_price( $filter_request );
-			$data['min_price'] = $price_results->min_price;
-			$data['max_price'] = $price_results->max_price;
+			$data['min_price'] = apply_filters( 'woocommerce_blocks_get_min_price', $price_results->min_price );
+			$data['max_price'] = apply_filters( 'woocommerce_blocks_get_max_price', $price_results->max_price );
 		}
 
 		if ( ! empty( $request['calculate_stock_status_counts'] ) ) {


### PR DESCRIPTION
This PR works along https://github.com/Automattic/woocommerce-payments/pull/5984.

In order to make the block support the Multi-Currency, we're suggesting adding a Compatibility layer with two filters on WooCommerce Payments (check the linked PR for more details).

This PR applies the filter `woocommerce_blocks_get_min_price` and `woocommerce_blocks_get_max_price`. If the WC Payments team approves our solution, we will work to add the remaining filters.

⚠️ This PR is just a POC.

cc @kmanijak 

