### PR TITLE
Product Price: remove underline on sale price

### DIFF
--- a/assets/js/atomic/blocks/product-elements/price/style.scss
+++ b/assets/js/atomic/blocks/product-elements/price/style.scss
@@ -4,4 +4,8 @@
 	.wc-block-all-products & {
 		margin-bottom: $gap-small;
 	}
+
+	ins {
+		text-decoration: none;
+	}
 }


### PR DESCRIPTION
This PR removes the underline on the sale price. In this way, we replicate the same design used by WooCommerce Core.

cc @kmanijak @imanish003 since impact the Products/Product Collection blocks.

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #9659 

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Classic Template | Blockified Template - Before | Blockified Template - After |
|--------|--------|--------|
|![image](https://github.com/woocommerce/woocommerce-blocks/assets/4463174/c9e62330-67ef-4551-b85d-ad3e86de0d84)|![image](https://github.com/woocommerce/woocommerce-blocks/assets/4463174/3ed960f0-4662-48dd-a5bd-cdad2b4c207b)|![image](https://github.com/woocommerce/woocommerce-blocks/assets/4463174/815594eb-873a-4a2b-a4b2-077631ef230b)|



| Classic Template | Blockified Template - Before |  Blockified Template - After |
|--------|--------|--------|
|![image](https://github.com/woocommerce/woocommerce-blocks/assets/4463174/bfe48925-b275-4dd0-b90e-cf081efcc7ef)|![image](https://github.com/woocommerce/woocommerce-blocks/assets/4463174/0a5bfee0-ae69-499d-9ea0-6c498ab25587)|![image](https://github.com/woocommerce/woocommerce-blocks/assets/4463174/8df93833-b0e1-407d-9e9e-53fb04115a90)|



### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Ensure you are using the Blockified Single Product Template and Product Catalog Template.
2. Visit a product with a sale price.
3. Ensure that the sale price isn't underlined.
4. Visit the `/shop` page.
5. Ensure that the sale price isn't underlined

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Product Price: remove underline on sale price.
