### PR TITLE
Product Gallery Block > Remove global variable overwrite and keep support for the Single Product Block.

### DIFF
--- a/src/BlockTypes/ProductImageGallery.php
+++ b/src/BlockTypes/ProductImageGallery.php
@@ -43,9 +43,8 @@ class ProductImageGallery extends AbstractBlock {
 			return '';
 		}
 
-		$single_post = get_post( $post_id );
-		$single_product = wc_get_product( $post_id );
-		if ( ! $single_product instanceof \WC_Product ) {
+		$product = wc_get_product( $post_id );
+		if ( ! $product instanceof \WC_Product ) {
 			return '';
 		}
 
@@ -54,26 +53,17 @@ class ProductImageGallery extends AbstractBlock {
 			$frontend_scripts::load_scripts();
 		}
 
-		$classname = $attributes['className'] ?? '';
-		ob_start();
-		if ( $single_product->is_on_sale() ) {
-			echo apply_filters( 'woocommerce_sale_flash', '<span class="onsale">' . esc_html__( 'Sale!', 'woocommerce' ) . '</span>', $single_post, $single_product );
-		}
-
-		$sale_badge_html = ob_get_clean();
-
-		ob_start();
-		$columns           = apply_filters( 'woocommerce_product_thumbnails_columns', 4 );
-		$post_thumbnail_id = $single_product->get_image_id();
-		$wrapper_classes   = apply_filters(
-			'woocommerce_single_product_image_gallery_classes',
-			array(
-				'woocommerce-product-gallery',
-				'woocommerce-product-gallery--' . ( $post_thumbnail_id ? 'with-images' : 'without-images' ),
-				'woocommerce-product-gallery--columns-' . absint( $columns ),
-				'images',
-			)
+		$classname         = $attributes['className'] ?? '';
+		$sale_badge_html   = $product->is_on_sale() ? '<span class="onsale">' . esc_html__( 'Sale!', 'woo-gutenberg-products-block' ) . '</span>' : '';
+		$columns           = 4;
+		$post_thumbnail_id = $product->get_image_id();
+		$wrapper_classes   = array(
+			'woocommerce-product-gallery',
+			'woocommerce-product-gallery--' . ( $post_thumbnail_id ? 'with-images' : 'without-images' ),
+			'woocommerce-product-gallery--columns-' . absint( $columns ),
+			'images',
 		);
+		ob_start();
 		?>
 		<div class="<?php echo esc_attr( implode( ' ', array_map( 'sanitize_html_class', $wrapper_classes ) ) ); ?>" data-columns="<?php echo esc_attr( $columns ); ?>" style="opacity: 0; transition: opacity .25s ease-in-out;">
 			<div class="woocommerce-product-gallery__wrapper">
@@ -82,17 +72,15 @@ class ProductImageGallery extends AbstractBlock {
 					$html = wc_get_gallery_image_html( $post_thumbnail_id, true );
 				} else {
 					$html  = '<div class="woocommerce-product-gallery__image--placeholder">';
-					$html .= sprintf( '<img src="%s" alt="%s" class="wp-post-image" />', esc_url( wc_placeholder_img_src( 'woocommerce_single' ) ), esc_html__( 'Awaiting product image', 'woocommerce' ) );
+					$html .= sprintf( '<img src="%s" alt="%s" class="wp-post-image" />', esc_url( wc_placeholder_img_src( 'woo-gutenberg-products-block' ) ), esc_html__( 'Awaiting product image', 'woo-gutenberg-products-block' ) );
 					$html .= '</div>';
 				}
 
-				echo apply_filters( 'woocommerce_single_product_image_thumbnail_html', $html, $post_thumbnail_id );
-
-				$attachment_ids = $single_product->get_gallery_image_ids();
-
-				if ( $attachment_ids && $single_product->get_image_id() ) {
+				echo wp_kses_post( $html );
+				$attachment_ids = $product->get_gallery_image_ids();
+				if ( $attachment_ids && $product->get_image_id() ) {
 					foreach ( $attachment_ids as $attachment_id ) {
-						echo apply_filters( 'woocommerce_single_product_image_thumbnail_html', wc_get_gallery_image_html( $attachment_id ), $attachment_id );
+						echo wc_get_gallery_image_html( $attachment_id ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 					}
 				}
 				?>

--- a/src/BlockTypes/ProductImageGallery.php
+++ b/src/BlockTypes/ProductImageGallery.php
@@ -37,10 +37,17 @@ class ProductImageGallery extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-
 		$post_id = $block->context['postId'];
-		global $product;
-		$product = wc_get_product( $post_id );
+
+		if ( ! isset( $post_id ) ) {
+			return '';
+		}
+
+		$single_post = get_post( $post_id );
+		$single_product = wc_get_product( $post_id );
+		if ( ! $single_product instanceof \WC_Product ) {
+			return '';
+		}
 
 		if ( class_exists( 'WC_Frontend_Scripts' ) ) {
 			$frontend_scripts = new \WC_Frontend_Scripts();
@@ -49,11 +56,49 @@ class ProductImageGallery extends AbstractBlock {
 
 		$classname = $attributes['className'] ?? '';
 		ob_start();
-		woocommerce_show_product_sale_flash();
+		if ( $single_product->is_on_sale() ) {
+			echo apply_filters( 'woocommerce_sale_flash', '<span class="onsale">' . esc_html__( 'Sale!', 'woocommerce' ) . '</span>', $single_post, $single_product );
+		}
+
 		$sale_badge_html = ob_get_clean();
 
 		ob_start();
-		woocommerce_show_product_images();
+		$columns           = apply_filters( 'woocommerce_product_thumbnails_columns', 4 );
+		$post_thumbnail_id = $single_product->get_image_id();
+		$wrapper_classes   = apply_filters(
+			'woocommerce_single_product_image_gallery_classes',
+			array(
+				'woocommerce-product-gallery',
+				'woocommerce-product-gallery--' . ( $post_thumbnail_id ? 'with-images' : 'without-images' ),
+				'woocommerce-product-gallery--columns-' . absint( $columns ),
+				'images',
+			)
+		);
+		?>
+		<div class="<?php echo esc_attr( implode( ' ', array_map( 'sanitize_html_class', $wrapper_classes ) ) ); ?>" data-columns="<?php echo esc_attr( $columns ); ?>" style="opacity: 0; transition: opacity .25s ease-in-out;">
+			<div class="woocommerce-product-gallery__wrapper">
+				<?php
+				if ( $post_thumbnail_id ) {
+					$html = wc_get_gallery_image_html( $post_thumbnail_id, true );
+				} else {
+					$html  = '<div class="woocommerce-product-gallery__image--placeholder">';
+					$html .= sprintf( '<img src="%s" alt="%s" class="wp-post-image" />', esc_url( wc_placeholder_img_src( 'woocommerce_single' ) ), esc_html__( 'Awaiting product image', 'woocommerce' ) );
+					$html .= '</div>';
+				}
+
+				echo apply_filters( 'woocommerce_single_product_image_thumbnail_html', $html, $post_thumbnail_id );
+
+				$attachment_ids = $single_product->get_gallery_image_ids();
+
+				if ( $attachment_ids && $single_product->get_image_id() ) {
+					foreach ( $attachment_ids as $attachment_id ) {
+						echo apply_filters( 'woocommerce_single_product_image_thumbnail_html', wc_get_gallery_image_html( $attachment_id ), $attachment_id );
+					}
+				}
+				?>
+			</div>
+		</div>
+		<?php
 		$product_image_gallery_html = ob_get_clean();
 
 		return sprintf(


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

This is a simplified version of https://github.com/woocommerce/woocommerce-blocks/pull/9458 aimed as a short-term solution for ensuring the `$product` global variable is not overwritten within the Product Gallery block while still keeping support for the (still experimental) Single Product block.

While for the Add to Cart with Options block it was possible to simply ditch the call to the global variable (as visible on https://github.com/woocommerce/woocommerce-blocks/pull/9457), that's not the case for this block, as due to the nature of how the templates and functions are structured, not invoking global `$product` results in fatal errors even within the context of the single product template.

With that said, a basic version of the following templates was added  to the `ProductImageGallery` class:

`single-product/product-thumbnails.php`
`single-product/product-image.php`
`single-product/sale-flash.php`

All hooks were deliberately removed in this first instance, more discussion and changes are expected to happen on https://github.com/woocommerce/woocommerce-blocks/pull/9458 later on.

<!-- Reference any related issues or PRs here -->

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/9453

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

#### User Facing Testing

1. While having a block theme enabled such as Twenty-twenty Three, head over to your Dashboard, and on the sidebar, click on "Appearance > Editor".
5. Select the Single Product template to customize it and click on edit.
6. If you are still not using the blockified version of the template, click on “Transform into blocks” first to ensure all blocks are in place.
7. Make sure the Product Gallery block is automatically added and available for usage on the inserter (you can remove/add the block from the template), add it, and save.
8. On the front end, ensure the block works as expected and the product can be added to the cart.
9. Now create a new post and add the Single Product Block to it.
10. Save the post and head over to the FE: make sure the Gallery Block is properly displayed on the post without any problems.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Fix: Remove the global variable overwrite for the Product Gallery block while still keeping support for the Single Product block.
