### PR TITLE
Fix/8771 prevent notice from appearing when clicking on add to cart button inside single product block

### DIFF
--- a/assets/js/atomic/blocks/product-elements/add-to-cart-form/block.json
+++ b/assets/js/atomic/blocks/product-elements/add-to-cart-form/block.json
@@ -3,6 +3,12 @@
 	"version": "1.0.0",
 	"title": "Add to Cart with Options",
 	"description": "Display a button so the customer can add a product to their cart. Options will also be displayed depending on product type. e.g. quantity, variation.",
+	"attributes": {
+		"isDescendentOfSingleProductBlock": {
+			"type": "boolean",
+			"default": false
+		}
+	},
 	"category": "woocommerce",
 	"keywords": [ "WooCommerce" ],
 	"usesContext": ["postId"],

--- a/assets/js/atomic/blocks/product-elements/add-to-cart-form/edit.tsx
+++ b/assets/js/atomic/blocks/product-elements/add-to-cart-form/edit.tsx
@@ -1,23 +1,38 @@
 /**
  * External dependencies
  */
+import { useEffect } from '@wordpress/element';
 import { useBlockProps } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { Button, Disabled, Tooltip } from '@wordpress/components';
 import { Skeleton } from '@woocommerce/base-components/skeleton';
+import { BlockEditProps } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
 import './editor.scss';
+import { useIsDescendentOfSingleProductBlock } from '../shared/use-is-descendent-of-single-product-block';
 export interface Attributes {
 	className?: string;
+	isDescendentOfSingleProductBlock: boolean;
 }
 
-const Edit = () => {
+const Edit = ( props: BlockEditProps< Attributes > ) => {
+	const { setAttributes } = props;
 	const blockProps = useBlockProps( {
 		className: 'wc-block-add-to-cart-form',
 	} );
+	const { isDescendentOfSingleProductBlock } =
+		useIsDescendentOfSingleProductBlock( {
+			blockClientId: blockProps?.id,
+		} );
+
+	useEffect( () => {
+		setAttributes( {
+			isDescendentOfSingleProductBlock,
+		} );
+	}, [ setAttributes, isDescendentOfSingleProductBlock ] );
 
 	return (
 		<div { ...blockProps }>

--- a/src/BlockTypes/AddToCartForm.php
+++ b/src/BlockTypes/AddToCartForm.php
@@ -16,6 +16,32 @@ class AddToCartForm extends AbstractBlock {
 	protected $block_name = 'add-to-cart-form';
 
 	/**
+	 * Initialize the block and Hook into the `render_block_context` filter
+	 * to update the context with the correct data.
+	 *
+	 * @var string
+	 */
+	protected function initialize() {
+		parent::initialize();
+		add_filter ( 'wc_add_to_cart_message_html', array( $this, 'wc_add_to_cart_message_html_filter' ), 10, 2 );
+	}
+
+	/**
+	 * Get the block's attributes.
+	 *
+	 * @param array $attributes Block attributes. Default empty array.
+	 * @return array  Block attributes merged with defaults.
+	 */
+	private function parse_attributes( $attributes ) {
+		// These should match what's set in JS `registerBlockType`.
+		$defaults = array(
+			'isDescendentOfSingleProductBlock' => false,
+		);
+
+		return wp_parse_args( $attributes, $defaults );
+	}
+
+	/**
 	 * Render the block.
 	 *
 	 * @param array    $attributes Block attributes.
@@ -42,6 +68,7 @@ class AddToCartForm extends AbstractBlock {
 		}
 
 		ob_start();
+
 		/**
 		 * Trigger the single product add to cart action for each product type.
 		*
@@ -57,6 +84,10 @@ class AddToCartForm extends AbstractBlock {
 			return '';
 		}
 
+		$parsed_attributes = $this->parse_attributes( $attributes );
+		$is_descendent_of_single_product_block = $parsed_attributes['isDescendentOfSingleProductBlock'];
+		$product = $this->add_is_descendent_of_single_product_block_hidden_input_to_product_form( $product, $is_descendent_of_single_product_block );
+
 		$classname          = $attributes['className'] ?? '';
 		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes );
 
@@ -71,6 +102,38 @@ class AddToCartForm extends AbstractBlock {
 		$product = $previous_product;
 
 		return $form;
+	}
+
+	/**
+	 * Add a hidden input to the Add to Cart form to indicate that it is a descendent of a Single Product block.
+	 *
+	 * @param string $product The Add to Cart Form HTML.
+	 *
+	 * @return string The Add to Cart Form HTML with the hidden input.
+	 */
+	protected function add_is_descendent_of_single_product_block_hidden_input_to_product_form( $product, $is_descendent_of_single_product_block ) {
+
+		$hidden_is_descendent_of_single_product_block_input = sprintf(
+			'<input type="hidden" name="is-descendent-of-single-product-block" value="%1$s">',
+			$is_descendent_of_single_product_block ? 'true' : 'false'
+		);
+		$regex_pattern = '/<button\s+type="submit"[^>]*>.*?<\/button>/i';
+
+		preg_match($regex_pattern, $product, $input_matches);
+
+		if ( ! empty( $input_matches ) ) {
+			$product = preg_replace( $regex_pattern, $hidden_is_descendent_of_single_product_block_input . $input_matches[0], $product );
+		}
+
+		return $product;
+
+	}
+ 
+	function wc_add_to_cart_message_html_filter( $message, $products ) {
+		if( isset( $_POST['is-descendent-of-single-product-block'] ) && 'true' == $_POST['is-descendent-of-single-product-block'] ){
+			return false;
+		}
+		return $message;
 	}
 
 	/**

--- a/src/BlockTypes/AddToCartForm.php
+++ b/src/BlockTypes/AddToCartForm.php
@@ -23,7 +23,7 @@ class AddToCartForm extends AbstractBlock {
 	 */
 	protected function initialize() {
 		parent::initialize();
-		add_filter ( 'wc_add_to_cart_message_html', array( $this, 'wc_add_to_cart_message_html_filter' ), 10, 2 );
+		add_filter( 'wc_add_to_cart_message_html', array( $this, 'wc_add_to_cart_message_html_filter' ), 10, 2 );
 	}
 
 	/**
@@ -108,6 +108,7 @@ class AddToCartForm extends AbstractBlock {
 	 * Add a hidden input to the Add to Cart form to indicate that it is a descendent of a Single Product block.
 	 *
 	 * @param string $product The Add to Cart Form HTML.
+	 * @param string $is_descendent_of_single_product_block Indicates if block is descendent of Single Product block.
 	 *
 	 * @return string The Add to Cart Form HTML with the hidden input.
 	 */
@@ -119,18 +120,20 @@ class AddToCartForm extends AbstractBlock {
 		);
 		$regex_pattern = '/<button\s+type="submit"[^>]*>.*?<\/button>/i';
 
-		preg_match($regex_pattern, $product, $input_matches);
+		preg_match( $regex_pattern, $product, $input_matches );
 
 		if ( ! empty( $input_matches ) ) {
 			$product = preg_replace( $regex_pattern, $hidden_is_descendent_of_single_product_block_input . $input_matches[0], $product );
 		}
 
 		return $product;
-
 	}
  
-	function wc_add_to_cart_message_html_filter( $message, $products ) {
-		if( isset( $_POST['is-descendent-of-single-product-block'] ) && 'true' == $_POST['is-descendent-of-single-product-block'] ){
+	/** 
+	 * Filter the add to cart message to prevent the Notice from being displayed when the Add to Cart form is a descendent of a Single Product block.
+	 */
+	public function wc_add_to_cart_message_html_filter( $message ) {
+		if ( isset( $_POST['is-descendent-of-single-product-block'] ) && 'true' == $_POST['is-descendent-of-single-product-block'] ) {
 			return false;
 		}
 		return $message;


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|        |       |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1.
2.
3.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Add suggested changelog entry here.
