### PR TITLE
Display Mini Cart overlay in template part editor

### DIFF
--- a/assets/js/blocks/mini-cart/mini-cart-contents/edit.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/edit.tsx
@@ -123,7 +123,7 @@ const Edit = ( {
 	}, [] );
 
 	return (
-		<div { ...blockProps }>
+		<>
 			<InspectorControls key="inspector">
 				<PanelBody
 					title={ __( 'Dimensions', 'woo-gutenberg-products-block' ) }
@@ -144,15 +144,23 @@ const Edit = ( {
 					/>
 				</PanelBody>
 			</InspectorControls>
-			<EditorProvider currentView={ currentView }>
-				<InnerBlocks
-					allowedBlocks={ ALLOWED_BLOCKS }
-					template={ defaultTemplate }
-					templateLock={ false }
-				/>
-			</EditorProvider>
-			<MiniCartInnerBlocksStyle style={ blockProps.style } />
-		</div>
+			<div
+				className="wc-block-components-drawer__screen-overlay"
+				aria-hidden="true"
+			></div>
+			<div className="wc-block-editor-mini-cart-contents__wrapper">
+				<div { ...blockProps }>
+					<EditorProvider currentView={ currentView }>
+						<InnerBlocks
+							allowedBlocks={ ALLOWED_BLOCKS }
+							template={ defaultTemplate }
+							templateLock={ false }
+						/>
+					</EditorProvider>
+					<MiniCartInnerBlocksStyle style={ blockProps.style } />
+				</div>
+			</div>
+		</>
 	);
 };
 

--- a/assets/js/blocks/mini-cart/mini-cart-contents/editor.scss
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/editor.scss
@@ -1,8 +1,13 @@
-.editor-styles-wrapper .wp-block-woocommerce-mini-cart-contents {
-	/* We need to override the margin top here to simulate the layout of
-	the mini cart contents on the front end. */
-	margin: 0 auto !important;
+// Extra classes added for specificity, so we get rid of a top margin added by GB.
+.editor-styles-wrapper .wc-block-editor-mini-cart-contents__wrapper.wc-block-editor-mini-cart-contents__wrapper {
+	display: flex;
+	justify-content: center;
+	margin: 0;
+	position: relative;
+	z-index: 9999;
+}
 
+.editor-styles-wrapper .wp-block-woocommerce-mini-cart-contents {
 	.wp-block-woocommerce-empty-mini-cart-contents-block[hidden],
 	.wp-block-woocommerce-filled-mini-cart-contents-block[hidden] {
 		display: none;


### PR DESCRIPTION
This PR adds the overlay to the Mini Cart template part editor so it's clear which part is the editable template part and which part is the background.

### Testing

#### User Facing Testing

1. Go to Appearance > Editor > Template Parts > Mini Cart.
2. Verify the Mini Cart template part is surrounded by space with a dimmed background (like the frontend overlay).

Before | After
--- | ---
![imatge](https://user-images.githubusercontent.com/3616980/231437877-8481f0ea-3fbc-4613-a5da-fcb6883c777c.png) | ![imatge](https://user-images.githubusercontent.com/3616980/231442269-0b222db1-8e4a-4d4c-b258-4c4aacc3e730.png)

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Display Mini Cart overlay in template part editor to better reflect the frontend experience.
