### PR TITLE
Blockified Single Product Template: add product-classes via `wc_get_product_class`

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -325,6 +325,13 @@ class BlockTemplatesController {
 
 				if ( str_contains( $template->slug, 'single-product' ) ) {
 					if ( ! is_admin() && ! BlockTemplateUtils::template_has_legacy_template_block( $template ) ) {
+						// Add the product class to the body. We should move this move this to a more appropriate place.
+						add_filter(
+							'body_class',
+							function( $classes ) {
+								return array_merge( $classes, wc_get_product_class() );
+							}
+						);
 
 						$new_content       = SingleProductTemplateCompatibility::add_compatibility_layer( $template->content );
 						$template->content = $new_content;

--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -325,7 +325,7 @@ class BlockTemplatesController {
 
 				if ( str_contains( $template->slug, 'single-product' ) ) {
 					if ( ! is_admin() && ! BlockTemplateUtils::template_has_legacy_template_block( $template ) ) {
-						// Add the product class to the body. We should move this move this to a more appropriate place.
+						// Add the product class to the body. We should move this to a more appropriate place.
 						add_filter(
 							'body_class',
 							function( $classes ) {

--- a/tests/e2e-pw/playwright.config.ts
+++ b/tests/e2e-pw/playwright.config.ts
@@ -35,7 +35,7 @@ const config: ExtendedPlaywrightTestConfig = {
 	use: {
 		baseURL: BASE_URL,
 		screenshot: 'only-on-failure',
-		stateDir: './tests/e2e-pw/test-results/storage/',
+		stateDir: 'tests/e2e-pw/test-results/storage/',
 		trace: 'retain-on-failure',
 		video: 'on-first-retry',
 		viewport: { width: 1280, height: 720 },

--- a/tests/e2e-pw/tests/single-product-template/single-product-template.block_theme.spec.ts
+++ b/tests/e2e-pw/tests/single-product-template/single-product-template.block_theme.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import { test, expect } from '@woocommerce/e2e-playwright-utils';
+
+const products = [
+	{
+		product: 'Album',
+		// Copy-pasted by WooCommerce Core Legacy Template.
+		classes: [
+			'product',
+			'type-product',
+			'status-publish',
+			'instock',
+			'product_cat-music',
+			'has-post-thumbnail',
+			'downloadable',
+			'virtual',
+			'purchasable',
+			'product-type-simple',
+		],
+		frontendPage: '/product/album/',
+	},
+	{
+		product: 'Hoodie',
+		// Copy-pasted by WooCommerce Core Legacy Template.
+		classes: [
+			'product',
+			'type-product',
+			'status-publish',
+			'instock',
+			'product_cat-hoodies',
+			'has-post-thumbnail',
+			'sale',
+			'shipping-taxable',
+			'purchasable',
+			'product-type-variable',
+		],
+		frontendPage: '/product/hoodie/',
+	},
+];
+
+for ( const { classes, product, frontendPage } of products ) {
+	test.describe( `The Single Product page of the ${ product }`, () =>
+		test( 'add product specific classes to the body', async ( {
+			page,
+		} ) => {
+			await page.goto( frontendPage );
+			const body = await page.locator( 'body' );
+			const bodyClasses = await body.getAttribute( 'class' );
+
+			classes.forEach( ( className ) => {
+				expect( bodyClasses?.split( ' ' ) ).toContain( className );
+			} );
+		} )
+	);
+}


### PR DESCRIPTION
@xristos3490 noticed that we don't load product classes on the Blockified Single Product Template. This PR fixes this. Instead of injecting on the main div wrapper as WooCommerce Core does, we inject the classes on the body.

I noticed that the classes `first` and `last` are added and this is odd in the case of the Single Product Template. The reason is that we invoke the function `wc_get_product_class` not in the appropriate place. We should refactor this when we will work on the refactor of the `BlockTemplatesController`. #9491

Fixes #9686 

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Ensure that you are using the Blockified Single Product Template. 
2. Visit a product page.
3. Check the body and ensure that the product classes are added

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental


### Changelog

> Blockified Single Product Template: add product-classes.
