### PR TITLE
Remove propTypes definitions from Add to Cart

### DIFF
--- a/assets/js/atomic/blocks/product-elements/add-to-cart/block.tsx
+++ b/assets/js/atomic/blocks/product-elements/add-to-cart/block.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import {
 	AddToCartFormContextProvider,
@@ -83,10 +82,6 @@ const Block = ( { className, showFormElements }: Props ) => {
 			</div>
 		</AddToCartFormContextProvider>
 	);
-};
-
-Block.propTypes = {
-	className: PropTypes.string,
 };
 
 export default withProductDataContext( Block );


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #9547 

### Changes in the PR:
Removed propTypes definitions from Newest Products block, price filters, add-to-cart and product-list block.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->
### Testing

#### Automated Tests
* [x] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [x] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
