### PR TITLE
Add `prepare` to Fix Husky Configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
 	},
 	"license": "GPL-3.0+",
 	"scripts": {
-		"pre-commit": "lint-staged",
 		"analyze-bundles": "cross-env WP_BUNDLE_ANALYZER=1 npm run build",
 		"build": "rimraf build/* && cross-env BABEL_ENV=default NODE_ENV=production webpack",
 		"build:check-assets": "rimraf build/* && cross-env ASSET_CHECK=true BABEL_ENV=default NODE_ENV=production webpack",
@@ -67,6 +66,8 @@
 		"package-plugin:zip-only": "rimraf woocommerce-gutenberg-products-block.zip && ./bin/build-plugin-zip.sh -z",
 		"package-plugin:deploy": "npm run build:deploy && npm run package-plugin:zip-only",
 		"postinstall": "patch-package",
+		"pre-commit": "lint-staged",
+		"prepare": "husky install",
 		"reformat-files": "prettier --ignore-path .eslintignore --write \"**/*.{js,jsx,json,ts,tsx}\"",
 		"release": "sh ./bin/wordpress-deploy.sh",
 		"rimraf": "./node_modules/rimraf/bin.js",


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
The `scripts` in the `package.json` file is missing the `prepare` script that installs/initializes Husky (see [Husky documentation](https://typicode.github.io/husky/#/?id=manual)).

This was resulting in the pre-commit hooks not firing off.

By adding the `prepare` script, this completes the Husky config and allows the pre-commit hooks to run our expected linting tasks.

<!-- Reference any related issues or PRs here -->

Fixes #9166

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|  ![CleanShot 2023-04-21 at 12 22 19](https://user-images.githubusercontent.com/481776/233686898-0cacf9c3-ea78-4c78-9f0c-f129e823e3e2.png)  |  ![CleanShot 2023-04-21 at 12 22 57](https://user-images.githubusercontent.com/481776/233686969-449cddd9-71d9-4846-8476-faff2c19c1e0.png)  |

### Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Preferably run a fresh clone of this repo. At the very minimum, run `rm -rf ./node_modules/ && npm i`.
2. Make a change to a scss file modifying the indentation so lint will fail.
3. Run `git add` on the file you modified and make a test commit.
4. Verify linting is run and you are **not** able to commit with the undesired indentation.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->