### PR TITLE
Fix/escape add query arg template url

### DIFF
--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -183,7 +183,7 @@ class MiniCart extends AbstractBlock {
 
 			$template_part_edit_uri = add_query_arg(
 				array(
-					'postId'   => sprintf( '%s//%s', $theme_slug, 'mini-cart' ),
+					'postId'   => sprintf( esc_attr( '%s//%s' ), $theme_slug, 'mini-cart' ),
 					'postType' => 'wp_template_part',
 				),
 				$site_editor_uri

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -181,7 +181,7 @@ class MiniCart extends AbstractBlock {
 				);
 			}
 
-			$template_part_edit_uri = esc_url(
+			$template_part_edit_uri = esc_url_raw(
 				add_query_arg(
 					array(
 						'postId'   => sprintf( '%s//%s', $theme_slug, 'mini-cart' ),

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -181,12 +181,14 @@ class MiniCart extends AbstractBlock {
 				);
 			}
 
-			$template_part_edit_uri = add_query_arg(
-				array(
-					'postId'   => sprintf( esc_attr( '%s//%s' ), $theme_slug, 'mini-cart' ),
-					'postType' => 'wp_template_part',
-				),
-				$site_editor_uri
+			$template_part_edit_uri = esc_url(
+				add_query_arg(
+					array(
+						'postId'   => sprintf( '%s//%s', $theme_slug, 'mini-cart' ),
+						'postType' => 'wp_template_part',
+					),
+					$site_editor_uri
+				)
 			);
 		}
 


### PR DESCRIPTION
Potential Unsafe usage (non escaped) of add_query_arg(), which could lead to XSS.

#### User Facing Testing

1. Enable block theme.
2. Smoke test Mini Cart template part on both the editor side and the frontend to ensure it loads itself and resources correctly.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> MiniCart: Escape template part URL
