### PR TITLE
Check that the customized fallback template is archive-product before…

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -116,7 +116,7 @@ class BlockTemplatesController {
 			return null;
 		}
 
-		if ( count( $posts ) > 0 ) {
+		if ( count( $posts ) > 0 && 'archive-product' === $posts[0]->post_name ) {
 			$template = _build_block_template_result_from_post( $posts[0] );
 
 			if ( ! is_wp_error( $template ) ) {


### PR DESCRIPTION
When we create a customized version of an _already customized_ fallback `archive-product` template (e.g. a Product Category template), we unset the `source` property introduced here https://github.com/woocommerce/woocommerce-blocks/pull/7975

However, when _we don't_ customize the Product Catalog template first we still unset this property which results in a database entry for being created for every customization. We need to only unset this property if the template we're customizing is a fallback version of the `archive-product` which forces WordPress to create a new database entry for our  template.

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/9275

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [x] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Go to Appearance > Site Editor and make sure no templates have any customizations
2. Make changes to Product Category and save.
3. Check these are reflected on the frontend.
4. Repeat step 2
5. Check these are reflected on the frontend, and also in the templates list check this has not created an additional template as previously demonstrated in the linked issue.
6. Now clear all customizations again
7. Customize the Product Catalog template and save
8. Check these are reflected on the frontend for the product archive page, and all taxonomy pages (Category/Tags etc)
9. In the Site Editor make some customizations to the Product Category page and save.
10. Make sure these are reflected on the frontend, and also in the templates list check this has not created an additional template as previously demonstrated in the linked issue.
11. Make sure that the Product Catalog changes are still as intended and are reflected on the product archive page, and all taxonomy pages _except_ Product Category (since we have now created its own customized version in Step 9)

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Fix duplicate taxonomy templates being created on every save.
