### PR TITLE
Classic Product Template block visible in the inserter

### DIFF
--- a/assets/js/blocks/classic-template/index.tsx
+++ b/assets/js/blocks/classic-template/index.tsx
@@ -9,10 +9,7 @@ import {
 	unregisterBlockType,
 } from '@wordpress/blocks';
 import type { BlockEditProps } from '@wordpress/blocks';
-import {
-	isExperimentalBuild,
-	WC_BLOCKS_IMAGE_URL,
-} from '@woocommerce/block-settings';
+import { WC_BLOCKS_IMAGE_URL } from '@woocommerce/block-settings';
 import {
 	useBlockProps,
 	BlockPreview,
@@ -340,55 +337,46 @@ const registerClassicTemplateBlock = ( {
 
 let currentTemplateId: string | undefined;
 
-if ( isExperimentalBuild() ) {
-	subscribe( () => {
-		const previousTemplateId = currentTemplateId;
-		const store = select( 'core/edit-site' );
-		currentTemplateId = store?.getEditedPostId() as string | undefined;
+subscribe( () => {
+	const previousTemplateId = currentTemplateId;
+	const store = select( 'core/edit-site' );
+	currentTemplateId = store?.getEditedPostId() as string | undefined;
 
-		if ( previousTemplateId === currentTemplateId ) {
-			return;
-		}
+	if ( previousTemplateId === currentTemplateId ) {
+		return;
+	}
 
-		const parsedTemplate = currentTemplateId?.split( '//' )[ 1 ];
+	const parsedTemplate = currentTemplateId?.split( '//' )[ 1 ];
 
-		if ( parsedTemplate === null || parsedTemplate === undefined ) {
-			return;
-		}
+	if ( parsedTemplate === null || parsedTemplate === undefined ) {
+		return;
+	}
 
-		const block = getBlockType( BLOCK_SLUG );
+	const block = getBlockType( BLOCK_SLUG );
 
-		if (
-			block !== undefined &&
-			( ! hasTemplateSupportForClassicTemplateBlock(
-				parsedTemplate,
-				TEMPLATES
-			) ||
-				isClassicTemplateBlockRegisteredWithAnotherTitle(
-					block,
-					parsedTemplate
-				) )
-		) {
-			unregisterBlockType( BLOCK_SLUG );
-			currentTemplateId = undefined;
-			return;
-		}
+	if (
+		block !== undefined &&
+		( ! hasTemplateSupportForClassicTemplateBlock(
+			parsedTemplate,
+			TEMPLATES
+		) ||
+			isClassicTemplateBlockRegisteredWithAnotherTitle(
+				block,
+				parsedTemplate
+			) )
+	) {
+		unregisterBlockType( BLOCK_SLUG );
+		currentTemplateId = undefined;
+		return;
+	}
 
-		if (
-			block === undefined &&
-			hasTemplateSupportForClassicTemplateBlock(
-				parsedTemplate,
-				TEMPLATES
-			)
-		) {
-			registerClassicTemplateBlock( {
-				template: parsedTemplate,
-				inserter: true,
-			} );
-		}
-	} );
-} else {
-	registerClassicTemplateBlock( {
-		inserter: false,
-	} );
-}
+	if (
+		block === undefined &&
+		hasTemplateSupportForClassicTemplateBlock( parsedTemplate, TEMPLATES )
+	) {
+		registerClassicTemplateBlock( {
+			template: parsedTemplate,
+			inserter: true,
+		} );
+	}
+} );


### PR DESCRIPTION
Since that we are working on the enable the blockified templates by default, we want to allow merchants to roll back to the classic template. For this reason, it is necessary to update how we register the Classic Product Template block.


### Testing
#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Open the Site Editor.
2. Edit the `Single Product` template.
3. Be sure that the `Classic Product Template` is visible.
4. Click on `transform into blocks` button.
5. Open the inserter and search for: `WooCommerce Single Product Template` (for other templates, update the name with the name of the template).
6. Repeat those steps for: `Product Catalog`, `Products by Attribute`, `Products by Category`, `Products by Tag` and `Products Search Results` templates.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Classic Product Template block visible in the inserter
