### PR TITLE
Add to Cart with Options: Fix styles that are not being applied correctly

### DIFF
--- a/assets/js/atomic/blocks/product-elements/add-to-cart-form/style.scss
+++ b/assets/js/atomic/blocks/product-elements/add-to-cart-form/style.scss
@@ -4,4 +4,9 @@
 		font-size: var(--wp--preset--font-size--large);
 	}
 	width: unset;
+
+	.input-text {
+		font-size: var(--wp--preset--font-size--small);
+		padding: 0.9rem 1.1rem;
+	}
 }

--- a/assets/js/atomic/blocks/product-elements/add-to-cart-form/style.scss
+++ b/assets/js/atomic/blocks/product-elements/add-to-cart-form/style.scss
@@ -5,6 +5,11 @@
 	}
 	width: unset;
 
+	/**
+	* This is a base style for the input text element in WooCommerce that prevents inputs from appearing too small.
+	*
+	* @link https://github.com/woocommerce/woocommerce/blob/95ca53675f2817753d484583c96ca9ab9f725172/plugins/woocommerce/client/legacy/css/woocommerce-blocktheme.scss#L203-L206
+	*/
 	.input-text {
 		font-size: var(--wp--preset--font-size--small);
 		padding: 0.9rem 1.1rem;

--- a/src/BlockTypes/AddToCartForm.php
+++ b/src/BlockTypes/AddToCartForm.php
@@ -59,7 +59,7 @@ class AddToCartForm extends AbstractBlock {
 		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes );
 
 		return sprintf(
-			'<div class="wp-block-add-to-cart-form %1$s %2$s" style="%3$s">%4$s</div>',
+			'<div class="wp-block-add-to-cart-form product %1$s %2$s" style="%3$s">%4$s</div>',
 			esc_attr( $classes_and_styles['classes'] ),
 			esc_attr( $classname ),
 			esc_attr( $classes_and_styles['styles'] ),

--- a/src/BlockTypes/SingleProduct.php
+++ b/src/BlockTypes/SingleProduct.php
@@ -51,7 +51,7 @@ class SingleProduct extends AbstractBlock {
 	 */
 	protected function render( $attributes, $content, $block ) {
 		$classname          = $attributes['className'] ?? '';
-		$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classname ) );
+		$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => trim( sprintf( 'woocommerce %1$s', $classname ) ) ) );
 
 		$html = sprintf(
 			'<div %1$s>


### PR DESCRIPTION
## Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8a6b878</samp>
<samp>👨‍💻 Enhanced by @thealexandrelara </samp>

This pull request adds some missing classes and styles to the Add to Cart with Options and Single Product blocks, to improve their appearance and functionality. It adjusts the `input-text` class in `style.scss`, and adds the `product` and `woocommerce` classes to the wrapper divs in `AddToCartForm.php` and `SingleProduct.php`.

## Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8a6b878</samp>
<samp>👨‍💻 Enhanced by @thealexandrelara </samp>

*  Add `woocommerce` and `product` classes to the wrapper divs of the Single Product and Add to Cart with Options blocks, respectively, to enable WooCommerce core styles for the blocks ([link](https://github.com/woocommerce/woocommerce-blocks/pull/9472/files?diff=unified&w=0#diff-1451a88b97f23703fea10b26f0ba902bc5690bf6a9454860fe3064e0766f0ea6L54-R54), [link](https://github.com/woocommerce/woocommerce-blocks/pull/9472/files?diff=unified&w=0#diff-b6dbf51b98c926a1ad3723993ddcb154b608d8abdda4d6282e38d325aa4f5ea8L62-R62))
*  Adjust the font size and padding of the `input-text` class for the quantity input field in the `style.scss` file of the Add to Cart with Options block to match the design of the block ([link](https://github.com/woocommerce/woocommerce-blocks/pull/9472/files?diff=unified&w=0#diff-b962447937ef506c56c0a3e351c9b37866d20c6a8b1b30509dbd4426f1884f1aR7-R11))

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #9455 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

#### Simple product
| Before | After |
|--------|--------|
| <img width="851" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/20469356/3662c10f-d274-4bd8-97e5-181363fbd02d"> | <img width="901" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/20469356/bc04bd5f-d66a-425e-be55-fcae6077af76"> | 


#### Variable product
| Before | After |
|--------|--------|
| <img width="782" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/20469356/02e31556-3d68-4880-a755-7818917ea9ea"> | <img width="846" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/20469356/0a854d0b-19f8-45e2-bd4f-0d261ca9b875"> | 

#### Grouped product
| Before | After |
|--------|--------|
| <img width="989" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/20469356/02819c8b-137c-4a96-8ef7-7f17265ec2b4"> | <img width="951" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/20469356/9e76e3c3-c914-49b3-b447-5047117796ea"> | 

#### External product
This is not being affected because there is no inputs associated with this type of product
| Before | After |
|--------|--------|
| <img width="987" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/20469356/734d1be9-5f05-4d7c-b44e-ab0b9de523ea"> | <img width="987" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/20469356/16224791-f03d-4938-9f8f-1200bc1f82b9"> | 

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Log in to your WordPress dashboard;
2. Go to Appearance > Themes, and select a block theme (for example: Twenty-twenty three);
3. Go to Appearance > Editor;
4. Click the Edit button;
5. Click on the "+" icon to add a new block and search for "Single Product" block in the search bar;
6. Click on the "Single Product" block to add it to your page or post;
7. Select a product on the Product Selector and click on the Save button;
8. Go to your website;
9. Check that the inputs are well positioned and the styles are according to the images above (the after images). Test it with different types of products: Simple, Variable, External, Grouped, etc.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental

