### PR TITLE
Mini Cart template part: give user customized template priority over theme template

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -445,7 +445,7 @@ class BlockTemplatesController {
 	 * @return array WP_Block_Template[] An array of block template objects.
 	 */
 	public function get_block_templates( $slugs = array(), $template_type = 'wp_template' ) {
-		$templates_from_db  = $this->get_block_templates_from_db( $slugs, $template_type );
+		$templates_from_db  = BlockTemplateUtils::get_block_templates_from_db( $slugs, $template_type );
 		$templates_from_woo = $this->get_block_templates_from_woocommerce( $slugs, $templates_from_db, $template_type );
 		$templates          = array_merge( $templates_from_db, $templates_from_woo );
 

--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -351,32 +351,7 @@ class BlockTemplatesController {
 	 * @return int[]|\WP_Post[] An array of found templates.
 	 */
 	public function get_block_templates_from_db( $slugs = array(), $template_type = 'wp_template' ) {
-		$check_query_args = array(
-			'post_type'      => $template_type,
-			'posts_per_page' => -1,
-			'no_found_rows'  => true,
-			'tax_query'      => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
-				array(
-					'taxonomy' => 'wp_theme',
-					'field'    => 'name',
-					'terms'    => array( BlockTemplateUtils::DEPRECATED_PLUGIN_SLUG, BlockTemplateUtils::PLUGIN_SLUG, get_stylesheet() ),
-				),
-			),
-		);
-
-		if ( is_array( $slugs ) && count( $slugs ) > 0 ) {
-			$check_query_args['post_name__in'] = $slugs;
-		}
-
-		$check_query         = new \WP_Query( $check_query_args );
-		$saved_woo_templates = $check_query->posts;
-
-		return array_map(
-			function( $saved_woo_template ) {
-				return BlockTemplateUtils::build_template_result_from_post( $saved_woo_template );
-			},
-			$saved_woo_templates
-		);
+		return BlockTemplateUtils::get_block_templates_from_db( $slugs, $template_type );
 	}
 
 	/**

--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -351,6 +351,7 @@ class BlockTemplatesController {
 	 * @return int[]|\WP_Post[] An array of found templates.
 	 */
 	public function get_block_templates_from_db( $slugs = array(), $template_type = 'wp_template' ) {
+		wc_deprecated_function( 'BlockTemplatesController::get_block_templates_from_db()', '7.8', '\Automattic\WooCommerce\Blocks\Utils\BlockTemplateUtils::get_block_templates_from_db()' );
 		return BlockTemplateUtils::get_block_templates_from_db( $slugs, $template_type );
 	}
 

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -471,10 +471,15 @@ class MiniCart extends AbstractBlock {
 
 		$template_part_contents = '';
 
-		// Determine if we need to load the template part from the theme, or WooCommerce in that order.
-		$theme_has_mini_cart   = BlockTemplateUtils::theme_has_template_part( 'mini-cart' );
-		$template_slug_to_load = $theme_has_mini_cart ? get_stylesheet() : BlockTemplateUtils::PLUGIN_SLUG;
-		$template_part         = BlockTemplateUtils::get_block_template( $template_slug_to_load . '//mini-cart', 'wp_template_part' );
+		// Determine if we need to load the template part from the DB, the theme or WooCommerce in that order.
+		$templates_from_db = BlockTemplateUtils::get_block_templates_from_db( array( 'mini-cart' ), 'wp_template_part' );
+		if ( count( $templates_from_db ) > 0 ) {
+			$template_slug_to_load = $templates_from_db[0]->theme;
+		} else {
+			$theme_has_mini_cart   = BlockTemplateUtils::theme_has_template_part( 'mini-cart' );
+			$template_slug_to_load = $theme_has_mini_cart ? get_stylesheet() : BlockTemplateUtils::PLUGIN_SLUG;
+		}
+		$template_part = BlockTemplateUtils::get_block_template( $template_slug_to_load . '//mini-cart', 'wp_template_part' );
 
 		if ( $template_part && ! empty( $template_part->content ) ) {
 			$template_part_contents = do_blocks( $template_part->content );


### PR DESCRIPTION
Fixes #8929.

### Testing

#### User Facing Testing

0. With [TT3](https://github.com/WordPress/twentytwentythree/), add the Mini Cart block to your store header via Appearance > Editor.
1. Also in Appearance > Editor, make some edits to the Mini Cart template part and save it.
2. Verify the edits are visible in the frontend when you open the Mini Cart drawer.
3. Now, let's imagine TT3 releases an update which introduces a custom Mini Cart template part. To do so, install this ZIP as a theme (it's TT3 with a `parts/mini-cart.html` file): [twentytwentythree.zip](https://github.com/woocommerce/woocommerce-blocks/files/11200877/twentytwentythree.zip).
4. Verify that going to Appearance > Editor > Template Parts > Mini Cart shows the template you modified in step 1 (instead of the theme template).
5. Verify that in the frontend the Mini Cart drawer shows the template you modified in step 1 (instead of the theme template).

In other words, given that you created a custom template in step 1, you should never see the template from the theme.

Editor | Frontend
--- | ---
![imatge](https://user-images.githubusercontent.com/3616980/231180345-b53dcf1e-ed60-4293-b8c8-86c549478da7.png) | ![imatge](https://user-images.githubusercontent.com/3616980/231180437-ac1c37e3-c380-46f8-b218-d815f709a100.png)


* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Give user customized Mini Cart template part priority over the template part from the theme
