### PR TITLE
Render Product Details block when used along the Post Content block

### DIFF
--- a/src/BlockTypes/ProductDetails.php
+++ b/src/BlockTypes/ProductDetails.php
@@ -54,7 +54,7 @@ class ProductDetails extends AbstractBlock {
 	 */
 	protected function render_tabs() {
 		ob_start();
-
+		rewind_posts();
 		while ( have_posts() ) {
 			the_post();
 			woocommerce_output_product_data_tabs();


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

This PR fixes the Product Details block when used along the Post Content Block. The fix is to invoke the function `rewind_posts()` for updating the internal pointer for the posts and preventing the conflicts with the Post Content block that we were discussing https://github.com/woocommerce/woocommerce-blocks/discussions/8792#discussioncomment-5387577.

<!-- Reference any related issues or PRs here -->

Fixes #9451

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->



### Testing



#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Edit the Single Product Template.
2. Migrate to the Blockified Template by clicking the button: `Transform into blocks`.
3. Add the `Post Content` as first block of the main group block.
4. Save.
5. Visit a Product page.
6. Ensure that the Product Details block and Post Content block are visible. 

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Product Details block: show the block when used along the Post Content block.
