### PR TITLE
Make Woo_Directive_Store PHP 7.3 compatible

### DIFF
--- a/src/Interactivity/directives/class-woo-directive-store.php
+++ b/src/Interactivity/directives/class-woo-directive-store.php
@@ -1,7 +1,7 @@
 <?php
 
 class Woo_Directive_Store {
-	private static array $store = array();
+	private static $store = array();
 
 	static function get_data() {
 		return self::$store;


### PR DESCRIPTION
While generating WC stubs
https://app.travis-ci.com/github/php-stubs/woocommerce-stubs/jobs/600173266
I've discovered a syntax error on PHP 7.3

https://github.com/woocommerce/woocommerce-blocks/blob/118a72462e3a9ec454c5eb6e7067af4e1aa56c01/readme.txt#L6
