### PR TITLE
Render pay for order checkout block if it is pay for order order

### DIFF
--- a/assets/js/base/context/hooks/cart/use-store-cart.ts
+++ b/assets/js/base/context/hooks/cart/use-store-cart.ts
@@ -36,6 +36,7 @@ import { emptyHiddenAddressFields } from '@woocommerce/base-utils';
  */
 import { useEditorContext } from '../../providers/editor-context';
 import { useStoreCartEventListeners } from './use-store-cart-event-listeners';
+import { useStoreOrder } from './use-store-order';
 
 declare module '@wordpress/html-entities' {
 	// eslint-disable-next-line @typescript-eslint/no-shadow
@@ -135,6 +136,7 @@ export const useStoreCart = (
 	options: { shouldSelect: boolean } = { shouldSelect: true }
 ): StoreCart => {
 	const { isEditor, previewData } = useEditorContext();
+	const { orderId, orderKey } = useStoreOrder();
 	const previewCart = previewData?.previewCart;
 	const { shouldSelect } = options;
 	const currentResults = useRef();
@@ -183,7 +185,7 @@ export const useStoreCart = (
 			}
 
 			const store = select( storeKey );
-			const cartData = store.getCartData();
+			const cartData = store.getCartData( orderId, orderKey );
 			const cartErrors = store.getCartErrors();
 			const cartTotals = store.getCartTotals();
 			const cartIsLoading =
@@ -240,7 +242,7 @@ export const useStoreCart = (
 				receiveCartContents,
 			};
 		},
-		[ shouldSelect ]
+		[ shouldSelect, orderId, orderKey ]
 	);
 
 	if (

--- a/assets/js/base/context/hooks/cart/use-store-order.ts
+++ b/assets/js/base/context/hooks/cart/use-store-order.ts
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import { useMemo } from '@wordpress/element';
+
+export const useStoreOrder = () => {
+	const isPayForOrder = () => {
+		const queryString = window.location.search;
+		const urlParams = new URLSearchParams( queryString );
+		return urlParams.get( 'pay_for_order' );
+	};
+
+	const getOrderKey = () => {
+		const queryString = window.location.search;
+		const urlParams = new URLSearchParams( queryString );
+		return urlParams.get( 'key' );
+	};
+
+	const getOrderId = () => {
+		const path = window.location.pathname;
+		const orderIdRegexp = new RegExp( /order-pay\/([0-9]*)/ );
+		const matches = path.match( orderIdRegexp );
+		return matches ? parseInt( matches[ 1 ], 10 ) : null;
+	};
+
+	const orderId = useMemo< number | null >( () => {
+		return isPayForOrder() ? getOrderId() : null;
+	}, [] );
+
+	const orderKey = useMemo< string | null >( () => {
+		return isPayForOrder() ? getOrderKey() : null;
+	}, [] );
+
+	return {
+		orderId,
+		orderKey,
+	};
+};

--- a/assets/js/base/context/providers/cart-checkout/checkout-processor.ts
+++ b/assets/js/base/context/providers/cart-checkout/checkout-processor.ts
@@ -40,6 +40,7 @@ import { preparePaymentData, processCheckoutResponseHeaders } from './utils';
 import { useCheckoutEventsContext } from './checkout-events';
 import { useShippingDataContext } from './shipping';
 import { useStoreCart } from '../../hooks/cart/use-store-cart';
+import { useStoreOrder } from '../../hooks/cart/use-store-order';
 
 /**
  * CheckoutProcessor component.
@@ -211,6 +212,8 @@ const CheckoutProcessor = () => {
 		}
 	}, [ checkoutIsComplete ] );
 
+	const { orderId, orderKey } = useStoreOrder();
+
 	// POST to the Store API and process and display any errors, or set order complete
 	const processOrder = useCallback( async () => {
 		if ( isProcessingOrder ) {
@@ -241,10 +244,14 @@ const CheckoutProcessor = () => {
 			create_account: shouldCreateAccount,
 			...paymentData,
 			extensions: { ...extensionData },
+			key: orderKey,
 		};
 
 		triggerFetch( {
-			path: '/wc/store/v1/checkout',
+			path:
+				orderKey && orderId
+					? `/wc/store/v1/checkout/${ orderId }`
+					: '/wc/store/v1/checkout',
 			method: 'POST',
 			data,
 			cache: 'no-store',

--- a/assets/js/blocks/checkout/block.tsx
+++ b/assets/js/blocks/checkout/block.tsx
@@ -29,6 +29,7 @@ import CheckoutOrderError from './checkout-order-error';
 import { LOGIN_TO_CHECKOUT_URL, isLoginRequired, reloadPage } from './utils';
 import type { Attributes } from './types';
 import { CheckoutBlockContext } from './context';
+import { useStoreOrder } from '../../base/context/hooks/cart/use-store-order';
 
 const MustLoginPrompt = () => {
 	return (
@@ -62,7 +63,7 @@ const Checkout = ( {
 		};
 	} );
 	const { cartItems, cartIsLoading } = useStoreCart();
-
+	const { orderId, orderKey } = useStoreOrder();
 	const {
 		showCompanyField,
 		requireCompanyField,
@@ -75,7 +76,8 @@ const Checkout = ( {
 		return <EmptyCart />;
 	}
 
-	if ( ! hasOrder ) {
+	const isPayForOrder = orderId && orderKey;
+	if ( ! hasOrder && ! isPayForOrder ) {
 		return <CheckoutOrderError />;
 	}
 

--- a/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/block.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/block.tsx
@@ -18,7 +18,11 @@ import {
  * Internal dependencies
  */
 import './style.scss';
-import { defaultPlaceOrderButtonLabel } from './constants';
+import {
+	defaultPlaceOrderButtonLabel,
+	defaultPayForOrderButtonLabel,
+} from './constants';
+import { useStoreOrder } from '../../../../base/context/hooks/cart/use-store-order';
 
 const Block = ( {
 	cartPageId,
@@ -32,12 +36,17 @@ const Block = ( {
 	placeOrderButtonLabel: string;
 } ): JSX.Element => {
 	const { paymentMethodButtonLabel } = useCheckoutSubmit();
+	const { orderId, orderKey } = useStoreOrder();
+	const defaultButtonLabel =
+		orderId && orderKey
+			? defaultPayForOrderButtonLabel
+			: defaultPlaceOrderButtonLabel;
 	const label = applyCheckoutFilter( {
 		filterName: 'placeOrderButtonLabel',
 		defaultValue:
 			paymentMethodButtonLabel ||
 			placeOrderButtonLabel ||
-			defaultPlaceOrderButtonLabel,
+			defaultButtonLabel,
 	} );
 
 	return (

--- a/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/constants.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/constants.tsx
@@ -7,3 +7,8 @@ export const defaultPlaceOrderButtonLabel = __(
 	'Place Order',
 	'woo-gutenberg-products-block'
 );
+
+export const defaultPayForOrderButtonLabel = __(
+	'Pay for order',
+	'woo-gutenberg-products-block'
+);

--- a/assets/js/data/cart/resolvers.ts
+++ b/assets/js/data/cart/resolvers.ts
@@ -11,13 +11,29 @@ import { CART_API_ERROR } from './constants';
 import type { CartDispatchFromMap, CartResolveSelectFromMap } from './index';
 
 /**
- * Resolver for retrieving all cart data.
+ * Get order endpoint.
+ *
+ * @param {number} orderId
+ * @param {string} orderKey
+ */
+export const getOrderEndpoint = ( orderId: number, orderKey: string ) => {
+	return `/wc/store/v1/order/${ orderId }?key=${ orderKey }`;
+};
+
+/**
+ * Resolver for retrieving all cart or order data.
+ *
+ * @param {number} orderId
+ * @param {string} orderKey
  */
 export const getCartData =
-	() =>
+	( orderId?: number, orderKey?: string ) =>
 	async ( { dispatch }: { dispatch: CartDispatchFromMap } ) => {
 		const cartData = await apiFetch< CartResponse >( {
-			path: '/wc/store/v1/cart',
+			path:
+				orderId && orderKey
+					? getOrderEndpoint( orderId, orderKey )
+					: '/wc/store/v1/cart',
 			method: 'GET',
 			cache: 'no-store',
 		} );

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -172,7 +172,7 @@ class Checkout extends AbstractBlock {
 	 * @return boolean
 	 */
 	protected function is_checkout_endpoint() {
-		return is_wc_endpoint_url( 'order-pay' ) || is_wc_endpoint_url( 'order-received' );
+		return is_wc_endpoint_url( 'order-received' );
 	}
 
 	/**

--- a/src/StoreApi/Routes/V1/CheckoutOrder.php
+++ b/src/StoreApi/Routes/V1/CheckoutOrder.php
@@ -1,0 +1,442 @@
+<?php
+namespace Automattic\WooCommerce\StoreApi\Routes\V1;
+
+use Automattic\WooCommerce\StoreApi\Payments\PaymentContext;
+use Automattic\WooCommerce\StoreApi\Payments\PaymentResult;
+use Automattic\WooCommerce\StoreApi\Exceptions\InvalidStockLevelsInCartException;
+use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
+
+/**
+ * CheckoutOrder class.
+ */
+class CheckoutOrder extends AbstractCartRoute {
+
+	/**
+	 * The route identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'checkout-order';
+
+	/**
+	 * The routes schema.
+	 *
+	 * @var string
+	 */
+	const SCHEMA_TYPE = 'checkout-order';
+
+	/**
+	 * Holds the current order being processed.
+	 *
+	 * @var \WC_Order
+	 */
+	private $order = null;
+
+	/**
+	 * Get the path of this REST route.
+	 *
+	 * @return string
+	 */
+	public function get_path() {
+		return '/checkout/(?P<id>[\d]+)';
+	}
+
+	/**
+	 * Checks if a nonce is required for the route.
+	 *
+	 * @param \WP_REST_Request $request Request.
+	 * @return bool
+	 */
+	protected function requires_nonce( \WP_REST_Request $request ) {
+		return true;
+	}
+
+	/**
+	 * Check if authorized to get the order.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 * @return boolean|WP_Error
+	 */
+	public function is_authorized( \WP_REST_Request $request ) {
+		$order_id    = absint( $request['id'] );
+		$order_key   = wc_clean( wp_unslash( $request->get_param( 'key' ) ) );
+		$user_id     = get_current_user_id();
+		$this->order = $this->order_controller->get_order( $order_id );
+
+		if ( $user_id !== $this->order->get_user_id() ) {
+			return false;
+		}
+
+		try {
+			$this->order_controller->validate_order_key( $order_id, $order_key );
+		} catch ( RouteException $error ) {
+			return new \WP_Error(
+				$error->getErrorCode(),
+				$error->getMessage(),
+				array( 'status' => $error->getCode() )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get method arguments for this REST route.
+	 *
+	 * @return array An array of endpoints.
+	 */
+	public function get_args() {
+		return [
+			[
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => [ $this, 'is_authorized' ],
+				'args'                => array_merge(
+					[
+						'payment_data' => [
+							'description' => __( 'Data to pass through to the payment method when processing payment.', 'woo-gutenberg-products-block' ),
+							'type'        => 'array',
+							'items'       => [
+								'type'       => 'object',
+								'properties' => [
+									'key'   => [
+										'type' => 'string',
+									],
+									'value' => [
+										'type' => [ 'string', 'boolean' ],
+									],
+								],
+							],
+						],
+					],
+					$this->schema->get_endpoint_args_for_item_schema( \WP_REST_Server::CREATABLE )
+				),
+			],
+			'schema'      => [ $this->schema, 'get_public_item_schema' ],
+			'allow_batch' => [ 'v1' => true ],
+		];
+	}
+
+	/**
+	 * Prepare a single item for response. Handles setting the status based on the payment result.
+	 *
+	 * @param mixed            $item Item to format to schema.
+	 * @param \WP_REST_Request $request Request object.
+	 * @return \WP_REST_Response $response Response data.
+	 */
+	public function prepare_item_for_response( $item, \WP_REST_Request $request ) {
+		$response     = parent::prepare_item_for_response( $item, $request );
+		$status_codes = [
+			'success' => 200,
+			'pending' => 202,
+			'failure' => 400,
+			'error'   => 500,
+		];
+
+		if ( isset( $item->payment_result ) && $item->payment_result instanceof PaymentResult ) {
+			$response->set_status( $status_codes[ $item->payment_result->status ] ?? 200 );
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Process an order.
+	 *
+	 * 1. Process Request
+	 * 2. Process Customer
+	 * 3. Validate Order
+	 * 4. Process Payment
+	 *
+	 * @throws RouteException On error.
+	 * @throws InvalidStockLevelsInCartException On error.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	protected function get_route_post_response( \WP_REST_Request $request ) {
+		/**
+		 * Process request data.
+		 *
+		 * Note: Customer data is persisted from the request first so that OrderController::update_addresses_from_cart
+		 * uses the up to date customer address.
+		 */
+		$this->update_customer_from_request( $request );
+		$this->update_order_from_request( $request );
+
+		/**
+		 * Process customer data.
+		 *
+		 * Update order with customer details, and sign up a user account as necessary.
+		 */
+		$this->process_customer( $request );
+
+		/**
+		 * Validate order.
+		 *
+		 * This logic ensures the order is valid before payment is attempted.
+		 */
+		$this->order_controller->validate_order_before_payment( $this->order );
+
+		/**
+		 * Fires before an order is processed by the Checkout Block/Store API.
+		 *
+		 * This hook informs extensions that $order has completed processing and is ready for payment.
+		 *
+		 * This is similar to existing core hook woocommerce_checkout_order_processed. We're using a new action:
+		 * - To keep the interface focused (only pass $order, not passing request data).
+		 * - This also explicitly indicates these orders are from checkout block/StoreAPI.
+		 *
+		 * @since 7.2.0
+		 *
+		 * @see https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3238
+		 * @example See docs/examples/checkout-order-processed.md
+
+		 * @param \WC_Order $order Order object.
+		 */
+		do_action( 'woocommerce_store_api_checkout_order_processed', $this->order );
+
+		/**
+		 * Process the payment and return the results.
+		 */
+		$payment_result = new PaymentResult();
+
+		if ( $this->order->needs_payment() ) {
+			$this->process_payment( $request, $payment_result );
+		} else {
+			$this->process_without_payment( $request, $payment_result );
+		}
+
+		return $this->prepare_item_for_response(
+			(object) [
+				'order'          => wc_get_order( $this->order ),
+				'payment_result' => $payment_result,
+			],
+			$request
+		);
+	}
+
+	/**
+	 * Updates the current customer session using data from the request (e.g. address data).
+	 *
+	 * Address session data is synced to the order itself later on by OrderController::update_order_from_cart()
+	 *
+	 * @param \WP_REST_Request $request Full details about the request.
+	 */
+	private function update_customer_from_request( \WP_REST_Request $request ) {
+		$customer = wc()->customer;
+
+		// Billing address is a required field.
+		foreach ( $request['billing_address'] as $key => $value ) {
+			if ( is_callable( [ $customer, "set_billing_$key" ] ) ) {
+				$customer->{"set_billing_$key"}( $value );
+			}
+		}
+
+		// If shipping address (optional field) was not provided, set it to the given billing address (required field).
+		$shipping_address_values = $request['shipping_address'] ?? $request['billing_address'];
+
+		foreach ( $shipping_address_values as $key => $value ) {
+			if ( is_callable( [ $customer, "set_shipping_$key" ] ) ) {
+				$customer->{"set_shipping_$key"}( $value );
+			} elseif ( 'phone' === $key ) {
+				$customer->update_meta_data( 'shipping_phone', $value );
+			}
+		}
+
+		/**
+		 * Fires when the Checkout Block/Store API updates a customer from the API request data.
+		 *
+		 * @since 8.2.0
+		 *
+		 * @param \WC_Customer $customer Customer object.
+		 * @param \WP_REST_Request $request Full details about the request.
+		 */
+		do_action( 'woocommerce_store_api_checkout_update_customer_from_request', $customer, $request );
+
+		$customer->save();
+	}
+
+	/**
+	 * Update the current order using the posted values from the request.
+	 *
+	 * @param \WP_REST_Request $request Full details about the request.
+	 */
+	private function update_order_from_request( \WP_REST_Request $request ) {
+		$this->order->set_customer_note( $request['customer_note'] ?? '' );
+		$this->order->set_payment_method( $this->get_request_payment_method_id( $request ) );
+
+		wc_do_deprecated_action(
+			'__experimental_woocommerce_blocks_checkout_update_order_from_request',
+			array(
+				$this->order,
+				$request,
+			),
+			'6.3.0',
+			'woocommerce_store_api_checkout_update_order_from_request',
+			'This action was deprecated in WooCommerce Blocks version 6.3.0. Please use woocommerce_store_api_checkout_update_order_from_request instead.'
+		);
+
+		wc_do_deprecated_action(
+			'woocommerce_blocks_checkout_update_order_from_request',
+			array(
+				$this->order,
+				$request,
+			),
+			'7.2.0',
+			'woocommerce_store_api_checkout_update_order_from_request',
+			'This action was deprecated in WooCommerce Blocks version 7.2.0. Please use woocommerce_store_api_checkout_update_order_from_request instead.'
+		);
+
+		/**
+		 * Fires when the Checkout Block/Store API updates an order's from the API request data.
+		 *
+		 * This hook gives extensions the chance to update orders based on the data in the request. This can be used in
+		 * conjunction with the ExtendSchema class to post custom data and then process it.
+		 *
+		 * @since 7.2.0
+		 *
+		 * @param \WC_Order $order Order object.
+		 * @param \WP_REST_Request $request Full details about the request.
+		 */
+		do_action( 'woocommerce_store_api_checkout_update_order_from_request', $this->order, $request );
+
+		$this->order->save();
+	}
+
+	/**
+	 * For orders which do not require payment, just update status.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 * @param PaymentResult    $payment_result Payment result object.
+	 */
+	private function process_without_payment( \WP_REST_Request $request, PaymentResult $payment_result ) {
+		// Transition the order to pending, and then completed. This ensures transactional emails fire for pending_to_complete events.
+		$this->order->update_status( 'pending' );
+		$this->order->payment_complete();
+
+		// Mark the payment as successful.
+		$payment_result->set_status( 'success' );
+		$payment_result->set_redirect_url( $this->order->get_checkout_order_received_url() );
+	}
+
+	/**
+	 * Fires an action hook instructing active payment gateways to process the payment for an order and provide a result.
+	 *
+	 * @throws RouteException On error.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 * @param PaymentResult    $payment_result Payment result object.
+	 */
+	private function process_payment( \WP_REST_Request $request, PaymentResult $payment_result ) {
+		try {
+			// Transition the order to pending before making payment.
+			$this->order->update_status( 'pending' );
+
+			// Prepare the payment context object to pass through payment hooks.
+			$context = new PaymentContext();
+			$context->set_payment_method( $this->get_request_payment_method_id( $request ) );
+			$context->set_payment_data( $this->get_request_payment_data( $request ) );
+			$context->set_order( $this->order );
+
+			/**
+			 * Process payment with context.
+			 *
+			 * @hook woocommerce_rest_checkout_process_payment_with_context
+			 *
+			 * @throws \Exception If there is an error taking payment, an \Exception object can be thrown with an error message.
+			 *
+			 * @param PaymentContext $context        Holds context for the payment, including order ID and payment method.
+			 * @param PaymentResult  $payment_result Result object for the transaction.
+			 */
+			do_action_ref_array( 'woocommerce_rest_checkout_process_payment_with_context', [ $context, &$payment_result ] );
+
+			if ( ! $payment_result instanceof PaymentResult ) {
+				throw new RouteException( 'woocommerce_rest_checkout_invalid_payment_result', __( 'Invalid payment result received from payment method.', 'woo-gutenberg-products-block' ), 500 );
+			}
+		} catch ( \Exception $e ) {
+			throw new RouteException( 'woocommerce_rest_checkout_process_payment_error', $e->getMessage(), 402 );
+		}
+	}
+
+	/**
+	 * Gets the chosen payment method ID from the request.
+	 *
+	 * @throws RouteException On error.
+	 * @param \WP_REST_Request $request Request object.
+	 * @return string
+	 */
+	private function get_request_payment_method_id( \WP_REST_Request $request ) {
+		$payment_method = $this->get_request_payment_method( $request );
+		return is_null( $payment_method ) ? '' : $payment_method->id;
+	}
+
+	/**
+	 * Gets the chosen payment method from the request.
+	 *
+	 * @throws RouteException On error.
+	 * @param \WP_REST_Request $request Request object.
+	 * @return \WC_Payment_Gateway|null
+	 */
+	private function get_request_payment_method( \WP_REST_Request $request ) {
+		$available_gateways      = WC()->payment_gateways->get_available_payment_gateways();
+		$request_payment_method  = wc_clean( wp_unslash( $request['payment_method'] ?? '' ) );
+		$requires_payment_method = $this->order->needs_payment();
+
+		if ( empty( $request_payment_method ) ) {
+			if ( $requires_payment_method ) {
+				throw new RouteException(
+					'woocommerce_rest_checkout_missing_payment_method',
+					__( 'No payment method provided.', 'woo-gutenberg-products-block' ),
+					400
+				);
+			}
+			return null;
+		}
+
+		if ( ! isset( $available_gateways[ $request_payment_method ] ) ) {
+			throw new RouteException(
+				'woocommerce_rest_checkout_payment_method_disabled',
+				sprintf(
+					// Translators: %s Payment method ID.
+					__( 'The %s payment gateway is not available.', 'woo-gutenberg-products-block' ),
+					esc_html( $request_payment_method )
+				),
+				400
+			);
+		}
+
+		return $available_gateways[ $request_payment_method ];
+	}
+
+	/**
+	 * Gets and formats payment request data.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 * @return array
+	 */
+	private function get_request_payment_data( \WP_REST_Request $request ) {
+		static $payment_data = [];
+		if ( ! empty( $payment_data ) ) {
+			return $payment_data;
+		}
+		if ( ! empty( $request['payment_data'] ) ) {
+			foreach ( $request['payment_data'] as $data ) {
+				$payment_data[ sanitize_key( $data['key'] ) ] = wc_clean( $data['value'] );
+			}
+		}
+
+		return $payment_data;
+	}
+
+	/**
+	 * Updates the order with user details (e.g. address).
+	 *
+	 * @throws RouteException API error object with error details.
+	 * @param \WP_REST_Request $request Request object.
+	 */
+	private function process_customer( \WP_REST_Request $request ) {
+		$this->order_controller->sync_customer_data_with_order( $this->order );
+	}
+}

--- a/src/StoreApi/Routes/V1/Order.php
+++ b/src/StoreApi/Routes/V1/Order.php
@@ -80,6 +80,12 @@ class Order extends AbstractRoute {
 	public function is_authorized( \WP_REST_Request $request ) {
 		$order_id  = absint( $request['id'] );
 		$order_key = wc_clean( wp_unslash( $request->get_param( 'key' ) ) );
+		$user_id   = get_current_user_id();
+		$order     = wc_get_order( $order_id );
+
+		if ( $user_id !== $order->get_user_id() ) {
+			return false;
+		}
 
 		try {
 			$this->order_controller->validate_order_key( $order_id, $order_key );

--- a/src/StoreApi/Routes/V1/Order.php
+++ b/src/StoreApi/Routes/V1/Order.php
@@ -4,6 +4,7 @@ namespace Automattic\WooCommerce\StoreApi\Routes\V1;
 use Automattic\WooCommerce\StoreApi\SchemaController;
 use Automattic\WooCommerce\StoreApi\Schemas\v1\AbstractSchema;
 use Automattic\WooCommerce\StoreApi\Utilities\OrderController;
+use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
 
 /**
  * Order class.
@@ -79,93 +80,15 @@ class Order extends AbstractRoute {
 	public function is_authorized( \WP_REST_Request $request ) {
 		$order_id  = absint( $request['id'] );
 		$order_key = wc_clean( wp_unslash( $request->get_param( 'key' ) ) );
-		$order     = $this->order_controller->get_order( $order_id );
 
-		if ( ! $order || $order->get_id() !== $order_id || ! hash_equals( $order->get_order_key(), $order_key ) ) {
-			return new \WP_Error( 'invalid_order', __( 'Sorry, this order is invalid and cannot be paid for.', 'woo-gutenberg-products-block' ), array( 'status' => 401 ) );
-		}
-
-		// Logged out customer does not have permission to pay for this order.
-		if ( ! current_user_can( 'pay_for_order', $order_id ) && ! is_user_logged_in() ) {
-			return new \WP_Error( 'invalid_user', __( 'Please log in to your account below to continue to the payment form.', 'woo-gutenberg-products-block' ), array( 'status' => 403 ) );
-		}
-
-		// Logged in customer trying to pay for someone else's order.
-		if ( ! current_user_can( 'pay_for_order', $order_id ) ) {
-			return new \WP_Error( 'invalid_user', __( 'This order cannot be paid for. Please contact us if you need assistance.', 'woo-gutenberg-products-block' ), array( 'status' => 403 ) );
-		}
-
-		// Does not need payment.
-		if ( ! $order->needs_payment() ) {
-			/* translators: %s: order status */
-			return new \WP_Error( '@Todo', sprintf( __( 'This order&rsquo;s status is &ldquo;%s&rdquo;&mdash;it cannot be paid for. Please contact us if you need assistance.', 'woo-gutenberg-products-block' ), wc_get_order_status_name( $order->get_status() ) ), array( 'status' => 403 ) );
-		}
-
-		// Ensure order items are still stocked if paying for a failed order. Pending orders do not need this check because stock is held.
-		if ( ! $order->has_status( wc_get_is_pending_statuses() ) ) {
-			$quantities = array();
-
-			foreach ( $order->get_items() as $item_key => $item ) {
-				if ( $item && is_callable( array( $item, 'get_product' ) ) ) {
-					$product = $item->get_product();
-
-					if ( ! $product ) {
-						continue;
-					}
-
-					$quantities[ $product->get_stock_managed_by_id() ] = isset( $quantities[ $product->get_stock_managed_by_id() ] ) ? $quantities[ $product->get_stock_managed_by_id() ] + $item->get_quantity() : $item->get_quantity();
-				}
-			}
-
-			// Stock levels may already have been adjusted for this order (in which case we don't need to worry about checking for low stock).
-			if ( ! $order->get_data_store()->get_stock_reduced( $order->get_id() ) ) {
-				foreach ( $order->get_items() as $item_key => $item ) {
-					if ( $item && is_callable( array( $item, 'get_product' ) ) ) {
-						$product = $item->get_product();
-
-						if ( ! $product ) {
-							continue;
-						}
-
-						/**
-						 * Filters whether or not the product is in stock for this pay for order.
-						 *
-						 * @param boolean True if in stock.
-						 * @param \WC_Product $product Product.
-						 * @param \WC_Order $order Order.
-						 *
-						 * @since 9.8.0-dev
-						 */
-						if ( ! apply_filters( 'woocommerce_pay_order_product_in_stock', $product->is_in_stock(), $product, $order ) ) {
-							/* translators: %s: product name */
-							return new \WP_Error( '@Todo', sprintf( __( 'Sorry, "%s" is no longer in stock so this order cannot be paid for. We apologize for any inconvenience caused.', 'woo-gutenberg-products-block' ), $product->get_name() ), array( 'status' => 403 ) );
-						}
-
-						// We only need to check products managing stock, with a limited stock qty.
-						if ( ! $product->managing_stock() || $product->backorders_allowed() ) {
-							continue;
-						}
-
-						// Check stock based on all items in the cart and consider any held stock within pending orders.
-						$held_stock     = wc_get_held_stock_quantity( $product, $order->get_id() );
-						$required_stock = $quantities[ $product->get_stock_managed_by_id() ];
-
-						/**
-						 * Filters whether or not the product has enough stock.
-						 *
-						 * @param boolean True if has enough stock.
-						 * @param \WC_Product $product Product.
-						 * @param \WC_Order $order Order.
-						 *
-						 * @since 9.8.0-dev
-						 */
-						if ( ! apply_filters( 'woocommerce_pay_order_product_has_enough_stock', ( $product->get_stock_quantity() >= ( $held_stock + $required_stock ) ), $product, $order ) ) {
-							/* translators: 1: product name 2: quantity in stock */
-							return new \WP_Error( '@Todo', sprintf( __( 'Sorry, we do not have enough "%1$s" in stock to fulfill your order (%2$s available). We apologize for any inconvenience caused.', 'woo-gutenberg-products-block' ), $product->get_name(), wc_format_stock_quantity_for_display( $product->get_stock_quantity() - $held_stock, $product ) ), array( 'status' => 403 ) );
-						}
-					}
-				}
-			}
+		try {
+			$this->order_controller->validate_order_key( $order_id, $order_key );
+		} catch ( RouteException $error ) {
+			return new \WP_Error(
+				$error->getErrorCode(),
+				$error->getMessage(),
+				array( 'status' => $error->getCode() )
+			);
 		}
 
 		return true;

--- a/src/StoreApi/Routes/V1/Order.php
+++ b/src/StoreApi/Routes/V1/Order.php
@@ -61,13 +61,114 @@ class Order extends AbstractRoute {
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'get_response' ],
-				'permission_callback' => '__return_true', // @Todo check authorization - order id and key.
+				'permission_callback' => [ $this, 'is_authorized' ],
 				'args'                => [
 					'context' => $this->get_context_param( [ 'default' => 'view' ] ),
 				],
 			],
 			'schema' => [ $this->schema, 'get_public_item_schema' ],
 		];
+	}
+
+	/**
+	 * Check if authorized to get the order.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 * @return boolean|WP_Error
+	 */
+	public function is_authorized( \WP_REST_Request $request ) {
+		$order_id  = absint( $request['id'] );
+		$order_key = wc_clean( wp_unslash( $request->get_param( 'key' ) ) );
+		$order     = $this->order_controller->get_order( $order_id );
+
+		if ( ! $order || $order->get_id() !== $order_id || ! hash_equals( $order->get_order_key(), $order_key ) ) {
+			return new \WP_Error( 'invalid_order', __( 'Sorry, this order is invalid and cannot be paid for.', 'woo-gutenberg-products-block' ), array( 'status' => 401 ) );
+		}
+
+		// Logged out customer does not have permission to pay for this order.
+		if ( ! current_user_can( 'pay_for_order', $order_id ) && ! is_user_logged_in() ) {
+			return new \WP_Error( 'invalid_user', __( 'Please log in to your account below to continue to the payment form.', 'woo-gutenberg-products-block' ), array( 'status' => 403 ) );
+		}
+
+		// Logged in customer trying to pay for someone else's order.
+		if ( ! current_user_can( 'pay_for_order', $order_id ) ) {
+			return new \WP_Error( 'invalid_user', __( 'This order cannot be paid for. Please contact us if you need assistance.', 'woo-gutenberg-products-block' ), array( 'status' => 403 ) );
+		}
+
+		// Does not need payment.
+		if ( ! $order->needs_payment() ) {
+			/* translators: %s: order status */
+			return new \WP_Error( '@Todo', sprintf( __( 'This order&rsquo;s status is &ldquo;%s&rdquo;&mdash;it cannot be paid for. Please contact us if you need assistance.', 'woo-gutenberg-products-block' ), wc_get_order_status_name( $order->get_status() ) ), array( 'status' => 403 ) );
+		}
+
+		// Ensure order items are still stocked if paying for a failed order. Pending orders do not need this check because stock is held.
+		if ( ! $order->has_status( wc_get_is_pending_statuses() ) ) {
+			$quantities = array();
+
+			foreach ( $order->get_items() as $item_key => $item ) {
+				if ( $item && is_callable( array( $item, 'get_product' ) ) ) {
+					$product = $item->get_product();
+
+					if ( ! $product ) {
+						continue;
+					}
+
+					$quantities[ $product->get_stock_managed_by_id() ] = isset( $quantities[ $product->get_stock_managed_by_id() ] ) ? $quantities[ $product->get_stock_managed_by_id() ] + $item->get_quantity() : $item->get_quantity();
+				}
+			}
+
+			// Stock levels may already have been adjusted for this order (in which case we don't need to worry about checking for low stock).
+			if ( ! $order->get_data_store()->get_stock_reduced( $order->get_id() ) ) {
+				foreach ( $order->get_items() as $item_key => $item ) {
+					if ( $item && is_callable( array( $item, 'get_product' ) ) ) {
+						$product = $item->get_product();
+
+						if ( ! $product ) {
+							continue;
+						}
+
+						/**
+						 * Filters whether or not the product is in stock for this pay for order.
+						 *
+						 * @param boolean True if in stock.
+						 * @param \WC_Product $product Product.
+						 * @param \WC_Order $order Order.
+						 *
+						 * @since 9.8.0-dev
+						 */
+						if ( ! apply_filters( 'woocommerce_pay_order_product_in_stock', $product->is_in_stock(), $product, $order ) ) {
+							/* translators: %s: product name */
+							return new \WP_Error( '@Todo', sprintf( __( 'Sorry, "%s" is no longer in stock so this order cannot be paid for. We apologize for any inconvenience caused.', 'woo-gutenberg-products-block' ), $product->get_name() ), array( 'status' => 403 ) );
+						}
+
+						// We only need to check products managing stock, with a limited stock qty.
+						if ( ! $product->managing_stock() || $product->backorders_allowed() ) {
+							continue;
+						}
+
+						// Check stock based on all items in the cart and consider any held stock within pending orders.
+						$held_stock     = wc_get_held_stock_quantity( $product, $order->get_id() );
+						$required_stock = $quantities[ $product->get_stock_managed_by_id() ];
+
+						/**
+						 * Filters whether or not the product has enough stock.
+						 *
+						 * @param boolean True if has enough stock.
+						 * @param \WC_Product $product Product.
+						 * @param \WC_Order $order Order.
+						 *
+						 * @since 9.8.0-dev
+						 */
+						if ( ! apply_filters( 'woocommerce_pay_order_product_has_enough_stock', ( $product->get_stock_quantity() >= ( $held_stock + $required_stock ) ), $product, $order ) ) {
+							/* translators: 1: product name 2: quantity in stock */
+							return new \WP_Error( '@Todo', sprintf( __( 'Sorry, we do not have enough "%1$s" in stock to fulfill your order (%2$s available). We apologize for any inconvenience caused.', 'woo-gutenberg-products-block' ), $product->get_name(), wc_format_stock_quantity_for_display( $product->get_stock_quantity() - $held_stock, $product ) ), array( 'status' => 403 ) );
+						}
+					}
+				}
+			}
+		}
+
+		return true;
 	}
 
 	/**

--- a/src/StoreApi/Routes/V1/Order.php
+++ b/src/StoreApi/Routes/V1/Order.php
@@ -1,0 +1,83 @@
+<?php
+namespace Automattic\WooCommerce\StoreApi\Routes\V1;
+
+use Automattic\WooCommerce\StoreApi\SchemaController;
+use Automattic\WooCommerce\StoreApi\Schemas\v1\AbstractSchema;
+use Automattic\WooCommerce\StoreApi\Utilities\OrderController;
+
+/**
+ * Order class.
+ */
+class Order extends AbstractRoute {
+	/**
+	 * The route identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'order';
+
+	/**
+	 * The schema item identifier.
+	 *
+	 * @var string
+	 */
+	const SCHEMA_TYPE = 'order';
+
+	/**
+	 * Order controller class instance.
+	 *
+	 * @var OrderController
+	 */
+	protected $order_controller;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param SchemaController $schema_controller Schema Controller instance.
+	 * @param AbstractSchema   $schema Schema class for this route.
+	 */
+	public function __construct( SchemaController $schema_controller, AbstractSchema $schema ) {
+		parent::__construct( $schema_controller, $schema );
+
+		$this->order_controller = new OrderController();
+	}
+
+	/**
+	 * Get the path of this REST route.
+	 *
+	 * @return string
+	 */
+	public function get_path() {
+		return '/order/(?P<id>[\d]+)';
+	}
+
+	/**
+	 * Get method arguments for this REST route.
+	 *
+	 * @return array An array of endpoints.
+	 */
+	public function get_args() {
+		return [
+			[
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'get_response' ],
+				'permission_callback' => '__return_true', // @Todo check authorization - order id and key.
+				'args'                => [
+					'context' => $this->get_context_param( [ 'default' => 'view' ] ),
+				],
+			],
+			'schema' => [ $this->schema, 'get_public_item_schema' ],
+		];
+	}
+
+	/**
+	 * Handle the request and return a valid response for this endpoint.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 * @return \WP_REST_Response
+	 */
+	protected function get_route_response( \WP_REST_Request $request ) {
+		$order_id = absint( $request['id'] );
+		return rest_ensure_response( $this->schema->get_item_response( $this->order_controller->get_order( $order_id ) ) );
+	}
+}

--- a/src/StoreApi/RoutesController.php
+++ b/src/StoreApi/RoutesController.php
@@ -47,6 +47,7 @@ class RoutesController {
 				Routes\V1\CartUpdateItem::IDENTIFIER     => Routes\V1\CartUpdateItem::class,
 				Routes\V1\CartUpdateCustomer::IDENTIFIER => Routes\V1\CartUpdateCustomer::class,
 				Routes\V1\Checkout::IDENTIFIER           => Routes\V1\Checkout::class,
+				Routes\V1\Order::IDENTIFIER              => Routes\V1\Order::class,
 				Routes\V1\ProductAttributes::IDENTIFIER  => Routes\V1\ProductAttributes::class,
 				Routes\V1\ProductAttributesById::IDENTIFIER => Routes\V1\ProductAttributesById::class,
 				Routes\V1\ProductAttributeTerms::IDENTIFIER => Routes\V1\ProductAttributeTerms::class,

--- a/src/StoreApi/RoutesController.php
+++ b/src/StoreApi/RoutesController.php
@@ -47,6 +47,7 @@ class RoutesController {
 				Routes\V1\CartUpdateItem::IDENTIFIER     => Routes\V1\CartUpdateItem::class,
 				Routes\V1\CartUpdateCustomer::IDENTIFIER => Routes\V1\CartUpdateCustomer::class,
 				Routes\V1\Checkout::IDENTIFIER           => Routes\V1\Checkout::class,
+				Routes\V1\CheckoutOrder::IDENTIFIER      => Routes\V1\CheckoutOrder::class,
 				Routes\V1\Order::IDENTIFIER              => Routes\V1\Order::class,
 				Routes\V1\ProductAttributes::IDENTIFIER  => Routes\V1\ProductAttributes::class,
 				Routes\V1\ProductAttributesById::IDENTIFIER => Routes\V1\ProductAttributesById::class,

--- a/src/StoreApi/SchemaController.php
+++ b/src/StoreApi/SchemaController.php
@@ -43,6 +43,7 @@ class SchemaController {
 				Schemas\V1\CartItemSchema::IDENTIFIER      => Schemas\V1\CartItemSchema::class,
 				Schemas\V1\CartSchema::IDENTIFIER          => Schemas\V1\CartSchema::class,
 				Schemas\V1\CartExtensionsSchema::IDENTIFIER => Schemas\V1\CartExtensionsSchema::class,
+				Schemas\V1\CheckoutOrderSchema::IDENTIFIER => Schemas\V1\CheckoutOrderSchema::class,
 				Schemas\V1\CheckoutSchema::IDENTIFIER      => Schemas\V1\CheckoutSchema::class,
 				Schemas\V1\OrderItemSchema::IDENTIFIER     => Schemas\V1\OrderItemSchema::class,
 				Schemas\V1\OrderSchema::IDENTIFIER         => Schemas\V1\OrderSchema::class,

--- a/src/StoreApi/SchemaController.php
+++ b/src/StoreApi/SchemaController.php
@@ -44,6 +44,7 @@ class SchemaController {
 				Schemas\V1\CartSchema::IDENTIFIER          => Schemas\V1\CartSchema::class,
 				Schemas\V1\CartExtensionsSchema::IDENTIFIER => Schemas\V1\CartExtensionsSchema::class,
 				Schemas\V1\CheckoutSchema::IDENTIFIER      => Schemas\V1\CheckoutSchema::class,
+				Schemas\V1\OrderSchema::IDENTIFIER         => Schemas\V1\OrderSchema::class,
 				Schemas\V1\ProductSchema::IDENTIFIER       => Schemas\V1\ProductSchema::class,
 				Schemas\V1\ProductAttributeSchema::IDENTIFIER => Schemas\V1\ProductAttributeSchema::class,
 				Schemas\V1\ProductCategorySchema::IDENTIFIER => Schemas\V1\ProductCategorySchema::class,

--- a/src/StoreApi/SchemaController.php
+++ b/src/StoreApi/SchemaController.php
@@ -44,6 +44,7 @@ class SchemaController {
 				Schemas\V1\CartSchema::IDENTIFIER          => Schemas\V1\CartSchema::class,
 				Schemas\V1\CartExtensionsSchema::IDENTIFIER => Schemas\V1\CartExtensionsSchema::class,
 				Schemas\V1\CheckoutSchema::IDENTIFIER      => Schemas\V1\CheckoutSchema::class,
+				Schemas\V1\OrderItemSchema::IDENTIFIER     => Schemas\V1\OrderItemSchema::class,
 				Schemas\V1\OrderSchema::IDENTIFIER         => Schemas\V1\OrderSchema::class,
 				Schemas\V1\ProductSchema::IDENTIFIER       => Schemas\V1\ProductSchema::class,
 				Schemas\V1\ProductAttributeSchema::IDENTIFIER => Schemas\V1\ProductAttributeSchema::class,

--- a/src/StoreApi/Schemas/V1/CartItemSchema.php
+++ b/src/StoreApi/Schemas/V1/CartItemSchema.php
@@ -2,6 +2,7 @@
 namespace Automattic\WooCommerce\StoreApi\Schemas\V1;
 
 use Automattic\WooCommerce\StoreApi\Utilities\DraftOrderTrait;
+use Automattic\WooCommerce\StoreApi\Utilities\ProductItemTrait;
 use Automattic\WooCommerce\StoreApi\Utilities\QuantityLimits;
 
 /**
@@ -9,6 +10,7 @@ use Automattic\WooCommerce\StoreApi\Utilities\QuantityLimits;
  */
 class CartItemSchema extends ProductSchema {
 	use DraftOrderTrait;
+	use ProductItemTrait;
 
 	/**
 	 * The schema item name.
@@ -364,82 +366,6 @@ class CartItemSchema extends ProductSchema {
 			'catalog_visibility'   => $product->get_catalog_visibility(),
 			self::EXTENDING_KEY    => $this->get_extended_data( self::IDENTIFIER, $cart_item ),
 		];
-	}
-
-	/**
-	 * Get an array of pricing data.
-	 *
-	 * @param \WC_Product $product Product instance.
-	 * @param string      $tax_display_mode If returned prices are incl or excl of tax.
-	 * @return array
-	 */
-	protected function prepare_product_price_response( \WC_Product $product, $tax_display_mode = '' ) {
-		$tax_display_mode = $this->get_tax_display_mode( $tax_display_mode );
-		$price_function   = $this->get_price_function_from_tax_display_mode( $tax_display_mode );
-		$prices           = parent::prepare_product_price_response( $product, $tax_display_mode );
-
-		// Add raw prices (prices with greater precision).
-		$prices['raw_prices'] = [
-			'precision'     => wc_get_rounding_precision(),
-			'price'         => $this->prepare_money_response( $price_function( $product ), wc_get_rounding_precision() ),
-			'regular_price' => $this->prepare_money_response( $price_function( $product, [ 'price' => $product->get_regular_price() ] ), wc_get_rounding_precision() ),
-			'sale_price'    => $this->prepare_money_response( $price_function( $product, [ 'price' => $product->get_sale_price() ] ), wc_get_rounding_precision() ),
-		];
-
-		return $prices;
-	}
-
-	/**
-	 * Format variation data, for example convert slugs such as attribute_pa_size to Size.
-	 *
-	 * @param array       $variation_data Array of data from the cart.
-	 * @param \WC_Product $product Product data.
-	 * @return array
-	 */
-	protected function format_variation_data( $variation_data, $product ) {
-		$return = [];
-
-		if ( ! is_iterable( $variation_data ) ) {
-			return $return;
-		}
-
-		foreach ( $variation_data as $key => $value ) {
-			$taxonomy = wc_attribute_taxonomy_name( str_replace( 'attribute_pa_', '', urldecode( $key ) ) );
-
-			if ( taxonomy_exists( $taxonomy ) ) {
-				// If this is a term slug, get the term's nice name.
-				$term = get_term_by( 'slug', $value, $taxonomy );
-				if ( ! is_wp_error( $term ) && $term && $term->name ) {
-					$value = $term->name;
-				}
-				$label = wc_attribute_label( $taxonomy );
-			} else {
-				/**
-				 * Filters the variation option name.
-				 *
-				 * Filters the variation option name for custom option slugs.
-				 *
-				 * @since 2.5.0
-				 *
-				 * @internal Matches filter name in WooCommerce core.
-				 *
-				 * @param string $value The name to display.
-				 * @param null $unused Unused because this is not a variation taxonomy.
-				 * @param string $taxonomy Taxonomy or product attribute name.
-				 * @param \WC_Product $product Product data.
-				 * @return string
-				 */
-				$value = apply_filters( 'woocommerce_variation_option_name', $value, null, $taxonomy, $product );
-				$label = wc_attribute_label( str_replace( 'attribute_', '', $key ), $product );
-			}
-
-			$return[] = [
-				'attribute' => $this->prepare_html_response( $label ),
-				'value'     => $this->prepare_html_response( $value ),
-			];
-		}
-
-		return $return;
 	}
 
 	/**

--- a/src/StoreApi/Schemas/V1/CheckoutOrderSchema.php
+++ b/src/StoreApi/Schemas/V1/CheckoutOrderSchema.php
@@ -1,0 +1,211 @@
+<?php
+namespace Automattic\WooCommerce\StoreApi\Schemas\V1;
+
+use Automattic\WooCommerce\StoreApi\SchemaController;
+use Automattic\WooCommerce\StoreApi\Payments\PaymentResult;
+use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
+
+
+/**
+ * CheckoutOrderSchema class.
+ */
+class CheckoutOrderSchema extends AbstractSchema {
+	/**
+	 * The schema item name.
+	 *
+	 * @var string
+	 */
+	protected $title = 'checkout-order';
+
+	/**
+	 * The schema item identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'checkout-order';
+
+	/**
+	 * Billing address schema instance.
+	 *
+	 * @var BillingAddressSchema
+	 */
+	protected $billing_address_schema;
+
+	/**
+	 * Shipping address schema instance.
+	 *
+	 * @var ShippingAddressSchema
+	 */
+	protected $shipping_address_schema;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param ExtendSchema     $extend Rest Extending instance.
+	 * @param SchemaController $controller Schema Controller instance.
+	 */
+	public function __construct( ExtendSchema $extend, SchemaController $controller ) {
+		parent::__construct( $extend, $controller );
+		$this->billing_address_schema  = $this->controller->get( BillingAddressSchema::IDENTIFIER );
+		$this->shipping_address_schema = $this->controller->get( ShippingAddressSchema::IDENTIFIER );
+	}
+
+	/**
+	 * Checkout schema properties.
+	 *
+	 * @return array
+	 */
+	public function get_properties() {
+		return [
+			'order_id'          => [
+				'description' => __( 'The order ID to process during checkout.', 'woo-gutenberg-products-block' ),
+				'type'        => 'integer',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
+			'status'            => [
+				'description' => __( 'Order status. Payment providers will update this value after payment.', 'woo-gutenberg-products-block' ),
+				'type'        => 'string',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
+			'order_key'         => [
+				'description' => __( 'Order key used to check validity or protect access to certain order data.', 'woo-gutenberg-products-block' ),
+				'type'        => 'string',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
+			'customer_note'     => [
+				'description' => __( 'Note added to the order by the customer during checkout.', 'woo-gutenberg-products-block' ),
+				'type'        => 'string',
+				'context'     => [ 'view', 'edit' ],
+			],
+			'customer_id'       => [
+				'description' => __( 'Customer ID if registered. Will return 0 for guests.', 'woo-gutenberg-products-block' ),
+				'type'        => 'integer',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
+			'billing_address'   => [
+				'description' => __( 'Billing address.', 'woo-gutenberg-products-block' ),
+				'type'        => 'object',
+				'context'     => [ 'view', 'edit' ],
+				'properties'  => $this->billing_address_schema->get_properties(),
+				'arg_options' => [
+					'sanitize_callback' => [ $this->billing_address_schema, 'sanitize_callback' ],
+					'validate_callback' => [ $this->billing_address_schema, 'validate_callback' ],
+				],
+				'required'    => true,
+			],
+			'shipping_address'  => [
+				'description' => __( 'Shipping address.', 'woo-gutenberg-products-block' ),
+				'type'        => 'object',
+				'context'     => [ 'view', 'edit' ],
+				'properties'  => $this->shipping_address_schema->get_properties(),
+				'arg_options' => [
+					'sanitize_callback' => [ $this->shipping_address_schema, 'sanitize_callback' ],
+					'validate_callback' => [ $this->shipping_address_schema, 'validate_callback' ],
+				],
+			],
+			'payment_method'    => [
+				'description' => __( 'The ID of the payment method being used to process the payment.', 'woo-gutenberg-products-block' ),
+				'type'        => 'string',
+				'context'     => [ 'view', 'edit' ],
+				'enum'        => wc()->payment_gateways->get_payment_gateway_ids(),
+			],
+			'payment_result'    => [
+				'description' => __( 'Result of payment processing, or false if not yet processed.', 'woo-gutenberg-products-block' ),
+				'type'        => 'object',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+				'properties'  => [
+					'payment_status'  => [
+						'description' => __( 'Status of the payment returned by the gateway. One of success, pending, failure, error.', 'woo-gutenberg-products-block' ),
+						'readonly'    => true,
+						'type'        => 'string',
+					],
+					'payment_details' => [
+						'description' => __( 'An array of data being returned from the payment gateway.', 'woo-gutenberg-products-block' ),
+						'readonly'    => true,
+						'type'        => 'array',
+						'items'       => [
+							'type'       => 'object',
+							'properties' => [
+								'key'   => [
+									'type' => 'string',
+								],
+								'value' => [
+									'type' => 'string',
+								],
+							],
+						],
+					],
+					'redirect_url'    => [
+						'description' => __( 'A URL to redirect the customer after checkout. This could be, for example, a link to the payment processors website.', 'woo-gutenberg-products-block' ),
+						'readonly'    => true,
+						'type'        => 'string',
+					],
+				],
+			],
+			self::EXTENDING_KEY => $this->get_extended_schema( self::IDENTIFIER ),
+		];
+	}
+
+	/**
+	 * Return the response for checkout.
+	 *
+	 * @param object $item Results from checkout action.
+	 * @return array
+	 */
+	public function get_item_response( $item ) {
+		return $this->get_checkout_response( $item->order, $item->payment_result );
+	}
+
+	/**
+	 * Get the checkout response based on the current order and any payments.
+	 *
+	 * @param \WC_Order     $order Order object.
+	 * @param PaymentResult $payment_result Payment result object.
+	 * @return array
+	 */
+	protected function get_checkout_response( \WC_Order $order, PaymentResult $payment_result = null ) {
+		return [
+			'order_id'          => $order->get_id(),
+			'status'            => $order->get_status(),
+			'order_key'         => $order->get_order_key(),
+			'customer_note'     => $order->get_customer_note(),
+			'customer_id'       => $order->get_customer_id(),
+			'billing_address'   => $this->billing_address_schema->get_item_response( $order ),
+			'shipping_address'  => $this->shipping_address_schema->get_item_response( $order ),
+			'payment_method'    => $order->get_payment_method(),
+			'payment_result'    => [
+				'payment_status'  => $payment_result->status,
+				'payment_details' => $this->prepare_payment_details_for_response( $payment_result->payment_details ),
+				'redirect_url'    => $payment_result->redirect_url,
+			],
+			self::EXTENDING_KEY => $this->get_extended_data( self::IDENTIFIER ),
+		];
+	}
+
+	/**
+	 * This prepares the payment details for the response so it's following the
+	 * schema where it's an array of objects.
+	 *
+	 * @param array $payment_details An array of payment details from the processed payment.
+	 *
+	 * @return array An array of objects where each object has the key and value
+	 *               as distinct properties.
+	 */
+	protected function prepare_payment_details_for_response( array $payment_details ) {
+		return array_map(
+			function( $key, $value ) {
+				return (object) [
+					'key'   => $key,
+					'value' => $value,
+				];
+			},
+			array_keys( $payment_details ),
+			$payment_details
+		);
+	}
+}

--- a/src/StoreApi/Schemas/V1/OrderItemSchema.php
+++ b/src/StoreApi/Schemas/V1/OrderItemSchema.php
@@ -29,25 +29,25 @@ class OrderItemSchema extends ProductSchema {
 	 */
 	public function get_properties() {
 		return [
-			'id'                => [
+			'id'                   => [
 				'description' => __( 'The order item product or variation ID.', 'woo-gutenberg-products-block' ),
 				'type'        => 'integer',
 				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
 			],
-			'quantity'          => [
+			'quantity'             => [
 				'description' => __( 'Quantity of this item in the order.', 'woo-gutenberg-products-block' ),
 				'type'        => 'number',
 				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
 			],
-			'name'              => [
+			'name'                 => [
 				'description' => __( 'Product name.', 'woo-gutenberg-products-block' ),
 				'type'        => 'string',
 				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
 			],
-			'item_data'         => [
+			'item_data'            => [
 				'description' => __( 'Metadata related to the order item', 'woo-gutenberg-products-block' ),
 				'type'        => 'array',
 				'context'     => [ 'view', 'edit' ],
@@ -76,7 +76,7 @@ class OrderItemSchema extends ProductSchema {
 					],
 				],
 			],
-			'totals'            => [
+			'totals'               => [
 				'description' => __( 'Item total amounts provided using the smallest unit of the currency.', 'woo-gutenberg-products-block' ),
 				'type'        => 'object',
 				'context'     => [ 'view', 'edit' ],
@@ -111,7 +111,216 @@ class OrderItemSchema extends ProductSchema {
 					]
 				),
 			],
-			self::EXTENDING_KEY => $this->get_extended_schema( self::IDENTIFIER ),
+			'key'                  => [
+				'description' => __( 'Unique identifier for the item within the order.', 'woo-gutenberg-products-block' ),
+				'type'        => 'string',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
+			'quantity_limits'      => [
+				'description' => __( 'How the quantity of this item should be controlled, for example, any limits in place.', 'woo-gutenberg-products-block' ),
+				'type'        => 'object',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+				'properties'  => [
+					'minimum'     => [
+						'description' => __( 'The minimum quantity allowed in the order for this line item.', 'woo-gutenberg-products-block' ),
+						'type'        => 'integer',
+						'context'     => [ 'view', 'edit' ],
+						'readonly'    => true,
+					],
+					'maximum'     => [
+						'description' => __( 'The maximum quantity allowed in the order for this line item.', 'woo-gutenberg-products-block' ),
+						'type'        => 'integer',
+						'context'     => [ 'view', 'edit' ],
+						'readonly'    => true,
+					],
+					'multiple_of' => [
+						'description' => __( 'The amount that quantities increment by. Quantity must be an multiple of this value.', 'woo-gutenberg-products-block' ),
+						'type'        => 'integer',
+						'context'     => [ 'view', 'edit' ],
+						'readonly'    => true,
+						'default'     => 1,
+					],
+					'editable'    => [
+						'description' => __( 'If the quantity in the order is editable or fixed.', 'woo-gutenberg-products-block' ),
+						'type'        => 'boolean',
+						'context'     => [ 'view', 'edit' ],
+						'readonly'    => true,
+						'default'     => true,
+					],
+				],
+			],
+			'short_description'    => [
+				'description' => __( 'Product short description in HTML format.', 'woo-gutenberg-products-block' ),
+				'type'        => 'string',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
+			'description'          => [
+				'description' => __( 'Product full description in HTML format.', 'woo-gutenberg-products-block' ),
+				'type'        => 'string',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
+			'sku'                  => [
+				'description' => __( 'Stock keeping unit, if applicable.', 'woo-gutenberg-products-block' ),
+				'type'        => 'string',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
+			'low_stock_remaining'  => [
+				'description' => __( 'Quantity left in stock if stock is low, or null if not applicable.', 'woo-gutenberg-products-block' ),
+				'type'        => [ 'integer', 'null' ],
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
+			'backorders_allowed'   => [
+				'description' => __( 'True if backorders are allowed past stock availability.', 'woo-gutenberg-products-block' ),
+				'type'        => [ 'boolean' ],
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
+			'show_backorder_badge' => [
+				'description' => __( 'True if the product is on backorder.', 'woo-gutenberg-products-block' ),
+				'type'        => [ 'boolean' ],
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
+			'sold_individually'    => [
+				'description' => __( 'If true, only one item of this product is allowed for purchase in a single order.', 'woo-gutenberg-products-block' ),
+				'type'        => 'boolean',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
+			'permalink'            => [
+				'description' => __( 'Product URL.', 'woo-gutenberg-products-block' ),
+				'type'        => 'string',
+				'format'      => 'uri',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
+			'images'               => [
+				'description' => __( 'List of images.', 'woo-gutenberg-products-block' ),
+				'type'        => 'array',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+				'items'       => [
+					'type'       => 'object',
+					'properties' => $this->image_attachment_schema->get_properties(),
+				],
+			],
+			'variation'            => [
+				'description' => __( 'Chosen attributes (for variations).', 'woo-gutenberg-products-block' ),
+				'type'        => 'array',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+				'items'       => [
+					'type'       => 'object',
+					'properties' => [
+						'attribute' => [
+							'description' => __( 'Variation attribute name.', 'woo-gutenberg-products-block' ),
+							'type'        => 'string',
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+						],
+						'value'     => [
+							'description' => __( 'Variation attribute value.', 'woo-gutenberg-products-block' ),
+							'type'        => 'string',
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+						],
+					],
+				],
+			],
+			'prices'               => [
+				'description' => __( 'Price data for the product in the current line item.', 'woo-gutenberg-products-block' ),
+				'type'        => 'object',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+				'properties'  => array_merge(
+					$this->get_store_currency_properties(),
+					[
+						'price'         => [
+							'description' => __( 'Current product price.', 'woo-gutenberg-products-block' ),
+							'type'        => 'string',
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+						],
+						'regular_price' => [
+							'description' => __( 'Regular product price.', 'woo-gutenberg-products-block' ),
+							'type'        => 'string',
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+						],
+						'sale_price'    => [
+							'description' => __( 'Sale product price, if applicable.', 'woo-gutenberg-products-block' ),
+							'type'        => 'string',
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+						],
+						'price_range'   => [
+							'description' => __( 'Price range, if applicable.', 'woo-gutenberg-products-block' ),
+							'type'        => [ 'object', 'null' ],
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+							'properties'  => [
+								'min_amount' => [
+									'description' => __( 'Price amount.', 'woo-gutenberg-products-block' ),
+									'type'        => 'string',
+									'context'     => [ 'view', 'edit' ],
+									'readonly'    => true,
+								],
+								'max_amount' => [
+									'description' => __( 'Price amount.', 'woo-gutenberg-products-block' ),
+									'type'        => 'string',
+									'context'     => [ 'view', 'edit' ],
+									'readonly'    => true,
+								],
+							],
+						],
+						'raw_prices'    => [
+							'description' => __( 'Raw unrounded product prices used in calculations. Provided using a higher unit of precision than the currency.', 'woo-gutenberg-products-block' ),
+							'type'        => [ 'object', 'null' ],
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+							'properties'  => [
+								'precision'     => [
+									'description' => __( 'Decimal precision of the returned prices.', 'woo-gutenberg-products-block' ),
+									'type'        => 'integer',
+									'context'     => [ 'view', 'edit' ],
+									'readonly'    => true,
+								],
+								'price'         => [
+									'description' => __( 'Current product price.', 'woo-gutenberg-products-block' ),
+									'type'        => 'string',
+									'context'     => [ 'view', 'edit' ],
+									'readonly'    => true,
+								],
+								'regular_price' => [
+									'description' => __( 'Regular product price.', 'woo-gutenberg-products-block' ),
+									'type'        => 'string',
+									'context'     => [ 'view', 'edit' ],
+									'readonly'    => true,
+								],
+								'sale_price'    => [
+									'description' => __( 'Sale product price, if applicable.', 'woo-gutenberg-products-block' ),
+									'type'        => 'string',
+									'context'     => [ 'view', 'edit' ],
+									'readonly'    => true,
+								],
+							],
+						],
+					]
+				),
+			],
+			'catalog_visibility'   => [
+				'description' => __( 'Whether the product is visible in the catalog', 'woo-gutenberg-products-block' ),
+				'type'        => 'string',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
+			self::EXTENDING_KEY    => $this->get_extended_schema( self::IDENTIFIER ),
 		];
 	}
 
@@ -124,11 +333,25 @@ class OrderItemSchema extends ProductSchema {
 	public function get_item_response( $item ) {
 		$order = $item->get_order();
 		return [
-			'id'        => $item->get_id(),
-			'quantity'  => $item->get_quantity(),
-			'name'      => $item->get_name(),
-			'item_data' => $item->get_all_formatted_meta_data(),
-			'totals'    => $this->get_totals( $item ),
+			'id'                   => $item->get_id(),
+			'quantity'             => $item->get_quantity(),
+			'name'                 => $item->get_name(),
+			'item_data'            => $item->get_all_formatted_meta_data(),
+			'totals'               => $this->get_totals( $item ),
+			'key'                  => $order->get_order_key(),
+			'quantity_limits'      => $item->get_quantity(),
+			'short_description'    => $this->prepare_html_response( wc_format_content( wp_kses_post( $item->get_product()->get_short_description() ) ) ),
+			'description'          => $this->prepare_html_response( wc_format_content( wp_kses_post( $item->get_product()->get_description() ) ) ),
+			'sku'                  => $this->prepare_html_response( $item->get_product()->get_sku() ),
+			'low_stock_remaining'  => null,
+			'backorders_allowed'   => false,
+			'show_backorder_badge' => false,
+			'sold_individually'    => false,
+			'permalink'            => $item->get_product()->get_permalink(),
+			'images'               => $this->get_images( $item->get_product() ),
+			// 'variation'            => $this->format_variation_data( $item->get_variation(), $item->get_product() ),
+			'prices'               => (object) $this->prepare_product_price_response( $item->get_product(), get_option( 'woocommerce_tax_display_cart' ) ),
+			'catalog_visibility'   => $item->get_product()->get_catalog_visibility(),
 		];
 	}
 

--- a/src/StoreApi/Schemas/V1/OrderItemSchema.php
+++ b/src/StoreApi/Schemas/V1/OrderItemSchema.php
@@ -1,12 +1,14 @@
 <?php
 namespace Automattic\WooCommerce\StoreApi\Schemas\V1;
 
+use Automattic\WooCommerce\StoreApi\Utilities\ProductItemTrait;
 use Automattic\WooCommerce\StoreApi\Utilities\QuantityLimits;
 
 /**
  * OrderItemSchema class.
  */
 class OrderItemSchema extends ProductSchema {
+	use ProductItemTrait;
 
 	/**
 	 * The schema item name.
@@ -331,7 +333,9 @@ class OrderItemSchema extends ProductSchema {
 	 * @return array
 	 */
 	public function get_item_response( $item ) {
-		$order = $item->get_order();
+		$order   = $item->get_order();
+		$product = $item->get_product();
+
 		return [
 			'id'                   => $item->get_id(),
 			'quantity'             => $item->get_quantity(),
@@ -339,19 +343,24 @@ class OrderItemSchema extends ProductSchema {
 			'item_data'            => $item->get_all_formatted_meta_data(),
 			'totals'               => $this->get_totals( $item ),
 			'key'                  => $order->get_order_key(),
-			'quantity_limits'      => $item->get_quantity(),
-			'short_description'    => $this->prepare_html_response( wc_format_content( wp_kses_post( $item->get_product()->get_short_description() ) ) ),
-			'description'          => $this->prepare_html_response( wc_format_content( wp_kses_post( $item->get_product()->get_description() ) ) ),
-			'sku'                  => $this->prepare_html_response( $item->get_product()->get_sku() ),
+			'quantity_limits'      => array(
+				'minimum'     => $item->get_quantity(),
+				'maximum'     => $item->get_quantity(),
+				'multiple_of' => 1,
+				'editable'    => false,
+			),
+			'short_description'    => $this->prepare_html_response( wc_format_content( wp_kses_post( $product->get_short_description() ) ) ),
+			'description'          => $this->prepare_html_response( wc_format_content( wp_kses_post( $product->get_description() ) ) ),
+			'sku'                  => $this->prepare_html_response( $product->get_sku() ),
 			'low_stock_remaining'  => null,
 			'backorders_allowed'   => false,
 			'show_backorder_badge' => false,
 			'sold_individually'    => false,
-			'permalink'            => $item->get_product()->get_permalink(),
-			'images'               => $this->get_images( $item->get_product() ),
-			// 'variation'            => $this->format_variation_data( $item->get_variation(), $item->get_product() ),
-			'prices'               => (object) $this->prepare_product_price_response( $item->get_product(), get_option( 'woocommerce_tax_display_cart' ) ),
-			'catalog_visibility'   => $item->get_product()->get_catalog_visibility(),
+			'permalink'            => $product->get_permalink(),
+			'images'               => $this->get_images( $product ),
+			'variation'            => $this->format_variation_data( $product->get_attributes(), $product ),
+			'prices'               => (object) $this->prepare_product_price_response( $product, get_option( 'woocommerce_tax_display_cart' ) ),
+			'catalog_visibility'   => $product->get_catalog_visibility(),
 		];
 	}
 

--- a/src/StoreApi/Schemas/V1/OrderItemSchema.php
+++ b/src/StoreApi/Schemas/V1/OrderItemSchema.php
@@ -1,0 +1,149 @@
+<?php
+namespace Automattic\WooCommerce\StoreApi\Schemas\V1;
+
+use Automattic\WooCommerce\StoreApi\Utilities\QuantityLimits;
+
+/**
+ * OrderItemSchema class.
+ */
+class OrderItemSchema extends ProductSchema {
+
+	/**
+	 * The schema item name.
+	 *
+	 * @var string
+	 */
+	protected $title = 'order_item';
+
+	/**
+	 * The schema item identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'order-item';
+
+	/**
+	 * Order schema properties.
+	 *
+	 * @return array
+	 */
+	public function get_properties() {
+		return [
+			'id'                => [
+				'description' => __( 'The order item product or variation ID.', 'woo-gutenberg-products-block' ),
+				'type'        => 'integer',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
+			'quantity'          => [
+				'description' => __( 'Quantity of this item in the order.', 'woo-gutenberg-products-block' ),
+				'type'        => 'number',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
+			'name'              => [
+				'description' => __( 'Product name.', 'woo-gutenberg-products-block' ),
+				'type'        => 'string',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
+			'item_data'         => [
+				'description' => __( 'Metadata related to the order item', 'woo-gutenberg-products-block' ),
+				'type'        => 'array',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+				'items'       => [
+					'type'       => 'object',
+					'properties' => [
+						'name'    => [
+							'description' => __( 'Name of the metadata.', 'woo-gutenberg-products-block' ),
+							'type'        => 'string',
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+						],
+						'value'   => [
+							'description' => __( 'Value of the metadata.', 'woo-gutenberg-products-block' ),
+							'type'        => 'string',
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+						],
+						'display' => [
+							'description' => __( 'Optionally, how the metadata value should be displayed to the user.', 'woo-gutenberg-products-block' ),
+							'type'        => 'string',
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+						],
+					],
+				],
+			],
+			'totals'            => [
+				'description' => __( 'Item total amounts provided using the smallest unit of the currency.', 'woo-gutenberg-products-block' ),
+				'type'        => 'object',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+				'properties'  => array_merge(
+					$this->get_store_currency_properties(),
+					[
+						'line_subtotal'     => [
+							'description' => __( 'Line subtotal (the price of the product before coupon discounts have been applied).', 'woo-gutenberg-products-block' ),
+							'type'        => 'string',
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+						],
+						'line_subtotal_tax' => [
+							'description' => __( 'Line subtotal tax.', 'woo-gutenberg-products-block' ),
+							'type'        => 'string',
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+						],
+						'line_total'        => [
+							'description' => __( 'Line total (the price of the product after coupon discounts have been applied).', 'woo-gutenberg-products-block' ),
+							'type'        => 'string',
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+						],
+						'line_total_tax'    => [
+							'description' => __( 'Line total tax.', 'woo-gutenberg-products-block' ),
+							'type'        => 'string',
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+						],
+					]
+				),
+			],
+			self::EXTENDING_KEY => $this->get_extended_schema( self::IDENTIFIER ),
+		];
+	}
+
+	/**
+	 * Get items data.
+	 *
+	 * @param \WC_Order_Item_Product $item Order item instance.
+	 * @return array
+	 */
+	public function get_item_response( $item ) {
+		$order = $item->get_order();
+		return [
+			'id'        => $item->get_id(),
+			'quantity'  => $item->get_quantity(),
+			'name'      => $item->get_name(),
+			'item_data' => $item->get_all_formatted_meta_data(),
+			'totals'    => $this->get_totals( $item ),
+		];
+	}
+
+	/**
+	 * Get totals data.
+	 *
+	 * @param \WC_Order_Item_Product $item Order item instance.
+	 * @return array
+	 */
+	public function get_totals( $item ) {
+		return [
+			'line_subtotal'     => $item->get_subtotal(),
+			'line_subtotal_tax' => $item->get_subtotal_tax(),
+			'line_total'        => $item->get_total(),
+			'line_total_tax'    => $item->get_total_tax(),
+		];
+	}
+}

--- a/src/StoreApi/Schemas/V1/OrderSchema.php
+++ b/src/StoreApi/Schemas/V1/OrderSchema.php
@@ -26,11 +26,100 @@ class OrderSchema extends AbstractSchema {
 	 */
 	public function get_properties() {
 		return [
-			'id' => [
+			'id'         => [
 				'description' => __( 'The order ID to process during checkout.', 'woo-gutenberg-products-block' ),
 				'type'        => 'integer',
 				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
+			],
+			'line_items' => [
+				'description' => __( 'Line items data.', 'woo-gutenberg-products-block' ),
+				'type'        => 'array',
+				'context'     => [ 'view', 'edit' ],
+				'items'       => [
+					'type'       => 'object',
+					'properties' => [
+						'id'        => [
+							'description' => __( 'Item ID.', 'woo-gutenberg-products-block' ),
+							'type'        => 'integer',
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+						],
+						'name'      => [
+							'description' => __( 'Product name.', 'woo-gutenberg-products-block' ),
+							'type'        => 'mixed',
+							'context'     => [ 'view', 'edit' ],
+						],
+						'quantity'  => [
+							'description' => __( 'Quantity ordered.', 'woo-gutenberg-products-block' ),
+							'type'        => 'integer',
+							'context'     => [ 'view', 'edit' ],
+						],
+						'subtotal'  => [
+							'description' => __( 'Line subtotal (before discounts).', 'woo-gutenberg-products-block' ),
+							'type'        => 'string',
+							'context'     => [ 'view', 'edit' ],
+						],
+						'meta_data' => [
+							'description' => __( 'Meta data.', 'woo-gutenberg-products-block' ),
+							'type'        => 'array',
+							'context'     => [ 'view', 'edit' ],
+							'items'       => [
+								'type'       => 'object',
+								'properties' => [
+									'id'            => [
+										'description' => __( 'Meta ID.', 'woo-gutenberg-products-block' ),
+										'type'        => 'integer',
+										'context'     => [ 'view', 'edit' ],
+										'readonly'    => true,
+									],
+									'key'           => [
+										'description' => __( 'Meta key.', 'woo-gutenberg-products-block' ),
+										'type'        => 'string',
+										'context'     => [ 'view', 'edit' ],
+									],
+									'value'         => [
+										'description' => __( 'Meta value.', 'woo-gutenberg-products-block' ),
+										'type'        => 'mixed',
+										'context'     => [ 'view', 'edit' ],
+									],
+									'display_key'   => [
+										'description' => __( 'Meta key for UI display.', 'woo-gutenberg-products-block' ),
+										'type'        => 'string',
+										'context'     => [ 'view', 'edit' ],
+									],
+									'display_value' => [
+										'description' => __( 'Meta value for UI display.', 'woo-gutenberg-products-block' ),
+										'type'        => 'string',
+										'context'     => [ 'view', 'edit' ],
+									],
+								],
+							],
+						],
+					],
+				],
+			],
+			'totals'     => [
+				'description' => __( 'Order totals.', 'woo-gutenberg-products-block' ),
+				'type'        => 'object',
+				'context'     => [ 'view', 'edit' ],
+				'items'       => [
+					'type'       => 'object',
+					'properties' => [
+						'label' => [
+							'description' => __( 'Label.', 'woo-gutenberg-products-block' ),
+							'type'        => 'string',
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+						],
+						'value' => [
+							'description' => __( 'Value.', 'woo-gutenberg-products-block' ),
+							'type'        => 'string',
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+						],
+					],
+				],
 			],
 		];
 	}
@@ -43,15 +132,9 @@ class OrderSchema extends AbstractSchema {
 	 */
 	public function get_item_response( $order ) {
 		return [
-			'id'             => $order->get_id(),
-			'line_items'     => $this->get_item_data( $order ),
-			'total_tax'      => $order->get_total_tax(),
-			'subtotal'       => $order->get_subtotal(),
-			'discount_total' => $order->get_discount_total(),
-			'shipping_total' => $order->get_shipping_total(),
-			'shipping_tax'   => $order->get_shipping_tax(),
-			'total_refunded' => $order->get_total_refunded(),
-			'fees_total'     => $this->get_fees_total( $order ),
+			'id'         => $order->get_id(),
+			'line_items' => $this->get_item_data( $order ),
+			'totals'     => $order->get_order_item_totals(),
 		];
 	}
 
@@ -74,35 +157,5 @@ class OrderSchema extends AbstractSchema {
 		}
 
 		return array_values( $data );
-	}
-
-	/**
-	 * Get fee.
-	 *
-	 * @param \WC_Order $order Order instance.
-	 * @return array
-	 */
-	private function get_fees_total( $order ) {
-		$fees       = $order->get_fees();
-		$total_fees = 0;
-
-		if ( $fees ) {
-			foreach ( $fees as $id => $fee ) {
-				/**
-				 * Filters whether or not free fees should be excluded.
-				 *
-				 * @param boolean True to skip the fee, false to include the fee.
-				 * @param integer $id Fee ID.
-				 *
-				 * @since 9.8.0-dev
-				 */
-				if ( apply_filters( 'woocommerce_get_order_item_totals_excl_free_fees', empty( $fee['line_total'] ) && empty( $fee['line_tax'] ), $id ) ) {
-					continue;
-				}
-				$total_fees += $fee->get_total();
-			}
-		}
-
-		return $total_fees;
 	}
 }

--- a/src/StoreApi/Schemas/V1/OrderSchema.php
+++ b/src/StoreApi/Schemas/V1/OrderSchema.php
@@ -1,0 +1,50 @@
+<?php
+namespace Automattic\WooCommerce\StoreApi\Schemas\V1;
+
+/**
+ * OrderSchema class.
+ */
+class OrderSchema extends AbstractSchema {
+	/**
+	 * The schema item name.
+	 *
+	 * @var string
+	 */
+	protected $title = 'order';
+
+	/**
+	 * The schema item identifier.
+	 *
+	 * @var string
+	 */
+	const IDENTIFIER = 'order';
+
+	/**
+	 * Order schema properties.
+	 *
+	 * @return array
+	 */
+	public function get_properties() {
+		return [
+			'id'          => [
+				'description' => __( 'The order ID to process during checkout.', 'woo-gutenberg-products-block' ),
+				'type'        => 'integer',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
+		];
+	}
+
+	/**
+	 * Get an order for response.
+	 *
+	 * @param \WC_Order $order Order instance.
+	 * @return array
+	 */
+	public function get_item_response( $order ) {
+		return [
+			'id' => $order->get_id(),
+			// @Todo Add pay-for-order order details.
+		];
+	}
+}

--- a/src/StoreApi/Schemas/V1/OrderSchema.php
+++ b/src/StoreApi/Schemas/V1/OrderSchema.php
@@ -37,7 +37,14 @@ class OrderSchema extends AbstractSchema {
 	 */
 	public function __construct( ExtendSchema $extend, SchemaController $controller ) {
 		parent::__construct( $extend, $controller );
-		$this->item_schema = $this->controller->get( OrderItemSchema::IDENTIFIER );
+		$this->item_schema             = $this->controller->get( OrderItemSchema::IDENTIFIER );
+		$this->cross_sells_item_schema = $this->controller->get( ProductSchema::IDENTIFIER );
+		$this->coupon_schema           = $this->controller->get( CartCouponSchema::IDENTIFIER );
+		$this->fee_schema              = $this->controller->get( CartFeeSchema::IDENTIFIER );
+		$this->shipping_rate_schema    = $this->controller->get( CartShippingRateSchema::IDENTIFIER );
+		$this->shipping_address_schema = $this->controller->get( ShippingAddressSchema::IDENTIFIER );
+		$this->billing_address_schema  = $this->controller->get( BillingAddressSchema::IDENTIFIER );
+		$this->error_schema            = $this->controller->get( ErrorSchema::IDENTIFIER );
 	}
 
 	/**
@@ -47,13 +54,13 @@ class OrderSchema extends AbstractSchema {
 	 */
 	public function get_properties() {
 		return [
-			'id'     => [
+			'id'                      => [
 				'description' => __( 'The order ID to process during checkout.', 'woo-gutenberg-products-block' ),
 				'type'        => 'integer',
 				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
 			],
-			'items'  => [
+			'items'                   => [
 				'description' => __( 'Line items data.', 'woo-gutenberg-products-block' ),
 				'type'        => 'array',
 				'context'     => [ 'view', 'edit' ],
@@ -62,7 +69,7 @@ class OrderSchema extends AbstractSchema {
 					'properties' => $this->force_schema_readonly( $this->item_schema->get_properties() ),
 				],
 			],
-			'totals' => [
+			'totals'                  => [
 				'description' => __( 'Order totals.', 'woo-gutenberg-products-block' ),
 				'type'        => 'object',
 				'context'     => [ 'view', 'edit' ],
@@ -70,50 +77,209 @@ class OrderSchema extends AbstractSchema {
 				'properties'  => array_merge(
 					$this->get_store_currency_properties(),
 					[
-						'subtotal'       => [
+						'subtotal'           => [
 							'description' => __( 'Subtotal of the order.', 'woo-gutenberg-products-block' ),
 							'type'        => 'string',
 							'context'     => [ 'view', 'edit' ],
 							'readonly'    => true,
 						],
-						'total_discount' => [
+						'total_discount'     => [
 							'description' => __( 'Total discount from applied coupons.', 'woo-gutenberg-products-block' ),
 							'type'        => 'string',
 							'context'     => [ 'view', 'edit' ],
 							'readonly'    => true,
 						],
-						'total_shipping' => [
+						'total_shipping'     => [
 							'description' => __( 'Total price of shipping.', 'woo-gutenberg-products-block' ),
 							'type'        => [ 'string', 'null' ],
 							'context'     => [ 'view', 'edit' ],
 							'readonly'    => true,
 						],
-						'total_fees'     => [
+						'total_fees'         => [
 							'description' => __( 'Total price of any applied fees.', 'woo-gutenberg-products-block' ),
 							'type'        => 'string',
 							'context'     => [ 'view', 'edit' ],
 							'readonly'    => true,
 						],
-						'total_tax'      => [
+						'total_tax'          => [
 							'description' => __( 'Total tax applied to the order.', 'woo-gutenberg-products-block' ),
 							'type'        => 'string',
 							'context'     => [ 'view', 'edit' ],
 							'readonly'    => true,
 						],
-						'total_refund'   => [
+						'total_refund'       => [
 							'description' => __( 'Total refund applied to the order.', 'woo-gutenberg-products-block' ),
 							'type'        => 'string',
 							'context'     => [ 'view', 'edit' ],
 							'readonly'    => true,
 						],
-						'total_price'    => [
+						'total_price'        => [
 							'description' => __( 'Total price the customer will pay.', 'woo-gutenberg-products-block' ),
 							'type'        => 'string',
 							'context'     => [ 'view', 'edit' ],
 							'readonly'    => true,
 						],
+						'total_items'        => [
+							'description' => __( 'Total price of items in the order.', 'woo-gutenberg-products-block' ),
+							'type'        => 'string',
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+						],
+						'total_items_tax'    => [
+							'description' => __( 'Total tax on items in the order.', 'woo-gutenberg-products-block' ),
+							'type'        => 'string',
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+						],
+						'total_fees_tax'     => [
+							'description' => __( 'Total tax on fees.', 'woo-gutenberg-products-block' ),
+							'type'        => 'string',
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+						],
+						'total_discount_tax' => [
+							'description' => __( 'Total tax removed due to discount from applied coupons.', 'woo-gutenberg-products-block' ),
+							'type'        => 'string',
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+						],
+						'total_shipping_tax' => [
+							'description' => __( 'Total tax on shipping. If shipping has not been calculated, a null response will be sent.', 'woo-gutenberg-products-block' ),
+							'type'        => [ 'string', 'null' ],
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+						],
+						'tax_lines'          => [
+							'description' => __( 'Lines of taxes applied to items and shipping.', 'woo-gutenberg-products-block' ),
+							'type'        => 'array',
+							'context'     => [ 'view', 'edit' ],
+							'readonly'    => true,
+							'items'       => [
+								'type'       => 'object',
+								'properties' => [
+									'name'  => [
+										'description' => __( 'The name of the tax.', 'woo-gutenberg-products-block' ),
+										'type'        => 'string',
+										'context'     => [ 'view', 'edit' ],
+										'readonly'    => true,
+									],
+									'price' => [
+										'description' => __( 'The amount of tax charged.', 'woo-gutenberg-products-block' ),
+										'type'        => 'string',
+										'context'     => [ 'view', 'edit' ],
+										'readonly'    => true,
+									],
+									'rate'  => [
+										'description' => __( 'The rate at which tax is applied.', 'woo-gutenberg-products-block' ),
+										'type'        => 'string',
+										'context'     => [ 'view', 'edit' ],
+										'readonly'    => true,
+									],
+								],
+							],
+						],
 					]
 				),
+			],
+			'coupons'                 => [
+				'description' => __( 'List of applied cart coupons.', 'woo-gutenberg-products-block' ),
+				'type'        => 'array',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+				'items'       => [
+					'type'       => 'object',
+					'properties' => $this->force_schema_readonly( $this->coupon_schema->get_properties() ),
+				],
+			],
+			'shipping_rates'          => [
+				'description' => __( 'List of available shipping rates for the cart.', 'woo-gutenberg-products-block' ),
+				'type'        => 'array',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+				'items'       => [
+					'type'       => 'object',
+					'properties' => $this->force_schema_readonly( $this->shipping_rate_schema->get_properties() ),
+				],
+			],
+			'shipping_address'        => [
+				'description' => __( 'Current set shipping address for the customer.', 'woo-gutenberg-products-block' ),
+				'type'        => 'object',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+				'properties'  => $this->force_schema_readonly( $this->shipping_address_schema->get_properties() ),
+			],
+			'billing_address'         => [
+				'description' => __( 'Current set billing address for the customer.', 'woo-gutenberg-products-block' ),
+				'type'        => 'object',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+				'properties'  => $this->force_schema_readonly( $this->billing_address_schema->get_properties() ),
+			],
+			'items_count'             => [
+				'description' => __( 'Number of items in the cart.', 'woo-gutenberg-products-block' ),
+				'type'        => 'integer',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
+			'items_weight'            => [
+				'description' => __( 'Total weight (in grams) of all products in the cart.', 'woo-gutenberg-products-block' ),
+				'type'        => 'number',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
+			'cross_sells'             => [
+				'description' => __( 'List of cross-sells items related to cart items.', 'woo-gutenberg-products-block' ),
+				'type'        => 'array',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+				'items'       => [
+					'type'       => 'object',
+					'properties' => $this->force_schema_readonly( $this->cross_sells_item_schema->get_properties() ),
+				],
+			],
+			'needs_payment'           => [
+				'description' => __( 'True if the cart needs payment. False for carts with only free products and no shipping costs.', 'woo-gutenberg-products-block' ),
+				'type'        => 'boolean',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
+			'needs_shipping'          => [
+				'description' => __( 'True if the cart needs shipping. False for carts with only digital goods or stores with no shipping methods set-up.', 'woo-gutenberg-products-block' ),
+				'type'        => 'boolean',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
+			'has_calculated_shipping' => [
+				'description' => __( 'True if the cart meets the criteria for showing shipping costs, and rates have been calculated and included in the totals.', 'woo-gutenberg-products-block' ),
+				'type'        => 'boolean',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
+			'fees'                    => [
+				'description' => __( 'List of cart fees.', 'woo-gutenberg-products-block' ),
+				'type'        => 'array',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+				'items'       => [
+					'type'       => 'object',
+					'properties' => $this->force_schema_readonly( $this->fee_schema->get_properties() ),
+				],
+			],
+			'errors'                  => [
+				'description' => __( 'List of cart item errors, for example, items in the cart which are out of stock.', 'woo-gutenberg-products-block' ),
+				'type'        => 'array',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+				'items'       => [
+					'type'       => 'object',
+					'properties' => $this->force_schema_readonly( $this->error_schema->get_properties() ),
+				],
+			],
+			'payment_requirements'    => [
+				'description' => __( 'List of required payment gateway features to process the order.', 'woo-gutenberg-products-block' ),
+				'type'        => 'array',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
 			],
 		];
 	}
@@ -126,9 +292,22 @@ class OrderSchema extends AbstractSchema {
 	 */
 	public function get_item_response( $order ) {
 		return [
-			'id'     => $order->get_id(),
-			'items'  => $this->get_item_responses_from_schema( $this->item_schema, $order->get_items() ),
-			'totals' => $this->get_totals( $order ),
+			'id'                      => $order->get_id(),
+			'items'                   => $this->get_item_responses_from_schema( $this->item_schema, $order->get_items() ),
+			'totals'                  => (object) $this->prepare_currency_response( $this->get_totals( $order ) ),
+			'coupons'                 => $this->get_item_responses_from_schema( $this->coupon_schema, $order->get_items( 'coupon' ) ),
+			'shipping_rates'          => array(),
+			'shipping_address'        => $this->shipping_address_schema->get_item_response( new \WC_Customer( $order->get_customer_id() ) ),
+			'billing_address'         => $this->billing_address_schema->get_item_response( new \WC_Customer( $order->get_customer_id() ) ),
+			'items_count'             => $order->get_item_count(),
+			'items_weight'            => 0,
+			'cross_sells'             => array(),
+			'needs_payment'           => $order->needs_payment(),
+			'needs_shipping'          => $order->needs_shipping_address(),
+			'has_calculated_shipping' => null,
+			'fees'                    => array(),
+			'errors'                  => [],
+			'payment_requirements'    => $this->extend->get_payment_requirements(),
 		];
 	}
 
@@ -140,13 +319,55 @@ class OrderSchema extends AbstractSchema {
 	 */
 	public function get_totals( $order ) {
 		return [
-			'subtotal'       => $order->get_subtotal(),
-			'total_discount' => $order->get_total_discount(),
-			'total_shipping' => $order->get_total_shipping(),
-			'total_fees'     => $order->get_total_fees(),
-			'total_tax'      => $order->get_total_tax(),
-			'total_refund'   => $order->get_total_refunded(),
-			'total_price'    => $order->get_total(),
+			'subtotal'           => $this->prepare_money_response( $order->get_subtotal() ),
+			'total_discount'     => $this->prepare_money_response( $order->get_total_discount() ),
+			'total_shipping'     => $this->prepare_money_response( $order->get_total_shipping() ),
+			'total_fees'         => $this->prepare_money_response( $order->get_total_fees() ),
+			'total_tax'          => $this->prepare_money_response( $order->get_total_tax() ),
+			'total_refund'       => $this->prepare_money_response( $order->get_total_refunded() ),
+			'total_price'        => $this->prepare_money_response( $order->get_total() ),
+			'total_items'        => $this->prepare_money_response(
+				array_sum(
+					array_map(
+						function( $item ) {
+							return $item->get_total();
+						},
+						array_values( $order->get_items( 'line_item' ) )
+					)
+				)
+			),
+			'total_items_tax'    => $this->prepare_money_response(
+				array_sum(
+					array_map(
+						function( $item ) {
+							return $item->get_tax_total();
+						},
+						array_values( $order->get_items( 'tax' ) )
+					)
+				)
+			),
+			'total_fees_tax'     => $this->prepare_money_response(
+				array_sum(
+					array_map(
+						function( $item ) {
+							return $item->get_total_tax();
+						},
+						array_values( $order->get_items( 'fee' ) )
+					)
+				)
+			),
+			'total_discount_tax' => $this->prepare_money_response( $order->get_discount_tax() ),
+			'total_shipping_tax' => $this->prepare_money_response( $order->get_shipping_tax() ),
+			'tax_lines'          => array_map(
+				function( $item ) {
+					return [
+						'name'  => $item->get_name(),
+						'price' => $item->get_tax_total(),
+						'rate'  => strval( $item->get_rate_percent() ),
+					];
+				},
+				array_values( $order->get_items( 'tax' ) )
+			),
 		];
 	}
 }

--- a/src/StoreApi/Schemas/V1/OrderSchema.php
+++ b/src/StoreApi/Schemas/V1/OrderSchema.php
@@ -26,7 +26,7 @@ class OrderSchema extends AbstractSchema {
 	 */
 	public function get_properties() {
 		return [
-			'id'          => [
+			'id' => [
 				'description' => __( 'The order ID to process during checkout.', 'woo-gutenberg-products-block' ),
 				'type'        => 'integer',
 				'context'     => [ 'view', 'edit' ],
@@ -43,8 +43,66 @@ class OrderSchema extends AbstractSchema {
 	 */
 	public function get_item_response( $order ) {
 		return [
-			'id' => $order->get_id(),
-			// @Todo Add pay-for-order order details.
+			'id'             => $order->get_id(),
+			'line_items'     => $this->get_item_data( $order ),
+			'total_tax'      => $order->get_total_tax(),
+			'subtotal'       => $order->get_subtotal(),
+			'discount_total' => $order->get_discount_total(),
+			'shipping_total' => $order->get_shipping_total(),
+			'shipping_tax'   => $order->get_shipping_tax(),
+			'total_refunded' => $order->get_total_refunded(),
+			'fees_total'     => $this->get_fees_total( $order ),
 		];
+	}
+
+	/**
+	 * Get items data.
+	 *
+	 * @param \WC_Order $order Order instance.
+	 * @return array
+	 */
+	private function get_item_data( $order ) {
+		$items = $order->get_items();
+		$data  = [];
+
+		foreach ( $items as $item ) {
+			$data[ $item->get_id() ]['id']        = $item->get_id();
+			$data[ $item->get_id() ]['name']      = $item->get_name();
+			$data[ $item->get_id() ]['meta_data'] = $item->get_all_formatted_meta_data();
+			$data[ $item->get_id() ]['quantity']  = $item->get_quantity();
+			$data[ $item->get_id() ]['subtotal']  = $order->get_line_subtotal( $item );
+		}
+
+		return array_values( $data );
+	}
+
+	/**
+	 * Get fee.
+	 *
+	 * @param \WC_Order $order Order instance.
+	 * @return array
+	 */
+	private function get_fees_total( $order ) {
+		$fees       = $order->get_fees();
+		$total_fees = 0;
+
+		if ( $fees ) {
+			foreach ( $fees as $id => $fee ) {
+				/**
+				 * Filters whether or not free fees should be excluded.
+				 *
+				 * @param boolean True to skip the fee, false to include the fee.
+				 * @param integer $id Fee ID.
+				 *
+				 * @since 9.8.0-dev
+				 */
+				if ( apply_filters( 'woocommerce_get_order_item_totals_excl_free_fees', empty( $fee['line_total'] ) && empty( $fee['line_tax'] ), $id ) ) {
+					continue;
+				}
+				$total_fees += $fee->get_total();
+			}
+		}
+
+		return $total_fees;
 	}
 }

--- a/src/StoreApi/Utilities/OrderController.php
+++ b/src/StoreApi/Utilities/OrderController.php
@@ -484,23 +484,23 @@ class OrderController {
 		$order = $this->get_order( $order_id );
 
 		if ( ! $order || $order->get_id() !== $order_id || ! hash_equals( $order->get_order_key(), $order_key ) ) {
-			throw new RouteException( 'invalid_order', __( 'Sorry, this order is invalid and cannot be paid for.', 'woo-gutenberg-products-block' ), 401 );
+			throw new RouteException( 'woocommerce_rest_invalid_order', __( 'Sorry, this order is invalid and cannot be paid for.', 'woo-gutenberg-products-block' ), 401 );
 		}
 
 		// Logged out customer does not have permission to pay for this order.
 		if ( ! current_user_can( 'pay_for_order', $order_id ) && ! is_user_logged_in() ) {
-			throw new RouteException( 'invalid_user', __( 'Please log in to your account below to continue to the payment form.', 'woo-gutenberg-products-block' ), 403 );
+			throw new RouteException( 'woocommerce_rest_invalid_user', __( 'Please log in to your account below to continue to the payment form.', 'woo-gutenberg-products-block' ), 403 );
 		}
 
 		// Logged in customer trying to pay for someone else's order.
 		if ( ! current_user_can( 'pay_for_order', $order_id ) ) {
-			throw new RouteException( 'invalid_user', __( 'This order cannot be paid for. Please contact us if you need assistance.', 'woo-gutenberg-products-block' ), 403 );
+			throw new RouteException( 'woocommerce_rest_invalid_user', __( 'This order cannot be paid for. Please contact us if you need assistance.', 'woo-gutenberg-products-block' ), 403 );
 		}
 
 		// Does not need payment.
 		if ( ! $order->needs_payment() ) {
 			/* translators: %s: order status */
-			throw new RouteException( '@Todo', sprintf( __( 'This order&rsquo;s status is &ldquo;%s&rdquo;&mdash;it cannot be paid for. Please contact us if you need assistance.', 'woo-gutenberg-products-block' ), wc_get_order_status_name( $order->get_status() ) ), 403 );
+			throw new RouteException( 'woocommerce_rest_no_payment_needed', sprintf( __( 'This order&rsquo;s status is &ldquo;%s&rdquo;&mdash;it cannot be paid for. Please contact us if you need assistance.', 'woo-gutenberg-products-block' ), wc_get_order_status_name( $order->get_status() ) ), 403 );
 		}
 
 		// Ensure order items are still stocked if paying for a failed order. Pending orders do not need this check because stock is held.
@@ -540,7 +540,7 @@ class OrderController {
 						 */
 						if ( ! apply_filters( 'woocommerce_pay_order_product_in_stock', $product->is_in_stock(), $product, $order ) ) {
 							/* translators: %s: product name */
-							throw new RouteException( '@Todo', sprintf( __( 'Sorry, "%s" is no longer in stock so this order cannot be paid for. We apologize for any inconvenience caused.', 'woo-gutenberg-products-block' ), $product->get_name() ), 403 );
+							throw new RouteException( 'woocommerce_rest_out_of_stock', sprintf( __( 'Sorry, "%s" is no longer in stock so this order cannot be paid for. We apologize for any inconvenience caused.', 'woo-gutenberg-products-block' ), $product->get_name() ), 403 );
 						}
 
 						// We only need to check products managing stock, with a limited stock qty.
@@ -563,7 +563,7 @@ class OrderController {
 						 */
 						if ( ! apply_filters( 'woocommerce_pay_order_product_has_enough_stock', ( $product->get_stock_quantity() >= ( $held_stock + $required_stock ) ), $product, $order ) ) {
 							/* translators: 1: product name 2: quantity in stock */
-							throw new RouteException( '@Todo', sprintf( __( 'Sorry, we do not have enough "%1$s" in stock to fulfill your order (%2$s available). We apologize for any inconvenience caused.', 'woo-gutenberg-products-block' ), $product->get_name(), wc_format_stock_quantity_for_display( $product->get_stock_quantity() - $held_stock, $product ) ), 403 );
+							throw new RouteException( 'woocommerce_rest_out_of_stock', sprintf( __( 'Sorry, we do not have enough "%1$s" in stock to fulfill your order (%2$s available). We apologize for any inconvenience caused.', 'woo-gutenberg-products-block' ), $product->get_name(), wc_format_stock_quantity_for_display( $product->get_stock_quantity() - $held_stock, $product ) ), 403 );
 						}
 					}
 				}

--- a/src/StoreApi/Utilities/OrderController.php
+++ b/src/StoreApi/Utilities/OrderController.php
@@ -39,6 +39,18 @@ class OrderController {
 	}
 
 	/**
+	 * Get order.
+	 *
+	 * @throws RouteException Exception if invalid data is detected.
+	 *
+	 * @param integer $order_id Order ID.
+	 * @return \WC_Order A new order object.
+	 */
+	public function get_order( $order_id ) {
+		return wc_get_order( $order_id );
+	}
+
+	/**
 	 * Update an order using data from the current cart.
 	 *
 	 * @param \WC_Order $order The order object to update.

--- a/src/StoreApi/Utilities/OrderController.php
+++ b/src/StoreApi/Utilities/OrderController.php
@@ -474,6 +474,104 @@ class OrderController {
 	}
 
 	/**
+	 * Check validation for the order key.
+	 *
+	 * @throws RouteException Exception if invalid data is detected.
+	 * @param integer $order_id Order ID.
+	 * @param string  $order_key Order key.
+	 */
+	public function validate_order_key( $order_id, $order_key ) {
+		$order = $this->get_order( $order_id );
+
+		if ( ! $order || $order->get_id() !== $order_id || ! hash_equals( $order->get_order_key(), $order_key ) ) {
+			throw new RouteException( 'invalid_order', __( 'Sorry, this order is invalid and cannot be paid for.', 'woo-gutenberg-products-block' ), 401 );
+		}
+
+		// Logged out customer does not have permission to pay for this order.
+		if ( ! current_user_can( 'pay_for_order', $order_id ) && ! is_user_logged_in() ) {
+			throw new RouteException( 'invalid_user', __( 'Please log in to your account below to continue to the payment form.', 'woo-gutenberg-products-block' ), 403 );
+		}
+
+		// Logged in customer trying to pay for someone else's order.
+		if ( ! current_user_can( 'pay_for_order', $order_id ) ) {
+			throw new RouteException( 'invalid_user', __( 'This order cannot be paid for. Please contact us if you need assistance.', 'woo-gutenberg-products-block' ), 403 );
+		}
+
+		// Does not need payment.
+		if ( ! $order->needs_payment() ) {
+			/* translators: %s: order status */
+			throw new RouteException( '@Todo', sprintf( __( 'This order&rsquo;s status is &ldquo;%s&rdquo;&mdash;it cannot be paid for. Please contact us if you need assistance.', 'woo-gutenberg-products-block' ), wc_get_order_status_name( $order->get_status() ) ), 403 );
+		}
+
+		// Ensure order items are still stocked if paying for a failed order. Pending orders do not need this check because stock is held.
+		if ( ! $order->has_status( wc_get_is_pending_statuses() ) ) {
+			$quantities = array();
+
+			foreach ( $order->get_items() as $item_key => $item ) {
+				if ( $item && is_callable( array( $item, 'get_product' ) ) ) {
+					$product = $item->get_product();
+
+					if ( ! $product ) {
+						continue;
+					}
+
+					$quantities[ $product->get_stock_managed_by_id() ] = isset( $quantities[ $product->get_stock_managed_by_id() ] ) ? $quantities[ $product->get_stock_managed_by_id() ] + $item->get_quantity() : $item->get_quantity();
+				}
+			}
+
+			// Stock levels may already have been adjusted for this order (in which case we don't need to worry about checking for low stock).
+			if ( ! $order->get_data_store()->get_stock_reduced( $order->get_id() ) ) {
+				foreach ( $order->get_items() as $item_key => $item ) {
+					if ( $item && is_callable( array( $item, 'get_product' ) ) ) {
+						$product = $item->get_product();
+
+						if ( ! $product ) {
+							continue;
+						}
+
+						/**
+						 * Filters whether or not the product is in stock for this pay for order.
+						 *
+						 * @param boolean True if in stock.
+						 * @param \WC_Product $product Product.
+						 * @param \WC_Order $order Order.
+						 *
+						 * @since 9.8.0-dev
+						 */
+						if ( ! apply_filters( 'woocommerce_pay_order_product_in_stock', $product->is_in_stock(), $product, $order ) ) {
+							/* translators: %s: product name */
+							throw new RouteException( '@Todo', sprintf( __( 'Sorry, "%s" is no longer in stock so this order cannot be paid for. We apologize for any inconvenience caused.', 'woo-gutenberg-products-block' ), $product->get_name() ), 403 );
+						}
+
+						// We only need to check products managing stock, with a limited stock qty.
+						if ( ! $product->managing_stock() || $product->backorders_allowed() ) {
+							continue;
+						}
+
+						// Check stock based on all items in the cart and consider any held stock within pending orders.
+						$held_stock     = wc_get_held_stock_quantity( $product, $order->get_id() );
+						$required_stock = $quantities[ $product->get_stock_managed_by_id() ];
+
+						/**
+						 * Filters whether or not the product has enough stock.
+						 *
+						 * @param boolean True if has enough stock.
+						 * @param \WC_Product $product Product.
+						 * @param \WC_Order $order Order.
+						 *
+						 * @since 9.8.0-dev
+						 */
+						if ( ! apply_filters( 'woocommerce_pay_order_product_has_enough_stock', ( $product->get_stock_quantity() >= ( $held_stock + $required_stock ) ), $product, $order ) ) {
+							/* translators: 1: product name 2: quantity in stock */
+							throw new RouteException( '@Todo', sprintf( __( 'Sorry, we do not have enough "%1$s" in stock to fulfill your order (%2$s available). We apologize for any inconvenience caused.', 'woo-gutenberg-products-block' ), $product->get_name(), wc_format_stock_quantity_for_display( $product->get_stock_quantity() - $held_stock, $product ) ), 403 );
+						}
+					}
+				}
+			}
+		}
+	}
+
+	/**
 	 * Changes default order status to draft for orders created via this API.
 	 *
 	 * @return string

--- a/src/StoreApi/Utilities/ProductItemTrait.php
+++ b/src/StoreApi/Utilities/ProductItemTrait.php
@@ -1,0 +1,85 @@
+<?php
+namespace Automattic\WooCommerce\StoreApi\Utilities;
+
+/**
+ * ProductItemTrait
+ *
+ * Shared functionality for formating product item data.
+ */
+trait ProductItemTrait {
+	/**
+	 * Get an array of pricing data.
+	 *
+	 * @param \WC_Product $product Product instance.
+	 * @param string      $tax_display_mode If returned prices are incl or excl of tax.
+	 * @return array
+	 */
+	protected function prepare_product_price_response( \WC_Product $product, $tax_display_mode = '' ) {
+		$tax_display_mode = $this->get_tax_display_mode( $tax_display_mode );
+		$price_function   = $this->get_price_function_from_tax_display_mode( $tax_display_mode );
+		$prices           = parent::prepare_product_price_response( $product, $tax_display_mode );
+
+		// Add raw prices (prices with greater precision).
+		$prices['raw_prices'] = [
+			'precision'     => wc_get_rounding_precision(),
+			'price'         => $this->prepare_money_response( $price_function( $product ), wc_get_rounding_precision() ),
+			'regular_price' => $this->prepare_money_response( $price_function( $product, [ 'price' => $product->get_regular_price() ] ), wc_get_rounding_precision() ),
+			'sale_price'    => $this->prepare_money_response( $price_function( $product, [ 'price' => $product->get_sale_price() ] ), wc_get_rounding_precision() ),
+		];
+
+		return $prices;
+	}
+
+	/**
+	 * Format variation data, for example convert slugs such as attribute_pa_size to Size.
+	 *
+	 * @param array       $variation_data Array of data from the cart.
+	 * @param \WC_Product $product Product data.
+	 * @return array
+	 */
+	protected function format_variation_data( $variation_data, $product ) {
+		$return = [];
+
+		if ( ! is_iterable( $variation_data ) ) {
+			return $return;
+		}
+
+		foreach ( $variation_data as $key => $value ) {
+			$taxonomy = wc_attribute_taxonomy_name( str_replace( 'attribute_pa_', '', urldecode( $key ) ) );
+
+			if ( taxonomy_exists( $taxonomy ) ) {
+				// If this is a term slug, get the term's nice name.
+				$term = get_term_by( 'slug', $value, $taxonomy );
+				if ( ! is_wp_error( $term ) && $term && $term->name ) {
+					$value = $term->name;
+				}
+				$label = wc_attribute_label( $taxonomy );
+			} else {
+				/**
+				 * Filters the variation option name.
+				 *
+				 * Filters the variation option name for custom option slugs.
+				 *
+				 * @since 2.5.0
+				 *
+				 * @internal Matches filter name in WooCommerce core.
+				 *
+				 * @param string $value The name to display.
+				 * @param null $unused Unused because this is not a variation taxonomy.
+				 * @param string $taxonomy Taxonomy or product attribute name.
+				 * @param \WC_Product $product Product data.
+				 * @return string
+				 */
+				$value = apply_filters( 'woocommerce_variation_option_name', $value, null, $taxonomy, $product );
+				$label = wc_attribute_label( str_replace( 'attribute_', '', $key ), $product );
+			}
+
+			$return[] = [
+				'attribute' => $this->prepare_html_response( $label ),
+				'value'     => $this->prepare_html_response( $value ),
+			];
+		}
+
+		return $return;
+	}
+}


### PR DESCRIPTION
Blocked by https://github.com/woocommerce/woocommerce-blocks/pull/9448

Instead of rendering checkout error, render pay-for-order checkout block if it is a pay-for-order order

Fixes #9459 



### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|<img width="586" alt="Screen Shot 2023-05-12 at 5 30 28 PM" src="https://github.com/woocommerce/woocommerce-blocks/assets/56378160/654af3cc-2828-4d65-8bb3-de8b9e4ffc7e">|<img width="668" alt="Screen Shot 2023-05-12 at 6 38 17 PM" src="https://github.com/woocommerce/woocommerce-blocks/assets/56378160/49756940-9935-4928-b172-cf4be6fee0a6">
    |

### Testing
1. Create a pay-for-order order
2. Go to WC -> Orders -> find the order you just created
3. Click on the Customer payment page
4. Should see the pay-for-order checkout block
5. Open the same URL in incognito
6. Make sure the page renders without error

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests


### Changelog

> Render pay for order checkout block if it is pay for order order
