### PR TITLE
Product Meta block: Block is not being displayed on the frontend

### DIFF
--- a/assets/js/atomic/blocks/product-elements/product-meta/index.tsx
+++ b/assets/js/atomic/blocks/product-elements/product-meta/index.tsx
@@ -8,6 +8,7 @@ import { registerBlockSingleProductTemplate } from '@woocommerce/atomic-utils';
  * Internal dependencies
  */
 import edit from './edit';
+import save from './save';
 import metadata from './block.json';
 
 registerBlockSingleProductTemplate( {
@@ -16,6 +17,7 @@ registerBlockSingleProductTemplate( {
 	blockMetadata: metadata,
 	blockSettings: {
 		edit,
+		save,
 		icon,
 		ancestor: [ 'woocommerce/single-product' ],
 	},


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
I have fixed an issue with the Product Meta block that was not being displayed. After analyzing the code, I noticed that the save method was missing from the block registration. To solve this problem, I added the save method to the block registration, and now the Product Meta block is displaying correctly.

<!-- Reference any related issues or PRs here -->

Fixes #9030 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [x] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
| <img width="1005" alt="image" src="https://user-images.githubusercontent.com/20469356/231877590-b5cfbcba-ed00-47e6-9272-98edebc366fd.png"> | <img width="1039" alt="image" src="https://user-images.githubusercontent.com/20469356/231877515-10c6e7d3-fa00-4633-b539-8c41c8878119.png"> |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Log in to your WordPress dashboard;
2. Go to Appearance > Themes, and select a block theme (for example: Twenty-twenty three);
3. Go to Appearance > Editor;
4. Click the Edit button;
5. Click on the "+" icon to add a new block and search for "Single Product" block in the search bar;
6. Click on the "Single Product" block to add it to your page or post;
7. Select a product on the Product Selector and click on the Save button;
8. On the frontend, check that the Product Meta is rendered and displays the Product SKU, Product Category, and Product Tags (when the block does not have some of these information, that piece of information will not be displayed, for example, if the block does not have tags, it won't be displayed)

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Fix an issue that was causing the Product Meta block to not render on the frontend
