### PR TITLE
#9546 replacing PropTypes with Typescript Definitions

### DIFF
--- a/assets/js/blocks/active-filters/block.tsx
+++ b/assets/js/blocks/active-filters/block.tsx
@@ -6,7 +6,6 @@ import { useQueryStateByKey } from '@woocommerce/base-context/hooks';
 import { getSetting, getSettingWithCoercion } from '@woocommerce/settings';
 import { useMemo, useEffect, useState } from '@wordpress/element';
 import classnames from 'classnames';
-import PropTypes from 'prop-types';
 import Label from '@woocommerce/base-components/label';
 import {
 	isAttributeQueryCollection,
@@ -412,16 +411,18 @@ const ActiveFiltersBlock = ( {
 		</>
 	);
 };
-
-ActiveFiltersBlock.propTypes = {
+interface ActiveFiltersBlockProps {
 	/**
 	 * The attributes for this block.
 	 */
-	attributes: PropTypes.object.isRequired,
+	attributes: {
+	  [key: string]: any;
+	};
 	/**
 	 * Whether it's in the editor or frontend display.
 	 */
-	isEditor: PropTypes.bool,
-};
+	isEditor?: boolean;
+  }
+
 
 export default ActiveFiltersBlock;

--- a/assets/js/blocks/active-filters/block.tsx
+++ b/assets/js/blocks/active-filters/block.tsx
@@ -411,6 +411,7 @@ const ActiveFiltersBlock = ( {
 		</>
 	);
 };
+
 interface ActiveFiltersBlockProps {
 	/**
 	 * The attributes for this block.


### PR DESCRIPTION
This PR replaces PropTypes used in block.tsx with Typescript definitions.

### Changelog

Replace propTypes with TypeScript definitions 
