### PR TITLE
Add permalink to plugin documentation in readme.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -12,7 +12,8 @@ License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
 WooCommerce Blocks are the easiest, most flexible way to display your products on posts and pages!
 
-For more information on what blocks are available, and how to use them, check out the official documentation: https://docs.woocommerce.com/document/woocommerce-blocks/
+For more information on what blocks are available, and how to use them, check out <a href="https://docs.woocommerce.com/document/woocommerce-blocks/
+">the official documentation</a>.
 
 **Note: Feature plugin for WooCommerce + Gutenberg. This plugin serves as a space to iterate and explore new Blocks and updates to existing blocks for WooCommerce, and how WooCommerce might work with the block editor.**
 


### PR DESCRIPTION
The plugin's readme.txt file had a URL to the official documentation but there was no hyperlink - only text.

This improves the page by removing the text link and hyperlinking the "**the official documentation**" text itself.

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #9342

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
| ![CleanShot 2023-05-03 at 17 02 37@2x](https://user-images.githubusercontent.com/481776/236049878-a6a4785d-62c9-459d-8ce2-26f20ebf8cc8.png) | ![CleanShot 2023-05-03 at 17 01 34@2x](https://user-images.githubusercontent.com/481776/236050202-3eeafb67-ae6c-4348-b848-c3a5367e2b87.png) |
