### PR TITLE
Clarify step when bumping a release in WC core

### DIFF
--- a/.github/patch-initial-checklist.md
+++ b/.github/patch-initial-checklist.md
@@ -79,7 +79,7 @@ This only needs done if the patch release needs to be included in WooCommerce Co
     -   The content for the pull release can follow [this example](https://github.com/woocommerce/woocommerce/pull/32627).
 
         -   [ ] Increase the version of `woocommerce/woocommerce-blocks` in the `plugins/woocommerce/composer.json` file
-        -   [ ] Run `composer update woocommerce/woocommerce-blocks` and make sure `composer-lock.json` was updated
+        -   [ ] Inside `plugins/woocommerce/`, run `composer update woocommerce/woocommerce-blocks` and make sure `composer.lock` was updated
         -   [ ] Run `pnpm --filter=woocommerce changelog add` to create a new changelog file similar to this one [plugins/woocommerce/changelog/update-woocommerce-blocks-7.4.1](https://github.com/woocommerce/woocommerce/blob/5040a10d01896bcf40fd0ac538f2b7bc584ffe0a/plugins/woocommerce/changelog/update-woocommerce-blocks-7.4.1). The file will be auto-generated with your answers. For the _Significance_ entry we’ll always use `patch` for WC Blocks patch releases:
 
             ```md

--- a/.github/release-initial-checklist.md
+++ b/.github/release-initial-checklist.md
@@ -93,7 +93,7 @@ This only needs to be done if this release is the last release of the feature pl
     -   The content for the pull release can follow [this example](https://github.com/woocommerce/woocommerce/pull/32627).
 
         -   [ ] Increase the version of `woocommerce/woocommerce-blocks` in the `plugins/woocommerce/composer.json` file
-        -   [ ] Run `composer update woocommerce/woocommerce-blocks` and make sure `composer-lock.json` was updated
+        -   [ ] Inside `plugins/woocommerce/`, run `composer update woocommerce/woocommerce-blocks` and make sure `composer.lock` was updated
         -   [ ] Run `pnpm --filter=woocommerce changelog add` to create a new changelog file similar to this one [plugins/woocommerce/changelog/update-woocommerce-blocks-7.4.1](https://github.com/woocommerce/woocommerce/blob/5040a10d01896bcf40fd0ac538f2b7bc584ffe0a/plugins/woocommerce/changelog/update-woocommerce-blocks-7.4.1). The file will be auto-generated with your answers. For the _Significance_ entry we’ll always use `minor` for WC Blocks major releases:
 
             ```md


### PR DESCRIPTION
This PR updates one of the release steps to clarify that the release lead needs to `cd plugins/woocommerce` before running `composer update woocommerce/woocommerce-blocks`. It also corrects the file name that needs to be added from `composer-lock.json` to `composer.lock`.

### Testing

1. Make sure the new step makes sense.

* [x] Do not include in the Testing Notes