### PR TITLE
Enable Single Product block

### DIFF
--- a/bin/webpack-entries.js
+++ b/bin/webpack-entries.js
@@ -64,9 +64,7 @@ const blocks = {
 	'reviews-by-product': {
 		customDir: 'reviews/reviews-by-product',
 	},
-	'single-product': {
-		isExperimental: true,
-	},
+	'single-product': {},
 	'stock-filter': {},
 	'product-collection': {
 		isExperimental: true,

--- a/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md
+++ b/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md
@@ -35,7 +35,6 @@ The majority of our feature flagging is blocks, this is a list of them:
 
 ### Experimental flag
 
--   Single Product block ([PHP flag](https://github.com/woocommerce/woocommerce-blocks/blob/cb11cd2537e35561a9c930f893ee72d82ab6bc75/src/BlockTypesController.php#L227) | [webpack flag](https://github.com/woocommerce/woocommerce-blocks/blob/cb11cd2537e35561a9c930f893ee72d82ab6bc75/bin/webpack-entries.js#L68)).
 -   Product Collection ([PHP flag](https://github.com/woocommerce/woocommerce-blocks/blob/17007169ea5f61e36903d7ca79902794cbb45100/src/BlockTypesController.php#L228) | [webpack flag](https://github.com/woocommerce/woocommerce-blocks/blob/17007169ea5f61e36903d7ca79902794cbb45100/bin/webpack-entries.js#L71-L73)).
 -   Product Template ([PHP flag](https://github.com/woocommerce/woocommerce-blocks/blob/17007169ea5f61e36903d7ca79902794cbb45100/src/BlockTypesController.php#L229) | [webpack flag](https://github.com/woocommerce/woocommerce-blocks/blob/17007169ea5f61e36903d7ca79902794cbb45100/bin/webpack-entries.js#L74-L76)).
 -   ⚛️ Add to cart ([JS flag](https://github.com/woocommerce/woocommerce-blocks/blob/dfd2902bd8a247b5d048577db6753c5e901fc60f/assets/js/atomic/blocks/product-elements/add-to-cart/index.ts#L26-L29)).

--- a/src/BlockTypesController.php
+++ b/src/BlockTypesController.php
@@ -224,7 +224,6 @@ final class BlockTypesController {
 		);
 
 		if ( Package::feature()->is_experimental_build() ) {
-			$block_types[] = 'SingleProduct';
 			$block_types[] = 'ProductCollection';
 			$block_types[] = 'ProductTemplate';
 		}


### PR DESCRIPTION
This PR enables the Single Product block. Kudos to @thealexandrelara for working on this block in the last weeks! 🙇 

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

⚠️  _For those who review this PR: use a product build (`npm run build:deploy`)_

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Add the Single Product block in a post/page.
2. Visit the created post/page.
3. Click the `add to cart` button .
4. Ensure that the product is added to the cart and any notice is visible.
5. Edit the Single Product Template.
6. Add the Single Product block.
7. Repeat 3-4 steps.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Enable Single Product Block.
