### PR TITLE
Fix Mini-Cart block conflict with Page Optimize and Product Bundles (II)

### DIFF
--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -328,7 +328,7 @@ class MiniCart extends AbstractBlock {
 		$wp_scripts = wp_scripts();
 
 		// This script and its dependencies have already been appended.
-		if ( ! $script || array_key_exists( $script->handle, $this->scripts_to_lazy_load ) ) {
+		if ( ! $script || array_key_exists( $script->handle, $this->scripts_to_lazy_load ) || wp_script_is( $script->handle, 'enqueued' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #9584.

Supersets https://github.com/woocommerce/woocommerce-blocks/pull/9585.

This PR ports the change introduced in https://github.com/woocommerce/woocommerce-blocks/pull/8979 to WC Blocks 10.0.x. It also modifies the status we compare against (`enqueued` instead of `done`), so we match any enqueued script, even if it hasn't been printed yet.

### Testing

#### User Facing Testing

0. Make sure you have WC core 7.7.
1. Search & replace all instances of `10.0.4` with `10.0.5` in the codebase and run `composer i`. Otherwise, WC core wouldn't load WC Blocks from the feature plugin.
2. Enable a block theme. 
3. Add the Mini-Cart block to the header of your store.
4. Install the Page Optimize and Product Bundles plugins (no need to change anything in their configuration).
5. Go to a page in the frontend that doesn't have any blocks besides the Mini-Cart you added to the header.
6. Open the Mini-Cart and verify there is no JS error:

Before | After
--- | ---
![imatge](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/307b07c5-0c59-4d04-9599-8cc38691ead9) | ![imatge](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/108f21c1-a658-4441-9bad-910ec701bb36)

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix a conflict between the Mini-Cart block and the Page Optimize and Product Bundles extensions.
