### PR TITLE
Fixed trim is not a function error when address has an attribute that is not a string

### DIFF
--- a/assets/js/data/cart/push-changes.ts
+++ b/assets/js/data/cart/push-changes.ts
@@ -44,13 +44,17 @@ export const normalizeAddress = ( address: BillingOrShippingAddress ) => {
 			//Skip normalizing for any non string field
 			if ( typeof value !== 'string' ) {
 				acc[ key as keyof BillingOrShippingAddress ] = value;
-			} else if ( key === 'postcode' ) {
+				return acc;
+			}
+
+			if ( key === 'postcode' ) {
 				acc[ key as keyof BillingOrShippingAddress ] = value
 					.replace( ' ', '' )
 					.toUpperCase();
-			} else {
-				acc[ key as keyof BillingOrShippingAddress ] = value.trim();
+				return acc;
 			}
+
+			acc[ key as keyof BillingOrShippingAddress ] = value.trim();
 			return acc;
 		},
 		{} as BillingOrShippingAddress

--- a/assets/js/data/cart/push-changes.ts
+++ b/assets/js/data/cart/push-changes.ts
@@ -41,7 +41,10 @@ const isBillingAddress = (
 export const normalizeAddress = ( address: BillingOrShippingAddress ) => {
 	const trimmedAddress = Object.entries( address ).reduce(
 		( acc, [ key, value ] ) => {
-			if ( key === 'postcode' ) {
+			//Skip normalizing for any non string field
+			if ( typeof value !== 'string' ) {
+				acc[ key as keyof BillingOrShippingAddress ] = value;
+			} else if ( key === 'postcode' ) {
 				acc[ key as keyof BillingOrShippingAddress ] = value
 					.replace( ' ', '' )
 					.toUpperCase();


### PR DESCRIPTION
This PR adds a check to prevent errors when the Address object contains an attribute that is not a string. This was happening in WooPay because it stores the Address id and blocks tried to execute `.trim()` in an integer. Now anything that is not a string will skip being trimmed.

### Testing
- It is easier to test if you call the function `normalizeAddress()` passing an address with an integer id but it can also be tested using WooPay

**How to test on WooPay**
- Make sure [this PR](https://github.com/Automattic/woopay/pull/1810) was not merged yet otherwise you'll need to revert the changes before testing
- Checkout using WooPay
- Add a new Address
- Select a different address
- Make sure no error saying `trim() is not a function` shows up in the console

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
### Changelog

> Checkout - prevent running trim in non-string address attributes