### PR TITLE
Single Product Block > Only reset the post data if `setup_postdata` was invoked.

### DIFF
--- a/src/BlockTypes/SingleProduct.php
+++ b/src/BlockTypes/SingleProduct.php
@@ -125,7 +125,7 @@ class SingleProduct extends AbstractBlock {
 		if ( $this->single_product_inner_blocks_names ) {
 			$block_name = array_pop( $this->single_product_inner_blocks_names );
 
-			$global_post_variable_changed = false;
+			static $global_post_variable_changed;
 
 			if ( $block_name === $block['blockName'] ) {
 				/**

--- a/src/BlockTypes/SingleProduct.php
+++ b/src/BlockTypes/SingleProduct.php
@@ -123,7 +123,8 @@ class SingleProduct extends AbstractBlock {
 	 */
 	protected function replace_post_for_single_product_inner_block( $block, &$context ) {
 		if ( $this->single_product_inner_blocks_names ) {
-			$block_name = array_pop( $this->single_product_inner_blocks_names );
+			$block_name                   = array_pop( $this->single_product_inner_blocks_names );
+			$global_post_variable_changed = false;
 
 			if ( $block_name === $block['blockName'] ) {
 				/**
@@ -138,11 +139,12 @@ class SingleProduct extends AbstractBlock {
 					// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 					$post = get_post( $this->product_id );
 					setup_postdata( $post );
+					$global_post_variable_changed = true;
 				}
 				$context['postId'] = $this->product_id;
 			}
 
-			if ( ! $this->single_product_inner_blocks_names ) {
+			if ( ! $this->single_product_inner_blocks_names && $global_post_variable_changed ) {
 				wp_reset_postdata();
 			}
 		}

--- a/src/BlockTypes/SingleProduct.php
+++ b/src/BlockTypes/SingleProduct.php
@@ -138,9 +138,8 @@ class SingleProduct extends AbstractBlock {
 				if ( 'core/post-excerpt' === $block_name || 'core/post-title' === $block_name ) {
 					global $post;
 					// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-					$post = get_post( $this->product_id );
-					setup_postdata( $post );
-					$global_post_variable_changed = true;
+					$post                         = get_post( $this->product_id );
+					$global_post_variable_changed = setup_postdata( $post );
 				}
 				$context['postId'] = $this->product_id;
 			}

--- a/src/BlockTypes/SingleProduct.php
+++ b/src/BlockTypes/SingleProduct.php
@@ -125,7 +125,7 @@ class SingleProduct extends AbstractBlock {
 		if ( $this->single_product_inner_blocks_names ) {
 			$block_name = array_pop( $this->single_product_inner_blocks_names );
 
-			static $global_post_variable_changed;
+			$global_post_variable_changed = false;
 
 			if ( $block_name === $block['blockName'] ) {
 				/**

--- a/src/BlockTypes/SingleProduct.php
+++ b/src/BlockTypes/SingleProduct.php
@@ -146,6 +146,7 @@ class SingleProduct extends AbstractBlock {
 
 			if ( ! $this->single_product_inner_blocks_names && $global_post_variable_changed ) {
 				wp_reset_postdata();
+				$global_post_variable_changed = false;
 			}
 		}
 	}

--- a/src/BlockTypes/SingleProduct.php
+++ b/src/BlockTypes/SingleProduct.php
@@ -123,8 +123,9 @@ class SingleProduct extends AbstractBlock {
 	 */
 	protected function replace_post_for_single_product_inner_block( $block, &$context ) {
 		if ( $this->single_product_inner_blocks_names ) {
-			$block_name                   = array_pop( $this->single_product_inner_blocks_names );
-			$global_post_variable_changed = false;
+			$block_name = array_pop( $this->single_product_inner_blocks_names );
+
+			static $global_post_variable_changed;
 
 			if ( $block_name === $block['blockName'] ) {
 				/**


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
Ensure `wp_reset_postdata()` is invoked only when the global `$post` variable is changed. In other words, it removes the assumption that inner blocks will always include at least one instance of `core/post-excerpt`  or `core/post-title`.

<!-- Reference any related issues or PRs here -->

Fixes #9473

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. While having a block theme enabled such as Twenty-twenty Three, head over to your Dashboard, and on the sidebar, click on "Appearance > Editor".
2. Select the Single Product template to customize it and click on edit.
3. Remove any pre-existing blocks and make sure you can successfully add the Single Product block to your template.
5. Save the changes and head over to a single product page: make sure all blocks are properly rendered.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental
