### PR TITLE
Update Husky config to v8

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npm run pre-commit

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
 	},
 	"license": "GPL-3.0+",
 	"scripts": {
+		"pre-commit": "lint-staged",
 		"analyze-bundles": "cross-env WP_BUNDLE_ANALYZER=1 npm run build",
 		"build": "rimraf build/* && cross-env BABEL_ENV=default NODE_ENV=production webpack",
 		"build:check-assets": "rimraf build/* && cross-env ASSET_CHECK=true BABEL_ENV=default NODE_ENV=production webpack",
@@ -276,11 +277,6 @@
 	},
 	"optionalDependencies": {
 		"ndb": "1.1.5"
-	},
-	"husky": {
-		"hooks": {
-			"pre-commit": "lint-staged"
-		}
 	},
 	"lint-staged": {
 		"*.scss": [


### PR DESCRIPTION
It looks like after #8171, the Husky hook was not being run. (Thanks @danielwrobert for raising this!)

This PR updates the configuration to the new format.

### Testing

#### User Facing Testing

1. Make sure to `npm ci` so you have the version 8 of Husky. You can `npm list husky` to verify version 8.0.x is installed.
2. Make a change to a `scss` file modifying the indentation so lint will fail.
3. `git add` the file you modified and make a test commit.
4. Verify you don't see a message saying `Can't find Husky, skipping...`.
5. Verify linting is run.
6. Verify CSS linting failed.
7. If it didn't work, try running `rm -rf .git/hooks/` (this is where Husky hooks were stored in a previous version) and run all steps again. (Please, mention in the comment whether you had to do this)
8. If it didn't work either, try running `rm -rf ./node_modules/ && npm i` to reinstall all NPM dependencies.  (Please, mention in the comment whether you had to do this)

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->
