### PR TITLE
Store API: Fix payment method validation (fixes COD)

### DIFF
--- a/src/StoreApi/Routes/V1/Checkout.php
+++ b/src/StoreApi/Routes/V1/Checkout.php
@@ -617,12 +617,14 @@ class Checkout extends AbstractCartRoute {
 		}
 
 		if ( ! isset( $available_gateways[ $request_payment_method ] ) ) {
+			$all_payment_gateways = WC()->payment_gateways->payment_gateways();
+			$gateway_title        = isset( $all_payment_gateways[ $request_payment_method ] ) ? $all_payment_gateways[ $request_payment_method ]->get_title() : $request_payment_method;
 			throw new RouteException(
 				'woocommerce_rest_checkout_payment_method_disabled',
 				sprintf(
 					// Translators: %s Payment method ID.
-					__( 'The %s payment gateway is not available.', 'woo-gutenberg-products-block' ),
-					esc_html( $request_payment_method )
+					__( '%s is not available for this order—please choose a different payment method', 'woo-gutenberg-products-block' ),
+					esc_html( $gateway_title )
 				),
 				400
 			);

--- a/src/StoreApi/Schemas/V1/CheckoutSchema.php
+++ b/src/StoreApi/Schemas/V1/CheckoutSchema.php
@@ -119,7 +119,9 @@ class CheckoutSchema extends AbstractSchema {
 				'description' => __( 'The ID of the payment method being used to process the payment.', 'woo-gutenberg-products-block' ),
 				'type'        => 'string',
 				'context'     => [ 'view', 'edit' ],
-				'enum'        => array_values( wp_list_pluck( WC()->payment_gateways->get_available_payment_gateways(), 'id' ) ),
+				// Validation may be based on cart contents which is not available here; this returns all enabled
+				// gateways. Further validation occurs during the request.
+				'enum'        => array_values( WC()->payment_gateways->get_payment_gateway_ids() ),
 			],
 			'create_account'    => [
 				'description' => __( 'Whether to create a new user account as part of order processing.', 'woo-gutenberg-products-block' ),


### PR DESCRIPTION
Widens the Store API Checkout Route enum for payment methods. Returns all payment methods, not just those "available". This is because schema is retrieved before a cart is loaded into session, and this is a dependency for validation.

I've noted this inline to prevent it being reverted.

Full validation occurs later during the checkout request. I've updated the error message to make it clear:

![Screenshot 2023-05-05 at 12 01 20](https://user-images.githubusercontent.com/90977/236441643-32a6ca19-e1f7-4ff8-b5cb-d5c028a51e3f.png)

@senadir see any issue with this?

Fixes #9074

### Testing

#### User Facing Testing

Use the following config for cash on delivery:

![Screenshot 2023-05-05 at 12 04 16](https://user-images.githubusercontent.com/90977/236441790-194a8a4b-08cf-456c-a7f1-55cb5170fdd3.png)

**To test the original issue:**

- Before using this branch, go to the store
- add an item to your cart
- go to checkout
- select COD
- Place the order. You'll see this error message:

**To test the fix**

The order will go through without an error message (the erroneous case has been fixed).

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix COD availability on checkout.
