### PR TITLE
Remove min-height and padding for WP Button elements

### DIFF
--- a/assets/js/base/components/button/style.scss
+++ b/assets/js/base/components/button/style.scss
@@ -57,6 +57,7 @@
 }
 
 body:not(.woocommerce-block-theme-has-button-styles) .wc-block-components-button:not(.is-link) {
+	min-height: 3em;
 
 	&:focus {
 		box-shadow: 0 0 0 2px $studio-blue;

--- a/assets/js/base/components/button/style.scss
+++ b/assets/js/base/components/button/style.scss
@@ -1,7 +1,6 @@
 .wc-block-components-button:not(.is-link) {
 	align-items: center;
 	display: inline-flex;
-	min-height: 3em;
 	height: auto;
 	justify-content: center;
 	text-align: center;
@@ -58,7 +57,6 @@
 }
 
 body:not(.woocommerce-block-theme-has-button-styles) .wc-block-components-button:not(.is-link) {
-	padding: 0 em($gap);
 
 	&:focus {
 		box-shadow: 0 0 0 2px $studio-blue;

--- a/assets/js/blocks/mini-cart/style.scss
+++ b/assets/js/blocks/mini-cart/style.scss
@@ -191,10 +191,6 @@ h2.wc-block-mini-cart__title {
 			display: inline-flex;
 		}
 
-		//a.wc-block-components-button {
-		//	min-height: initial;
-		//}
-
 		.wp-block-woocommerce-mini-cart-cart-button-block {
 			display: none;
 

--- a/assets/js/blocks/mini-cart/style.scss
+++ b/assets/js/blocks/mini-cart/style.scss
@@ -191,6 +191,10 @@ h2.wc-block-mini-cart__title {
 			display: inline-flex;
 		}
 
+		//a.wc-block-components-button {
+		//	min-height: initial;
+		//}
+
 		.wp-block-woocommerce-mini-cart-cart-button-block {
 			display: none;
 


### PR DESCRIPTION
For some reason there was some default styling for `min-height` and `padding` for .`wc-block-components-button` elements.

I'm not sure the context as to why these were added but with my testing I can't see that this PR introduces any obvious regressions around buttons.

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/8587

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

**Before**

| Editor | Front-end |
| ------ | ----- |
| <img width="486" alt="Screenshot 2023-02-28 at 10 41 52" src="https://user-images.githubusercontent.com/186112/221814583-b6cf968b-5b5b-4d70-821b-7667f83aa5f9.png"> | <img width="485" alt="Screenshot 2023-02-28 at 10 41 46" src="https://user-images.githubusercontent.com/186112/221814479-f42ec118-b41e-4372-9ec8-c52a1d927716.png"> |

| Editor | Front-end |
| ------ | ----- |
| <img width="499" alt="Screenshot 2023-03-01 at 10 01 41" src="https://user-images.githubusercontent.com/186112/222092514-201d45e3-88be-47c5-ad9a-58af77f8ef97.png">|<img width="512" alt="Screenshot 2023-03-01 at 10 01 51" src="https://user-images.githubusercontent.com/186112/222092537-fae29747-d360-406c-b0df-35f02a5b78b3.png">|

**After**

| Editor | Frontend |
| ------ | ----- |
| ![Screenshot 2023-04-27 at 12 08 37](https://user-images.githubusercontent.com/8639742/234844843-d68ab22c-dc4d-438c-9e43-01d31a14840a.png) | ![Screenshot 2023-04-27 at 12 09 03](https://user-images.githubusercontent.com/8639742/234844913-30d6d194-251e-4875-82b6-c5e104828195.png) |

| Editor | Frontend |
| ------ | ----- |
|![Screenshot 2023-04-27 at 12 10 34](https://user-images.githubusercontent.com/8639742/234845240-32b16895-9150-40a5-82f9-064b4e5e7292.png)|![Screenshot 2023-04-27 at 12 10 47](https://user-images.githubusercontent.com/8639742/234845279-cb8163a7-187e-4b96-bf41-5dcfe1c379b3.png) |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. Enable TT3 theme with the Aubergine style.
2. Go to the Site Editor and add the mini-cart block to the header and save.
3. Go to the Site Editor and edit the mini-cart template part and save.
4. Check the cart buttons in the editor vs the cart buttons in the front-end are the same.
5. Enable TT3 theme with the Whisper style.
2. Create a new page and add a Single Product and a Checkout block and save.
3. Check the cart buttons in the editor vs the cart buttons in the front-end are the same.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix consistency between editor and frontend button styling.
