### PR TITLE
Skip the failing test

### DIFF
--- a/tests/e2e/specs/shopper/cart-checkout/checkout.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/checkout.test.js
@@ -125,6 +125,11 @@ describe( 'Shopper → Checkout', () => {
 			);
 		} );
 
+		/**
+		 * Temporarily disable test as it often fails on a pipeline,
+		 * but cannot be reproduced manually.
+		 */
+		// eslint-disable-next-line jest/no-disabled-tests
 		it.skip( 'Switching between local pickup and shipping does not affect the address', async () => {
 			await shopper.block.emptyCart();
 			await shopper.block.goToShop();

--- a/tests/e2e/specs/shopper/cart-checkout/checkout.test.js
+++ b/tests/e2e/specs/shopper/cart-checkout/checkout.test.js
@@ -125,7 +125,7 @@ describe( 'Shopper → Checkout', () => {
 			);
 		} );
 
-		it( 'Switching between local pickup and shipping does not affect the address', async () => {
+		it.skip( 'Switching between local pickup and shipping does not affect the address', async () => {
 			await shopper.block.emptyCart();
 			await shopper.block.goToShop();
 			await shopper.addToCartFromShopPage( SIMPLE_PHYSICAL_PRODUCT_NAME );


### PR DESCRIPTION
Skip the failing test:

“Shopper → Checkout › Local pickup › Switching between local pickup and shipping does not affect the address”

Test is failing consistently:
Example actions:
- [1](https://github.com/woocommerce/woocommerce-blocks/actions/runs/4915636339/jobs/8778358205),
- [2](https://github.com/woocommerce/woocommerce-blocks/actions/runs/4923144200/jobs/8794629544),
- [3](https://github.com/woocommerce/woocommerce-blocks/actions/runs/4914818772/jobs/8776572044),
- [4](https://github.com/woocommerce/woocommerce-blocks/actions/runs/4915490372/jobs/8778043052)