### PR TITLE
Customer Account block: Fix padding for the block in the Editor

### DIFF
--- a/assets/js/blocks/customer-account/edit.tsx
+++ b/assets/js/blocks/customer-account/edit.tsx
@@ -20,7 +20,7 @@ const Edit = ( {
 }: BlockEditProps< Attributes > ) => {
 	const { className } = attributes;
 	const blockProps = useBlockProps( {
-		className: classNames( 'wc-block-customer-account', className ),
+		className: classNames( 'wc-block-editor-customer-account', className ),
 	} );
 
 	return (

--- a/assets/js/blocks/customer-account/editor.scss
+++ b/assets/js/blocks/customer-account/editor.scss
@@ -1,4 +1,8 @@
-.wc-block-customer-account__icon-style-toggle {
+.wc-block-editor-customer-account {
+	padding: em($gap-smaller) em($gap-smaller);
+}
+
+.wc-block-editor-customer-account__icon-style-toggle {
 	width: 100%;
 }
 

--- a/assets/js/blocks/customer-account/sidebar-settings.tsx
+++ b/assets/js/blocks/customer-account/sidebar-settings.tsx
@@ -123,7 +123,7 @@ export const BlockSettings = ( {
 								iconStyle: value,
 							} )
 						}
-						className="wc-block-customer-account__icon-style-toggle"
+						className="wc-block-editor-customer-account__icon-style-toggle"
 					>
 						<ToggleGroupControlOption
 							value={ IconStyle.DEFAULT }
@@ -132,7 +132,7 @@ export const BlockSettings = ( {
 									icon={ customerAccountStyle }
 									size={ 16 }
 									className={ classNames(
-										'wc-block-customer-account__icon-option',
+										'wc-block-editor-customer-account__icon-option',
 										{
 											active:
 												iconStyle === IconStyle.DEFAULT,
@@ -148,7 +148,7 @@ export const BlockSettings = ( {
 									icon={ customerAccountStyleAlt }
 									size={ 20 }
 									className={ classNames(
-										'wc-block-customer-account__icon-option',
+										'wc-block-editor-customer-account__icon-option',
 										{
 											active: iconStyle === IconStyle.ALT,
 										}

--- a/assets/js/blocks/customer-account/style.scss
+++ b/assets/js/blocks/customer-account/style.scss
@@ -9,11 +9,6 @@
 			text-decoration: underline !important;
 		}
 
-		.icon + .label,
-		.wc-block-customer-account__account-icon + .label {
-			margin-left: $gap-smaller;
-		}
-
 		.icon {
 			height: em(16px);
 			width: em(16px);
@@ -22,6 +17,7 @@
 		.wc-block-customer-account__account-icon {
 			height: em(23px);
 			width: em(23px);
+			padding: em($gap-smaller);
 		}
 	}
 }


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
The Customer Account block currently has no padding set to it. This makes the clickable area too small for this block when the user is on the Editor page.

This PR solves that by adding a padding equal to what we have for the Mini Cart block. I also refactored the CSS classes to follow our guidelines 

<!-- Reference any related issues or PRs here -->

Fixes #8942 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/20469356/231238038-acdde4b8-1f6e-421f-8773-dfa65f9366d1.png) |  ![image](https://user-images.githubusercontent.com/20469356/231238150-301b0cf9-01ff-4b8c-979d-c6e875bded03.png) |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Log in to your WordPress dashboard;
2. Go to Appearance > Themes, and select a block theme (for example: Twenty-twenty three);
3. Go to Appearance > Site Editor;
4. Click the Edit button;
5. Click on the "+" icon to add a new block and search for "Customer Account" block in the search bar;
6. Click on the "Customer Account" block to add it to your page or post;
7. On the right side, click on the dropdown menu inside the Icon Options section;
8. Select the "Icon-only" option;
9. Check that the Customer Account block is displayed as an Icon and that it has some spacing around the icon

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Add spacing around the Customer Account block to make it more easily clickable on the Editor page
