### PR TITLE
Fix esc_html error in footer pattern

### DIFF
--- a/patterns/footer-with-3-menus.php
+++ b/patterns/footer-with-3-menus.php
@@ -56,11 +56,16 @@
 
 				<!-- wp:paragraph {"align":"right","style":{"typography":{"fontSize":"12px"}}} -->
 				<p class="has-text-align-right" style="font-size:12px">
-					<?php echo sprintf(
-						__( 'Powered by %s with %s', 'woo-gutenberg-products-block' ),
-						'<a href="https://wordpress.org">WordPress</a>',
-						'<a href="https://woocommerce.com">WooCommerce</a>'
-					) ?>
+					<?php
+						echo sprintf(
+							esc_html(
+								/* translators: Footer powered by text. %1$s being WordPress, %2$s being WooCommerce */
+								__( 'Powered by %1$s with %2$s', 'woo-gutenberg-products-block' )
+							),
+							'<a href="https://wordpress.org">WordPress</a>',
+							'<a href="https://woocommerce.com">WooCommerce</a>'
+						);
+						?>
 				</p>
 				<!-- /wp:paragraph -->
 			</div>


### PR DESCRIPTION
Correctly escape HTML in footer pattern

### Testing

#### User Facing Testing

1. With a block theme go to Appearance > Editor > Template Parts
2. Replace footer with "Footer with 3 menus" pattern and check the outputted markup is correct "Powered by WordPress with WooCommerce" in the bottom right.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
