### PR TITLE
Create `Customer account` block e2e playwright tests

### DIFF
--- a/tests/e2e-pw/tests/customer-account/customer-account.block_theme.spec.ts
+++ b/tests/e2e-pw/tests/customer-account/customer-account.block_theme.spec.ts
@@ -1,0 +1,125 @@
+/**
+ * External dependencies
+ */
+import { expect, test } from '@woocommerce/e2e-playwright-utils';
+import { getBlockByName } from '@woocommerce/e2e-utils';
+
+const blockData = {
+	name: 'woocommerce/customer-account',
+	selectors: {
+		frontend: {
+			icon: 'svg',
+			label: '.label',
+		},
+		editor: {
+			iconOptions: '.customer-account-display-style select',
+			iconToggle: '.wc-block-customer-account__icon-style-toggle',
+		},
+	},
+};
+
+const publishAndVisitPost = async ( { page, editor } ) => {
+	await editor.publishPost();
+	await page.waitForLoadState( 'networkidle' );
+	const url = new URL( page.url() );
+	const postId = url.searchParams.get( 'post' );
+	await page.goto( `/?p=${ postId }`, { waitUntil: 'networkidle' } );
+};
+
+const selectTextOnlyOption = async ( { page } ) => {
+	await page
+		.locator( blockData.selectors.editor.iconOptions )
+		.selectOption( 'Text-only' );
+
+	await expect(
+		await page.locator( blockData.selectors.editor.iconToggle )
+	).not.toBeVisible();
+};
+
+const selectIconOnlyOption = async ( { page } ) => {
+	await page
+		.locator( blockData.selectors.editor.iconOptions )
+		.selectOption( 'Icon-only' );
+
+	await expect(
+		await page.locator( blockData.selectors.editor.iconToggle )
+	).toBeVisible();
+};
+
+const selectIconAndTextOption = async ( { page } ) => {
+	await page
+		.locator( blockData.selectors.editor.iconOptions )
+		.selectOption( 'Icon and text' );
+
+	await expect(
+		await page.locator( blockData.selectors.editor.iconToggle )
+	).toBeVisible();
+};
+
+test.describe( `${ blockData.name } Block`, () => {
+	test( 'Icon Options can be set to Text-only', async ( {
+		admin,
+		editor,
+		page,
+	} ) => {
+		await admin.createNewPost();
+		await editor.insertBlock( { name: blockData.name } );
+
+		await selectTextOnlyOption( { page } );
+
+		await publishAndVisitPost( { page, editor } );
+
+		const block = await getBlockByName( { page, name: blockData.name } );
+
+		await expect(
+			block.locator( blockData.selectors.frontend.label )
+		).toBeVisible();
+		await expect(
+			block.locator( blockData.selectors.frontend.icon )
+		).not.toBeVisible();
+	} );
+
+	test( 'Icon Options can be set to Icon-only', async ( {
+		admin,
+		editor,
+		page,
+	} ) => {
+		await admin.createNewPost();
+		await editor.insertBlock( { name: blockData.name } );
+
+		await selectIconOnlyOption( { page } );
+
+		await publishAndVisitPost( { page, editor } );
+
+		const block = await getBlockByName( { page, name: blockData.name } );
+
+		await expect(
+			block.locator( blockData.selectors.frontend.label )
+		).not.toBeVisible();
+		await expect(
+			block.locator( blockData.selectors.frontend.icon )
+		).toBeVisible();
+	} );
+
+	test( 'Icon Options can be set to Icon and text', async ( {
+		admin,
+		editor,
+		page,
+	} ) => {
+		await admin.createNewPost();
+		await editor.insertBlock( { name: blockData.name } );
+
+		await selectIconAndTextOption( { page } );
+
+		await publishAndVisitPost( { page, editor } );
+
+		const block = await getBlockByName( { page, name: blockData.name } );
+
+		await expect(
+			block.locator( blockData.selectors.frontend.label )
+		).toBeVisible();
+		await expect(
+			block.locator( blockData.selectors.frontend.icon )
+		).toBeVisible();
+	} );
+} );

--- a/tests/e2e-pw/tests/customer-account/customer-account.block_theme.spec.ts
+++ b/tests/e2e-pw/tests/customer-account/customer-account.block_theme.spec.ts
@@ -31,9 +31,7 @@ const selectTextOnlyOption = async ( { page } ) => {
 		.locator( blockData.selectors.editor.iconOptions )
 		.selectOption( 'Text-only' );
 
-	await expect(
-		await page.locator( blockData.selectors.editor.iconToggle )
-	).not.toBeVisible();
+	await page.locator( blockData.selectors.editor.iconToggle );
 };
 
 const selectIconOnlyOption = async ( { page } ) => {
@@ -49,9 +47,7 @@ const selectIconAndTextOption = async ( { page } ) => {
 		.locator( blockData.selectors.editor.iconOptions )
 		.selectOption( 'Icon and text' );
 
-	await expect(
-		await page.locator( blockData.selectors.editor.iconToggle )
-	).toBeVisible();
+	await page.locator( blockData.selectors.editor.iconToggle );
 };
 
 test.describe( `${ blockData.name } Block`, () => {

--- a/tests/e2e-pw/tests/customer-account/customer-account.block_theme.spec.ts
+++ b/tests/e2e-pw/tests/customer-account/customer-account.block_theme.spec.ts
@@ -41,9 +41,7 @@ const selectIconOnlyOption = async ( { page } ) => {
 		.locator( blockData.selectors.editor.iconOptions )
 		.selectOption( 'Icon-only' );
 
-	await expect(
-		await page.locator( blockData.selectors.editor.iconToggle )
-	).toBeVisible();
+	await page.locator( blockData.selectors.editor.iconToggle );
 };
 
 const selectIconAndTextOption = async ( { page } ) => {


### PR DESCRIPTION
The goal of this PR is to migrate the `Customer account` block test to Playwright.
### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests

Make sure all the tests are passing in CI.

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
