### PR TITLE
Mini Cart Contents block: set minimum width

### DIFF
--- a/assets/js/blocks/mini-cart/mini-cart-contents/edit.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/edit.tsx
@@ -140,7 +140,13 @@ const Edit = ( {
 								setAttributes( { width: value } );
 							} }
 							onBlur={ ( e: FocusEvent< HTMLInputElement > ) => {
-								if ( Number( e.target.value ) < MIN_WIDTH ) {
+								if ( e.target.value === '' ) {
+									setAttributes( {
+										width: defaultAttributes.width.default,
+									} );
+								} else if (
+									Number( e.target.value ) < MIN_WIDTH
+								) {
 									setAttributes( {
 										width: MIN_WIDTH,
 									} );

--- a/assets/js/blocks/mini-cart/mini-cart-contents/edit.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/edit.tsx
@@ -10,7 +10,7 @@ import {
 import { EditorProvider } from '@woocommerce/base-context';
 import type { TemplateArray } from '@wordpress/blocks';
 import { useEffect } from '@wordpress/element';
-import type { ReactElement } from 'react';
+import type { FocusEvent, ReactElement } from 'react';
 import { __ } from '@wordpress/i18n';
 import {
 	PanelBody,
@@ -31,6 +31,7 @@ const ALLOWED_BLOCKS = [
 	'woocommerce/filled-mini-cart-contents-block',
 	'woocommerce/empty-mini-cart-contents-block',
 ];
+const MIN_WIDTH = 300;
 
 interface Props {
 	clientId: string;
@@ -132,6 +133,13 @@ const Edit = ( {
 					<UnitControl
 						onChange={ ( value ) => {
 							setAttributes( { width: value } );
+						} }
+						onBlur={ ( e: FocusEvent< HTMLInputElement > ) => {
+							if ( Number( e.target.value ) < MIN_WIDTH ) {
+								setAttributes( {
+									width: MIN_WIDTH,
+								} );
+							}
 						} }
 						value={ width }
 						units={ [

--- a/assets/js/blocks/mini-cart/mini-cart-contents/edit.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/edit.tsx
@@ -148,7 +148,7 @@ const Edit = ( {
 									Number( e.target.value ) < MIN_WIDTH
 								) {
 									setAttributes( {
-										width: MIN_WIDTH,
+										width: MIN_WIDTH + 'px',
 									} );
 								}
 							} }

--- a/assets/js/blocks/mini-cart/mini-cart-contents/edit.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/edit.tsx
@@ -8,6 +8,7 @@ import {
 	InspectorControls,
 } from '@wordpress/block-editor';
 import { EditorProvider } from '@woocommerce/base-context';
+import { isFeaturePluginBuild } from '@woocommerce/block-settings';
 import type { TemplateArray } from '@wordpress/blocks';
 import { useEffect } from '@wordpress/element';
 import type { FocusEvent, ReactElement } from 'react';
@@ -125,33 +126,38 @@ const Edit = ( {
 
 	return (
 		<>
-			<InspectorControls key="inspector">
-				<PanelBody
-					title={ __( 'Dimensions', 'woo-gutenberg-products-block' ) }
-					initialOpen
-				>
-					<UnitControl
-						onChange={ ( value ) => {
-							setAttributes( { width: value } );
-						} }
-						onBlur={ ( e: FocusEvent< HTMLInputElement > ) => {
-							if ( Number( e.target.value ) < MIN_WIDTH ) {
-								setAttributes( {
-									width: MIN_WIDTH,
-								} );
-							}
-						} }
-						value={ width }
-						units={ [
-							{
-								value: 'px',
-								label: 'px',
-								default: defaultAttributes.width.default,
-							},
-						] }
-					/>
-				</PanelBody>
-			</InspectorControls>
+			{ isFeaturePluginBuild() && (
+				<InspectorControls key="inspector">
+					<PanelBody
+						title={ __(
+							'Dimensions',
+							'woo-gutenberg-products-block'
+						) }
+						initialOpen
+					>
+						<UnitControl
+							onChange={ ( value ) => {
+								setAttributes( { width: value } );
+							} }
+							onBlur={ ( e: FocusEvent< HTMLInputElement > ) => {
+								if ( Number( e.target.value ) < MIN_WIDTH ) {
+									setAttributes( {
+										width: MIN_WIDTH,
+									} );
+								}
+							} }
+							value={ width }
+							units={ [
+								{
+									value: 'px',
+									label: 'px',
+									default: defaultAttributes.width.default,
+								},
+							] }
+						/>
+					</PanelBody>
+				</InspectorControls>
+			) }
 			<div
 				className="wc-block-components-drawer__screen-overlay"
 				aria-hidden="true"


### PR DESCRIPTION
This PR introduces three changes:

* 697b17c1aaec66e74b2c8f0f93b21d26b57b2f90 sets a minimum width for the Mini Cart Contents block, preventing the user to break the UI setting a width too small. I set it to `300px`, but we can change it if needed.
* 7ae66fb29cbb4e482358dae6f96d6a6524c3edaf hides the width controls under the Feature Plugin flag. I noticed `UnitControl` is an experimental component, so I think it's better to have it only in the feature plugin for now.
* 21e704189f5f1b241ea6a8836334b564fddb9a88 makes it so the default width value is used (instead of the min width value) when leaving the input field empty.

### Testing

#### User Facing Testing

#### Feature plugin testing

1. Go to Appearance > Editor > Template Parts > Mini Cart.
3. Select the Mini Cart Contents block (you can use the List View to find it).
4. In the sidebar, set a custom width lower than 300px.
5. Verify when you move the focus somewhere else, it's set to 300px.
6. Remove the value from the custom width input.
7. Verify it gets resetted to the default (480px).
8. Try setting an allowed value (ie: 350px, 500px, etc.).
9. Verify the value persists.

#### Internal testing

1. Build the plugin as if it was the WC core version (`WOOCOMMERCE_BLOCKS_PHASE=1 npm run build`).
2. Go to Appearance > Editor > Template Parts > Mini Cart.
3. Select the Mini Cart Contents block (you can use the List View to find it).
4. In the sidebar, notice there is no input to set the custom width.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [ ] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental

### Changelog

> Set minimum width for the Mini Cart Contents block.
