### PR TITLE
Fix: Edit Mini Cart template part URL.

### DIFF
--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -181,14 +181,12 @@ class MiniCart extends AbstractBlock {
 				);
 			}
 
-			$template_part_edit_uri = esc_url(
-				add_query_arg(
-					array(
-						'postId'   => sprintf( '%s//%s', $theme_slug, 'mini-cart' ),
-						'postType' => 'wp_template_part',
-					),
-					$site_editor_uri
-				)
+			$template_part_edit_uri = add_query_arg(
+				array(
+					'postId'   => sprintf( '%s//%s', $theme_slug, 'mini-cart' ),
+					'postType' => 'wp_template_part',
+				),
+				$site_editor_uri
 			);
 		}
 


### PR DESCRIPTION
This PR fixes the link in the settings panel of the Mini Cart which is titled Edit Mini Basket template part. For some reason the `esc_url()` was adding `#038;` to the URL which was causing the problem. Since we generate this URL ourself we can not only be pretty confident that it's a clean URL but also we sanitize it anyway [here](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/src/Assets/AssetDataRegistry.php#L372).

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/9256

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|        |       |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Go to Appearance > Site Editor > Template Parts > Header
2. Add the Mini Cart block to the header. In the settings panel see the link "Edit Mini Basket template part".
3. Clicking this link should take you to the correct URL.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Fix "Edit Mini Cart template part" URL for the Mini Cart block.
