### PR TITLE
E2E tests fix: enable the attribute lookup direct updates settings

### DIFF
--- a/tests/e2e/config/setup.js
+++ b/tests/e2e/config/setup.js
@@ -20,6 +20,7 @@ import {
 	createBlockPages,
 	enablePaymentGateways,
 	createProductAttributes,
+	enableAttributeLookupDirectUpdates,
 } from '../fixtures/fixture-loaders';
 import { PERFORMANCE_REPORT_FILENAME } from '../../utils/constants';
 
@@ -28,9 +29,12 @@ module.exports = async ( globalConfig ) => {
 	await setupPuppeteer( globalConfig );
 
 	try {
+		await enableAttributeLookupDirectUpdates();
+
 		// do setupSettings separately which hopefully gives a chance for WooCommerce
 		// to be configured before the others are executed.
 		await setupSettings();
+
 		const pages = await createBlockPages();
 
 		/**

--- a/tests/e2e/fixtures/fixture-loaders.js
+++ b/tests/e2e/fixtures/fixture-loaders.js
@@ -481,7 +481,16 @@ const deleteProductAttributes = ( ids ) => {
 	return WooCommerce.post( 'products/attributes/batch', { delete: ids } );
 };
 
+const enableAttributeLookupDirectUpdates = () =>
+	WooCommerce.put(
+		'settings/products/woocommerce_attribute_lookup_direct_updates',
+		{
+			value: 'yes',
+		}
+	);
+
 module.exports = {
+	enableAttributeLookupDirectUpdates,
 	createProductAttributes,
 	deleteProductAttributes,
 	setupSettings,

--- a/tests/e2e/specs/backend/customer-account.test.js
+++ b/tests/e2e/specs/backend/customer-account.test.js
@@ -15,13 +15,13 @@ import { openSettingsSidebar } from '../../utils.js';
 const block = {
 	name: 'Customer account',
 	slug: 'woocommerce/customer-account',
-	class: '.wc-block-customer-account',
+	class: '.wc-block-editor-customer-account',
 };
 
 const SELECTORS = {
 	icon: '.wp-block-woocommerce-customer-account svg',
 	label: '.wp-block-woocommerce-customer-account .label',
-	iconToggle: '.wc-block-customer-account__icon-style-toggle',
+	iconToggle: '.wc-block-editor-customer-account__icon-style-toggle',
 	displayDropdown: '.customer-account-display-style select',
 };
 

--- a/tests/e2e/specs/shopper/filter-products-by-attribute.test.ts
+++ b/tests/e2e/specs/shopper/filter-products-by-attribute.test.ts
@@ -259,6 +259,7 @@ describe( `${ block.name } Block`, () => {
 		} );
 
 		it( 'should render products', async () => {
+			page.setDefaultTimeout( 200000 );
 			const products = await page.$$(
 				selectors.frontend.queryProductsList
 			);
@@ -267,6 +268,7 @@ describe( `${ block.name } Block`, () => {
 		} );
 
 		it( 'should show only products that match the filter', async () => {
+			page.setDefaultTimeout( 200000 );
 			const isRefreshed = jest.fn( () => void 0 );
 			page.on( 'load', isRefreshed );
 
@@ -299,6 +301,7 @@ describe( `${ block.name } Block`, () => {
 		} );
 
 		it( 'should refresh the page only if the user clicks on button', async () => {
+			page.setDefaultTimeout( 200000 );
 			await page.goto( editorPageUrl );
 
 			await waitForCanvas();


### PR DESCRIPTION
We are importing products using the batch api and we need the `wc_product_attributes_lookup` tables to be updated immediately for our tests to pass. Enabling this setting will do that, instead of regenerating the table asynchronously which was causing the `Filter by Attribute` test to fail.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests

Make sure all e2e tests are passing in CI.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
