### PR TITLE
Update the logic of disabling some blocks in the widget areas and post editor

### DIFF
--- a/src/BlockTypesController.php
+++ b/src/BlockTypesController.php
@@ -175,7 +175,7 @@ final class BlockTypesController {
 		/**
 		 * This disables specific blocks in Widget Areas.
 		 */
-		if ( 'core/edit-widgets' === $block_editor_context->name ) {
+		if ( 'core/edit-widgets' === $block_editor_context->name && is_array( $registered_blocks ) && ! empty( $registered_blocks ) ) {
 			unset( $registered_blocks['woocommerce/cart'] );
 			unset( $registered_blocks['woocommerce/all-products'] );
 			unset( $registered_blocks['woocommerce/checkout'] );
@@ -186,7 +186,7 @@ final class BlockTypesController {
 		/**
 		 * This disables specific blocks in Post and Page editor.
 		 */
-		if ( 'core/edit-post' === $block_editor_context->name ) {
+		if ( 'core/edit-post' === $block_editor_context->name && is_array( $registered_blocks ) && ! empty( $registered_blocks ) ) {
 			unset( $registered_blocks['woocommerce/add-to-cart-form'] );
 			unset( $registered_blocks['woocommerce/breadcrumbs'] );
 			unset( $registered_blocks['woocommerce/catalog-sorting'] );
@@ -207,8 +207,6 @@ final class BlockTypesController {
 	 * @return array
 	 */
 	protected function get_block_types() {
-		global $pagenow;
-
 		$block_types = [
 			'ActiveFilters',
 			'AddToCartForm',

--- a/src/BlockTypesController.php
+++ b/src/BlockTypesController.php
@@ -52,6 +52,7 @@ final class BlockTypesController {
 		add_filter( 'render_block', array( $this, 'add_data_attributes' ), 10, 2 );
 		add_action( 'woocommerce_login_form_end', array( $this, 'redirect_to_field' ) );
 		add_filter( 'widget_types_to_hide_from_legacy_widget_block', array( $this, 'hide_legacy_widgets_with_block_equivalent' ) );
+		add_filter( 'allowed_block_types_all', array( $this, 'disable_blocks_depending_on_context' ), 10, 2 );
 	}
 
 	/**
@@ -161,6 +162,46 @@ final class BlockTypesController {
 	}
 
 	/**
+	 * Disable specific woocommerce blocks on the widgets area, post and page editor.
+	 *
+	 * @param bool|string[]           $allowed_block_types Array of block type slugs, or boolean to enable/disable all. Default true (all registered block types supported).
+	 * @param WP_Block_Editor_Context $block_editor_context The current block editor context.
+	 *
+	 * @return array|bool The updated allowed block types depending on context
+	 */
+	public function disable_blocks_depending_on_context( $allowed_block_types, $block_editor_context ) {
+		$registered_blocks = \WP_Block_Type_Registry::get_instance()->get_all_registered();
+
+		/**
+		 * This disables specific blocks in Widget Areas.
+		 */
+		if ( 'core/edit-widgets' === $block_editor_context->name ) {
+			unset( $registered_blocks['woocommerce/cart'] );
+			unset( $registered_blocks['woocommerce/all-products'] );
+			unset( $registered_blocks['woocommerce/checkout'] );
+
+			return array_keys( $registered_blocks );
+		}
+
+		/**
+		 * This disables specific blocks in Post and Page editor.
+		 */
+		if ( 'core/edit-post' === $block_editor_context->name ) {
+			unset( $registered_blocks['woocommerce/add-to-cart-form'] );
+			unset( $registered_blocks['woocommerce/breadcrumbs'] );
+			unset( $registered_blocks['woocommerce/catalog-sorting'] );
+			unset( $registered_blocks['woocommerce/legacy-template'] );
+			unset( $registered_blocks['woocommerce/product-results-count'] );
+			unset( $registered_blocks['woocommerce/product-details'] );
+			unset( $registered_blocks['woocommerce/store-notices'] );
+
+			return array_keys( $registered_blocks );
+		}
+
+		return $allowed_block_types;
+	}
+
+	/**
 	 * Get list of block types.
 	 *
 	 * @return array
@@ -225,38 +266,6 @@ final class BlockTypesController {
 
 		if ( Package::feature()->is_experimental_build() ) {
 			$block_types[] = 'SingleProduct';
-		}
-
-		/**
-		 * This disables specific blocks in Widget Areas by not registering them.
-		 */
-		if ( in_array( $pagenow, [ 'widgets.php', 'themes.php', 'customize.php' ], true ) && ( empty( $_GET['page'] ) || 'gutenberg-edit-site' !== $_GET['page'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			$block_types = array_diff(
-				$block_types,
-				[
-					'AllProducts',
-					'Cart',
-					'Checkout',
-				]
-			);
-		}
-
-		/**
-		 * This disables specific blocks in Post and Page editor by not registering them.
-		 */
-		if ( in_array( $pagenow, [ 'post.php', 'post-new.php' ], true ) ) {
-			$block_types = array_diff(
-				$block_types,
-				[
-					'AddToCartForm',
-					'Breadcrumbs',
-					'CatalogSorting',
-					'ClassicTemplate',
-					'ProductResultsCount',
-					'ProductDetails',
-					'StoreNotices',
-				]
-			);
 		}
 
 		return $block_types;


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
The goal of this PR is to update the existing logic behind disabling certain blocks in the widget areas and post editor using the new `allowed_block_types_all` filter.

<!-- Reference any related issues or PRs here -->

Fixes woocommerce/woocommerce#42383

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Testing

#### User-Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

Use case 1 - Widget areas using a classic theme
1. Install and active [storefront theme](https://wordpress.org/themes/storefront/)
2. Go to Admin > Appearance > Widgets
3. Add a block to any widget area and search for the following blocks
    - WooCommerce cart
    - WooCommerce all products
    - WooCommerce checkout 


Use case 2 - Post editor using a theme that supports Gutenberg
1. Install and active [twentytwentythree theme](https://wordpress.org/themes/twentytwentythree/)
2. Go to Admin > Posts > Add New (or edit an existing post)
3. Add a block to the post editor and search for the following blocks
    - WooCommerce add-to-cart form
    - WooCommerce breadcrumbs
    - WooCommerce classic template (legacy template)
    - WooCommerce product results count
    - WooCommerce product details
    - WooCommerce store notices

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Update the logic behind disabling some blocks in the widget areas and post editor using the `allowed_block_types_all` filter introduced in WP 5.8.0
