### PR TITLE
Remove propTypes definitions from  Grid Content Control

### DIFF
--- a/assets/js/editor-components/grid-content-control/index.tsx
+++ b/assets/js/editor-components/grid-content-control/index.tsx
@@ -2,9 +2,20 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import PropTypes from 'prop-types';
 import { ToggleControl } from '@wordpress/components';
 
+interface GridContentControlProps {
+	onChange: ( settings: GridContentSettings ) => void;
+	settings: GridContentSettings;
+}
+
+interface GridContentSettings {
+	image: boolean;
+	button: boolean;
+	price: boolean;
+	rating: boolean;
+	title: boolean;
+}
 /**
  * A combination of toggle controls for content visibility in product grids.
  *
@@ -12,7 +23,10 @@ import { ToggleControl } from '@wordpress/components';
  * @param {function(any):any} props.onChange
  * @param {Object}            props.settings
  */
-const GridContentControl = ( { onChange, settings } ) => {
+const GridContentControl = ( {
+	onChange,
+	settings,
+}: GridContentControlProps ) => {
 	const { image, button, price, rating, title } = settings;
 	// If `image` is undefined, that might be because it's a block that was
 	// created before the `image` attribute existed, so we default to true.
@@ -51,23 +65,6 @@ const GridContentControl = ( { onChange, settings } ) => {
 			/>
 		</>
 	);
-};
-
-GridContentControl.propTypes = {
-	/**
-	 * The current title visibility.
-	 */
-	settings: PropTypes.shape( {
-		image: PropTypes.bool.isRequired,
-		button: PropTypes.bool.isRequired,
-		price: PropTypes.bool.isRequired,
-		rating: PropTypes.bool.isRequired,
-		title: PropTypes.bool.isRequired,
-	} ).isRequired,
-	/**
-	 * Callback to update the layout settings.
-	 */
-	onChange: PropTypes.func.isRequired,
 };
 
 export default GridContentControl;

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -3038,7 +3038,7 @@
 <error line="55" column="6" severity="error" message="Type &apos;{ selected: number[]; onChange: (value?: never[]) =&gt; void; }&apos; is not assignable to type &apos;IntrinsicAttributes &amp; { selected: number[]; }&apos;.
   Property &apos;onChange&apos; does not exist on type &apos;IntrinsicAttributes &amp; { selected: number[]; }&apos;." source="TS2322" />
 </file>
-<file name="assets/js/editor-components/grid-content-control/index.js">
+<file name="assets/js/editor-components/grid-content-control/index.tsx">
 <error line="16" column="10" severity="error" message="Property &apos;image&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
 <error line="16" column="17" severity="error" message="Property &apos;button&apos; does not exist on type &apos;Object&apos;." source="TS2339" />
 <error line="16" column="25" severity="error" message="Property &apos;price&apos; does not exist on type &apos;Object&apos;." source="TS2339" />


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #9533 

### Changes in the PR:
Removed propTypes definitions from Reviews By Category.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->
### Testing

#### Automated Tests
* [x] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [x] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
