### PR TITLE
fix/8946: replace ToggleGroupControl with ToggleControl

### DIFF
--- a/assets/js/blocks/mini-cart/edit.tsx
+++ b/assets/js/blocks/mini-cart/edit.tsx
@@ -7,6 +7,7 @@ import {
 	PanelBody,
 	ExternalLink,
 	ToggleControl,
+	BaseControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 	__experimentalToggleGroupControl as ToggleGroupControl,
 } from '@wordpress/components';
@@ -58,36 +59,28 @@ const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
 						'woo-gutenberg-products-block'
 					) }
 				>
-					<ToggleGroupControl
-						className="wc-block-mini-cart__add-to-cart-behaviour-toggle"
+					<BaseControl
+						id="wc-block-mini-cart__add-to-cart-behaviour-toggle"
 						label={ __(
 							'Add-to-Cart behaviour',
 							'woo-gutenberg-products-block'
 						) }
-						value={ addToCartBehaviour }
-						onChange={ ( value ) => {
-							setAttributes( { addToCartBehaviour: value } );
-						} }
-						help={ __(
-							'Select what happens when a customer adds a product to the cart.',
-							'woo-gutenberg-products-block'
-						) }
 					>
-						<ToggleGroupControlOption
-							value="none"
+						<ToggleControl
 							label={ __(
-								'Do nothing',
+								'Open cart in a drawer',
 								'woo-gutenberg-products-block'
 							) }
-						/>
-						<ToggleGroupControlOption
-							value="open_drawer"
-							label={ __(
-								'Open cart drawer',
+							onChange={ ( value ) => {
+								setAttributes( { addToCartBehaviour: value ? 'open_drawer' : 'none' } );
+							} }
+							help={ __(
+								'Select what happens when a customer adds a product to the cart.',
 								'woo-gutenberg-products-block'
 							) }
+							checked={ 'open_drawer' === addToCartBehaviour }
 						/>
-					</ToggleGroupControl>
+					</BaseControl>
 					<ToggleControl
 						label={ __(
 							'Hide Cart Price',

--- a/assets/js/blocks/mini-cart/edit.tsx
+++ b/assets/js/blocks/mini-cart/edit.tsx
@@ -72,13 +72,17 @@ const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
 								'woo-gutenberg-products-block'
 							) }
 							onChange={ ( value ) => {
-								setAttributes( { addToCartBehaviour: value ? 'open_drawer' : 'none' } );
+								setAttributes(
+									{
+										addToCartBehaviour: value ? 'open_drawer' : 'none'
+									}
+								);
 							} }
 							help={ __(
 								'Select what happens when a customer adds a product to the cart.',
 								'woo-gutenberg-products-block'
 							) }
-							checked={ 'open_drawer' === addToCartBehaviour }
+							checked={ addToCartBehaviour === 'open_drawer' }
 						/>
 					</BaseControl>
 					<ToggleControl

--- a/assets/js/blocks/mini-cart/edit.tsx
+++ b/assets/js/blocks/mini-cart/edit.tsx
@@ -72,11 +72,11 @@ const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
 								'woo-gutenberg-products-block'
 							) }
 							onChange={ ( value ) => {
-								setAttributes(
-									{
-										addToCartBehaviour: value ? 'open_drawer' : 'none'
-									}
-								);
+								setAttributes( {
+									addToCartBehaviour: value
+										? 'open_drawer'
+										: 'none',
+								} );
 							} }
 							help={ __(
 								'Select what happens when a customer adds a product to the cart.',


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #8946 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
| <img width="281" alt="Screenshot 2023-04-19 at 4 03 59 PM" src="https://user-images.githubusercontent.com/17757960/233048887-2a5e2f17-c36a-43f3-b1c4-f4913a685ede.png">|<img width="281" alt="Screenshot 2023-04-19 at 4 03 27 PM" src="https://user-images.githubusercontent.com/17757960/233048778-e74b9550-4672-4113-9042-e6e6d394cd09.png">|

### Testing

1. Go to widgets > add the Mini cart block and enable "Open cart in drawer".
2. Add any product to cart from the shop page.
3. Observe and verify that the drawer opens up.
4. Now disable "Open cart in drawer", repeat step (2) and verify that the drawer doesn't open up.
5. Verify this behaviour is consistent between trunk and the fix branch.

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Fix: replace ToggleGroupControl with ToggleControl
