### PR TITLE
Rename the Add to Cart Options block to Add to Cart with Options

### DIFF
--- a/assets/js/atomic/blocks/product-elements/add-to-cart-form/block.json
+++ b/assets/js/atomic/blocks/product-elements/add-to-cart-form/block.json
@@ -1,7 +1,7 @@
 {
 	"name": "woocommerce/add-to-cart-form",
 	"version": "1.0.0",
-	"title": "Add to Cart Options",
+	"title": "Add to Cart with Options",
 	"description": "Display a button so the customer can add a product to their cart. Options will also be displayed depending on product type. e.g. quantity, variation.",
 	"category": "woocommerce",
 	"keywords": [ "WooCommerce" ],

--- a/tests/e2e/specs/backend/add-to-cart-form.test.js
+++ b/tests/e2e/specs/backend/add-to-cart-form.test.js
@@ -20,7 +20,7 @@ import {
 } from '../../utils.js';
 
 const block = {
-	name: 'Add to Cart Options',
+	name: 'Add to Cart with Options',
 	slug: 'woocommerce/add-to-cart-form',
 	class: '.wc-block-add-to-cart-form',
 };


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #8453 

Rename of the "Add to Cart Options" block to "Add to Cart **with** Options".

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

<img width="302" alt="Screenshot 2023-05-02 at 10 32 02" src="https://user-images.githubusercontent.com/15730971/235619427-7c42d415-d45c-4825-996f-f6fbf2f682fa.png">

### Testing

#### User Facing Testing

- With a block theme enabled (such as [Twenty Twenty-Three](https://wordpress.org/themes/twentytwentythree/)), click on Edit Site > Templates > Single Product and edit it.
- Add the Add to Cart with Options block and make sure you can insert it without any problems and the name is correct.

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Rename the Add to Cart Options block to Add to Cart with Options
