### PR TITLE
Single Product Template - Compatibility Layer: don't skip block without name

### DIFF
--- a/src/Templates/SingleProductTemplateCompatibility.php
+++ b/src/Templates/SingleProductTemplateCompatibility.php
@@ -321,7 +321,7 @@ class SingleProductTemplateCompatibility extends AbstractTemplateCompatibility {
 				$carry['index'] = $carry['index'] + 1;
 				$block          = $item[0];
 
-				if ( 'core/template-part' === $block['blockName'] ) {
+				if ( 'core/template-part' === $block['blockName'] || self::is_custom_html( $block ) ) {
 					$carry['template'][] = $block;
 					return $carry;
 				}
@@ -433,9 +433,6 @@ class SingleProductTemplateCompatibility extends AbstractTemplateCompatibility {
 					$carry[] = array( $block );
 					return $carry;
 				}
-				if ( empty( $block['blockName'] ) ) {
-					return $carry;
-				}
 				$last_element_index = count( $carry ) - 1;
 				if ( isset( $carry[ $last_element_index ][0]['blockName'] ) && 'core/template-part' !== $carry[ $last_element_index ][0]['blockName'] ) {
 					$carry[ $last_element_index ][] = $block;
@@ -468,6 +465,16 @@ class SingleProductTemplateCompatibility extends AbstractTemplateCompatibility {
 			$closing_tag_position + 1,
 			0
 		);
+	}
 
+
+	/**
+	 * Plain custom HTML block is parsed as block with an empty blockName with a filled innerHTML.
+	 *
+	 * @param array $block Parse block.
+	 * @return bool
+	 */
+	private static function is_custom_html( $block ) {
+		return empty( $block['blockName'] ) && ! empty( $block['innerHTML'] );
 	}
 }

--- a/tests/php/Templates/SingleProductTemplateCompatibilityTests.php
+++ b/tests/php/Templates/SingleProductTemplateCompatibilityTests.php
@@ -327,4 +327,41 @@ class SingleProductTemplateCompatibilityTests extends WP_UnitTestCase {
 
 		$this->assertEquals( $result_without_withespace, $expected_single_product_template_without_whitespace, '' );
 	}
+
+	/**
+	 * Test that the Single Product Template is wrapped in a div with the correct class if it contains a block related to the Single Product Template and custom HTML isn't removed.
+	 */
+	public function test_add_compatibility_layer_if_contains_single_product_blocks_and_custom_HTML_not_removed() {
+
+		$default_single_product_template = '
+		<!-- wp:template-part {"slug":"header","theme":"twentytwentythree","tagName":"header"} /-->
+		<span>Custom HTML</span>
+		<!-- wp:group {"layout":{"inherit":true,"type":"constrained"}} -->
+		<div class="wp-block-group">
+		   <!-- wp:woocommerce/product-image-gallery /-->
+		</div>
+		<!-- /wp:group -->
+		<!-- wp:template-part {"slug":"footer","theme":"twentytwentythree","tagName":"footer"} /-->';
+
+		$expected_single_product_template = '
+		<!-- wp:template-part {"slug":"header","theme":"twentytwentythree","tagName":"header"} /-->
+		<span>Custom HTML</span>
+		<!-- wp:group {"className":"woocommerce product", "__wooCommerceIsFirstBlock":true,"__wooCommerceIsLastBlock":true} -->
+		<div class="wp-block-group woocommerce product">
+		   <!-- wp:group {"layout":{"inherit":true,"type":"constrained"}} -->
+		   <div class="wp-block-group">
+			  <!-- wp:woocommerce/product-image-gallery /-->
+		   </div>
+		   <!-- /wp:group -->
+		</div>
+		<!-- /wp:group -->
+		<!-- wp:template-part {"slug":"footer","theme":"twentytwentythree","tagName":"footer"} /-->';
+
+		$result = SingleProductTemplateCompatibility::add_compatibility_layer( $default_single_product_template );
+
+		$result_without_withespace                           = preg_replace( '/\s+/', '', $result );
+		$expected_single_product_template_without_whitespace = preg_replace( '/\s+/', '', $expected_single_product_template );
+
+		$this->assertEquals( $result_without_withespace, $expected_single_product_template_without_whitespace, '' );
+	}
 }


### PR DESCRIPTION
This PR fixes the Single Product Compatibility Layer, adding support for custom HTML Blocks. When the Custom HTML is parsed, the result is a block without the name but with the `innerHTML` content.

Currently, there is a check that cleans the blocks without a name, but with this PR, I removed this check.

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #9073


### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Go to Appearance > Editor and in the Single Product template before upgrading to the blockified version, add a HTML Block _outside_ of the Group block as shown in the screenshot below with the contents `<h2>HTML Block here</h2>` (or similar)
2. Save and view this block on the frontend.
3. Return to the template, upgrade it to the blockified version
4. Save and view on the frontend. Be sure that the HTML is visible on the page.


![Screenshot 2023-04-17 at 14 34 13](https://user-images.githubusercontent.com/8639742/232499923-9ca7cb7a-c4e7-417d-af78-a8b86b87ea10.png)


* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog
> Single Product Compatibility Layer: add support for custom HTML Blocks.
