### PR TITLE
Ensure local pickup warning shows on Cart page

### DIFF
--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -204,6 +204,11 @@ class Cart extends AbstractBlock {
 		$this->asset_data_registry->add( 'hasDarkEditorStyleSupport', current_theme_supports( 'dark-editor-style' ), true );
 		$this->asset_data_registry->register_page_id( isset( $attributes['checkoutPageId'] ) ? $attributes['checkoutPageId'] : 0 );
 
+		$pickup_location_settings = get_option( 'woocommerce_pickup_location_settings', [] );
+		$local_pickup_enabled     = wc_string_to_bool( $pickup_location_settings['enabled'] ?? 'no' );
+
+		$this->asset_data_registry->add( 'localPickupEnabled', $local_pickup_enabled, true );
+
 		// Hydrate the following data depending on admin or frontend context.
 		if ( ! is_admin() && ! WC()->is_rest_api_request() ) {
 			$this->hydrate_from_api();


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR ensures the `localPickupEnabled` setting is passed to the front-end Cart block.

By doing this, we ensure the local pickup features (specifically, multiple package detection) work in the Cart block.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
| <img width="242" alt="image" src="https://user-images.githubusercontent.com/5656702/231154865-9b699c59-fbd9-4287-9f41-b084c26d4fea.png"> | <img width="267" alt="image" src="https://user-images.githubusercontent.com/5656702/231154824-c8e1782b-8caa-402a-bba6-3abbec19a35a.png"> |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Install and activate [Multiple Packages for WooCommerce](https://wordpress.org/plugins/multiple-packages-for-woocommerce/)
2. Go to WooCommerce -> Settings -> Multiple Packages and change the "Group by" option to "Product (individual)"
4. Go to WooCommerce -> Shipping -> Local Pickup and enable local pickup. Add **two** locations.
5. Go to WooCommerce -> Shipping and set up some rates. Set two up.
6. Go to the front-end and add at least two physical items that require shipping to your cart.
7. Go to the Cart block. In the sidebar where you can select shipping options, change one of the packages to use one of the local pickup locations, and set the other package to use a regular shipping method.
8. Ensure the `Multiple shipments must have the same pickup location` warning appears.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

