### PR TITLE
Product Categories List: Add show child categories only toggle

### DIFF
--- a/assets/js/blocks/product-categories/block.js
+++ b/assets/js/blocks/product-categories/block.js
@@ -43,8 +43,14 @@ const EmptyPlaceholder = () => (
  */
 const ProductCategoriesBlock = ( { attributes, setAttributes, name } ) => {
 	const getInspectorControls = () => {
-		const { hasCount, hasImage, hasEmpty, isDropdown, isHierarchical } =
-			attributes;
+		const {
+			hasCount,
+			hasImage,
+			hasEmpty,
+			isDropdown,
+			isHierarchical,
+			showChildrenOnly,
+		} = attributes;
 
 		return (
 			<InspectorControls key="inspector">
@@ -140,6 +146,22 @@ const ProductCategoriesBlock = ( { attributes, setAttributes, name } ) => {
 						checked={ hasEmpty }
 						onChange={ () =>
 							setAttributes( { hasEmpty: ! hasEmpty } )
+						}
+					/>
+					<ToggleControl
+						label={ __(
+							'Only show children of current category',
+							'woo-gutenberg-products-block'
+						) }
+						help={ __(
+							'When enabled this will only apply to product category pages',
+							'woo-gutenberg-products-block'
+						) }
+						checked={ showChildrenOnly }
+						onChange={ () =>
+							setAttributes( {
+								showChildrenOnly: ! showChildrenOnly,
+							} )
 						}
 					/>
 				</PanelBody>

--- a/assets/js/blocks/product-categories/block.js
+++ b/assets/js/blocks/product-categories/block.js
@@ -6,7 +6,7 @@ import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import ServerSideRender from '@wordpress/server-side-render';
 import PropTypes from 'prop-types';
 import { Icon, listView } from '@wordpress/icons';
-import { isSiteEditorPage } from '@woocommerce/utils';
+import { isSiteEditorPage, isWidgetEditorPage } from '@woocommerce/utils';
 import { useSelect } from '@wordpress/data';
 import {
 	Disabled,
@@ -45,7 +45,9 @@ const EmptyPlaceholder = () => (
  */
 const ProductCategoriesBlock = ( { attributes, setAttributes, name } ) => {
 	const editSiteStore = useSelect( 'core/edit-site' );
+	const editWidgetStore = useSelect( 'core/edit-widgets' );
 	const isSiteEditor = isSiteEditorPage( editSiteStore );
+	const isWidgetEditor = isWidgetEditorPage( editWidgetStore );
 	const getInspectorControls = () => {
 		const {
 			hasCount,
@@ -152,7 +154,7 @@ const ProductCategoriesBlock = ( { attributes, setAttributes, name } ) => {
 							setAttributes( { hasEmpty: ! hasEmpty } )
 						}
 					/>
-					{ isSiteEditor && (
+					{ ( isSiteEditor || isWidgetEditor ) && (
 						<ToggleControl
 							label={ __(
 								'Only show children of current category',

--- a/assets/js/blocks/product-categories/block.js
+++ b/assets/js/blocks/product-categories/block.js
@@ -6,6 +6,8 @@ import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import ServerSideRender from '@wordpress/server-side-render';
 import PropTypes from 'prop-types';
 import { Icon, listView } from '@wordpress/icons';
+import { isSiteEditorPage } from '@woocommerce/utils';
+import { useSelect } from '@wordpress/data';
 import {
 	Disabled,
 	PanelBody,
@@ -42,6 +44,9 @@ const EmptyPlaceholder = () => (
  * @param {string}            props.name          Name for block.
  */
 const ProductCategoriesBlock = ( { attributes, setAttributes, name } ) => {
+	const editSiteStore = useSelect( 'core/edit-site' );
+	const isSiteEditor = isSiteEditorPage( editSiteStore );
+
 	const getInspectorControls = () => {
 		const {
 			hasCount,
@@ -148,22 +153,24 @@ const ProductCategoriesBlock = ( { attributes, setAttributes, name } ) => {
 							setAttributes( { hasEmpty: ! hasEmpty } )
 						}
 					/>
-					<ToggleControl
-						label={ __(
-							'Only show children of current category',
-							'woo-gutenberg-products-block'
-						) }
-						help={ __(
-							'When enabled this will only apply to product category pages',
-							'woo-gutenberg-products-block'
-						) }
-						checked={ showChildrenOnly }
-						onChange={ () =>
-							setAttributes( {
-								showChildrenOnly: ! showChildrenOnly,
-							} )
-						}
-					/>
+					{ isSiteEditor && (
+						<ToggleControl
+							label={ __(
+								'Only show children of current category',
+								'woo-gutenberg-products-block'
+							) }
+							help={ __(
+								'When enabled this will only apply to product category pages',
+								'woo-gutenberg-products-block'
+							) }
+							checked={ showChildrenOnly }
+							onChange={ () =>
+								setAttributes( {
+									showChildrenOnly: ! showChildrenOnly,
+								} )
+							}
+						/>
+					) }
 				</PanelBody>
 			</InspectorControls>
 		);

--- a/assets/js/blocks/product-categories/block.js
+++ b/assets/js/blocks/product-categories/block.js
@@ -46,7 +46,6 @@ const EmptyPlaceholder = () => (
 const ProductCategoriesBlock = ( { attributes, setAttributes, name } ) => {
 	const editSiteStore = useSelect( 'core/edit-site' );
 	const isSiteEditor = isSiteEditorPage( editSiteStore );
-
 	const getInspectorControls = () => {
 		const {
 			hasCount,
@@ -160,7 +159,7 @@ const ProductCategoriesBlock = ( { attributes, setAttributes, name } ) => {
 								'woo-gutenberg-products-block'
 							) }
 							help={ __(
-								'When enabled this will only apply to product category pages',
+								'This will effect product category pages',
 								'woo-gutenberg-products-block'
 							) }
 							checked={ showChildrenOnly }

--- a/assets/js/blocks/product-categories/block.js
+++ b/assets/js/blocks/product-categories/block.js
@@ -159,7 +159,7 @@ const ProductCategoriesBlock = ( { attributes, setAttributes, name } ) => {
 								'woo-gutenberg-products-block'
 							) }
 							help={ __(
-								'This will effect product category pages',
+								'This will affect product category pages',
 								'woo-gutenberg-products-block'
 							) }
 							checked={ showChildrenOnly }

--- a/assets/js/blocks/product-categories/block.json
+++ b/assets/js/blocks/product-categories/block.json
@@ -39,7 +39,11 @@
     "isHierarchical": {
       "type": "boolean",
       "default": true
-    }
+    },
+	"showChildrenOnly": {
+	  "type": "boolean",
+	  "default": false
+	}
   },
   "example": {
     "attributes": {

--- a/assets/js/utils/index.ts
+++ b/assets/js/utils/index.ts
@@ -8,3 +8,4 @@ export * from './products';
 export * from './shared-attributes';
 export * from './sanitize-html';
 export * from './is-site-editor-page';
+export * from './is-widget-editor-page';

--- a/assets/js/utils/is-widget-editor-page.ts
+++ b/assets/js/utils/is-widget-editor-page.ts
@@ -1,0 +1,18 @@
+/**
+ * Internal dependencies
+ */
+import { isObject } from '../types/type-guards';
+
+export const isWidgetEditorPage = ( store: unknown ): boolean => {
+	if ( isObject( store ) ) {
+		const widgetAreas = (
+			store as {
+				getWidgetAreas: () => string;
+			}
+		 ).getWidgetAreas();
+
+		return Array.isArray( widgetAreas ) && widgetAreas.length > 0;
+	}
+
+	return false;
+};

--- a/src/BlockTypes/ProductCategories.php
+++ b/src/BlockTypes/ProductCategories.php
@@ -79,7 +79,7 @@ class ProductCategories extends AbstractDynamicBlock {
 			if ( strstr( $content, 'data-is-dropdown="true"' ) ) {
 				$attributes['isDropdown'] = true;
 			}
-			if ( strstr( $content, 'data-i\s-hierarchical="false"' ) ) {
+			if ( strstr( $content, 'data-is-hierarchical="false"' ) ) {
 				$attributes['isHierarchical'] = false;
 			}
 			if ( strstr( $content, 'data-has-empty="true"' ) ) {

--- a/src/BlockTypes/ProductCategories.php
+++ b/src/BlockTypes/ProductCategories.php
@@ -22,11 +22,12 @@ class ProductCategories extends AbstractDynamicBlock {
 	 * @var array
 	 */
 	protected $defaults = array(
-		'hasCount'       => true,
-		'hasImage'       => false,
-		'hasEmpty'       => false,
-		'isDropdown'     => false,
-		'isHierarchical' => true,
+		'hasCount'         => true,
+		'hasImage'         => false,
+		'hasEmpty'         => false,
+		'isDropdown'       => false,
+		'isHierarchical'   => true,
+		'showChildrenOnly' => false,
 	);
 
 	/**
@@ -38,17 +39,18 @@ class ProductCategories extends AbstractDynamicBlock {
 		return array_merge(
 			parent::get_block_type_attributes(),
 			array(
-				'align'          => $this->get_schema_align(),
-				'className'      => $this->get_schema_string(),
-				'hasCount'       => $this->get_schema_boolean( true ),
-				'hasImage'       => $this->get_schema_boolean( false ),
-				'hasEmpty'       => $this->get_schema_boolean( false ),
-				'isDropdown'     => $this->get_schema_boolean( false ),
-				'isHierarchical' => $this->get_schema_boolean( true ),
-				'textColor'      => $this->get_schema_string(),
-				'fontSize'       => $this->get_schema_string(),
-				'lineHeight'     => $this->get_schema_string(),
-				'style'          => array( 'type' => 'object' ),
+				'align'            => $this->get_schema_align(),
+				'className'        => $this->get_schema_string(),
+				'hasCount'         => $this->get_schema_boolean( true ),
+				'hasImage'         => $this->get_schema_boolean( false ),
+				'hasEmpty'         => $this->get_schema_boolean( false ),
+				'isDropdown'       => $this->get_schema_boolean( false ),
+				'isHierarchical'   => $this->get_schema_boolean( true ),
+				'showChildrenOnly' => $this->get_schema_boolean( false ),
+				'textColor'        => $this->get_schema_string(),
+				'fontSize'         => $this->get_schema_string(),
+				'lineHeight'       => $this->get_schema_string(),
+				'style'            => array( 'type' => 'object' ),
 			)
 		);
 	}
@@ -77,7 +79,7 @@ class ProductCategories extends AbstractDynamicBlock {
 			if ( strstr( $content, 'data-is-dropdown="true"' ) ) {
 				$attributes['isDropdown'] = true;
 			}
-			if ( strstr( $content, 'data-is-hierarchical="false"' ) ) {
+			if ( strstr( $content, 'data-i\s-hierarchical="false"' ) ) {
 				$attributes['isHierarchical'] = false;
 			}
 			if ( strstr( $content, 'data-has-empty="true"' ) ) {
@@ -134,15 +136,30 @@ class ProductCategories extends AbstractDynamicBlock {
 	 * @return array
 	 */
 	protected function get_categories( $attributes ) {
-		$hierarchical = wc_string_to_bool( $attributes['isHierarchical'] );
-		$categories   = get_terms(
-			'product_cat',
-			[
-				'hide_empty'   => ! $attributes['hasEmpty'],
-				'pad_counts'   => true,
-				'hierarchical' => true,
-			]
-		);
+		$hierarchical  = wc_string_to_bool( $attributes['isHierarchical'] );
+		$children_only = wc_string_to_bool( $attributes['showChildrenOnly'] ) && is_product_category();
+
+		if ( $children_only ) {
+			$term_id    = get_queried_object_id();
+			$categories = get_terms(
+				'product_cat',
+				[
+					'hide_empty'   => ! $attributes['hasEmpty'],
+					'pad_counts'   => true,
+					'hierarchical' => true,
+					'child_of'     => $term_id,
+				]
+			);
+		} else {
+			$categories = get_terms(
+				'product_cat',
+				[
+					'hide_empty'   => ! $attributes['hasEmpty'],
+					'pad_counts'   => true,
+					'hierarchical' => true,
+				]
+			);
+		}
 
 		if ( ! is_array( $categories ) || empty( $categories ) ) {
 			return [];
@@ -157,17 +174,17 @@ class ProductCategories extends AbstractDynamicBlock {
 				}
 			);
 		}
-
-		return $hierarchical ? $this->build_category_tree( $categories ) : $categories;
+		return $hierarchical ? $this->build_category_tree( $categories, $children_only ) : $categories;
 	}
 
 	/**
 	 * Build hierarchical tree of categories.
 	 *
 	 * @param array $categories List of terms.
+	 * @param bool  $children_only Is the block rendering only the children of the current category.
 	 * @return array
 	 */
-	protected function build_category_tree( $categories ) {
+	protected function build_category_tree( $categories, $children_only ) {
 		$categories_by_parent = [];
 
 		foreach ( $categories as $category ) {
@@ -177,8 +194,9 @@ class ProductCategories extends AbstractDynamicBlock {
 			$categories_by_parent[ 'cat-' . $category->parent ][] = $category;
 		}
 
-		$tree = $categories_by_parent['cat-0'];
-		unset( $categories_by_parent['cat-0'] );
+		$parent_id = $children_only ? get_queried_object_id() : 0;
+		$tree      = $categories_by_parent[ 'cat-' . $parent_id ]; // these are top level categories. So all parents.
+		unset( $categories_by_parent[ 'cat-' . $parent_id ] );
 
 		foreach ( $tree as $category ) {
 			if ( ! empty( $categories_by_parent[ 'cat-' . $category->term_id ] ) ) {

--- a/src/BlockTypes/ProductCategories.php
+++ b/src/BlockTypes/ProductCategories.php
@@ -161,6 +161,13 @@ class ProductCategories extends AbstractDynamicBlock {
 			);
 		}
 
+		// If they have $children_only enabled, and the current category is the last child in the hierarchy
+		// we need to show the current category instead of rendering nothing at all.
+		if ( $children_only && ( ! is_array( $categories ) || empty( $categories ) ) ) {
+			$current_category = get_term( $term_id, 'product_cat' );
+			return [ $current_category ];
+		}
+
 		if ( ! is_array( $categories ) || empty( $categories ) ) {
 			return [];
 		}

--- a/src/BlockTypes/ProductCategories.php
+++ b/src/BlockTypes/ProductCategories.php
@@ -161,13 +161,6 @@ class ProductCategories extends AbstractDynamicBlock {
 			);
 		}
 
-		// If they have $children_only enabled, and the current category is the last child in the hierarchy
-		// we need to show the current category instead of rendering nothing at all.
-		if ( $children_only && ( ! is_array( $categories ) || empty( $categories ) ) ) {
-			$current_category = get_term( $term_id, 'product_cat' );
-			return [ $current_category ];
-		}
-
 		if ( ! is_array( $categories ) || empty( $categories ) ) {
 			return [];
 		}


### PR DESCRIPTION
Add a "Only show children of current category" toggle for the Product Categories List block. This will only work on product category pages (e.g. when used on the Product Category template).

<!-- Reference any related issues or PRs here -->

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/6346

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Set up product categories with children and grandchildren, making sure they have products.
2. Add the Product Categories List block to a page, and also to the Products by Category template.
3. Check that the toggle only appears when the block is used in the Site Editor (e.g. on a template)
4. Ensure that when the toggle is enabled and you're visiting a category with children, only the children are shown.
5. Make sure that if when you have the _show children only_ toggle enabled, and you click the last child then it renders the current category instead of rendering nothing at all.
6. Ensure no regressions when using this block on posts/pages
7. Enable Classic theme such as Storefront
8. Usage the block in the widget area and check that the feature is available and works as expected and described above.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Product Categories List: Add "Show child categories only" toggle.
