### PR TITLE
Create a `PayForOrder` service class to implement authentication checks

### DIFF
--- a/src/Domain/Bootstrap.php
+++ b/src/Domain/Bootstrap.php
@@ -11,6 +11,7 @@ use Automattic\WooCommerce\Blocks\Domain\Services\CreateAccount;
 use Automattic\WooCommerce\Blocks\Domain\Services\DraftOrders;
 use Automattic\WooCommerce\Blocks\Domain\Services\FeatureGating;
 use Automattic\WooCommerce\Blocks\Domain\Services\GoogleAnalytics;
+use Automattic\WooCommerce\Blocks\Domain\Services\PayForOrder;
 use Automattic\WooCommerce\Blocks\InboxNotifications;
 use Automattic\WooCommerce\Blocks\Installer;
 use Automattic\WooCommerce\Blocks\Migration;
@@ -126,6 +127,7 @@ class Bootstrap {
 		$this->container->get( CreateAccount::class )->init();
 		$this->container->get( StoreApi::class )->init();
 		$this->container->get( GoogleAnalytics::class );
+		$this->container->get( PayForOrder::class )->init();
 		$this->container->get( BlockTypesController::class );
 		$this->container->get( BlockTemplatesController::class );
 		$this->container->get( ProductSearchResultsTemplate::class );
@@ -312,6 +314,12 @@ class Bootstrap {
 				}
 				$asset_api = $container->get( AssetApi::class );
 				return new GoogleAnalytics( $asset_api );
+			}
+		);
+		$this->container->register(
+			PayForOrder::class,
+			function () {
+				return new PayForOrder();
 			}
 		);
 		$this->container->register(

--- a/src/Domain/Services/PayForOrder.php
+++ b/src/Domain/Services/PayForOrder.php
@@ -1,0 +1,51 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\Domain\Services;
+
+/**
+ * Service class implementing authentication checks for pay-for-order checkout block.
+ */
+class PayForOrder {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->init();
+	}
+
+	/**
+	 * Hook into WP.
+	 */
+	public function init() {
+		add_filter( 'the_content', array( $this, 'check_authentication' ) );
+	}
+
+	/**
+	 * Check authentication for pay for order
+	 *
+	 * @param string $content Content.
+	 */
+	public function check_authentication( $content ) {
+		global $wp;
+
+		$order_id = ! empty( $wp->query_vars['order-pay'] ) ? $wp->query_vars['order-pay'] : null;
+
+		if ( isset( $_GET['pay_for_order'], $_GET['key'] ) && $order_id ) { // phpcs:ignore WordPress.Security.NonceVerification
+			$order = wc_get_order( $order_id );
+
+			// Logged out customer does not have permission to pay for this order.
+			if ( ! current_user_can( 'pay_for_order', $order_id ) && ! is_user_logged_in() ) {
+				ob_start();
+				wc_print_notice( esc_html__( 'Please log in to your account below to continue to the payment form.', 'woo-gutenberg-products-block' ), 'notice' );
+				woocommerce_login_form(
+					array(
+						'redirect' => $order->get_checkout_payment_url(),
+					)
+				);
+				return ob_get_clean();
+			}
+		}
+
+		return $content;
+	}
+}


### PR DESCRIPTION
Create a `PayForOrder` service class to implement authentication checks for the pay-for-order checkout block.

Fixes #9400 

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| | Before | After |
| ------ | ----- | ----- |
| Customer |<img width="707" alt="Screen Shot 2023-05-08 at 10 27 33 PM" src="https://user-images.githubusercontent.com/56378160/237002178-e5b5faa8-0069-4d62-a9c4-2a14549a6874.png">|<img width="735" alt="Screen Shot 2023-05-08 at 10 28 12 PM" src="https://user-images.githubusercontent.com/56378160/237002273-9c8d183b-3559-4404-934a-4b1b580aaaf9.png">|
| Guest |<img width="707" alt="Screen Shot 2023-05-08 at 10 27 33 PM" src="https://user-images.githubusercontent.com/56378160/237002178-e5b5faa8-0069-4d62-a9c4-2a14549a6874.png">|<img width="707" alt="Screen Shot 2023-05-08 at 10 27 33 PM" src="https://user-images.githubusercontent.com/56378160/237002178-e5b5faa8-0069-4d62-a9c4-2a14549a6874.png">|

### Testing
1. Comment out `is_wc_endpoint_url( 'order-pay' )` ( Done in [this PR ](https://github.com/woocommerce/woocommerce-blocks/pull/9344/files))
2. Create a pay-for-order order as a guest
1. Go to WC -> Orders -> find the order you just created
1. Click on the `Customer payment page` and copy the URL to incognito
1. See `Your cart is currently empty!` ( Because we don't allow guest to pay for order )
3. Go back to the order you just created
4. Change `Customer` to an existing customer
5. Go back to the `Your cart is currently empty!`  page and refresh
6. See the login form

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
 
### Changelog

> Create a `PayForOrder` service class to implement authentication checks
