### PR TITLE
Fix Mini Cart drawer not opening in RTL locales

### DIFF
--- a/assets/js/base/components/drawer/style.scss
+++ b/assets/js/base/components/drawer/style.scss
@@ -67,6 +67,10 @@ $drawer-animation-duration: 0.3s;
 	max-width: 100%;
 }
 
+.rtl .wc-block-components-drawer {
+	transform: translateX(max(100%, var(--drawer-width)));
+}
+
 .wc-block-components-drawer__screen-overlay--with-slide-out .wc-block-components-drawer {
 	transition: transform $drawer-animation-duration;
 }


### PR DESCRIPTION
Fix an issue that caused the Mini Cart drawer to be displayed outside of the viewport in RTL locales. The issue was caused by this line: `transform: translateX(max(-100%, var(--neg-drawer-width)))`, which wasn't correctly translated to the RTL equivalent.

I added the `skip-changelog` label because this regression was never included in a release (it was introduced in https://github.com/woocommerce/woocommerce-blocks/pull/8930).

### Testing

#### User Facing Testing

1. With a block theme, add the Mini Cart block to the header of your site.
2. In, wp-admin, go to Settings > General and change your store language to a RTL locale, like Arabic (`العربية`).
3. In the frontend, click on the Mini Cart button to open the drawer.
4. Verify the drawer is opened correctly from the left side of the screen.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
