### PR TITLE
Removed header and footer from checkout template.

### DIFF
--- a/src/Templates/CheckoutTemplate.php
+++ b/src/Templates/CheckoutTemplate.php
@@ -81,7 +81,6 @@ class CheckoutTemplate {
 
 		if ( $page && ! empty( $page->post_content ) ) {
 			$template_content = '
-				<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 				<!-- wp:group {"layout":{"inherit":true}} -->
 				<div class="wp-block-group">
 					<!-- wp:heading {"level":1} -->
@@ -90,7 +89,6 @@ class CheckoutTemplate {
 					' . wp_kses_post( $page->post_content ) . '
 				</div>
 				<!-- /wp:group -->
-				<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->
 			';
 		}
 

--- a/templates/templates/checkout.html
+++ b/templates/templates/checkout.html
@@ -1,4 +1,3 @@
-<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 <!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group">
 	<!-- wp:woocommerce/checkout -->
@@ -90,4 +89,3 @@
 	<!-- /wp:woocommerce/checkout -->
 </div>
 <!-- /wp:group -->
-<!-- wp:template-part {"slug":"footer"} /-->


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #9291

Removed header and footer template parts from default template and migrated templates.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->



### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Enable a blocks theme and go to the Site Editor
2. Verify the checkout template does not have the footer and header present
3. Repeat the same steps starting with an empty checkout page

* [X] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->



### Changelog

> n/a
