### PR TITLE
Mini Cart: stop using Modal component

### DIFF
--- a/assets/js/base/components/drawer/index.tsx
+++ b/assets/js/base/components/drawer/index.tsx
@@ -1,14 +1,35 @@
 /**
+ * Some code of the Drawer component is based on the Modal component from Gutenberg:
+ * https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/modal/index.tsx
+ */
+/**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { Modal } from 'wordpress-components';
-import { useDebounce } from 'use-debounce';
 import classNames from 'classnames';
+import { useDebounce } from 'use-debounce';
+import type { ForwardedRef, KeyboardEvent } from 'react';
+import { __ } from '@wordpress/i18n';
+import {
+	createPortal,
+	useEffect,
+	useRef,
+	forwardRef,
+} from '@wordpress/element';
+import { close } from '@wordpress/icons';
+import {
+	useFocusReturn,
+	useFocusOnMount,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalUseFocusOutside as useFocusOutside,
+	useConstrainedTabbing,
+	useMergeRefs,
+} from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
+import Button from '../button';
+import * as ariaHelper from './utils/aria-helper';
 import './style.scss';
 
 interface DrawerProps {
@@ -18,32 +39,77 @@ interface DrawerProps {
 	onClose: () => void;
 	slideIn?: boolean;
 	slideOut?: boolean;
-	title: string;
 }
 
-const Drawer = ( {
-	children,
-	className,
-	isOpen,
-	onClose,
-	slideIn = true,
-	slideOut = true,
-	title,
-}: DrawerProps ): JSX.Element | null => {
+const UnforwardedDrawer = (
+	{
+		children,
+		className,
+		isOpen,
+		onClose,
+		slideIn = true,
+		slideOut = true,
+	}: DrawerProps,
+	forwardedRef: ForwardedRef< HTMLDivElement >
+): JSX.Element | null => {
 	const [ debouncedIsOpen ] = useDebounce< boolean >( isOpen, 300 );
 	const isClosing = ! isOpen && debouncedIsOpen;
+	const bodyOpenClassName = 'drawer-open';
+
+	const onRequestClose = () => {
+		document.body.classList.remove( bodyOpenClassName );
+		ariaHelper.showApp();
+		onClose();
+	};
+
+	const ref = useRef< HTMLDivElement >();
+	const focusOnMountRef = useFocusOnMount();
+	const constrainedTabbingRef = useConstrainedTabbing();
+	const focusReturnRef = useFocusReturn();
+	const focusOutsideProps = useFocusOutside( onRequestClose );
+	const contentRef = useRef< HTMLDivElement >( null );
+
+	useEffect( () => {
+		if ( isOpen ) {
+			ariaHelper.hideApp( ref.current );
+			document.body.classList.add( bodyOpenClassName );
+		}
+	}, [ isOpen, bodyOpenClassName ] );
+
+	const overlayRef = useMergeRefs( [ ref, forwardedRef ] );
+	const drawerRef = useMergeRefs( [
+		constrainedTabbingRef,
+		focusReturnRef,
+		focusOnMountRef,
+	] );
 
 	if ( ! isOpen && ! isClosing ) {
 		return null;
 	}
 
-	return (
-		<Modal
-			title={ title }
-			focusOnMount={ true }
-			onRequestClose={ onClose }
-			className={ classNames( className, 'wc-block-components-drawer' ) }
-			overlayClassName={ classNames(
+	function handleEscapeKeyDown( event: KeyboardEvent< HTMLDivElement > ) {
+		if (
+			// Ignore keydowns from IMEs
+			event.nativeEvent.isComposing ||
+			// Workaround for Mac Safari where the final Enter/Backspace of an IME composition
+			// is `isComposing=false`, even though it's technically still part of the composition.
+			// These can only be detected by keyCode.
+			event.keyCode === 229
+		) {
+			return;
+		}
+
+		if ( event.code === 'Escape' && ! event.defaultPrevented ) {
+			event.preventDefault();
+			onRequestClose();
+		}
+	}
+
+	return createPortal(
+		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
+		<div
+			ref={ overlayRef }
+			className={ classNames(
 				'wc-block-components-drawer__screen-overlay',
 				{
 					'wc-block-components-drawer__screen-overlay--is-hidden':
@@ -54,11 +120,38 @@ const Drawer = ( {
 						slideOut,
 				}
 			) }
-			closeButtonLabel={ __( 'Close', 'woo-gutenberg-products-block' ) }
+			onKeyDown={ handleEscapeKeyDown }
 		>
-			{ children }
-		</Modal>
+			<div
+				className={ classNames(
+					className,
+					'wc-block-components-drawer'
+				) }
+				ref={ drawerRef }
+				role="dialog"
+				tabIndex={ -1 }
+				{ ...focusOutsideProps }
+			>
+				<div
+					className="wc-block-components-drawer__content"
+					role="document"
+					ref={ contentRef }
+				>
+					<Button
+						className="wc-block-components-drawer__close"
+						onClick={ onRequestClose }
+						icon={ close }
+						label={ __( 'Close', 'woo-gutenberg-products-block' ) }
+						showTooltip={ false }
+					/>
+					{ children }
+				</div>
+			</div>
+		</div>,
+		document.body
 	);
 };
+
+export const Drawer = forwardRef( UnforwardedDrawer );
 
 export default Drawer;

--- a/assets/js/base/components/drawer/style.scss
+++ b/assets/js/base/components/drawer/style.scss
@@ -131,6 +131,15 @@ $drawer-animation-duration: 0.3s;
 		opacity: 1;
 	}
 
+	// Don't show focus styles if the close button hasn't been focused by the
+	// user directly. This is done to prevent focus styles to appear when
+	// opening the drawer with the mouse, as the focus is moved inside
+	// programmatically.
+	&:focus:not(:focus-visible) {
+		box-shadow: none;
+		outline: none;
+	}
+
 	> span {
 		@include visually-hidden();
 	}

--- a/assets/js/base/components/drawer/style.scss
+++ b/assets/js/base/components/drawer/style.scss
@@ -111,44 +111,48 @@ $drawer-animation-duration: 0.3s;
 	}
 }
 
-.wc-block-components-drawer .components-modal__content {
-	padding: $gap-largest $gap;
-}
+// Important rules are needed to reset button styles.
+.wc-block-components-drawer__close {
+	@include reset-box();
+	background: transparent !important;
+	color: inherit !important;
+	position: absolute !important;
+	top: $gap-small;
+	right: $gap-small;
+	opacity: 0.6;
+	z-index: 2;
+	// Increase clickable area.
+	padding: 1em !important;
+	margin: -1em;
 
-.wc-block-components-drawer .components-modal__header {
-	position: relative;
+	&:hover,
+	&:focus,
+	&:active {
+		opacity: 1;
+	}
 
-	// Close button.
-	.components-button {
-		@include reset-box();
-		background: transparent;
-		color: inherit;
-		position: absolute;
-		opacity: 0.6;
-		z-index: 2;
-		// The SVG has some white spacing around, thus we have to set this magic number.
-		right: 8px;
-		top: 0;
-		// Increase clickable area.
-		padding: 1em;
-		margin: -1em;
-
-		&:hover,
-		&:focus,
-		&:active {
-			opacity: 1;
-		}
-
-		> span {
-			@include visually-hidden();
-		}
+	> span {
+		@include visually-hidden();
+	}
+	svg {
+		fill: currentColor;
+		display: block;
 	}
 }
 
-// Same styles as `Title` component.
-.wc-block-components-drawer .components-modal__header-heading {
-	@include reset-box();
-	// We need the font size to be in rem so it doesn't change depending on the parent element.
-	@include font-size(large, 1rem);
-	word-break: break-word;
+.wc-block-components-drawer__content {
+	height: 100dvh;
+	position: relative;
+}
+
+.admin-bar .wc-block-components-drawer__content {
+	margin-top: 46px;
+	height: calc(100dvh - 46px);
+}
+
+@media only screen and (min-width: 783px) {
+	.admin-bar .wc-block-components-drawer__content {
+		margin-top: 32px;
+		height: calc(100dvh - 32px);
+	}
 }

--- a/assets/js/base/components/drawer/utils/aria-helper.ts
+++ b/assets/js/base/components/drawer/utils/aria-helper.ts
@@ -1,0 +1,74 @@
+/**
+ * Copied from https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/modal/aria-helper.ts
+ */
+const LIVE_REGION_ARIA_ROLES = new Set( [
+	'alert',
+	'status',
+	'log',
+	'marquee',
+	'timer',
+] );
+
+let hiddenElements: Element[] = [],
+	isHidden = false;
+
+/**
+ * Determines if the passed element should not be hidden from screen readers.
+ *
+ * @param {HTMLElement} element The element that should be checked.
+ *
+ * @return {boolean} Whether the element should not be hidden from screen-readers.
+ */
+export function elementShouldBeHidden( element: Element ) {
+	const role = element.getAttribute( 'role' );
+	return ! (
+		element.tagName === 'SCRIPT' ||
+		element.hasAttribute( 'aria-hidden' ) ||
+		element.hasAttribute( 'aria-live' ) ||
+		( role && LIVE_REGION_ARIA_ROLES.has( role ) )
+	);
+}
+
+/**
+ * Hides all elements in the body element from screen-readers except
+ * the provided element and elements that should not be hidden from
+ * screen-readers.
+ *
+ * The reason we do this is because `aria-modal="true"` currently is bugged
+ * in Safari, and support is spotty in other browsers overall. In the future
+ * we should consider removing these helper functions in favor of
+ * `aria-modal="true"`.
+ *
+ * @param {HTMLDivElement} unhiddenElement The element that should not be hidden.
+ */
+export function hideApp( unhiddenElement?: HTMLDivElement ) {
+	if ( isHidden ) {
+		return;
+	}
+	const elements = Array.from( document.body.children );
+	elements.forEach( ( element ) => {
+		if ( element === unhiddenElement ) {
+			return;
+		}
+		if ( elementShouldBeHidden( element ) ) {
+			element.setAttribute( 'aria-hidden', 'true' );
+			hiddenElements.push( element );
+		}
+	} );
+	isHidden = true;
+}
+
+/**
+ * Makes all elements in the body that have been hidden by `hideApp`
+ * visible again to screen-readers.
+ */
+export function showApp() {
+	if ( ! isHidden ) {
+		return;
+	}
+	hiddenElements.forEach( ( element ) => {
+		element.removeAttribute( 'aria-hidden' );
+	} );
+	hiddenElements = [];
+	isHidden = false;
+}

--- a/assets/js/base/components/quantity-selector/index.tsx
+++ b/assets/js/base/components/quantity-selector/index.tsx
@@ -75,6 +75,14 @@ const QuantitySelector = ( {
 	const canIncrease =
 		! disabled && ( ! hasMaximum || quantity + step <= maximum );
 
+	// When the increase or decrease buttons get disabled, the focus
+	// gets moved to the `<body>` element. This was causing weird
+	// issues in the Mini-Cart block, as the drawer expects focus to be
+	// inside.
+	// To fix this, we move the focus to the text input after the
+	// increase or decrease buttons get disabled. We only do that if
+	// the focus is on the button or the body element.
+	// See https://github.com/woocommerce/woocommerce-blocks/pull/9345
 	useLayoutEffect( () => {
 		// Refs are not available yet, so abort.
 		if (

--- a/assets/js/base/components/quantity-selector/index.tsx
+++ b/assets/js/base/components/quantity-selector/index.tsx
@@ -4,7 +4,7 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
 import classNames from 'classnames';
-import { useCallback, useLayoutEffect } from '@wordpress/element';
+import { useCallback, useLayoutEffect, useRef } from '@wordpress/element';
 import { DOWN, UP } from '@wordpress/keycodes';
 import { useDebouncedCallback } from 'use-debounce';
 
@@ -67,9 +67,38 @@ const QuantitySelector = ( {
 		className
 	);
 
+	const inputRef = useRef< HTMLInputElement | null >( null );
+	const decreaseButtonRef = useRef< HTMLButtonElement | null >( null );
+	const increaseButtonRef = useRef< HTMLButtonElement | null >( null );
 	const hasMaximum = typeof maximum !== 'undefined';
-	const canDecrease = quantity - step >= minimum;
-	const canIncrease = ! hasMaximum || quantity + step <= maximum;
+	const canDecrease = ! disabled && quantity - step >= minimum;
+	const canIncrease =
+		! disabled && ( ! hasMaximum || quantity + step <= maximum );
+
+	useLayoutEffect( () => {
+		// Refs are not available yet, so abort.
+		if (
+			! inputRef.current ||
+			! decreaseButtonRef.current ||
+			! increaseButtonRef.current
+		) {
+			return;
+		}
+		if (
+			! canDecrease &&
+			decreaseButtonRef.current ===
+				decreaseButtonRef.current.ownerDocument.activeElement
+		) {
+			inputRef.current.focus();
+		}
+		if (
+			! canIncrease &&
+			increaseButtonRef.current ===
+				decreaseButtonRef.current.ownerDocument.activeElement
+		) {
+			inputRef.current.focus();
+		}
+	}, [ canDecrease, canIncrease ] );
 
 	/**
 	 * The goal of this function is to normalize what was inserted,
@@ -154,6 +183,7 @@ const QuantitySelector = ( {
 	return (
 		<div className={ classes }>
 			<input
+				ref={ inputRef }
 				className="wc-block-components-quantity-selector__input"
 				disabled={ disabled }
 				type="number"
@@ -186,6 +216,7 @@ const QuantitySelector = ( {
 				) }
 			/>
 			<button
+				ref={ decreaseButtonRef }
 				aria-label={ sprintf(
 					/* translators: %s refers to the item name in the cart. */
 					__(
@@ -195,7 +226,7 @@ const QuantitySelector = ( {
 					itemName
 				) }
 				className="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--minus"
-				disabled={ disabled || ! canDecrease }
+				disabled={ ! canDecrease }
 				onClick={ () => {
 					const newQuantity = quantity - step;
 					onChange( newQuantity );
@@ -215,6 +246,7 @@ const QuantitySelector = ( {
 				&#65293;
 			</button>
 			<button
+				ref={ increaseButtonRef }
 				aria-label={ sprintf(
 					/* translators: %s refers to the item's name in the cart. */
 					__(
@@ -223,7 +255,7 @@ const QuantitySelector = ( {
 					),
 					itemName
 				) }
-				disabled={ disabled || ! canIncrease }
+				disabled={ ! canIncrease }
 				className="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--plus"
 				onClick={ () => {
 					const newQuantity = quantity + step;

--- a/assets/js/base/components/quantity-selector/index.tsx
+++ b/assets/js/base/components/quantity-selector/index.tsx
@@ -194,11 +194,8 @@ const QuantitySelector = ( {
 					),
 					itemName
 				) }
-				className={ classNames(
-					'wc-block-components-quantity-selector__button',
-					'wc-block-components-quantity-selector__button--minus',
-					{ 'is-disabled': disabled || ! canDecrease }
-				) }
+				className="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--minus"
+				disabled={ disabled || ! canDecrease }
 				onClick={ () => {
 					const newQuantity = quantity - step;
 					onChange( newQuantity );
@@ -214,8 +211,6 @@ const QuantitySelector = ( {
 					);
 					normalizeQuantity( newQuantity );
 				} }
-				aria-disabled={ disabled || ! canDecrease }
-				tabIndex={ disabled || ! canDecrease ? -1 : undefined }
 			>
 				&#65293;
 			</button>
@@ -228,11 +223,8 @@ const QuantitySelector = ( {
 					),
 					itemName
 				) }
-				className={ classNames(
-					'wc-block-components-quantity-selector__button',
-					'wc-block-components-quantity-selector__button--plus',
-					{ 'is-disabled': disabled || ! canIncrease }
-				) }
+				disabled={ disabled || ! canIncrease }
+				className="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--plus"
 				onClick={ () => {
 					const newQuantity = quantity + step;
 					onChange( newQuantity );
@@ -248,8 +240,6 @@ const QuantitySelector = ( {
 					);
 					normalizeQuantity( newQuantity );
 				} }
-				aria-disabled={ disabled || ! canIncrease }
-				tabIndex={ disabled || ! canIncrease ? -1 : undefined }
 			>
 				&#65291;
 			</button>

--- a/assets/js/base/components/quantity-selector/index.tsx
+++ b/assets/js/base/components/quantity-selector/index.tsx
@@ -84,17 +84,19 @@ const QuantitySelector = ( {
 		) {
 			return;
 		}
+
+		const currentDocument = inputRef.current.ownerDocument;
 		if (
 			! canDecrease &&
-			decreaseButtonRef.current ===
-				decreaseButtonRef.current.ownerDocument.activeElement
+			( currentDocument.activeElement === decreaseButtonRef.current ||
+				currentDocument.activeElement === currentDocument.body )
 		) {
 			inputRef.current.focus();
 		}
 		if (
 			! canIncrease &&
-			increaseButtonRef.current ===
-				decreaseButtonRef.current.ownerDocument.activeElement
+			( currentDocument.activeElement === increaseButtonRef.current ||
+				currentDocument.activeElement === currentDocument.body )
 		) {
 			inputRef.current.focus();
 		}

--- a/assets/js/base/components/quantity-selector/index.tsx
+++ b/assets/js/base/components/quantity-selector/index.tsx
@@ -194,8 +194,11 @@ const QuantitySelector = ( {
 					),
 					itemName
 				) }
-				className="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--minus"
-				disabled={ disabled || ! canDecrease }
+				className={ classNames(
+					'wc-block-components-quantity-selector__button',
+					'wc-block-components-quantity-selector__button--minus',
+					{ 'is-disabled': disabled || ! canDecrease }
+				) }
 				onClick={ () => {
 					const newQuantity = quantity - step;
 					onChange( newQuantity );
@@ -211,6 +214,8 @@ const QuantitySelector = ( {
 					);
 					normalizeQuantity( newQuantity );
 				} }
+				aria-disabled={ disabled || ! canDecrease }
+				tabIndex={ disabled || ! canDecrease ? -1 : undefined }
 			>
 				&#65293;
 			</button>
@@ -223,8 +228,11 @@ const QuantitySelector = ( {
 					),
 					itemName
 				) }
-				disabled={ disabled || ! canIncrease }
-				className="wc-block-components-quantity-selector__button wc-block-components-quantity-selector__button--plus"
+				className={ classNames(
+					'wc-block-components-quantity-selector__button',
+					'wc-block-components-quantity-selector__button--plus',
+					{ 'is-disabled': disabled || ! canIncrease }
+				) }
 				onClick={ () => {
 					const newQuantity = quantity + step;
 					onChange( newQuantity );
@@ -240,6 +248,8 @@ const QuantitySelector = ( {
 					);
 					normalizeQuantity( newQuantity );
 				} }
+				aria-disabled={ disabled || ! canIncrease }
+				tabIndex={ disabled || ! canIncrease ? -1 : undefined }
 			>
 				&#65291;
 			</button>

--- a/assets/js/base/components/quantity-selector/style.scss
+++ b/assets/js/base/components/quantity-selector/style.scss
@@ -81,7 +81,7 @@
 		&:focus {
 			opacity: 1;
 		}
-		&:disabled {
+		&.is-disabled {
 			box-shadow: none;
 			cursor: default;
 			opacity: 0.6;

--- a/assets/js/base/components/quantity-selector/style.scss
+++ b/assets/js/base/components/quantity-selector/style.scss
@@ -81,7 +81,7 @@
 		&:focus {
 			opacity: 1;
 		}
-		&.is-disabled {
+		&:disabled {
 			box-shadow: none;
 			cursor: default;
 			opacity: 0.6;

--- a/assets/js/blocks/mini-cart/block.tsx
+++ b/assets/js/blocks/mini-cart/block.tsx
@@ -257,7 +257,6 @@ const MiniCartBlock = ( attributes: Props ): JSX.Element => {
 						'is-loading': cartIsLoading,
 					}
 				) }
-				title=""
 				isOpen={ isOpen }
 				onClose={ () => {
 					setIsOpen( false );

--- a/assets/js/blocks/mini-cart/style.scss
+++ b/assets/js/blocks/mini-cart/style.scss
@@ -2,6 +2,11 @@
 	display: inline-block;
 }
 
+.wc-block-mini-cart__template-part,
+.wp-block-woocommerce-mini-cart-contents {
+	height: 100%;
+}
+
 .wc-block-mini-cart__button {
 	align-items: center;
 	background-color: transparent;
@@ -41,7 +46,7 @@
 	}
 }
 
-.modal-open .wc-block-mini-cart__button {
+.drawer-open .wc-block-mini-cart__button {
 	pointer-events: none;
 }
 
@@ -50,6 +55,10 @@
 	font-size: 1rem;
 
 	.wp-block-woocommerce-mini-cart-contents {
+		box-sizing: border-box;
+		padding: 0;
+		justify-content: center;
+
 		.wc-block-components-notices {
 			margin: #{$gap} #{$gap-largest} -#{$gap} #{$gap};
 			margin-bottom: unset;
@@ -57,39 +66,12 @@
 			.wc-block-components-notices__notice {
 				margin-bottom: unset;
 			}
+
+			&:empty {
+				display: none;
+			}
 		}
 	}
-
-	.components-modal__content {
-		padding: 0;
-		position: relative;
-	}
-
-	.components-modal__header {
-		position: relative;
-		height: calc($gap-largest + $gap);
-		position: absolute;
-		top: $gap-largest;
-		right: $gap-smallest;
-
-		button {
-			margin: 0;
-			right: 0;
-			transform: translateY(-50%);
-		}
-
-		svg {
-			fill: currentColor;
-			display: block;
-		}
-	}
-}
-
-.wp-block-woocommerce-mini-cart-contents {
-	box-sizing: border-box;
-	height: 100dvh;
-	padding: 0;
-	justify-content: center;
 }
 :where(.wp-block-woocommerce-mini-cart-contents) {
 	background: #fff;
@@ -222,17 +204,5 @@ h2.wc-block-mini-cart__title {
 			border-color: $gray-900;
 			color: $white;
 		}
-	}
-}
-
-.admin-bar .wp-block-woocommerce-mini-cart-contents {
-	margin-top: 46px;
-	height: calc(100dvh - 46px);
-}
-
-@media only screen and (min-width: 783px) {
-	.admin-bar .wp-block-woocommerce-mini-cart-contents {
-		margin-top: 32px;
-		height: calc(100dvh - 32px);
 	}
 }

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -496,12 +496,9 @@ class MiniCart extends AbstractBlock {
 
 		return '<div class="' . esc_attr( $wrapper_classes ) . '" style="' . esc_attr( $wrapper_styles ) . '">
 			<button class="wc-block-mini-cart__button" aria-label="' . esc_attr( $aria_label ) . '">' . $button_html . '</button>
-			<div class="wc-block-mini-cart__drawer is-loading is-mobile wc-block-components-drawer__screen-overlay wc-block-components-drawer__screen-overlay--is-hidden" aria-hidden="true">
-				<div class="components-modal__frame wc-block-components-drawer">
-					<div class="components-modal__content">
-						<div class="components-modal__header">
-							<div class="components-modal__header-heading-container"></div>
-						</div>
+			<div class="is-loading wc-block-components-drawer__screen-overlay wc-block-components-drawer__screen-overlay--is-hidden" aria-hidden="true">
+				<div class="wc-block-mini-cart__drawer wc-block-components-drawer">
+					<div class="wc-block-components-drawer__content">
 						<div class="wc-block-mini-cart__template-part">'
 						. wp_kses_post( $template_part_contents ) .
 						'</div>

--- a/src/BlockTypes/MiniCartContents.php
+++ b/src/BlockTypes/MiniCartContents.php
@@ -75,15 +75,6 @@ class MiniCartContents extends AbstractBlock {
 
 		$styles = array(
 			array(
-				'selector'   => '.wc-block-mini-cart__drawer .components-modal__header',
-				'properties' => array(
-					array(
-						'property' => 'color',
-						'value'    => $text_color ? $text_color['value'] : false,
-					),
-				),
-			),
-			array(
 				'selector'   => array(
 					'.wc-block-mini-cart__footer .wc-block-mini-cart__footer-actions .wc-block-mini-cart__footer-checkout',
 					'.wc-block-mini-cart__footer .wc-block-mini-cart__footer-actions .wc-block-mini-cart__footer-checkout:hover',

--- a/tests/e2e/specs/shopper/mini-cart.test.js
+++ b/tests/e2e/specs/shopper/mini-cart.test.js
@@ -139,9 +139,7 @@ describe( 'Shopper → Mini-Cart', () => {
 			// Wait for the drawer to fully open.
 			await page.waitForTimeout( 500 );
 
-			await page.click(
-				'.wc-block-mini-cart__drawer .components-modal__header button'
-			);
+			await page.click( '.wc-block-components-drawer__close' );
 
 			await expect( page ).not.toMatchElement(
 				'.wc-block-mini-cart__drawer',


### PR DESCRIPTION
This PR removes the usage of the `Modal` component from `@wordpress/components`. Instead, it updates our `Drawer` component to incorporate some functionality from `Modal`. I didn't copy & paste everything from the `Modal` component, instead, I just tried to import the features that were needed for our use case.

Fixes #8606.

Part of #8452.

#### Accessibility

- [x] I've tested using only a keyboard (no mouse)
- [x] I've tested using a screen reader
- [x] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Testing

#### User Facing Testing

This PR shouldn't introduce any visual changes for users, so testing it means making sure there are no regressions.

1. Add the Mini Cart block to the header of your site via (Appearance > Editor). 
2. In the frontend and with the Cart empty, open the Mini Cart drawer, verify you can open and close the drawer without problems.
3. Add some products to your cart and open the Mini Cart drawer again. Verify you can open and close it, you can change the products quantity, etc.
4. Go to Appearance > Editor > Template Parts > Mini Cart and change some of the styles of the inner blocks. For example, add a custom background, border and width to the Mini Cart Contents block.
5. Repeat step 3.

Now, let's test that things keep working if there are two Mini Cart blocks in the same page. We don't officially support it, but at the same time we don't want the experience to be broken.

6. create a post or page and add the Mini Cart block.
7. Open that post/page in the frontend. You should now have two Mini Cart buttons in the screen, the one from the site header and the one from the post/page.
8. Verify both buttons work as expected.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Mini Cart block no longer uses the Modal component from `@wordpress/components`.
