### PR TITLE
fix/8129: remove rounding the caused issue with UI

### DIFF
--- a/assets/js/base/components/price-slider/index.tsx
+++ b/assets/js/base/components/price-slider/index.tsx
@@ -147,18 +147,13 @@ const PriceSlider = ( {
 			};
 		}
 
-		const low =
-			Math.round(
-				100 *
-					( ( minPrice - minConstraint ) /
-						( maxConstraint - minConstraint ) )
-			) - 0.5;
-		const high =
-			Math.round(
-				100 *
-					( ( maxPrice - minConstraint ) /
-						( maxConstraint - minConstraint ) )
-			) + 0.5;
+		const low = 100 * (
+			( minPrice - minConstraint ) / ( maxConstraint - minConstraint )
+		);
+
+		const high = 100 * (
+			( maxPrice - minConstraint ) / ( maxConstraint - minConstraint )
+		);
 
 		return {
 			'--low': low + '%',

--- a/assets/js/base/components/price-slider/index.tsx
+++ b/assets/js/base/components/price-slider/index.tsx
@@ -147,13 +147,15 @@ const PriceSlider = ( {
 			};
 		}
 
-		const low = 100 * (
-			( minPrice - minConstraint ) / ( maxConstraint - minConstraint )
-		);
+		const low =
+			100 *
+			( ( minPrice - minConstraint ) /
+				( maxConstraint - minConstraint ) );
 
-		const high = 100 * (
-			( maxPrice - minConstraint ) / ( maxConstraint - minConstraint )
-		);
+		const high =
+			100 *
+			( ( maxPrice - minConstraint ) /
+				( maxConstraint - minConstraint ) );
 
 		return {
 			'--low': low + '%',


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #8129 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

Thie PR removes the rounding of `low` and `high` values that caused issue with the range slider's UI.

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

#### Before

<img width="2336" alt="Screenshot 2023-04-19 at 7 15 18 PM" src="https://user-images.githubusercontent.com/17757960/233094659-27a2a274-a442-43c4-926f-94769ba77e95.png">

#### After

<img width="2355" alt="Screenshot 2023-04-19 at 7 15 54 PM" src="https://user-images.githubusercontent.com/17757960/233094845-ace5aca0-d8d4-4db2-9f91-f088180da3ff.png">

### Testing

1. Use a wide screen (min. 1500px wide). Issue occurs on a smaller screens as well, but the position difference is smaller than the thumb radius, hence the glitch is "covered" by the thumb.
2. Create a new page
3. Add a Filter by Price block
4. Save and see go to frontend
5. Move the thumbs slowly
6. Expected: Thumb is in synced position with the slider

Please see the issue for more details.

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests


* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Add suggested changelog entry here.
