### PR TITLE
Filter Products by Attribute e2e test: wait until networkidle before running tests

### DIFF
--- a/tests/e2e/specs/shopper/filter-products-by-attribute.test.ts
+++ b/tests/e2e/specs/shopper/filter-products-by-attribute.test.ts
@@ -238,17 +238,14 @@ describe( `${ block.name } Block`, () => {
 
 			await insertBlock( 'Products (Beta)' );
 			await insertBlock( block.name );
-			await page.waitForNetworkIdle();
+			const canvasEl = canvas();
 
-			await canvas().waitForSelector(
-				block.selectors.editor.firstAttributeInTheList
-			);
 			// It seems that .click doesn't work well with radio input element.
-			await canvas().$eval(
+			await canvasEl.$eval(
 				block.selectors.editor.firstAttributeInTheList,
 				( el ) => ( el as HTMLInputElement ).click()
 			);
-			await canvas().click( selectors.editor.doneButton );
+			await canvasEl.click( selectors.editor.doneButton );
 			await publishPost();
 
 			editorPageUrl = page.url();

--- a/tests/e2e/specs/shopper/filter-products-by-attribute.test.ts
+++ b/tests/e2e/specs/shopper/filter-products-by-attribute.test.ts
@@ -59,6 +59,18 @@ const goToShopPage = () =>
 	} );
 
 describe( `${ block.name } Block`, () => {
+	const insertFilterByAttributeBlock = async () => {
+		await insertBlock( block.name );
+		const canvasEl = canvas();
+
+		// It seems that .click doesn't work well with radio input element.
+		await canvasEl.$eval(
+			block.selectors.editor.firstAttributeInTheList,
+			( el ) => ( el as HTMLInputElement ).click()
+		);
+		await canvasEl.click( selectors.editor.doneButton );
+	};
+
 	describe( 'with All Products Block', () => {
 		beforeAll( async () => {
 			await switchUserToAdmin();
@@ -68,15 +80,7 @@ describe( `${ block.name } Block`, () => {
 			} );
 
 			await insertAllProductsBlock();
-			await insertBlock( block.name );
-			const canvasEl = canvas();
-
-			// It seems that .click doesn't work well with radio input element.
-			await canvasEl.$eval(
-				block.selectors.editor.firstAttributeInTheList,
-				( el ) => ( el as HTMLInputElement ).click()
-			);
-			await canvasEl.click( selectors.editor.doneButton );
+			await insertFilterByAttributeBlock();
 			await publishPost();
 
 			const link = await page.evaluate( () =>
@@ -120,15 +124,7 @@ describe( `${ block.name } Block`, () => {
 			await goToTemplateEditor( {
 				postId: productCatalogTemplateId,
 			} );
-			await insertBlock( block.name );
-			const canvasEl = canvas();
-
-			// It seems that .click doesn't work well with radio input element.
-			await canvasEl.$eval(
-				block.selectors.editor.firstAttributeInTheList,
-				( el ) => ( el as HTMLInputElement ).click()
-			);
-			await canvasEl.click( selectors.editor.doneButton );
+			await insertFilterByAttributeBlock();
 			await saveTemplate();
 		} );
 
@@ -237,15 +233,7 @@ describe( `${ block.name } Block`, () => {
 			} );
 
 			await insertBlock( 'Products (Beta)' );
-			await insertBlock( block.name );
-			const canvasEl = canvas();
-
-			// It seems that .click doesn't work well with radio input element.
-			await canvasEl.$eval(
-				block.selectors.editor.firstAttributeInTheList,
-				( el ) => ( el as HTMLInputElement ).click()
-			);
-			await canvasEl.click( selectors.editor.doneButton );
+			await insertFilterByAttributeBlock();
 			await publishPost();
 
 			editorPageUrl = page.url();

--- a/tests/e2e/specs/shopper/filter-products-by-attribute.test.ts
+++ b/tests/e2e/specs/shopper/filter-products-by-attribute.test.ts
@@ -255,11 +255,10 @@ describe( `${ block.name } Block`, () => {
 			frontedPageUrl = await page.evaluate( () =>
 				wp.data.select( 'core/editor' ).getPermalink()
 			);
-			await page.goto( frontedPageUrl );
+			await page.goto( frontedPageUrl, { waitUntil: 'networkidle2' } );
 		} );
 
 		it( 'should render products', async () => {
-			page.setDefaultTimeout( 200000 );
 			const products = await page.$$(
 				selectors.frontend.queryProductsList
 			);
@@ -268,7 +267,6 @@ describe( `${ block.name } Block`, () => {
 		} );
 
 		it( 'should show only products that match the filter', async () => {
-			page.setDefaultTimeout( 200000 );
 			const isRefreshed = jest.fn( () => void 0 );
 			page.on( 'load', isRefreshed );
 
@@ -301,7 +299,6 @@ describe( `${ block.name } Block`, () => {
 		} );
 
 		it( 'should refresh the page only if the user clicks on button', async () => {
-			page.setDefaultTimeout( 200000 );
 			await page.goto( editorPageUrl );
 
 			await waitForCanvas();


### PR DESCRIPTION
This PR tries to make the `tests/e2e/specs/shopper/filter-products-by-attribute.test.ts` e2e test a bit less flaky. I run it three times and it seemed to pass in all of them on the first try. Before, it was failing quite often, as it can be seen in some of the [last commits merged to `trunk`](https://github.com/woocommerce/woocommerce-blocks/commits/trunk).

### Testing

#### User Facing Testing

1. Verify e2e tests pass.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->
