### PR TITLE
Add `revalidateDependencies` to `ValidatedTextInput`

### DIFF
--- a/assets/js/data/cart/actions.ts
+++ b/assets/js/data/cart/actions.ts
@@ -479,13 +479,6 @@ export const updateCustomerData =
 		}
 	};
 
-export const setFullShippingAddressPushed = (
-	fullShippingAddressPushed: boolean
-) => ( {
-	type: types.SET_FULL_SHIPPING_ADDRESS_PUSHED,
-	fullShippingAddressPushed,
-} );
-
 type Actions =
 	| typeof addItemToCart
 	| typeof applyCoupon
@@ -506,7 +499,6 @@ type Actions =
 	| typeof setShippingAddress
 	| typeof shippingRatesBeingSelected
 	| typeof updateCustomerData
-	| typeof setFullShippingAddressPushed
 	| typeof updatingCustomerData;
 
 export type CartAction = ReturnOrGeneratorYieldUnion< Actions | Thunks >;

--- a/assets/js/data/cart/default-state.ts
+++ b/assets/js/data/cart/default-state.ts
@@ -100,7 +100,6 @@ export const defaultCartState: CartState = {
 		applyingCoupon: '',
 		removingCoupon: '',
 		isCartDataStale: false,
-		fullShippingAddressPushed: false,
 	},
 	errors: EMPTY_CART_ERRORS,
 };

--- a/assets/js/data/cart/push-changes.ts
+++ b/assets/js/data/cart/push-changes.ts
@@ -20,7 +20,6 @@ import isShallowEqual from '@wordpress/is-shallow-equal';
 import { STORE_KEY } from './constants';
 import { VALIDATION_STORE_KEY } from '../validation';
 import { processErrorResponse } from '../utils';
-import { shippingAddressHasValidationErrors } from './utils';
 
 type CustomerData = {
 	billingAddress: CartBillingAddress;
@@ -211,11 +210,6 @@ const updateCustomerData = debounce( (): void => {
 							customerDataToUpdate.shipping_address
 						) as BaseAddressKey[] ),
 					];
-				}
-			} )
-			.finally( () => {
-				if ( ! shippingAddressHasValidationErrors() ) {
-					dispatch( STORE_KEY ).setFullShippingAddressPushed( true );
 				}
 			} );
 	}

--- a/assets/js/data/cart/reducers.ts
+++ b/assets/js/data/cart/reducers.ts
@@ -48,15 +48,6 @@ const reducer: Reducer< CartState > = (
 	action: Partial< CartAction >
 ) => {
 	switch ( action.type ) {
-		case types.SET_FULL_SHIPPING_ADDRESS_PUSHED:
-			state = {
-				...state,
-				metaData: {
-					...state.metaData,
-					fullShippingAddressPushed: action.fullShippingAddressPushed,
-				},
-			};
-			break;
 		case types.SET_ERROR_DATA:
 			if ( action.error ) {
 				state = {

--- a/assets/js/data/cart/resolvers.ts
+++ b/assets/js/data/cart/resolvers.ts
@@ -9,7 +9,6 @@ import { CartResponse } from '@woocommerce/types';
  */
 import { CART_API_ERROR } from './constants';
 import type { CartDispatchFromMap, CartResolveSelectFromMap } from './index';
-import { shippingAddressHasValidationErrors } from './utils';
 
 /**
  * Resolver for retrieving all cart data.
@@ -27,10 +26,6 @@ export const getCartData =
 		if ( ! cartData ) {
 			receiveError( CART_API_ERROR );
 			return;
-		}
-
-		if ( ! shippingAddressHasValidationErrors() ) {
-			dispatch.setFullShippingAddressPushed( true );
 		}
 		receiveCart( cartData );
 	};

--- a/assets/js/data/cart/selectors.ts
+++ b/assets/js/data/cart/selectors.ts
@@ -222,10 +222,3 @@ export const getItemsPendingQuantityUpdate = ( state: CartState ): string[] => {
 export const getItemsPendingDelete = ( state: CartState ): string[] => {
 	return state.cartItemsPendingDelete;
 };
-
-/**
- * Whether the address has changes that have not been synced with the server.
- */
-export const getFullShippingAddressPushed = ( state: CartState ): boolean => {
-	return state.metaData.fullShippingAddressPushed;
-};

--- a/assets/js/types/type-defs/cart.ts
+++ b/assets/js/types/type-defs/cart.ts
@@ -210,8 +210,6 @@ export interface CartMeta {
 	isCartDataStale: boolean;
 	applyingCoupon: string;
 	removingCoupon: string;
-	/* Whether the full address has been previously pushed to the server */
-	fullShippingAddressPushed: boolean;
 }
 export interface ExtensionCartUpdateArgs {
 	data: Record< string, unknown >;

--- a/packages/checkout/components/text-input/validated-text-input.tsx
+++ b/packages/checkout/components/text-input/validated-text-input.tsx
@@ -121,7 +121,6 @@ const ValidatedTextInput = ( {
 			} );
 		},
 		[
-			previousValue,
 			clearValidationError,
 			customValidation,
 			errorIdString,

--- a/packages/checkout/components/text-input/validated-text-input.tsx
+++ b/packages/checkout/components/text-input/validated-text-input.tsx
@@ -102,10 +102,6 @@ const ValidatedTextInput = ( {
 			inputObject.value = inputObject.value.trim();
 			inputObject.setCustomValidity( '' );
 
-			if ( previousValue === inputObject.value && ! forceRevalidation ) {
-				return;
-			}
-
 			const inputIsValid = customValidation
 				? inputObject.checkValidity() && customValidation( inputObject )
 				: inputObject.checkValidity();
@@ -238,7 +234,16 @@ const ValidatedTextInput = ( {
 				onChange( val );
 			} }
 			onBlur={ () => {
-				validateInput( { errorsHidden: false } );
+				// Don't validate on blur if the value is unchanged and the field is not required.
+				const inputObject = inputRef.current || null;
+				if (
+					inputObject &&
+					inputObject.value === previousValue &&
+					! inputObject.required
+				) {
+					return;
+				}
+				validateInput( false );
 			} }
 			ariaDescribedBy={ describedBy }
 			value={ value }

--- a/packages/checkout/components/text-input/validated-text-input.tsx
+++ b/packages/checkout/components/text-input/validated-text-input.tsx
@@ -91,7 +91,7 @@ const ValidatedTextInput = ( {
 	} );
 
 	const validateInput = useCallback(
-		( { errorsHidden = true, forceRevalidation = false } = {} ) => {
+		( errorsHidden = true ) => {
 			const inputObject = inputRef.current || null;
 
 			if ( inputObject === null ) {
@@ -138,10 +138,7 @@ const ValidatedTextInput = ( {
 		if ( isPristine ) {
 			return;
 		}
-		validateInput( {
-			errorsHidden: value === '',
-			forceRevalidation: true,
-		} );
+		validateInput( value === '' );
 		// Purposely skip running this unless any of the revalidateDependencies change. Also don't run it on mount (isPristine).
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ ...revalidateDependencies ] );
@@ -162,7 +159,7 @@ const ValidatedTextInput = ( {
 			inputRef.current !== null &&
 			inputRef.current?.ownerDocument?.activeElement !== inputRef.current
 		) {
-			validateInput( { errorsHidden: false } );
+			validateInput( false );
 		}
 		// We need to track value even if it is not directly used so we know when it changes.
 	}, [ value, previousValue, validateInput ] );

--- a/packages/checkout/components/text-input/validated-text-input.tsx
+++ b/packages/checkout/components/text-input/validated-text-input.tsx
@@ -51,6 +51,8 @@ interface ValidatedTextInputProps
 		| undefined;
 	// Whether validation should run when focused - only has an effect when focusOnMount is also true.
 	validateOnMount?: boolean | undefined;
+	// A set of dependencies to watch, and revalidate if they change.
+	revalidateDependencies?: unknown[] | undefined;
 }
 
 const ValidatedTextInput = ( {
@@ -67,6 +69,7 @@ const ValidatedTextInput = ( {
 	customValidation,
 	label,
 	validateOnMount = true,
+	revalidateDependencies = [],
 	...rest
 }: ValidatedTextInputProps ): JSX.Element => {
 	const [ isPristine, setIsPristine ] = useState( true );

--- a/packages/checkout/components/text-input/validated-text-input.tsx
+++ b/packages/checkout/components/text-input/validated-text-input.tsx
@@ -236,10 +236,12 @@ const ValidatedTextInput = ( {
 			onBlur={ () => {
 				// Don't validate on blur if the value is unchanged and the field is not required.
 				const inputObject = inputRef.current || null;
+
 				if (
 					inputObject &&
 					inputObject.value === previousValue &&
-					! inputObject.required
+					! inputObject.required &&
+					inputObject.value !== ''
 				) {
 					return;
 				}

--- a/packages/checkout/components/text-input/validated-text-input.tsx
+++ b/packages/checkout/components/text-input/validated-text-input.tsx
@@ -88,7 +88,7 @@ const ValidatedTextInput = ( {
 	} );
 
 	const validateInput = useCallback(
-		( errorsHidden = true ) => {
+		( { errorsHidden = true, forceRevalidation = false } = {} ) => {
 			const inputObject = inputRef.current || null;
 
 			if ( inputObject === null ) {
@@ -99,7 +99,7 @@ const ValidatedTextInput = ( {
 			inputObject.value = inputObject.value.trim();
 			inputObject.setCustomValidity( '' );
 
-			if ( previousValue === inputObject.value ) {
+			if ( previousValue === inputObject.value && ! forceRevalidation ) {
 				return;
 			}
 
@@ -147,7 +147,7 @@ const ValidatedTextInput = ( {
 			inputRef.current !== null &&
 			inputRef.current?.ownerDocument?.activeElement !== inputRef.current
 		) {
-			validateInput( false );
+			validateInput( { errorsHidden: false } );
 		}
 		// We need to track value even if it is not directly used so we know when it changes.
 	}, [ value, previousValue, validateInput ] );
@@ -170,7 +170,7 @@ const ValidatedTextInput = ( {
 
 		// if validateOnMount is false, only validate input if focusOnMount is also false
 		if ( validateOnMount || ! focusOnMount ) {
-			validateInput( true );
+			validateInput();
 		}
 
 		setIsPristine( false );
@@ -220,13 +220,13 @@ const ValidatedTextInput = ( {
 				hideValidationError( errorIdString );
 
 				// Revalidate on user input so we know if the value is valid.
-				validateInput( true );
+				validateInput();
 
 				// Push the changes up to the parent component if the value is valid.
 				onChange( val );
 			} }
 			onBlur={ () => {
-				validateInput( false );
+				validateInput( { errorsHidden: false } );
 			} }
 			ariaDescribedBy={ describedBy }
 			value={ value }

--- a/packages/checkout/components/text-input/validated-text-input.tsx
+++ b/packages/checkout/components/text-input/validated-text-input.tsx
@@ -134,6 +134,15 @@ const ValidatedTextInput = ( {
 		]
 	);
 
+	useEffect( () => {
+		if ( isPristine ) {
+			return;
+		}
+		validateInput( { errorsHidden: false, forceRevalidation: true } );
+		// Purposely skip running this unless any of the revalidateDependencies change. Also don't run it on mount (isPristine).
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ ...revalidateDependencies ] );
+
 	/**
 	 * Handle browser autofill / changes via data store.
 	 *

--- a/packages/checkout/components/text-input/validated-text-input.tsx
+++ b/packages/checkout/components/text-input/validated-text-input.tsx
@@ -138,7 +138,10 @@ const ValidatedTextInput = ( {
 		if ( isPristine ) {
 			return;
 		}
-		validateInput( { errorsHidden: false, forceRevalidation: true } );
+		validateInput( {
+			errorsHidden: value === '',
+			forceRevalidation: true,
+		} );
 		// Purposely skip running this unless any of the revalidateDependencies change. Also don't run it on mount (isPristine).
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ ...revalidateDependencies ] );


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This is based on `fix/address-pushing` and includes changes from woocommerce/woocommerce-blocks#9606.

This PR introduces a new property on `ValidatedTextInput` called `revalidateDependencies` which is intended to work the same as `useEffect`'s dependencies array. This prop will be an array of variables. When one of the variables changes, it will call `validateInput` again.

I added an object in `address-form.tsx` which is keyed by existing fields, and the values are arrays of dependencies that should cause the field to revalidated. When rendering a field, the object is checked and if there's an entry for that field, the value is passed to `ValidateInput`'s `revalidateDependencies` prop. The only items in there now are: `postcode: [ country ]` which means that when rendering the postcode field, changing the country will cause it to revalidate. (The country is derived from the `wc/store/cart` data store in the `useSelect` above).

Finally, I moved the `if ( previousValue === inputObject.value ) {` check to the `onBlur` function of `ValidatedTextInput` this is so that when the coupon code shows an error, it does not clear when blurring the field.

<!-- Reference any related issues or PRs here -->

Fixes woocommerce/woocommerce-blocks#9591

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. In an incognito window...
2. Add an item to your cart, go to the Checkout block.
3. Click the "Apply a coupon" link.
4. Enter an invalid coupon, and see the error. Click into and out of the field a few times, ensure the error remains.
5. Type a new code into the box (no need to submit) and ensure the error goes away.
6. Click into the First name field, and then out of it. Ensure an error shows. Repeat for last name.
7. Enter a full address using United Kingdom as the country, enter `L1 0BP` as the Postcode.
8. Change country to Portugal. Do not change anything else.
9. Ensure the postcode field is marked as invalid.
10. Click into the country field, **do not type in the box** - scroll down to United Kingdom. Select it.
11. Ensure the postcode error is removed.
12. Go back to Portugal, ensure the error reappears.
13. Try to check out, ensure checkout cannot be completed.
14. Enter `8200-294` into the postcode box and check out successfully.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Revalidate the postcode when changing country in the Checkout form.
