### PR TITLE
Use consistent and semantically correct HTML elements in the Cart and Checkout blocks

### DIFF
--- a/assets/js/base/components/cart-checkout/order-summary/index.tsx
+++ b/assets/js/base/components/cart-checkout/order-summary/index.tsx
@@ -35,7 +35,6 @@ const OrderSummary = ( {
 					{ __( 'Order summary', 'woo-gutenberg-products-block' ) }
 				</span>
 			}
-			titleTag="h2"
 		>
 			<div className="wc-block-components-order-summary__content">
 				{ cartItems.map( ( cartItem ) => {

--- a/assets/js/blocks/cart/inner-blocks/cart-order-summary-heading/block.tsx
+++ b/assets/js/blocks/cart/inner-blocks/cart-order-summary-heading/block.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import Title from '@woocommerce/base-components/title';
 import classnames from 'classnames';
 
 const Block = ( {
@@ -12,12 +11,11 @@ const Block = ( {
 	content: string;
 } ): JSX.Element => {
 	return (
-		<Title
-			headingLevel="2"
+		<span
 			className={ classnames( className, 'wc-block-cart__totals-title' ) }
 		>
 			{ content }
-		</Title>
+		</span>
 	);
 };
 

--- a/assets/js/blocks/cart/inner-blocks/cart-order-summary-heading/edit.tsx
+++ b/assets/js/blocks/cart/inner-blocks/cart-order-summary-heading/edit.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { PlainText, useBlockProps } from '@wordpress/block-editor';
-import Title from '@woocommerce/base-components/title';
 import classnames from 'classnames';
 
 /**
@@ -24,8 +23,7 @@ export const Edit = ( {
 	const blockProps = useBlockProps();
 	return (
 		<div { ...blockProps }>
-			<Title
-				headingLevel="2"
+			<span
 				className={ classnames(
 					className,
 					'wc-block-cart__totals-title'
@@ -39,7 +37,7 @@ export const Edit = ( {
 					}
 					style={ { backgroundColor: 'transparent' } }
 				/>
-			</Title>
+			</span>
 		</div>
 	);
 };


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 05bf111</samp>

### Summary
🚚🧹🎨

<!--
1.  🚚 - This emoji represents the removal of the `titleTag` prop from the `OrderSummary` component, as it indicates that something has been moved or deleted from the codebase.
2. 🧹 - This emoji represents the removal of the `Title` component from the `cart-order-summary-heading` block, as it indicates that something has been cleaned up or simplified in the codebase.
3. 🎨 - This emoji represents the removal of the `Title` component from the `cart-order-summary-heading` block edit component, as it indicates that something has been improved or refined in the appearance or design of the codebase.
-->
This pull request refactors the order summary heading components in the cart and checkout blocks, to improve their accessibility, semantics, and reusability. It removes the `Title` component and the `titleTag` prop, and uses simple `span` elements instead of nested headings.

> _We're refactoring the order summary_
> _To make it more accessible and tidy_
> _We're dropping the `titleTag` prop_
> _And the `Title` component we'll chop_

### Walkthrough
*  Remove `titleTag` prop from `OrderSummary` component to simplify API and avoid nested headings ([link](https://github.com/woocommerce/woocommerce-blocks/pull/9065/files?diff=unified&w=0#diff-9d93e50bc53fe392974d7340d8d896c2e970e2af39b00eb719442b0a78bda531L38))
* Replace `Title` component with `span` element in `cart-order-summary-heading` block and edit components to align with `OrderSummary` change and reduce bundle size ([link](https://github.com/woocommerce/woocommerce-blocks/pull/9065/files?diff=unified&w=0#diff-4e5bbbf7774b175e23ac58bdcbbaa093b69373967e6bec45820cddbd2a81b6a3L4), [link](https://github.com/woocommerce/woocommerce-blocks/pull/9065/files?diff=unified&w=0#diff-4e5bbbf7774b175e23ac58bdcbbaa093b69373967e6bec45820cddbd2a81b6a3L15-R18), [link](https://github.com/woocommerce/woocommerce-blocks/pull/9065/files?diff=unified&w=0#diff-abe9e3934a8eaffe26b7364844f16caae2956038434520b0b20d87eeaa04d0a8L5), [link](https://github.com/woocommerce/woocommerce-blocks/pull/9065/files?diff=unified&w=0#diff-abe9e3934a8eaffe26b7364844f16caae2956038434520b0b20d87eeaa04d0a8L27-R26), [link](https://github.com/woocommerce/woocommerce-blocks/pull/9065/files?diff=unified&w=0#diff-abe9e3934a8eaffe26b7364844f16caae2956038434520b0b20d87eeaa04d0a8L42-R40))

---

### 👨‍💼 Enhanced by @nielslange 

Fixes #8976

### Testing

#### User Facing Testing

1. Create a test page and add the Cart block.
2. Within the post editor, verify that the `CART TOTALS` element, with the CSS class `.wc-block-cart__totals-title`, is using a `<span>` instead of an `<h2>`.
3. Create another test page and add the Checkout block.
4. Within the post editor, verify that the `Order summary` element, with the CSS class `.wc-block-components-order-summary`, is using a `<div>` instead of an `<h2>`.
5. Go to the frontend and add a product to the cart.
6. On the page with the Cart block, verify that the `CART TOTALS` element, with the CSS class `.wc-block-cart__totals-title`, is using a `<span>` instead of an `<h2>`.
7. On the page with the Checkout block, verify that the `Order summary` element, with the CSS class `.wc-block-components-order-summary`, is using a `<div>` instead of an `<h2>`.

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
