### PR TITLE
[Patterns]: Add new `WooCommerce 2-by-2 Product Feature Grid` pattern

### DIFF
--- a/patterns/product-feature-rigid-grid.php
+++ b/patterns/product-feature-rigid-grid.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Title: WooCommerce Product Features Rigid Grid
+ * Slug: woocommerce-blocks/product-features-rigid-grid
+ * Categories: WooCommerce
+ */
+?>
+
+<!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignwide">
+	<!-- wp:heading {"textAlign":"left","level":4,"align":"wide"} -->
+	<h4 class="wp-block-heading alignwide has-text-align-left">
+		<strong>What makes this product unique?</strong>
+	</h4>
+	<!-- /wp:heading -->
+
+	<!-- wp:heading {"level":6,"align":"wide","style":{"typography":{"textTransform":"none"}}} -->
+	<h6 class="wp-block-heading alignwide" style="text-transform:none">
+		At dui sed egestas suspendisse. Consectetur tellus mattis aliquam semper posuere aliquam. Magna eu vulputate et blandit mi placerat enim.
+	</h6>
+	<!-- /wp:heading -->
+
+	<!-- wp:columns {"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|40"}}}} -->
+	<div class="wp-block-columns alignwide" style="margin-top:var(--wp--preset--spacing--50);margin-bottom:var(--wp--preset--spacing--40)">
+		<!-- wp:column -->
+		<div class="wp-block-column">
+			<!-- wp:image -->
+			<figure class="wp-block-image"><img alt="" /></figure>
+			<!-- /wp:image -->
+
+			<!-- wp:paragraph {"fontSize":"small"} -->
+			<p class="has-small-font-size">
+				At dui sed egestas suspendisse. Consectetur tellus mattis aliquam semper posuere aliquam. Magna eu vulputate et blandit mi placerat enim.
+			</p>
+			<!-- /wp:paragraph -->
+		</div>
+		<!-- /wp:column -->
+
+		<!-- wp:column -->
+		<div class="wp-block-column">
+			<!-- wp:image -->
+			<figure class="wp-block-image"><img alt="" /></figure>
+			<!-- /wp:image -->
+
+			<!-- wp:paragraph {"fontSize":"small"} -->
+			<p class="has-small-font-size">
+				At dui sed egestas suspendisse. Consectetur tellus mattis aliquam semper posuere aliquam. Magna eu vulputate et blandit mi placerat enim.
+			</p>
+			<!-- /wp:paragraph -->
+		</div>
+		<!-- /wp:column -->
+	</div>
+	<!-- /wp:columns -->
+
+	<!-- wp:columns {"align":"wide","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|50"}}}} -->
+	<div class="wp-block-columns alignwide" style="margin-bottom:var(--wp--preset--spacing--50)">
+		<!-- wp:column -->
+		<div class="wp-block-column">
+			<!-- wp:image -->
+			<figure class="wp-block-image"><img alt="" /></figure>
+			<!-- /wp:image -->
+
+			<!-- wp:paragraph {"fontSize":"small"} -->
+			<p class="has-small-font-size">
+				At dui sed egestas suspendisse. Consectetur tellus mattis aliquam semper posuere aliquam. Magna eu vulputate et blandit mi placerat enim.
+			</p>
+			<!-- /wp:paragraph --></div>
+		<!-- /wp:column -->
+
+		<!-- wp:column -->
+		<div class="wp-block-column">
+			<!-- wp:image -->
+			<figure class="wp-block-image"><img alt="" /></figure>
+			<!-- /wp:image -->
+
+			<!-- wp:paragraph {"fontSize":"small"} -->
+			<p class="has-small-font-size">
+				At dui sed egestas suspendisse. Consectetur tellus mattis aliquam semper posuere aliquam. Magna eu vulputate et blandit mi placerat enim.
+			</p>
+			<!-- /wp:paragraph -->
+		</div>
+		<!-- /wp:column -->
+	</div>
+	<!-- /wp:columns -->
+
+	<!-- wp:buttons {"align":"wide","layout":{"type":"flex","justifyContent":"center"}} -->
+	<div class="wp-block-buttons alignwide">
+		<!-- wp:button -->
+		<div class="wp-block-button">
+			<a class="wp-block-button__link wp-element-button">Add To Cart</a>
+		</div>
+		<!-- /wp:button -->
+	</div>
+	<!-- /wp:buttons -->
+</div>
+<!-- /wp:group -->

--- a/patterns/product-feature-rigid-grid.php
+++ b/patterns/product-feature-rigid-grid.php
@@ -21,7 +21,7 @@
 		<!-- wp:column -->
 		<div class="wp-block-column">
 			<!-- wp:image -->
-			<figure class="wp-block-image"><img src="/wp-content/plugins/woocommerce/packages/woocommerce-blocks/images/previews/hoodie-with-logo.jpg" /></figure>
+			<figure class="wp-block-image"><img src="<?php echo esc_url( plugins_url() ); ?>/woocommerce-blocks/images/previews/hoodie-with-logo.jpg" /></figure>
 			<!-- /wp:image -->
 
 			<!-- wp:paragraph {"fontSize":"small"} -->
@@ -33,7 +33,7 @@
 		<!-- wp:column -->
 		<div class="wp-block-column">
 			<!-- wp:image -->
-			<figure class="wp-block-image"><img src="/wp-content/plugins/woocommerce/packages/woocommerce-blocks/images/previews/long-sleeve-tee.jpg" /></figure>
+			<figure class="wp-block-image"><img src="<?php echo esc_url( plugins_url() ); ?>/woocommerce-blocks/images/previews/long-sleeve-tee.jpg" /></figure>
 			<!-- /wp:image -->
 
 			<!-- wp:paragraph {"fontSize":"small"} -->
@@ -49,7 +49,7 @@
 		<!-- wp:column -->
 		<div class="wp-block-column">
 			<!-- wp:image -->
-			<figure class="wp-block-image"><img src="/wp-content/plugins/woocommerce/packages/woocommerce-blocks/images/previews/cap.jpg" /></figure>
+			<figure class="wp-block-image"><img src="<?php echo esc_url( plugins_url() ); ?>/woocommerce-blocks/images/previews/cap.jpg" /></figure>
 			<!-- /wp:image -->
 
 			<!-- wp:paragraph {"fontSize":"small"} -->
@@ -60,7 +60,7 @@
 		<!-- wp:column -->
 		<div class="wp-block-column">
 			<!-- wp:image -->
-			<figure class="wp-block-image"><img src="/wp-content/plugins/woocommerce/packages/woocommerce-blocks/images/previews/beanie.jpg" /></figure>
+			<figure class="wp-block-image"><img src="<?php echo esc_url( plugins_url() ); ?>/woocommerce-blocks/images/previews/beanie.jpg" /></figure>
 			<!-- /wp:image -->
 
 			<!-- wp:paragraph {"fontSize":"small"} -->

--- a/patterns/product-feature-rigid-grid.php
+++ b/patterns/product-feature-rigid-grid.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Title: WooCommerce Product Features Rigid Grid
- * Slug: woocommerce-blocks/product-features-rigid-grid
+ * Title: WooCommerce 2-by-2 Product Feature Grid
+ * Slug: woocommerce-blocks/2-by-2-product-feature-grid
  * Categories: WooCommerce
  */
 ?>
@@ -9,15 +9,11 @@
 <!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignwide">
 	<!-- wp:heading {"textAlign":"left","level":4,"align":"wide"} -->
-	<h4 class="wp-block-heading alignwide has-text-align-left">
-		<strong>What makes this product unique?</strong>
-	</h4>
+	<h4 class="wp-block-heading alignwide has-text-align-left">Our Product Features</h4>
 	<!-- /wp:heading -->
 
 	<!-- wp:heading {"level":6,"align":"wide","style":{"typography":{"textTransform":"none"}}} -->
-	<h6 class="wp-block-heading alignwide" style="text-transform:none">
-		At dui sed egestas suspendisse. Consectetur tellus mattis aliquam semper posuere aliquam. Magna eu vulputate et blandit mi placerat enim.
-	</h6>
+	<h6 class="wp-block-heading alignwide" style="text-transform:none">Our clothing line is packed with features that make it stand out from the competition. Here are just a few of the highlights:</h6>
 	<!-- /wp:heading -->
 
 	<!-- wp:columns {"align":"wide","style":{"spacing":{"margin":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|40"}}}} -->
@@ -25,13 +21,11 @@
 		<!-- wp:column -->
 		<div class="wp-block-column">
 			<!-- wp:image -->
-			<figure class="wp-block-image"><img alt="" /></figure>
+			<figure class="wp-block-image"><img src="/wp-content/plugins/woocommerce/packages/woocommerce-blocks/images/previews/hoodie-with-logo.jpg" /></figure>
 			<!-- /wp:image -->
 
 			<!-- wp:paragraph {"fontSize":"small"} -->
-			<p class="has-small-font-size">
-				At dui sed egestas suspendisse. Consectetur tellus mattis aliquam semper posuere aliquam. Magna eu vulputate et blandit mi placerat enim.
-			</p>
+			<p class="has-small-font-size">Our clothing is made with high-quality materials, ensuring that they not only look great but also last long. You'll love the feel of our soft and breathable fabrics, and the attention to detail in the stitching and finishing.</p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:column -->
@@ -39,13 +33,11 @@
 		<!-- wp:column -->
 		<div class="wp-block-column">
 			<!-- wp:image -->
-			<figure class="wp-block-image"><img alt="" /></figure>
+			<figure class="wp-block-image"><img src="/wp-content/plugins/woocommerce/packages/woocommerce-blocks/images/previews/long-sleeve-tee.jpg" /></figure>
 			<!-- /wp:image -->
 
 			<!-- wp:paragraph {"fontSize":"small"} -->
-			<p class="has-small-font-size">
-				At dui sed egestas suspendisse. Consectetur tellus mattis aliquam semper posuere aliquam. Magna eu vulputate et blandit mi placerat enim.
-			</p>
+			<p class="has-small-font-size">All our products offer unique and eye-catching designs that are sure to turn heads. From bold prints and colors to intricate details and textures, our clothes are a perfect combination of style and comfort.</p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:column -->
@@ -57,26 +49,22 @@
 		<!-- wp:column -->
 		<div class="wp-block-column">
 			<!-- wp:image -->
-			<figure class="wp-block-image"><img alt="" /></figure>
+			<figure class="wp-block-image"><img src="/wp-content/plugins/woocommerce/packages/woocommerce-blocks/images/previews/cap.jpg" /></figure>
 			<!-- /wp:image -->
 
 			<!-- wp:paragraph {"fontSize":"small"} -->
-			<p class="has-small-font-size">
-				At dui sed egestas suspendisse. Consectetur tellus mattis aliquam semper posuere aliquam. Magna eu vulputate et blandit mi placerat enim.
-			</p>
+			<p class="has-small-font-size">Everything we make is designed to fit perfectly and flatter all body types. With a range of sizes and styles to choose from, you'll find the perfect fit for your body type and personal style.</p>
 			<!-- /wp:paragraph --></div>
 		<!-- /wp:column -->
 
 		<!-- wp:column -->
 		<div class="wp-block-column">
 			<!-- wp:image -->
-			<figure class="wp-block-image"><img alt="" /></figure>
+			<figure class="wp-block-image"><img src="/wp-content/plugins/woocommerce/packages/woocommerce-blocks/images/previews/beanie.jpg" /></figure>
 			<!-- /wp:image -->
 
 			<!-- wp:paragraph {"fontSize":"small"} -->
-			<p class="has-small-font-size">
-				At dui sed egestas suspendisse. Consectetur tellus mattis aliquam semper posuere aliquam. Magna eu vulputate et blandit mi placerat enim.
-			</p>
+			<p class="has-small-font-size">We make fashion that is versatile and suitable for a wide range of occasions. Whether you're dressing up for a special event or keeping it casual on the weekends, our clothes are a perfect fit. With a variety of styles and colors to choose from, you'll always look your best.</p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:column -->
@@ -87,7 +75,7 @@
 	<div class="wp-block-buttons alignwide">
 		<!-- wp:button -->
 		<div class="wp-block-button">
-			<a class="wp-block-button__link wp-element-button">Add To Cart</a>
+			<a class="wp-block-button__link wp-element-button">Add to cart</a>
 		</div>
 		<!-- /wp:button -->
 	</div>


### PR DESCRIPTION
This PR implements the `WooCommerce 2-by-2 Product Feature Grid` pattern.

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/9052

### Screenshots

| Design | Pattern |
| ------ | ----- |
| ![Rigid grid](https://user-images.githubusercontent.com/186112/232024052-e81ee9c3-74fb-4b4a-927e-3b6cade16157.png) | ![CleanShot 2023-04-17 at 13 57 46@2x](https://user-images.githubusercontent.com/186112/232477593-ba10ba2d-a435-4c1b-af86-bd741bdf6d5f.png) |

### Testing
#### User-Facing Testing
1. Create a new page or post
2. Make sure the `WooCommerce 2-by-2 Product Feature Grid` pattern appears under the WooCommerce category dropdown.
3. Insert in and make sure it shows as expected on the design.

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

> Add the new `WooCommerce 2-by-2 Product Feature Grid` pattern.
