### PR TITLE
#9511 replacing PropTypes with Typescript definitions

### DIFF
--- a/assets/js/blocks/active-filters/block.tsx
+++ b/assets/js/blocks/active-filters/block.tsx
@@ -6,7 +6,6 @@ import { useQueryStateByKey } from '@woocommerce/base-context/hooks';
 import { getSetting, getSettingWithCoercion } from '@woocommerce/settings';
 import { useMemo, useEffect, useState } from '@wordpress/element';
 import classnames from 'classnames';
-import PropTypes from 'prop-types';
 import Label from '@woocommerce/base-components/label';
 import {
 	isAttributeQueryCollection,
@@ -412,16 +411,18 @@ const ActiveFiltersBlock = ( {
 		</>
 	);
 };
-
-ActiveFiltersBlock.propTypes = {
+interface ActiveFiltersBlockProps {
 	/**
 	 * The attributes for this block.
 	 */
-	attributes: PropTypes.object.isRequired,
+	attributes: {
+	  [key: string]: any;
+	};
 	/**
 	 * Whether it's in the editor or frontend display.
 	 */
-	isEditor: PropTypes.bool,
-};
+	isEditor?: boolean;
+  }
+
 
 export default ActiveFiltersBlock;

--- a/assets/js/blocks/active-filters/block.tsx
+++ b/assets/js/blocks/active-filters/block.tsx
@@ -411,6 +411,7 @@ const ActiveFiltersBlock = ( {
 		</>
 	);
 };
+
 interface ActiveFiltersBlockProps {
 	/**
 	 * The attributes for this block.


### PR DESCRIPTION
This PR replaces PropTypes used in block.tsx with TypeScript definitions


### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1.
2.
3.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

 [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Add suggested changelog entry here.
