### PR TITLE
Mini Cart drawer: print width in PHP

### DIFF
--- a/assets/js/base/components/drawer/style.scss
+++ b/assets/js/base/components/drawer/style.scss
@@ -1,4 +1,6 @@
 :root {
+	/* This value might be overridden in PHP based on the attribute set by the user. */
+	--drawer-width: 480px;
 	--neg-drawer-width: calc(var(--drawer-width) * -1);
 }
 

--- a/assets/js/blocks/mini-cart/mini-cart-contents/block.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/block.tsx
@@ -15,12 +15,7 @@ type MiniCartContentsBlockProps = {
 export const MiniCartContentsBlock = (
 	props: MiniCartContentsBlockProps
 ): JSX.Element => {
-	const {
-		children,
-		attributes: { width },
-	} = props;
-
-	document.documentElement.style.setProperty( '--drawer-width', width );
+	const { children } = props;
 
 	return <>{ children }</>;
 };

--- a/src/BlockTypes/MiniCartContents.php
+++ b/src/BlockTypes/MiniCartContents.php
@@ -110,7 +110,8 @@ class MiniCartContents extends AbstractBlock {
 			),
 		);
 
-		$parsed_style = '';
+		$drawer_width = array_key_exists( 'width', $attributes ) ? $attributes['width'] : '480px';
+		$parsed_style = ':root{--drawer-width: ' . esc_html( $drawer_width ) . '}';
 
 		foreach ( $styles as $style ) {
 			$selector = is_array( $style['selector'] ) ? implode( ',', $style['selector'] ) : $style['selector'];

--- a/src/BlockTypes/MiniCartContents.php
+++ b/src/BlockTypes/MiniCartContents.php
@@ -110,8 +110,10 @@ class MiniCartContents extends AbstractBlock {
 			),
 		);
 
-		$drawer_width = array_key_exists( 'width', $attributes ) ? $attributes['width'] : '480px';
-		$parsed_style = ':root{--drawer-width: ' . esc_html( $drawer_width ) . '}';
+		$parsed_style = '';
+		if ( array_key_exists( 'width', $attributes ) ) {
+			$parsed_style .= ':root{--drawer-width: ' . esc_html( $attributes['width'] ) . '}';
+		}
 
 		foreach ( $styles as $style ) {
 			$selector = is_array( $style['selector'] ) ? implode( ',', $style['selector'] ) : $style['selector'];

--- a/tests/e2e/specs/shopper/mini-cart.test.js
+++ b/tests/e2e/specs/shopper/mini-cart.test.js
@@ -304,8 +304,6 @@ describe( 'Shopper → Mini Cart', () => {
 				'.wc-block-components-quantity-selector__button--plus'
 			);
 
-			await page.waitForTimeout( 500 );
-
 			await page.click(
 				'.wc-block-components-quantity-selector__button--plus'
 			);


### PR DESCRIPTION
This PR moves the logic to print `--drawer-width` from JS to PHP, this makes the value to be available before the React component is loaded, meaning the drawer can be visible earlier.

This is a regression from #8930.

### Testing

#### User Facing Testing

1. Add the Mini Cart block to the header of your site (via Appearance > Editor).
2. In the frontend, open the Mini Cart drawer clicking on the button.
3. Verify the drawer is opened instantly. Until now, there might be a small delay if the shopper clicked the button very quickly right after the page was loaded and the network was slow.

Before | After
--- | ---
![Enregistrament de pantalla des de 2023-05-03 11-15-25](https://user-images.githubusercontent.com/3616980/235877974-4c094a6a-ae92-4522-a769-52760916c78c.gif) | ![Enregistrament de pantalla des de 2023-05-03 11-14-17](https://user-images.githubusercontent.com/3616980/235877766-ceb23c1f-dd3a-4a0e-b40d-a1eca9963347.gif)

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix a regression which caused the Mini Cart drawer not to open until its contents have completely loaded.
