### PR TITLE
Related Products: Fix hardcoded limit product

### DIFF
--- a/src/BlockTypes/RelatedProducts.php
+++ b/src/BlockTypes/RelatedProducts.php
@@ -115,10 +115,10 @@ class RelatedProducts extends AbstractBlock {
 
 		// If there are no related products, render nothing.
 		$related_products_ids = $this->get_related_products_ids();
-
 		if ( count( $related_products_ids ) < 1 ) {
 			return '';
 		}
+
 		return $content;
 	}
 

--- a/src/BlockTypes/RelatedProducts.php
+++ b/src/BlockTypes/RelatedProducts.php
@@ -87,7 +87,7 @@ class RelatedProducts extends AbstractBlock {
 			return $query;
 		}
 
-		$related_products_ids = $this->get_related_products_ids();
+		$related_products_ids = $this->get_related_products_ids( $query['posts_per_page'] );
 		if ( count( $related_products_ids ) < 1 ) {
 			return array();
 		}
@@ -113,6 +113,7 @@ class RelatedProducts extends AbstractBlock {
 			return $content;
 		}
 
+		// If there are no related products, render nothing.
 		$related_products_ids = $this->get_related_products_ids();
 
 		if ( count( $related_products_ids ) < 1 ) {
@@ -142,14 +143,15 @@ class RelatedProducts extends AbstractBlock {
 	 * Get related products ids.
 	 * The logic is copied from the core function woocommerce_related_products. https://github.com/woocommerce/woocommerce/blob/ca49caabcba84ce9f60a03c6d3534ec14b350b80/plugins/woocommerce/includes/wc-template-functions.php/#L2039-L2074
 	 *
+	 * @param number $product_per_page Products per page.
 	 * @return array Products ids.
 	 */
-	private function get_related_products_ids() {
+	private function get_related_products_ids( $product_per_page = 5 ) {
 		global $post;
 
 		$product = wc_get_product( $post->ID );
 
-		$related_products = array_filter( array_map( 'wc_get_product', wc_get_related_products( $product->get_id(), 5, $product->get_upsell_ids() ) ), 'wc_products_array_filter_visible' );
+		$related_products = array_filter( array_map( 'wc_get_product', wc_get_related_products( $product->get_id(), $product_per_page, $product->get_upsell_ids() ) ), 'wc_products_array_filter_visible' );
 		$related_products = wc_products_array_orderby( $related_products, 'rand', 'desc' );
 
 		$related_product_ids = array_map(


### PR DESCRIPTION
This PR removes the hardcoded limit to return related products. The limit should be set via the block settings:

![image](https://github.com/woocommerce/woocommerce-blocks/assets/4463174/489c7b90-5735-428a-a28b-8e69c6d392a6)


### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Open the Single Product Template.
2. Switch to the blockified template.
3. Focus on the `Related Products Controls` block.
4. Change the option `Items per Page`, for example, put 10.
5. Be sure that there are often related products. (if not, you can just clone the same product multiple times)
6. Save the template.
7. Visit a Product and be sure that the Related Products block shows the number of products that you selected before. (if you select a high number, there is the risk that there will be displayed fewer products. It is not a bug, but it means that aren't so many related products).

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

