### PR TITLE
Fix invisible Mini-Cart badge in themes without <body> background

### DIFF
--- a/assets/js/blocks/mini-cart/utils/set-styles.ts
+++ b/assets/js/blocks/mini-cart/utils/set-styles.ts
@@ -26,12 +26,10 @@ function setStyles() {
 	const firstMiniCartButton = document.querySelector(
 		'.wc-block-mini-cart__button'
 	);
-	const badgeTextColor = firstMiniCartButton
-		? getClosestColor( firstMiniCartButton, 'backgroundColor' )
-		: 'inherit';
-	const badgeBackgroundColor = firstMiniCartButton
-		? getClosestColor( firstMiniCartButton, 'color' )
-		: 'inherit';
+	const badgeTextColor =
+		getClosestColor( firstMiniCartButton, 'backgroundColor' ) || '#fff';
+	const badgeBackgroundColor =
+		getClosestColor( firstMiniCartButton, 'color' ) || '#000';
 
 	// We use :where here to reduce specificity so customized colors and theme
 	// CSS take priority.


### PR DESCRIPTION
This PR simplifies the code and fixes the case where, if a theme had no background color, the Mini-Cart badge text would be invisible.

Note: this PR assumes that if a theme has no background, the background of the page is going to be white. It's technically possible for a user to set a different background color in their browser settings, but I think we can assume this is going to be an edge case.

### Testing

#### User Facing Testing

1. With any block theme, go to Appearance > Editor > edit any template > Styles > Additional CSS and add these styles:
```CSS
body {
  background: transparent !important;
}
```
2. Add the Mini-Cart block to the header of your site or to a post or page.
3. In the frontend, add some products to your cart.
4. Verify the Mini-Cart badge is visible.

Before | After
--- | ---
![imatge](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/f1be4c5a-b9ec-4b92-bb3d-3083ceb9f4e9) | ![imatge](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/01ed4c2f-f2a8-4fee-abba-e4c53413079c)

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix Mini-Cart badge not visible in themes without a `<body>` background color
