### PR TITLE
Prevent error when entering postcode for countries without specific validation rules

### DIFF
--- a/packages/checkout/utils/validation/is-postcode.ts
+++ b/packages/checkout/utils/validation/is-postcode.ts
@@ -27,8 +27,10 @@ export interface IsPostcodeProps {
 }
 
 const isPostcode = ( { postcode, country }: IsPostcodeProps ): boolean => {
-	// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-	return DEFAULT_REGEXES.get( country )!.test( postcode );
+	// If the country is not in the list of regexes, trying to test it would result in an error, so we skip and assume
+	// that it is valid.
+	const postcodeTest = DEFAULT_REGEXES.get( country )?.test( postcode );
+	return typeof postcodeTest !== 'undefined' ? postcodeTest : true;
 };
 
 export default isPostcode;

--- a/tests/e2e/fixtures/fixture-data.js
+++ b/tests/e2e/fixtures/fixture-data.js
@@ -278,7 +278,7 @@ const Settings = () => [
 	},
 	{
 		id: 'woocommerce_specific_allowed_countries',
-		value: [ 'DZ', 'CA', 'NZ', 'ES', 'GB', 'US' ],
+		value: [ 'AL', 'DZ', 'CA', 'NZ', 'ES', 'GB', 'US' ],
 	},
 	{
 		id: 'woocommerce_ship_to_countries',
@@ -286,7 +286,7 @@ const Settings = () => [
 	},
 	{
 		id: 'woocommerce_specific_ship_to_countries',
-		value: [ 'DZ', 'CA', 'NZ', 'ES', 'GB', 'US' ],
+		value: [ 'AL', 'DZ', 'CA', 'NZ', 'ES', 'GB', 'US' ],
 	},
 	{
 		id: 'woocommerce_enable_coupons',

--- a/tests/e2e/specs/shopper/cart-checkout/checkout.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/checkout.test.js
@@ -207,24 +207,18 @@ describe( 'Shopper → Checkout', () => {
 			await unsetCheckbox(
 				'.wc-block-checkout__use-address-for-billing input[type="checkbox"]'
 			);
-			await shopper.block.fillShippingDetails(
-				{
-					...SHIPPING_DETAILS,
-					country: 'Albania',
-					state: 'Berat',
-					postcode: '1234',
-				},
-				true
-			);
+			await shopper.block.fillShippingDetails( {
+				...SHIPPING_DETAILS,
+				country: 'Albania',
+				state: 'Berat',
+				postcode: '1234',
+			} );
 
-			await shopper.block.fillBillingDetails(
-				{
-					...BILLING_DETAILS,
-					country: 'United Kingdom',
-					postcode: 'SW1 1AA',
-				},
-				true
-			);
+			await shopper.block.fillBillingDetails( {
+				...BILLING_DETAILS,
+				country: 'United Kingdom',
+				postcode: 'SW1 1AA',
+			} );
 
 			await expect( page ).not.toMatchElement(
 				'.wc-block-components-validation-error p',

--- a/tests/e2e/specs/shopper/cart-checkout/checkout.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/checkout.test.js
@@ -197,6 +197,42 @@ describe( 'Shopper → Checkout', () => {
 			await shopper.block.verifyShippingDetails( SHIPPING_DETAILS );
 			await shopper.block.verifyBillingDetails( BILLING_DETAILS );
 		} );
+		it( 'User can add postcodes for different countries', async () => {
+			await shopper.block.goToShop();
+			await shopper.addToCartFromShopPage( SIMPLE_PHYSICAL_PRODUCT_NAME );
+			await shopper.block.goToCheckout();
+			await page.waitForSelector(
+				'.wc-block-checkout__use-address-for-billing input[type="checkbox"]'
+			);
+			await unsetCheckbox(
+				'.wc-block-checkout__use-address-for-billing input[type="checkbox"]'
+			);
+			await shopper.block.fillShippingDetails(
+				{
+					...SHIPPING_DETAILS,
+					country: 'Albania',
+					state: 'Berat',
+					postcode: '1234',
+				},
+				true
+			);
+
+			await shopper.block.fillBillingDetails(
+				{
+					...BILLING_DETAILS,
+					country: 'United Kingdom',
+					postcode: 'SW1 1AA',
+				},
+				true
+			);
+
+			await expect( page ).not.toMatchElement(
+				'.wc-block-components-validation-error p',
+				{
+					text: 'Please enter a valid postcode',
+				}
+			);
+		} );
 	} );
 
 	describe( 'Checkout Form Errors', () => {

--- a/tests/utils/shopper.js
+++ b/tests/utils/shopper.js
@@ -276,7 +276,7 @@ export const shopper = {
 			await page.evaluate( 'document.activeElement.blur()' );
 		},
 		// prettier-ignore
-		fillBillingDetails: async ( customerBillingDetails, skipPushCheck = false ) => {
+		fillBillingDetails: async ( customerBillingDetails ) => {
 			await page.waitForSelector( '#billing-fields' );
 			const companyInputField = await page.$( '#billing-company' );
 
@@ -300,14 +300,12 @@ export const shopper = {
 			await expect( page ).toFill( '#email', customerBillingDetails.email );
 			// Blur active field to trigger customer address update, then wait for requests to finish.
 			await page.evaluate( 'document.activeElement.blur()' );
-			if ( ! skipPushCheck ) {
-				await checkCustomerPushCompleted( 'billing', customerBillingDetails );
+			await checkCustomerPushCompleted( 'billing', customerBillingDetails );
 
-			}
 		},
 
 		// prettier-ignore
-		fillShippingDetails: async ( customerShippingDetails, skipPushCheck = false ) => {
+		fillShippingDetails: async ( customerShippingDetails ) => {
 			const companyInputField = await page.$( '#shipping-company' );
 
 			if ( companyInputField ) {
@@ -328,9 +326,7 @@ export const shopper = {
 			await expect( page ).toFill( '#shipping-phone', customerShippingDetails.phone );
 			// Blur active field to customer address update, then wait for requests to finish.
 			await page.evaluate( 'document.activeElement.blur()' );
-			if ( ! skipPushCheck ) {
-				await checkCustomerPushCompleted( 'shipping', customerShippingDetails );
-			}
+			await checkCustomerPushCompleted( 'shipping', customerShippingDetails );
 		},
 
 		// prettier-ignore

--- a/tests/utils/shopper.js
+++ b/tests/utils/shopper.js
@@ -276,7 +276,7 @@ export const shopper = {
 			await page.evaluate( 'document.activeElement.blur()' );
 		},
 		// prettier-ignore
-		fillBillingDetails: async ( customerBillingDetails ) => {
+		fillBillingDetails: async ( customerBillingDetails, skipPushCheck = false ) => {
 			await page.waitForSelector( '#billing-fields' );
 			const companyInputField = await page.$( '#billing-company' );
 
@@ -290,17 +290,24 @@ export const shopper = {
 			await expect( page ).toFill( '#billing-address_1', customerBillingDetails.addressfirstline );
 			await expect( page ).toFill( '#billing-address_2', customerBillingDetails.addresssecondline );
 			await expect( page ).toFill( '#billing-city', customerBillingDetails.city );
-			await expect( page ).toFill( '#billing-state input', customerBillingDetails.state );
+
+			const stateInputField = await page.$( '#billing-state input' );
+			if ( stateInputField ) {
+				await expect( page ).toFill( '#billing-state input', customerBillingDetails.state );
+			}
 			await expect( page ).toFill( '#billing-postcode', customerBillingDetails.postcode );
 			await expect( page ).toFill( '#billing-phone', customerBillingDetails.phone );
 			await expect( page ).toFill( '#email', customerBillingDetails.email );
 			// Blur active field to trigger customer address update, then wait for requests to finish.
 			await page.evaluate( 'document.activeElement.blur()' );
-			await checkCustomerPushCompleted( 'billing', customerBillingDetails );
+			if ( ! skipPushCheck ) {
+				await checkCustomerPushCompleted( 'billing', customerBillingDetails );
+
+			}
 		},
 
 		// prettier-ignore
-		fillShippingDetails: async ( customerShippingDetails ) => {
+		fillShippingDetails: async ( customerShippingDetails, skipPushCheck = false ) => {
 			const companyInputField = await page.$( '#shipping-company' );
 
 			if ( companyInputField ) {
@@ -313,12 +320,17 @@ export const shopper = {
 			await expect( page ).toFill( '#shipping-address_1', customerShippingDetails.addressfirstline );
 			await expect( page ).toFill( '#shipping-address_2', customerShippingDetails.addresssecondline );
 			await expect( page ).toFill( '#shipping-city', customerShippingDetails.city );
-			await expect( page ).toFill( '#shipping-state input', customerShippingDetails.state );
+			const stateInputField = await page.$( '#shipping-state input' );
+			if ( stateInputField ) {
+				await expect( page ).toFill( '#shipping-state input', customerShippingDetails.state );
+			}
 			await expect( page ).toFill( '#shipping-postcode', customerShippingDetails.postcode );
 			await expect( page ).toFill( '#shipping-phone', customerShippingDetails.phone );
 			// Blur active field to customer address update, then wait for requests to finish.
 			await page.evaluate( 'document.activeElement.blur()' );
-			await checkCustomerPushCompleted( 'shipping', customerShippingDetails );
+			if ( ! skipPushCheck ) {
+				await checkCustomerPushCompleted( 'shipping', customerShippingDetails );
+			}
 		},
 
 		// prettier-ignore


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
In #8503 we added a regression when users entered certain countries (e.g. Afghanistan or Albania) and then could not use the Postcode field, or a block error appeared preventing address entry.

This PR fixes that by checking whether the country has any regex rules before validating. If it does not we fall back to allowing the postcode through.

It also modifies the tests to test for a country we know is problematic (Albania).

<!-- Reference any related issues or PRs here -->

Fixes #8983

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Ensure the shipping calculator is enabled on the Cart block.
2. Add an item to your cart and go to the Cart block.
3. Use the shipping calculator to enter an address, choose Albania as your country. Ensure you can enter a postcode with no errors.
4. Add an item to your cart and go to the Checkout block. Ensure there are no errors on the shipping fields.
5. Enter Afghanistan as your shipping country. Ensure the form does not error.
6. Enter any value into the postcode field, ensure you can type it in without any issues.
7. Place the order and verify it works.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Prevent the shipping/billing address forms from breaking when entering postcodes for specific countries.
