### PR TITLE
Sync endpoints with pages

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -668,7 +668,7 @@ class BlockTemplatesController {
 					'title'    => __( 'Checkout page', 'woo-gutenberg-products-block' ),
 					'desc'     => sprintf(
 						// translators: %1$s: opening anchor tag, %2$s: closing anchor tag.
-						__( 'The checkout page template can be %1$s edited here%2$s.', 'woo-gutenberg-products-block' ),
+						__( 'The checkout template can be %1$s edited here%2$s.', 'woo-gutenberg-products-block' ),
 						'<a href="' . esc_url( admin_url( 'site-editor.php?postType=wp_template&postId=woocommerce%2Fwoocommerce%2F%2F' . CheckoutTemplate::get_slug() ) ) . '" target="_blank">',
 						'</a>'
 					),
@@ -685,7 +685,7 @@ class BlockTemplatesController {
 					'title'    => __( 'Cart page', 'woo-gutenberg-products-block' ),
 					'desc'     => sprintf(
 						// translators: %1$s: opening anchor tag, %2$s: closing anchor tag.
-						__( 'The cart page template can be %1$s edited here%2$s.', 'woo-gutenberg-products-block' ),
+						__( 'The cart template can be %1$s edited here%2$s.', 'woo-gutenberg-products-block' ),
 						'<a href="' . esc_url( admin_url( 'site-editor.php?postType=wp_template&postId=woocommerce%2Fwoocommerce%2F%2F' . CartTemplate::get_slug() ) ) . '" target="_blank">',
 						'</a>'
 					),

--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -9,6 +9,7 @@ use Automattic\WooCommerce\Blocks\Templates\SingleProductTemplateCompatibility;
 use Automattic\WooCommerce\Blocks\Utils\BlockTemplateUtils;
 use Automattic\WooCommerce\Blocks\Templates\OrderReceivedTemplate;
 use Automattic\WooCommerce\Blocks\Utils\SettingsUtils;
+use \WP_Post;
 
 /**
  * BlockTypesController class.
@@ -75,16 +76,9 @@ class BlockTemplatesController {
 		add_filter( 'post_type_archive_title', array( $this, 'update_product_archive_title' ), 10, 2 );
 
 		if ( wc_current_theme_is_fse_theme() ) {
-			add_action( 'init', array( $this, 'register_template_endpoints' ) );
-			add_filter( 'woocommerce_is_checkout', array( $this, 'is_checkout_endpoint' ) );
-			add_filter( 'woocommerce_is_cart', array( $this, 'is_cart_endpoint' ) );
-			add_filter( 'woocommerce_get_cart_url', array( $this, 'get_cart_url' ) );
-			add_filter( 'woocommerce_get_checkout_url', array( $this, 'get_checkout_url' ) );
 			add_filter( 'woocommerce_settings_pages', array( $this, 'template_permalink_settings' ) );
+			add_filter( 'pre_update_option', array( $this, 'update_template_permalink' ), 10, 2 );
 			add_action( 'woocommerce_admin_field_permalink', array( SettingsUtils::class, 'permalink_input_field' ) );
-			add_action( 'after_switch_theme', 'flush_rewrite_rules' );
-			add_action( 'update_option_woocommerce_checkout_page_endpoint', 'flush_rewrite_rules' );
-			add_action( 'update_option_woocommerce_cart_page_endpoint', 'flush_rewrite_rules' );
 		}
 
 		if ( $this->package->is_experimental_build() ) {
@@ -661,72 +655,6 @@ class BlockTemplatesController {
 	}
 
 	/**
-	 * Registers rewrite endpoints for templates during init.
-	 */
-	public function register_template_endpoints() {
-		$query_vars        = WC()->query->get_query_vars();
-		$cart_page         = CartTemplate::get_legacy_page();
-		$cart_endpoint     = get_option( 'woocommerce_cart_page_endpoint', $cart_page ? $cart_page->post_name : CartTemplate::get_slug() );
-		$checkout_page     = CheckoutTemplate::get_legacy_page();
-		$checkout_endpoint = get_option( 'woocommerce_checkout_page_endpoint', $checkout_page ? $checkout_page->post_name : CheckoutTemplate::get_slug() );
-
-		add_rewrite_endpoint( $checkout_endpoint . '/' . $query_vars['order-received'], \EP_ROOT, $query_vars['order-received'] );
-		add_rewrite_endpoint( $checkout_endpoint . '/' . $query_vars['order-pay'], \EP_ROOT, $query_vars['order-pay'] );
-		add_rewrite_endpoint( $checkout_endpoint, \EP_ROOT, CheckoutTemplate::get_slug() );
-		add_rewrite_endpoint( $cart_endpoint, \EP_ROOT, CartTemplate::get_slug() );
-	}
-
-	/**
-	 * Filters the `is_checkout` function so we can return true when the endpoint is active, or if one of its other endpoints are in use (e.g. order received).
-	 *
-	 * @param boolean $return True when on the checkout page.
-	 * @return boolean
-	 */
-	public function is_checkout_endpoint( $return ) {
-		global $wp;
-
-		if ( isset( $wp->query_vars[ CheckoutTemplate::get_slug() ] ) || isset( $wp->query_vars[ OrderReceivedTemplate::get_slug() ] ) ) {
-			return true;
-		}
-
-		return $return;
-	}
-
-	/**
-	 * Filters the `is_cart` function so we can return true when the endpoint is active.
-	 *
-	 * @param boolean $return True when on the checkout page.
-	 * @return boolean
-	 */
-	public function is_cart_endpoint( $return ) {
-		global $wp;
-
-		if ( isset( $wp->query_vars[ CartTemplate::get_slug() ] ) ) {
-			return true;
-		}
-
-		return $return;
-	}
-
-	/**
-	 * Replace the cart PAGE URL with the template endpoint URL.
-	 *
-	 * @return string
-	 */
-	public function get_cart_url() {
-		return site_url( '/' . CartTemplate::get_slug() );
-	}
-
-	/**
-	 * Replace the checkout PAGE URL with the template endpoint URL.
-	 *
-	 * @return string
-	 */
-	public function get_checkout_url() {
-		return site_url( '/' . CheckoutTemplate::get_slug() );
-	}
-
-	/**
 	 * Replaces page settings in WooCommerce with text based permalinks which point to a template.
 	 *
 	 * @param array $settings Settings pages.
@@ -735,7 +663,7 @@ class BlockTemplatesController {
 	public function template_permalink_settings( $settings ) {
 		foreach ( $settings as $key => $setting ) {
 			if ( 'woocommerce_checkout_page_id' === $setting['id'] ) {
-				$checkout_page    = CheckoutTemplate::get_legacy_page();
+				$checkout_page    = CheckoutTemplate::get_placeholder_page();
 				$settings[ $key ] = [
 					'title'    => __( 'Checkout page', 'woo-gutenberg-products-block' ),
 					'desc'     => sprintf(
@@ -752,7 +680,7 @@ class BlockTemplatesController {
 				];
 			}
 			if ( 'woocommerce_cart_page_id' === $setting['id'] ) {
-				$cart_page        = CartTemplate::get_legacy_page();
+				$cart_page        = CartTemplate::get_placeholder_page();
 				$settings[ $key ] = [
 					'title'    => __( 'Cart page', 'woo-gutenberg-products-block' ),
 					'desc'     => sprintf(
@@ -771,5 +699,56 @@ class BlockTemplatesController {
 		}
 
 		return $settings;
+	}
+
+	/**
+	 * Syncs entered permalink with the pages and returns the correct value.
+	 *
+	 * @param string $value     Value of the option.
+	 * @param string $option    Name of the option.
+	 * @return string
+	 */
+	public function update_template_permalink( $value, $option ) {
+		if ( 'woocommerce_checkout_page_endpoint' === $option ) {
+			return $this->sync_endpoint_with_page( CheckoutTemplate::get_placeholder_page(), 'checkout', $value );
+		}
+		if ( 'woocommerce_cart_page_endpoint' === $option ) {
+			return $this->sync_endpoint_with_page( CartTemplate::get_placeholder_page(), 'cart', $value );
+		}
+		return $value;
+	}
+
+	/**
+	 * Syncs the provided permalink with the actual WP page.
+	 *
+	 * @param WP_Post|null $page The page object, or null if it does not exist.
+	 * @param string       $page_slug The identifier for the page e.g. cart, checkout.
+	 * @param string       $permalink The new permalink to use.
+	 * @return string THe actual permalink assigned to the page. May differ from $permalink if it was already taken.
+	 */
+	protected function sync_endpoint_with_page( $page, $page_slug, $permalink ) {
+		if ( ! $page ) {
+			$updated_page_id = wc_create_page(
+				esc_sql( $permalink ),
+				'woocommerce_' . $page_slug . '_page_id',
+				$page_slug,
+				'',
+				'',
+				'publish'
+			);
+		} else {
+			$updated_page_id = wp_update_post(
+				[
+					'ID'        => $page->ID,
+					'post_name' => esc_sql( $permalink ),
+				]
+			);
+		}
+
+		// Get post again in case slug was updated with a suffix.
+		if ( $updated_page_id && ! is_wp_error( $updated_page_id ) ) {
+			return get_post( $updated_page_id )->post_name;
+		}
+		return $permalink;
 	}
 }

--- a/src/Templates/AbstractPageTemplate.php
+++ b/src/Templates/AbstractPageTemplate.php
@@ -37,11 +37,18 @@ abstract class AbstractPageTemplate {
 	abstract public static function get_slug();
 
 	/**
-	 * Returns the page object assigned to this template/page used for legacy purposes. Pages are no longer required.
+	 * Returns the page object assigned to this template/page.
 	 *
 	 * @return \WP_Post|null Post object or null.
 	 */
-	abstract public static function get_legacy_page();
+	abstract public static function get_placeholder_page();
+
+	/**
+	 * Should return the title of the page.
+	 *
+	 * @return string
+	 */
+	abstract public static function get_template_title();
 
 	/**
 	 * Should return true on pages/endpoints/routes where the template should be shown.
@@ -49,13 +56,6 @@ abstract class AbstractPageTemplate {
 	 * @return boolean
 	 */
 	abstract protected function is_active_template();
-
-	/**
-	 * Should return the title of the page.
-	 *
-	 * @return string
-	 */
-	abstract protected function get_template_title();
 
 	/**
 	 * Returns the URL to edit the template.
@@ -114,7 +114,7 @@ abstract class AbstractPageTemplate {
 	 * @param \WP_Screen $current_screen Current screen information.
 	 */
 	public function page_template_editor_redirect( \WP_Screen $current_screen ) {
-		$page         = $this->get_legacy_page();
+		$page         = $this->get_placeholder_page();
 		$edit_page_id = 'page' === $current_screen->id && ! empty( $_GET['post'] ) ? absint( $_GET['post'] ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 		if ( $page && $edit_page_id === $page->id ) {

--- a/src/Templates/CartTemplate.php
+++ b/src/Templates/CartTemplate.php
@@ -17,11 +17,11 @@ class CartTemplate extends AbstractPageTemplate {
 	}
 
 	/**
-	 * Returns the page object assigned to this template/page used for legacy purposes. Pages are no longer required.
+	 * Returns the page object assigned to this template/page.
 	 *
 	 * @return \WP_Post|null Post object or null.
 	 */
-	public static function get_legacy_page() {
+	public static function get_placeholder_page() {
 		$page_id = wc_get_page_id( 'cart' );
 		return $page_id ? get_post( $page_id ) : null;
 	}
@@ -40,7 +40,7 @@ class CartTemplate extends AbstractPageTemplate {
 	 *
 	 * @return string
 	 */
-	protected function get_template_title() {
+	public static function get_template_title() {
 		return __( 'Cart', 'woo-gutenberg-products-block' );
 	}
 
@@ -51,7 +51,7 @@ class CartTemplate extends AbstractPageTemplate {
 	 * @return string
 	 */
 	public function get_default_template_content( $template_content ) {
-		$page = $this->get_legacy_page();
+		$page = $this->get_placeholder_page();
 
 		if ( $page && ! empty( $page->post_content ) ) {
 			$template_content = '

--- a/src/Templates/CheckoutTemplate.php
+++ b/src/Templates/CheckoutTemplate.php
@@ -17,13 +17,22 @@ class CheckoutTemplate extends AbstractPageTemplate {
 	}
 
 	/**
-	 * Returns the page object assigned to this template/page used for legacy purposes. Pages are no longer required.
+	 * Returns the page object assigned to this template/page.
 	 *
 	 * @return \WP_Post|null Post object or null.
 	 */
-	public static function get_legacy_page() {
+	public static function get_placeholder_page() {
 		$page_id = wc_get_page_id( 'checkout' );
 		return $page_id ? get_post( $page_id ) : null;
+	}
+
+	/**
+	 * Should return the title of the page.
+	 *
+	 * @return string
+	 */
+	public static function get_template_title() {
+		return __( 'Checkout', 'woo-gutenberg-products-block' );
 	}
 
 	/**
@@ -36,22 +45,13 @@ class CheckoutTemplate extends AbstractPageTemplate {
 	}
 
 	/**
-	 * Should return the title of the page.
-	 *
-	 * @return string
-	 */
-	protected function get_template_title() {
-		return __( 'Checkout', 'woo-gutenberg-products-block' );
-	}
-
-	/**
 	 * Migrates an existing page using blocks to the block templates.
 	 *
 	 * @param string $template_content The content of the template.
 	 * @return string
 	 */
 	public function get_default_template_content( $template_content ) {
-		$page = $this->get_legacy_page();
+		$page = $this->get_placeholder_page();
 
 		if ( $page && ! empty( $page->post_content ) ) {
 			$template_content = '

--- a/src/Templates/OrderReceivedTemplate.php
+++ b/src/Templates/OrderReceivedTemplate.php
@@ -17,11 +17,11 @@ class OrderReceivedTemplate extends AbstractPageTemplate {
 	}
 
 	/**
-	 * Returns the page object assigned to this template/page used for legacy purposes. Pages are no longer required.
+	 * Returns the page object assigned to this template/page.
 	 *
 	 * @return \WP_Post|null Post object or null.
 	 */
-	public static function get_legacy_page() {
+	public static function get_placeholder_page() {
 		return null;
 	}
 
@@ -39,7 +39,7 @@ class OrderReceivedTemplate extends AbstractPageTemplate {
 	 *
 	 * @return string
 	 */
-	protected function get_template_title() {
+	public static function get_template_title() {
 		return __( 'Order Received', 'woo-gutenberg-products-block' );
 	}
 }


### PR DESCRIPTION
As discussed with @wavvves, this removes endpoints and instead syncs permalinks (for templates) with the pages themselves. This allows us to maintain backwards compatibility with pages, whilst introducing a method of changing the permalink, and then replace the page with a block template.

Follow up task—hide the pages from the pages screen.