### PR TITLE
Blockified Single Product Template: Show upsells.

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -336,3 +336,8 @@
 .screen-reader-text:focus {
 	@include visually-hidden-focus-reveal();
 }
+
+
+.wp-block-group.woocommerce.product .up-sells.upsells.products {
+	max-width: var(--wp--style--global--wide-size);
+}

--- a/src/Templates/SingleProductTemplateCompatibility.php
+++ b/src/Templates/SingleProductTemplateCompatibility.php
@@ -241,10 +241,11 @@ class SingleProductTemplateCompatibility extends AbstractTemplateCompatibility {
 			),
 			'woocommerce_after_single_product_summary'  => array(
 				'block_name' => 'woocommerce/product-details',
-				'position'   => 'before',
+				'position'   => 'after',
 				'hooked'     => array(
 					'woocommerce_output_product_data_tabs' => 10,
-					'woocommerce_upsell_display'           => 15,
+					// We want to display the upsell products after the last block that belongs to the Single Product.
+					// 'woocommerce_upsell_display'           => 15.
 					'woocommerce_output_related_products'  => 20,
 				),
 			),


### PR DESCRIPTION
This is a partial fix for woocommerce/woocommerce#42358. As @manospsyx noticed, it could not be the best approach to have every product feature represented by a Block in the Single Product template. It is necessary an in-depth discussion about the best approach. In the meantime, I think that we should restore the possibility to display the upsell products on the blockified Single Product Template (since that we will enable them in the new store woocommerce/woocommerce-blocks#9551).

This PR restores the action that renders the grid that includes the upsell products.




Fixes #

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|![image](https://github.com/woocommerce/woocommerce-blocks/assets/4463174/4e295855-db19-474b-b870-9022701be44c)|![image](https://github.com/woocommerce/woocommerce-blocks/assets/4463174/0e144aa8-031c-4515-afd5-8772f2919f45)|

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Edit a product.
2. Add upsells.
3. Open the Site Editor.
4. Edit the Single Product Template.
5. Migrate to the blockified template.
6. Visit the product.
7. Be sure that upsells are visible

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Blockified Single Product Template: Show upsells.