### PR TITLE
Ensure aria-label is showing correct value based on setting

### DIFF
--- a/assets/js/blocks/mini-cart/block.tsx
+++ b/assets/js/blocks/mini-cart/block.tsx
@@ -212,17 +212,31 @@ const MiniCartBlock = ( attributes: Props ): JSX.Element => {
 		  parseInt( cartTotals.total_items_tax, 10 )
 		: parseInt( cartTotals.total_items, 10 );
 
-	const ariaLabel = sprintf(
-		/* translators: %1$d is the number of products in the cart. %2$s is the cart total */
-		_n(
-			'%1$d item in cart, total price of %2$s',
-			'%1$d items in cart, total price of %2$s',
-			cartItemsCount,
-			'woo-gutenberg-products-block'
-		),
-		cartItemsCount,
-		formatPrice( subTotal, getCurrencyFromPriceResponse( cartTotals ) )
-	);
+	const ariaLabel = hasHiddenPrice
+		? sprintf(
+				/* translators: %1$d is the number of products in the cart. */
+				_n(
+					'%1$d item in cart',
+					'%1$d items in cart',
+					cartItemsCount,
+					'woo-gutenberg-products-block'
+				),
+				cartItemsCount
+		  )
+		: sprintf(
+				/* translators: %1$d is the number of products in the cart. %2$s is the cart total */
+				_n(
+					'%1$d item in cart, total price of %2$s',
+					'%1$d items in cart, total price of %2$s',
+					cartItemsCount,
+					'woo-gutenberg-products-block'
+				),
+				cartItemsCount,
+				formatPrice(
+					subTotal,
+					getCurrencyFromPriceResponse( cartTotals )
+				)
+		  );
 
 	const colorStyle = {
 		backgroundColor: style?.color?.background,

--- a/assets/js/blocks/mini-cart/utils/data.ts
+++ b/assets/js/blocks/mini-cart/utils/data.ts
@@ -13,8 +13,8 @@ export const updateTotals = ( totals: [ string, number ] | undefined ) => {
 		return;
 	}
 	const [ amount, quantity ] = totals;
-	const miniCartButtons = document.querySelectorAll(
-		'.wc-block-mini-cart__button'
+	const miniCarts = document.querySelectorAll(
+		'.wc-block-mini-cart.wp-block-woocommerce-mini-cart'
 	);
 	const miniCartQuantities = document.querySelectorAll(
 		'.wc-block-mini-cart__badge'
@@ -23,21 +23,40 @@ export const updateTotals = ( totals: [ string, number ] | undefined ) => {
 		'.wc-block-mini-cart__amount'
 	);
 
-	miniCartButtons.forEach( ( miniCartButton ) => {
-		miniCartButton.setAttribute(
-			'aria-label',
-			sprintf(
-				/* translators: %s number of products in cart. */
-				_n(
-					'%1$d item in cart, total price of %2$s',
-					'%1$d items in cart, total price of %2$s',
+	miniCarts.forEach( ( miniCart ) => {
+		const hasHiddenPrice = miniCart.getAttribute( 'data-has-hidden-price' );
+		const button = miniCart.querySelector( '.wc-block-mini-cart__button' );
+
+		if ( hasHiddenPrice ) {
+			button?.setAttribute(
+				'aria-label',
+				sprintf(
+					/* translators: %s number of products in cart. */
+					_n(
+						'%1$d item in cart',
+						'%1$d items in cart',
+						quantity,
+						'woo-gutenberg-products-block'
+					),
+					quantity
+				)
+			);
+		} else {
+			button?.setAttribute(
+				'aria-label',
+				sprintf(
+					/* translators: %1$d is the number of products in the cart. %2$s is the cart total */
+					_n(
+						'%1$d item in cart, total price of %2$s',
+						'%1$d items in cart, total price of %2$s',
+						quantity,
+						'woo-gutenberg-products-block'
+					),
 					quantity,
-					'woo-gutenberg-products-block'
-				),
-				quantity,
-				amount
-			)
-		);
+					amount
+				)
+			);
+		}
 	} );
 	miniCartQuantities.forEach( ( miniCartQuantity ) => {
 		if ( quantity > 0 || miniCartQuantity.textContent !== '' ) {

--- a/assets/js/blocks/mini-cart/utils/data.ts
+++ b/assets/js/blocks/mini-cart/utils/data.ts
@@ -13,9 +13,7 @@ export const updateTotals = ( totals: [ string, number ] | undefined ) => {
 		return;
 	}
 	const [ amount, quantity ] = totals;
-	const miniCarts = document.querySelectorAll(
-		'.wc-block-mini-cart.wp-block-woocommerce-mini-cart'
-	);
+	const miniCartBlocks = document.querySelectorAll( '.wc-block-mini-cart' );
 	const miniCartQuantities = document.querySelectorAll(
 		'.wc-block-mini-cart__badge'
 	);
@@ -23,40 +21,40 @@ export const updateTotals = ( totals: [ string, number ] | undefined ) => {
 		'.wc-block-mini-cart__amount'
 	);
 
-	miniCarts.forEach( ( miniCart ) => {
-		const hasHiddenPrice = miniCart.getAttribute( 'data-has-hidden-price' );
-		const button = miniCart.querySelector( '.wc-block-mini-cart__button' );
-
-		if ( hasHiddenPrice ) {
-			button?.setAttribute(
-				'aria-label',
-				sprintf(
-					/* translators: %s number of products in cart. */
-					_n(
-						'%1$d item in cart',
-						'%1$d items in cart',
-						quantity,
-						'woo-gutenberg-products-block'
-					),
-					quantity
-				)
-			);
-		} else {
-			button?.setAttribute(
-				'aria-label',
-				sprintf(
-					/* translators: %1$d is the number of products in the cart. %2$s is the cart total */
-					_n(
-						'%1$d item in cart, total price of %2$s',
-						'%1$d items in cart, total price of %2$s',
-						quantity,
-						'woo-gutenberg-products-block'
-					),
-					quantity,
-					amount
-				)
-			);
+	miniCartBlocks.forEach( ( miniCartBlock ) => {
+		if ( ! ( miniCartBlock instanceof HTMLElement ) ) {
+			return;
 		}
+
+		const miniCartButton = miniCartBlock.querySelector(
+			'.wc-block-mini-cart__button'
+		);
+
+		miniCartButton?.setAttribute(
+			'aria-label',
+			miniCartBlock.dataset.hasHiddenPrice
+				? sprintf(
+						/* translators: %s number of products in cart. */
+						_n(
+							'%1$d item in cart',
+							'%1$d items in cart',
+							quantity,
+							'woo-gutenberg-products-block'
+						),
+						quantity
+				  )
+				: sprintf(
+						/* translators: %1$d is the number of products in the cart. %2$s is the cart total */
+						_n(
+							'%1$d item in cart, total price of %2$s',
+							'%1$d items in cart, total price of %2$s',
+							quantity,
+							'woo-gutenberg-products-block'
+						),
+						quantity,
+						amount
+				  )
+		);
 	} );
 	miniCartQuantities.forEach( ( miniCartQuantity ) => {
 		if ( quantity > 0 || miniCartQuantity.textContent !== '' ) {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/9645

This PR fixes the issue where the attribute `aria-label` is always displaying the `total price` information even when `Display total price` setting is false.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Display total price: false | Display total price: true |
| ------ | ----- |
| ![uSQ1Un.png](https://github.com/woocommerce/woocommerce-blocks/assets/2132595/055e4ed3-b04a-46b8-b64b-db74bc166004)       | ![3pi88T.png](https://github.com/woocommerce/woocommerce-blocks/assets/2132595/ac659d15-2636-48a9-8d30-a0f99505ad34)      |

### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Add the Mini-Cart block to a post or page and set the Display total price attribute to false.
2. Go to the frontend and with your browser devtools (F12). Inspect element and look for the`.wc-block-mini-cart__button` on the `mini cart block`. Find the `aria-label`.
3. Notice it says `X item(s) in cart`, with the price. Hover over the `mini cart` icon and click on. Inspect the element again to ensure it is still displaying `X item(s) in cart`.
4. Go back to the `mini cart` settings and switch it to show `Display total price`.
5. The `aria-label` should now show "X item(s) in cart, total price of Y".
6. BONUS: Add another instance of the `mini cart` in the header and perform the same tests and ensure each instance of the `mini cart` shows their own `aria-label` value depending on the `Display total price` settings.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Fix aria-label displaying wrong information on mini-cart