### PR TITLE
Adjust escaping of script output in Store directive.

### DIFF
--- a/src/Interactivity/directives/class-woo-directive-store.php
+++ b/src/Interactivity/directives/class-woo-directive-store.php
@@ -20,10 +20,8 @@ class Woo_Directive_Store {
 			return;
 		}
 
-		$id = 'store';
 		echo sprintf(
-			'<script id="%s" type="application/json">%s</script>',
-			esc_attr( $id ),
+			'<script id="store" type="application/json">%s</script>',
 			json_encode( self::$store )
 		);
 	}

--- a/src/Interactivity/directives/class-woo-directive-store.php
+++ b/src/Interactivity/directives/class-woo-directive-store.php
@@ -11,10 +11,6 @@ class Woo_Directive_Store {
 		self::$store = array_replace_recursive( self::$store, $data );
 	}
 
-	static function serialize() {
-		return json_encode( self::$store );
-	}
-
 	static function reset() {
 		self::$store = array();
 	}
@@ -24,8 +20,11 @@ class Woo_Directive_Store {
 			return;
 		}
 
-		$id    = 'store';
-		$store = self::serialize();
-		echo "<script id=\"$id\" type=\"application/json\">$store</script>";
+		$id = 'store';
+		echo sprintf(
+			'<script id="%s" type="application/json">%s</script>',
+			esc_attr( $id ),
+			json_encode( self::$store )
+		);
 	}
 }


### PR DESCRIPTION
This moves the `json_encode()` from the `serialize` method to the output (promoting later escaping) and removes the now unneeded `serialize` method.

Also, runs the `$id` variable through the `esc_attr()` function.

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

### Testing
<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Confirm the `WordPress.Security.EscapeOutput.OutputNotEscaped` is no longer failing on `woo-gutenberg-products-block/src/Interactivity/directives/class-woo-directive-store.php`
2. Confirm that the store directive still functions, as expected.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental

### Changelog

> Add suggested changelog entry here.
