### PR TITLE
Remove duplicated code in BlockTypesController.php

### DIFF
--- a/src/BlockTypesController.php
+++ b/src/BlockTypesController.php
@@ -242,20 +242,6 @@ final class BlockTypesController {
 		}
 
 		/**
-		 * This disables specific blocks in Widget Areas by not registering them.
-		 */
-		if ( in_array( $pagenow, [ 'widgets.php', 'themes.php', 'customize.php' ], true ) && ( empty( $_GET['page'] ) || 'gutenberg-edit-site' !== $_GET['page'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			$block_types = array_diff(
-				$block_types,
-				[
-					'AllProducts',
-					'Cart',
-					'Checkout',
-				]
-			);
-		}
-
-		/**
 		 * This disables specific blocks in Post and Page editor by not registering them.
 		 */
 		if ( in_array( $pagenow, [ 'post.php', 'post-new.php' ], true ) ) {


### PR DESCRIPTION
While creating https://github.com/woocommerce/woocommerce/issues/42383 I noticed that we have some lines of code duplicated. It was introduced [here](https://github.com/woocommerce/woocommerce-blocks/commit/031141e794daae4dfe2857feff52b528fef40a8b), and I imagine it appeared while fixing some conflicts.

### Testing

#### User Facing Testing

1. Change your theme to a classic theme (ie: Storefront).
2. Go to Appearance > Widgets.
3. Verify the All Products, Cart and Checkout block don't appear in the inserter.

(Note: there is _Cart_ widget which _is_ available in the inserter, you can distinguish it from the block because it doesn't have a trolley icon)

![imatge](https://user-images.githubusercontent.com/3616980/235144478-759ecd4f-63bc-4722-80c1-6ae468e567e0.png)

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
