### PR TITLE
Product Image Gallery block: Fix magnifying glass appearing outside the block content area

### DIFF
--- a/assets/js/atomic/blocks/product-elements/product-image-gallery/style.scss
+++ b/assets/js/atomic/blocks/product-elements/product-image-gallery/style.scss
@@ -19,6 +19,6 @@
 
 
 .woocommerce .wp-block-woocommerce-product-image-gallery .woocommerce-product-gallery.images {
-	width: 100%;
+	width: auto;
 }
 


### PR DESCRIPTION
## Description
This PR fixes the Product Image Gallery block that was displaying the magnifying glass icon (that contains the zoom functionality) outside the content area of the block.

## Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1f58de7</samp>
<samp>👨‍💻 Enhanced by @thealexandrelara </samp>

* Fix layout issue with product image gallery by changing width from 100% to auto ([link](https://github.com/woocommerce/woocommerce-blocks/pull/9594/files?diff=unified&w=0#diff-8832fcfeefd6161e24404f8912dab1c267c44243bc00c1fdc67ff923d154dfceL22-R22)) 

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #9402 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
| <img width="1333" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/20469356/f40a1223-8557-4556-9497-988876b72c77"> |  <img width="1333" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/20469356/cb151288-1838-40dc-9fdd-49d035a263a3">  |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Log in to your WordPress dashboard.
2. From your WordPress dashboard, go to Appearance > Themes. Make sure you have a block-based theme installed and activated. If not, you can install one from the Add New option. Block-based themes include "Twenty-twenty Two," "Twenty-twenty Three", etc.
3. On the left-hand side menu, click on Appearance > Editor. This will open the Site Editor.
4. On the left-hand side menu, click on Templates. This will open the list of available templates.
5. Find and select the Single Product template from the list.
6. When the Classic Product Template renders, click on Transform into Blocks. This will transform the Classic template in a block template if you haven't done it before.
7. Inside the Site editor, click on the List View button, usually found at the top left of the editing space, to see the list of blocks added to the editor area.
8. In the list of blocks, move the Product Image Gallery block to be above the Breadcrumbs block;
9. Once the Product Image Gallery block is displayed on top of the Breadcrumbs block in the Editor area, on the top-right side click on the Save button;
10. Visit the product page and make sure that the magnifying glass is correctly displayed on the top right corner of the image

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Product Image Gallery block: Fix magnifying glass appearing outside the block content area 