### PR TITLE
[Patterns] Add new `Testimonials: 3 columns` pattern

### DIFF
--- a/patterns/testimonials-3-columns.php
+++ b/patterns/testimonials-3-columns.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Title: Testimonials 3 Columns
+ * Slug: woocommerce-blocks/testimonials-3-columns
+ * Categories: WooCommerce
+ */
+?>
+
+<!-- wp:columns {"align":"full"} -->
+<div class="wp-block-columns alignfull">
+	<!-- wp:column -->
+	<div class="wp-block-column">
+		<!-- wp:heading {"level":4,"style":{"typography":{"textTransform":"none","fontSize":"18px"}}} -->
+		<h4 class="wp-block-heading" style="font-size:18px;text-transform:none"><strong>Great experience</strong></h4>
+		<!-- /wp:heading -->
+
+		<!-- wp:paragraph {"style":{"typography":{"fontSize":"18px"}}} -->
+		<p style="font-size:18px">
+			In the end the couch wasn’t exactly what I was looking for but my experience with the
+			Burrow team was excellent. First in providing a discount when the couch was delayed, then timely feedback
+			and updates as the…
+		</p>
+		<!-- /wp:paragraph -->
+
+		<!-- wp:paragraph {"style":{"typography":{"fontSize":"18px"},"color":{"text":"#646970"}}} -->
+		<p class="has-text-color" style="color:#646970;font-size:18px">~ Tanner P.</p>
+		<!-- /wp:paragraph --></div>
+	<!-- /wp:column -->
+
+	<!-- wp:column -->
+	<div class="wp-block-column">
+		<!-- wp:heading {"level":4,"style":{"typography":{"textTransform":"none","fontSize":"18px"}}} -->
+		<h4 class="wp-block-heading" style="font-size:18px;text-transform:none"><strong>LOVE IT</strong></h4>
+		<!-- /wp:heading -->
+
+		<!-- wp:paragraph {"style":{"typography":{"fontSize":"18px"}}} -->
+		<p style="font-size:18px">
+			Great couch. color as advertise. seat is nice and firm. Easy to put together.
+			Versatile. Bought one for my mother in law as well. And she loves hers!
+		</p>
+		<!-- /wp:paragraph -->
+
+		<!-- wp:paragraph {"style":{"typography":{"fontSize":"18px"},"color":{"text":"#646970"}}} -->
+		<p class="has-text-color" style="color:#646970;font-size:18px">~ Abigail N.</p>
+		<!-- /wp:paragraph --></div>
+	<!-- /wp:column -->
+
+	<!-- wp:column -->
+	<div class="wp-block-column">
+		<!-- wp:heading {"level":4,"style":{"typography":{"textTransform":"none","fontSize":"18px"}}} -->
+		<h4 class="wp-block-heading" style="font-size:18px;text-transform:none"><strong>Awesome couch and great buying experience</strong></h4>
+		<!-- /wp:heading -->
+
+		<!-- wp:paragraph {"style":{"typography":{"fontSize":"18px"}}} -->
+		<p style="font-size:18px">
+			I got the kind sofa. The look and feel is high quality, and I enjoy that it is a
+			medium level of firmness. Assembly took a little longer than I expected, and it came in 4 boxes. I am
+			excited about the time / st…
+		</p>
+		<!-- /wp:paragraph -->
+
+		<!-- wp:paragraph {"style":{"typography":{"fontSize":"18px"},"color":{"text":"#646970"}}} -->
+		<p class="has-text-color" style="color:#646970;font-size:18px">~ Albert L.</p>
+		<!-- /wp:paragraph --></div>
+	<!-- /wp:column --></div>
+<!-- /wp:columns -->


### PR DESCRIPTION
This PR implements the `Testimonials: 3 columns` pattern.

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/9151

### Screenshots

#### Design
![Centered Search](https://user-images.githubusercontent.com/186112/233589157-6f180ad7-ea3c-4073-852a-22de4d1e597d.png)

### Testing
#### User-Facing Testing

1. Create a new page or post
2. Make sure the `Testimonials 3 columns` pattern appears under the WooCommerce category dropdown.
3. Insert in and make sure it shows as expected on the design.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

> Add new `Testimonials 3 columns` pattern
