### PR TITLE
Mini Cart Contents block: fix wide width not being applied in the editor

### DIFF
--- a/assets/js/blocks/mini-cart/mini-cart-contents/edit.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/edit.tsx
@@ -54,7 +54,7 @@ const Edit = ( {
 		 */
 		style: {
 			minHeight: '100vh',
-			maxWidth: width,
+			width,
 		},
 	} );
 


### PR DESCRIPTION
Fixes #9197.

### Testing

#### User Facing Testing

1. Go to the `Editor`, open the `Header template`, and insert the `Mini Cart` block.
2. Go to the `Editor` > `Template parts` and open the `Mini Cart` template.
3. Open the `List View` and click on the `Mini Cart Contents` block.
4. On the settings sidebar change the `Dimensions` to a wider size (like `9000`) and save.
5. Verify that the change is applied and the Mini Cart Contents block occupies the entire available width.

Before | After
--- | ---
![imatge](https://user-images.githubusercontent.com/3616980/234297598-6863ccaf-2b05-49c2-b7f8-7a135e02d353.png) | ![imatge](https://user-images.githubusercontent.com/3616980/234297459-db30474b-2b39-44bc-988c-f97bd239de61.png)

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [ ] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental

### Changelog

> Make it so wide widths are correctly applied to the Mini Cart Contents block in the editor
