### PR TITLE
Prevent QuantitySelector stealing focus on page load

### DIFF
--- a/assets/js/base/components/quantity-selector/index.tsx
+++ b/assets/js/base/components/quantity-selector/index.tsx
@@ -6,6 +6,7 @@ import { speak } from '@wordpress/a11y';
 import classNames from 'classnames';
 import { useCallback, useLayoutEffect, useRef } from '@wordpress/element';
 import { DOWN, UP } from '@wordpress/keycodes';
+import { usePrevious } from '@woocommerce/base-hooks';
 import { useDebouncedCallback } from 'use-debounce';
 
 /**
@@ -74,6 +75,8 @@ const QuantitySelector = ( {
 	const canDecrease = ! disabled && quantity - step >= minimum;
 	const canIncrease =
 		! disabled && ( ! hasMaximum || quantity + step <= maximum );
+	const previousCanDecrease = usePrevious( canDecrease );
+	const previousCanIncrease = usePrevious( canIncrease );
 
 	// When the increase or decrease buttons get disabled, the focus
 	// gets moved to the `<body>` element. This was causing weird
@@ -95,6 +98,7 @@ const QuantitySelector = ( {
 
 		const currentDocument = inputRef.current.ownerDocument;
 		if (
+			previousCanDecrease &&
 			! canDecrease &&
 			( currentDocument.activeElement === decreaseButtonRef.current ||
 				currentDocument.activeElement === currentDocument.body )
@@ -102,13 +106,14 @@ const QuantitySelector = ( {
 			inputRef.current.focus();
 		}
 		if (
+			previousCanIncrease &&
 			! canIncrease &&
 			( currentDocument.activeElement === increaseButtonRef.current ||
 				currentDocument.activeElement === currentDocument.body )
 		) {
 			inputRef.current.focus();
 		}
-	}, [ canDecrease, canIncrease ] );
+	}, [ previousCanDecrease, previousCanIncrease, canDecrease, canIncrease ] );
 
 	/**
 	 * The goal of this function is to normalize what was inserted,


### PR DESCRIPTION
In #9345 I introduced a regression: when opening the Cart page, if a product quantity couldn't be decreased, the quantity input was getting the focus. This PR fixes it, making sure we only move the focus to the input field when the decrease/increase button changes from enabled to disabled.

For [context](https://github.com/woocommerce/woocommerce-blocks/blob/cabbaa270194eb75aff4a3ab442a4da3d00d80f8/assets/js/base/components/quantity-selector/index.tsx#L78-L85): moving the focus was required to make sure the Mini Cart drawer was closing when a button which had focused changed from enabled to disabled.

### Testing

#### User Facing Testing

1. Add one product to your page, making sure you only have one item of that product.
2. Go to the Cart page (with the Cart block).
3. Verify the quantity field input doesn't get the focus on page load.

Before | After
--- | ---
[before.webm](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/5953bf59-0445-4bd5-9e50-cd56cf1e78fa) | [after.webm](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/37b7d040-692d-4b16-88ee-0f6fffae1060)

* [ ] Do not include in the Testing Notes

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
