### PR TITLE
Prevent horizontal shift when opening the Mini-Cart drawer if scrollbars are visible

### DIFF
--- a/assets/js/blocks/mini-cart/block.tsx
+++ b/assets/js/blocks/mini-cart/block.tsx
@@ -51,6 +51,10 @@ interface Props {
 	hasHiddenPrice: boolean;
 }
 
+function getScrollbarWidth() {
+	return window.innerWidth - document.documentElement.clientWidth;
+}
+
 const MiniCartBlock = ( attributes: Props ): JSX.Element => {
 	const {
 		isInitiallyOpen = false,
@@ -91,10 +95,14 @@ const MiniCartBlock = ( attributes: Props ): JSX.Element => {
 	useEffect( () => {
 		const body = document.querySelector( 'body' );
 		if ( body ) {
+			const scrollBarWidth = getScrollbarWidth();
 			if ( isOpen ) {
-				Object.assign( body.style, { overflow: 'hidden' } );
+				Object.assign( body.style, {
+					overflow: 'hidden',
+					paddingRight: scrollBarWidth + 'px',
+				} );
 			} else {
-				Object.assign( body.style, { overflow: '' } );
+				Object.assign( body.style, { overflow: '', paddingRight: 0 } );
 			}
 		}
 	}, [ isOpen ] );

--- a/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-products-table-block/block.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-products-table-block/block.tsx
@@ -5,11 +5,13 @@ import { useStoreCart } from '@woocommerce/base-context/hooks';
 import { CartLineItemsTable } from '@woocommerce/base-components/cart-checkout';
 import classNames from 'classnames';
 
-type MiniCartContentsBlockProps = {
+type MiniCartProductsTableBlockProps = {
 	className: string;
 };
 
-const Block = ( { className }: MiniCartContentsBlockProps ): JSX.Element => {
+const Block = ( {
+	className,
+}: MiniCartProductsTableBlockProps ): JSX.Element => {
 	const { cartItems, cartIsLoading } = useStoreCart();
 	return (
 		<div


### PR DESCRIPTION
Fixes #9635.

### Testing

#### User Facing Testing

1. Set up your browser so scrollbars are visible (that might depend on the browser/OS you use).
2. Add the Mini-Cart block to the header of your store.
3. In the frontend, open the Mini-Cart drawer and verify there is no horizontal shift of the contents.

Before | After
--- | ---
[before](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/dedaa44b-2a07-4fd5-9ea2-c3d1b9e13080) | [after](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/9bc56a48-88df-4e0a-af9e-98843433ca7a)

* [ ] Do not include in the Testing Notes

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Prevent horizontal shift when opening the Mini-Cart drawer if scrollbars are visible
