### PR TITLE
Wrap getComputedStyle function inside a useMemo

### DIFF
--- a/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/block.tsx
+++ b/assets/js/blocks/cart/inner-blocks/proceed-to-checkout-block/block.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { useState, useEffect } from '@wordpress/element';
+import { useState, useEffect, useMemo } from '@wordpress/element';
 import Button from '@woocommerce/base-components/button';
 import { CHECKOUT_URL } from '@woocommerce/block-settings';
 import { usePositionRelativeToViewport } from '@woocommerce/base-hooks';
@@ -87,7 +87,10 @@ const Block = ( {
 	);
 
 	// Get the body background color to use as the sticky container background color.
-	const backgroundColor = getComputedStyle( document.body ).backgroundColor;
+	const backgroundColor = useMemo(
+		() => getComputedStyle( document.body ).backgroundColor,
+		[]
+	);
 
 	return (
 		<div className={ classnames( 'wc-block-cart__submit', className ) }>


### PR DESCRIPTION
#9103 introduces a getComputedStyle in the React code. Since that `getComputedStyle` triggers a layout reflow, to improve the performance is better to wrap the function inside a `useMemo` hook.

### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Set your theme to a dark style (ie TT3 with Pilgrimage styling).
2. Go to the Cart block page on mobile.
3. Verify the sticky footer background match the body background color.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
