### PR TITLE
Related Products: make Product Title a link by default

### DIFF
--- a/assets/js/blocks/product-query/variations/related-products.tsx
+++ b/assets/js/blocks/product-query/variations/related-products.tsx
@@ -68,6 +68,7 @@ export const INNER_BLOCKS_TEMPLATE: InnerBlockTemplate[] = [
 					textAlign: 'center',
 					level: 3,
 					fontSize: 'medium',
+					isLink: true,
 					__woocommerceNamespace: PRODUCT_TITLE_ID,
 				},
 				[],


### PR DESCRIPTION
I think it makes sense for the Product Title in the Related Products block to be a link to the product page by default.

cc @gigitux in case you want to include this in the Single Product template epic.

### Testing

#### User Facing Testing

1. Go to Appearance > Site Editor > Templates > Single Product.
2. Add the Related Products somewhere in the page.
3. Click on the Product Title inner block.
4. Verify the _Make title a link_ toggle is on by default.

![image](https://user-images.githubusercontent.com/3616980/233985216-63eb1ae0-8e1b-4195-a74e-c07fee622d4b.png)

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Related Products: make Product Title a link by default
