### PR TITLE
Fix broken post/page editor screens in WordPress versions earlier than 6.2

### DIFF
--- a/assets/js/atomic/utils/register-block-single-product-template.ts
+++ b/assets/js/atomic/utils/register-block-single-product-template.ts
@@ -16,6 +16,10 @@ import { subscribe, select } from '@wordpress/data';
 // Creating a local cache to prevent multiple registration tries.
 const blocksRegistered = new Set();
 
+function parseTemplateId( templateId: string | undefined ) {
+	return templateId?.split( '//' )[ 1 ];
+}
+
 export const registerBlockSingleProductTemplate = ( {
 	blockName,
 	blockMetadata,
@@ -34,9 +38,7 @@ export const registerBlockSingleProductTemplate = ( {
 	subscribe( () => {
 		const previousTemplateId = currentTemplateId;
 		const store = select( 'core/edit-site' );
-		currentTemplateId = store?.getEditedPostContext< {
-			templateSlug?: string;
-		} >()?.templateSlug;
+		currentTemplateId = parseTemplateId( store?.getEditedPostId() );
 		const hasChangedTemplate = previousTemplateId !== currentTemplateId;
 		const hasTemplateId = Boolean( currentTemplateId );
 


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 656de50</samp>

Improve block registration performance and reliability in `registerBlockSingleProductTemplate`. Use a local cache to prevent duplicate calls to `registerBlockType` and `registerBlockVariation` for single product blocks. This also prevents an infinite loop.

This fixes an [issue that surfaced](https://wordpress.org/support/topic/cant-edit-any-pages-2/) where the WordPress core post (or page) editor was broken with WooCommerce Blocks active. 

## Explanation of Changes

WordPress 6.2 introduces an update to the `subscribe` function returned by registered `wp.data` stores that enables passing along as an (optional) second argument the specific store that the subscribe callback should be registered to. On previous versions of WordPress, this second argument is ignored (there is no handling) which means the subscribe callback will be registered and invoked on _every_ store change.

Where this is problematic is when the `core/blocks` store is updated which typically happens when registering a block or a variation. So the existing checks in this callback were insufficient for preventing an infinite loop from happening.

**Edit by @tjcafferkey**: In addition to the above, it looks like the store method `getEditedPostContext` is also not present in 6.1.1 (presumably also introduced in 6.2) resulting in a crashing Site Editor. This was replaced with `getEditedPostId` similar to [how the Classic Template block retrieves the template Id](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/assets/js/blocks/classic-template/index.tsx#L217).

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

**Note to reviewer: Please assist with these testing notes to verify that the single product block (and inner blocks) are registered correctly and work as expected. Expand user testing notes below as necessary.**

Experimental testing:

1. Make sure your environment is WordPress 6.1.1
2. Ensure with this branch, the Post, Page and Site editors load without issues.
3. Verify that Single Product Block behaviour works as expected.

WC core/feature plugin testing:

1. Make sure your environment is WordPress 6.1.1
2. Ensure the Post, Page and Site editors load without issues.
3. Go to Appearance > Editor > Templates > Single Product and add the Product Image Gallery block somewhere on the page.
4. Without reloading the page, edit the Single template (or any other template unrelated to WooCommerce). Verify you can't add the Product Image Gallery block.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Fix infinite loop with the registration of Single Product Block (and inner blocks) breaking WP Post and Page editors in WP 6.1.
