### PR TITLE
Improve the Contact Information section in the post editor

### DIFF
--- a/assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/edit.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-contact-information-block/edit.tsx
@@ -42,7 +42,10 @@ export const Edit = ( {
 		>
 			<InspectorControls>
 				<PanelBody
-					title={ __( 'Account', 'woo-gutenberg-products-block' ) }
+					title={ __(
+						'Account creation and guest checkout',
+						'woo-gutenberg-products-block'
+					) }
 				>
 					<p className="wc-block-checkout__controls-text">
 						{ __(

--- a/assets/js/blocks/checkout/styles/editor.scss
+++ b/assets/js/blocks/checkout/styles/editor.scss
@@ -51,16 +51,10 @@ body.wc-lock-selected-block--remove {
 	}
 }
 
-.wc-block-checkout__controls-text {
-	color: #999;
-	font-style: italic;
-}
-
 .components-base-control--nested {
 	padding-left: 52px;
 	margin-top: -12px;
 }
-
 
 .components-panel__body-title .components-button {
 	opacity: 1;


### PR DESCRIPTION
Updates the account settings display in the inspector when editing the contact information block. 

Fixes #9278

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
| ![Screenshot 2023-05-11 at 12 58 19](https://github.com/woocommerce/woocommerce-blocks/assets/90977/7c015227-6a32-4bbf-8ff4-337c1061deb8) | ![Screenshot 2023-05-11 at 12 38 03](https://github.com/woocommerce/woocommerce-blocks/assets/90977/3336a031-10be-4932-bad9-d81bbe53af05) |

### Testing

#### User Facing Testing

1. Edit the checkout block
2. Focus on the contact information inner block
3. Confirm the appearance in the sidebar matches the screenshots above

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental