### PR TITLE
Fix Mini-Cart block conflict with Page Optimize and Product Bundles

### DIFF
--- a/assets/js/base/utils/lazy-load-script.ts
+++ b/assets/js/base/utils/lazy-load-script.ts
@@ -45,6 +45,28 @@ const isScriptTagInDOM = ( scriptId: string, src = '' ): boolean => {
 		}
 	}
 
+	// PageOptimize concatenates several scripts into one. They can be
+	// identified with the `data-handles` attribute.
+	const pageOptimizeScriptTags = Array.from(
+		document.querySelectorAll( 'script[data-handles]' )
+	);
+	const pageOptimizeScriptInDom = pageOptimizeScriptTags.some(
+		( pageOptimizeScriptTag ) => {
+			if ( pageOptimizeScriptTag instanceof HTMLScriptElement ) {
+				const { handles } = pageOptimizeScriptTag.dataset;
+				const handlesArray = handles?.split( ',' );
+				const scriptSlug = scriptId.replace( '-js', '' );
+				if ( handlesArray?.includes( scriptSlug ) ) {
+					return true;
+				}
+			}
+			return false;
+		}
+	);
+	if ( pageOptimizeScriptInDom ) {
+		return true;
+	}
+
 	const srcParts = src.split( '?' );
 	if ( srcParts?.length > 1 ) {
 		src = srcParts[ 0 ];


### PR DESCRIPTION
Fixes #9584.

This PR refactors how we lazy-load Mini-Cart scripts, so we check if that script has already been loaded in a Page Optimize bundle. #9584 is not reproducible in the latest version of WC Blocks, as the dependency that was causing an issue was removed in https://github.com/woocommerce/woocommerce-blocks/pull/9251. However, I think it's a good idea to merge this PR into `trunk` instead of `release/10.0`, as the extra check can be beneficial to prevent potential future conflicts with Page Optimize.

### Testing

#### User Facing Testing

The issue is only reproducible in WC core 7.7 or WC Blocks 10.0.x. So please test with WC core 7.7 and [this zip](https://github.com/woocommerce/woocommerce-blocks/files/11554268/woocommerce-gutenberg-products-block.zip). (You can alternatively checkout the branch `release/10.0.0` and cherry-pick the commit included in this PR)

1. Add the Mini-Cart block to the header of your store.
2. Install the Page Optimize and Product Bundles plugins (no need to change anything in their configuration).
3. Go to a page in the frontend that doesn't have any block besides the Mini-Cart you added to the header.
4. Open the Mini-Cart and verify there is no JS error:

Before | After
--- | ---
![imatge](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/307b07c5-0c59-4d04-9599-8cc38691ead9) | ![imatge](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/108f21c1-a658-4441-9bad-910ec701bb36)

* [x] Do not include in the Testing Notes

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix a conflict between the Mini-Cart block and the Page Optimize and Product Bundles extensions.
