### PR TITLE
Fix - "Order received" page does not display the payment method information.

### DIFF
--- a/src/StoreApi/Routes/V1/Checkout.php
+++ b/src/StoreApi/Routes/V1/Checkout.php
@@ -473,7 +473,7 @@ class Checkout extends AbstractCartRoute {
 	 */
 	private function update_order_from_request( \WP_REST_Request $request ) {
 		$this->order->set_customer_note( $request['customer_note'] ?? '' );
-		$this->order->set_payment_method( $this->get_request_payment_method_id( $request ) );
+		$this->order->set_payment_method( $this->get_request_payment_method( $request ) );
 
 		wc_do_deprecated_action(
 			'__experimental_woocommerce_blocks_checkout_update_order_from_request',

--- a/src/StoreApi/Routes/V1/Checkout.php
+++ b/src/StoreApi/Routes/V1/Checkout.php
@@ -473,7 +473,8 @@ class Checkout extends AbstractCartRoute {
 	 */
 	private function update_order_from_request( \WP_REST_Request $request ) {
 		$this->order->set_customer_note( $request['customer_note'] ?? '' );
-		$this->order->set_payment_method( $this->get_request_payment_method( $request ) );
+		$this->order->set_payment_method( $this->get_request_payment_method_id( $request ) );
+		$this->order->set_payment_method_title( $this->get_request_payment_method_title( $request ) );
 
 		wc_do_deprecated_action(
 			'__experimental_woocommerce_blocks_checkout_update_order_from_request',
@@ -578,6 +579,18 @@ class Checkout extends AbstractCartRoute {
 	private function get_request_payment_method_id( \WP_REST_Request $request ) {
 		$payment_method = $this->get_request_payment_method( $request );
 		return is_null( $payment_method ) ? '' : $payment_method->id;
+	}
+
+	/**
+	 * Gets the chosen payment method title from the request.
+	 *
+	 * @throws RouteException On error.
+	 * @param \WP_REST_Request $request Request object.
+	 * @return string
+	 */
+	private function get_request_payment_method_title( \WP_REST_Request $request ) {
+		$payment_method = $this->get_request_payment_method( $request );
+		return is_null( $payment_method ) ? '' : $payment_method->get_title();
 	}
 
 	/**


### PR DESCRIPTION
This PR contains a minor change to fix #8448. Currently, when we place an order using the checkout block, the payment method title information not getting saved to the order and it results in payment method information is not showing on Order received page and backed order list page as described in the reported issue.

This was happening due to we are passing the payment method ID in `set_payment_method()` in the `update_order_from_request` function so, Payment method title is not getting updated for orders. This PR updates it to pass the payment method object to update the payment method title to order.

Fixes #8448 


#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|![Screenshot 2023-04-19 at 11 06 06 AM](https://user-images.githubusercontent.com/10613171/232976522-a4eb7766-ed8c-4ca2-8cbe-9405d0f72b14.png) | ![Screenshot 2023-04-19 at 11 05 00 AM](https://user-images.githubusercontent.com/10613171/232976539-4d54e550-44b0-49e5-8f05-ce9bef717989.png) |
|![image](https://user-images.githubusercontent.com/10613171/232976862-37f6630b-b9d0-4a26-a079-41e6c1aef103.png)|![image](https://user-images.githubusercontent.com/10613171/232976932-6e09dfd7-6155-4151-8545-a6ffbccbe111.png)|


### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Checkout to this PR branch.
2. Create a product and add it to the site's shopping cart.
3. Proceed to checkout using the "Checkout" Block
4. Complete the checkout process and confirm the order.
5. Verify that payment method information is there on the "Order received" page.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Fix - "Order received" page does not display the payment method information.
