### PR TITLE
[Patterns] Add new `Footer with 3 menus` menu

### DIFF
--- a/patterns/footer-with-3-menus.php
+++ b/patterns/footer-with-3-menus.php
@@ -46,7 +46,11 @@
 		<div class="wp-block-column is-vertically-aligned-top">
 			<!-- wp:group {"style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"},"blockGap":"5px"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"right","verticalAlignment":"space-between"}} -->
 			<div class="wp-block-group" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">
-				<!-- wp:search {"label":"Search","showLabel":false,"placeholder":"Search our store","width":240,"widthUnit":"px","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"query":{"post_type":"product"},"backgroundColor":"base","textColor":"contrast"} /-->
+				<!-- wp:group {"style":{"border":{"top":{"width":"1px","style":"solid"},"right":{"width":"1px","style":"solid"},"bottom":{"width":"1px","style":"solid"},"left":{"width":"1px","style":"solid"}}},"layout":{"type":"flex","orientation":"vertical"}} -->
+				<div class="wp-block-group" style="border-top-style:solid;border-top-width:1px;border-right-style:solid;border-right-width:1px;border-bottom-style:solid;border-bottom-width:1px;border-left-style:solid;border-left-width:1px">
+					<!-- wp:search {"label":"Search","showLabel":false,"placeholder":"Search our store","width":280,"widthUnit":"px","buttonText":"Search","buttonUseIcon":true,"query":{"post_type":"product"},"style":{"border":{"top":{"width":"0px","style":"none"},"right":{"width":"0px","style":"none"},"bottom":{"width":"0px","style":"none"},"left":{"width":"0px","style":"none"}}},"backgroundColor":"background","textColor":"foreground"} /-->
+				</div>
+				<!-- /wp:group -->
 
 				<!-- wp:site-title {"level":0,"textAlign":"right","style":{"typography":{"fontStyle":"normal","fontWeight":"700","fontSize":"14px"},"spacing":{"margin":{"top":"var:preset|spacing|50"}}},"anchor":""} /-->
 

--- a/patterns/footer-with-3-menus.php
+++ b/patterns/footer-with-3-menus.php
@@ -7,12 +7,12 @@
  */
 ?>
 
-<!-- wp:group {"align":"full","style":{"spacing":{"blockGap":"40px"}}} -->
-<div class="wp-block-group alignfull">
+<!-- wp:group {"align":"full","style":{"spacing":{"blockGap":"40px","padding":{"right":"var:preset|spacing|30","left":"var:preset|spacing|30"}}}} -->
+<div class="wp-block-group alignfull" style="padding-right:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)">
 	<!-- wp:columns -->
-	<div class="wp-block-columns">
-		<!-- wp:column {"verticalAlignment":"center","width":"70%"} -->
-		<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:70%">
+	<div class="wp-block-columns are-vertically-aligned-top">
+		<!-- wp:column {"verticalAlignment":"top","width":"70%"} -->
+		<div class="wp-block-column is-vertically-aligned-top" style="flex-basis:70%">
 			<!-- wp:group {"style":{"spacing":{"blockGap":"32px"}},"layout":{"type":"flex","flexWrap":"wrap","verticalAlignment":"top"}} -->
 			<div class="wp-block-group"><!-- wp:site-logo {"shouldSyncIcon":false} /-->
 

--- a/patterns/footer-with-3-menus.php
+++ b/patterns/footer-with-3-menus.php
@@ -7,8 +7,8 @@
  */
 ?>
 
-<!-- wp:group {"align":"full","style":{"spacing":{"blockGap":"40px","padding":{"right":"var:preset|spacing|30","left":"var:preset|spacing|30"}}}} -->
-<div class="wp-block-group alignfull" style="padding-right:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)">
+<!-- wp:group {"align":"full","style":{"spacing":{"blockGap":"40px","padding":{"top":"var:preset|spacing|30","right":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30"}}}} -->
+<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)">
 	<!-- wp:columns -->
 	<div class="wp-block-columns are-vertically-aligned-top">
 		<!-- wp:column {"verticalAlignment":"top","width":"70%"} -->
@@ -52,7 +52,11 @@
 
 				<!-- wp:paragraph {"align":"right","style":{"typography":{"fontSize":"12px"}}} -->
 				<p class="has-text-align-right" style="font-size:12px">
-					Powered by <a href="https://wordpress.com/">WordPress</a> with <a href="https://woocommerce.com/">WooCommerce</a>
+					<?php echo sprintf(
+						__( 'Powered by %s with %s', 'woo-gutenberg-products-block' ),
+						'<a href="https://wordpress.org">WordPress</a>',
+						'<a href="https://woocommerce.com">WooCommerce</a>'
+					) ?>
 				</p>
 				<!-- /wp:paragraph -->
 			</div>

--- a/patterns/footer-with-3-menus.php
+++ b/patterns/footer-with-3-menus.php
@@ -48,7 +48,7 @@
 			<div class="wp-block-group" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">
 				<!-- wp:search {"label":"Search","showLabel":false,"placeholder":"Search our store","width":240,"widthUnit":"px","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"query":{"post_type":"product"},"backgroundColor":"base","textColor":"contrast"} /-->
 
-				<!-- wp:site-title {"textAlign":"right","style":{"typography":{"fontStyle":"normal","fontWeight":"700","fontSize":"14px"},"spacing":{"margin":{"top":"var:preset|spacing|50"}}}} /-->
+				<!-- wp:site-title {"level":0,"textAlign":"right","style":{"typography":{"fontStyle":"normal","fontWeight":"700","fontSize":"14px"},"spacing":{"margin":{"top":"var:preset|spacing|50"}}},"anchor":""} /-->
 
 				<!-- wp:paragraph {"align":"right","style":{"typography":{"fontSize":"12px"}}} -->
 				<p class="has-text-align-right" style="font-size:12px">

--- a/patterns/footer-with-3-menus.php
+++ b/patterns/footer-with-3-menus.php
@@ -16,15 +16,27 @@
 			<!-- wp:group {"style":{"spacing":{"blockGap":"32px"}},"layout":{"type":"flex","flexWrap":"wrap","verticalAlignment":"top"}} -->
 			<div class="wp-block-group"><!-- wp:site-logo {"shouldSyncIcon":false} /-->
 
-				<!-- wp:group {"style":{"spacing":{"blockGap":"130px"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"left"}} -->
-				<div class="wp-block-group">
-					<!-- wp:navigation {"ref":1855,"layout":{"type":"flex","orientation":"vertical","flexWrap":"wrap"},"style":{"spacing":{"blockGap":"10px"}}} /-->
+				<!-- wp:columns {"style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"},"blockGap":{"top":"var:preset|spacing|70","left":"var:preset|spacing|70"}}}} -->
+				<div class="wp-block-columns" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">
+					<!-- wp:column -->
+					<div class="wp-block-column">
+						<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical","flexWrap":"wrap"},"style":{"spacing":{"blockGap":"10px"}}} /-->
+					</div>
+					<!-- /wp:column -->
 
-					<!-- wp:navigation {"ref":1855,"layout":{"type":"flex","orientation":"vertical"},"style":{"spacing":{"blockGap":"10px"}}} /-->
+					<!-- wp:column -->
+					<div class="wp-block-column">
+						<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"},"style":{"spacing":{"blockGap":"10px"}}} /-->
+					</div>
+					<!-- /wp:column -->
 
-					<!-- wp:navigation {"ref":1855,"layout":{"type":"flex","orientation":"vertical"},"style":{"spacing":{"blockGap":"10px"}}} /-->
+					<!-- wp:column -->
+					<div class="wp-block-column">
+						<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"},"style":{"spacing":{"blockGap":"10px"}}} /-->
+					</div>
+					<!-- /wp:column -->
 				</div>
-				<!-- /wp:group -->
+				<!-- /wp:columns -->
 			</div>
 			<!-- /wp:group -->
 		</div>

--- a/patterns/footer-with-3-menus.php
+++ b/patterns/footer-with-3-menus.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Title: Footer with 3 menus
+ * Slug: woocommerce-blocks/footer-with-3-menus
+ * Categories: WooCommerce
+ * Block Types: core/template-part/footer
+ */
+?>
+
+<!-- wp:group {"align":"full","style":{"spacing":{"blockGap":"40px"}}} -->
+<div class="wp-block-group alignfull">
+	<!-- wp:columns -->
+	<div class="wp-block-columns">
+		<!-- wp:column {"verticalAlignment":"center","width":"70%"} -->
+		<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:70%">
+			<!-- wp:group {"style":{"spacing":{"blockGap":"32px"}},"layout":{"type":"flex","flexWrap":"wrap","verticalAlignment":"top"}} -->
+			<div class="wp-block-group"><!-- wp:site-logo {"shouldSyncIcon":false} /-->
+
+				<!-- wp:group {"style":{"spacing":{"blockGap":"130px"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"left"}} -->
+				<div class="wp-block-group">
+					<!-- wp:navigation {"ref":1855,"layout":{"type":"flex","orientation":"vertical","flexWrap":"wrap"},"style":{"spacing":{"blockGap":"10px"}}} /-->
+
+					<!-- wp:navigation {"ref":1855,"layout":{"type":"flex","orientation":"vertical"},"style":{"spacing":{"blockGap":"10px"}}} /-->
+
+					<!-- wp:navigation {"ref":1855,"layout":{"type":"flex","orientation":"vertical"},"style":{"spacing":{"blockGap":"10px"}}} /-->
+				</div>
+				<!-- /wp:group -->
+			</div>
+			<!-- /wp:group -->
+		</div>
+		<!-- /wp:column -->
+
+		<!-- wp:column {"verticalAlignment":"top","style":{"spacing":{"blockGap":"60px"}},"layout":{"type":"default"}} -->
+		<div class="wp-block-column is-vertically-aligned-top">
+			<!-- wp:group {"style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"},"blockGap":"5px"}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"right","verticalAlignment":"space-between"}} -->
+			<div class="wp-block-group" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">
+				<!-- wp:search {"label":"Search","showLabel":false,"placeholder":"Search our store","width":240,"widthUnit":"px","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true,"query":{"post_type":"product"},"backgroundColor":"base","textColor":"contrast"} /-->
+
+				<!-- wp:site-title {"textAlign":"right","style":{"typography":{"fontStyle":"normal","fontWeight":"700","fontSize":"14px"},"spacing":{"margin":{"top":"var:preset|spacing|50"}}}} /-->
+
+				<!-- wp:paragraph {"align":"right","style":{"typography":{"fontSize":"12px"}}} -->
+				<p class="has-text-align-right" style="font-size:12px">
+					Powered by <a href="https://wordpress.com/">WordPress</a> with <a href="https://woocommerce.com/">WooCommerce</a>
+				</p>
+				<!-- /wp:paragraph -->
+			</div>
+			<!-- /wp:group -->
+		</div>
+		<!-- /wp:column -->
+	</div>
+	<!-- /wp:columns -->
+</div>
+<!-- /wp:group -->


### PR DESCRIPTION
This PR implements the `Footer with 3 menus` pattern.

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/9055

### Screenshots

#### Design
![Centered Search](https://user-images.githubusercontent.com/186112/233028392-4000d58a-a1be-41ad-9420-c8559bd01149.png)
#### Implementation
<img width="2004" alt="Screenshot 2023-04-24 at 12 17 39" src="https://user-images.githubusercontent.com/186112/233968590-c5a00d1f-f057-49ee-9703-c75ec9bc6499.png">

### Testing
#### User-Facing Testing

1. Create a new page or post
2. Make sure the `Footer with 3 menus` pattern appears under the WooCommerce category dropdown.
3. Insert in and make sure it shows as expected on the design.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog
> Add new `Footer with 3 menus` pattern
