### PR TITLE
Fix Product SKU not being displayed on frontend

### DIFF
--- a/assets/js/atomic/blocks/product-elements/shared/use-is-descendent-of-single-product-block.tsx
+++ b/assets/js/atomic/blocks/product-elements/shared/use-is-descendent-of-single-product-block.tsx
@@ -1,0 +1,30 @@
+/**
+ * External dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+interface UseIsDescendentOfSingleProductBlockProps {
+	blockClientId: string;
+}
+
+export const useIsDescendentOfSingleProductBlock = ( {
+	blockClientId,
+}: UseIsDescendentOfSingleProductBlockProps ) => {
+	const { isDescendentOfSingleProductBlock } = useSelect(
+		( select ) => {
+			const { getBlockParentsByBlockName } =
+				select( 'core/block-editor' );
+			const blockParentBlocksIds = getBlockParentsByBlockName(
+				blockClientId?.replace( 'block-', '' ),
+				[ 'woocommerce/single-product' ]
+			);
+			return {
+				isDescendentOfSingleProductBlock:
+					blockParentBlocksIds.length > 0,
+			};
+		},
+		[ blockClientId ]
+	);
+
+	return { isDescendentOfSingleProductBlock };
+};

--- a/assets/js/atomic/blocks/product-elements/sku/edit.tsx
+++ b/assets/js/atomic/blocks/product-elements/sku/edit.tsx
@@ -13,6 +13,7 @@ import { useSelect } from '@wordpress/data';
  */
 import Block from './block';
 import type { Attributes } from './types';
+import { useIsDescendentOfSingleProductBlock } from '../shared/use-is-descendent-of-single-product-block';
 
 const Edit = ( {
 	attributes,
@@ -28,6 +29,8 @@ const Edit = ( {
 		...context,
 	};
 	const isDescendentOfQueryLoop = Number.isFinite( context.queryId );
+	const { isDescendentOfSingleProductBlock } =
+		useIsDescendentOfSingleProductBlock( { blockClientId: blockProps.id } );
 
 	const isDescendentOfSingleProductTemplate = useSelect(
 		( select ) => {
@@ -51,11 +54,13 @@ const Edit = ( {
 			setAttributes( {
 				isDescendentOfQueryLoop,
 				isDescendentOfSingleProductTemplate,
+				isDescendentOfSingleProductBlock,
 			} ),
 		[
 			setAttributes,
 			isDescendentOfQueryLoop,
 			isDescendentOfSingleProductTemplate,
+			isDescendentOfSingleProductBlock,
 		]
 	);
 

--- a/assets/js/atomic/blocks/product-elements/sku/types.ts
+++ b/assets/js/atomic/blocks/product-elements/sku/types.ts
@@ -2,6 +2,7 @@ export interface Attributes {
 	productId: number;
 	isDescendentOfQueryLoop: boolean;
 	isDescendentOfSingleProductTemplate: boolean;
+	isDescendentOfSingleProductBlock: boolean;
 	showProductSelector: boolean;
 	isDescendantOfAllProducts: boolean;
 }


### PR DESCRIPTION
## Description
<!--
copilot:summary
-->
#### <samp>🤖 Generated by Copilot at bd5da9a</samp>
<samp>👨‍💻 Enhanced by @thealexandrelara </samp>

This pull request adds a custom hook `useIsDescendentOfSingleProductBlock` and uses it in the SKU block to make it compatible with both global and single product contexts. This allows the SKU block to display the correct product data and format depending on where it is inserted.

## Walkthrough
<!--
copilot:walkthrough
-->
#### <samp>🤖 Generated by Copilot at bd5da9a</samp>
<samp>👨‍💻 Enhanced by @thealexandrelara </samp>

*  Add a custom hook `useIsDescendentOfSingleProductBlock` that returns a boolean indicating whether a given block is a descendent of a single product block ([link](https://github.com/woocommerce/woocommerce-blocks/pull/9446/files?diff=unified&w=0#diff-aa49fde87e5be80d4599f058ff17824385a92823312142c5e9c846be37525168R1-R30))
* Use the hook in the SKU block edit component to get the value of `isDescendentOfSingleProductBlock` for the current block ([link](https://github.com/woocommerce/woocommerce-blocks/pull/9446/files?diff=unified&w=0#diff-273af84aa585a8e5a5a1446b8e97d85242eca59f5bf0696f3111b6627794ebaeR16), [link](https://github.com/woocommerce/woocommerce-blocks/pull/9446/files?diff=unified&w=0#diff-273af84aa585a8e5a5a1446b8e97d85242eca59f5bf0696f3111b6627794ebaeR32-R33))
* Pass the value to the `useProductDataContext` hook and the `ProductSKU` component as a prop ([link](https://github.com/woocommerce/woocommerce-blocks/pull/9446/files?diff=unified&w=0#diff-273af84aa585a8e5a5a1446b8e97d85242eca59f5bf0696f3111b6627794ebaeR32-R33), [link](https://github.com/woocommerce/woocommerce-blocks/pull/9446/files?diff=unified&w=0#diff-273af84aa585a8e5a5a1446b8e97d85242eca59f5bf0696f3111b6627794ebaeR57), [link](https://github.com/woocommerce/woocommerce-blocks/pull/9446/files?diff=unified&w=0#diff-273af84aa585a8e5a5a1446b8e97d85242eca59f5bf0696f3111b6627794ebaeR63))
* Use the value to determine the product data source and the SKU value rendering in the `useProductDataContext` hook and the `ProductSKU` component respectively ([link](https://github.com/woocommerce/woocommerce-blocks/pull/9446/files?diff=unified&w=0#diff-273af84aa585a8e5a5a1446b8e97d85242eca59f5bf0696f3111b6627794ebaeR57), [link](https://github.com/woocommerce/woocommerce-blocks/pull/9446/files?diff=unified&w=0#diff-273af84aa585a8e5a5a1446b8e97d85242eca59f5bf0696f3111b6627794ebaeR63))
* Add the value to the SKU block attributes type definition in `types.ts` ([link](https://github.com/woocommerce/woocommerce-blocks/pull/9446/files?diff=unified&w=0#diff-5379610aca73c6047987a3ba4cb81dcde9c96a0944cf62b52c7c5aa0d159eb08R5))

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #9030 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|  ![image](https://github.com/woocommerce/woocommerce-blocks/assets/20469356/5e062bea-0172-455a-884b-c74d59a98b93)  | ![image](https://github.com/woocommerce/woocommerce-blocks/assets/20469356/c1c74051-3e14-4d0b-84e9-db7ebd71f5b0) |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Log in to your WordPress dashboard.
2. On the left-hand side menu, click on 'Posts' and then 'Add New' to create a new post. Alternatively, if you want to add the block to an existing post, you can simply find that post and click 'Edit'.
3. Inside the post editor, click on the '+' button, usually found at the top left of the editing space or within the content area itself, to add a new block.
4. In the block library that pops up, you can search for the 'Single Product' block. You can do this by typing 'Single Product' into the search bar at the top of the block library.
5. Click on the 'Single Product' block to add it to your post. You'll be prompted to select a product from your WooCommerce store to feature in the block. Make sure to select a product that contains a SKU.
6. Once you've selected a product, the block will be inserted into your post and will display information about the product you've selected.
7. Click on the 'Single Product' block in your post to select it.
8. Once the product is selected, click on the top-right side click on the Save button;
9. Visit the post that you just created and check if the Product SKU is displayed.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental
