### PR TITLE
Single Product Template - Related Products: fix items per page option

### DIFF
--- a/src/BlockTypes/RelatedProducts.php
+++ b/src/BlockTypes/RelatedProducts.php
@@ -93,9 +93,10 @@ class RelatedProducts extends AbstractBlock {
 		}
 
 		return array(
-			'post_type'   => 'product',
-			'post__in'    => $related_products_ids,
-			'post_status' => 'publish',
+			'post_type'      => 'product',
+			'post__in'       => $related_products_ids,
+			'post_status'    => 'publish',
+			'posts_per_page' => $query['posts_per_page'],
 		);
 	}
 


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 57a4e90</samp>

### Summary
🛠️📄🔢

<!--
1.  🛠️ - This emoji represents a tool or a fix, and it can be used to indicate that the `build_query` function was modified or improved to add a new feature or functionality.
2.  📄 - This emoji represents a document or a page, and it can be used to indicate that the `posts_per_page` parameter affects the output of the block on the editor and the frontend, where the related products are displayed.
3.  🔢 - This emoji represents numbers or digits, and it can be used to indicate that the `posts_per_page` parameter controls the number of related products to show, which is a numerical value.
-->
Added `posts_per_page` parameter to `RelatedProducts` block query. This lets users control the number of related products displayed in the block.

### Walkthrough
*  Add `posts_per_page` parameter to the query array returned by `build_query` function in `RelatedProducts` class ([link](https://github.com/woocommerce/woocommerce-blocks/pull/9286/files?diff=unified&w=0#diff-09d3eb8f54af4a481bb7bca86049dbf47e5165da48cb0310a02a37076e89518eL96-R99)). This allows the block to display the user's chosen number of related products in the editor and the frontend.




<!-- Reference any related issues or PRs here -->

Fixes #9122

### Testing


#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Edit the Single Product Template.
2. Click on the button `Upgrade to Blockified Single Product template`.
3. Focus the `Related Products Controls` block.
4. Change the option `Items per Page`, for example put 1. (check the image below)
5. Save the template.
6. Visit a Product and be sure that the Related Products block shows the number of products that you selected before. (if you select a high number, there is the risk that there will be displayed fewer products. It is not a bug, but it means that aren't so many related products).

![image](https://user-images.githubusercontent.com/4463174/235158040-5ba081c4-1635-4fb9-8ab2-b7e3ce8aacc7.png)


* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Single Product Template - Related Products: fix items per page option.
