### PR TITLE
Mini Cart: Remove excessive margin under cart items

### DIFF
--- a/assets/js/base/components/cart-checkout/cart-line-items-table/style.scss
+++ b/assets/js/base/components/cart-checkout/cart-line-items-table/style.scss
@@ -5,7 +5,7 @@ table.wc-block-cart-items td {
 	background: none !important;
 	// Remove borders on default themes.
 	border: 0;
-	margin: 0 0 2em;
+	margin: 0;
 }
 
 .editor-styles-wrapper table.wc-block-cart-items,

--- a/assets/js/blocks/cart/style.scss
+++ b/assets/js/blocks/cart/style.scss
@@ -12,12 +12,16 @@
 			}
 		}
 	}
-}
 
-.wc-block-cart {
 	.wc-block-components-totals-taxes,
 	.wc-block-components-totals-footer-item {
 		margin: 0;
+	}
+
+	table.wc-block-cart-items,
+	table.wc-block-cart-items th,
+	table.wc-block-cart-items td {
+		margin: 0 0 2em;
 	}
 }
 


### PR DESCRIPTION
The Mini Cart block was inhering a bottom margin in the items list that made it take too much space and felt excessive. This PR removes it so it's only visible in the Cart block, but not in the Mini Cart block.

### Testing

#### User Facing Testing

1. With a block theme, add the Mini Cart block to the header of your page (via Appearance > Editor).
2. In the frontend, open the Mini Cart drawer.
3. Verify the margin between cart items has been reduced (see screenshots).
4. Create a page with the Cart block and verify there are no visual regressions regarding the margins between cart items.

| Before | After |
| ------ | ----- |
| ![imatge](https://user-images.githubusercontent.com/3616980/232020460-2a37f031-f30a-4481-aca1-eba55be82866.png) | ![imatge](https://user-images.githubusercontent.com/3616980/232020360-1842ab41-762e-4465-a98c-11e2972b122f.png) |

| Before & After |
| --- |
| ![imatge](https://user-images.githubusercontent.com/3616980/232021033-eb0b943f-3765-4890-9b01-2ab1547a4d93.png) |

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Remove excessive margin between cart items in the Mini Cart block.
