### PR TITLE
Single Product Template: fix Compatibility Layer when the template implements the Single Product Template

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -313,16 +313,6 @@ class BlockTemplatesController {
 		 */
 		$query_result = array_map(
 			function( $template ) {
-				if ( 'theme' === $template->origin && BlockTemplateUtils::template_has_title( $template ) ) {
-					return $template;
-				}
-				if ( $template->title === $template->slug ) {
-					$template->title = BlockTemplateUtils::get_block_template_title( $template->slug );
-				}
-				if ( ! $template->description ) {
-					$template->description = BlockTemplateUtils::get_block_template_description( $template->slug );
-				}
-
 				if ( str_contains( $template->slug, 'single-product' ) ) {
 					// We don't want to add the compatibility layer on the Editor Side.
 					// The second condition is necessary to not apply the compatibility layer on the REST API. Gutenberg uses the REST API to clone the template.
@@ -339,7 +329,16 @@ class BlockTemplatesController {
 						$new_content       = SingleProductTemplateCompatibility::add_compatibility_layer( $template->content );
 						$template->content = $new_content;
 					}
+				}
+
+				if ( 'theme' === $template->origin && BlockTemplateUtils::template_has_title( $template ) ) {
 					return $template;
+				}
+				if ( $template->title === $template->slug ) {
+					$template->title = BlockTemplateUtils::get_block_template_title( $template->slug );
+				}
+				if ( ! $template->description ) {
+					$template->description = BlockTemplateUtils::get_block_template_description( $template->slug );
 				}
 
 				return $template;


### PR DESCRIPTION
We noticed that the Compatibility Layer isn't applied when a theme implements its own Single Product Template. This happens because when [this check is true](https://github.com/woocommerce/woocommerce-blocks/blob/cf6df66b5f107b115e8bda74e41da9a03975b832/src/BlockTemplatesController.php/#L316-L318), we return the template and for this reason, the Compatibility Layer isn't applied.

This PR reorganizes the check and ensures that the logic to apply the Compatibility Layer is always executed.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Enable the `Basti` theme (this theme has its own Single Product Template)
2. Ensure that you have enabled the Blockified Single Product Template.
3. Visit a product page. 
4. Ensure that the first div that wraps the Single Product Template has the `woocommerce` class.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental


