### PR TITLE
Product Rating block: Refactor the block to use useIsDescendentOfSingleProductBlock hook

### DIFF
--- a/assets/js/atomic/blocks/product-elements/rating/edit.tsx
+++ b/assets/js/atomic/blocks/product-elements/rating/edit.tsx
@@ -10,7 +10,6 @@ import {
 import type { BlockEditProps } from '@wordpress/blocks';
 import { useEffect } from '@wordpress/element';
 import { ProductQueryContext as Context } from '@woocommerce/blocks/product-query/types';
-import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -20,6 +19,7 @@ import withProductSelector from '../shared/with-product-selector';
 import { BLOCK_TITLE, BLOCK_ICON } from './constants';
 import { BlockAttributes } from './types';
 import './editor.scss';
+import { useIsDescendentOfSingleProductBlock } from '../shared/use-is-descendent-of-single-product-block';
 
 const Edit = ( {
 	attributes,
@@ -34,16 +34,10 @@ const Edit = ( {
 		...context,
 	};
 	const isDescendentOfQueryLoop = Number.isFinite( context.queryId );
-	const { isDescendentOfSingleProductBlock } = useSelect( ( select ) => {
-		const { getBlockParentsByBlockName } = select( 'core/block-editor' );
-		const blockParentBlocksIds = getBlockParentsByBlockName(
-			blockProps?.id?.replace( 'block-', '' ),
-			[ 'woocommerce/single-product' ]
-		);
-		return {
-			isDescendentOfSingleProductBlock: blockParentBlocksIds.length > 0,
-		};
-	} );
+	const { isDescendentOfSingleProductBlock } =
+		useIsDescendentOfSingleProductBlock( {
+			blockClientId: blockProps?.id,
+		} );
 
 	useEffect( () => {
 		setAttributes( { isDescendentOfQueryLoop } );


### PR DESCRIPTION
## Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f2c9bbb</samp>

Refactor rating block edit component to use a custom hook for single product block detection. This simplifies the code and avoids duplication.

## Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f2c9bbb</samp>

* Extract the logic to check if the rating block is a descendent of the single product block into a custom hook `useIsDescendentOfSingleProductBlock` in `assets/js/atomic/blocks/product-elements/rating/edit.tsx` ([link](https://github.com/woocommerce/woocommerce-blocks/pull/9489/files?diff=unified&w=0#diff-4e154173c83a90857629f0bdf60e0af8dbd33560750747056a1535ad9132e966R22))
* Replace the `useSelect` hook call with the custom hook call in the rating block edit component, passing the block client ID as an argument and destructuring the `isDescendentOfSingleProductBlock` property from the returned object ([link](https://github.com/woocommerce/woocommerce-blocks/pull/9489/files?diff=unified&w=0#diff-4e154173c83a90857629f0bdf60e0af8dbd33560750747056a1535ad9132e966L37-R40))
* Remove the unused `useSelect` hook import from `@wordpress/data` in the same file ([link](https://github.com/woocommerce/woocommerce-blocks/pull/9489/files?diff=unified&w=0#diff-4e154173c83a90857629f0bdf60e0af8dbd33560750747056a1535ad9132e966L13))

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #9413

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Log in to your WordPress dashboard.
2. On the left-hand side menu, click on 'Posts' and then 'Add New' to create a new post. Alternatively, if you want to add the block to an existing post, you can simply find that post and click 'Edit'.
3. Inside the post editor, click on the '+' button, usually found at the top left of the editing space or within the content area itself, to add a new block.
4. In the block library that pops up, you can search for the 'Single Product' block. You can do this by typing 'Single Product' into the search bar at the top of the block library.
5. Click on the 'Single Product' block to add it to your post. You'll be prompted to select a product from your WooCommerce store to feature in the block.
6. Once you've selected a product, the block will be inserted into your post and will display information about the product you've selected.
7. Click on the 'Single Product' block in your post to select it.
8. In the blocks list on the left-hand side, you should see different components of the 'Single Product' block that you can select, remove, or modify. These components typically include the product image, title, price, rating, summary, and button.
9. Find the 'Product Rating' component, click on the three dots to the right side, click Remove. This will remove the product rating from the block.
10. To add the Product Rating back into the Single Product block, simply click on the 'Single Product' block to select it again.
11. With the block selected, add the Product Rating block inside it.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental
