### PR TITLE
Product Search Results Template: fix compatibility layer when the Product Catalog isn't blockified

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -3,6 +3,7 @@ namespace Automattic\WooCommerce\Blocks;
 
 use Automattic\WooCommerce\Blocks\Domain\Package;
 use Automattic\WooCommerce\Blocks\Templates\ProductAttributeTemplate;
+use Automattic\WooCommerce\Blocks\Templates\ProductSearchResultsTemplate;
 use Automattic\WooCommerce\Blocks\Templates\SingleProductTemplateCompatibility;
 use Automattic\WooCommerce\Blocks\Utils\BlockTemplateUtils;
 
@@ -546,6 +547,16 @@ class BlockTemplatesController {
 			}
 
 			if ( ! BlockTemplateUtils::theme_has_template( 'taxonomy-product_tag' ) ) {
+				add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
+			}
+		} elseif ( is_post_type_archive( 'product' ) && is_search() ) {
+			$templates = get_block_templates( array( 'slug__in' => array( ProductSearchResultsTemplate::SLUG ) ) );
+
+			if ( isset( $templates[0] ) && BlockTemplateUtils::template_has_legacy_template_block( $templates[0] ) ) {
+				add_filter( 'woocommerce_disable_compatibility_layer', '__return_true' );
+			}
+
+			if ( ! BlockTemplateUtils::theme_has_template( ProductSearchResultsTemplate::SLUG ) ) {
 				add_filter( 'woocommerce_has_block_template', '__return_true', 10, 0 );
 			}
 		} elseif (


### PR DESCRIPTION
This PR fixes #9490. Also, I think that we should refactor the `render_block_template` function. For this reason, I created a follow-up issue #9491.

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Install `Code Snippets` plugin (https://wordpress.org/plugins/code-snippets/).
2. With `Code Snippets` adds the following PHP code:
```
add_action( 'woocommerce_before_shop_loop' , function () {
	echo 'Hook: woocommerce_before_shop_loop';
});
add_action( 'woocommerce_after_shop_loop' , function () {
	echo 'Hook: woocommerce_after_shop_loop';
});
```
4. Open the Site Editor. 
5. Be sure that the Product Catalog **ISN'T** blockified.
6. Edit the Product Search Results Template and blockified it.
7. Visit a Search Result page (e.g: `/?s=shirt&post_type=product`)
8. Ensure that the hooks are injected.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Product Search Results Template: fix compatibility layer when the Product Catalog isn't blockified.
