### PR TITLE
Blockified Single Product Template: avoid to add another group block on the editor side when the user creates a template for a specific product

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -325,7 +325,7 @@ class BlockTemplatesController {
 
 				if ( str_contains( $template->slug, 'single-product' ) ) {
 					// We don't want to add the compatibility layer on the Editor Side.
-					// The second condition is necessary to not applied the compatibility layer on the REST API. Gutenberg uses the REST API to clone the template.
+					// The second condition is necessary to not apply the compatibility layer on the REST API. Gutenberg uses the REST API to clone the template.
 					// More details: https://github.com/woocommerce/woocommerce-blocks/issues/9662.
 					if ( ( ! is_admin() && ! ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) && ! BlockTemplateUtils::template_has_legacy_template_block( $template ) ) {
 						$new_content       = SingleProductTemplateCompatibility::add_compatibility_layer( $template->content );

--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -324,8 +324,10 @@ class BlockTemplatesController {
 				}
 
 				if ( str_contains( $template->slug, 'single-product' ) ) {
-					if ( ! is_admin() && ! BlockTemplateUtils::template_has_legacy_template_block( $template ) ) {
-
+					// We don't want to add the compatibility layer on the Editor Side.
+					// The second condition is necessary to not applied the compatibility layer on the REST API. Gutenberg uses the REST API to clone the template.
+					// More details: https://github.com/woocommerce/woocommerce-blocks/issues/9662.
+					if ( ( ! is_admin() && ! ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) && ! BlockTemplateUtils::template_has_legacy_template_block( $template ) ) {
 						$new_content       = SingleProductTemplateCompatibility::add_compatibility_layer( $template->content );
 						$template->content = $new_content;
 					}


### PR DESCRIPTION
Without this PR when the user creates a template for a specific product, the Single Product Template is wrapped by two group blocks instead of one. 
This happens because the creation of a template for a specific product is done via REST API. For fixing this issue, I added another check.


<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #9662 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->




### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Open the Site Editor.
2. Be sure that the Single Product template is blockified.
3. Click `Manage All Templates` button.
4. Click `Add New`.
5. Select Product.
6. Select a product.
7. Open the list view.
8. Ensure that the template is wrapped by just one group block.
9. Visit the product. 
10. Ensure that there is a div with the class `woocommerce` that wraps the entire template.
11. Visit another product.
12. Ensure that there is a div with the class `woocommerce` that wraps the entire template.


* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental


