### PR TITLE
Update sidebar notice for Block based themes

### DIFF
--- a/assets/js/blocks/cart-checkout-shared/sidebar-notices/index.tsx
+++ b/assets/js/blocks/cart-checkout-shared/sidebar-notices/index.tsx
@@ -12,10 +12,13 @@ import { CartCheckoutSidebarCompatibilityNotice } from '@woocommerce/editor-comp
 import { NoPaymentMethodsNotice } from '@woocommerce/editor-components/no-payment-methods-notice';
 import { PAYMENT_STORE_KEY } from '@woocommerce/block-data';
 import { DefaultNotice } from '@woocommerce/editor-components/default-notice';
+import { TemplateNotice } from '@woocommerce/editor-components/template-notice';
 import { IncompatiblePaymentGatewaysNotice } from '@woocommerce/editor-components/incompatible-payment-gateways-notice';
 import { useSelect } from '@wordpress/data';
 import { CartCheckoutFeedbackPrompt } from '@woocommerce/editor-components/feedback-prompt';
 import { useState } from '@wordpress/element';
+import { getSetting } from '@woocommerce/settings';
+
 declare module '@wordpress/editor' {
 	let store: StoreDescriptor;
 }
@@ -35,6 +38,8 @@ const withSidebarNotices = createHigherOrderComponent(
 			name: blockName,
 			isSelected: isBlockSelected,
 		} = props;
+
+		const isBlockTheme = getSetting( 'isBlockTheme' );
 
 		const [
 			isIncompatiblePaymentGatewaysNoticeDismissed,
@@ -101,15 +106,20 @@ const withSidebarNotices = createHigherOrderComponent(
 						}
 					/>
 
+					{ isBlockTheme ? (
+						<TemplateNotice
+							block={ isCheckout ? 'checkout' : 'cart' }
+						/>
+					) : (
+						<DefaultNotice
+							block={ isCheckout ? 'checkout' : 'cart' }
+						/>
+					) }
+
 					{ isIncompatiblePaymentGatewaysNoticeDismissed ? (
-						<>
-							<DefaultNotice
-								block={ isCheckout ? 'checkout' : 'cart' }
-							/>
-							<CartCheckoutSidebarCompatibilityNotice
-								block={ isCheckout ? 'checkout' : 'cart' }
-							/>
-						</>
+						<CartCheckoutSidebarCompatibilityNotice
+							block={ isCheckout ? 'checkout' : 'cart' }
+						/>
 					) : null }
 
 					{ isPaymentMethodsBlock && ! hasPaymentMethods && (

--- a/assets/js/editor-components/template-notice/editor.scss
+++ b/assets/js/editor-components/template-notice/editor.scss
@@ -1,0 +1,14 @@
+.wc-default-template-notice.is-dismissible {
+	margin: 0;
+	padding-right: 16px;
+	.components-notice__dismiss {
+		min-width: 24px;
+	}
+	.components-notice__content {
+		margin: 4px 0;
+	}
+	svg {
+		width: 16px;
+		height: 16px;
+	}
+}

--- a/assets/js/editor-components/template-notice/index.tsx
+++ b/assets/js/editor-components/template-notice/index.tsx
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { Notice, Button } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { isSiteEditorPage } from '@woocommerce/utils';
+import { select } from '@wordpress/data';
+import { getSetting } from '@woocommerce/settings';
+
+/**
+ * Internal dependencies
+ */
+import './editor.scss';
+
+export function TemplateNotice( { block }: { block: string } ) {
+	const [ settingStatus, setStatus ] = useState( 'pristine' );
+	const store = select( 'core/edit-site' );
+
+	if ( settingStatus === 'dismissed' || isSiteEditorPage( store ) ) {
+		return null;
+	}
+
+	const editUrl = `${ getSetting(
+		'adminUrl'
+	) }site-editor.php?postType=wp_template&postId=woocommerce%2Fwoocommerce%2F%2F${ block }`;
+
+	const noticeContent = sprintf(
+		// translators: %s: cart or checkout page name.
+		__(
+			'The default %s can be customized in the Site Editor',
+			'woo-gutenberg-products-block'
+		),
+		block === 'checkout'
+			? __( 'checkout', 'woo-gutenberg-products-block' )
+			: __( 'cart', 'woo-gutenberg-products-block' )
+	);
+
+	return (
+		<Notice
+			className="wc-default-template-notice"
+			status={ 'warning' }
+			onRemove={ () => setStatus( 'dismissed' ) }
+			spokenMessage={ noticeContent }
+		>
+			<>
+				<p>{ noticeContent }</p>
+				<Button href={ editUrl } variant="secondary" isSmall={ true }>
+					{ __( 'Edit template', 'woo-gutenberg-products-block' ) }
+				</Button>
+			</>
+		</Notice>
+	);
+}

--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -199,6 +199,7 @@ class Cart extends AbstractBlock {
 		$this->asset_data_registry->add( 'shippingEnabled', wc_shipping_enabled(), true );
 		$this->asset_data_registry->add( 'hasDarkEditorStyleSupport', current_theme_supports( 'dark-editor-style' ), true );
 		$this->asset_data_registry->register_page_id( isset( $attributes['checkoutPageId'] ) ? $attributes['checkoutPageId'] : 0 );
+		$this->asset_data_registry->add( 'isBlockTheme', wc_current_theme_is_fse_theme(), true );
 
 		$pickup_location_settings = get_option( 'woocommerce_pickup_location_settings', [] );
 		$this->asset_data_registry->add( 'localPickupEnabled', wc_string_to_bool( $pickup_location_settings['enabled'] ?? 'no' ), true );

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -258,6 +258,7 @@ class Checkout extends AbstractBlock {
 		$this->asset_data_registry->add( 'shippingEnabled', wc_shipping_enabled(), true );
 		$this->asset_data_registry->add( 'hasDarkEditorStyleSupport', current_theme_supports( 'dark-editor-style' ), true );
 		$this->asset_data_registry->register_page_id( isset( $attributes['cartPageId'] ) ? $attributes['cartPageId'] : 0 );
+		$this->asset_data_registry->add( 'isBlockTheme', wc_current_theme_is_fse_theme(), true );
 
 		$pickup_location_settings = get_option( 'woocommerce_pickup_location_settings', [] );
 		$this->asset_data_registry->add( 'localPickupEnabled', wc_string_to_bool( $pickup_location_settings['enabled'] ?? 'no' ), true );


### PR DESCRIPTION
Removes the existing notice which asks the user to update the checkout and cart page IDs, and replaces it with one that links to the site editor. If the user is already viewing the template in the site editor, no notice is displayed.

Fixes #9496 if approved.

### Screenshots

![Screenshot 2023-05-18 at 15 45 23](https://github.com/woocommerce/woocommerce-blocks/assets/90977/c9af3320-a8eb-4329-927e-01e0befec55a)

![Screenshot 2023-05-18 at 15 45 05](https://github.com/woocommerce/woocommerce-blocks/assets/90977/4e58ed5f-1a78-43d0-8937-d2d1e782ba16)

### Testing

1. With a block based theme, edit a page containing a checkout or cart block.
2. Confirm the notice matches the screenshots above.
3. Use the link to visit the site editor.
4. Confirm the notice is not displayed.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->
