### PR TITLE
10.1.0 testing steps: move Mini Cart width items under Feature plugin section

### DIFF
--- a/docs/internal-developers/testing/releases/1010.md
+++ b/docs/internal-developers/testing/releases/1010.md
@@ -253,16 +253,6 @@ Before | After
 --- | ---
 ![imatge](https://user-images.githubusercontent.com/3616980/231437877-8481f0ea-3fbc-4613-a5da-fcb6883c777c.png) | ![imatge](https://user-images.githubusercontent.com/3616980/231442269-0b222db1-8e4a-4d4c-b258-4c4aacc3e730.png)
 
-### Mini cart: allow changing the drawer width ([#8930](https://github.com/woocommerce/woocommerce-blocks/pull/8930))
-
-1. Go to the `Editor`, open the `Header` template, and insert the `Mini Cart` block.
-2. Go to the `Editor > Template parts` and open the `Mini Cart` template.
-3. Open the `List View` and click on the `Mini Cart Contents` block.
-4. In the settings sidebar you should see a new `Dimensions` section with a width selector.
-<img width="292" alt="Screenshot 2023-04-04 at 09 55 09" src="https://user-images.githubusercontent.com/186112/229725817-a5ab4f9d-edaa-4894-9d5b-031e2caaf5f0.png">
-5. Change the width, see the changes are visible on the editor, and save.
-6. Go to the front-end and check the changes are also reflected there.
-
 ### [Mini cart] Make the title customizable ([#8905](https://github.com/woocommerce/woocommerce-blocks/pull/8905))
 
 _**Use Case 1**_
@@ -330,8 +320,20 @@ Mini Cart | Cart
 4. Open Mini Cart.
 5. Verify the Mini Cart slides in and animation finishes when the Mini Cart covers viewport.
 6. Repeat steps 4 and 5 with a narrow view simulating mobile (<kbd>F12</kbd> and then <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>M</kbd> in Firefox & Chrome).
-7. Go to Appearance > Editor > Template parts > Mini Cart and select the Mini Cart Contents block. Set it to a different width than its default and repeat steps 4-6.
+7. (Only do this step if you are testing WC Blocks feature plugin) Go to Appearance > Editor > Template parts > Mini Cart and select the Mini Cart Contents block. Set it to a different width than its default and repeat steps 4-6.
 8. Switch to a RTL language like Arabic (from Settings > General) and repeat steps 4-7.
+
+## Feature plugin
+
+### Mini cart: allow changing the drawer width ([#8930](https://github.com/woocommerce/woocommerce-blocks/pull/8930))
+
+1. Go to the `Editor`, open the `Header` template, and insert the `Mini Cart` block.
+2. Go to the `Editor > Template parts` and open the `Mini Cart` template.
+3. Open the `List View` and click on the `Mini Cart Contents` block.
+4. In the settings sidebar you should see a new `Dimensions` section with a width selector.
+<img width="292" alt="Screenshot 2023-04-04 at 09 55 09" src="https://user-images.githubusercontent.com/186112/229725817-a5ab4f9d-edaa-4894-9d5b-031e2caaf5f0.png">
+5. Change the width, see the changes are visible on the editor, and save.
+6. Go to the front-end and check the changes are also reflected there.
 
 ### Set minimum width for the Mini Cart Contents block ([#9196](https://github.com/woocommerce/woocommerce-blocks/pull/9196))
 


### PR DESCRIPTION
In #9196 we moved the Mini Cart width feature under the Feature plugin flag. This PR updates the testing steps so the ones related to that feature are under the _Feature plugin_ section.

cc @thealexandrelara for awareness.

### Testing

#### User Facing Testing

1. Verify all testing steps related to setting the Mini Cart Contents block width are marked as a _Feature plugin_ feature.
 
* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->
