### PR TITLE
fix/8651: Use body background color as the Cart block sticky footer background color

### DIFF
--- a/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/block.tsx
+++ b/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/block.tsx
@@ -86,6 +86,9 @@ const Block = ( {
 		</Button>
 	);
 
+	// Get the body background color to use as the sticky container background color.
+	const backgroundColor = getComputedStyle( document.body ).backgroundColor;
+
 	return (
 		<div className={ classnames( 'wc-block-cart__submit', className ) }>
 			{ positionReferenceElement }
@@ -95,7 +98,10 @@ const Block = ( {
 			</div>
 			{ /* If the positionReferenceElement is below the viewport, display the sticky container. */ }
 			{ positionRelativeToViewport === 'below' && (
-				<div className="wc-block-cart__submit-container wc-block-cart__submit-container--sticky">
+				<div
+					className="wc-block-cart__submit-container wc-block-cart__submit-container--sticky"
+					style={ { backgroundColor } }
+				>
 					{ submitContainerContents }
 				</div>
 			) }

--- a/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/style.scss
+++ b/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/style.scss
@@ -33,7 +33,7 @@
 
 		&::before {
 			box-shadow: 0 -10px 20px 10px currentColor;
-			color: color.adjust($gray-400, $alpha: -0.5);
+			color: color.adjust($gray-400, $alpha: -0.7);
 			content: "";
 			height: 100%;
 			left: 0;

--- a/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/style.scss
+++ b/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/style.scss
@@ -30,6 +30,7 @@
 		position: fixed;
 		width: 100%;
 		z-index: 9999;
+		box-sizing: border-box;
 
 		&::before {
 			box-shadow: 0 -10px 20px 10px currentColor;


### PR DESCRIPTION
PR adds a dynamic background-color style to the sticky footer container div to make it match with the body background color.

Fixes #8651 

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|![image](https://user-images.githubusercontent.com/10613171/233061614-eaa259cf-292a-4527-b626-744db3c26b14.png)|![image](https://user-images.githubusercontent.com/10613171/233061356-0610eada-e08b-4719-8b28-91cea5382072.png)|

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Set your theme to a dark style (ie TT3 with Pilgrimage styling).
2. Go to the Cart block page on mobile.
3. Verify the sticky footer background (available on a mobile view) match the body background color.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Use body background color as the Cart block sticky footer background color
