### PR TITLE
Check if categories are set before accessing them

### DIFF
--- a/patterns/featured-category-triple.php
+++ b/patterns/featured-category-triple.php
@@ -23,9 +23,9 @@ if ( ( false === $categories ) || ( defined( 'WP_DEBUG' ) && WP_DEBUG ) ) {
 	set_transient( $transient_name, $categories, DAY_IN_SECONDS * 14 );
 }
 
-$cat1 = $categories[0]['term_id'] ? $categories[0]['term_id'] : 0;
-$cat2 = $categories[1]['term_id'] ? $categories[1]['term_id'] : 0;
-$cat3 = $categories[2]['term_id'] ? $categories[2]['term_id'] : 0;
+$cat1 = isset( $categories[0]['term_id'] ) ? $categories[0]['term_id'] : 0;
+$cat2 = isset( $categories[1]['term_id'] ) ? $categories[1]['term_id'] : 0;
+$cat3 = isset( $categories[2]['term_id'] ) ? $categories[2]['term_id'] : 0;
 
 ?>
 <!-- wp:columns {"align":"full","style":{"spacing":{"blockGap":{"top":"0","left":"0"},"padding":{"top":"0","right":"0","bottom":"0","left":"0"}}}} -->


### PR DESCRIPTION
The PR fixes the PHP warning messages 👇 
![image](https://user-images.githubusercontent.com/186112/235923493-98301225-ebcf-4f74-a4a8-5f96ba17084c.png)

### Testing

#### Automated Tests
#### User Facing Testing

1. Check there are no PHP warnings or errors in the `patterns/featured-category-triple.php` file on CI.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental


