### PR TITLE
Prevent shipping cost being applied to the Local Pickup rates when using multiple packages

### DIFF
--- a/assets/js/base/components/cart-checkout/shipping-rates-control/index.tsx
+++ b/assets/js/base/components/cart-checkout/shipping-rates-control/index.tsx
@@ -8,6 +8,7 @@ import { ExperimentalOrderShippingPackages } from '@woocommerce/blocks-checkout'
 import {
 	getShippingRatesPackageCount,
 	getShippingRatesRateCount,
+	isPackageRateCollectable,
 } from '@woocommerce/base-utils';
 import {
 	useStoreCart,
@@ -15,6 +16,7 @@ import {
 	useShippingData,
 } from '@woocommerce/base-context';
 import NoticeBanner from '@woocommerce/base-components/notice-banner';
+import { CartShippingPackageShippingRate } from '@woocommerce/type-defs/cart';
 
 /**
  * Internal dependencies
@@ -94,6 +96,18 @@ const ShippingRatesControl = ( {
 		},
 		context,
 	};
+
+	const allPackagesUsingLocalPickup = shippingRates.every(
+		( packageRate ) => {
+			const selectedRate = packageRate.shipping_rates.find(
+				( rate ) => rate.selected
+			) as CartShippingPackageShippingRate;
+			if ( ! selectedRate ) {
+				return false;
+			}
+			return isPackageRateCollectable( selectedRate );
+		}
+	);
 	const { isEditor } = useEditorContext();
 	const { hasSelectedLocalPickup } = useShippingData();
 	return (
@@ -107,7 +121,8 @@ const ShippingRatesControl = ( {
 		>
 			<ExperimentalOrderShippingPackages.Slot { ...slotFillProps } />
 			{ hasSelectedLocalPickup &&
-				shippingRates.length > 1 &&
+				context !== 'woocommerce/checkout' &&
+				! allPackagesUsingLocalPickup &&
 				! isEditor && (
 					<NoticeBanner
 						className="wc-block-components-notice"

--- a/assets/js/base/context/hooks/shipping/use-shipping-data.ts
+++ b/assets/js/base/context/hooks/shipping/use-shipping-data.ts
@@ -100,7 +100,7 @@ export const useShippingData = (): ShippingData => {
 			 * Forces pickup location to be selected for all packages since we don't allow a mix of shipping and pickup.
 			 */
 			if (
-				hasCollectableRate( newShippingRateId.split( ':' )[ 0 ] ) ||
+				// Do not pass a packageId because we want this pickup rate to apply to all packages.
 				hasSelectedLocalPickup
 			) {
 				selectPromise = dispatchSelectShippingRate( newShippingRateId );

--- a/assets/js/base/context/hooks/shipping/use-shipping-data.ts
+++ b/assets/js/base/context/hooks/shipping/use-shipping-data.ts
@@ -99,10 +99,8 @@ export const useShippingData = (): ShippingData => {
 			 *
 			 * Forces pickup location to be selected for all packages since we don't allow a mix of shipping and pickup.
 			 */
-			if (
+			if ( hasCollectableRate( newShippingRateId.split( ':' )[ 0 ] ) ) {
 				// Do not pass a packageId because we want this pickup rate to apply to all packages.
-				hasSelectedLocalPickup
-			) {
 				selectPromise = dispatchSelectShippingRate( newShippingRateId );
 			} else {
 				selectPromise = dispatchSelectShippingRate(

--- a/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/block.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/block.tsx
@@ -146,6 +146,7 @@ const Block = (): JSX.Element | null => {
 
 	const onSelectRate = useCallback(
 		( rateId: string ) => {
+			// Do not pass a packageId because we want this pickup rate to apply to all packages.
 			selectShippingRate( rateId );
 		},
 		[ selectShippingRate ]

--- a/assets/js/data/cart/actions.ts
+++ b/assets/js/data/cart/actions.ts
@@ -385,7 +385,7 @@ export const changeCartItemQuantity =
  * @param {number | string} [packageId] The key of the packages that we will select within.
  */
 export const selectShippingRate =
-	( rateId: string, packageId = 0 ) =>
+	( rateId: string, packageId?: number | undefined ) =>
 	async ( {
 		dispatch,
 		select,
@@ -406,15 +406,18 @@ export const selectShippingRate =
 		if ( selectedShippingRate?.rate_id === rateId ) {
 			return;
 		}
+		const data: { rate_id: string; package_id?: number } = {
+			rate_id: rateId,
+		};
+		if ( typeof packageId !== 'undefined' ) {
+			data.package_id = packageId;
+		}
 		try {
 			dispatch.shippingRatesBeingSelected( true );
 			const { response } = await apiFetchWithHeaders( {
 				path: `/wc/store/v1/cart/select-shipping-rate`,
 				method: 'POST',
-				data: {
-					package_id: packageId,
-					rate_id: rateId,
-				},
+				data,
 				cache: 'no-store',
 			} );
 			// Remove shipping and billing address from the response, so we don't overwrite what the shopper is

--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -204,6 +204,11 @@ class Cart extends AbstractBlock {
 		$this->asset_data_registry->add( 'hasDarkEditorStyleSupport', current_theme_supports( 'dark-editor-style' ), true );
 		$this->asset_data_registry->register_page_id( isset( $attributes['checkoutPageId'] ) ? $attributes['checkoutPageId'] : 0 );
 
+		$pickup_location_settings = get_option( 'woocommerce_pickup_location_settings', [] );
+		$local_pickup_enabled     = wc_string_to_bool( $pickup_location_settings['enabled'] ?? 'no' );
+
+		$this->asset_data_registry->add( 'localPickupEnabled', $local_pickup_enabled, true );
+
 		// Hydrate the following data depending on admin or frontend context.
 		if ( ! is_admin() && ! WC()->is_rest_api_request() ) {
 			$this->hydrate_from_api();


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR changes some of the logic around selecting shipping rates, when a local pickup rate is selected, it applies the same rate to _all_ packages.

On the Cart block, when selecting rates in the sidebar (see screenshot below)

<img width="252" alt="image" src="https://user-images.githubusercontent.com/5656702/230611061-c791a8d1-01d6-41ec-a75f-a3d26dd8cbf8.png">

a warning is shown if the shopper selects a mixture of local pickup/regular shipping rates, this warning currently shows in the Checkout block, but is not applicable since it is impossible to select a mixture there, so this PR hides that.



<!-- Reference any related issues or PRs here -->

Fixes woocommerce/woocommerce#42421 

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. Install and activate [Multiple Packages for WooCommerce](https://wordpress.org/plugins/multiple-packages-for-woocommerce/)
2. Go to WooCommerce -> Settings -> Multiple packages. Change the `Group By` setting to `Product (individual)`.
3. Go to WooCommerce -> Settings -> Shipping -> Local Pickup. Enable local pickup and add some pickup locations.
4. Go to WooCommerce -> Settings -> Shipping. Add a few shipping rates (one or two flat rates, free shipping)
5. Add 3 items to your cart.
6. Go to the Cart block.
7. In the sidebar, see that you can choose different shipping methods for each package.
8. Select a **local pickup** rate for one of the packages.
9. Ensure the shipping rate updates to show the collection location. Ensure it does **not** show the shipping rate (flat rate/free shipping).

| ✅  | 🚫  |
| ------ | ----- |
| <img width="244" alt="image" src="https://user-images.githubusercontent.com/5656702/230612517-a8e4f54d-0d30-4578-b1bb-b740eac277cb.png"> | <img width="243" alt="image" src="https://user-images.githubusercontent.com/5656702/230612697-feadcc79-5eda-46a6-a156-66bc6a8b3e53.png"> |

10. Change one of the rates to a regular shipping rate. Ensure a warning shows beneath the packages.
<img width="259" alt="image" src="https://user-images.githubusercontent.com/5656702/230612815-a3f6d703-96e4-49cb-a52a-8af997f8fd87.png">

11. Proceed to the Checkout block.
12. When arriving on the Checkout block, ensure the warning from step 10 is not visible.
13. Before changing anything, check the shipping method selector block. Depending on what the first package was set to in the Cart block, it will either be set to `Shipping` or `Local Pickup`.
14. If it is set to shipping, ensure all packages have a selected rate, the rate **does not** need to be the same for all packages.
15. Ensure the sidebar shows the correct rates.
16. <img width="315" alt="image" src="https://user-images.githubusercontent.com/5656702/230613747-71a104bf-0022-4a81-89dd-4f1d69028810.png">
17. If it is set to Local Pickup, ensure the sidebar shows only **one** rate, and that it is the selected local pickup rate.
18. <img width="324" alt="image" src="https://user-images.githubusercontent.com/5656702/230613853-29eb9427-7d77-493f-8e6b-4138950b09a1.png">
19. Check out once with local pickup selected, and once again with regular shipping selected.
20. In both cases, check the order in the dashboard and order confirmation email to ensure the shipping/collection information is correct.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Ensure that shipping prices are set correctly when using local pickup.
