### PR TITLE
Add an endpoint for processing pay for order orders

### DIFF
--- a/src/StoreApi/Routes/V1/CheckoutOrder.php
+++ b/src/StoreApi/Routes/V1/CheckoutOrder.php
@@ -1,0 +1,442 @@
+<?php
+namespace Automattic\WooCommerce\StoreApi\Routes\V1;
+
+use Automattic\WooCommerce\StoreApi\Payments\PaymentContext;
+use Automattic\WooCommerce\StoreApi\Payments\PaymentResult;
+use Automattic\WooCommerce\StoreApi\Exceptions\InvalidStockLevelsInCartException;
+use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
+
+/**
+ * CheckoutOrder class.
+ */
+class CheckoutOrder extends AbstractCartRoute {
+
+	/**
+	 * The route identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'checkout-order';
+
+	/**
+	 * The routes schema.
+	 *
+	 * @var string
+	 */
+	const SCHEMA_TYPE = 'checkout-order';
+
+	/**
+	 * Holds the current order being processed.
+	 *
+	 * @var \WC_Order
+	 */
+	private $order = null;
+
+	/**
+	 * Get the path of this REST route.
+	 *
+	 * @return string
+	 */
+	public function get_path() {
+		return '/checkout/(?P<id>[\d]+)';
+	}
+
+	/**
+	 * Checks if a nonce is required for the route.
+	 *
+	 * @param \WP_REST_Request $request Request.
+	 * @return bool
+	 */
+	protected function requires_nonce( \WP_REST_Request $request ) {
+		return true;
+	}
+
+	/**
+	 * Check if authorized to get the order.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 * @return boolean|WP_Error
+	 */
+	public function is_authorized( \WP_REST_Request $request ) {
+		$order_id    = absint( $request['id'] );
+		$order_key   = wc_clean( wp_unslash( $request->get_param( 'key' ) ) );
+		$user_id     = get_current_user_id();
+		$this->order = $this->order_controller->get_order( $order_id );
+
+		if ( $user_id !== $this->order->get_user_id() ) {
+			return false;
+		}
+
+		try {
+			$this->order_controller->validate_order_key( $order_id, $order_key );
+		} catch ( RouteException $error ) {
+			return new \WP_Error(
+				$error->getErrorCode(),
+				$error->getMessage(),
+				array( 'status' => $error->getCode() )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get method arguments for this REST route.
+	 *
+	 * @return array An array of endpoints.
+	 */
+	public function get_args() {
+		return [
+			[
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => [ $this, 'is_authorized' ],
+				'args'                => array_merge(
+					[
+						'payment_data' => [
+							'description' => __( 'Data to pass through to the payment method when processing payment.', 'woo-gutenberg-products-block' ),
+							'type'        => 'array',
+							'items'       => [
+								'type'       => 'object',
+								'properties' => [
+									'key'   => [
+										'type' => 'string',
+									],
+									'value' => [
+										'type' => [ 'string', 'boolean' ],
+									],
+								],
+							],
+						],
+					],
+					$this->schema->get_endpoint_args_for_item_schema( \WP_REST_Server::CREATABLE )
+				),
+			],
+			'schema'      => [ $this->schema, 'get_public_item_schema' ],
+			'allow_batch' => [ 'v1' => true ],
+		];
+	}
+
+	/**
+	 * Prepare a single item for response. Handles setting the status based on the payment result.
+	 *
+	 * @param mixed            $item Item to format to schema.
+	 * @param \WP_REST_Request $request Request object.
+	 * @return \WP_REST_Response $response Response data.
+	 */
+	public function prepare_item_for_response( $item, \WP_REST_Request $request ) {
+		$response     = parent::prepare_item_for_response( $item, $request );
+		$status_codes = [
+			'success' => 200,
+			'pending' => 202,
+			'failure' => 400,
+			'error'   => 500,
+		];
+
+		if ( isset( $item->payment_result ) && $item->payment_result instanceof PaymentResult ) {
+			$response->set_status( $status_codes[ $item->payment_result->status ] ?? 200 );
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Process an order.
+	 *
+	 * 1. Process Request
+	 * 2. Process Customer
+	 * 3. Validate Order
+	 * 4. Process Payment
+	 *
+	 * @throws RouteException On error.
+	 * @throws InvalidStockLevelsInCartException On error.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	protected function get_route_post_response( \WP_REST_Request $request ) {
+		/**
+		 * Process request data.
+		 *
+		 * Note: Customer data is persisted from the request first so that OrderController::update_addresses_from_cart
+		 * uses the up to date customer address.
+		 */
+		$this->update_customer_from_request( $request );
+		$this->update_order_from_request( $request );
+
+		/**
+		 * Process customer data.
+		 *
+		 * Update order with customer details, and sign up a user account as necessary.
+		 */
+		$this->process_customer( $request );
+
+		/**
+		 * Validate order.
+		 *
+		 * This logic ensures the order is valid before payment is attempted.
+		 */
+		$this->order_controller->validate_order_before_payment( $this->order );
+
+		/**
+		 * Fires before an order is processed by the Checkout Block/Store API.
+		 *
+		 * This hook informs extensions that $order has completed processing and is ready for payment.
+		 *
+		 * This is similar to existing core hook woocommerce_checkout_order_processed. We're using a new action:
+		 * - To keep the interface focused (only pass $order, not passing request data).
+		 * - This also explicitly indicates these orders are from checkout block/StoreAPI.
+		 *
+		 * @since 7.2.0
+		 *
+		 * @see https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3238
+		 * @example See docs/examples/checkout-order-processed.md
+
+		 * @param \WC_Order $order Order object.
+		 */
+		do_action( 'woocommerce_store_api_checkout_order_processed', $this->order );
+
+		/**
+		 * Process the payment and return the results.
+		 */
+		$payment_result = new PaymentResult();
+
+		if ( $this->order->needs_payment() ) {
+			$this->process_payment( $request, $payment_result );
+		} else {
+			$this->process_without_payment( $request, $payment_result );
+		}
+
+		return $this->prepare_item_for_response(
+			(object) [
+				'order'          => wc_get_order( $this->order ),
+				'payment_result' => $payment_result,
+			],
+			$request
+		);
+	}
+
+	/**
+	 * Updates the current customer session using data from the request (e.g. address data).
+	 *
+	 * Address session data is synced to the order itself later on by OrderController::update_order_from_cart()
+	 *
+	 * @param \WP_REST_Request $request Full details about the request.
+	 */
+	private function update_customer_from_request( \WP_REST_Request $request ) {
+		$customer = wc()->customer;
+
+		// Billing address is a required field.
+		foreach ( $request['billing_address'] as $key => $value ) {
+			if ( is_callable( [ $customer, "set_billing_$key" ] ) ) {
+				$customer->{"set_billing_$key"}( $value );
+			}
+		}
+
+		// If shipping address (optional field) was not provided, set it to the given billing address (required field).
+		$shipping_address_values = $request['shipping_address'] ?? $request['billing_address'];
+
+		foreach ( $shipping_address_values as $key => $value ) {
+			if ( is_callable( [ $customer, "set_shipping_$key" ] ) ) {
+				$customer->{"set_shipping_$key"}( $value );
+			} elseif ( 'phone' === $key ) {
+				$customer->update_meta_data( 'shipping_phone', $value );
+			}
+		}
+
+		/**
+		 * Fires when the Checkout Block/Store API updates a customer from the API request data.
+		 *
+		 * @since 8.2.0
+		 *
+		 * @param \WC_Customer $customer Customer object.
+		 * @param \WP_REST_Request $request Full details about the request.
+		 */
+		do_action( 'woocommerce_store_api_checkout_update_customer_from_request', $customer, $request );
+
+		$customer->save();
+	}
+
+	/**
+	 * Update the current order using the posted values from the request.
+	 *
+	 * @param \WP_REST_Request $request Full details about the request.
+	 */
+	private function update_order_from_request( \WP_REST_Request $request ) {
+		$this->order->set_customer_note( $request['customer_note'] ?? '' );
+		$this->order->set_payment_method( $this->get_request_payment_method_id( $request ) );
+
+		wc_do_deprecated_action(
+			'__experimental_woocommerce_blocks_checkout_update_order_from_request',
+			array(
+				$this->order,
+				$request,
+			),
+			'6.3.0',
+			'woocommerce_store_api_checkout_update_order_from_request',
+			'This action was deprecated in WooCommerce Blocks version 6.3.0. Please use woocommerce_store_api_checkout_update_order_from_request instead.'
+		);
+
+		wc_do_deprecated_action(
+			'woocommerce_blocks_checkout_update_order_from_request',
+			array(
+				$this->order,
+				$request,
+			),
+			'7.2.0',
+			'woocommerce_store_api_checkout_update_order_from_request',
+			'This action was deprecated in WooCommerce Blocks version 7.2.0. Please use woocommerce_store_api_checkout_update_order_from_request instead.'
+		);
+
+		/**
+		 * Fires when the Checkout Block/Store API updates an order's from the API request data.
+		 *
+		 * This hook gives extensions the chance to update orders based on the data in the request. This can be used in
+		 * conjunction with the ExtendSchema class to post custom data and then process it.
+		 *
+		 * @since 7.2.0
+		 *
+		 * @param \WC_Order $order Order object.
+		 * @param \WP_REST_Request $request Full details about the request.
+		 */
+		do_action( 'woocommerce_store_api_checkout_update_order_from_request', $this->order, $request );
+
+		$this->order->save();
+	}
+
+	/**
+	 * For orders which do not require payment, just update status.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 * @param PaymentResult    $payment_result Payment result object.
+	 */
+	private function process_without_payment( \WP_REST_Request $request, PaymentResult $payment_result ) {
+		// Transition the order to pending, and then completed. This ensures transactional emails fire for pending_to_complete events.
+		$this->order->update_status( 'pending' );
+		$this->order->payment_complete();
+
+		// Mark the payment as successful.
+		$payment_result->set_status( 'success' );
+		$payment_result->set_redirect_url( $this->order->get_checkout_order_received_url() );
+	}
+
+	/**
+	 * Fires an action hook instructing active payment gateways to process the payment for an order and provide a result.
+	 *
+	 * @throws RouteException On error.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 * @param PaymentResult    $payment_result Payment result object.
+	 */
+	private function process_payment( \WP_REST_Request $request, PaymentResult $payment_result ) {
+		try {
+			// Transition the order to pending before making payment.
+			$this->order->update_status( 'pending' );
+
+			// Prepare the payment context object to pass through payment hooks.
+			$context = new PaymentContext();
+			$context->set_payment_method( $this->get_request_payment_method_id( $request ) );
+			$context->set_payment_data( $this->get_request_payment_data( $request ) );
+			$context->set_order( $this->order );
+
+			/**
+			 * Process payment with context.
+			 *
+			 * @hook woocommerce_rest_checkout_process_payment_with_context
+			 *
+			 * @throws \Exception If there is an error taking payment, an \Exception object can be thrown with an error message.
+			 *
+			 * @param PaymentContext $context        Holds context for the payment, including order ID and payment method.
+			 * @param PaymentResult  $payment_result Result object for the transaction.
+			 */
+			do_action_ref_array( 'woocommerce_rest_checkout_process_payment_with_context', [ $context, &$payment_result ] );
+
+			if ( ! $payment_result instanceof PaymentResult ) {
+				throw new RouteException( 'woocommerce_rest_checkout_invalid_payment_result', __( 'Invalid payment result received from payment method.', 'woo-gutenberg-products-block' ), 500 );
+			}
+		} catch ( \Exception $e ) {
+			throw new RouteException( 'woocommerce_rest_checkout_process_payment_error', $e->getMessage(), 402 );
+		}
+	}
+
+	/**
+	 * Gets the chosen payment method ID from the request.
+	 *
+	 * @throws RouteException On error.
+	 * @param \WP_REST_Request $request Request object.
+	 * @return string
+	 */
+	private function get_request_payment_method_id( \WP_REST_Request $request ) {
+		$payment_method = $this->get_request_payment_method( $request );
+		return is_null( $payment_method ) ? '' : $payment_method->id;
+	}
+
+	/**
+	 * Gets the chosen payment method from the request.
+	 *
+	 * @throws RouteException On error.
+	 * @param \WP_REST_Request $request Request object.
+	 * @return \WC_Payment_Gateway|null
+	 */
+	private function get_request_payment_method( \WP_REST_Request $request ) {
+		$available_gateways      = WC()->payment_gateways->get_available_payment_gateways();
+		$request_payment_method  = wc_clean( wp_unslash( $request['payment_method'] ?? '' ) );
+		$requires_payment_method = $this->order->needs_payment();
+
+		if ( empty( $request_payment_method ) ) {
+			if ( $requires_payment_method ) {
+				throw new RouteException(
+					'woocommerce_rest_checkout_missing_payment_method',
+					__( 'No payment method provided.', 'woo-gutenberg-products-block' ),
+					400
+				);
+			}
+			return null;
+		}
+
+		if ( ! isset( $available_gateways[ $request_payment_method ] ) ) {
+			throw new RouteException(
+				'woocommerce_rest_checkout_payment_method_disabled',
+				sprintf(
+					// Translators: %s Payment method ID.
+					__( 'The %s payment gateway is not available.', 'woo-gutenberg-products-block' ),
+					esc_html( $request_payment_method )
+				),
+				400
+			);
+		}
+
+		return $available_gateways[ $request_payment_method ];
+	}
+
+	/**
+	 * Gets and formats payment request data.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 * @return array
+	 */
+	private function get_request_payment_data( \WP_REST_Request $request ) {
+		static $payment_data = [];
+		if ( ! empty( $payment_data ) ) {
+			return $payment_data;
+		}
+		if ( ! empty( $request['payment_data'] ) ) {
+			foreach ( $request['payment_data'] as $data ) {
+				$payment_data[ sanitize_key( $data['key'] ) ] = wc_clean( $data['value'] );
+			}
+		}
+
+		return $payment_data;
+	}
+
+	/**
+	 * Updates the order with user details (e.g. address).
+	 *
+	 * @throws RouteException API error object with error details.
+	 * @param \WP_REST_Request $request Request object.
+	 */
+	private function process_customer( \WP_REST_Request $request ) {
+		$this->order_controller->sync_customer_data_with_order( $this->order );
+	}
+}

--- a/src/StoreApi/Routes/V1/Order.php
+++ b/src/StoreApi/Routes/V1/Order.php
@@ -80,6 +80,12 @@ class Order extends AbstractRoute {
 	public function is_authorized( \WP_REST_Request $request ) {
 		$order_id  = absint( $request['id'] );
 		$order_key = wc_clean( wp_unslash( $request->get_param( 'key' ) ) );
+		$user_id   = get_current_user_id();
+		$order     = wc_get_order( $order_id );
+
+		if ( $user_id !== $order->get_user_id() ) {
+			return false;
+		}
 
 		try {
 			$this->order_controller->validate_order_key( $order_id, $order_key );

--- a/src/StoreApi/Routes/V1/Order.php
+++ b/src/StoreApi/Routes/V1/Order.php
@@ -4,6 +4,7 @@ namespace Automattic\WooCommerce\StoreApi\Routes\V1;
 use Automattic\WooCommerce\StoreApi\SchemaController;
 use Automattic\WooCommerce\StoreApi\Schemas\v1\AbstractSchema;
 use Automattic\WooCommerce\StoreApi\Utilities\OrderController;
+use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
 
 /**
  * Order class.
@@ -79,93 +80,15 @@ class Order extends AbstractRoute {
 	public function is_authorized( \WP_REST_Request $request ) {
 		$order_id  = absint( $request['id'] );
 		$order_key = wc_clean( wp_unslash( $request->get_param( 'key' ) ) );
-		$order     = $this->order_controller->get_order( $order_id );
 
-		if ( ! $order || $order->get_id() !== $order_id || ! hash_equals( $order->get_order_key(), $order_key ) ) {
-			return new \WP_Error( 'invalid_order', __( 'Sorry, this order is invalid and cannot be paid for.', 'woo-gutenberg-products-block' ), array( 'status' => 401 ) );
-		}
-
-		// Logged out customer does not have permission to pay for this order.
-		if ( ! current_user_can( 'pay_for_order', $order_id ) && ! is_user_logged_in() ) {
-			return new \WP_Error( 'invalid_user', __( 'Please log in to your account below to continue to the payment form.', 'woo-gutenberg-products-block' ), array( 'status' => 403 ) );
-		}
-
-		// Logged in customer trying to pay for someone else's order.
-		if ( ! current_user_can( 'pay_for_order', $order_id ) ) {
-			return new \WP_Error( 'invalid_user', __( 'This order cannot be paid for. Please contact us if you need assistance.', 'woo-gutenberg-products-block' ), array( 'status' => 403 ) );
-		}
-
-		// Does not need payment.
-		if ( ! $order->needs_payment() ) {
-			/* translators: %s: order status */
-			return new \WP_Error( '@Todo', sprintf( __( 'This order&rsquo;s status is &ldquo;%s&rdquo;&mdash;it cannot be paid for. Please contact us if you need assistance.', 'woo-gutenberg-products-block' ), wc_get_order_status_name( $order->get_status() ) ), array( 'status' => 403 ) );
-		}
-
-		// Ensure order items are still stocked if paying for a failed order. Pending orders do not need this check because stock is held.
-		if ( ! $order->has_status( wc_get_is_pending_statuses() ) ) {
-			$quantities = array();
-
-			foreach ( $order->get_items() as $item_key => $item ) {
-				if ( $item && is_callable( array( $item, 'get_product' ) ) ) {
-					$product = $item->get_product();
-
-					if ( ! $product ) {
-						continue;
-					}
-
-					$quantities[ $product->get_stock_managed_by_id() ] = isset( $quantities[ $product->get_stock_managed_by_id() ] ) ? $quantities[ $product->get_stock_managed_by_id() ] + $item->get_quantity() : $item->get_quantity();
-				}
-			}
-
-			// Stock levels may already have been adjusted for this order (in which case we don't need to worry about checking for low stock).
-			if ( ! $order->get_data_store()->get_stock_reduced( $order->get_id() ) ) {
-				foreach ( $order->get_items() as $item_key => $item ) {
-					if ( $item && is_callable( array( $item, 'get_product' ) ) ) {
-						$product = $item->get_product();
-
-						if ( ! $product ) {
-							continue;
-						}
-
-						/**
-						 * Filters whether or not the product is in stock for this pay for order.
-						 *
-						 * @param boolean True if in stock.
-						 * @param \WC_Product $product Product.
-						 * @param \WC_Order $order Order.
-						 *
-						 * @since 9.8.0-dev
-						 */
-						if ( ! apply_filters( 'woocommerce_pay_order_product_in_stock', $product->is_in_stock(), $product, $order ) ) {
-							/* translators: %s: product name */
-							return new \WP_Error( '@Todo', sprintf( __( 'Sorry, "%s" is no longer in stock so this order cannot be paid for. We apologize for any inconvenience caused.', 'woo-gutenberg-products-block' ), $product->get_name() ), array( 'status' => 403 ) );
-						}
-
-						// We only need to check products managing stock, with a limited stock qty.
-						if ( ! $product->managing_stock() || $product->backorders_allowed() ) {
-							continue;
-						}
-
-						// Check stock based on all items in the cart and consider any held stock within pending orders.
-						$held_stock     = wc_get_held_stock_quantity( $product, $order->get_id() );
-						$required_stock = $quantities[ $product->get_stock_managed_by_id() ];
-
-						/**
-						 * Filters whether or not the product has enough stock.
-						 *
-						 * @param boolean True if has enough stock.
-						 * @param \WC_Product $product Product.
-						 * @param \WC_Order $order Order.
-						 *
-						 * @since 9.8.0-dev
-						 */
-						if ( ! apply_filters( 'woocommerce_pay_order_product_has_enough_stock', ( $product->get_stock_quantity() >= ( $held_stock + $required_stock ) ), $product, $order ) ) {
-							/* translators: 1: product name 2: quantity in stock */
-							return new \WP_Error( '@Todo', sprintf( __( 'Sorry, we do not have enough "%1$s" in stock to fulfill your order (%2$s available). We apologize for any inconvenience caused.', 'woo-gutenberg-products-block' ), $product->get_name(), wc_format_stock_quantity_for_display( $product->get_stock_quantity() - $held_stock, $product ) ), array( 'status' => 403 ) );
-						}
-					}
-				}
-			}
+		try {
+			$this->order_controller->validate_order_key( $order_id, $order_key );
+		} catch ( RouteException $error ) {
+			return new \WP_Error(
+				$error->getErrorCode(),
+				$error->getMessage(),
+				array( 'status' => $error->getCode() )
+			);
 		}
 
 		return true;

--- a/src/StoreApi/Routes/V1/Order.php
+++ b/src/StoreApi/Routes/V1/Order.php
@@ -61,13 +61,114 @@ class Order extends AbstractRoute {
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'get_response' ],
-				'permission_callback' => '__return_true', // @Todo check authorization - order id and key.
+				'permission_callback' => [ $this, 'is_authorized' ],
 				'args'                => [
 					'context' => $this->get_context_param( [ 'default' => 'view' ] ),
 				],
 			],
 			'schema' => [ $this->schema, 'get_public_item_schema' ],
 		];
+	}
+
+	/**
+	 * Check if authorized to get the order.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 * @return boolean|WP_Error
+	 */
+	public function is_authorized( \WP_REST_Request $request ) {
+		$order_id  = absint( $request['id'] );
+		$order_key = wc_clean( wp_unslash( $request->get_param( 'key' ) ) );
+		$order     = $this->order_controller->get_order( $order_id );
+
+		if ( ! $order || $order->get_id() !== $order_id || ! hash_equals( $order->get_order_key(), $order_key ) ) {
+			return new \WP_Error( 'invalid_order', __( 'Sorry, this order is invalid and cannot be paid for.', 'woo-gutenberg-products-block' ), array( 'status' => 401 ) );
+		}
+
+		// Logged out customer does not have permission to pay for this order.
+		if ( ! current_user_can( 'pay_for_order', $order_id ) && ! is_user_logged_in() ) {
+			return new \WP_Error( 'invalid_user', __( 'Please log in to your account below to continue to the payment form.', 'woo-gutenberg-products-block' ), array( 'status' => 403 ) );
+		}
+
+		// Logged in customer trying to pay for someone else's order.
+		if ( ! current_user_can( 'pay_for_order', $order_id ) ) {
+			return new \WP_Error( 'invalid_user', __( 'This order cannot be paid for. Please contact us if you need assistance.', 'woo-gutenberg-products-block' ), array( 'status' => 403 ) );
+		}
+
+		// Does not need payment.
+		if ( ! $order->needs_payment() ) {
+			/* translators: %s: order status */
+			return new \WP_Error( '@Todo', sprintf( __( 'This order&rsquo;s status is &ldquo;%s&rdquo;&mdash;it cannot be paid for. Please contact us if you need assistance.', 'woo-gutenberg-products-block' ), wc_get_order_status_name( $order->get_status() ) ), array( 'status' => 403 ) );
+		}
+
+		// Ensure order items are still stocked if paying for a failed order. Pending orders do not need this check because stock is held.
+		if ( ! $order->has_status( wc_get_is_pending_statuses() ) ) {
+			$quantities = array();
+
+			foreach ( $order->get_items() as $item_key => $item ) {
+				if ( $item && is_callable( array( $item, 'get_product' ) ) ) {
+					$product = $item->get_product();
+
+					if ( ! $product ) {
+						continue;
+					}
+
+					$quantities[ $product->get_stock_managed_by_id() ] = isset( $quantities[ $product->get_stock_managed_by_id() ] ) ? $quantities[ $product->get_stock_managed_by_id() ] + $item->get_quantity() : $item->get_quantity();
+				}
+			}
+
+			// Stock levels may already have been adjusted for this order (in which case we don't need to worry about checking for low stock).
+			if ( ! $order->get_data_store()->get_stock_reduced( $order->get_id() ) ) {
+				foreach ( $order->get_items() as $item_key => $item ) {
+					if ( $item && is_callable( array( $item, 'get_product' ) ) ) {
+						$product = $item->get_product();
+
+						if ( ! $product ) {
+							continue;
+						}
+
+						/**
+						 * Filters whether or not the product is in stock for this pay for order.
+						 *
+						 * @param boolean True if in stock.
+						 * @param \WC_Product $product Product.
+						 * @param \WC_Order $order Order.
+						 *
+						 * @since 9.8.0-dev
+						 */
+						if ( ! apply_filters( 'woocommerce_pay_order_product_in_stock', $product->is_in_stock(), $product, $order ) ) {
+							/* translators: %s: product name */
+							return new \WP_Error( '@Todo', sprintf( __( 'Sorry, "%s" is no longer in stock so this order cannot be paid for. We apologize for any inconvenience caused.', 'woo-gutenberg-products-block' ), $product->get_name() ), array( 'status' => 403 ) );
+						}
+
+						// We only need to check products managing stock, with a limited stock qty.
+						if ( ! $product->managing_stock() || $product->backorders_allowed() ) {
+							continue;
+						}
+
+						// Check stock based on all items in the cart and consider any held stock within pending orders.
+						$held_stock     = wc_get_held_stock_quantity( $product, $order->get_id() );
+						$required_stock = $quantities[ $product->get_stock_managed_by_id() ];
+
+						/**
+						 * Filters whether or not the product has enough stock.
+						 *
+						 * @param boolean True if has enough stock.
+						 * @param \WC_Product $product Product.
+						 * @param \WC_Order $order Order.
+						 *
+						 * @since 9.8.0-dev
+						 */
+						if ( ! apply_filters( 'woocommerce_pay_order_product_has_enough_stock', ( $product->get_stock_quantity() >= ( $held_stock + $required_stock ) ), $product, $order ) ) {
+							/* translators: 1: product name 2: quantity in stock */
+							return new \WP_Error( '@Todo', sprintf( __( 'Sorry, we do not have enough "%1$s" in stock to fulfill your order (%2$s available). We apologize for any inconvenience caused.', 'woo-gutenberg-products-block' ), $product->get_name(), wc_format_stock_quantity_for_display( $product->get_stock_quantity() - $held_stock, $product ) ), array( 'status' => 403 ) );
+						}
+					}
+				}
+			}
+		}
+
+		return true;
 	}
 
 	/**

--- a/src/StoreApi/Routes/V1/Order.php
+++ b/src/StoreApi/Routes/V1/Order.php
@@ -1,0 +1,83 @@
+<?php
+namespace Automattic\WooCommerce\StoreApi\Routes\V1;
+
+use Automattic\WooCommerce\StoreApi\SchemaController;
+use Automattic\WooCommerce\StoreApi\Schemas\v1\AbstractSchema;
+use Automattic\WooCommerce\StoreApi\Utilities\OrderController;
+
+/**
+ * Order class.
+ */
+class Order extends AbstractRoute {
+	/**
+	 * The route identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'order';
+
+	/**
+	 * The schema item identifier.
+	 *
+	 * @var string
+	 */
+	const SCHEMA_TYPE = 'order';
+
+	/**
+	 * Order controller class instance.
+	 *
+	 * @var OrderController
+	 */
+	protected $order_controller;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param SchemaController $schema_controller Schema Controller instance.
+	 * @param AbstractSchema   $schema Schema class for this route.
+	 */
+	public function __construct( SchemaController $schema_controller, AbstractSchema $schema ) {
+		parent::__construct( $schema_controller, $schema );
+
+		$this->order_controller = new OrderController();
+	}
+
+	/**
+	 * Get the path of this REST route.
+	 *
+	 * @return string
+	 */
+	public function get_path() {
+		return '/order/(?P<id>[\d]+)';
+	}
+
+	/**
+	 * Get method arguments for this REST route.
+	 *
+	 * @return array An array of endpoints.
+	 */
+	public function get_args() {
+		return [
+			[
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true', // @Todo check authorization - order id and key.
+				'args'                => [
+					'context' => $this->get_context_param( [ 'default' => 'view' ] ),
+				],
+			],
+			'schema' => [ $this->schema, 'get_public_item_schema' ],
+		];
+	}
+
+	/**
+	 * Handle the request and return a valid response for this endpoint.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 * @return \WP_REST_Response
+	 */
+	protected function get_route_response( \WP_REST_Request $request ) {
+		$order_id = absint( $request['id'] );
+		return rest_ensure_response( $this->schema->get_item_response( $this->order_controller->get_order( $order_id ) ) );
+	}
+}

--- a/src/StoreApi/RoutesController.php
+++ b/src/StoreApi/RoutesController.php
@@ -47,6 +47,7 @@ class RoutesController {
 				Routes\V1\CartUpdateItem::IDENTIFIER     => Routes\V1\CartUpdateItem::class,
 				Routes\V1\CartUpdateCustomer::IDENTIFIER => Routes\V1\CartUpdateCustomer::class,
 				Routes\V1\Checkout::IDENTIFIER           => Routes\V1\Checkout::class,
+				Routes\V1\Order::IDENTIFIER              => Routes\V1\Order::class,
 				Routes\V1\ProductAttributes::IDENTIFIER  => Routes\V1\ProductAttributes::class,
 				Routes\V1\ProductAttributesById::IDENTIFIER => Routes\V1\ProductAttributesById::class,
 				Routes\V1\ProductAttributeTerms::IDENTIFIER => Routes\V1\ProductAttributeTerms::class,

--- a/src/StoreApi/RoutesController.php
+++ b/src/StoreApi/RoutesController.php
@@ -47,6 +47,7 @@ class RoutesController {
 				Routes\V1\CartUpdateItem::IDENTIFIER     => Routes\V1\CartUpdateItem::class,
 				Routes\V1\CartUpdateCustomer::IDENTIFIER => Routes\V1\CartUpdateCustomer::class,
 				Routes\V1\Checkout::IDENTIFIER           => Routes\V1\Checkout::class,
+				Routes\V1\CheckoutOrder::IDENTIFIER      => Routes\V1\CheckoutOrder::class,
 				Routes\V1\Order::IDENTIFIER              => Routes\V1\Order::class,
 				Routes\V1\ProductAttributes::IDENTIFIER  => Routes\V1\ProductAttributes::class,
 				Routes\V1\ProductAttributesById::IDENTIFIER => Routes\V1\ProductAttributesById::class,

--- a/src/StoreApi/SchemaController.php
+++ b/src/StoreApi/SchemaController.php
@@ -43,6 +43,7 @@ class SchemaController {
 				Schemas\V1\CartItemSchema::IDENTIFIER      => Schemas\V1\CartItemSchema::class,
 				Schemas\V1\CartSchema::IDENTIFIER          => Schemas\V1\CartSchema::class,
 				Schemas\V1\CartExtensionsSchema::IDENTIFIER => Schemas\V1\CartExtensionsSchema::class,
+				Schemas\V1\CheckoutOrderSchema::IDENTIFIER => Schemas\V1\CheckoutOrderSchema::class,
 				Schemas\V1\CheckoutSchema::IDENTIFIER      => Schemas\V1\CheckoutSchema::class,
 				Schemas\V1\OrderItemSchema::IDENTIFIER     => Schemas\V1\OrderItemSchema::class,
 				Schemas\V1\OrderSchema::IDENTIFIER         => Schemas\V1\OrderSchema::class,

--- a/src/StoreApi/SchemaController.php
+++ b/src/StoreApi/SchemaController.php
@@ -44,6 +44,7 @@ class SchemaController {
 				Schemas\V1\CartSchema::IDENTIFIER          => Schemas\V1\CartSchema::class,
 				Schemas\V1\CartExtensionsSchema::IDENTIFIER => Schemas\V1\CartExtensionsSchema::class,
 				Schemas\V1\CheckoutSchema::IDENTIFIER      => Schemas\V1\CheckoutSchema::class,
+				Schemas\V1\OrderSchema::IDENTIFIER         => Schemas\V1\OrderSchema::class,
 				Schemas\V1\ProductSchema::IDENTIFIER       => Schemas\V1\ProductSchema::class,
 				Schemas\V1\ProductAttributeSchema::IDENTIFIER => Schemas\V1\ProductAttributeSchema::class,
 				Schemas\V1\ProductCategorySchema::IDENTIFIER => Schemas\V1\ProductCategorySchema::class,

--- a/src/StoreApi/SchemaController.php
+++ b/src/StoreApi/SchemaController.php
@@ -44,6 +44,7 @@ class SchemaController {
 				Schemas\V1\CartSchema::IDENTIFIER          => Schemas\V1\CartSchema::class,
 				Schemas\V1\CartExtensionsSchema::IDENTIFIER => Schemas\V1\CartExtensionsSchema::class,
 				Schemas\V1\CheckoutSchema::IDENTIFIER      => Schemas\V1\CheckoutSchema::class,
+				Schemas\V1\OrderItemSchema::IDENTIFIER     => Schemas\V1\OrderItemSchema::class,
 				Schemas\V1\OrderSchema::IDENTIFIER         => Schemas\V1\OrderSchema::class,
 				Schemas\V1\ProductSchema::IDENTIFIER       => Schemas\V1\ProductSchema::class,
 				Schemas\V1\ProductAttributeSchema::IDENTIFIER => Schemas\V1\ProductAttributeSchema::class,

--- a/src/StoreApi/Schemas/V1/CheckoutOrderSchema.php
+++ b/src/StoreApi/Schemas/V1/CheckoutOrderSchema.php
@@ -1,0 +1,211 @@
+<?php
+namespace Automattic\WooCommerce\StoreApi\Schemas\V1;
+
+use Automattic\WooCommerce\StoreApi\SchemaController;
+use Automattic\WooCommerce\StoreApi\Payments\PaymentResult;
+use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
+
+
+/**
+ * CheckoutOrderSchema class.
+ */
+class CheckoutOrderSchema extends AbstractSchema {
+	/**
+	 * The schema item name.
+	 *
+	 * @var string
+	 */
+	protected $title = 'checkout-order';
+
+	/**
+	 * The schema item identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'checkout-order';
+
+	/**
+	 * Billing address schema instance.
+	 *
+	 * @var BillingAddressSchema
+	 */
+	protected $billing_address_schema;
+
+	/**
+	 * Shipping address schema instance.
+	 *
+	 * @var ShippingAddressSchema
+	 */
+	protected $shipping_address_schema;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param ExtendSchema     $extend Rest Extending instance.
+	 * @param SchemaController $controller Schema Controller instance.
+	 */
+	public function __construct( ExtendSchema $extend, SchemaController $controller ) {
+		parent::__construct( $extend, $controller );
+		$this->billing_address_schema  = $this->controller->get( BillingAddressSchema::IDENTIFIER );
+		$this->shipping_address_schema = $this->controller->get( ShippingAddressSchema::IDENTIFIER );
+	}
+
+	/**
+	 * Checkout schema properties.
+	 *
+	 * @return array
+	 */
+	public function get_properties() {
+		return [
+			'order_id'          => [
+				'description' => __( 'The order ID to process during checkout.', 'woo-gutenberg-products-block' ),
+				'type'        => 'integer',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
+			'status'            => [
+				'description' => __( 'Order status. Payment providers will update this value after payment.', 'woo-gutenberg-products-block' ),
+				'type'        => 'string',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
+			'order_key'         => [
+				'description' => __( 'Order key used to check validity or protect access to certain order data.', 'woo-gutenberg-products-block' ),
+				'type'        => 'string',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
+			'customer_note'     => [
+				'description' => __( 'Note added to the order by the customer during checkout.', 'woo-gutenberg-products-block' ),
+				'type'        => 'string',
+				'context'     => [ 'view', 'edit' ],
+			],
+			'customer_id'       => [
+				'description' => __( 'Customer ID if registered. Will return 0 for guests.', 'woo-gutenberg-products-block' ),
+				'type'        => 'integer',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
+			'billing_address'   => [
+				'description' => __( 'Billing address.', 'woo-gutenberg-products-block' ),
+				'type'        => 'object',
+				'context'     => [ 'view', 'edit' ],
+				'properties'  => $this->billing_address_schema->get_properties(),
+				'arg_options' => [
+					'sanitize_callback' => [ $this->billing_address_schema, 'sanitize_callback' ],
+					'validate_callback' => [ $this->billing_address_schema, 'validate_callback' ],
+				],
+				'required'    => true,
+			],
+			'shipping_address'  => [
+				'description' => __( 'Shipping address.', 'woo-gutenberg-products-block' ),
+				'type'        => 'object',
+				'context'     => [ 'view', 'edit' ],
+				'properties'  => $this->shipping_address_schema->get_properties(),
+				'arg_options' => [
+					'sanitize_callback' => [ $this->shipping_address_schema, 'sanitize_callback' ],
+					'validate_callback' => [ $this->shipping_address_schema, 'validate_callback' ],
+				],
+			],
+			'payment_method'    => [
+				'description' => __( 'The ID of the payment method being used to process the payment.', 'woo-gutenberg-products-block' ),
+				'type'        => 'string',
+				'context'     => [ 'view', 'edit' ],
+				'enum'        => wc()->payment_gateways->get_payment_gateway_ids(),
+			],
+			'payment_result'    => [
+				'description' => __( 'Result of payment processing, or false if not yet processed.', 'woo-gutenberg-products-block' ),
+				'type'        => 'object',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+				'properties'  => [
+					'payment_status'  => [
+						'description' => __( 'Status of the payment returned by the gateway. One of success, pending, failure, error.', 'woo-gutenberg-products-block' ),
+						'readonly'    => true,
+						'type'        => 'string',
+					],
+					'payment_details' => [
+						'description' => __( 'An array of data being returned from the payment gateway.', 'woo-gutenberg-products-block' ),
+						'readonly'    => true,
+						'type'        => 'array',
+						'items'       => [
+							'type'       => 'object',
+							'properties' => [
+								'key'   => [
+									'type' => 'string',
+								],
+								'value' => [
+									'type' => 'string',
+								],
+							],
+						],
+					],
+					'redirect_url'    => [
+						'description' => __( 'A URL to redirect the customer after checkout. This could be, for example, a link to the payment processors website.', 'woo-gutenberg-products-block' ),
+						'readonly'    => true,
+						'type'        => 'string',
+					],
+				],
+			],
+			self::EXTENDING_KEY => $this->get_extended_schema( self::IDENTIFIER ),
+		];
+	}
+
+	/**
+	 * Return the response for checkout.
+	 *
+	 * @param object $item Results from checkout action.
+	 * @return array
+	 */
+	public function get_item_response( $item ) {
+		return $this->get_checkout_response( $item->order, $item->payment_result );
+	}
+
+	/**
+	 * Get the checkout response based on the current order and any payments.
+	 *
+	 * @param \WC_Order     $order Order object.
+	 * @param PaymentResult $payment_result Payment result object.
+	 * @return array
+	 */
+	protected function get_checkout_response( \WC_Order $order, PaymentResult $payment_result = null ) {
+		return [
+			'order_id'          => $order->get_id(),
+			'status'            => $order->get_status(),
+			'order_key'         => $order->get_order_key(),
+			'customer_note'     => $order->get_customer_note(),
+			'customer_id'       => $order->get_customer_id(),
+			'billing_address'   => $this->billing_address_schema->get_item_response( $order ),
+			'shipping_address'  => $this->shipping_address_schema->get_item_response( $order ),
+			'payment_method'    => $order->get_payment_method(),
+			'payment_result'    => [
+				'payment_status'  => $payment_result->status,
+				'payment_details' => $this->prepare_payment_details_for_response( $payment_result->payment_details ),
+				'redirect_url'    => $payment_result->redirect_url,
+			],
+			self::EXTENDING_KEY => $this->get_extended_data( self::IDENTIFIER ),
+		];
+	}
+
+	/**
+	 * This prepares the payment details for the response so it's following the
+	 * schema where it's an array of objects.
+	 *
+	 * @param array $payment_details An array of payment details from the processed payment.
+	 *
+	 * @return array An array of objects where each object has the key and value
+	 *               as distinct properties.
+	 */
+	protected function prepare_payment_details_for_response( array $payment_details ) {
+		return array_map(
+			function( $key, $value ) {
+				return (object) [
+					'key'   => $key,
+					'value' => $value,
+				];
+			},
+			array_keys( $payment_details ),
+			$payment_details
+		);
+	}
+}

--- a/src/StoreApi/Schemas/V1/OrderItemSchema.php
+++ b/src/StoreApi/Schemas/V1/OrderItemSchema.php
@@ -1,0 +1,149 @@
+<?php
+namespace Automattic\WooCommerce\StoreApi\Schemas\V1;
+
+use Automattic\WooCommerce\StoreApi\Utilities\QuantityLimits;
+
+/**
+ * OrderItemSchema class.
+ */
+class OrderItemSchema extends ProductSchema {
+
+	/**
+	 * The schema item name.
+	 *
+	 * @var string
+	 */
+	protected $title = 'order_item';
+
+	/**
+	 * The schema item identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'order-item';
+
+	/**
+	 * Order schema properties.
+	 *
+	 * @return array
+	 */
+	public function get_properties() {
+		return [
+			'id'                => [
+				'description' => __( 'The order item product or variation ID.', 'woo-gutenberg-products-block' ),
+				'type'        => 'integer',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
+			'quantity'          => [
+				'description' => __( 'Quantity of this item in the order.', 'woo-gutenberg-products-block' ),
+				'type'        => 'number',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
+			'name'              => [
+				'description' => __( 'Product name.', 'woo-gutenberg-products-block' ),
+				'type'        => 'string',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
+			'item_data'         => [
+				'description' => __( 'Metadata related to the order item', 'woo-gutenberg-products-block' ),
+				'type'        => 'array',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+				'items'       => [
+					'type'       => 'object',
+					'properties' => [
+						'name'    => [
+							'description' => __( 'Name of the metadata.', 'woo-gutenberg-products-block' ),
+							'type'        => 'string',
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+						],
+						'value'   => [
+							'description' => __( 'Value of the metadata.', 'woo-gutenberg-products-block' ),
+							'type'        => 'string',
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+						],
+						'display' => [
+							'description' => __( 'Optionally, how the metadata value should be displayed to the user.', 'woo-gutenberg-products-block' ),
+							'type'        => 'string',
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+						],
+					],
+				],
+			],
+			'totals'            => [
+				'description' => __( 'Item total amounts provided using the smallest unit of the currency.', 'woo-gutenberg-products-block' ),
+				'type'        => 'object',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+				'properties'  => array_merge(
+					$this->get_store_currency_properties(),
+					[
+						'line_subtotal'     => [
+							'description' => __( 'Line subtotal (the price of the product before coupon discounts have been applied).', 'woo-gutenberg-products-block' ),
+							'type'        => 'string',
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+						],
+						'line_subtotal_tax' => [
+							'description' => __( 'Line subtotal tax.', 'woo-gutenberg-products-block' ),
+							'type'        => 'string',
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+						],
+						'line_total'        => [
+							'description' => __( 'Line total (the price of the product after coupon discounts have been applied).', 'woo-gutenberg-products-block' ),
+							'type'        => 'string',
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+						],
+						'line_total_tax'    => [
+							'description' => __( 'Line total tax.', 'woo-gutenberg-products-block' ),
+							'type'        => 'string',
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+						],
+					]
+				),
+			],
+			self::EXTENDING_KEY => $this->get_extended_schema( self::IDENTIFIER ),
+		];
+	}
+
+	/**
+	 * Get items data.
+	 *
+	 * @param \WC_Order_Item_Product $item Order item instance.
+	 * @return array
+	 */
+	public function get_item_response( $item ) {
+		$order = $item->get_order();
+		return [
+			'id'        => $item->get_id(),
+			'quantity'  => $item->get_quantity(),
+			'name'      => $item->get_name(),
+			'item_data' => $item->get_all_formatted_meta_data(),
+			'totals'    => $this->get_totals( $item ),
+		];
+	}
+
+	/**
+	 * Get totals data.
+	 *
+	 * @param \WC_Order_Item_Product $item Order item instance.
+	 * @return array
+	 */
+	public function get_totals( $item ) {
+		return [
+			'line_subtotal'     => $item->get_subtotal(),
+			'line_subtotal_tax' => $item->get_subtotal_tax(),
+			'line_total'        => $item->get_total(),
+			'line_total_tax'    => $item->get_total_tax(),
+		];
+	}
+}

--- a/src/StoreApi/Schemas/V1/OrderSchema.php
+++ b/src/StoreApi/Schemas/V1/OrderSchema.php
@@ -26,11 +26,100 @@ class OrderSchema extends AbstractSchema {
 	 */
 	public function get_properties() {
 		return [
-			'id' => [
+			'id'         => [
 				'description' => __( 'The order ID to process during checkout.', 'woo-gutenberg-products-block' ),
 				'type'        => 'integer',
 				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
+			],
+			'line_items' => [
+				'description' => __( 'Line items data.', 'woo-gutenberg-products-block' ),
+				'type'        => 'array',
+				'context'     => [ 'view', 'edit' ],
+				'items'       => [
+					'type'       => 'object',
+					'properties' => [
+						'id'        => [
+							'description' => __( 'Item ID.', 'woo-gutenberg-products-block' ),
+							'type'        => 'integer',
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+						],
+						'name'      => [
+							'description' => __( 'Product name.', 'woo-gutenberg-products-block' ),
+							'type'        => 'mixed',
+							'context'     => [ 'view', 'edit' ],
+						],
+						'quantity'  => [
+							'description' => __( 'Quantity ordered.', 'woo-gutenberg-products-block' ),
+							'type'        => 'integer',
+							'context'     => [ 'view', 'edit' ],
+						],
+						'subtotal'  => [
+							'description' => __( 'Line subtotal (before discounts).', 'woo-gutenberg-products-block' ),
+							'type'        => 'string',
+							'context'     => [ 'view', 'edit' ],
+						],
+						'meta_data' => [
+							'description' => __( 'Meta data.', 'woo-gutenberg-products-block' ),
+							'type'        => 'array',
+							'context'     => [ 'view', 'edit' ],
+							'items'       => [
+								'type'       => 'object',
+								'properties' => [
+									'id'            => [
+										'description' => __( 'Meta ID.', 'woo-gutenberg-products-block' ),
+										'type'        => 'integer',
+										'context'     => [ 'view', 'edit' ],
+										'readonly'    => true,
+									],
+									'key'           => [
+										'description' => __( 'Meta key.', 'woo-gutenberg-products-block' ),
+										'type'        => 'string',
+										'context'     => [ 'view', 'edit' ],
+									],
+									'value'         => [
+										'description' => __( 'Meta value.', 'woo-gutenberg-products-block' ),
+										'type'        => 'mixed',
+										'context'     => [ 'view', 'edit' ],
+									],
+									'display_key'   => [
+										'description' => __( 'Meta key for UI display.', 'woo-gutenberg-products-block' ),
+										'type'        => 'string',
+										'context'     => [ 'view', 'edit' ],
+									],
+									'display_value' => [
+										'description' => __( 'Meta value for UI display.', 'woo-gutenberg-products-block' ),
+										'type'        => 'string',
+										'context'     => [ 'view', 'edit' ],
+									],
+								],
+							],
+						],
+					],
+				],
+			],
+			'totals'     => [
+				'description' => __( 'Order totals.', 'woo-gutenberg-products-block' ),
+				'type'        => 'object',
+				'context'     => [ 'view', 'edit' ],
+				'items'       => [
+					'type'       => 'object',
+					'properties' => [
+						'label' => [
+							'description' => __( 'Label.', 'woo-gutenberg-products-block' ),
+							'type'        => 'string',
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+						],
+						'value' => [
+							'description' => __( 'Value.', 'woo-gutenberg-products-block' ),
+							'type'        => 'string',
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+						],
+					],
+				],
 			],
 		];
 	}
@@ -43,15 +132,9 @@ class OrderSchema extends AbstractSchema {
 	 */
 	public function get_item_response( $order ) {
 		return [
-			'id'             => $order->get_id(),
-			'line_items'     => $this->get_item_data( $order ),
-			'total_tax'      => $order->get_total_tax(),
-			'subtotal'       => $order->get_subtotal(),
-			'discount_total' => $order->get_discount_total(),
-			'shipping_total' => $order->get_shipping_total(),
-			'shipping_tax'   => $order->get_shipping_tax(),
-			'total_refunded' => $order->get_total_refunded(),
-			'fees_total'     => $this->get_fees_total( $order ),
+			'id'         => $order->get_id(),
+			'line_items' => $this->get_item_data( $order ),
+			'totals'     => $order->get_order_item_totals(),
 		];
 	}
 
@@ -74,35 +157,5 @@ class OrderSchema extends AbstractSchema {
 		}
 
 		return array_values( $data );
-	}
-
-	/**
-	 * Get fee.
-	 *
-	 * @param \WC_Order $order Order instance.
-	 * @return array
-	 */
-	private function get_fees_total( $order ) {
-		$fees       = $order->get_fees();
-		$total_fees = 0;
-
-		if ( $fees ) {
-			foreach ( $fees as $id => $fee ) {
-				/**
-				 * Filters whether or not free fees should be excluded.
-				 *
-				 * @param boolean True to skip the fee, false to include the fee.
-				 * @param integer $id Fee ID.
-				 *
-				 * @since 9.8.0-dev
-				 */
-				if ( apply_filters( 'woocommerce_get_order_item_totals_excl_free_fees', empty( $fee['line_total'] ) && empty( $fee['line_tax'] ), $id ) ) {
-					continue;
-				}
-				$total_fees += $fee->get_total();
-			}
-		}
-
-		return $total_fees;
 	}
 }

--- a/src/StoreApi/Schemas/V1/OrderSchema.php
+++ b/src/StoreApi/Schemas/V1/OrderSchema.php
@@ -1,0 +1,50 @@
+<?php
+namespace Automattic\WooCommerce\StoreApi\Schemas\V1;
+
+/**
+ * OrderSchema class.
+ */
+class OrderSchema extends AbstractSchema {
+	/**
+	 * The schema item name.
+	 *
+	 * @var string
+	 */
+	protected $title = 'order';
+
+	/**
+	 * The schema item identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'order';
+
+	/**
+	 * Order schema properties.
+	 *
+	 * @return array
+	 */
+	public function get_properties() {
+		return [
+			'id'          => [
+				'description' => __( 'The order ID to process during checkout.', 'woo-gutenberg-products-block' ),
+				'type'        => 'integer',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
+		];
+	}
+
+	/**
+	 * Get an order for response.
+	 *
+	 * @param \WC_Order $order Order instance.
+	 * @return array
+	 */
+	public function get_item_response( $order ) {
+		return [
+			'id' => $order->get_id(),
+			// @Todo Add pay-for-order order details.
+		];
+	}
+}

--- a/src/StoreApi/Schemas/V1/OrderSchema.php
+++ b/src/StoreApi/Schemas/V1/OrderSchema.php
@@ -26,7 +26,7 @@ class OrderSchema extends AbstractSchema {
 	 */
 	public function get_properties() {
 		return [
-			'id'          => [
+			'id' => [
 				'description' => __( 'The order ID to process during checkout.', 'woo-gutenberg-products-block' ),
 				'type'        => 'integer',
 				'context'     => [ 'view', 'edit' ],
@@ -43,8 +43,66 @@ class OrderSchema extends AbstractSchema {
 	 */
 	public function get_item_response( $order ) {
 		return [
-			'id' => $order->get_id(),
-			// @Todo Add pay-for-order order details.
+			'id'             => $order->get_id(),
+			'line_items'     => $this->get_item_data( $order ),
+			'total_tax'      => $order->get_total_tax(),
+			'subtotal'       => $order->get_subtotal(),
+			'discount_total' => $order->get_discount_total(),
+			'shipping_total' => $order->get_shipping_total(),
+			'shipping_tax'   => $order->get_shipping_tax(),
+			'total_refunded' => $order->get_total_refunded(),
+			'fees_total'     => $this->get_fees_total( $order ),
 		];
+	}
+
+	/**
+	 * Get items data.
+	 *
+	 * @param \WC_Order $order Order instance.
+	 * @return array
+	 */
+	private function get_item_data( $order ) {
+		$items = $order->get_items();
+		$data  = [];
+
+		foreach ( $items as $item ) {
+			$data[ $item->get_id() ]['id']        = $item->get_id();
+			$data[ $item->get_id() ]['name']      = $item->get_name();
+			$data[ $item->get_id() ]['meta_data'] = $item->get_all_formatted_meta_data();
+			$data[ $item->get_id() ]['quantity']  = $item->get_quantity();
+			$data[ $item->get_id() ]['subtotal']  = $order->get_line_subtotal( $item );
+		}
+
+		return array_values( $data );
+	}
+
+	/**
+	 * Get fee.
+	 *
+	 * @param \WC_Order $order Order instance.
+	 * @return array
+	 */
+	private function get_fees_total( $order ) {
+		$fees       = $order->get_fees();
+		$total_fees = 0;
+
+		if ( $fees ) {
+			foreach ( $fees as $id => $fee ) {
+				/**
+				 * Filters whether or not free fees should be excluded.
+				 *
+				 * @param boolean True to skip the fee, false to include the fee.
+				 * @param integer $id Fee ID.
+				 *
+				 * @since 9.8.0-dev
+				 */
+				if ( apply_filters( 'woocommerce_get_order_item_totals_excl_free_fees', empty( $fee['line_total'] ) && empty( $fee['line_tax'] ), $id ) ) {
+					continue;
+				}
+				$total_fees += $fee->get_total();
+			}
+		}
+
+		return $total_fees;
 	}
 }

--- a/src/StoreApi/Utilities/OrderController.php
+++ b/src/StoreApi/Utilities/OrderController.php
@@ -484,23 +484,23 @@ class OrderController {
 		$order = $this->get_order( $order_id );
 
 		if ( ! $order || $order->get_id() !== $order_id || ! hash_equals( $order->get_order_key(), $order_key ) ) {
-			throw new RouteException( 'invalid_order', __( 'Sorry, this order is invalid and cannot be paid for.', 'woo-gutenberg-products-block' ), 401 );
+			throw new RouteException( 'woocommerce_rest_invalid_order', __( 'Sorry, this order is invalid and cannot be paid for.', 'woo-gutenberg-products-block' ), 401 );
 		}
 
 		// Logged out customer does not have permission to pay for this order.
 		if ( ! current_user_can( 'pay_for_order', $order_id ) && ! is_user_logged_in() ) {
-			throw new RouteException( 'invalid_user', __( 'Please log in to your account below to continue to the payment form.', 'woo-gutenberg-products-block' ), 403 );
+			throw new RouteException( 'woocommerce_rest_invalid_user', __( 'Please log in to your account below to continue to the payment form.', 'woo-gutenberg-products-block' ), 403 );
 		}
 
 		// Logged in customer trying to pay for someone else's order.
 		if ( ! current_user_can( 'pay_for_order', $order_id ) ) {
-			throw new RouteException( 'invalid_user', __( 'This order cannot be paid for. Please contact us if you need assistance.', 'woo-gutenberg-products-block' ), 403 );
+			throw new RouteException( 'woocommerce_rest_invalid_user', __( 'This order cannot be paid for. Please contact us if you need assistance.', 'woo-gutenberg-products-block' ), 403 );
 		}
 
 		// Does not need payment.
 		if ( ! $order->needs_payment() ) {
 			/* translators: %s: order status */
-			throw new RouteException( '@Todo', sprintf( __( 'This order&rsquo;s status is &ldquo;%s&rdquo;&mdash;it cannot be paid for. Please contact us if you need assistance.', 'woo-gutenberg-products-block' ), wc_get_order_status_name( $order->get_status() ) ), 403 );
+			throw new RouteException( 'woocommerce_rest_no_payment_needed', sprintf( __( 'This order&rsquo;s status is &ldquo;%s&rdquo;&mdash;it cannot be paid for. Please contact us if you need assistance.', 'woo-gutenberg-products-block' ), wc_get_order_status_name( $order->get_status() ) ), 403 );
 		}
 
 		// Ensure order items are still stocked if paying for a failed order. Pending orders do not need this check because stock is held.
@@ -540,7 +540,7 @@ class OrderController {
 						 */
 						if ( ! apply_filters( 'woocommerce_pay_order_product_in_stock', $product->is_in_stock(), $product, $order ) ) {
 							/* translators: %s: product name */
-							throw new RouteException( '@Todo', sprintf( __( 'Sorry, "%s" is no longer in stock so this order cannot be paid for. We apologize for any inconvenience caused.', 'woo-gutenberg-products-block' ), $product->get_name() ), 403 );
+							throw new RouteException( 'woocommerce_rest_out_of_stock', sprintf( __( 'Sorry, "%s" is no longer in stock so this order cannot be paid for. We apologize for any inconvenience caused.', 'woo-gutenberg-products-block' ), $product->get_name() ), 403 );
 						}
 
 						// We only need to check products managing stock, with a limited stock qty.
@@ -563,7 +563,7 @@ class OrderController {
 						 */
 						if ( ! apply_filters( 'woocommerce_pay_order_product_has_enough_stock', ( $product->get_stock_quantity() >= ( $held_stock + $required_stock ) ), $product, $order ) ) {
 							/* translators: 1: product name 2: quantity in stock */
-							throw new RouteException( '@Todo', sprintf( __( 'Sorry, we do not have enough "%1$s" in stock to fulfill your order (%2$s available). We apologize for any inconvenience caused.', 'woo-gutenberg-products-block' ), $product->get_name(), wc_format_stock_quantity_for_display( $product->get_stock_quantity() - $held_stock, $product ) ), 403 );
+							throw new RouteException( 'woocommerce_rest_out_of_stock', sprintf( __( 'Sorry, we do not have enough "%1$s" in stock to fulfill your order (%2$s available). We apologize for any inconvenience caused.', 'woo-gutenberg-products-block' ), $product->get_name(), wc_format_stock_quantity_for_display( $product->get_stock_quantity() - $held_stock, $product ) ), 403 );
 						}
 					}
 				}

--- a/src/StoreApi/Utilities/OrderController.php
+++ b/src/StoreApi/Utilities/OrderController.php
@@ -39,6 +39,18 @@ class OrderController {
 	}
 
 	/**
+	 * Get order.
+	 *
+	 * @throws RouteException Exception if invalid data is detected.
+	 *
+	 * @param integer $order_id Order ID.
+	 * @return \WC_Order A new order object.
+	 */
+	public function get_order( $order_id ) {
+		return wc_get_order( $order_id );
+	}
+
+	/**
 	 * Update an order using data from the current cart.
 	 *
 	 * @param \WC_Order $order The order object to update.

--- a/src/StoreApi/Utilities/OrderController.php
+++ b/src/StoreApi/Utilities/OrderController.php
@@ -474,6 +474,104 @@ class OrderController {
 	}
 
 	/**
+	 * Check validation for the order key.
+	 *
+	 * @throws RouteException Exception if invalid data is detected.
+	 * @param integer $order_id Order ID.
+	 * @param string  $order_key Order key.
+	 */
+	public function validate_order_key( $order_id, $order_key ) {
+		$order = $this->get_order( $order_id );
+
+		if ( ! $order || $order->get_id() !== $order_id || ! hash_equals( $order->get_order_key(), $order_key ) ) {
+			throw new RouteException( 'invalid_order', __( 'Sorry, this order is invalid and cannot be paid for.', 'woo-gutenberg-products-block' ), 401 );
+		}
+
+		// Logged out customer does not have permission to pay for this order.
+		if ( ! current_user_can( 'pay_for_order', $order_id ) && ! is_user_logged_in() ) {
+			throw new RouteException( 'invalid_user', __( 'Please log in to your account below to continue to the payment form.', 'woo-gutenberg-products-block' ), 403 );
+		}
+
+		// Logged in customer trying to pay for someone else's order.
+		if ( ! current_user_can( 'pay_for_order', $order_id ) ) {
+			throw new RouteException( 'invalid_user', __( 'This order cannot be paid for. Please contact us if you need assistance.', 'woo-gutenberg-products-block' ), 403 );
+		}
+
+		// Does not need payment.
+		if ( ! $order->needs_payment() ) {
+			/* translators: %s: order status */
+			throw new RouteException( '@Todo', sprintf( __( 'This order&rsquo;s status is &ldquo;%s&rdquo;&mdash;it cannot be paid for. Please contact us if you need assistance.', 'woo-gutenberg-products-block' ), wc_get_order_status_name( $order->get_status() ) ), 403 );
+		}
+
+		// Ensure order items are still stocked if paying for a failed order. Pending orders do not need this check because stock is held.
+		if ( ! $order->has_status( wc_get_is_pending_statuses() ) ) {
+			$quantities = array();
+
+			foreach ( $order->get_items() as $item_key => $item ) {
+				if ( $item && is_callable( array( $item, 'get_product' ) ) ) {
+					$product = $item->get_product();
+
+					if ( ! $product ) {
+						continue;
+					}
+
+					$quantities[ $product->get_stock_managed_by_id() ] = isset( $quantities[ $product->get_stock_managed_by_id() ] ) ? $quantities[ $product->get_stock_managed_by_id() ] + $item->get_quantity() : $item->get_quantity();
+				}
+			}
+
+			// Stock levels may already have been adjusted for this order (in which case we don't need to worry about checking for low stock).
+			if ( ! $order->get_data_store()->get_stock_reduced( $order->get_id() ) ) {
+				foreach ( $order->get_items() as $item_key => $item ) {
+					if ( $item && is_callable( array( $item, 'get_product' ) ) ) {
+						$product = $item->get_product();
+
+						if ( ! $product ) {
+							continue;
+						}
+
+						/**
+						 * Filters whether or not the product is in stock for this pay for order.
+						 *
+						 * @param boolean True if in stock.
+						 * @param \WC_Product $product Product.
+						 * @param \WC_Order $order Order.
+						 *
+						 * @since 9.8.0-dev
+						 */
+						if ( ! apply_filters( 'woocommerce_pay_order_product_in_stock', $product->is_in_stock(), $product, $order ) ) {
+							/* translators: %s: product name */
+							throw new RouteException( '@Todo', sprintf( __( 'Sorry, "%s" is no longer in stock so this order cannot be paid for. We apologize for any inconvenience caused.', 'woo-gutenberg-products-block' ), $product->get_name() ), 403 );
+						}
+
+						// We only need to check products managing stock, with a limited stock qty.
+						if ( ! $product->managing_stock() || $product->backorders_allowed() ) {
+							continue;
+						}
+
+						// Check stock based on all items in the cart and consider any held stock within pending orders.
+						$held_stock     = wc_get_held_stock_quantity( $product, $order->get_id() );
+						$required_stock = $quantities[ $product->get_stock_managed_by_id() ];
+
+						/**
+						 * Filters whether or not the product has enough stock.
+						 *
+						 * @param boolean True if has enough stock.
+						 * @param \WC_Product $product Product.
+						 * @param \WC_Order $order Order.
+						 *
+						 * @since 9.8.0-dev
+						 */
+						if ( ! apply_filters( 'woocommerce_pay_order_product_has_enough_stock', ( $product->get_stock_quantity() >= ( $held_stock + $required_stock ) ), $product, $order ) ) {
+							/* translators: 1: product name 2: quantity in stock */
+							throw new RouteException( '@Todo', sprintf( __( 'Sorry, we do not have enough "%1$s" in stock to fulfill your order (%2$s available). We apologize for any inconvenience caused.', 'woo-gutenberg-products-block' ), $product->get_name(), wc_format_stock_quantity_for_display( $product->get_stock_quantity() - $held_stock, $product ) ), 403 );
+						}
+					}
+				}
+			}
+		}
+	}
+
+	/**
 	 * Changes default order status to draft for orders created via this API.
 	 *
 	 * @return string


### PR DESCRIPTION
Add an endpoint for processing pay-for-order orders so we can pay for the orders.

Fixes #9312 

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots
<img width="595" alt="Screen Shot 2023-05-01 at 2 49 05 PM" src="https://user-images.githubusercontent.com/56378160/235537660-e3eed9f8-491f-4d8f-91d1-95c787786f53.png">


### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests


### Changelog

> Add an endpoint for processing pay for order orders.
