### PR TITLE
Enable blockified conversation to archive templates

### DIFF
--- a/assets/js/blocks/classic-template/archive-product.ts
+++ b/assets/js/blocks/classic-template/archive-product.ts
@@ -7,7 +7,6 @@ import {
 	type BlockInstance,
 } from '@wordpress/blocks';
 import { isWpVersion } from '@woocommerce/settings';
-import { isExperimentalBuild } from '@woocommerce/block-settings';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -64,7 +63,7 @@ const getBlockifiedTemplateWithTermDescription = (
 const isConversionPossible = () => {
 	// Blockification is possible for the WP version 6.1 and above,
 	// which are the versions the Products block supports.
-	return isExperimentalBuild() && isWpVersion( '6.1', '>=' );
+	return isWpVersion( '6.1', '>=' );
 };
 
 const getDescriptionAllowingConversion = ( templateTitle: string ) =>

--- a/assets/js/blocks/classic-template/product-search-results.ts
+++ b/assets/js/blocks/classic-template/product-search-results.ts
@@ -8,7 +8,6 @@ import {
 	type InnerBlockTemplate,
 } from '@wordpress/blocks';
 import { isWpVersion } from '@woocommerce/settings';
-import { isExperimentalBuild } from '@woocommerce/block-settings';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
@@ -111,7 +110,7 @@ const getBlockifiedTemplate = ( inheritedAttributes: InheritedAttributes ) =>
 const isConversionPossible = () => {
 	// Blockification is possible for the WP version 6.1 and above,
 	// which are the versions the Products block supports.
-	return isExperimentalBuild() && isWpVersion( '6.1', '>=' );
+	return isWpVersion( '6.1', '>=' );
 };
 
 const getDescriptionAllowingConversion = ( templateTitle: string ) =>


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

Since we fixed the Compatibility Layer for the Archive Templates (#9452), the button to migrate to the blockified template can be visible.



<!-- Reference any related issues or PRs here -->


<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|![image](https://github.com/woocommerce/woocommerce-blocks/assets/4463174/3cec818e-49eb-4562-840a-26d1ae4558da)|![image](https://github.com/woocommerce/woocommerce-blocks/assets/4463174/9d3651ab-7a17-4c96-9e0e-c276c49d222d)|

### Testing


#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

##### Only for developers that will review this PR
Test this PR with a build generated with the `npm run build:deploy` command


1. Open the Site Editor.
2. Edit the `Product Catalog`.
3. Ensure the button  `Transform into blocks` is visible.
4. Do the same steps for: `Products By Category`,  `Products By Tag`, `Products By Attribute`, and `Products Search Results`.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental


### Changelog

> Enable blockified conversation to archive templates.
