### PR TITLE
Mini Cart block: fix slide in animation

### DIFF
--- a/assets/js/base/components/drawer/style.scss
+++ b/assets/js/base/components/drawer/style.scss
@@ -20,7 +20,17 @@ $drawer-animation-duration: 0.3s;
 	}
 
 	to {
-		transform: translateX(var(--neg-drawer-width));
+		transform: translateX(max(-100%, var(--neg-drawer-width)));
+	}
+}
+
+@keyframes rtlslidein {
+	from {
+		transform: translateX(0);
+	}
+
+	to {
+		transform: translateX(min(100%, var(--drawer-width)));
 	}
 }
 
@@ -68,7 +78,7 @@ $drawer-animation-duration: 0.3s;
 }
 
 .rtl .wc-block-components-drawer {
-	transform: translateX(max(100%, var(--drawer-width)));
+	transform: translateX(min(100%, var(--drawer-width)));
 }
 
 .wc-block-components-drawer__screen-overlay--with-slide-out .wc-block-components-drawer {
@@ -78,6 +88,10 @@ $drawer-animation-duration: 0.3s;
 .wc-block-components-drawer__screen-overlay--with-slide-in .wc-block-components-drawer {
 	animation-duration: $drawer-animation-duration;
 	animation-name: slidein;
+}
+
+.rtl .wc-block-components-drawer__screen-overlay--with-slide-in .wc-block-components-drawer {
+	animation-name: rtlslidein;
 }
 
 .wc-block-components-drawer__screen-overlay--is-hidden .wc-block-components-drawer {


### PR DESCRIPTION
Fixes #9194.

### Testing

#### User Facing Testing

1. Add Mini Cart to the Header.
2. Go to the frontend.
3. Add some products to cart.
4. Open Mini Cart.
5. Verify the Mini Cart slides in and animation finishes when the Mini Cart covers viewport.
6. Repeat steps 4 and 5 with a narrow view simulating mobile (<kbd>F12</kbd> and then <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>M</kbd> in Firefox & Chrome).
7. Go to Appearance > Editor > Template parts > Mini Cart and select the Mini Cart Contents block. Set it to a different width than its default and repeat steps 4-6.
8. Switch to a RTL language like Arabic (from Settings > General) and repeat steps 4-7.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
