### PR TITLE
Fix PHP lint

### DIFF
--- a/src/BlockTypes/ProductCollection.php
+++ b/src/BlockTypes/ProductCollection.php
@@ -4,10 +4,6 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
 use WP_Query;
 
-// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_tax_query
-// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_key
-
 /**
  * ProductCollection class.
  */
@@ -129,6 +125,7 @@ class ProductCollection extends AbstractBlock {
 		$block_context_query = $block->context['query'];
 
 		$common_query_values = array(
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 			'meta_query'     => array(),
 			'posts_per_page' => $block_context_query['perPage'],
 			'order'          => $block_context_query['order'],
@@ -136,6 +133,7 @@ class ProductCollection extends AbstractBlock {
 			'post__in'       => array(),
 			'post_status'    => 'publish',
 			'post_type'      => 'product',
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 			'tax_query'      => array(),
 			'paged'          => $page,
 		);
@@ -228,6 +226,7 @@ class ProductCollection extends AbstractBlock {
 		);
 
 		return array(
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 			'meta_key' => $meta_keys[ $orderby ],
 			'orderby'  => 'meta_value_num',
 		);
@@ -392,6 +391,7 @@ class ProductCollection extends AbstractBlock {
 		}
 
 		return array(
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 			'meta_query' => array(
 				array(
 					'key'     => '_stock_status',
@@ -419,6 +419,7 @@ class ProductCollection extends AbstractBlock {
 		}
 
 		return array(
+			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 			'tax_query' => array(
 				array(
 					'taxonomy' => 'product_visibility',
@@ -443,6 +444,7 @@ class ProductCollection extends AbstractBlock {
 				$tax_query = array_merge( $tax_query, $query['tax_query'] );
 			}
 		}
+		// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 		return [ 'tax_query' => $tax_query ];
 	}
 }

--- a/src/BlockTypes/ProductCollection.php
+++ b/src/BlockTypes/ProductCollection.php
@@ -4,6 +4,10 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
 use WP_Query;
 
+// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+
 /**
  * ProductCollection class.
  */

--- a/src/BlockTypes/ProductImage.php
+++ b/src/BlockTypes/ProductImage.php
@@ -145,7 +145,7 @@ class ProductImage extends AbstractBlock {
 	 * @return string
 	 */
 	private function render_image( $product, $attributes ) {
-		$image_type = 'single' == $attributes['imageSizing'] ? 'woocommerce_single' : 'woocommerce_thumbnail';
+		$image_type = 'single' === $attributes['imageSizing'] ? 'woocommerce_single' : 'woocommerce_thumbnail';
 		$image_info = wp_get_attachment_image_src( get_post_thumbnail_id( $product->get_id() ), $image_type );
 
 		if ( ! isset( $image_info[0] ) ) {

--- a/src/BlockTypes/ProductRating.php
+++ b/src/BlockTypes/ProductRating.php
@@ -60,10 +60,10 @@ class ProductRating extends AbstractBlock {
 	private function parse_attributes( $attributes ) {
 		// These should match what's set in JS `registerBlockType`.
 		$defaults = array(
-			'productId'               => 0,
-			'isDescendentOfQueryLoop' => false,
-			'textAlign'         => '',
-			'isDescendentOfSingleProductBlock'           => false,
+			'productId'                        => 0,
+			'isDescendentOfQueryLoop'          => false,
+			'textAlign'                        => '',
+			'isDescendentOfSingleProductBlock' => false,
 		);
 
 		return wp_parse_args( $attributes, $defaults );
@@ -105,9 +105,9 @@ class ProductRating extends AbstractBlock {
 		$product = wc_get_product( $post_id );
 
 		if ( $product ) {
-			$product_reviews_count = $product->get_review_count();
-			$product_rating = $product->get_average_rating();
-			$parsed_attributes = $this->parse_attributes( $attributes );
+			$product_reviews_count                 = $product->get_review_count();
+			$product_rating                        = $product->get_average_rating();
+			$parsed_attributes                     = $this->parse_attributes( $attributes );
 			$is_descendent_of_single_product_block = $parsed_attributes['isDescendentOfSingleProductBlock'];
 
 			$styles_and_classes            = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes );
@@ -123,8 +123,8 @@ class ProductRating extends AbstractBlock {
 			 */
 			$filter_rating_html = function( $html, $rating, $count ) use ( $product_rating, $product_reviews_count, $is_descendent_of_single_product_block ) {
 				$product_permalink = get_permalink();
-				$reviews_count = $count;
-				$average_rating = $rating;
+				$reviews_count     = $count;
+				$average_rating    = $rating;
 
 				if ( $product_rating ) {
 					$average_rating = $product_rating;
@@ -136,7 +136,7 @@ class ProductRating extends AbstractBlock {
 
 				if ( 0 < $average_rating || false === $product_permalink ) {
 					/* translators: %s: rating */
-					$label = sprintf( __( 'Rated %s out of 5', 'woo-gutenberg-products-block' ), $average_rating );
+					$label                  = sprintf( __( 'Rated %s out of 5', 'woo-gutenberg-products-block' ), $average_rating );
 					$customer_reviews_count = sprintf(
 						/* translators: %s is referring to the total of reviews for a product */
 						_n(
@@ -153,7 +153,7 @@ class ProductRating extends AbstractBlock {
 						</span>',
 						$customer_reviews_count
 					);
-					$html  = sprintf(
+					$html               = sprintf(
 						'<div class="wc-block-components-product-rating__container">
 							<div class="wc-block-components-product-rating__stars wc-block-grid__product-rating__stars" role="img" aria-label="%1$s">
 								%2$s
@@ -166,7 +166,7 @@ class ProductRating extends AbstractBlock {
 						$is_descendent_of_single_product_block ? $reviews_count_html : ''
 					);
 				} else {
-					$html               = '';
+					$html = '';
 				}
 
 				return $html;

--- a/src/BlockTypes/ProductTemplate.php
+++ b/src/BlockTypes/ProductTemplate.php
@@ -37,7 +37,8 @@ class ProductTemplate extends AbstractBlock {
 	 */
 	protected function render( $attributes, $content, $block ) {
 		$page_key = isset( $block->context['queryId'] ) ? 'query-' . $block->context['queryId'] . '-page' : 'query-page';
-		$page     = empty( $_GET[ $page_key ] ) ? 1 : (int) $_GET[ $page_key ];
+		// phpcs:ignore WordPress.Security.NonceVerification
+		$page = empty( $_GET[ $page_key ] ) ? 1 : (int) $_GET[ $page_key ];
 
 		// Use global query if needed.
 		$use_global_query = ( isset( $block->context['query']['inherit'] ) && $block->context['query']['inherit'] );

--- a/src/StoreApi/Utilities/ProductQueryFilters.php
+++ b/src/StoreApi/Utilities/ProductQueryFilters.php
@@ -5,7 +5,6 @@ use Automattic\WooCommerce\StoreApi\Utilities\ProductQuery;
 use Exception;
 use WP_REST_Request;
 
-// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.UnquotedComplexPlaceholder
 
 /**
  * Product Query filters class.
@@ -277,6 +276,7 @@ class ProductQueryFilters {
 
 		global $wpdb;
 		$counts = $wpdb->get_results(
+		// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.UnquotedComplexPlaceholder
 			$wpdb->prepare(
 				"
 				SELECT attributes.term_id as term_count_id, coalesce(term_count, 0) as term_count
@@ -298,6 +298,7 @@ class ProductQueryFilters {
 			)
 		);
 
+		// phpcs:enable
 		$results = array_map( 'absint', wp_list_pluck( $counts, 'term_count', 'term_count_id' ) );
 
 		set_transient( $transient_key, $results, 24 * HOUR_IN_SECONDS );
@@ -413,6 +414,7 @@ class ProductQueryFilters {
 			$where_clause = implode( ' AND ', $where );
 			$where_clause = sprintf( $where_clause, ...$params );
 
+		// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.UnquotedComplexPlaceholder
 			$results = $wpdb->get_col(
 				$wpdb->prepare(
 					"SELECT DISTINCT product_id FROM {$wpdb->prefix}wc_product_meta_lookup WHERE %1s",
@@ -420,6 +422,7 @@ class ProductQueryFilters {
 				)
 			);
 		}
+		// phpcs:enable
 
 		return $results;
 	}
@@ -442,6 +445,7 @@ class ProductQueryFilters {
 
 		if ( 'or' === $query_type ) {
 			$results = $wpdb->get_col(
+			// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.UnquotedComplexPlaceholder
 				$wpdb->prepare(
 					"
 					SELECT DISTINCT `product_or_parent_id`
@@ -452,11 +456,13 @@ class ProductQueryFilters {
 					$taxonomy,
 					$term_ids
 				)
+			// phpcs:enable
 			);
 		}
 
 		if ( 'and' === $query_type ) {
 			$results = $wpdb->get_col(
+			// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.UnquotedComplexPlaceholder
 				$wpdb->prepare(
 					"
 					SELECT DISTINCT `product_or_parent_id`
@@ -470,6 +476,7 @@ class ProductQueryFilters {
 					$term_ids,
 					$term_count
 				)
+			// phpcs:enable
 			);
 		}
 

--- a/src/StoreApi/Utilities/ProductQueryFilters.php
+++ b/src/StoreApi/Utilities/ProductQueryFilters.php
@@ -5,6 +5,8 @@ use Automattic\WooCommerce\StoreApi\Utilities\ProductQuery;
 use Exception;
 use WP_REST_Request;
 
+// phpcs:disable WordPress.DB.PreparedSQLPlaceholders.UnquotedComplexPlaceholder
+
 /**
  * Product Query filters class.
  */


### PR DESCRIPTION
I noticed that the PHP Coding Standard job didn't fail even if `npm run lint:php` locally returned errors. This PR fixes this wrong behavior.


<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 9370e88</samp>

### Summary
🛠️🚫🎨

<!--
1.  🛠️ for fixing the strict comparison operator and the indentation and whitespace issues.
2. 🚫 for disabling some coding standards checks that are not applicable or necessary for the block functionality.
3. 🎨 for improving the code style and readability of the product template class.
-->
This pull request fixes some code style and formatting issues in the product collection block and its related classes, and adds some PHPCS directives to avoid coding standards warnings for some necessary queries. It affects the files `src/BlockTypes/ProductRating.php`, `src/BlockTypes/ProductTemplate.php`, `src/BlockTypes/ProductCollection.php`, `src/BlockTypes/ProductImage.php`, and `src/StoreApi/Utilities/ProductQueryFilters.php`.

> _We are the masters of the block_
> _We defy the standards of the flock_
> _We render, filter, query and rate_
> _We code with style and seal our fate_

### Walkthrough
*  Disable coding standards checks for tax query and meta query parts of product collection block ([link](https://github.com/woocommerce/woocommerce-blocks/pull/9608/files?diff=unified&w=0#diff-75d156222859a3e0accbc0ca51367843adb6a7be8c1fbc27ab183f0cd25d35b6R7-R10))
*  Fix strict comparison operator for `imageSizing` attribute in `render_image` method of `ProductImage` class ([link](https://github.com/woocommerce/woocommerce-blocks/pull/9608/files?diff=unified&w=0#diff-39f14c2d1e1a8ef0880484caca890c50d7823373786c07162fb50bb43acbc235L148-R148))
*  Align indentation of array elements, variable assignments, and HTML output in `parse_attributes` and `render` methods of `ProductRating` class ([link](https://github.com/woocommerce/woocommerce-blocks/pull/9608/files?diff=unified&w=0#diff-9defe615963571610affb73341a43db364eeb7fc5616000176494510be3e8e70L63-R66), [link](https://github.com/woocommerce/woocommerce-blocks/pull/9608/files?diff=unified&w=0#diff-9defe615963571610affb73341a43db364eeb7fc5616000176494510be3e8e70L108-R110), [link](https://github.com/woocommerce/woocommerce-blocks/pull/9608/files?diff=unified&w=0#diff-9defe615963571610affb73341a43db364eeb7fc5616000176494510be3e8e70L126-R127), [link](https://github.com/woocommerce/woocommerce-blocks/pull/9608/files?diff=unified&w=0#diff-9defe615963571610affb73341a43db364eeb7fc5616000176494510be3e8e70L139-R139), [link](https://github.com/woocommerce/woocommerce-blocks/pull/9608/files?diff=unified&w=0#diff-9defe615963571610affb73341a43db364eeb7fc5616000176494510be3e8e70L156-R156), [link](https://github.com/woocommerce/woocommerce-blocks/pull/9608/files?diff=unified&w=0#diff-9defe615963571610affb73341a43db364eeb7fc5616000176494510be3e8e70L169-R169))
*  Add empty line after namespace declaration and PHPCS ignore comment for `$page` variable assignment from `$_GET` superglobal in `render` method of `ProductTemplate` class ([link](https://github.com/woocommerce/woocommerce-blocks/pull/9608/files?diff=unified&w=0#diff-d3c351cc9679b1bcce48c9bae74cec6eed74ba97feb4542847064d72ee74d2fbR8-R9), [link](https://github.com/woocommerce/woocommerce-blocks/pull/9608/files?diff=unified&w=0#diff-d3c351cc9679b1bcce48c9bae74cec6eed74ba97feb4542847064d72ee74d2fbL40-R43))
*  Disable coding standards check for unquoted complex placeholder in `get_products` method of `ProductQueryFilters` class in `src/StoreApi/Utilities/ProductQueryFilters.php` ([link](https://github.com/woocommerce/woocommerce-blocks/pull/9608/files?diff=unified&w=0#diff-6cb17b3225eb1e5b3f6b92fbd6e93bca76025ae4a68984d9e1894e3111828dfcR8-R9))




### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Be sure that PHP Coding Standard job doesn't fail 

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental


