### PR TITLE
[Patterns]: Add new `Featured products: minimal 2` pattern

### DIFF
--- a/patterns/product-feature-minimal.php
+++ b/patterns/product-feature-minimal.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Title: WooCommerce Product Features Minimal
+ * Slug: woocommerce-blocks/product-features-minimal
+ * Categories: WooCommerce
+ */
+?>
+
+<!-- wp:columns {"verticalAlignment":null,"align":"wide"} -->
+<div class="wp-block-columns alignwide">
+	<!-- wp:column {"verticalAlignment":"center","width":"66.66%"} -->
+	<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:66.66%">
+		<!-- wp:heading {"textAlign":"left","level":4,"align":"wide"} -->
+		<h4 class="wp-block-heading alignwide has-text-align-left"><strong>The timeless trench</strong></h4>
+		<!-- /wp:heading -->
+
+		<!-- wp:paragraph -->
+		<p>Lorem ipsum dolor sit amet, consectetur adipisci elit, sed eiusmod tempor incidunt ut labore et dolore magna
+			aliqua. Ut enim ad minim veniam, quis nostrum.</p>
+		<!-- /wp:paragraph -->
+
+		<!-- wp:paragraph -->
+		<p><strong style="text-decoration: underline;">Discover more</strong></p>
+		<!-- /wp:paragraph --></div>
+	<!-- /wp:column -->
+
+	<!-- wp:column {"width":"33.33%"} -->
+	<div class="wp-block-column" style="flex-basis:33.33%">
+		<!-- wp:image -->
+		<figure class="wp-block-image size-full"><img /></figure>
+		<!-- /wp:image --></div>
+	<!-- /wp:column --></div>
+<!-- /wp:columns -->


### PR DESCRIPTION
This PR implements the `Featured products: minimal 2` pattern.

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/8951

| Design | Pattern |
| ------ | ----- |
| <img src="https://user-images.githubusercontent.com/186112/229753210-869d742f-4df7-4bc9-82dc-ba4abc468a92.png" /> | <img width="1221" alt="Screenshot 2023-04-17 at 14 22 23" src="https://user-images.githubusercontent.com/186112/232482722-1ca06c47-5e22-4cf6-9458-1328549e2943.png"> |

### Testing

#### User Facing Testing

1. Create a new page or post
2. Make sure the `WooCommerce Featured products: minimal` pattern appears under the WooCommerce category dropdown.
3. Insert in and make sure it shows as expected on the design.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Add new `Featured products: minimal 2` pattern.
