### PR TITLE
Fix undo button

### DIFF
--- a/assets/js/blocks/classic-template/index.tsx
+++ b/assets/js/blocks/classic-template/index.tsx
@@ -22,7 +22,7 @@ import { Button, Placeholder, Popover } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { box, Icon } from '@wordpress/icons';
 import { useDispatch, subscribe, useSelect, select } from '@wordpress/data';
-import { useEffect, useMemo, useState } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { store as noticesStore } from '@wordpress/notices';
 import { useEntityRecord } from '@wordpress/core-data';
 
@@ -100,12 +100,6 @@ const Edit = ( {
 
 	const { createInfoNotice } = useDispatch( noticesStore );
 
-	const blocks = getBlocks();
-
-	const clientIds = useMemo( () => {
-		pickBlockClientIds( blocks );
-	}, [ blocks ] );
-
 	const blockProps = useBlockProps();
 	const templateDetails = getTemplateDetailsBySlug(
 		attributes.template,
@@ -177,6 +171,11 @@ const Edit = ( {
 															'woo-gutenberg-products-block'
 														),
 														onClick: () => {
+															const clientIds =
+																pickBlockClientIds(
+																	getBlocks()
+																);
+
 															replaceBlocks(
 																clientIds,
 																createBlock(

--- a/assets/js/blocks/classic-template/single-product.ts
+++ b/assets/js/blocks/classic-template/single-product.ts
@@ -63,7 +63,7 @@ const getDescriptionAllowingConversion = ( templateTitle: string ) =>
 	sprintf(
 		/* translators: %s is the template title */
 		__(
-			'Transform this template into multiple blocks so you can add, remove, reorder, and customize your %s.',
+			'Transform this template into multiple blocks so you can add, remove, reorder, and customize your %s template.',
 			'woo-gutenberg-products-block'
 		),
 		templateTitle


### PR DESCRIPTION
This PR fixes the undo button introduced with #9386.

### Testing
#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Open the Single Product Template.
2. Be sure that the description is: "Transform this template into multiple blocks so you can add, remove, reorder, and customize your **single product template** (for other templates, this should correspond to the name of the template)."
3. Hover the button "transform into blocks".
4. Ensure the preview corresponds to the "blockified template".
5. Click the button.
6. Ensure that the group block around the blockified product is selected.
7. Ensure the snackbar is visible and the undo button works correctly.


* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
