### PR TITLE
Fix image editor in Featured Product/Category blocks on WP 6.2

### DIFF
--- a/assets/js/blocks/featured-items/image-editor.tsx
+++ b/assets/js/blocks/featured-items/image-editor.tsx
@@ -3,6 +3,7 @@
 /**
  * External dependencies
  */
+import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { WP_REST_API_Category } from 'wp-types';
 import { ProductResponseItem } from '@woocommerce/types';
 import {
@@ -18,7 +19,7 @@ import { BLOCK_NAMES, DEFAULT_EDITOR_SIZE } from './constants';
 import { EditorBlock } from './types';
 import { useBackgroundImage } from './use-background-image';
 
-type MediaAttributes = { mediaId: number; mediaSrc: string };
+type MediaAttributes = { align: string; mediaId: number; mediaSrc: string };
 type MediaSize = { height: number; width: number };
 
 interface WithImageEditorRequiredProps< T > {
@@ -45,24 +46,70 @@ type WithImageEditorProps< T extends EditorBlock< T > > =
 	| ( T & WithImageEditorProductProps< T > );
 
 interface ImageEditorProps {
+	align: string;
 	backgroundImageId: number;
 	backgroundImageSize: MediaSize;
 	backgroundImageSrc: string;
+	containerRef: React.RefObject< HTMLDivElement >;
 	isEditingImage: boolean;
 	setAttributes: ( attrs: MediaAttributes ) => void;
 	setIsEditingImage: ( value: boolean ) => void;
 }
 
+// Adapted from:
+// https://github.com/WordPress/gutenberg/blob/v15.6.1/packages/block-library/src/image/use-client-width.js
+function useClientWidth(
+	ref: React.RefObject< HTMLDivElement >,
+	dependencies: string[]
+) {
+	const [ clientWidth, setClientWidth ]: [
+		number | undefined,
+		Dispatch< SetStateAction< number | undefined > >
+	] = useState();
+
+	const calculateClientWidth = useCallback( () => {
+		setClientWidth( ref.current?.clientWidth );
+	}, [ ref ] );
+
+	useEffect( calculateClientWidth, [
+		calculateClientWidth,
+		...dependencies,
+	] );
+	useEffect( () => {
+		if ( ! ref.current ) {
+			return;
+		}
+		const { defaultView } = ref.current.ownerDocument;
+
+		if ( ! defaultView ) {
+			return;
+		}
+		defaultView.addEventListener( 'resize', calculateClientWidth );
+
+		return () => {
+			defaultView.removeEventListener( 'resize', calculateClientWidth );
+		};
+	}, [ ref, calculateClientWidth ] );
+
+	return clientWidth;
+}
+
 export const ImageEditor = ( {
+	align,
 	backgroundImageId,
 	backgroundImageSize,
 	backgroundImageSrc,
+	containerRef,
 	isEditingImage,
 	setAttributes,
 	setIsEditingImage,
 }: ImageEditorProps ) => {
-	return (
-		<>
+	const clientWidth = useClientWidth( containerRef, [ align ] );
+
+	// Fallback for WP 6.1 or lower. In WP 6.2. ImageEditingProvider was merged
+	// with ImageEditor, see: https://github.com/WordPress/gutenberg/pull/47171
+	if ( typeof ImageEditingProvider === 'function' ) {
+		return (
 			<ImageEditingProvider
 				id={ backgroundImageId }
 				url={ backgroundImageSrc }
@@ -88,7 +135,23 @@ export const ImageEditor = ( {
 					}
 				/>
 			</ImageEditingProvider>
-		</>
+		);
+	}
+
+	return (
+		<GutenbergImageEditor
+			id={ backgroundImageId }
+			url={ backgroundImageSrc }
+			height={ backgroundImageSize.height || DEFAULT_EDITOR_SIZE.height }
+			width={ backgroundImageSize.width || DEFAULT_EDITOR_SIZE.width }
+			naturalHeight={ backgroundImageSize.height }
+			naturalWidth={ backgroundImageSize.width }
+			onSaveImage={ ( { id, url }: { id: number; url: string } ) => {
+				setAttributes( { mediaId: id, mediaSrc: url } );
+			} }
+			onFinishEditing={ () => setIsEditingImage( false ) }
+			clientWidth={ clientWidth }
+		/>
 	);
 };
 
@@ -96,6 +159,8 @@ export const withImageEditor =
 	< T extends EditorBlock< T > >( Component: ComponentType< T > ) =>
 	( props: WithImageEditorProps< T > ) => {
 		const [ isEditingImage, setIsEditingImage ] = props.useEditingImage;
+
+		const ref = useRef< HTMLDivElement >( null );
 
 		const { attributes, backgroundImageSize, name, setAttributes } = props;
 		const { mediaId, mediaSrc } = attributes;
@@ -113,14 +178,18 @@ export const withImageEditor =
 
 		if ( isEditingImage ) {
 			return (
-				<ImageEditor
-					backgroundImageId={ backgroundImageId }
-					backgroundImageSize={ backgroundImageSize }
-					backgroundImageSrc={ backgroundImageSrc }
-					isEditingImage={ isEditingImage }
-					setAttributes={ setAttributes }
-					setIsEditingImage={ setIsEditingImage }
-				/>
+				<div ref={ ref }>
+					<ImageEditor
+						align={ attributes.align }
+						backgroundImageId={ backgroundImageId }
+						backgroundImageSize={ backgroundImageSize }
+						backgroundImageSrc={ backgroundImageSrc }
+						containerRef={ ref }
+						isEditingImage={ isEditingImage }
+						setAttributes={ setAttributes }
+						setIsEditingImage={ setIsEditingImage }
+					/>
+				</div>
 			);
 		}
 


### PR DESCRIPTION
Fixes #9100.

The issue was caused because we were using a Gutenberg component which is no longer available in WP 6.2 (`ImageEditingProvider`), this PR refactors the code so it works without that component.

### Testing

#### User Facing Testing

0. With WP 6.2:
1. Create a post and add the Featured Category block.
2. Click on the button to edit the image (note: this button is only available if the category has an image, if you don't have any categories with images, go to `wp-admin` > Products > Categories and edit a category to add an image):
![imatge](https://user-images.githubusercontent.com/3616980/233357474-a8574b19-62c6-425b-b76a-f36b3cbc14b2.png)
3. Make some changes (rotate, zoom, change aspect ratio, etc.) and apply them.
4. Verify the changes are applied and there are no errors in the browser devtools console (you can open it with <kbd>F12</kbd>).
5. Repeat all the steps above with the Featured Product block.
6. Repeat all steps above with WP 6.1 (you can use [WP Downgrade](https://wordpress.org/plugins/wp-downgrade/)).

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix image editor in Featured Product/Category blocks on WP 6.2.