### PR TITLE
Rename docs which unnecessary mention the All Products block

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -111,7 +111,7 @@ The WooCommerce Blocks Handbook provides documentation for designers and develop
 > Are you a designer? The following documents explain how to apply design-changes to the WooCommerce Blocks plugin.
 
 -   [Theming](designers/theming/README.md)
-    -   [All Products & filters](designers/theming/all-products-and-filters.md)
+    -   [Filter blocks](designers/theming/filter-blocks.md)
     -   [Cart and Checkout](designers/theming/cart-and-checkout.md)
     -   [Class names update in 4.6.0](designers/theming/class-names-update-460.md)
     -   [Class names update in 3.4.0](designers/theming/class-names-update-340.md)

--- a/docs/designers/theming/README.md
+++ b/docs/designers/theming/README.md
@@ -69,7 +69,7 @@ WooCommerce Blocks avoids using legacy unprefixed classes as much as possible. H
 
 ## Blocks
 
--   [All Products & filters](all-products-and-filters.md)
+-   [Filter blocks](filter-blocks.md)
 -   [Cart and Checkout](cart-and-checkout.md)
 
 ## Other docs

--- a/docs/designers/theming/filter-blocks.md
+++ b/docs/designers/theming/filter-blocks.md
@@ -34,7 +34,7 @@ Notice the code snippet above uses a CSS custom property, so the default color m
 
 [We're hiring!](https://woocommerce.com/careers/) Come work with us!
 
-🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-blocks/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/designers/theming/all-products-and-filters.md)
+🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-blocks/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/designers/theming/filter-blocks.md)
 
 <!-- /FEEDBACK -->
 

--- a/docs/designers/theming/filter-blocks.md
+++ b/docs/designers/theming/filter-blocks.md
@@ -1,4 +1,4 @@
-# All Products and filters
+# Filter blocks
 
 ## Price slider accent color
 


### PR DESCRIPTION
We have a documentation page called `All Products and Filters` even though inside it only has docs about the Price Filter block. This PR renames that document to simply `Filter blocks`. The goal is to make it clear that the Filter blocks can be used in other contexts besides the All Products block.

### Testing

#### User Facing Testing

1. Make sure the new document title makes sense.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->
