### PR TITLE
Product Image Gallery: Reintroduce filters and override-restore the global product variable.

### DIFF
--- a/src/BlockTypes/ProductImageGallery.php
+++ b/src/BlockTypes/ProductImageGallery.php
@@ -22,7 +22,7 @@ class ProductImageGallery extends AbstractBlock {
 	/**
 	 *  Register the context
 	 *
-	 * @var string
+	 * @return string[]
 	 */
 	protected function get_block_type_uses_context() {
 		return [ 'query', 'queryId', 'postId' ];
@@ -66,16 +66,13 @@ class ProductImageGallery extends AbstractBlock {
 		woocommerce_show_product_images();
 		$product_image_gallery_html = ob_get_clean();
 
-		$classname                  = $attributes['className'] ?? '';
-		$product_image_gallery_html = sprintf(
+		$product   = $previous_product;
+		$classname = $attributes['className'] ?? '';
+		return sprintf(
 			'<div class="wp-block-woocommerce-product-image-gallery %1$s">%2$s %3$s</div>',
 			esc_attr( $classname ),
 			$sale_badge_html,
 			$product_image_gallery_html
 		);
-
-		$product = $previous_product;
-
-		return $product_image_gallery_html;
 	}
 }

--- a/src/BlockTypes/ProductImageGallery.php
+++ b/src/BlockTypes/ProductImageGallery.php
@@ -43,8 +43,13 @@ class ProductImageGallery extends AbstractBlock {
 			return '';
 		}
 
-		$product = wc_get_product( $post_id );
+		global $product;
+
+		$previous_product = $product;
+		$product          = wc_get_product( $post_id );
 		if ( ! $product instanceof \WC_Product ) {
+			$product = $previous_product;
+
 			return '';
 		}
 
@@ -53,48 +58,24 @@ class ProductImageGallery extends AbstractBlock {
 			$frontend_scripts::load_scripts();
 		}
 
-		$classname         = $attributes['className'] ?? '';
-		$sale_badge_html   = $product->is_on_sale() ? '<span class="onsale">' . esc_html__( 'Sale!', 'woo-gutenberg-products-block' ) . '</span>' : '';
-		$columns           = 4;
-		$post_thumbnail_id = $product->get_image_id();
-		$wrapper_classes   = array(
-			'woocommerce-product-gallery',
-			'woocommerce-product-gallery--' . ( $post_thumbnail_id ? 'with-images' : 'without-images' ),
-			'woocommerce-product-gallery--columns-' . absint( $columns ),
-			'images',
-		);
 		ob_start();
-		?>
-		<div class="<?php echo esc_attr( implode( ' ', array_map( 'sanitize_html_class', $wrapper_classes ) ) ); ?>" data-columns="<?php echo esc_attr( $columns ); ?>" style="opacity: 0; transition: opacity .25s ease-in-out;">
-			<div class="woocommerce-product-gallery__wrapper">
-				<?php
-				if ( $post_thumbnail_id ) {
-					$html = wc_get_gallery_image_html( $post_thumbnail_id, true );
-				} else {
-					$html  = '<div class="woocommerce-product-gallery__image--placeholder">';
-					$html .= sprintf( '<img src="%s" alt="%s" class="wp-post-image" />', esc_url( wc_placeholder_img_src( 'woo-gutenberg-products-block' ) ), esc_html__( 'Awaiting product image', 'woo-gutenberg-products-block' ) );
-					$html .= '</div>';
-				}
+		woocommerce_show_product_sale_flash();
+		$sale_badge_html = ob_get_clean();
 
-				echo wp_kses_post( $html );
-				$attachment_ids = $product->get_gallery_image_ids();
-				if ( $attachment_ids && $product->get_image_id() ) {
-					foreach ( $attachment_ids as $attachment_id ) {
-						echo wc_get_gallery_image_html( $attachment_id ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-					}
-				}
-				?>
-			</div>
-		</div>
-		<?php
+		ob_start();
+		woocommerce_show_product_images();
 		$product_image_gallery_html = ob_get_clean();
 
-		return sprintf(
+		$classname                  = $attributes['className'] ?? '';
+		$product_image_gallery_html = sprintf(
 			'<div class="wp-block-woocommerce-product-image-gallery %1$s">%2$s %3$s</div>',
 			esc_attr( $classname ),
 			$sale_badge_html,
 			$product_image_gallery_html
 		);
 
+		$product = $previous_product;
+
+		return $product_image_gallery_html;
 	}
 }


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #9618

- Reintroduce the `'woocommerce_single_product_image_gallery_classes'`, `'woocommerce_single_product_image_thumbnail_html'`, `'woocommerce_sale_flash'` and `'woocommerce_product_thumbnails_columns'` filters to the Product Image Gallery block (originally removed on #9475).
- Adopt the approach of overriding and restoring the global variable while relying on native template functions. This is a short-term implementation until we figure out a clear upgrade/transition path for code using those filters.

Internal discussion ref. p1685275379858039-slack-C02UBB1EPEF

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. While having a block theme enabled such as Twenty-twenty Three, head over to your Dashboard, and on the sidebar, click on "Appearance > Editor".
2. Select the Single Product template to customize it and click on edit.
3. If you are still using the Classic template, click on the button to transform it to the blockifyed version.
4. Make sure the Product Image Gallery block is available for usage on the inserter (you can remove/add the block from the template), add it, and save.
5. On the frontend, ensure the gallery works as expected, and the thumbnails can be selected.

#### Hooks Testing
Add the following by the end of your `woocommerce-gutenberg-products-block.php` file:

```php
add_filter( 'woocommerce_sale_flash', function () {
	return "<div>Sale!!!!!!</div>";
} );

add_filter( 'woocommerce_single_product_image_gallery_classes', function ( $wrapper_classes ) {
	$wrapper_classes[] = 'my-custom-class';

	return $wrapper_classes;
} );

add_filter( 'woocommerce_single_product_image_thumbnail_html', function ( $html ) {
	return $html . '<div>Thumbnail</div>';
} );

add_filter( 'woocommerce_product_thumbnails_columns', function () {
	return 1;
} );
```

1. Access a single product with an Image Gallery (including thumbnails: if you are using the default Woo dummy products, this can be tested with the "Logo Collection" product).
2. Ensure the "Sale!!!!!!" text is visible on the front-end.
3. Open the browser dev tools and search for the appended `my-custom-class`: make sure it is in place as one of the available product gallery classes.
4. While still on dev tools, search for the `'woocommerce-product-gallery--columns-1'` class and make sure it exists (the number attached to this class corresponds to the number of columns modified via `woocommerce_product_thumbnails_columns` filter).
5. Now click on the thumbnails below the main image: make sure you can read the appended "Thumbnail" div for all of them.

<img width="1937" alt="Screenshot 2023-05-29 at 11 24 11" src="https://github.com/woocommerce/woocommerce-blocks/assets/15730971/2a7c797c-dd08-434a-86a3-31880e8e3f56">


### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Product Image Gallery Block: Reintroduce filters and override-restore the global product variable.