### PR TITLE
Checkout block: Full width Place Order button when Return To Cart link is disabled.

### DIFF
--- a/assets/js/base/components/cart-checkout/place-order-button/index.tsx
+++ b/assets/js/base/components/cart-checkout/place-order-button/index.tsx
@@ -1,15 +1,20 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
 import { useCheckoutSubmit } from '@woocommerce/base-context/hooks';
 import { Icon, check } from '@wordpress/icons';
 import Button from '@woocommerce/base-components/button';
 
 interface PlaceOrderButton {
 	label: string;
+	fullWidth?: boolean;
 }
 
-const PlaceOrderButton = ( { label }: PlaceOrderButton ): JSX.Element => {
+const PlaceOrderButton = ( {
+	label,
+	fullWidth = false,
+}: PlaceOrderButton ): JSX.Element => {
 	const {
 		onSubmit,
 		isCalculating,
@@ -20,7 +25,13 @@ const PlaceOrderButton = ( { label }: PlaceOrderButton ): JSX.Element => {
 
 	return (
 		<Button
-			className="wc-block-components-checkout-place-order-button"
+			className={ classnames(
+				'wc-block-components-checkout-place-order-button',
+				{
+					'wc-block-components-checkout-place-order-button--full-width':
+						fullWidth,
+				}
+			) }
 			onClick={ onSubmit }
 			disabled={
 				isCalculating ||

--- a/assets/js/base/components/cart-checkout/place-order-button/index.tsx
+++ b/assets/js/base/components/cart-checkout/place-order-button/index.tsx
@@ -8,7 +8,7 @@ import Button from '@woocommerce/base-components/button';
 
 interface PlaceOrderButton {
 	label: string;
-	fullWidth?: boolean;
+	fullWidth?: boolean | undefined;
 }
 
 const PlaceOrderButton = ( {

--- a/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/block.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/block.tsx
@@ -53,7 +53,10 @@ const Block = ( {
 						link={ getSetting( 'page-' + cartPageId, false ) }
 					/>
 				) }
-				<PlaceOrderButton label={ label } />
+				<PlaceOrderButton
+					label={ label }
+					fullWidth={ ! showReturnToCart }
+				/>
 			</div>
 		</div>
 	);

--- a/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/edit.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/edit.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import classnames from 'classnames';
 import { useRef } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -105,7 +106,14 @@ export const Edit = ( {
 						) }
 					</Noninteractive>
 					<EditableButton
-						className="wc-block-cart__submit-button wc-block-components-checkout-place-order-button"
+						className={ classnames(
+							'wc-block-cart__submit-button',
+							'wc-block-components-checkout-place-order-button',
+							{
+								'wc-block-components-checkout-place-order-button--full-width':
+									! showReturnToCart,
+							}
+						) }
 						value={ placeOrderButtonLabel }
 						placeholder={ defaultPlaceOrderButtonLabel }
 						onChange={ ( content ) => {

--- a/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/style.scss
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-actions-block/style.scss
@@ -9,6 +9,10 @@
 			padding: 1em;
 			height: auto;
 
+			&--full-width {
+				width: 100%;
+			}
+
 			.wc-block-components-button__text {
 				> svg {
 					fill: $white;


### PR DESCRIPTION
When the "Return To Cart link is disabled", make "Place Order" button full width as suggested [here](https://github.com/woocommerce/woocommerce-blocks/issues/9205#issuecomment-1525553656).

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/9205

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [x] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

**Before:**
![Screenshot 2023-06-05 at 13 58 45](https://github.com/woocommerce/woocommerce-blocks/assets/8639742/8506fb1a-71dc-4439-95a7-bb755c04d726)

**After:**
![Screenshot 2023-06-05 at 13 58 39](https://github.com/woocommerce/woocommerce-blocks/assets/8639742/e0c39980-f069-40ae-917d-3a5426309818)

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Create a test page and add the Checkout block.
2. Open the Document Overview.
3. Go to Checkout » Checkout Fields » Actions.
4. Toggle the checkbox Show a "Return to Cart" link.
5. See the button go full/half width depending on the toggle option.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Checkout block: When the "Return To Cart link is disabled", make "Place Order" button full width
