### PR TITLE
Add to Cart with Options block: Restore the global variable to its original value after being overriden

### DIFF
--- a/src/BlockTypes/AddToCartForm.php
+++ b/src/BlockTypes/AddToCartForm.php
@@ -25,14 +25,19 @@ class AddToCartForm extends AbstractBlock {
 	 * @return string | void Rendered block output.
 	 */
 	protected function render( $attributes, $content, $block ) {
+		global $product;
+
 		$post_id = $block->context['postId'];
 
 		if ( ! isset( $post_id ) ) {
 			return '';
 		}
 
-		$product = wc_get_product( $post_id );
+		$previous_product = $product;
+		$product          = wc_get_product( $post_id );
 		if ( ! $product instanceof \WC_Product ) {
+			$product = $previous_product;
+
 			return '';
 		}
 
@@ -47,19 +52,25 @@ class AddToCartForm extends AbstractBlock {
 		$product = ob_get_clean();
 
 		if ( ! $product ) {
+			$product = $previous_product;
+
 			return '';
 		}
 
 		$classname          = $attributes['className'] ?? '';
 		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes );
 
-		return sprintf(
+		$form = sprintf(
 			'<div class="wp-block-add-to-cart-form product %1$s %2$s" style="%3$s">%4$s</div>',
 			esc_attr( $classes_and_styles['classes'] ),
 			esc_attr( $classname ),
 			esc_attr( $classes_and_styles['styles'] ),
 			$product
 		);
+
+		$product = $previous_product;
+
+		return $form;
 	}
 
 	/**


### PR DESCRIPTION
This is a short-term solution to restore the global product variable to its original value after being overridden within the Add to Cart with Options block. The definitive fix will be shipped on the next upcoming release as part of [9457](https://github.com/woocommerce/woocommerce-blocks/pull/9457) and [9494](https://github.com/woocommerce/woocommerce-blocks/pull/9494)

Ref. p1684924768318569/1684844881.656519-slack-C02UBB1EPEF

### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. While having a block theme enabled such as Twenty-twenty Three, head over to your Dashboard and on the sidebar, click on "Appearance > Editor".
2. Select the Single Product template to customize it and click on edit.
3. If you are still using the Classic template, click on the button to transform it to the blockifyed version. 
4. Make sure the Add to Cart with Options block is available for usage on the inserter (you can remove/add the block from the template), add it, and save.
5. On the frontend, ensure the button works as expected, and the product can be added to the cart.
6. Access the single template for all available product types, including simple, variable, grouped, and external and make sure you can add all of them to the cart.



#### Testing with Jetpack

1. Install and enable the Jetpack plugin on a live site (such as Jurassic Ninja).
3. Access `wp-admin/admin.php?page=jetpack_modules` to confirm the WooCommerce Analytics module is enabled.
4. While having a block theme enabled such as Twenty-twenty Three, head over to your Dashboard and on the sidebar, click on "Appearance > Editor".
2. Select the Single Product template to customize it and click on edit.
3. Add the single product block on the single product template and save.
4. Visit the product page on the front end when logged out and make sure everything works as expected (no fatal errors should be observed).

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix: ensure the global product variable is restored to its original value after being overridden within the Add to Cart with Options block.