### PR TITLE
Prevent Mini-Cart dependency scripts to lazy-load if they have already been enqueued

### DIFF
--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -330,7 +330,7 @@ class MiniCart extends AbstractBlock {
 		$wp_scripts = wp_scripts();
 
 		// This script and its dependencies have already been appended.
-		if ( ! $script || array_key_exists( $script->handle, $this->scripts_to_lazy_load ) || wp_script_is( $script->handle, 'done' ) ) {
+		if ( ! $script || array_key_exists( $script->handle, $this->scripts_to_lazy_load ) || wp_script_is( $script->handle, 'enqueued' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Applies the fix from https://github.com/woocommerce/woocommerce-blocks/pull/9586 into `trunk`.

### Testing

#### User Facing Testing

1. Add the Mini Cart block to the header of your site (via Appearance > Editor).
2. Create a post or page with the All Products block.
3. Create another post or page without any WC Blocks.
4. In the frontend, visit both pages and in the browser console (<kbd>F12</kbd>) print these values: `Object.keys( wcBlocksMiniCartFrontendDependencies ).length` and `wcBlocksMiniCartFrontendDependencies['wp-react-refresh-entry']`.
5. Verify in the page with no blocks: `wcBlocksMiniCartFrontendDependencies['wp-react-refresh-entry']` is defined.
6. Verify in the All Products block page: `wcBlocksMiniCartFrontendDependencies['wp-react-refresh-entry']` is undefined and `Object.keys( wcBlocksMiniCartFrontendDependencies ).length` is smaller.
7. Verify in both pages you can interact with the Mini Cart block: open the drawer, change the items quantity, remove items from the cart, etc.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Exclude already-enqueued scripts from scripts to lazy load in the Mini Cart block
