### PR TITLE
React warning about javascript: URLs in `CheckoutOrderError`

### DIFF
--- a/assets/js/blocks/checkout/checkout-order-error/index.js
+++ b/assets/js/blocks/checkout/checkout-order-error/index.js
@@ -123,7 +123,9 @@ const ErrorButton = ( { errorData } ) => {
 
 	if ( cartItemErrorCodes.includes( errorData.code ) ) {
 		buttonText = __( 'Edit your cart', 'woo-gutenberg-products-block' );
-		onClickHandler = () => ( window.location.href = CART_URL );
+		onClickHandler = () => {
+			window.location.href = CART_URL;
+		};
 	}
 
 	return (

--- a/assets/js/blocks/checkout/checkout-order-error/index.js
+++ b/assets/js/blocks/checkout/checkout-order-error/index.js
@@ -119,18 +119,21 @@ const ErrorMessage = ( { errorData } ) => {
  */
 const ErrorButton = ( { errorData } ) => {
 	let buttonText = __( 'Retry', 'woo-gutenberg-products-block' );
-	let buttonUrl = 'javascript:window.location.reload(true)';
+	let onClickHandler = () => window.location.reload();
 
 	if ( cartItemErrorCodes.includes( errorData.code ) ) {
 		buttonText = __( 'Edit your cart', 'woo-gutenberg-products-block' );
-		buttonUrl = CART_URL;
+		onClickHandler = () => ( window.location.href = CART_URL );
 	}
 
 	return (
 		<span className="wp-block-button">
-			<a href={ buttonUrl } className="wp-block-button__link">
+			<button
+				onClick={ onClickHandler }
+				className="wp-block-button__link"
+			>
 				{ buttonText }
-			</a>
+			</button>
 		</span>
 	);
 };


### PR DESCRIPTION
Fixes woocommerce/woocommerce#42354 
This PR adds `onClickHandler` in assets/js/block/checkout/checkout-order-error/index.js

### Testing

#### Automated Tests
* [x] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
