### PR TITLE
Update @actions/core and @actions/github

### DIFF
--- a/.github/workflows/generate-zip.yml
+++ b/.github/workflows/generate-zip.yml
@@ -39,7 +39,7 @@ jobs:
         run: mv woocommerce-gutenberg-products-block.zip wc-blocks-pr-release__temp/woocommerce-gutenberg-products-block-${{ github.event.pull_request.number }}.zip
 
       - name: Transfer ZIP file via SFTP
-        uses: AbleLincoln/push-to-sftp@v2.0
+        uses: AbleLincoln/push-to-sftp@v2.1
         with:
           host: ${{ secrets.FTP_HOST }}
           port: 22

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,8 +46,8 @@
 				"wordpress-components": "npm:@wordpress/components@14.2.0"
 			},
 			"devDependencies": {
-				"@actions/core": "1.9.1",
-				"@actions/github": "5.0.3",
+				"@actions/core": "1.10.0",
+				"@actions/github": "5.1.1",
 				"@automattic/color-studio": "2.5.0",
 				"@babel/cli": "7.18.9",
 				"@babel/core": "7.18.9",
@@ -205,18 +205,20 @@
 			}
 		},
 		"node_modules/@actions/core": {
-			"version": "1.9.1",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
+			"integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"@actions/http-client": "^2.0.1",
 				"uuid": "^8.3.2"
 			}
 		},
 		"node_modules/@actions/github": {
-			"version": "5.0.3",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/@actions/github/-/github-5.1.1.tgz",
+			"integrity": "sha512-Nk59rMDoJaV+mHCOJPXuvB1zIbomlKS0dmSIqPGxd0enAXBnOfn4VWF+CGtRCwXZG9Epa54tZA7VIRlJDS8A6g==",
 			"dev": true,
-			"license": "MIT",
 			"dependencies": {
 				"@actions/http-client": "^2.0.1",
 				"@octokit/core": "^3.6.0",
@@ -50770,7 +50772,9 @@
 	},
 	"dependencies": {
 		"@actions/core": {
-			"version": "1.9.1",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
+			"integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
 			"dev": true,
 			"requires": {
 				"@actions/http-client": "^2.0.1",
@@ -50778,7 +50782,9 @@
 			}
 		},
 		"@actions/github": {
-			"version": "5.0.3",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/@actions/github/-/github-5.1.1.tgz",
+			"integrity": "sha512-Nk59rMDoJaV+mHCOJPXuvB1zIbomlKS0dmSIqPGxd0enAXBnOfn4VWF+CGtRCwXZG9Epa54tZA7VIRlJDS8A6g==",
 			"dev": true,
 			"requires": {
 				"@actions/http-client": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
 		"postinstall": "patch-package",
 		"reformat-files": "prettier --ignore-path .eslintignore --write \"**/*.{js,jsx,json,ts,tsx}\"",
 		"release": "sh ./bin/wordpress-deploy.sh",
+		"rimraf": "./node_modules/rimraf/bin.js",
 		"start": "rimraf build/* && cross-env BABEL_ENV=default CHECK_CIRCULAR_DEPS=true webpack --watch --info-verbosity none",
 		"storybook": "start-storybook  -c ./storybook -p 6006 --ci",
 		"storybook:build": "BABEL_ENV=development build-storybook  -c ./storybook -o ./storybook/dist",

--- a/package.json
+++ b/package.json
@@ -93,8 +93,8 @@
 		"wp-env:config": "./bin/wp-env-pre-config.sh"
 	},
 	"devDependencies": {
-		"@actions/core": "1.9.1",
-		"@actions/github": "5.0.3",
+		"@actions/core": "1.10.0",
+		"@actions/github": "5.1.1",
 		"@automattic/color-studio": "2.5.0",
 		"@babel/cli": "7.18.9",
 		"@babel/core": "7.18.9",


### PR DESCRIPTION
This PR updates dependencies used in GitHub actions to prevent warnings:

#### 1. Warning about the deprecation of `save-state` and `set-output` commands
Example: [here](https://github.com/woocommerce/woocommerce-blocks/actions/runs/4740814203)

This is fixed by update of `@actions/core` and `@actions/github`

This occurred on jobs:
- **Check Modified Assets**
- **Monitor TypeScript errors**
and the fix can be confirmed in this PR.

It occurs also on **Deploy to WordPress.org**, however, the warning doesn't show the source, so I _assume_ it will be fixed as well but we can confirm it with the upcoming release.

#### 2. Warning about "Node.js 12 actions are deprecated."
Example: [here](https://github.com/woocommerce/woocommerce-blocks/actions/runs/4752720125) 

This is occurring on multiple jobs, this PR fixes it for:

1. **Generate ZIP**
Fixed by an update of `AbleLincoln/push-to-sftp` in the scope of this PR

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/8523

### Testing

#### User Facing Testing

1. Go to [Checks](https://github.com/woocommerce/woocommerce-blocks/pull/9133/checks) of this PR
2. Enter actions:
  - Check Modified Assets
  - Monitor TypeScript errors
  - Generate ZIP
3. Expected: There are no warnings and annotations sections like [this one](https://github.com/woocommerce/woocommerce-blocks/actions/runs/4740814203) and jobs are passing successfuly

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

