### PR TITLE
Add isSiteEditorPage util

### DIFF
--- a/assets/js/blocks/product-query/utils.tsx
+++ b/assets/js/blocks/product-query/utils.tsx
@@ -3,6 +3,7 @@
  */
 import { useSelect } from '@wordpress/data';
 import { store as WP_BLOCKS_STORE } from '@wordpress/blocks';
+import { isSiteEditorPage } from '@woocommerce/utils';
 
 /**
  * Internal dependencies
@@ -79,7 +80,7 @@ export function isWooInheritQueryEnabled(
 export function useAllowedControls(
 	attributes: ProductQueryBlock[ 'attributes' ]
 ) {
-	const isSiteEditor = useSelect( 'core/edit-site' ) !== undefined;
+	const editSiteStore = useSelect( 'core/edit-site' );
 
 	const controls = useSelect(
 		( select ) =>
@@ -90,7 +91,7 @@ export function useAllowedControls(
 		[ attributes ]
 	);
 
-	if ( ! isSiteEditor ) {
+	if ( ! isSiteEditorPage( editSiteStore ) ) {
 		return controls.filter( ( control ) => control !== 'wooInherit' );
 	}
 

--- a/assets/js/blocks/product-query/variations/product-query.tsx
+++ b/assets/js/blocks/product-query/variations/product-query.tsx
@@ -11,6 +11,7 @@ import { stacks } from '@woocommerce/icons';
 import { isWpVersion } from '@woocommerce/settings';
 import { select, subscribe } from '@wordpress/data';
 import { QueryBlockAttributes } from '@woocommerce/blocks/product-query/types';
+import { isSiteEditorPage } from '@woocommerce/utils';
 
 /**
  * Internal dependencies
@@ -66,7 +67,7 @@ const registerProductsBlock = ( attributes: QueryBlockAttributes ) => {
 if ( isWpVersion( '6.1', '>=' ) ) {
 	const store = select( 'core/edit-site' );
 
-	if ( store ) {
+	if ( isSiteEditorPage( store ) ) {
 		let currentTemplateId: string | undefined;
 
 		subscribe( () => {

--- a/assets/js/templates/revert-button/index.tsx
+++ b/assets/js/templates/revert-button/index.tsx
@@ -9,8 +9,8 @@ import { __ } from '@wordpress/i18n';
 import { createInterpolateElement, useMemo } from '@wordpress/element';
 import { useEntityRecord } from '@wordpress/core-data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
+import { isSiteEditorPage } from '@woocommerce/utils';
 
-// @ts-expect-error: @wordpress/plugin is typed in the newer versions
 // eslint-disable-next-line @woocommerce/dependency-group
 import {
 	registerPlugin,
@@ -140,7 +140,12 @@ let currentTemplateId: string | undefined;
 subscribe( () => {
 	const previousTemplateId = currentTemplateId;
 	const store = select( 'core/edit-site' );
-	currentTemplateId = store.getEditedPostId();
+
+	if ( ! isSiteEditorPage( store ) ) {
+		return;
+	}
+
+	currentTemplateId = store?.getEditedPostId();
 
 	if ( previousTemplateId === currentTemplateId ) {
 		return;

--- a/assets/js/utils/index.ts
+++ b/assets/js/utils/index.ts
@@ -7,3 +7,4 @@ export * from './object-operations';
 export * from './products';
 export * from './shared-attributes';
 export * from './sanitize-html';
+export * from './is-site-editor-page';

--- a/assets/js/utils/is-site-editor-page.ts
+++ b/assets/js/utils/is-site-editor-page.ts
@@ -1,0 +1,21 @@
+/**
+ * Internal dependencies
+ */
+import { isObject } from '../types/type-guards';
+
+export const isSiteEditorPage = ( store: unknown ): boolean => {
+	if ( isObject( store ) ) {
+		const editedPostType = (
+			store as {
+				getEditedPostType: () => string;
+			}
+		 ).getEditedPostType();
+
+		return (
+			editedPostType === 'wp_template' ||
+			editedPostType === 'wp_template_part'
+		);
+	}
+
+	return false;
+};

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
 		"./assets/js/blocks/filter-wrapper/register-components.ts",
 		"./assets/js/blocks/product-query/variations/**.tsx",
 		"./assets/js/blocks/product-query/index.tsx",
-		"./assets/js/blocks/product-query/inspector-controls.tsx"
+		"./assets/js/blocks/product-query/inspector-controls.tsx",
+		"./assets/js/templates/revert-button/index.tsx"
 	],
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
This PR fixes an issue introduced with woocommerce/woocommerce-blocks#9386. Since we are currently importing the redux store `core/edit-site`, the store is initialized (as an empty object), and for this reason some checks that we are currently failing. Also, I added the file `revert-button.ts` in the `sideEffect` array in the package.json, so this file will be run on production builds too.


This PR adds the `isSiteEditorPage` that returns a boolean to check whether the current page is a site editor.

I tried to create some E2E tests around this function without success. Can we create a follow-up issue to do during the cooldown?

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.


### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Open the Post Editor.
2. Ensure that the Products block is available.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental


