### PR TITLE
Update Mini-Cart block logic to use isSiteEditorPage util

### DIFF
--- a/assets/js/blocks/mini-cart/edit.tsx
+++ b/assets/js/blocks/mini-cart/edit.tsx
@@ -14,8 +14,9 @@ import {
 import { getSetting } from '@woocommerce/settings';
 import { __ } from '@wordpress/i18n';
 import Noninteractive from '@woocommerce/base-components/noninteractive';
+import { isSiteEditorPage } from '@woocommerce/utils';
 import type { ReactElement } from 'react';
-import { useSelect } from '@wordpress/data';
+import { select } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -41,7 +42,7 @@ const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
 		className: `wc-block-mini-cart`,
 	} );
 
-	const isSiteEditor = useSelect( 'core/edit-site' ) !== undefined;
+	const isSiteEditor = isSiteEditorPage( select( 'core/edit-site' ) );
 
 	const templatePartEditUri = getSetting(
 		'templatePartEditUri',

--- a/assets/js/blocks/mini-cart/edit.tsx
+++ b/assets/js/blocks/mini-cart/edit.tsx
@@ -15,6 +15,7 @@ import { getSetting } from '@woocommerce/settings';
 import { __ } from '@wordpress/i18n';
 import Noninteractive from '@woocommerce/base-components/noninteractive';
 import type { ReactElement } from 'react';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -33,18 +34,14 @@ interface Props {
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
 }
 
-const Edit = ( {
-	attributes,
-	setAttributes,
-	context: { postType, postId },
-}: Props ): ReactElement => {
+const Edit = ( { attributes, setAttributes }: Props ): ReactElement => {
 	const { addToCartBehaviour, hasHiddenPrice, cartAndCheckoutRenderStyle } =
 		attributes;
 	const blockProps = useBlockProps( {
 		className: `wc-block-mini-cart`,
 	} );
 
-	const isSiteEditor = postType === undefined || postId === undefined;
+	const isSiteEditor = useSelect( 'core/edit-site' ) !== undefined;
 
 	const templatePartEditUri = getSetting(
 		'templatePartEditUri',

--- a/assets/js/blocks/mini-cart/index.tsx
+++ b/assets/js/blocks/mini-cart/index.tsx
@@ -48,7 +48,6 @@ const settings: BlockConfiguration = {
 			className: 'wc-block-mini-cart--preview',
 		},
 	},
-	usesContext: [ 'postId', 'postType' ],
 	attributes: {
 		isPreview: {
 			type: 'boolean',


### PR DESCRIPTION
In #9468, @gigitux introduced a `isSiteEditorPage()` util to detect when we are in the site editor.

This PR reverts https://github.com/woocommerce/woocommerce-blocks/pull/9442 and updates the Mini-Cart block logic code to use that util, instead of its own solution.

### Testing

#### User Facing Testing

1. Create a post or page.
2. Add the Mini Cart block and select it.
3. Verify in the sidebar there is no _Mini-Cart in cart and checkout pages_ toggle.
4. Now go to the Site Editor (Appearance > Editor).
5. Add the Mini Cart block to the header of your theme.
6. Verify in the sidebar there is a _Mini-Cart in cart and checkout pages_ toggle.
![imatge](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/96bccc7b-3a1d-479e-a98b-54b600582747)
7. Now change to a classic theme (ie: Storefront).
8. Go to Appearance > Widgets and add the Mini Cart block to a widget area.
9. Verify in the sidebar there is no _Mini-Cart in cart and checkout pages_ toggle.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
