### PR TITLE
Fix Mini Cart block not respecting Add-to-Cart behaviour attribute when adding the first product

### DIFF
--- a/assets/js/blocks/mini-cart/frontend.ts
+++ b/assets/js/blocks/mini-cart/frontend.ts
@@ -111,7 +111,7 @@ window.addEventListener( 'load', () => {
 			document.body.removeEventListener(
 				'wc-blocks_added_to_cart',
 				// eslint-disable-next-line @typescript-eslint/no-use-before-define
-				openDrawerWithRefresh
+				funcOnAddToCart
 			);
 			document.body.removeEventListener(
 				'wc-blocks_removed_from_cart',
@@ -150,12 +150,17 @@ window.addEventListener( 'load', () => {
 		miniCartButton.addEventListener( 'focus', loadScripts );
 		miniCartButton.addEventListener( 'click', openDrawer );
 
+		const funcOnAddToCart =
+			miniCartBlock.dataset.addToCartBehaviour === 'open_drawer'
+				? openDrawerWithRefresh
+				: loadContentsWithRefresh;
+
 		// There might be more than one Mini Cart block in the page. Make sure
 		// only one opens when adding a product to the cart.
 		if ( i === 0 ) {
 			document.body.addEventListener(
 				'wc-blocks_added_to_cart',
-				openDrawerWithRefresh
+				funcOnAddToCart
 			);
 			document.body.addEventListener(
 				'wc-blocks_removed_from_cart',


### PR DESCRIPTION
Fixes #9255.

### Testing

#### User Facing Testing

1. Go to Appearance > Editor and add the Mini Cart block to the header of your store.
2. Make sure the _Open cart in a drawer_ option is disabled:
![imatge](https://user-images.githubusercontent.com/3616980/234832024-e0cd3be2-ac08-4e73-9590-70b6bcef9b4d.png)
3. Go to the frontend and add a product to your cart from the Shop page.
4. Verify the drawer doesn't open but the Mini Cart value increases.
5. Go back to the site editor and enable the _Open cart in a drawer_ option.
6. Again from the frontend add a product to your cart.
7. Verify now the drawer does open.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix Mini Cart block not respecting Add-to-Cart behaviour attribute when adding the first product
