### PR TITLE
Migrate pages to templates once

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -681,6 +681,7 @@ class BlockTemplatesController {
 	 */
 	protected function migrate_page( $page_id, $page ) {
 		if ( ! $page || empty( $page->post_content ) ) {
+			update_option( 'has_migrated_' . $page_id, '1' );
 			return;
 		}
 

--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -689,7 +689,7 @@ class BlockTemplatesController {
 		$request->set_body_params(
 			[
 				'id'      => 'woocommerce/woocommerce//' . $page_id,
-				'content' => \block_header_area() . '
+				'content' => '<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 					<!-- wp:group {"layout":{"inherit":true}} -->
 					<div class="wp-block-group">
 						<!-- wp:heading {"level":1} -->
@@ -697,7 +697,8 @@ class BlockTemplatesController {
 						<!-- /wp:heading -->
 						' . wp_kses_post( $page->post_content ) . '
 					</div>
-					<!-- /wp:group -->' . \block_footer_area(),
+					<!-- /wp:group -->
+					<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->',
 			]
 		);
 		rest_get_server()->dispatch( $request );

--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -76,6 +76,7 @@ class BlockTemplatesController {
 		add_filter( 'post_type_archive_title', array( $this, 'update_product_archive_title' ), 10, 2 );
 
 		if ( wc_current_theme_is_fse_theme() ) {
+			add_action( 'init', array( $this, 'maybe_migrate_content' ) );
 			add_filter( 'woocommerce_settings_pages', array( $this, 'template_permalink_settings' ) );
 			add_filter( 'pre_update_option', array( $this, 'update_template_permalink' ), 10, 2 );
 			add_action( 'woocommerce_admin_field_permalink', array( SettingsUtils::class, 'permalink_input_field' ) );
@@ -335,16 +336,12 @@ class BlockTemplatesController {
 				if ( ! $template->description ) {
 					$template->description = BlockTemplateUtils::get_block_template_description( $template->slug );
 				}
-
 				if ( str_contains( $template->slug, 'single-product' ) ) {
 					if ( ! is_admin() && ! BlockTemplateUtils::template_has_legacy_template_block( $template ) ) {
-
 						$new_content       = SingleProductTemplateCompatibility::add_compatibility_layer( $template->content );
 						$template->content = $new_content;
 					}
-					return $template;
 				}
-
 				return $template;
 			},
 			$query_result
@@ -652,6 +649,58 @@ class BlockTemplatesController {
 		}
 
 		return $post_type_name;
+	}
+
+	/**
+	 * Migrates page content to templates if needed.
+	 */
+	public function maybe_migrate_content() {
+		if ( ! $this->has_migrated_page( 'cart' ) ) {
+			$this->migrate_page( 'cart', CartTemplate::get_placeholder_page() );
+		}
+		if ( ! $this->has_migrated_page( 'checkout' ) ) {
+			$this->migrate_page( 'checkout', CheckoutTemplate::get_placeholder_page() );
+		}
+	}
+
+	/**
+	 * Check if a page has been migrated to a template.
+	 *
+	 * @param string $page_id Page ID.
+	 * @return boolean
+	 */
+	protected function has_migrated_page( $page_id ) {
+		return (bool) get_option( 'has_migrated_' . $page_id, false );
+	}
+
+	/**
+	 * Migrates a page to a template if needed.
+	 *
+	 * @param string   $page_id Page ID.
+	 * @param \WP_Post $page Page object.
+	 */
+	protected function migrate_page( $page_id, $page ) {
+		if ( ! $page || empty( $page->post_content ) ) {
+			return;
+		}
+
+		$request = new \WP_REST_Request( 'POST', '/wp/v2/templates/woocommerce/woocommerce//' . $page_id );
+		$request->set_body_params(
+			[
+				'id'      => 'woocommerce/woocommerce//' . $page_id,
+				'content' => \block_header_area() . '
+					<!-- wp:group {"layout":{"inherit":true}} -->
+					<div class="wp-block-group">
+						<!-- wp:heading {"level":1} -->
+						<h1 class="wp-block-heading">' . wp_kses_post( $page->post_title ) . '</h1>
+						<!-- /wp:heading -->
+						' . wp_kses_post( $page->post_content ) . '
+					</div>
+					<!-- /wp:group -->' . \block_footer_area(),
+			]
+		);
+		rest_get_server()->dispatch( $request );
+		update_option( 'has_migrated_' . $page_id, '1' );
 	}
 
 	/**

--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -338,8 +338,7 @@ class BlockTemplatesController {
 				}
 				if ( str_contains( $template->slug, 'single-product' ) ) {
 					if ( ! is_admin() && ! BlockTemplateUtils::template_has_legacy_template_block( $template ) ) {
-						$new_content       = SingleProductTemplateCompatibility::add_compatibility_layer( $template->content );
-						$template->content = $new_content;
+						$template->content = SingleProductTemplateCompatibility::add_compatibility_layer( $template->content );
 					}
 				}
 				return $template;

--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -689,20 +689,35 @@ class BlockTemplatesController {
 		$request->set_body_params(
 			[
 				'id'      => 'woocommerce/woocommerce//' . $page_id,
-				'content' => '<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
-					<!-- wp:group {"layout":{"inherit":true}} -->
+				'content' => $this->get_block_template_part( 'header' ) .
+					'<!-- wp:group {"layout":{"inherit":true}} -->
 					<div class="wp-block-group">
 						<!-- wp:heading {"level":1} -->
 						<h1 class="wp-block-heading">' . wp_kses_post( $page->post_title ) . '</h1>
 						<!-- /wp:heading -->
 						' . wp_kses_post( $page->post_content ) . '
 					</div>
-					<!-- /wp:group -->
-					<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->',
+					<!-- /wp:group -->' .
+					$this->get_block_template_part( 'footer' ),
 			]
 		);
 		rest_get_server()->dispatch( $request );
 		update_option( 'has_migrated_' . $page_id, '1' );
+	}
+
+	/**
+	 * Returns the requested template part.
+	 *
+	 * @param string $part The part to return.
+	 *
+	 * @return string
+	 */
+	protected function get_block_template_part( $part ) {
+		$template_part = get_block_template( get_stylesheet() . '//' . $part, 'wp_template_part' );
+		if ( ! $template_part || empty( $template_part->content ) ) {
+			return '';
+		}
+		return $template_part->content;
 	}
 
 	/**

--- a/src/Templates/AbstractPageTemplate.php
+++ b/src/Templates/AbstractPageTemplate.php
@@ -90,7 +90,7 @@ abstract class AbstractPageTemplate {
 		$page         = $this->get_placeholder_page();
 		$edit_page_id = 'page' === $current_screen->id && ! empty( $_GET['post'] ) ? absint( $_GET['post'] ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
-		if ( $page && $edit_page_id === $page->id ) {
+		if ( $page && $edit_page_id === $page->ID ) {
 			wp_safe_redirect( $this->get_edit_template_url() );
 			exit;
 		}

--- a/src/Templates/AbstractPageTemplate.php
+++ b/src/Templates/AbstractPageTemplate.php
@@ -24,7 +24,6 @@ abstract class AbstractPageTemplate {
 	protected function init() {
 		add_filter( 'page_template_hierarchy', array( $this, 'page_template_hierarchy' ), 1 );
 		add_filter( 'frontpage_template_hierarchy', array( $this, 'page_template_hierarchy' ), 1 );
-		add_filter( 'woocommerce_blocks_template_content', array( $this, 'page_template_content' ), 10, 2 );
 		add_action( 'current_screen', array( $this, 'page_template_editor_redirect' ) );
 		add_filter( 'pre_get_document_title', array( $this, 'page_template_title' ) );
 	}
@@ -67,18 +66,6 @@ abstract class AbstractPageTemplate {
 	}
 
 	/**
-	 * Get the default content for a template.
-	 *
-	 * Overridden by child class to include their own logic.
-	 *
-	 * @param string $template_content The original content of the template.
-	 * @return string
-	 */
-	protected function get_default_template_content( $template_content ) {
-		return $template_content;
-	}
-
-	/**
 	 * When the page should be displaying the template, add it to the hierarchy.
 	 *
 	 * This places the template name e.g. `cart`, at the beginning of the template hierarchy array. The hook priority
@@ -92,20 +79,6 @@ abstract class AbstractPageTemplate {
 			array_unshift( $templates, $this->get_slug() );
 		}
 		return $templates;
-	}
-
-	/**
-	 * Returns the default template content.
-	 *
-	 * @param string $template_content The content of the template.
-	 * @param object $template_file The template file object.
-	 * @return string
-	 */
-	public function page_template_content( $template_content, $template_file ) {
-		if ( $this->get_slug() !== $template_file->slug ) {
-			return $template_content;
-		}
-		return $this->get_default_template_content( $template_content );
 	}
 
 	/**

--- a/src/Templates/CartTemplate.php
+++ b/src/Templates/CartTemplate.php
@@ -43,31 +43,4 @@ class CartTemplate extends AbstractPageTemplate {
 	public static function get_template_title() {
 		return __( 'Cart', 'woo-gutenberg-products-block' );
 	}
-
-	/**
-	 * Migrates an existing page using blocks to the block templates.
-	 *
-	 * @param string $template_content The content of the template.
-	 * @return string
-	 */
-	public function get_default_template_content( $template_content ) {
-		$page = $this->get_placeholder_page();
-
-		if ( $page && ! empty( $page->post_content ) ) {
-			$template_content = '
-				<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
-				<!-- wp:group {"layout":{"inherit":true}} -->
-				<div class="wp-block-group">
-					<!-- wp:heading {"level":1} -->
-					<h1 class="wp-block-heading">' . wp_kses_post( $page->post_title ) . '</h1>
-					<!-- /wp:heading -->
-					' . wp_kses_post( $page->post_content ) . '
-				</div>
-				<!-- /wp:group -->
-				<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->
-			';
-		}
-
-		return $template_content;
-	}
 }

--- a/src/Templates/CheckoutTemplate.php
+++ b/src/Templates/CheckoutTemplate.php
@@ -43,29 +43,4 @@ class CheckoutTemplate extends AbstractPageTemplate {
 	public function is_active_template() {
 		return is_checkout();
 	}
-
-	/**
-	 * Migrates an existing page using blocks to the block templates.
-	 *
-	 * @param string $template_content The content of the template.
-	 * @return string
-	 */
-	public function get_default_template_content( $template_content ) {
-		$page = $this->get_placeholder_page();
-
-		if ( $page && ! empty( $page->post_content ) ) {
-			$template_content = '
-				<!-- wp:group {"layout":{"inherit":true}} -->
-				<div class="wp-block-group">
-					<!-- wp:heading {"level":1} -->
-					<h1 class="wp-block-heading">' . wp_kses_post( $page->post_title ) . '</h1>
-					<!-- /wp:heading -->
-					' . wp_kses_post( $page->post_content ) . '
-				</div>
-				<!-- /wp:group -->
-			';
-		}
-
-		return $template_content;
-	}
 }

--- a/src/Utils/BlockTemplateUtils.php
+++ b/src/Utils/BlockTemplateUtils.php
@@ -195,24 +195,8 @@ class BlockTemplateUtils {
 		$template_is_from_theme = 'theme' === $template_file->source;
 		$theme_name             = wp_get_theme()->get( 'TextDomain' );
 
-		/**
-		 * Hook that allows the content to be filtered before it is returned.
-		 *
-		 * @since TBD
-		 *
-		 * @param string $content The content of the template.
-		 * @param object $template_file The template file.
-		 * @param string $template_type The type of template.
-		 * @return string
-		 */
-		$template_content = apply_filters(
-			'woocommerce_blocks_template_content',
-			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-			file_get_contents( $template_file->path ),
-			$template_file,
-			$template_type
-		);
-
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		$template_content  = file_get_contents( $template_file->path );
 		$template          = new \WP_Block_Template();
 		$template->id      = $template_is_from_theme ? $theme_name . '//' . $template_file->slug : self::PLUGIN_SLUG . '//' . $template_file->slug;
 		$template->theme   = $template_is_from_theme ? $theme_name : self::PLUGIN_SLUG;

--- a/templates/templates/cart.html
+++ b/templates/templates/cart.html
@@ -1,33 +1,26 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
-<!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group">
-	<!-- wp:woocommerce/cart -->
-	<div class="wp-block-woocommerce-cart is-loading"><!-- wp:woocommerce/filled-cart-block -->
-		<div class="wp-block-woocommerce-filled-cart-block"><!-- wp:woocommerce/cart-items-block -->
-			<div class="wp-block-woocommerce-cart-items-block">
-				<!-- wp:woocommerce/cart-line-items-block -->
+<!-- wp:group {"layout":{"inherit":true,"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:woocommerce/cart -->
+	<div class="wp-block-woocommerce-cart alignwide is-loading"><!-- wp:woocommerce/filled-cart-block {"align":"wide"} -->
+		<div class="wp-block-woocommerce-filled-cart-block alignwide"><!-- wp:woocommerce/cart-items-block -->
+			<div class="wp-block-woocommerce-cart-items-block"><!-- wp:woocommerce/cart-line-items-block -->
 				<div class="wp-block-woocommerce-cart-line-items-block"></div>
 				<!-- /wp:woocommerce/cart-line-items-block -->
 
 				<!-- wp:woocommerce/cart-cross-sells-block -->
-				<div class="wp-block-woocommerce-cart-cross-sells-block">
-					<!-- wp:heading {"fontSize":"large"} -->
+				<div class="wp-block-woocommerce-cart-cross-sells-block"><!-- wp:heading {"fontSize":"large"} -->
 					<h2 class="wp-block-heading has-large-font-size">You may be interested in…</h2>
 					<!-- /wp:heading -->
 
 					<!-- wp:woocommerce/cart-cross-sells-products-block -->
 					<div class="wp-block-woocommerce-cart-cross-sells-products-block"></div>
-					<!-- /wp:woocommerce/cart-cross-sells-products-block -->
-				</div>
-				<!-- /wp:woocommerce/cart-cross-sells-block -->
-			</div>
+					<!-- /wp:woocommerce/cart-cross-sells-products-block --></div>
+				<!-- /wp:woocommerce/cart-cross-sells-block --></div>
 			<!-- /wp:woocommerce/cart-items-block -->
 
 			<!-- wp:woocommerce/cart-totals-block -->
-			<div class="wp-block-woocommerce-cart-totals-block">
-				<!-- wp:woocommerce/cart-order-summary-block -->
-				<div class="wp-block-woocommerce-cart-order-summary-block">
-					<!-- wp:woocommerce/cart-order-summary-heading-block -->
+			<div class="wp-block-woocommerce-cart-totals-block"><!-- wp:woocommerce/cart-order-summary-block -->
+				<div class="wp-block-woocommerce-cart-order-summary-block"><!-- wp:woocommerce/cart-order-summary-heading-block -->
 					<div class="wp-block-woocommerce-cart-order-summary-heading-block"></div>
 					<!-- /wp:woocommerce/cart-order-summary-heading-block -->
 
@@ -53,8 +46,7 @@
 
 					<!-- wp:woocommerce/cart-order-summary-taxes-block -->
 					<div class="wp-block-woocommerce-cart-order-summary-taxes-block"></div>
-					<!-- /wp:woocommerce/cart-order-summary-taxes-block -->
-				</div>
+					<!-- /wp:woocommerce/cart-order-summary-taxes-block --></div>
 				<!-- /wp:woocommerce/cart-order-summary-block -->
 
 				<!-- wp:woocommerce/cart-express-payment-block -->
@@ -67,37 +59,94 @@
 
 				<!-- wp:woocommerce/cart-accepted-payment-methods-block -->
 				<div class="wp-block-woocommerce-cart-accepted-payment-methods-block"></div>
-				<!-- /wp:woocommerce/cart-accepted-payment-methods-block -->
-			</div>
-			<!-- /wp:woocommerce/cart-totals-block -->
-		</div>
+				<!-- /wp:woocommerce/cart-accepted-payment-methods-block --></div>
+			<!-- /wp:woocommerce/cart-totals-block --></div>
 		<!-- /wp:woocommerce/filled-cart-block -->
 
-		<!-- wp:woocommerce/empty-cart-block -->
-		<div class="wp-block-woocommerce-empty-cart-block">
-			<!-- wp:heading {"textAlign":"center","className":"with-empty-cart-icon wc-block-cart__empty-cart__title"} -->
-			<h2
-				class="wp-block-heading has-text-align-center with-empty-cart-icon wc-block-cart__empty-cart__title">
-				Your cart is currently empty!</h2>
-			<!-- /wp:heading -->
+		<!-- wp:woocommerce/empty-cart-block {"align":"wide"} -->
+		<div class="wp-block-woocommerce-empty-cart-block alignwide"><!-- wp:woocommerce/filled-cart-block -->
+			<div class="wp-block-woocommerce-filled-cart-block"><!-- wp:woocommerce/cart-items-block -->
+				<div class="wp-block-woocommerce-cart-items-block"><!-- wp:woocommerce/cart-line-items-block -->
+					<div class="wp-block-woocommerce-cart-line-items-block"></div>
+					<!-- /wp:woocommerce/cart-line-items-block -->
 
-			<!-- wp:paragraph {"align":"center"} -->
-			<p class="has-text-align-center"><a href="http://localhost/shop/">Browse store</a></p>
-			<!-- /wp:paragraph -->
+					<!-- wp:woocommerce/cart-cross-sells-block -->
+					<div class="wp-block-woocommerce-cart-cross-sells-block"><!-- wp:heading {"fontSize":"large"} -->
+						<h2 class="wp-block-heading has-large-font-size">You may be interested in…</h2>
+						<!-- /wp:heading -->
 
-			<!-- wp:separator {"className":"is-style-dots"} -->
-			<hr class="wp-block-separator has-alpha-channel-opacity is-style-dots" />
-			<!-- /wp:separator -->
+						<!-- wp:woocommerce/cart-cross-sells-products-block -->
+						<div class="wp-block-woocommerce-cart-cross-sells-products-block"></div>
+						<!-- /wp:woocommerce/cart-cross-sells-products-block --></div>
+					<!-- /wp:woocommerce/cart-cross-sells-block --></div>
+				<!-- /wp:woocommerce/cart-items-block -->
 
-			<!-- wp:heading {"textAlign":"center"} -->
-			<h2 class="wp-block-heading has-text-align-center">New in store</h2>
-			<!-- /wp:heading -->
+				<!-- wp:woocommerce/cart-totals-block -->
+				<div class="wp-block-woocommerce-cart-totals-block"><!-- wp:woocommerce/cart-order-summary-block -->
+					<div class="wp-block-woocommerce-cart-order-summary-block"><!-- wp:woocommerce/cart-order-summary-heading-block -->
+						<div class="wp-block-woocommerce-cart-order-summary-heading-block"></div>
+						<!-- /wp:woocommerce/cart-order-summary-heading-block -->
 
-			<!-- wp:woocommerce/product-new {"rows":1} /-->
-		</div>
-		<!-- /wp:woocommerce/empty-cart-block -->
-	</div>
-	<!-- /wp:woocommerce/cart -->
-</div>
+						<!-- wp:woocommerce/cart-order-summary-coupon-form-block -->
+						<div class="wp-block-woocommerce-cart-order-summary-coupon-form-block"></div>
+						<!-- /wp:woocommerce/cart-order-summary-coupon-form-block -->
+
+						<!-- wp:woocommerce/cart-order-summary-subtotal-block -->
+						<div class="wp-block-woocommerce-cart-order-summary-subtotal-block"></div>
+						<!-- /wp:woocommerce/cart-order-summary-subtotal-block -->
+
+						<!-- wp:woocommerce/cart-order-summary-fee-block -->
+						<div class="wp-block-woocommerce-cart-order-summary-fee-block"></div>
+						<!-- /wp:woocommerce/cart-order-summary-fee-block -->
+
+						<!-- wp:woocommerce/cart-order-summary-discount-block -->
+						<div class="wp-block-woocommerce-cart-order-summary-discount-block"></div>
+						<!-- /wp:woocommerce/cart-order-summary-discount-block -->
+
+						<!-- wp:woocommerce/cart-order-summary-shipping-block -->
+						<div class="wp-block-woocommerce-cart-order-summary-shipping-block"></div>
+						<!-- /wp:woocommerce/cart-order-summary-shipping-block -->
+
+						<!-- wp:woocommerce/cart-order-summary-taxes-block -->
+						<div class="wp-block-woocommerce-cart-order-summary-taxes-block"></div>
+						<!-- /wp:woocommerce/cart-order-summary-taxes-block --></div>
+					<!-- /wp:woocommerce/cart-order-summary-block -->
+
+					<!-- wp:woocommerce/cart-express-payment-block -->
+					<div class="wp-block-woocommerce-cart-express-payment-block"></div>
+					<!-- /wp:woocommerce/cart-express-payment-block -->
+
+					<!-- wp:woocommerce/proceed-to-checkout-block -->
+					<div class="wp-block-woocommerce-proceed-to-checkout-block"></div>
+					<!-- /wp:woocommerce/proceed-to-checkout-block -->
+
+					<!-- wp:woocommerce/cart-accepted-payment-methods-block -->
+					<div class="wp-block-woocommerce-cart-accepted-payment-methods-block"></div>
+					<!-- /wp:woocommerce/cart-accepted-payment-methods-block --></div>
+				<!-- /wp:woocommerce/cart-totals-block --></div>
+			<!-- /wp:woocommerce/filled-cart-block -->
+
+			<!-- wp:woocommerce/empty-cart-block -->
+			<div class="wp-block-woocommerce-empty-cart-block"><!-- wp:heading {"textAlign":"center","className":"with-empty-cart-icon wc-block-cart__empty-cart__title"} -->
+				<h2 class="wp-block-heading has-text-align-center with-empty-cart-icon wc-block-cart__empty-cart__title">
+					Your cart is currently empty!</h2>
+				<!-- /wp:heading -->
+
+				<!-- wp:paragraph {"align":"center"} -->
+				<p class="has-text-align-center"><a href="http://localhost/shop/">Browse store</a></p>
+				<!-- /wp:paragraph -->
+
+				<!-- wp:separator {"className":"is-style-dots"} -->
+				<hr class="wp-block-separator has-alpha-channel-opacity is-style-dots"/>
+				<!-- /wp:separator -->
+
+				<!-- wp:heading {"textAlign":"center"} -->
+				<h2 class="wp-block-heading has-text-align-center">New in store</h2>
+				<!-- /wp:heading -->
+
+				<!-- wp:woocommerce/product-new {"rows":1} /--></div>
+			<!-- /wp:woocommerce/empty-cart-block --></div>
+		<!-- /wp:woocommerce/empty-cart-block --></div>
+	<!-- /wp:woocommerce/cart --></div>
 <!-- /wp:group -->
 <!-- wp:template-part {"slug":"footer"} /-->

--- a/templates/templates/checkout.html
+++ b/templates/templates/checkout.html
@@ -1,10 +1,7 @@
-<!-- wp:group {"layout":{"inherit":true}} -->
-<div class="wp-block-group">
-	<!-- wp:woocommerce/checkout -->
-	<div class="wp-block-woocommerce-checkout wc-block-checkout is-loading">
-		<!-- wp:woocommerce/checkout-fields-block -->
-		<div class="wp-block-woocommerce-checkout-fields-block">
-			<!-- wp:woocommerce/checkout-express-payment-block -->
+<!-- wp:group {"layout":{"inherit":true,"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:woocommerce/checkout {"className":"wc-block-checkout"} -->
+	<div class="wp-block-woocommerce-checkout alignwide wc-block-checkout is-loading"><!-- wp:woocommerce/checkout-fields-block -->
+		<div class="wp-block-woocommerce-checkout-fields-block"><!-- wp:woocommerce/checkout-express-payment-block -->
 			<div class="wp-block-woocommerce-checkout-express-payment-block"></div>
 			<!-- /wp:woocommerce/checkout-express-payment-block -->
 
@@ -46,15 +43,12 @@
 
 			<!-- wp:woocommerce/checkout-actions-block -->
 			<div class="wp-block-woocommerce-checkout-actions-block"></div>
-			<!-- /wp:woocommerce/checkout-actions-block -->
-		</div>
+			<!-- /wp:woocommerce/checkout-actions-block --></div>
 		<!-- /wp:woocommerce/checkout-fields-block -->
 
 		<!-- wp:woocommerce/checkout-totals-block -->
-		<div class="wp-block-woocommerce-checkout-totals-block">
-			<!-- wp:woocommerce/checkout-order-summary-block -->
-			<div class="wp-block-woocommerce-checkout-order-summary-block">
-				<!-- wp:woocommerce/checkout-order-summary-cart-items-block -->
+		<div class="wp-block-woocommerce-checkout-totals-block"><!-- wp:woocommerce/checkout-order-summary-block -->
+			<div class="wp-block-woocommerce-checkout-order-summary-block"><!-- wp:woocommerce/checkout-order-summary-cart-items-block -->
 				<div class="wp-block-woocommerce-checkout-order-summary-cart-items-block"></div>
 				<!-- /wp:woocommerce/checkout-order-summary-cart-items-block -->
 
@@ -80,12 +74,8 @@
 
 				<!-- wp:woocommerce/checkout-order-summary-taxes-block -->
 				<div class="wp-block-woocommerce-checkout-order-summary-taxes-block"></div>
-				<!-- /wp:woocommerce/checkout-order-summary-taxes-block -->
-			</div>
-			<!-- /wp:woocommerce/checkout-order-summary-block -->
-		</div>
-		<!-- /wp:woocommerce/checkout-totals-block -->
-	</div>
-	<!-- /wp:woocommerce/checkout -->
-</div>
+				<!-- /wp:woocommerce/checkout-order-summary-taxes-block --></div>
+			<!-- /wp:woocommerce/checkout-order-summary-block --></div>
+		<!-- /wp:woocommerce/checkout-totals-block --></div>
+	<!-- /wp:woocommerce/checkout --></div>
 <!-- /wp:group -->


### PR DESCRIPTION
Migrates page content on init rather than replacing the default content with page content.

Fixes #9470

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Testing

Before checking out this branch, you can start with a clean slate by deleting all posts with post type `wp_template` from your `wp_posts` table.

After checking out the branch, loading any page with trigger the migration. Check that your cart and checkout templates contain the content from your cart and checkout pages.

Next, "reset" the changes via the editor. You should see the default content, not the page content. Migration will not happen again.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->