### PR TITLE
Fix value without onchaning warning

### DIFF
--- a/assets/js/atomic/blocks/product-elements/add-to-cart-form/edit.tsx
+++ b/assets/js/atomic/blocks/product-elements/add-to-cart-form/edit.tsx
@@ -49,6 +49,7 @@ const Edit = ( props: BlockEditProps< Attributes > ) => {
 							className={
 								'wc-block-editor-add-to-cart-form__quantity'
 							}
+							readOnly
 						/>
 						<Button
 							variant={ 'primary' }


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/8904

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. With a block theme, go to Themes->Editor->Templates->Single Product (Ensure you have the blockified version).
2. Ensure there are no JS warnings in the console.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Fix warning shown in the add to cart form block in the editor
