### PR TITLE
Remove `setFullAddressPushed` to prevent address continually pushing

### DIFF
--- a/assets/js/data/cart/actions.ts
+++ b/assets/js/data/cart/actions.ts
@@ -479,13 +479,6 @@ export const updateCustomerData =
 		}
 	};
 
-export const setFullShippingAddressPushed = (
-	fullShippingAddressPushed: boolean
-) => ( {
-	type: types.SET_FULL_SHIPPING_ADDRESS_PUSHED,
-	fullShippingAddressPushed,
-} );
-
 type Actions =
 	| typeof addItemToCart
 	| typeof applyCoupon
@@ -506,7 +499,6 @@ type Actions =
 	| typeof setShippingAddress
 	| typeof shippingRatesBeingSelected
 	| typeof updateCustomerData
-	| typeof setFullShippingAddressPushed
 	| typeof updatingCustomerData;
 
 export type CartAction = ReturnOrGeneratorYieldUnion< Actions | Thunks >;

--- a/assets/js/data/cart/default-state.ts
+++ b/assets/js/data/cart/default-state.ts
@@ -100,7 +100,6 @@ export const defaultCartState: CartState = {
 		applyingCoupon: '',
 		removingCoupon: '',
 		isCartDataStale: false,
-		fullShippingAddressPushed: false,
 	},
 	errors: EMPTY_CART_ERRORS,
 };

--- a/assets/js/data/cart/push-changes.ts
+++ b/assets/js/data/cart/push-changes.ts
@@ -20,7 +20,6 @@ import isShallowEqual from '@wordpress/is-shallow-equal';
 import { STORE_KEY } from './constants';
 import { VALIDATION_STORE_KEY } from '../validation';
 import { processErrorResponse } from '../utils';
-import { shippingAddressHasValidationErrors } from './utils';
 
 type CustomerData = {
 	billingAddress: CartBillingAddress;
@@ -211,11 +210,6 @@ const updateCustomerData = debounce( (): void => {
 							customerDataToUpdate.shipping_address
 						) as BaseAddressKey[] ),
 					];
-				}
-			} )
-			.finally( () => {
-				if ( ! shippingAddressHasValidationErrors() ) {
-					dispatch( STORE_KEY ).setFullShippingAddressPushed( true );
 				}
 			} );
 	}

--- a/assets/js/data/cart/reducers.ts
+++ b/assets/js/data/cart/reducers.ts
@@ -48,15 +48,6 @@ const reducer: Reducer< CartState > = (
 	action: Partial< CartAction >
 ) => {
 	switch ( action.type ) {
-		case types.SET_FULL_SHIPPING_ADDRESS_PUSHED:
-			state = {
-				...state,
-				metaData: {
-					...state.metaData,
-					fullShippingAddressPushed: action.fullShippingAddressPushed,
-				},
-			};
-			break;
 		case types.SET_ERROR_DATA:
 			if ( action.error ) {
 				state = {

--- a/assets/js/data/cart/resolvers.ts
+++ b/assets/js/data/cart/resolvers.ts
@@ -9,7 +9,6 @@ import { CartResponse } from '@woocommerce/types';
  */
 import { CART_API_ERROR } from './constants';
 import type { CartDispatchFromMap, CartResolveSelectFromMap } from './index';
-import { shippingAddressHasValidationErrors } from './utils';
 
 /**
  * Resolver for retrieving all cart data.
@@ -27,10 +26,6 @@ export const getCartData =
 		if ( ! cartData ) {
 			receiveError( CART_API_ERROR );
 			return;
-		}
-
-		if ( ! shippingAddressHasValidationErrors() ) {
-			dispatch.setFullShippingAddressPushed( true );
 		}
 		receiveCart( cartData );
 	};

--- a/assets/js/data/cart/selectors.ts
+++ b/assets/js/data/cart/selectors.ts
@@ -222,10 +222,3 @@ export const getItemsPendingQuantityUpdate = ( state: CartState ): string[] => {
 export const getItemsPendingDelete = ( state: CartState ): string[] => {
 	return state.cartItemsPendingDelete;
 };
-
-/**
- * Whether the address has changes that have not been synced with the server.
- */
-export const getFullShippingAddressPushed = ( state: CartState ): boolean => {
-	return state.metaData.fullShippingAddressPushed;
-};

--- a/assets/js/types/type-defs/cart.ts
+++ b/assets/js/types/type-defs/cart.ts
@@ -210,8 +210,6 @@ export interface CartMeta {
 	isCartDataStale: boolean;
 	applyingCoupon: string;
 	removingCoupon: string;
-	/* Whether the full address has been previously pushed to the server */
-	fullShippingAddressPushed: boolean;
 }
 export interface ExtensionCartUpdateArgs {
 	data: Record< string, unknown >;


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

⚠️ Note, this is a 'bandaid' fix that does not fully resolve the underlying issue, but it does remove a symptom.

This PR removes the actions, selectors, and reducer case for `setFullAddressPushed` from the `wc/store/cart` data store.

This is no longer used by anything and should have been removed in #8964

Removing this fixes #9591. The reason it fixes it is because we subscribe to changes in the data store in https://github.com/woocommerce/woocommerce-blocks/blob/981affaab611d26eb07f238818e3103dac3bd7c4/assets/js/data/cart/index.ts#L35

Due to this, every time the `wc/store/cart` data store changes in any way, the [`pushChanges`](https://github.com/woocommerce/woocommerce-blocks/blob/f861dd6e9fa0d7e35f950bf3d94fa52903a31600/assets/js/data/cart/push-changes.ts#L222) function runs. This is responsible for sending the client-side address to the server.

The `pushChanges` function diffs the address in the data store, and the address in the form, and if they are different it sends it to the server.

In #9591 we illustrate a case where the address does not push to the server due to an incorrect ZIP code when changing country. Because of this, when the server returns the cart following a push attempt, the old address is there (it doesn't update on the server because it's invalid). Because of this, the push-changes code notices the diff, and tries to re-push.

Because the ZIP code is never revalidated on the client, nothing stops push-changes from running.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Ensure you have shipping rates set up for UK.
2. Add an item to your cart, go to the Checkout block.
3. Enter a full address using United Kingdom as the country, enter `L1 0BP` as the Postcode. Wait for shipping rates to load.
4. Change country to Portugal. Do not change anything else.
5. Ensure the shipping rates don't continually load.

##### Internal testing
Repeat steps above, but use the network monitor in dev tools to watch for batch requests, you should not see continually repeated batch requests.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix an issue where changing country could cause shipping rates to constantly reload.
