### PR TITLE
Use currentColor for Mini Cart footer border

### DIFF
--- a/assets/js/blocks/mini-cart/style.scss
+++ b/assets/js/blocks/mini-cart/style.scss
@@ -159,7 +159,7 @@ h2.wc-block-mini-cart__title {
 }
 
 .wc-block-mini-cart__footer {
-	border-top: 1px solid $gray-300;
+	@include with-translucent-border( 1px 0 0 );
 	padding: $gap-large $gap;
 
 	.wc-block-components-totals-item.wc-block-mini-cart__footer-subtotal {


### PR DESCRIPTION
### Testing

#### User Facing Testing

1. Go to the Appearance > Editor > Template Parts, open the `Header template`, and insert the `Mini Cart` block.
2. Go to the Appearance > Editor > Template Parts and open the `Mini Cart` template part.
3. Change the text color of the Mini Cart template part to something different than black or gray. For example, set it to red, blue or green.
4. Save it and, in the frontend, open the Mini Cart drawer.
5. Verify the border between the main content of the Mini Cart drawer and the Mini Cart footer follows the text color (it's expected to be a translucent version of that color, similar to the border of the quantity input field of products).

Before | After
--- | ---
![imatge](https://user-images.githubusercontent.com/3616980/234541810-02e0d4e7-1c27-4582-aaeb-dc3562c73660.png) | ![imatge](https://user-images.githubusercontent.com/3616980/234540651-dbbf6747-196d-4b97-87ad-193d62ef6bcb.png)

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Make Mini Cart footer border follow the current text color.
