### PR TITLE
Fix > Product details listing pattern - Ensure the editor preview is properly rendered after page refresh

### DIFF
--- a/patterns/product-details-listing.php
+++ b/patterns/product-details-listing.php
@@ -36,12 +36,12 @@
 
 		<!-- wp:group {"align":"full","style":{"spacing":{"padding":"0px","blockGap":"0px","margin":{"top":"0px","bottom":"40px","left":"0px"}}},"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"center","verticalAlignment":"center"}} -->
 		<div class="wp-block-group alignfull" style="margin-top:0px;margin-bottom:40px;margin-left:0px;padding:0">
-			<!-- wp:paragraph {"style":{"typography":{"fontSize":"28px"},"color":{"text":"#000000"},"spacing":{"margin":{"right":"8px"}}}} -->
-			<p class="has-text-color" style="color:#000000;margin-right:8px;font-size:28px;"><strong><sup><sub>$</sub></sup>37.49</strong></p>
+			<!-- wp:paragraph {"style":{"spacing":{"padding":{"right":"5px"}},"typography":{"fontSize":"28px"},"color":{"text":"#000000"}}} -->
+			<p class="has-text-color" style="color:#000000;font-size:28px;padding-right:5px"><strong><sup><sub>$</sub></sup>37.49</strong></p>
 			<!-- /wp:paragraph -->
 
-			<!-- wp:paragraph {"style":{"typography":{"fontSize":"28px"},"layout":{"selfStretch":"fit","flexSize":null},"color":{"text":"#d3d3d3ff"}}} -->
-			<p class="has-text-color" style="color:#d3d3d3ff;font-size:28px;"><s>$47.49</s></p>
+			<!-- wp:paragraph {"style":{"typography":{"fontSize":"28px","fontWeight":"400"},"layout":{"selfStretch":"fit","flexSize":null},"color":{"text":"#d3d3d3ff"}}} -->
+			<p class="has-text-color" style="color:#d3d3d3ff;font-size:28px;font-weight:400;"><s>$47.49</s></p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:group -->

--- a/patterns/product-details-listing.php
+++ b/patterns/product-details-listing.php
@@ -14,27 +14,38 @@
 			<img src="<?php echo esc_url( plugins_url( 'images/pattern-placeholders/product-details-product-listing.jpg', dirname( __FILE__ ) ) ); ?>" alt="" />
 		</figure>
 		<!-- /wp:image -->
-		<!-- wp:group {"style":{"spacing":{"padding":"0px","blockGap":"0px","margin":{"top":"30px","bottom":"20px","left":"31%"}}},"layout":{"type":"flex","flexWrap":"nowrap","verticalAlignment":"center"}} -->
-		<div class="wp-block-group is-content-justification-center" style="margin-top:30px;margin-bottom:20px;margin-left:31%;padding:0">
-			<!-- wp:paragraph {"style":{"typography":{"fontSize":"24px","textColor":"#fda700"}} -->
-			<p class="has-text-color" style="color:#fda700;font-size:24px">★★★★</p>
+		<!-- wp:group {"align":"full","style":{"spacing":{"padding":"0px","blockGap":"0px","margin":{"top":"30px","bottom":"20px","left":"0px"}}},"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"center","verticalAlignment":"center"}} -->
+		<div class="wp-block-group alignfull" style="margin-top:30px;margin-bottom:20px;margin-left:0px;padding:0">
+			<!-- wp:paragraph {"style":{"typography":{"fontSize":"24px"},"color":{"text":"#fda700"}}} -->
+			<p class="has-text-color" style="color:#fda700;font-size:24px;">★★★★</p>
 			<!-- /wp:paragraph -->
-			<!-- wp:paragraph {"style":{"typography":{"fontSize":"24px"},"textColor":"#ffe8a4","spacing":{"margin":{"right":"8px"}}} -->
-			<p class="has-text-color" style="color:#ffe8a4;margin-right:8px;font-size:24px">★</p>
+
+			<!-- wp:paragraph {"style":{"typography":{"fontSize":"24px"},"color":{"text":"#ffe8a4"},"spacing":{"margin":{"right":"8px"}}}} -->
+			<p class="has-text-color" style="color:#ffe8a4;margin-right:8px;font-size:24px;">★</p>
 			<!-- /wp:paragraph -->
-			<!-- wp:paragraph {"style":{"typography":{"fontSize":"13px"},"textColor":"foreground"} -->
-			<p class="has-foreground-color has-text-color" style="font-size:13px"><strong>4.2 </strong>(1,079 reviews)</p>
+
+			<!-- wp:paragraph {"style":{"typography":{"fontSize":"13px"},"color":{"text":"#000000"}}} -->
+			<p class="has-text-color" style="color:#000000;font-size:13px;"><strong>4.2 </strong>(1,079 reviews)</p>
 			<!-- /wp:paragraph -->
 		</div>
 		<!-- /wp:group -->
+
 		<!-- wp:heading {"style":{"spacing":{"margin":{"bottom":"20px"}},"typography":{"fontSize":"48px","fontStyle":"normal","fontWeight":"700","lineHeight":"120%"}},"textColor":"black","fontSize":"x-large"} -->
 		<h2 class="wp-block-heading has-black-color has-text-color has-text-align-center has-x-large-font-size" style="font-size:48px;font-style:normal;font-weight:700;line-height:120%;margin-bottom:20px;">Bella Pro Series - 1.6-qt. Deep Fryer - Stainless Steel</h2>
 		<!-- /wp:heading -->
-		<!-- wp:paragraph {"style":{"spacing":{"margin":{"bottom":"40px"}},"padding":"0px","blockGap":"0px","margin":{"bottom":"20px"}},"typography":{"fontSize":"28px","fontWeight":"700"}},"textColor":"foreground"} -->
-		<p class="has-foreground-color has-text-color has-text-align-center" style="font-size:28px;margin-bottom:40px;">
-			<strong><sup><sub>$</sub></sup>37.49 </strong><s style="color:lightgrey;font-weight:400;">$47.49</s>
-		</p>
-		<!-- /wp:paragraph -->
+
+		<!-- wp:group {"align":"full","style":{"spacing":{"padding":"0px","blockGap":"0px","margin":{"top":"0px","bottom":"40px","left":"0px"}}},"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"center","verticalAlignment":"center"}} -->
+		<div class="wp-block-group alignfull" style="margin-top:0px;margin-bottom:40px;margin-left:0px;padding:0">
+			<!-- wp:paragraph {"style":{"typography":{"fontSize":"28px"},"color":{"text":"#000000"},"spacing":{"margin":{"right":"8px"}}}} -->
+			<p class="has-text-color" style="color:#000000;margin-right:8px;font-size:28px;"><strong><sup><sub>$</sub></sup>37.49</strong></p>
+			<!-- /wp:paragraph -->
+
+			<!-- wp:paragraph {"style":{"typography":{"fontSize":"28px"},"layout":{"selfStretch":"fit","flexSize":null},"color":{"text":"#d3d3d3ff"}}} -->
+			<p class="has-text-color" style="color:#d3d3d3ff;font-size:28px;"><s>$47.49</s></p>
+			<!-- /wp:paragraph -->
+		</div>
+		<!-- /wp:group -->
+
 		<!-- wp:buttons {"style":{"spacing":{"blockGap":"0px"}}} -->
 		<div class="wp-block-buttons is-content-justification-center">
 			<!-- wp:button {"backgroundColor":"black","textColor":"white","className":"is-style-fill","fontSize":"medium","style":{"spacing":{"padding":{"left":"94px","right":"94px","top":"20px","bottom":"20px"}}}} -->


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

Ensure the editor preview for the Product Details Listing Pattern is correctly rendered after refreshing the editor page.

<!-- Reference any related issues or PRs here -->

Fixes #9562

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Screencast

https://github.com/woocommerce/woocommerce-blocks/assets/15730971/dca50261-fefe-49dd-8ae4-1127caa44564

### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Create a new post
2. Insert the new "Product Details: product listing" as demonstrated on the screencast.
3. Make sure the pattern is properly displayed on the Editor side without any errors in the console.
4. Save the post and refresh the editor page: make sure everything works as expected and without any errors.
5. Make sure the pattern is also displayed on the front end without any problems.

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Fix: Ensure the Product Details listing pattern is properly displayed in the editor after page refresh.
