### PR TITLE
Change the button text in the pattern to make it matching the content

### DIFF
--- a/patterns/featured-category-focus.php
+++ b/patterns/featured-category-focus.php
@@ -7,8 +7,8 @@
 ?>
 <!-- wp:group {"align":"full","style":{"color":{"background":"#84bfe1"},"spacing":{"padding":{"top":"var:preset|spacing|70","right":"var:preset|spacing|70","bottom":"var:preset|spacing|70","left":"var:preset|spacing|70"}}},"layout":{"type":"flex","orientation":"vertical","justifyContent":"center","flexWrap":"wrap"}} -->
 <div class="wp-block-group alignfull has-background" style="background-color:#84bfe1;padding-top:var(--wp--preset--spacing--70);padding-right:var(--wp--preset--spacing--70);padding-bottom:var(--wp--preset--spacing--70);padding-left:var(--wp--preset--spacing--70)">
-	<!-- wp:image {"id":1,"width":626,"height":316,"sizeSlug":"full","linkDestination":"none"} -->
-	<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( plugins_url( 'images/pattern-placeholders/product-furniture-10.png', dirname( __FILE__ ) ) ); ?>" alt="" class="wp-image-1" width="626" height="316"/></figure>
+	<!-- wp:image {"id":1,"width":502,"height":335,"sizeSlug":"full","linkDestination":"none"} -->
+	<figure class="wp-block-image size-full is-resized"><img src="<?php echo esc_url( plugins_url( 'images/pattern-placeholders/product-furniture-10.png', dirname( __FILE__ ) ) ); ?>" alt="" class="wp-image-1" width="502" height="335"/></figure>
 	<!-- /wp:image -->
 
 	<!-- wp:paragraph {"align":"center","fontSize":"large"} -->

--- a/patterns/featured-category-focus.php
+++ b/patterns/featured-category-focus.php
@@ -17,7 +17,7 @@
 
 	<!-- wp:buttons -->
 	<div class="wp-block-buttons"><!-- wp:button {"backgroundColor":"contrast","textColor":"base"} -->
-		<div class="wp-block-button"><a class="wp-block-button__link has-base-color has-contrast-background-color has-text-color has-background wp-element-button">Shop shoes</a></div>
+		<div class="wp-block-button"><a class="wp-block-button__link has-base-color has-contrast-background-color has-text-color has-background wp-element-button">Shop now</a></div>
 		<!-- /wp:button --></div>
 	<!-- /wp:buttons --></div>
 <!-- /wp:group -->


### PR DESCRIPTION
Recently the Featured Category pattern has been changed (photo and heading). But the button text remained the same and wasn't matching the content.

Also, the size of the image has been changed so the image is not skewed but keeps the original ratio.

This PR changes the button text from "Shop shoes" to neutral "Shop now".

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

Keep in mind the differences of styling comes from a theme and are not part of the PR, just the button text change.

| Before | After |
| ------ | ----- |
|    ![image](https://github.com/woocommerce/woocommerce-blocks/assets/20098064/fdc5e3b0-52cf-4620-842b-070a68cd0ee1)    |    <img width="1045" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/20098064/18ae832c-ae58-4c40-b852-2a533f0ebafb"> |

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Create a page and use the block inserter->patterns->WooCommerce and to insert the Featured Category Focus.
2. Notice the preview shows per design screenshot shown above.
3. Insert the pattern and then update/save and check the frontend and ensure it is displaying as the screenshot above.
4. Make sure the button text says "Show now" and the image is not skewed

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental


> Add suggested changelog entry here.
