### PR TITLE
Release: 10.0.2

### DIFF
--- a/assets/js/atomic/utils/register-block-single-product-template.ts
+++ b/assets/js/atomic/utils/register-block-single-product-template.ts
@@ -13,6 +13,13 @@ import {
 } from '@wordpress/blocks';
 import { subscribe, select } from '@wordpress/data';
 
+// Creating a local cache to prevent multiple registration tries.
+const blocksRegistered = new Set();
+
+function parseTemplateId( templateId: string | undefined ) {
+	return templateId?.split( '//' )[ 1 ];
+}
+
 export const registerBlockSingleProductTemplate = ( {
 	blockName,
 	blockMetadata,
@@ -31,9 +38,7 @@ export const registerBlockSingleProductTemplate = ( {
 	subscribe( () => {
 		const previousTemplateId = currentTemplateId;
 		const store = select( 'core/edit-site' );
-		currentTemplateId = store?.getEditedPostContext< {
-			templateSlug?: string;
-		} >()?.templateSlug;
+		currentTemplateId = parseTemplateId( store?.getEditedPostId() );
 		const hasChangedTemplate = previousTemplateId !== currentTemplateId;
 		const hasTemplateId = Boolean( currentTemplateId );
 
@@ -86,16 +91,21 @@ export const registerBlockSingleProductTemplate = ( {
 	}, 'core/edit-site' );
 
 	subscribe( () => {
-		const isBlockRegistered = Boolean( getBlockType( blockName ) );
-		const editPostStoreExists = Boolean( select( 'core/edit-post' ) );
-
-		if ( ! isBlockRegistered && editPostStoreExists ) {
+		const isBlockRegistered = Boolean( variationName )
+			? blocksRegistered.has( variationName )
+			: blocksRegistered.has( blockName );
+		// This subscribe callback could be invoked with the core/blocks store
+		// which would cause infinite registration loops because of the `registerBlockType` call.
+		// This local cache helps prevent that.
+		if ( ! isBlockRegistered ) {
 			if ( isVariationBlock ) {
+				blocksRegistered.add( variationName );
 				registerBlockVariation(
 					blockName,
 					blockSettings as BlockVariation< BlockAttributes >
 				);
 			} else {
+				blocksRegistered.add( blockName );
 				// @ts-expect-error: `registerBlockType` is typed in WordPress core
 				registerBlockType( blockMetadata, blockSettings );
 			}

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"description": "WooCommerce blocks for the Gutenberg editor.",
 	"homepage": "https://woocommerce.com/",
 	"type": "wordpress-plugin",
-	"version": "10.0.1",
+	"version": "10.0.2",
 	"keywords": [
 		"gutenberg",
 		"woocommerce",

--- a/docs/internal-developers/testing/releases/1002.md
+++ b/docs/internal-developers/testing/releases/1002.md
@@ -1,0 +1,12 @@
+# Testing notes and ZIP for release 10.0.2
+
+Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.com/woocommerce/woocommerce-blocks/files/11269797/woocommerce-gutenberg-products-block.zip)
+
+## WooCommerce Core
+
+### Fix broken post/page editor screens in WordPress versions earlier than 6.2. [(9090)](https://github.com/woocommerce/woocommerce-blocks/pull/9090)
+
+1. Make sure your environment is WordPress 6.1.1
+2. Ensure the Post, Page and Site editors load without issues.
+3. Go to Appearance > Editor > Templates > Single Product and add the Product Image Gallery block somewhere on the page.
+4. Without reloading the page, edit the Single template (or any other template unrelated to WooCommerce). Verify you can't add the Product Image Gallery block.

--- a/docs/internal-developers/testing/releases/README.md
+++ b/docs/internal-developers/testing/releases/README.md
@@ -138,6 +138,7 @@ Every release includes specific testing instructions for new features and bug fi
 -   [9.9.0](./990.md)
 -   [10.0.0](./1000.md)
     -   [10.0.1](./1001.md)
+    -   [10.0.2](./1002.md)
 
 
 <!-- FEEDBACK -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@woocommerce/block-library",
-	"version": "10.0.1",
+	"version": "10.0.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@woocommerce/block-library",
-			"version": "10.0.1",
+			"version": "10.0.2",
 			"hasInstallScript": true,
 			"license": "GPL-3.0+",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "@woocommerce/block-library",
 	"title": "WooCommerce Blocks",
 	"author": "Automattic",
-	"version": "10.0.1",
+	"version": "10.0.2",
 	"description": "WooCommerce blocks for the Gutenberg editor.",
 	"homepage": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/",
 	"keywords": [

--- a/readme.txt
+++ b/readme.txt
@@ -80,6 +80,12 @@ Release and roadmap notes available on the [WooCommerce Developers Blog](https:/
 
 == Changelog ==
 
+= 10.0.2 - 2023-04-19 =
+
+#### Bug Fixes
+
+- Fix infinite loop with the registration of Single Product Block (and inner blocks) breaking WP Post and Page editors in WP 6.1. ([9090](https://github.com/woocommerce/woocommerce-blocks/pull/9090))
+
 = 10.0.1 - 2023-04-18 =
 
 #### Bug Fixes

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: gutenberg, woocommerce, woo commerce, products, blocks, woocommerce blocks
 Requires at least: 6.1
 Tested up to: 6.2
 Requires PHP: 7.3
-Stable tag: 10.0.1
+Stable tag: 10.0.2
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/src/Package.php
+++ b/src/Package.php
@@ -109,7 +109,7 @@ class Package {
 				NewPackage::class,
 				function ( $container ) {
 					// leave for automated version bumping.
-					$version = '10.0.1';
+					$version = '10.0.2';
 					return new NewPackage(
 						$version,
 						dirname( __DIR__ ),

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce Blocks
  * Plugin URI: https://github.com/woocommerce/woocommerce-gutenberg-products-block
  * Description: WooCommerce blocks for the Gutenberg editor.
- * Version: 10.0.1
+ * Version: 10.0.2
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain:  woo-gutenberg-products-block


### PR DESCRIPTION
# Patch release

This is the patch release pull request for WooCommerce Blocks plugin `10.0.2`.

## Changelog

---

```md
#### Bug Fixes

- Fix infinite loop with the registration of Single Product Block (and inner blocks) breaking WP Post and Page editors in WP 6.1. ([9090](https://github.com/woocommerce/woocommerce-blocks/pull/9090))
```

---

## Communication

### Prepared Updates

Please leave a comment on this PR with links to the following:

-   [ ] Release announcement (announcement post on developer.woocommerce.com published after release).


-   [ ] Happiness engineering or Happiness/Support (if special instructions needed).
-   [ ] Relevant developer documentation (if applicable).

## Quality

> This section is for things related to quality around the release.

-   [x] Testing Instructions are included in this PR

https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/testing/releases/1002.md

-   [ ] Any performance impacts are documented.

---

