### PR TITLE
Temporarily disable Playwright tests until the conflict with PHP version is resolved

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   PlaywrightE2ETests:
-    enabled: false
+    if: false
     name: Playwright E2E tests
     timeout-minutes: 60
     runs-on: ubuntu-latest

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   PlaywrightE2ETests:
+    enabled: false
     name: Playwright E2E tests
     timeout-minutes: 60
     runs-on: ubuntu-latest

--- a/assets/js/blocks/attribute-filter/style.scss
+++ b/assets/js/blocks/attribute-filter/style.scss
@@ -16,7 +16,7 @@
 }
 
 .wc-block-attribute-filter {
-	  margin-bottom: $gap;
+	margin-bottom: $gap;
 	border-radius: inherit;
 	border-color: inherit;
 

--- a/assets/js/blocks/attribute-filter/style.scss
+++ b/assets/js/blocks/attribute-filter/style.scss
@@ -16,7 +16,7 @@
 }
 
 .wc-block-attribute-filter {
-	margin-bottom: $gap;
+	  margin-bottom: $gap;
 	border-radius: inherit;
 	border-color: inherit;
 


### PR DESCRIPTION
Temporarily disable Playwright tests as they are consistently failing for now due to conflict with multiple PHP versions setup added in https://github.com/woocommerce/woocommerce-blocks/pull/8757.

Issue: https://github.com/woocommerce/woocommerce-blocks/issues/9170 (that PR doesn't fix the issue, but temporarily disables the job, so the pipelines are green). We don't yet fully rely on the Playwright tests, hence it's safe to do this change until the full migration.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. Go to this PR's [Checks](https://github.com/woocommerce/woocommerce-blocks/pull/9183/checks) tab
2. Find "Playwright Tests" job and click on it
3. It should say "Status: skipped" as on a screenshot below
<img width="121" alt="image" src="https://user-images.githubusercontent.com/20098064/234030939-30e7c6e2-3ff7-4ed7-9269-cf0e528581ee.png">


* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

