### PR TITLE
Remove propTypes definitions from Product List container

### DIFF
--- a/assets/js/base/components/product-list/container.tsx
+++ b/assets/js/base/components/product-list/container.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { useState, useEffect } from '@wordpress/element';
-import PropTypes from 'prop-types';
 import type { HTMLElementEvent } from '@woocommerce/types';
 
 /**
@@ -38,11 +37,6 @@ const ProductListContainer = ( {
 			sortValue={ currentSort }
 		/>
 	);
-};
-
-ProductListContainer.propTypes = {
-	attributes: PropTypes.object.isRequired,
-	hideOutOfStockItems: PropTypes.bool,
 };
 
 export default ProductListContainer;


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #9548 

### Changes in the PR:
Removed propTypes definitions from Newest Products block, price filters, add-to-cart and product-list block.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->
### Testing

#### Automated Tests
* [x] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [x] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
