### PR TITLE
Prevent Mini-Cart table to show horizontal scrollbar

### DIFF
--- a/assets/js/blocks/mini-cart/style.scss
+++ b/assets/js/blocks/mini-cart/style.scss
@@ -127,8 +127,6 @@ h2.wc-block-mini-cart__title {
 
 	.wc-block-mini-cart__products-table {
 		margin-bottom: auto;
-		margin-right: -$gap;
-		padding-right: $gap;
 
 		.wc-block-cart-items__row {
 			padding-top: $gap-smaller;


### PR DESCRIPTION
Fixes #9669.

### Testing

#### User Facing Testing

1. Set up your browser so scrollbars are visible (see [instructions for Mac](https://support.vagaro.com/hc/en-us/articles/204347160-Disable-Disappearing-Scroll-Bars-on-Mac-Computers), on GNOME it's under Settings > Accessibility).
2. Add the Mini-Cart block to the header of your store.
3. In the frontend, open the Mini-Cart drawer and verify there is no horizontal scrollbar in the contents table.

Before | After
--- | ---
![imatge](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/084b8dee-aff3-435a-aaec-b231609afe6e) | ![imatge](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/1db799a4-cd27-4c06-9acf-b18ffa96bad1)

* [ ] Do not include in the Testing Notes

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Prevent Mini-Cart drawer to show horizontal scrollbar if the system has visible scrollbars
