### PR TITLE
Update GitHub Action for checking Markdown links

### DIFF
--- a/.github/workflows/check-doc-links.yml
+++ b/.github/workflows/check-doc-links.yml
@@ -2,8 +2,6 @@ name: Check Markdown links
 
 on:
   pull_request:
-    paths:
-      - '**.md'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/check-doc-links.yml
+++ b/.github/workflows/check-doc-links.yml
@@ -19,20 +19,6 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v3
 
-            - name: Get changed Markdown files
-              id: files
-              run: |
-                  echo "::set-output name=md::$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep .md)"
-              shell: bash
-
-            - name: Check for Markdown changes
-              run: |
-                  if [[ -z "${{ steps.files.outputs.md }}" ]]; then
-                    echo "No Markdown files changed, skipping the link check."
-                    exit 0
-                  fi
-              shell: bash
-
             - name: Run Markdown link check
               uses: gaurav-nelson/github-action-markdown-link-check@v1
               with:

--- a/.github/workflows/check-doc-links.yml
+++ b/.github/workflows/check-doc-links.yml
@@ -1,14 +1,14 @@
 name: Check Markdown links
 
 on:
-    workflow_dispatch:
-    pull_request:
+  pull_request:
+    paths:
+      - '**.md'
+  workflow_dispatch:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
     cancel-in-progress: true
-
-permissions: {}
 
 jobs:
     markdown-link-check:
@@ -16,13 +16,28 @@ jobs:
         permissions:
             contents: read
         steps:
-            - uses: actions/checkout@v3
-            - uses: gaurav-nelson/github-action-markdown-link-check@v1
+            - name: Checkout repository
+              uses: actions/checkout@v3
+
+            - name: Get changed Markdown files
+              id: files
+              run: |
+                  echo "::set-output name=md::$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep .md)"
+              shell: bash
+
+            - name: Check for Markdown changes
+              run: |
+                  if [[ -z "${{ steps.files.outputs.md }}" ]]; then
+                    echo "No Markdown files changed, skipping the link check."
+                    exit 0
+                  fi
+              shell: bash
+
+            - name: Run Markdown link check
+              uses: gaurav-nelson/github-action-markdown-link-check@v1
               with:
                   use-quiet-mode: 'yes'
-                  use-verbose-mode: 'no'
                   config-file: '.github/workflows/check-doc-links-config.json'
                   folder-path: './docs'
                   file-path: './README.md'
-                  max-depth: 3
                   base-branch: 'trunk'


### PR DESCRIPTION
While creating #9622, I noticed that the GitHub Action to check links within Markdown files only goes 3 levels deep. As some of our Markdown files are located deeper than three levels, we would not detect broken links in these files. 

### Changes

This PR applies the following changes:

- Remove `use-verbose-mode: ‘no’`, as `no` is the default value
- Remove `max-depth: 3`to detect broken links in all Markdown files
- Remove global `permissions: {}` entry

### Testing

TBD