### PR TITLE
Performance: Cache script data in a transient for production builds

### DIFF
--- a/src/Assets/Api.php
+++ b/src/Assets/Api.php
@@ -46,7 +46,7 @@ class Api {
 	 */
 	public function __construct( Package $package ) {
 		$this->package       = $package;
-		$this->disable_cache = $this->package->feature()->is_development_environment() || ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG );
+		$this->disable_cache = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) || $this->package->feature()->is_development_environment() || $this->package->feature()->is_test_environment();
 
 		if ( ! $this->disable_cache ) {
 			add_action( 'shutdown', array( $this, 'save_cached_script_data' ), 20 );

--- a/src/Assets/Api.php
+++ b/src/Assets/Api.php
@@ -92,9 +92,9 @@ class Api {
 	 */
 	private function get_cached_script_data( $relative_src ) {
 		if ( is_null( $this->cached_script_data ) ) {
-			$transient_value = get_transient( 'woocommerce_blocks_asset_api_script_data' ) ?? [];
+			$transient_value = json_decode( (string) get_transient( 'woocommerce_blocks_asset_api_script_data' ), true );
 
-			if ( empty( $transient_value['script_data'] ) || empty( $transient_value['version'] ) || $transient_value['version'] !== $this->package->get_version() ) {
+			if ( empty( $transient_value ) || empty( $transient_value['script_data'] ) || empty( $transient_value['version'] ) || $transient_value['version'] !== $this->package->get_version() ) {
 				$transient_value = [
 					'script_data' => [],
 					'version'     => $this->package->get_version(),
@@ -123,7 +123,7 @@ class Api {
 		if ( $this->package->feature()->is_development_environment() ) {
 			delete_transient( 'woocommerce_blocks_asset_api_script_data' );
 		} else {
-			set_transient( 'woocommerce_blocks_asset_api_script_data', $this->cached_script_data, DAY_IN_SECONDS * 30 );
+			set_transient( 'woocommerce_blocks_asset_api_script_data', wp_json_encode( $this->cached_script_data ), DAY_IN_SECONDS * 30 );
 		}
 	}
 

--- a/src/Assets/Api.php
+++ b/src/Assets/Api.php
@@ -58,7 +58,7 @@ class Api {
 	 * @return string The cache buster value to use for the given file.
 	 */
 	protected function get_file_version( $file ) {
-		if ( file_exists( $this->package->get_path() . $file ) ) {
+		if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG && file_exists( $this->package->get_path() . $file ) ) {
 			return filemtime( $this->package->get_path( trim( $file, '/' ) ) );
 		}
 		return $this->package->get_version();

--- a/src/Assets/Api.php
+++ b/src/Assets/Api.php
@@ -115,6 +115,9 @@ class Api {
 	 * Store all cached script data in the transient cache.
 	 */
 	public function update_script_data_cache() {
+		if ( is_null( $this->script_data ) || $this->disable_cache ) {
+			return;
+		}
 		set_transient(
 			'woocommerce_blocks_asset_api_script_data',
 			wp_json_encode(


### PR DESCRIPTION
Adds caching to asset src, dependencies, and file version lookups to prevent the same data being requested on each page load. Values are stored in transients, and invalidated when the plugin package version increases. Development builds are excluded from caching to prevent issues when developing blocks.

Fixes #8796

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

Mainly testing for regressions, so check that frontend scripts load correctly and existing blocks continue to function. Note; development builds do not use the cache.

1. Run `npm run start` for a development build.
2. Check cart/checkout blocks load normally on the frontend.
3. Run `npm run build` for a production build.
4. Check cart/checkout blocks load normally on the frontend.

To see the contents of the transient, when running a production build (and assuming you are using WP Local), open database > adminer and check the wp_options table for the option named `_transient_woocommerce_blocks_asset_api_script_data`. It should contain JSON containing the list of assets/dependencies etc.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

Positive; unsure how to get accurate metrics, but in limited testing with query monitor, a few seconds were shaved off of page load times. The original issue claimed 10% improvement. 

### Changelog

> Improved the performance of loading frontend assets through the use of caching.
