### PR TITLE
Product Image Gallery: fix inline 

### DIFF
--- a/assets/js/atomic/blocks/product-elements/product-image-gallery/style.scss
+++ b/assets/js/atomic/blocks/product-elements/product-image-gallery/style.scss
@@ -1,5 +1,7 @@
 .woocommerce .wp-block-woocommerce-product-image-gallery {
 	position: relative;
+	// This is necessary to calculate the correct width of the gallery. https://www.lockedownseo.com/parent-div-100-height-child-floated-elements/#:~:text=Solution%20%232%3A%20Float%20Parent%20Container
+	clear: both;
 
 	span.onsale {
 		right: unset;
@@ -8,6 +10,15 @@
 	}
 }
 
+// This is necessary to calculate the correct width of the gallery. https://www.lockedownseo.com/parent-div-100-height-child-floated-elements/#:~:text=Solution%20%232%3A%20Float%20Parent%20Container
+.woocommerce .wp-block-woocommerce-product-image-gallery::after {
+	clear: both;
+	content: "";
+	display: table;
+}
+
+
 .woocommerce .wp-block-woocommerce-product-image-gallery .woocommerce-product-gallery.images {
 	width: initial;
 }
+


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

On the front end, the Product Image Gallery block renders inline with other blocks, even if the block takes the full width of the row in the Site Editor. The reason is that the parent div doesn't have height because the content inside it is floated. Floated elements are ignored when calculating the height of their parent. 

This can be fixed in [different ways](https://www.lockedownseo.com/parent-div-100-height-child-floated-elements/).

The solution via the `overflow:hidden` caused an issue with the on-sale badge (it was cut), so I used the second approach.



<!-- Reference any related issues or PRs here -->

Fixes #9000 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|![image](https://user-images.githubusercontent.com/4463174/235434939-74d096e8-d56a-4082-9675-499c419236e9.png)|![image](https://user-images.githubusercontent.com/4463174/235435119-2cef77b1-34c6-4d09-a3f2-3138c807555e.png)|

### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Edit the Single Product Template.
2. Switch to the blockified version.
3. Move the Product Image Gallery before the block `Store breadcrumbs`.
4. Save.
5. Visit a product page.
6. Be sure that the Product Image Gallery isn't displayed inline. 

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Product Image Gallery: fix the inline displayed issue.
