### PR TITLE
Add notice when shipping is selected but no methods are available yet

### DIFF
--- a/assets/js/base/components/cart-checkout/totals/shipping/utils.ts
+++ b/assets/js/base/components/cart-checkout/totals/shipping/utils.ts
@@ -65,37 +65,3 @@ export const areShippingMethodsMissing = (
 
 	return false;
 };
-
-export const useShippingTotalWarning = () => {
-	const context = 'woocommerce/checkout-totals-block';
-	const errorNoticeId = 'wc-blocks-totals-shipping-warning';
-
-	const { shippingRates } = useShippingData();
-	const hasRates = hasShippingRate( shippingRates );
-	const prefersCollection = useSelect( ( select ) => {
-		return select( CHECKOUT_STORE_KEY ).prefersCollection();
-	} );
-	const { createInfoNotice, removeNotice } = useDispatch( 'core/notices' );
-	const shippingMethodsMissing = areShippingMethodsMissing(
-		hasRates,
-		prefersCollection,
-		shippingRates
-	);
-	useEffect( () => {
-		removeNotice( errorNoticeId, context );
-
-		if ( shippingMethodsMissing ) {
-			createInfoNotice(
-				__(
-					'Totals will be recalculated when a valid shipping method is selected.',
-					'woo-gutenberg-products-block'
-				),
-				{
-					id: 'wc-blocks-totals-shipping-warning',
-					isDismissible: false,
-					context,
-				}
-			);
-		}
-	}, [ shippingMethodsMissing, createInfoNotice, removeNotice ] );
-};

--- a/assets/js/base/components/cart-checkout/totals/shipping/utils.ts
+++ b/assets/js/base/components/cart-checkout/totals/shipping/utils.ts
@@ -4,11 +4,6 @@
 import { getSetting } from '@woocommerce/settings';
 import type { CartResponseShippingRate } from '@woocommerce/type-defs/cart-response';
 import { hasCollectableRate } from '@woocommerce/base-utils';
-import { useShippingData } from '@woocommerce/base-context';
-import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
-import { useDispatch, useSelect } from '@wordpress/data';
-import { useEffect } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
 
 /**
  * Searches an array of packages/rates to see if there are actually any rates

--- a/assets/js/base/context/hooks/index.js
+++ b/assets/js/base/context/hooks/index.js
@@ -10,4 +10,5 @@ export * from './use-customer-data';
 export * from './use-checkout-address';
 export * from './use-checkout-submit';
 export * from './use-checkout-extension-data';
+export * from './use-show-shipping-total-warning';
 export * from './use-validation';

--- a/assets/js/base/context/hooks/tsconfig.json
+++ b/assets/js/base/context/hooks/tsconfig.json
@@ -7,6 +7,7 @@
 		"../providers/cart-checkout/checkout-events/index.tsx",
 		"../providers/cart-checkout/payment-events/index.tsx",
 		"../providers/cart-checkout/shipping/index.js",
+		"../../components/cart-checkout/totals/shipping",
 		"../../../editor-components/utils/*",
 		"../../../data/index.ts"
 	],

--- a/assets/js/base/context/hooks/use-show-shipping-total-warning.ts
+++ b/assets/js/base/context/hooks/use-show-shipping-total-warning.ts
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import { useShippingData } from '@woocommerce/base-context';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
+import { useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import {
+	areShippingMethodsMissing,
+	hasShippingRate,
+} from '@woocommerce/base-components/cart-checkout/totals/shipping/utils';
+
+export const useShowShippingTotalWarning = () => {
+	const context = 'woocommerce/checkout-totals-block';
+	const errorNoticeId = 'wc-blocks-totals-shipping-warning';
+
+	const { shippingRates } = useShippingData();
+	const hasRates = hasShippingRate( shippingRates );
+	const prefersCollection = useSelect( ( select ) => {
+		return select( CHECKOUT_STORE_KEY ).prefersCollection();
+	} );
+	const { createInfoNotice, removeNotice } = useDispatch( 'core/notices' );
+	const shippingMethodsMissing = areShippingMethodsMissing(
+		hasRates,
+		prefersCollection,
+		shippingRates
+	);
+	useEffect( () => {
+		removeNotice( errorNoticeId, context );
+
+		if ( shippingMethodsMissing ) {
+			createInfoNotice(
+				__(
+					'Totals will be recalculated when a valid shipping method is selected.',
+					'woo-gutenberg-products-block'
+				),
+				{
+					id: 'wc-blocks-totals-shipping-warning',
+					isDismissible: false,
+					context,
+				}
+			);
+		}
+	}, [ shippingMethodsMissing, createInfoNotice, removeNotice ] );
+};

--- a/assets/js/base/context/hooks/use-show-shipping-total-warning.ts
+++ b/assets/js/base/context/hooks/use-show-shipping-total-warning.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { useShippingData } from '@woocommerce/base-context';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
 import { useEffect } from '@wordpress/element';
@@ -10,6 +9,11 @@ import {
 	areShippingMethodsMissing,
 	hasShippingRate,
 } from '@woocommerce/base-components/cart-checkout/totals/shipping/utils';
+
+/**
+ * Internal dependencies
+ */
+import { useShippingData } from './shipping/use-shipping-data';
 
 export const useShowShippingTotalWarning = () => {
 	const context = 'woocommerce/checkout-totals-block';

--- a/assets/js/base/context/hooks/use-show-shipping-total-warning.ts
+++ b/assets/js/base/context/hooks/use-show-shipping-total-warning.ts
@@ -2,13 +2,12 @@
  * External dependencies
  */
 import { useDispatch, useSelect } from '@wordpress/data';
-import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
+import { CART_STORE_KEY, CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
 import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import {
-	areShippingMethodsMissing,
-	hasShippingRate,
-} from '@woocommerce/base-components/cart-checkout/totals/shipping/utils';
+import { hasShippingRate } from '@woocommerce/base-components/cart-checkout/totals/shipping/utils';
+import { hasCollectableRate } from '@woocommerce/base-utils';
+import { isString } from '@woocommerce/types';
 
 /**
  * Internal dependencies
@@ -19,33 +18,71 @@ export const useShowShippingTotalWarning = () => {
 	const context = 'woocommerce/checkout-totals-block';
 	const errorNoticeId = 'wc-blocks-totals-shipping-warning';
 
-	const { shippingRates } = useShippingData();
+	const { shippingRates, selectedRates } = useShippingData();
 	const hasRates = hasShippingRate( shippingRates );
-	const prefersCollection = useSelect( ( select ) => {
-		return select( CHECKOUT_STORE_KEY ).prefersCollection();
-	} );
+	const { prefersCollection, isRateBeingSelected, shippingNotices } =
+		useSelect( ( select ) => {
+			return {
+				prefersCollection:
+					select( CHECKOUT_STORE_KEY ).prefersCollection(),
+				isRateBeingSelected:
+					select( CART_STORE_KEY ).isShippingRateBeingSelected(),
+				shippingNotices: select( 'core/notices' ).getNotices( context ),
+			};
+		} );
 	const { createInfoNotice, removeNotice } = useDispatch( 'core/notices' );
-	const shippingMethodsMissing = areShippingMethodsMissing(
-		hasRates,
-		prefersCollection,
-		shippingRates
-	);
+
 	useEffect( () => {
-		if ( ! shippingMethodsMissing ) {
-			removeNotice( errorNoticeId, context );
+		if ( ! hasRates || isRateBeingSelected ) {
+			// Early return because shipping rates were not yet loaded from the cart data store, or the user is changing
+			// rate, no need to alter the notice until we know what the actual rate is.
+			return;
+		}
+		const isPickupRateSelected = Object.values( selectedRates ).some(
+			( rate: unknown ) => {
+				if ( isString( rate ) ) {
+					return hasCollectableRate( rate.split( ':' )[ 0 ] );
+				}
+				return false;
+			}
+		);
+
+		// There is a mismatch between the method the user chose (pickup or shipping) and the currently selected rate.
+		if (
+			hasRates &&
+			! prefersCollection &&
+			! isRateBeingSelected &&
+			isPickupRateSelected &&
+			shippingNotices.length === 0
+		) {
+			createInfoNotice(
+				__(
+					'Totals will be recalculated when a valid shipping method is selected.',
+					'woo-gutenberg-products-block'
+				),
+				{
+					id: 'wc-blocks-totals-shipping-warning',
+					isDismissible: false,
+					context,
+				}
+			);
 			return;
 		}
 
-		createInfoNotice(
-			__(
-				'Totals will be recalculated when a valid shipping method is selected.',
-				'woo-gutenberg-products-block'
-			),
-			{
-				id: 'wc-blocks-totals-shipping-warning',
-				isDismissible: false,
-				context,
-			}
-		);
-	}, [ shippingMethodsMissing, createInfoNotice, removeNotice ] );
+		// Don't show the notice if they have selected local pickup, or if they have selected a valid regular shipping rate.
+		if (
+			( prefersCollection || ! isPickupRateSelected ) &&
+			shippingNotices.length > 0
+		) {
+			removeNotice( errorNoticeId, context );
+		}
+	}, [
+		createInfoNotice,
+		hasRates,
+		selectedRates,
+		isRateBeingSelected,
+		prefersCollection,
+		removeNotice,
+		shippingNotices,
+	] );
 };

--- a/assets/js/base/context/hooks/use-show-shipping-total-warning.ts
+++ b/assets/js/base/context/hooks/use-show-shipping-total-warning.ts
@@ -31,20 +31,21 @@ export const useShowShippingTotalWarning = () => {
 		shippingRates
 	);
 	useEffect( () => {
-		removeNotice( errorNoticeId, context );
-
-		if ( shippingMethodsMissing ) {
-			createInfoNotice(
-				__(
-					'Totals will be recalculated when a valid shipping method is selected.',
-					'woo-gutenberg-products-block'
-				),
-				{
-					id: 'wc-blocks-totals-shipping-warning',
-					isDismissible: false,
-					context,
-				}
-			);
+		if ( ! shippingMethodsMissing ) {
+			removeNotice( errorNoticeId, context );
+			return;
 		}
+
+		createInfoNotice(
+			__(
+				'Totals will be recalculated when a valid shipping method is selected.',
+				'woo-gutenberg-products-block'
+			),
+			{
+				id: 'wc-blocks-totals-shipping-warning',
+				isDismissible: false,
+				context,
+			}
+		);
 	}, [ shippingMethodsMissing, createInfoNotice, removeNotice ] );
 };

--- a/assets/js/blocks/checkout/block.tsx
+++ b/assets/js/blocks/checkout/block.tsx
@@ -29,6 +29,15 @@ import CheckoutOrderError from './checkout-order-error';
 import { LOGIN_TO_CHECKOUT_URL, isLoginRequired, reloadPage } from './utils';
 import type { Attributes } from './types';
 import { CheckoutBlockContext } from './context';
+import {
+	areShippingMethodsMissing,
+	hasShippingRate,
+	useShippingTotalWarning,
+} from '@woocommerce/base-components/cart-checkout/totals/shipping/utils';
+import {
+	isAddressComplete,
+	isPackageRateCollectable,
+} from '@woocommerce/base-utils';
 
 const MustLoginPrompt = () => {
 	return (
@@ -161,6 +170,7 @@ const Block = ( {
 	children: React.ReactChildren;
 	scrollToTop: ( props: Record< string, unknown > ) => void;
 } ): JSX.Element => {
+	useShippingTotalWarning();
 	return (
 		<BlockErrorBoundary
 			header={ __(

--- a/assets/js/blocks/checkout/block.tsx
+++ b/assets/js/blocks/checkout/block.tsx
@@ -29,15 +29,6 @@ import CheckoutOrderError from './checkout-order-error';
 import { LOGIN_TO_CHECKOUT_URL, isLoginRequired, reloadPage } from './utils';
 import type { Attributes } from './types';
 import { CheckoutBlockContext } from './context';
-import {
-	areShippingMethodsMissing,
-	hasShippingRate,
-	useShippingTotalWarning,
-} from '@woocommerce/base-components/cart-checkout/totals/shipping/utils';
-import {
-	isAddressComplete,
-	isPackageRateCollectable,
-} from '@woocommerce/base-utils';
 
 const MustLoginPrompt = () => {
 	return (

--- a/assets/js/blocks/checkout/block.tsx
+++ b/assets/js/blocks/checkout/block.tsx
@@ -4,7 +4,10 @@
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 import { createInterpolateElement, useEffect } from '@wordpress/element';
-import { useStoreCart } from '@woocommerce/base-context/hooks';
+import {
+	useStoreCart,
+	useShowShippingTotalWarning,
+} from '@woocommerce/base-context/hooks';
 import { CheckoutProvider, noticeContexts } from '@woocommerce/base-context';
 import BlockErrorBoundary from '@woocommerce/base-components/block-error-boundary';
 import { SidebarLayout } from '@woocommerce/base-components/sidebar-layout';
@@ -161,7 +164,7 @@ const Block = ( {
 	children: React.ReactChildren;
 	scrollToTop: ( props: Record< string, unknown > ) => void;
 } ): JSX.Element => {
-	useShippingTotalWarning();
+	useShowShippingTotalWarning();
 	return (
 		<BlockErrorBoundary
 			header={ __(

--- a/assets/js/blocks/checkout/inner-blocks/checkout-totals-block/frontend.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-totals-block/frontend.tsx
@@ -8,6 +8,7 @@ import { Sidebar } from '@woocommerce/base-components/sidebar-layout';
  * Internal dependencies
  */
 import './style.scss';
+import { StoreNoticesContainer } from '@woocommerce/blocks-checkout';
 
 const FrontendBlock = ( {
 	children,
@@ -20,6 +21,9 @@ const FrontendBlock = ( {
 		<Sidebar
 			className={ classnames( 'wc-block-checkout__sidebar', className ) }
 		>
+			<StoreNoticesContainer
+				context={ 'woocommerce/checkout-totals-block' }
+			/>
 			{ children }
 		</Sidebar>
 	);

--- a/assets/js/blocks/checkout/inner-blocks/checkout-totals-block/frontend.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-totals-block/frontend.tsx
@@ -3,12 +3,12 @@
  */
 import classnames from 'classnames';
 import { Sidebar } from '@woocommerce/base-components/sidebar-layout';
+import { StoreNoticesContainer } from '@woocommerce/blocks-checkout';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
-import { StoreNoticesContainer } from '@woocommerce/blocks-checkout';
 
 const FrontendBlock = ( {
 	children,


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR is based on `fix/total-shipping-display-info` (https://github.com/woocommerce/woocommerce-blocks/pull/8819)

When no shipping methods are shown (due to the site's "default location" settings being set to "no location by default" and the shopper not entering an address), then the totals do not update correctly, due to the cart still technically having the previous local pickup shipping rate selected (it is not possible to "unselect" a rate). In this case, we shall show a warning letting the shopper know the totals are incorrect and that they need to select a valid shipping address before they will update correctly.


The changes included here are:
- Add a new hook `useShowShippingTotalWarning` which adds a notice to the `core/notices` data store. This uses `areShippingMethodsMissing` to determine when no regular shipping methods are available (and local pickup is selected) a warning is added to the if so, and removed if not.
- Add a `StoreNoticesContainer` to the checkout totals sidebar with the `woocommerce/checkout-totals-block` context.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/5656702/233788833-79c882d5-36b0-4383-9df5-9e508d787364.png) | ![image](https://user-images.githubusercontent.com/5656702/233792944-46bbe42a-8973-4965-af20-9b2c3e3ca757.png) |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Go to WooCommerce -> Settings -> General and set `Default customer location` to `No location by default`.
2. Go to WooCommerce -> Settings -> Shipping and ensure you have shipping rates set up. Ensure `Locations not covered by your other zones` does NOT have any rates set up.
3. Go to WooCommerce -> Settings -> Shipping -> Local pickup and ensure you have some local pickup locations set up.
4. In an incognito window, add an item to your cart and go to the Cart block. Ensure you don't see any notices. Ensure the local pickup rates you set up are visible.
5. Go to the Checkout block. Ensure by default the `Local pickup` option is selected as the shipping method. Ensure the totals/taxes are correct.
6. Change the method to Shipping.
7. See the warning appear above the sidebar.
8. Ensure no rates show up until you have started to enter an address. It is OK for them to appear as soon as the country is entered.
9. Enter your address, and ensure rates appear. Ensure the notice disappears as soon as the rates are available.
10. Change country to one that does not have any shipping rates set up. Ensure the notice appears while no shipping methods are available.
11. Switch back to Local Pickup and ensure the notice disappears.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Show a notice in the Checkout block explaining that totals will not update until a valid shipping rates is selected.
