### PR TITLE
Fix colors not being applied to Mini-Cart Proceed to Checkout Button in the editor

### DIFF
--- a/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-checkout-button-block/edit.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/inner-blocks/mini-cart-checkout-button-block/edit.tsx
@@ -36,6 +36,7 @@ export const Edit = ( {
 						checkoutButtonLabel: content,
 					} );
 				} }
+				style={ blockProps.style }
 			/>
 		</div>
 	);


### PR DESCRIPTION
Fixes a regression that caused the Mini-Cart Proceed to Checkout Button not to show the correct colors in the Site Editor.

### Testing

#### User Facing Testing

1. Enable a block theme. 
2. Add the Mini-Cart block to the header of your store.
3. Go to Appearance > Editor > Template Parts > Mini-Cart.
4. Modify the text and background colors of _Mini-Cart View Cart Button_ and _Mini-Cart Proceed to Checkout Button_. Try with colors from the palette and with custom colors. Try also changing the Style from _Default_ to _Outline_/Fill_.
5. Save the template part and reload the page. Verify the colors persisted.
6. Go to the frontend, open the Mini-Cart drawer and verify the colors are applied correctly there too.

Before | After
--- | ---
![imatge](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/f182c75d-055c-4f62-820e-1efc608aae97) | ![imatge](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/35a43651-a145-4e3d-96c9-af17a9c61655)

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
