### PR TITLE
Update `Hero Product – Split` Pattern Color Settings

### DIFF
--- a/patterns/hero-product-split.php
+++ b/patterns/hero-product-split.php
@@ -6,17 +6,20 @@
  */
 ?>
 
-<!-- wp:media-text {"align":"full","mediaPosition":"right","mediaType":"image","mediaSizeSlug":"full","imageFill":false,"backgroundColor":"contrast","textColor":"base"} -->
-<div class="wp-block-media-text alignfull has-media-on-the-right is-stacked-on-mobile has-base-color has-contrast-background-color has-text-color has-background">
-	<div class="wp-block-media-text__content"><!-- wp:heading -->
-		<h2 class="wp-block-heading">Get cozy this fall with flannel shirts</h2>
+<!-- wp:media-text {"align":"full","mediaPosition":"right","mediaType":"image","mediaSizeSlug":"full","imageFill":false,"style":{"color":{"background":"#000000","text":"#ffffff"}}} -->
+<div class="wp-block-media-text alignfull has-media-on-the-right is-stacked-on-mobile has-text-color has-background" style="color:#ffffff;background-color:#000000">
+	<div class="wp-block-media-text__content">
+		<!-- wp:heading {"textColor":"background"} -->
+		<h2 class="wp-block-heading has-background-color has-text-color">Get cozy this fall with flannel shirts</h2>
 		<!-- /wp:heading -->
 
 		<!-- wp:buttons {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}}} -->
 		<div class="wp-block-buttons" style="margin-bottom:var(--wp--preset--spacing--40)">
-			<!-- wp:button -->
-			<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Shop now</a></div>
-			<!-- /wp:button -->
+		<!-- wp:button {"style":{"color":{"text":"#000000","background":"#ffffff"}}} -->
+		<div class="wp-block-button">
+			<a class="wp-block-button__link has-text-color has-background wp-element-button" style="color:#000000;background-color:#ffffff;">Shop now</a>
+		</div>
+		<!-- /wp:button -->
 		</div>
 		<!-- /wp:buttons -->
 	</div>

--- a/patterns/hero-product-split.php
+++ b/patterns/hero-product-split.php
@@ -9,8 +9,8 @@
 <!-- wp:media-text {"align":"full","mediaPosition":"right","mediaType":"image","mediaSizeSlug":"full","imageFill":false,"style":{"color":{"background":"#000000","text":"#ffffff"}}} -->
 <div class="wp-block-media-text alignfull has-media-on-the-right is-stacked-on-mobile has-text-color has-background" style="color:#ffffff;background-color:#000000">
 	<div class="wp-block-media-text__content">
-		<!-- wp:heading {"textColor":"background"} -->
-		<h2 class="wp-block-heading has-background-color has-text-color">Get cozy this fall with flannel shirts</h2>
+		<!-- wp:heading {"style":{"color":{"text":"#ffffff"}}} -->
+		<h2 class="wp-block-heading has-text-color" style="color:#ffffff;">Get cozy this fall with flannel shirts</h2>
 		<!-- /wp:heading -->
 
 		<!-- wp:buttons {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}}} -->

--- a/patterns/hero-product-split.php
+++ b/patterns/hero-product-split.php
@@ -10,14 +10,14 @@
 <div class="wp-block-media-text alignfull has-media-on-the-right is-stacked-on-mobile has-text-color has-background" style="color:#ffffff;background-color:#000000">
 	<div class="wp-block-media-text__content">
 		<!-- wp:heading {"style":{"color":{"text":"#ffffff"}}} -->
-		<h2 class="wp-block-heading has-text-color" style="color:#ffffff;">Get cozy this fall with flannel shirts</h2>
+		<h2 class="wp-block-heading has-text-color" style="color:#ffffff;"><?php esc_html_e( 'Get cozy this fall with flannel shirts', 'woo-gutenberg-products-block' ); ?></h2>
 		<!-- /wp:heading -->
 
 		<!-- wp:buttons {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}}} -->
 		<div class="wp-block-buttons" style="margin-bottom:var(--wp--preset--spacing--40)">
 		<!-- wp:button {"style":{"color":{"text":"#000000","background":"#ffffff"}}} -->
 		<div class="wp-block-button">
-			<a class="wp-block-button__link has-text-color has-background wp-element-button" style="color:#000000;background-color:#ffffff;">Shop now</a>
+			<a class="wp-block-button__link has-text-color has-background wp-element-button" style="color:#000000;background-color:#ffffff;"><?php esc_html_e( 'Shop now', 'woo-gutenberg-products-block' ); ?></a>
 		</div>
 		<!-- /wp:button -->
 		</div>
@@ -25,7 +25,7 @@
 	</div>
 
 	<figure class="wp-block-media-text__media">
-		<img src="<?php echo esc_url( plugins_url( 'images/pattern-placeholders/hero-product-split.webp', dirname( __FILE__ ) ) ); ?>" alt="Woman in red, black, and white plaid hoodie." />
+		<img src="<?php echo esc_url( plugins_url( 'images/pattern-placeholders/hero-product-split.webp', dirname( __FILE__ ) ) ); ?>" alt="<?php esc_attr_e( 'Woman in red, black, and white plaid hoodie.', 'woo-gutenberg-products-block' ); ?>" />
 	</figure>
 </div>
 <!-- /wp:media-text -->


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
Update the color settings in the `Hero Product – Split` to abide by the designs by default, regardless of the active theme.

This prevents the potential for the pattern to look other than intended due to theme styling. Once inserted, the user is free to change the color settings and styles from the editor.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

**TT3 Theme**

| Before | After |
| ------ | ----- |
| <img width="1211" alt="CleanShot 2023-05-10 at 16 00 55@2x" src="https://github.com/woocommerce/woocommerce-blocks/assets/481776/6e557ff5-a948-4043-86ef-59d71fe121bc"> | <img width="1211" alt="CleanShot 2023-05-10 at 15 59 23@2x" src="https://github.com/woocommerce/woocommerce-blocks/assets/481776/eb1e0309-97df-44cd-a65b-4cfa828e2738"> |

**Wabi Theme**

| Before | After |
| ------ | ----- |
| <img width="1212" alt="CleanShot 2023-05-10 at 16 03 13@2x" src="https://github.com/woocommerce/woocommerce-blocks/assets/481776/69481f46-0bcd-4f06-9608-96e300d727ae"> | <img width="1211" alt="CleanShot 2023-05-10 at 16 05 02@2x" src="https://github.com/woocommerce/woocommerce-blocks/assets/481776/76253343-c0f1-42fe-b3f2-a361c95f80a2"> |

### Testing
<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Activate a block theme (TT3).
2. From the editor, insert the `Hero Product – Split` pattern (under the WooCommerce section).
3. Confirm the text area has a black background, a white heading, and a white button with black text.
4. Switch to another block theme and repeat steps 2-3.
5. Confirm there is no change in colors on the pattern, by default.
6. Confirm it is possible to update the color settings in the editor.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
