### PR TITLE
Ensure inner content is not truncated on different widths

### DIFF
--- a/patterns/just-arrived-full-hero.php
+++ b/patterns/just-arrived-full-hero.php
@@ -5,19 +5,20 @@
  * Categories: WooCommerce
  */
 ?>
-<!-- wp:cover {"useFeaturedImage":true,"dimRatio":0,"minHeight":50,"minHeightUnit":"vw","contentPosition":"center center","isDark":false,"align":"full","style":{"spacing":{"padding":{"left":"50vw"}}}} -->
-<div class="wp-block-cover alignfull is-light" style="padding-left:50vw;min-height:50vw"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:heading {"style":{"spacing":{"margin":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}},"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"x-large"} -->
-<h2 class="has-x-large-font-size" id="just-arrived" style="margin-top:0px;margin-right:0px;margin-bottom:0px;margin-left:0px;font-style:normal;font-weight:700"><?php esc_html_e( 'Just arrived', 'woo-gutenberg-products-block' ); ?></h2>
+<!-- wp:cover {"useFeaturedImage":true,"dimRatio":0,"contentPosition":"center right","isDark":false,"align":"full","style":{"spacing":{"padding":{"right":"4em"}}}} -->
+<div class="wp-block-cover alignfull is-light has-custom-content-position is-position-center-right" style="padding-right:4em"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"x-large","anchor":"just-arrived"} -->
+<h2 class="wp-block-heading has-x-large-font-size" id="just-arrived" style="font-style:normal;font-weight:700">Just arrived</h2>
 <!-- /wp:heading -->
 
 <!-- wp:paragraph {"fontSize":"medium"} -->
-<p class="has-medium-font-size"><?php esc_html_e( 'Our early autumn collection is here.', 'woo-gutenberg-products-block' ); ?></p>
+<p class="has-medium-font-size">Our early autumn collection is here.</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:buttons {"style":{"spacing":{"blockGap":"0px"}}} -->
+<!-- wp:buttons -->
 <div class="wp-block-buttons"><!-- wp:button {"backgroundColor":"black","textColor":"white","className":"is-style-fill","fontSize":"small"} -->
-<div class="wp-block-button has-custom-font-size is-style-fill has-small-font-size"><a class="wp-block-button__link has-white-color has-black-background-color has-text-color has-background wp-element-button"><?php esc_html_e( 'Shop now', 'woo-gutenberg-products-block' ); ?></a></div>
+<div class="wp-block-button has-custom-font-size is-style-fill has-small-font-size"><a class="wp-block-button__link has-white-color has-black-background-color has-text-color has-background wp-element-button">Shop now</a></div>
 <!-- /wp:button --></div>
-<!-- /wp:buttons --></div></div>
+<!-- /wp:buttons --></div>
+<!-- /wp:group --></div></div>
 <!-- /wp:cover -->
-


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/9555

This PR fixes the issue where the inner content of the cover block gets truncated in different widths. Note that I also added a inner group so the content is easier to manipulate as a whole instead of individual content items.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Full | Wide | None |
| ------ | ----- | ----- |
|![l2BKsH.png](https://github.com/woocommerce/woocommerce-blocks/assets/2132595/ea0fb370-2fb7-4606-8957-41218cc64590)|![25wYeD.png](https://github.com/woocommerce/woocommerce-blocks/assets/2132595/52162cdf-2bea-432d-aea5-240372b906a9)|![mUK3yI.png](https://github.com/woocommerce/woocommerce-blocks/assets/2132595/12d4b20e-e819-4bab-83fb-ffde0833559d)|

### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Create a new post & add the WooCommerce Just Arrived Full Hero pattern.
2. Adjust the alignment on the Cover Block from Full width (the pattern's default) to either Wide width or None.
3. Note that the text (Heading, Paragraph, and Buttons blocks) are not squished or truncated to the right and that they show as expected aligning towards the right side of the block.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix text alignment issue on various widths for Just arrived full hero pattern