### PR TITLE
add cursor:pointer to checkbox and radio fields

### DIFF
--- a/assets/js/base/components/radio-control/style.scss
+++ b/assets/js/base/components/radio-control/style.scss
@@ -4,6 +4,7 @@
 	margin: em($gap) 0;
 	padding: 0 0 0 em($gap-larger);
 	position: relative;
+	cursor: pointer;
 
 	&:first-child {
 		margin-top: 0;
@@ -70,6 +71,7 @@
 		left: 0;
 		top: 50%;
 		transform: translate(0, -50%);
+		cursor: pointer;
 
 		&:checked::before {
 			background: #000;

--- a/packages/checkout/components/checkbox-control/style.scss
+++ b/packages/checkout/components/checkbox-control/style.scss
@@ -6,7 +6,12 @@
 		align-items: flex-start;
 		display: flex;
 		position: relative;
+		cursor: pointer;
 		@include font-size(small);
+
+		input[type="checkbox"] {
+			cursor: inherit;
+		}
 	}
 
 	.wc-block-components-checkbox__input[type="checkbox"] {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #8424 

Adds pointer cursor whenever radio and checkbox fields are hovered.

#### Steps to test

1. Add multiple shipping methods and enable multiple payment methods so that multiple radio input fields are shown on the Checkout page.
2. Add the Checkout block to the checkout page.
3. In the fix branch, observe all the radio/checkbox input fields on the Checkout page, hover over them and their associated labels and observe that the mouse cursor shows as a pointer.
4. Observe in the trunk branch, the cursor was shown as a mouse pointer instead.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.


* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Add: pointer cursor to checkbox and radio input fields on the Checkout page.
