### PR TITLE
Fix shipping notices for multiple packages

### DIFF
--- a/assets/js/base/components/cart-checkout/shipping-rates-control/index.tsx
+++ b/assets/js/base/components/cart-checkout/shipping-rates-control/index.tsx
@@ -105,8 +105,8 @@ const ShippingRatesControl = ( {
 			) }
 			showSpinner={ true }
 		>
-			<ExperimentalOrderShippingPackages.Slot { ...slotFillProps } />
 			{ hasSelectedLocalPickup &&
+				context === 'woocommerce/cart' &&
 				shippingRates.length > 1 &&
 				! isEditor && (
 					<NoticeBanner
@@ -120,6 +120,7 @@ const ShippingRatesControl = ( {
 						) }
 					</NoticeBanner>
 				) }
+			<ExperimentalOrderShippingPackages.Slot { ...slotFillProps } />
 			<ExperimentalOrderShippingPackages>
 				<Packages
 					packages={ shippingRates }

--- a/assets/js/base/components/cart-checkout/shipping-rates-control/index.tsx
+++ b/assets/js/base/components/cart-checkout/shipping-rates-control/index.tsx
@@ -95,7 +95,14 @@ const ShippingRatesControl = ( {
 		context,
 	};
 	const { isEditor } = useEditorContext();
-	const { hasSelectedLocalPickup } = useShippingData();
+	const { hasSelectedLocalPickup, selectedRates } = useShippingData();
+
+	// Check if all rates selected are the same.
+	const selectedRateIds = Object.values( selectedRates ) as string[];
+	const allPackagesHaveSameRate = selectedRateIds.every( ( rate: string ) => {
+		return rate === selectedRateIds[ 0 ];
+	} );
+
 	return (
 		<LoadingMask
 			isLoading={ isLoadingRates }
@@ -108,6 +115,7 @@ const ShippingRatesControl = ( {
 			{ hasSelectedLocalPickup &&
 				context === 'woocommerce/cart' &&
 				shippingRates.length > 1 &&
+				! allPackagesHaveSameRate &&
 				! isEditor && (
 					<NoticeBanner
 						className="wc-block-components-notice"

--- a/assets/js/base/components/cart-checkout/shipping-rates-control/index.tsx
+++ b/assets/js/base/components/cart-checkout/shipping-rates-control/index.tsx
@@ -15,6 +15,7 @@ import {
 	useShippingData,
 } from '@woocommerce/base-context';
 import NoticeBanner from '@woocommerce/base-components/notice-banner';
+import { isObject } from '@woocommerce/types';
 
 /**
  * Internal dependencies
@@ -98,7 +99,9 @@ const ShippingRatesControl = ( {
 	const { hasSelectedLocalPickup, selectedRates } = useShippingData();
 
 	// Check if all rates selected are the same.
-	const selectedRateIds = Object.values( selectedRates ) as string[];
+	const selectedRateIds = isObject( selectedRates )
+		? ( Object.values( selectedRates ) as string[] )
+		: [];
 	const allPackagesHaveSameRate = selectedRateIds.every( ( rate: string ) => {
 		return rate === selectedRateIds[ 0 ];
 	} );

--- a/assets/js/base/context/hooks/shipping/use-shipping-data.ts
+++ b/assets/js/base/context/hooks/shipping/use-shipping-data.ts
@@ -76,7 +76,7 @@ export const useShippingData = (): ShippingData => {
 	} as {
 		selectShippingRate: (
 			newShippingRateId: string,
-			packageId?: string | number | undefined
+			packageId?: string | number | null
 		) => Promise< unknown >;
 	};
 
@@ -99,11 +99,11 @@ export const useShippingData = (): ShippingData => {
 			 *
 			 * Forces pickup location to be selected for all packages since we don't allow a mix of shipping and pickup.
 			 */
-			if (
-				hasCollectableRate( newShippingRateId.split( ':' )[ 0 ] ) ||
-				hasSelectedLocalPickup
-			) {
-				selectPromise = dispatchSelectShippingRate( newShippingRateId );
+			if ( hasCollectableRate( newShippingRateId.split( ':' )[ 0 ] ) ) {
+				selectPromise = dispatchSelectShippingRate(
+					newShippingRateId,
+					null
+				);
 			} else {
 				selectPromise = dispatchSelectShippingRate(
 					newShippingRateId,

--- a/assets/js/data/cart/actions.ts
+++ b/assets/js/data/cart/actions.ts
@@ -383,7 +383,7 @@ export const changeCartItemQuantity =
  * @param {number | string} [packageId] The key of the packages that we will select within.
  */
 export const selectShippingRate =
-	( rateId: string, packageId = 0 ) =>
+	( rateId: string, packageId: number | null = null ) =>
 	async ( {
 		dispatch,
 		select,

--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -1,10 +1,6 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
-use Automattic\WooCommerce\Blocks\Package;
-use Automattic\WooCommerce\Blocks\Assets;
-use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
-
 /**
  * Cart class.
  *
@@ -203,6 +199,9 @@ class Cart extends AbstractBlock {
 		$this->asset_data_registry->add( 'shippingEnabled', wc_shipping_enabled(), true );
 		$this->asset_data_registry->add( 'hasDarkEditorStyleSupport', current_theme_supports( 'dark-editor-style' ), true );
 		$this->asset_data_registry->register_page_id( isset( $attributes['checkoutPageId'] ) ? $attributes['checkoutPageId'] : 0 );
+
+		$pickup_location_settings = get_option( 'woocommerce_pickup_location_settings', [] );
+		$this->asset_data_registry->add( 'localPickupEnabled', wc_string_to_bool( $pickup_location_settings['enabled'] ?? 'no' ), true );
 
 		// Hydrate the following data depending on admin or frontend context.
 		if ( ! is_admin() && ! WC()->is_rest_api_request() ) {

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -1,7 +1,6 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
-use Automattic\WooCommerce\Blocks\Package;
 use Automattic\WooCommerce\StoreApi\Utilities\LocalPickupUtils;
 
 /**
@@ -261,9 +260,7 @@ class Checkout extends AbstractBlock {
 		$this->asset_data_registry->register_page_id( isset( $attributes['cartPageId'] ) ? $attributes['cartPageId'] : 0 );
 
 		$pickup_location_settings = get_option( 'woocommerce_pickup_location_settings', [] );
-		$local_pickup_enabled     = wc_string_to_bool( $pickup_location_settings['enabled'] ?? 'no' );
-
-		$this->asset_data_registry->add( 'localPickupEnabled', $local_pickup_enabled, true );
+		$this->asset_data_registry->add( 'localPickupEnabled', wc_string_to_bool( $pickup_location_settings['enabled'] ?? 'no' ), true );
 
 		$is_block_editor = $this->is_block_editor();
 

--- a/src/StoreApi/Routes/V1/CartSelectShippingRate.php
+++ b/src/StoreApi/Routes/V1/CartSelectShippingRate.php
@@ -37,7 +37,7 @@ class CartSelectShippingRate extends AbstractCartRoute {
 				'args'                => [
 					'package_id' => array(
 						'description' => __( 'The ID of the package being shipped. Leave blank to apply to all packages.', 'woo-gutenberg-products-block' ),
-						'type'        => [ 'integer', 'string' ],
+						'type'        => [ 'integer', 'string', 'null' ],
 						'required'    => false,
 					),
 					'rate_id'    => [


### PR DESCRIPTION
Resolves 2 issues with the multiple packages notice:

1. It was no longer rendered on the cart page (missing a setting)
2. It was displayed briefly on the checkout page when switching between local pickup and shipping

Fixes #9239

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

- Enable “Multiple Packages for WooCommerce” extension.
- Go to WooCommerce > Settings > Multiple packages
- Select "group by" product, then save changes.
- Add several items to your cart.
- Go to the cart page, toggle open a package section, and choose “local pickup”
- Toggle open another package and choose something other than "local pickup"
- See the “Multiple shipments must have the same pickup location” notice above the packages
- Go to the checkout page
- Choose "shipping" in the shipping method block
- Quickly look at the shipping section below and ensure no notice was visible

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix shipping notices when cart contains multiple packages
