### PR TITLE
Mini-Cart: prevent 'Mini-Cart in cart and checkout pages' toggle from showing up in the post/page editor

### DIFF
--- a/assets/js/blocks/mini-cart/edit.tsx
+++ b/assets/js/blocks/mini-cart/edit.tsx
@@ -15,7 +15,6 @@ import { getSetting } from '@woocommerce/settings';
 import { __ } from '@wordpress/i18n';
 import Noninteractive from '@woocommerce/base-components/noninteractive';
 import type { ReactElement } from 'react';
-import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -34,14 +33,18 @@ interface Props {
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
 }
 
-const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
+const Edit = ( {
+	attributes,
+	setAttributes,
+	context: { postType, postId },
+}: Props ): ReactElement => {
 	const { addToCartBehaviour, hasHiddenPrice, cartAndCheckoutRenderStyle } =
 		attributes;
 	const blockProps = useBlockProps( {
 		className: `wc-block-mini-cart`,
 	} );
 
-	const isSiteEditor = useSelect( 'core/edit-site' ) !== undefined;
+	const isSiteEditor = postType === undefined || postId === undefined;
 
 	const templatePartEditUri = getSetting(
 		'templatePartEditUri',

--- a/assets/js/blocks/mini-cart/index.tsx
+++ b/assets/js/blocks/mini-cart/index.tsx
@@ -48,6 +48,7 @@ const settings: BlockConfiguration = {
 			className: 'wc-block-mini-cart--preview',
 		},
 	},
+	usesContext: [ 'postId', 'postType' ],
 	attributes: {
 		isPreview: {
 			type: 'boolean',


### PR DESCRIPTION
Fixes #9428.

The code of this PR is based on similar code found in Gutenberg:

https://github.com/WordPress/gutenberg/blob/37d98396f63dd7463287fd9d2124a179a1f68458/packages/block-library/src/post-comments-form/form.js#L63

Note: I added the `skip-changelog` label as it looks like #9428 was only reproducible on `npm run start`, but not on `npm run build`, so it never impacted users.

### Testing

#### User Facing Testing

1. Create a post or page.
2. Add the Mini Cart block and select it.
3. Verify in the sidebar there is no _Mini-Cart in cart and checkout pages_ toggle.
4. Now go to the Site Editor (Appearance > Editor).
5. Add the Mini Cart block to the header of your theme.
6. Verify in the sidebar there is a _Mini-Cart in cart and checkout pages_ toggle.
![imatge](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/96bccc7b-3a1d-479e-a98b-54b600582747)
7. Now change to a classic theme (ie: Storefront).
8. Go to Appearance > Widgets and add the Mini Cart block to a widget area.
9. Verify in the sidebar there is a _Mini-Cart in cart and checkout pages_ toggle as well.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
