### PR TITLE
Fix Mini-Cart block check to see whether a script has already been enqueued

### DIFF
--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -330,7 +330,7 @@ class MiniCart extends AbstractBlock {
 		$wp_scripts = wp_scripts();
 
 		// This script and its dependencies have already been appended.
-		if ( ! $script || array_key_exists( $script->handle, $this->scripts_to_lazy_load ) || wp_script_is( $script->handle, 'enqueued' ) ) {
+		if ( ! $script || array_key_exists( $script->handle, $this->scripts_to_lazy_load ) || isset( $wp_scripts->queue[ $script->handle ] ) ) {
 			return;
 		}
 


### PR DESCRIPTION
It looks like the fix we introduced in https://github.com/woocommerce/woocommerce-blocks/pull/9586 was causing some dependencies not to be loaded on WC 7.7.x. This PR should fix this.

### Testing

#### User Facing Testing

0. Make sure you have WC core 7.7.1.
1. Enable a block theme. 
2. Add the Mini-Cart block to the header of your store.
3. Go to the frontend and open the Mini-Cart drawer. Verify it opens.
4. Install the Page Optimize and Product Bundles plugins (no need to change anything in their configuration).
5. Go to a page in the frontend that doesn't have any blocks besides the Mini-Cart you added to the header.
6. Open the Mini-Cart drawer and verify it opens without JS errors.

***Testing steps for internal testers only***

This is to test the same fixes with WC 10.0.x:

1. Switch to branch `release/10.0.5`: `git checkout release/10.0.5`.
2. Run `npm run change-versions` and set the new version to 10.0.6.
3. Cherry-pick the commit included in this PR: `git cherry-pick 3e1e880798aea9c4b673fcb02356c802112d05d0`.
4. Enable a block theme. 
5. Add the Mini-Cart block to the header of your store.
6. Go to the frontend and open the Mini-Cart drawer. Verify it opens.
7. Install the Page Optimize and Product Bundles plugins (no need to change anything in their configuration).
8. Go to a page in the frontend that doesn't have any blocks besides the Mini-Cart you added to the header.
9. Open the Mini-Cart drawer and verify it opens without JS errors.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix some scripts needed by the Mini-Cart block not loading.
