### PR TITLE
Fix Filter by Price block making a 404 request in the frontend

### DIFF
--- a/src/BlockTypes/PriceFilter.php
+++ b/src/BlockTypes/PriceFilter.php
@@ -14,4 +14,13 @@ class PriceFilter extends AbstractBlock {
 	protected $block_name     = 'price-filter';
 	const MIN_PRICE_QUERY_VAR = 'min_price';
 	const MAX_PRICE_QUERY_VAR = 'max_price';
+
+	/**
+	 * Get the frontend script handle for this block type.
+	 *
+	 * @param string $key Data to get, or default to everything.
+	 */
+	protected function get_block_type_script( $key = null ) {
+		return null;
+	}
 }


### PR DESCRIPTION
### Testing

#### User Facing Testing

1. Add the Filter by Price and All Products blocks to a post or page.
2. Open the _Network_ tab of your browser devtools (<kbd>F12</kbd>).
3. View the post or page you created in step 1 in the frontend.
4. Verify there are no requests to `/wp-content/plugins/woocommerce-blocks/build/price-filter-frontend.js` causing a 404 request.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
