### PR TITLE
Product Rating: fix the filter woocommerce_product_get_rating_html is removed

### DIFF
--- a/src/BlockTypes/ProductRating.php
+++ b/src/BlockTypes/ProductRating.php
@@ -183,7 +183,7 @@ class ProductRating extends AbstractBlock {
 
 			remove_filter(
 				'woocommerce_product_get_rating_html',
-				[ $this, 'filter_rating_html' ],
+				$filter_rating_html,
 				10
 			);
 


### PR DESCRIPTION
@kmanijak noticed that the reviews display the current average rating. This happen because we added a filter for the `Product Rating` block and we don't remove it in the right way

https://github.com/woocommerce/woocommerce-blocks/assets/4463174/a0a71495-1a2f-4a9c-83ce-66fac15d6cdc



### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Ensure that you have the Blockified Single Product Template.
2. Visit a product.
3. Add some comments and rate the product.
4. Be sure that the ratings in the comments don't show the average rating 

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
