### PR TITLE
Add color and typography styles on the mini cart title block

### DIFF
--- a/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-title-block/block.json
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-title-block/block.json
@@ -13,7 +13,7 @@
 		"lock": false,
 		"color": {
 			"text": true,
-			"background": true
+			"background": false
 		},
 		"typography": {
 			"fontSize": true

--- a/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-title-block/block.json
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-title-block/block.json
@@ -10,7 +10,14 @@
 		"multiple": false,
 		"reusable": false,
 		"inserter": false,
-		"lock": false
+		"lock": false,
+		"color": {
+			"text": true,
+			"background": true
+		},
+		"typography": {
+			"fontSize": true
+		}
 	},
 	"attributes": {
 		"lock": {


### PR DESCRIPTION
The goal of this PR is to make the Mini Cart Title customizable through the settings sidebar (colors, typography).
In which the two inner blocks `Mini Cart Title Label` and `Mini Cart Title Items Counter` will inherit by default.

Fixes #9346

### Testing

1. Install and activate the Twenty Twenty-Three theme
1. Go to Appearance > Editor > Template parts > Mini Cart
1. Select the `Mini Cart Title` block and add some customizations on the settings sidebar (colors, typography).
1. Check if the customizations are applied in the editor and in the frontend of the website.

### Screenshots

<table>
<tr>
<td valign="top">Before:
<br><br>

 ![image](https://user-images.githubusercontent.com/25006926/236684541-f60af3bd-294d-4b48-8529-a7c7576691a0.png)
</td>
<td valign="top">After:
<br><br>

![image](https://user-images.githubusercontent.com/25006926/236684549-d38e2c98-c85a-467c-94de-0738457da314.png)
</td>
</tr>
</table>

### WooCommerce Visibility

* [X] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Mini cart: add color and typography styles on the mini cart title block
