### PR TITLE
Stack cart and checkout buttons on smaller screens

### DIFF
--- a/assets/js/blocks/mini-cart/style.scss
+++ b/assets/js/blocks/mini-cart/style.scss
@@ -174,11 +174,13 @@ h2.wc-block-mini-cart__title {
 		}
 
 		.wp-block-woocommerce-mini-cart-cart-button-block {
-			display: none;
-
 			@media only screen and (min-width: 480px) {
 				display: inline-flex;
 			}
+		}
+
+		@media only screen and (max-width: 480px) {
+			flex-direction: column;
 		}
 	}
 


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/9557

This PR removes a curious `display: none` on the `View my cart` button and in addition, styles the buttons to stack on smaller screens.

Note that I opted not to put `Checkout` before `View my cart` button as in the suggested design because there is not clean way to make the `tabbing` order to work well which would introduce an accessibility issue. For example changing `order` property on the two buttons in CSS would indeed visually work however tabbing would then be off. You would need to utilize `tabindex` and have that change based on browser width via JS but in this case I don't think that is urgent.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Regular width | Mobile width |
| ------ | ----- |
|![eEU1UJ.png](https://github.com/woocommerce/woocommerce-blocks/assets/2132595/5f6d0e3b-adf6-4d4b-9f01-2b0798e72674)|![oxQbkR.png](https://github.com/woocommerce/woocommerce-blocks/assets/2132595/7a4d6753-6b7f-463a-935d-f8d0f153a26d)|

### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. In a post/page add the `Mini Cart` block.
2. In the frontend, click on the mini cart button to reveal the drawer.
3. Ensure the `View my cart` and `Checkout` buttons are visible and side by side.
4. Using the developer tools, switch to a mobile view.
5. Ensure now the `View my cart` and `Checkout` buttons are visible and now stacked top and bottom.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix non visible cart button on mini cart in certain themes