### PR TITLE
Refactor: Add useIsDescendentOfSingleProductTemplate hook

### DIFF
--- a/assets/js/atomic/blocks/product-elements/price/edit.tsx
+++ b/assets/js/atomic/blocks/product-elements/price/edit.tsx
@@ -8,12 +8,12 @@ import {
 } from '@wordpress/block-editor';
 import { useEffect } from '@wordpress/element';
 import type { BlockAlignment } from '@wordpress/blocks';
-import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import Block from './block';
+import { useIsDescendentOfSingleProductTemplate } from '../shared/use-is-descendent-of-single-product-template';
 
 type UnsupportedAligments = 'wide' | 'full';
 type AllowedAlignments = Exclude< BlockAlignment, UnsupportedAligments >;
@@ -53,18 +53,12 @@ const PriceEdit = ( {
 	};
 	const isDescendentOfQueryLoop = Number.isFinite( context.queryId );
 
-	const isDescendentOfSingleProductTemplate = useSelect(
-		( select ) => {
-			const store = select( 'core/edit-site' );
-			const postId = store?.getEditedPostId< string | undefined >();
+	let { isDescendentOfSingleProductTemplate } =
+		useIsDescendentOfSingleProductTemplate( { isDescendentOfQueryLoop } );
 
-			return (
-				postId?.includes( '//single-product' ) &&
-				! isDescendentOfQueryLoop
-			);
-		},
-		[ isDescendentOfQueryLoop ]
-	);
+	if ( isDescendentOfQueryLoop ) {
+		isDescendentOfSingleProductTemplate = false;
+	}
 
 	useEffect(
 		() =>

--- a/assets/js/atomic/blocks/product-elements/product-meta/edit.tsx
+++ b/assets/js/atomic/blocks/product-elements/product-meta/edit.tsx
@@ -3,20 +3,16 @@
  */
 import { InnerBlocks, useBlockProps } from '@wordpress/block-editor';
 import { InnerBlockTemplate } from '@wordpress/blocks';
-import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import './editor.scss';
+import { useIsDescendentOfSingleProductTemplate } from '../shared/use-is-descendent-of-single-product-template';
 
 const Edit = () => {
-	const isDescendentOfSingleProductTemplate = useSelect( ( select ) => {
-		const store = select( 'core/edit-site' );
-		const postId = store?.getEditedPostId< string | undefined >();
-
-		return postId?.includes( '//single-product' );
-	}, [] );
+	const isDescendentOfSingleProductTemplate =
+		useIsDescendentOfSingleProductTemplate();
 
 	const TEMPLATE: InnerBlockTemplate[] = [
 		[

--- a/assets/js/atomic/blocks/product-elements/rating/edit.tsx
+++ b/assets/js/atomic/blocks/product-elements/rating/edit.tsx
@@ -9,7 +9,6 @@ import {
 import type { BlockEditProps } from '@wordpress/blocks';
 import { useEffect } from '@wordpress/element';
 import { ProductQueryContext as Context } from '@woocommerce/blocks/product-query/types';
-import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -18,6 +17,7 @@ import Block from './block';
 import { BlockAttributes } from './types';
 import './editor.scss';
 import { useIsDescendentOfSingleProductBlock } from '../shared/use-is-descendent-of-single-product-block';
+import { useIsDescendentOfSingleProductTemplate } from '../shared/use-is-descendent-of-single-product-template';
 
 const Edit = (
 	props: BlockEditProps< BlockAttributes > & { context: Context }
@@ -36,21 +36,12 @@ const Edit = (
 		useIsDescendentOfSingleProductBlock( {
 			blockClientId: blockProps?.id,
 		} );
-	const { isDescendentOfSingleProductTemplate } = useSelect(
-		( select ) => {
-			const store = select( 'core/edit-site' );
-			const postId = store?.getEditedPostId< string | undefined >();
+	let { isDescendentOfSingleProductTemplate } =
+		useIsDescendentOfSingleProductTemplate();
 
-			return {
-				isDescendentOfSingleProductTemplate: Boolean(
-					postId?.includes( '//single-product' ) &&
-						! isDescendentOfQueryLoop &&
-						! isDescendentOfSingleProductBlock
-				),
-			};
-		},
-		[ isDescendentOfQueryLoop, isDescendentOfSingleProductBlock ]
-	);
+	if ( isDescendentOfQueryLoop || isDescendentOfSingleProductBlock ) {
+		isDescendentOfSingleProductTemplate = false;
+	}
 
 	useEffect( () => {
 		setAttributes( {

--- a/assets/js/atomic/blocks/product-elements/shared/use-is-descendent-of-single-product-template.tsx
+++ b/assets/js/atomic/blocks/product-elements/shared/use-is-descendent-of-single-product-template.tsx
@@ -1,0 +1,15 @@
+/**
+ * External dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+export const useIsDescendentOfSingleProductTemplate = () => {
+	const isDescendentOfSingleProductTemplate = useSelect( ( select ) => {
+		const store = select( 'core/edit-site' );
+		const postId = store?.getEditedPostId< string | undefined >();
+
+		return Boolean( postId?.includes( '//single-product' ) );
+	}, [] );
+
+	return { isDescendentOfSingleProductTemplate };
+};

--- a/assets/js/atomic/blocks/product-elements/sku/edit.tsx
+++ b/assets/js/atomic/blocks/product-elements/sku/edit.tsx
@@ -6,7 +6,6 @@ import type { BlockEditProps } from '@wordpress/blocks';
 import EditProductLink from '@woocommerce/editor-components/edit-product-link';
 import { ProductQueryContext as Context } from '@woocommerce/blocks/product-query/types';
 import { useEffect } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -14,6 +13,7 @@ import { useSelect } from '@wordpress/data';
 import Block from './block';
 import type { Attributes } from './types';
 import { useIsDescendentOfSingleProductBlock } from '../shared/use-is-descendent-of-single-product-block';
+import { useIsDescendentOfSingleProductTemplate } from '../shared/use-is-descendent-of-single-product-template';
 
 const Edit = ( {
 	attributes,
@@ -32,22 +32,12 @@ const Edit = ( {
 	const { isDescendentOfSingleProductBlock } =
 		useIsDescendentOfSingleProductBlock( { blockClientId: blockProps.id } );
 
-	const isDescendentOfSingleProductTemplate = useSelect(
-		( select ) => {
-			const store = select( 'core/edit-site' );
-			const postId = store?.getEditedPostId< string | undefined >();
+	let { isDescendentOfSingleProductTemplate } =
+		useIsDescendentOfSingleProductTemplate();
 
-			if ( ! postId ) {
-				return false;
-			}
-
-			return (
-				postId.includes( '//single-product' ) &&
-				! isDescendentOfQueryLoop
-			);
-		},
-		[ isDescendentOfQueryLoop ]
-	);
+	if ( isDescendentOfQueryLoop ) {
+		isDescendentOfSingleProductTemplate = false;
+	}
 
 	useEffect(
 		() =>


### PR DESCRIPTION
## Description
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at eee8e03</samp>
<samp>👨‍💻 Enhanced by @thealexandrelara </samp>

Refactored Product Price, Product Rating, Product Meta, and Product SKU blocks to use the custom useIsDescendentOfSingleProductTemplate hook for checking the block context and whether they are inside a single product template. The custom hook `useIsDescendentOfSingleProductTemplate` is defined in `shared/use-is-descendent-of-single-product-template.tsx`.

## Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at eee8e03</samp>

*  Refactor the logic for checking if the block is a descendent of a single product template into a custom hook `useIsDescendentOfSingleProductTemplate` in the `shared` folder ([link](https://github.com/woocommerce/woocommerce-blocks/pull/9657/files?diff=unified&w=0#diff-e03da019d3b03555a3f898fffb45a2a269520dceb2464d85fbcca62308ee7014R1-R15))
* Remove the `useSelect` hook from the `price`, `product-meta`, `rating`, and `sku` blocks, as they can reuse the custom hook instead ([link](https://github.com/woocommerce/woocommerce-blocks/pull/9657/files?diff=unified&w=0#diff-c5cd130a6f41a1c44ae606d5b8cf1c7a136f2cede2fbc326067436b84731b401L11), [link](https://github.com/woocommerce/woocommerce-blocks/pull/9657/files?diff=unified&w=0#diff-7ceb581377fdb6b548ba2e62514df3eb2721267e7c289ac3797c1122d863d212L6), [link](https://github.com/woocommerce/woocommerce-blocks/pull/9657/files?diff=unified&w=0#diff-4e154173c83a90857629f0bdf60e0af8dbd33560750747056a1535ad9132e966L12), [link](https://github.com/woocommerce/woocommerce-blocks/pull/9657/files?diff=unified&w=0#diff-273af84aa585a8e5a5a1446b8e97d85242eca59f5bf0696f3111b6627794ebaeL9))
* Import the custom hook from the `shared` folder and assign the returned value to a variable `isDescendentOfSingleProductTemplate` in each block ([link](https://github.com/woocommerce/woocommerce-blocks/pull/9657/files?diff=unified&w=0#diff-c5cd130a6f41a1c44ae606d5b8cf1c7a136f2cede2fbc326067436b84731b401R16), [link](https://github.com/woocommerce/woocommerce-blocks/pull/9657/files?diff=unified&w=0#diff-7ceb581377fdb6b548ba2e62514df3eb2721267e7c289ac3797c1122d863d212L12-R16), [link](https://github.com/woocommerce/woocommerce-blocks/pull/9657/files?diff=unified&w=0#diff-4e154173c83a90857629f0bdf60e0af8dbd33560750747056a1535ad9132e966R20), [link](https://github.com/woocommerce/woocommerce-blocks/pull/9657/files?diff=unified&w=0#diff-273af84aa585a8e5a5a1446b8e97d85242eca59f5bf0696f3111b6627794ebaeR16))
* Add additional conditions to override the variable to `false` if the block is also a descendent of a query loop or a single product block, depending on the block's behavior ([link](https://github.com/woocommerce/woocommerce-blocks/pull/9657/files?diff=unified&w=0#diff-c5cd130a6f41a1c44ae606d5b8cf1c7a136f2cede2fbc326067436b84731b401L56-R61), [link](https://github.com/woocommerce/woocommerce-blocks/pull/9657/files?diff=unified&w=0#diff-4e154173c83a90857629f0bdf60e0af8dbd33560750747056a1535ad9132e966L39-R44), [link](https://github.com/woocommerce/woocommerce-blocks/pull/9657/files?diff=unified&w=0#diff-273af84aa585a8e5a5a1446b8e97d85242eca59f5bf0696f3111b6627794ebaeL35-R41))

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

##### Single Product Block
1. Log in to your WordPress dashboard.
2. From your WordPress dashboard, go to Appearance > Themes. Make sure you have a block-based theme installed and activated. If not, you can install one from the Add New option. Block-based themes include "Twenty-twenty Two," "Twenty-twenty Three," etc.
3. On the left-hand side menu, click on Appearance > Editor. This will open the Site Editor.
4. On the left-hand side menu, click on Templates. This will open the list of available templates.
5. Find and select any template from the list.
6. Inside the Site editor, click on the '+' button, usually found at the top left of the editing space or within the content area itself, to add a new block.
7. In the block library that pops up, you can search for the 'Single Product' block. You can do this by typing 'Single Product' into the search bar at the top of the block library.
8. Click on the 'Single Product' block to add it to the template. You'll be prompted to select a product from your WooCommerce store to feature in the block. Make sure to select a product that contains at least one review.
9. Once you've selected a product, the block will be inserted into your template and will display information about the product you've selected.
10. Once the block is added to the template, make sure the Product Price, Product Meta, Product Rating, and Product SKU blocks appears for the selected product.
13. On the top-right side, click on the Save button.
14. Visit a product and check if the Product Price, Product Meta, Product Rating, and Product SKU blocks are displayed correctly.

##### Single Product Template
1. Log in to your WordPress dashboard.
2. From your WordPress dashboard, go to Appearance > Themes. Make sure you have a block-based theme installed and activated. If not, you can install one from the Add New option. Block-based themes include "Twenty-twenty Two," "Twenty-twenty Three", etc.
3. On the left-hand side menu, click on Appearance > Editor. This will open the Site Editor.
4. On the left-hand side menu, click on Templates. This will open the list of available templates.
5. Find and select the Single Product template from the list.
6. When the Classic Product Template renders, click on Transform into Blocks. This will transform the Classic template in a block template if you haven't done it before.
7. Make sure the Product Price, Product Meta, Product Rating, and Product SKU blocks appears for the selected product;
8. On the top right side, click on Save;
9. Visit a product and check if the Product Price, Product Meta, Product Rating, and Product SKU blocks are displayed correctly.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->
