### PR TITLE
Fix Cambodian postcode validation

### DIFF
--- a/packages/checkout/utils/validation/is-postcode.ts
+++ b/packages/checkout/utils/validation/is-postcode.ts
@@ -14,6 +14,7 @@ const CUSTOM_REGEXES = new Map< string, RegExp >( [
 	[ 'LI', /^(94[8-9][0-9])$/ ],
 	[ 'NL', /^([1-9][0-9]{3})(\s?)(?!SA|SD|SS)[A-Z]{2}$/i ],
 	[ 'SI', /^([1-9][0-9]{3})$/ ],
+	[ 'KH', /^[0-9]{6}$/ ], // Cambodia (6-digit postal code)
 ] );
 
 const DEFAULT_REGEXES = new Map< string, RegExp >( [

--- a/packages/checkout/utils/validation/test/is-postcode.ts
+++ b/packages/checkout/utils/validation/test/is-postcode.ts
@@ -167,6 +167,11 @@ describe( 'isPostcode', () => {
 		[ true, '99577-0727', 'US' ],
 		[ false, 'ABCDE', 'US' ],
 		[ false, 'ABCDE-9999', 'US' ],
+
+		// Cambodian postcodes
+		[ false, '12345', 'KH' ],
+		[ false, '1234', 'KH' ],
+		[ true, '123456', 'KH' ],
 	];
 
 	test.each( cases )( '%s: %s for %s', ( result, postcode, country ) =>


### PR DESCRIPTION
Cambodia previously required a 5-digit postal code, but since 2018, the country has shifted to a 6-digit postal code system. This PR aims to rectify Cambodia's postal code validation process, allowing for the acceptance of 6-digit postal codes instead of 5-digit ones.

The issue was reported Slack: p1684956900749749-slack-C7U3Y3VMY


## Changes in the PR:
- Added the regex for Cambodia postal code. 
- Added the unit test for Cambodia.



### Testing

#### Automated Tests
* [x] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Add a product to the cart and go to the checkout page.
2. Select Cambodia country as country. 
3. Enter a 5-digit postcode. 
4. Verify that the postcode fails the validation.
5. Enter a 6-digit postcode. 
6. Verify that the postcode passes the validation.
7. Select United Kingdom (UK) as country.
8. Verify that the postcode `AA9A 9AA` passes the validation.
9. Verify that the postcode `9999 999` fails the validation.
10. Verify that it's not possible to have spaces before the postcode, .e.g. ` AA9A 9AA`.
11. Verify that lowercase letters, e.g. `aa9A 9aa`, are automatically converted to uppercase letters, e.g. `AA9A 9AA`.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental


### Changelog

> Fix Cambodian postcode validation