### PR TITLE
Skeleton component: fix warning about key prop

### DIFF
--- a/assets/js/base/components/skeleton/index.tsx
+++ b/assets/js/base/components/skeleton/index.tsx
@@ -10,11 +10,15 @@ export interface SkeletonProps {
 export const Skeleton = ( {
 	numberOfLines = 1,
 }: SkeletonProps ): JSX.Element => {
-	const skeletonLines = Array( numberOfLines ).fill(
-		<span
-			className="wc-block-components-skeleton-text-line"
-			aria-hidden="true"
-		/>
+	const skeletonLines = Array.from(
+		{ length: numberOfLines },
+		( _: undefined, index ) => (
+			<span
+				className="wc-block-components-skeleton-text-line"
+				aria-hidden="true"
+				key={ index }
+			/>
+		)
 	);
 	return (
 		<div className="wc-block-components-skeleton">{ skeletonLines }</div>


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Currently, the Skeleton component returns an array with a child of element that doesn't have a key. This caused the warning React message:

```
Warning: Each child in a list should have a unique "key" prop.
```

This PR fixes this warning.


### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Edit the Single Product Template.
2. Switch to the blockified version.
3. Check that in the console the warning message about the "key" isn't visible.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

