### PR TITLE
Customer Account block: Fix inspector control border

### DIFF
--- a/assets/js/blocks/customer-account/editor.scss
+++ b/assets/js/blocks/customer-account/editor.scss
@@ -6,7 +6,3 @@
 .block-editor-block-card + div > .wc-block-editor-customer-account__link {
 	padding: 0 $gap $gap 52px;
 }
-/* In tabbed sidebar (ie: WP >=6.2) */
-.wc-block-editor-customer-account__link {
-	padding: $gap;
-}

--- a/assets/js/blocks/customer-account/sidebar-settings.tsx
+++ b/assets/js/blocks/customer-account/sidebar-settings.tsx
@@ -66,7 +66,9 @@ export const BlockSettings = ( {
 
 	return (
 		<InspectorControls key="inspector">
-			<AccountSettingsLink />
+			<PanelBody>
+				<AccountSettingsLink />
+			</PanelBody>
 			<PanelBody
 				title={ __(
 					'Display settings',


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
Currently, the inspector control for the Customer Account block has no border under the tabs. This PR solves that by adding the "Manage Account Settings" link inside a PanelBody that, by default, handles the padding and the border.

<!-- Reference any related issues or PRs here -->

Fixes #8941 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/20469356/231226537-0056be06-0a18-43fe-8314-1bbaedc7b275.png) | ![image](https://user-images.githubusercontent.com/20469356/231226836-075fa210-82e6-4b9b-83f4-c792efdc6eff.png) |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Log in to your WordPress dashboard;
2. Go to Appearance > Themes, and select a block theme (for example: Twenty-twenty three);
3. Go to Appearance < Site Editor (Beta);
4. Click the Edit button;
5. Click on the "+" icon to add a new block and search for "Customer Account" block in the search bar;
6. Click on the "Customer Account" block to add it to your page or post;
7. On the right side, check that a border exists under the tabs, separating the tabs from the "Manage account settings" link.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Add bottom border on the Inspector Controls for the Customer Account block
