### PR TITLE
Remove `<br>` In `Hero Product – Split` Pattern Heading

### DIFF
--- a/patterns/hero-product-split.php
+++ b/patterns/hero-product-split.php
@@ -9,7 +9,7 @@
 <!-- wp:media-text {"align":"full","mediaPosition":"right","mediaType":"image","mediaSizeSlug":"full","imageFill":false,"backgroundColor":"contrast","textColor":"base"} -->
 <div class="wp-block-media-text alignfull has-media-on-the-right is-stacked-on-mobile has-base-color has-contrast-background-color has-text-color has-background">
 	<div class="wp-block-media-text__content"><!-- wp:heading -->
-		<h2 class="wp-block-heading">Get cozy this fall with<br>flannel shirts</h2>
+		<h2 class="wp-block-heading">Get cozy this fall with flannel shirts</h2>
 		<!-- /wp:heading -->
 
 		<!-- wp:buttons {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}}} -->


### PR DESCRIPTION
This quickfix allows the text to flow more naturally, as opposed to having unexpected line-breaks at certain screen widths.

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
| ![CleanShot 2023-05-09 at 10 20 38](https://github.com/woocommerce/woocommerce-blocks/assets/481776/7b0c044c-c3f6-4082-800e-ad04008162ef) | ![CleanShot 2023-05-09 at 10 21 22](https://github.com/woocommerce/woocommerce-blocks/assets/481776/295dedc8-ee1a-4c78-b27a-3095b4d5c1a3) |


### Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. In the editor, insert the `Hero Product – Split` pattern.
2. Inspect the output and confirm that there is no `<br>` in the heading.
3. Adjust the browser/viewport width and confirm that the text flows naturally without any unexpected line-breaks.

![CleanShot 2023-05-09 at 10 24 32](https://github.com/woocommerce/woocommerce-blocks/assets/481776/b118ae6d-9c9d-477c-8d2e-9c88faa52179)

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
