### PR TITLE
Fix compatibility between the checkout block and the template editor.

### DIFF
--- a/src/Assets/AssetDataRegistry.php
+++ b/src/Assets/AssetDataRegistry.php
@@ -66,23 +66,8 @@ class AssetDataRegistry {
 	 * Hook into WP asset registration for enqueueing asset data.
 	 */
 	protected function init() {
-		if ( $this->is_site_editor() ) {
-			add_action( 'enqueue_block_editor_assets', array( $this, 'register_data_script' ) );
-		} else {
-			add_action( 'init', array( $this, 'register_data_script' ) );
-		}
-		add_action( 'wp_print_footer_scripts', array( $this, 'enqueue_asset_data' ), 2 );
-		add_action( 'admin_print_footer_scripts', array( $this, 'enqueue_asset_data' ), 2 );
-	}
-
-	/**
-	 * Checks if the current URL is the Site Editor.
-	 *
-	 * @return boolean
-	 */
-	protected function is_site_editor() {
-		$url_path = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
-		return str_contains( $url_path, 'site-editor.php' );
+		add_action( 'init', array( $this, 'register_data_script' ) );
+		add_action( is_admin() ? 'admin_print_footer_scripts' : 'wp_print_footer_scripts', array( $this, 'enqueue_asset_data' ), 2 );
 	}
 
 	/**


### PR DESCRIPTION
This PR fixes a conflict between block assets and the template editor. It reverts the change in #9332 and instead enqueues assets in the correct place.

To replicate the original issue:

1. Ensure the latest version of Gutenberg is installed. This is required to reproduce the issue.
2. Go into the template editor
3. Add the checkout block within a template
4. Notice how the payment methods are missing

This was a total pain to debug but to summarise, the fix in #9332 broke payment methods when editing the checkout block in the template editor. Payment method scripts were dequeued because the `wc-settings` hook dependency was not registered soon enough. `verify_payment_methods_dependencies` removes payment method scripts if a dependency is missing to avoid breaking the main checkout block.

Therefore I have reverted the #9332 change.

Reverting #9332 reintroduced the issue it fixed; broken image urls. I found that (with the help of @senadir) this was due to `wcBlocksConfig` being missing when viewing the template editor. Eventually I found that we were rendering 2 `wcSettings` objects in the template editor, and one of them was missing `wcBlocksConfig`. 

If you look at the changes in https://github.com/WordPress/gutenberg/pull/49655/files, you can see that the template editor calls `wp_print_footer_scripts`. This was the problem. We enqueue asset data on 2 hooks:

1. `wp_print_footer_scripts` for the frontend.
2. `admin_print_footer_scripts` for the admin.

So in this context we should only be using `admin_print_footer_scripts` to avoid the duplication. Adding a simple `is_admin` check resolves the issue.

Reverts #9332
Fixes #9331

### Testing

Confirm that the payment methods and shipping methods are rendered correctly, and image previews (cart items) are shown for the following test cases:

**Template Editor**

1. Ensure the latest version of Gutenberg is installed. This is required to reproduce the issue.
2. Go into the template editor
3. Add the checkout block within a template

**Page Editor**

1. Repeat the above test within a page rather than a template. Create a new page and insert the checkout block within it.
2. View the page on the frontend and confirm everything renders normally.

**Without Gutenberg**

1. Disable the Gutenberg plugin.
2. Repeat the above test confirming the block renders correctly in the page editor and on the frontend.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix compatibility between the checkout block and the template editor.
