### PR TITLE
Hide Product SKU if product has no SKU

### DIFF
--- a/src/BlockTypes/ProductSKU.php
+++ b/src/BlockTypes/ProductSKU.php
@@ -93,8 +93,8 @@ class ProductSKU extends AbstractBlock {
 	protected function is_content_loading( $content ) {
 		$block_name = 'woocommerce/' . $this->block_name;
 
-		$pattern = '/<div(?:\s+\w+="[^"]*")*\s+data-block-name="' . preg_quote($block_name, '/') . '"(?:\s+\w+="[^"]*")*\s+class="(?:[^"]*\s+)?is-loading(?:\s+[^"]*)?"(?:\s+\w+="[^"]*")*\s*><\/div>/';
-		
-		return preg_match($pattern, $content);
+		$pattern = '/<div(?:\s+\w+="[^"]*")*\s+data-block-name="' . preg_quote( $block_name, '/' ) . '"(?:\s+\w+="[^"]*")*\s+class="(?:[^"]*\s+)?is-loading(?:\s+[^"]*)?"(?:\s+\w+="[^"]*")*\s*><\/div>/';
+
+		return preg_match( $pattern, $content );
 	}
 }

--- a/src/BlockTypes/ProductSKU.php
+++ b/src/BlockTypes/ProductSKU.php
@@ -48,9 +48,8 @@ class ProductSKU extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		
 		if ( ! empty( $content ) ) {
-			if( $this->is_content_loading( $content ) ) {
+			if ( $this->is_content_loading( $content ) ) {
 				return '';
 			}
 
@@ -85,14 +84,16 @@ class ProductSKU extends AbstractBlock {
 		);
 	}
 
+	/**
+	 * Checks if the given content contains a loading indicator for the current block.
+	 *
+	 * @param string $content The content to check for a loading indicator.
+	 * @return bool True if the content contains a loading indicator, false otherwise.
+	 */
 	protected function is_content_loading( $content ) {
-		var_dump( $content );
-		$blockName = 'woocommerce/' . $this->block_name;
+		$block_name = 'woocommerce/' . $this->block_name;
 
-		$pattern = '/<div(?:\s+\w+="[^"]*")*\s+data-block-name="' . preg_quote($blockName, '/') . '"(?:\s+\w+="[^"]*")*\s+class="(?:[^"]*\s+)?is-loading(?:\s+[^"]*)?"(?:\s+\w+="[^"]*")*\s*><\/div>/';
-
-		var_dump( $pattern );
-		var_dump( preg_match($pattern, $content) );
+		$pattern = '/<div(?:\s+\w+="[^"]*")*\s+data-block-name="' . preg_quote($block_name, '/') . '"(?:\s+\w+="[^"]*")*\s+class="(?:[^"]*\s+)?is-loading(?:\s+[^"]*)?"(?:\s+\w+="[^"]*")*\s*><\/div>/';
 		
 		return preg_match($pattern, $content);
 	}

--- a/src/BlockTypes/ProductSKU.php
+++ b/src/BlockTypes/ProductSKU.php
@@ -48,7 +48,12 @@ class ProductSKU extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
+		
 		if ( ! empty( $content ) ) {
+			if( $this->is_content_loading( $content ) ) {
+				return '';
+			}
+
 			parent::register_block_type_assets();
 			$this->register_chunk_translations( [ $this->block_name ] );
 			return $content;
@@ -78,5 +83,17 @@ class ProductSKU extends AbstractBlock {
 			esc_attr( $styles_and_classes['styles'] ?? '' ),
 			$product_sku
 		);
+	}
+
+	protected function is_content_loading( $content ) {
+		var_dump( $content );
+		$blockName = 'woocommerce/' . $this->block_name;
+
+		$pattern = '/<div(?:\s+\w+="[^"]*")*\s+data-block-name="' . preg_quote($blockName, '/') . '"(?:\s+\w+="[^"]*")*\s+class="(?:[^"]*\s+)?is-loading(?:\s+[^"]*)?"(?:\s+\w+="[^"]*")*\s*><\/div>/';
+
+		var_dump( $pattern );
+		var_dump( preg_match($pattern, $content) );
+		
+		return preg_match($pattern, $content);
 	}
 }


### PR DESCRIPTION
## Description
This update addresses an issue where Product Meta inner blocks were misaligned when the product did not have a SKU. This PR solves that by including a check to determine if the content returned by the Product SKU is empty. If empty (indicated by a loading indicator), the PR ensures that nothing is returned instead of a `div` tag. This approach was implemented because the Group block is a flex container, and returning any content (such as a div) would introduce unnecessary spacing between the blocks (such as the Product Category).

## Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4dc899a</samp>

*  Add a condition to render the block content only if it is not loading ([link](https://github.com/woocommerce/woocommerce-blocks/pull/9732/files?diff=unified&w=0#diff-d4d0de8af6c116c865c3c28650faa6add48b104a81436edcff7aa5051dec5babL51-R56))
*  Define a new method `is_content_loading` to check if the block content contains a loading placeholder div ([link](https://github.com/woocommerce/woocommerce-blocks/pull/9732/files?diff=unified&w=0#diff-d4d0de8af6c116c865c3c28650faa6add48b104a81436edcff7aa5051dec5babR87-R98))
*  Use the `is_content_loading` method in the `render` method of the `ProductSKU` class in `src/BlockTypes/ProductSKU.php` ([link](https://github.com/woocommerce/woocommerce-blocks/pull/9732/files?diff=unified&w=0#diff-d4d0de8af6c116c865c3c28650faa6add48b104a81436edcff7aa5051dec5babL51-R56), [link](https://github.com/woocommerce/woocommerce-blocks/pull/9732/files?diff=unified&w=0#diff-d4d0de8af6c116c865c3c28650faa6add48b104a81436edcff7aa5051dec5babR87-R98))

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes woocommerce/woocommerce#42349

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
|--------|--------|
| <img width="1113" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/20469356/c7f95d80-572b-4b4c-9222-a9b791b1ea86"> | <img width="1154" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/20469356/0b6a4c42-2d1f-49f7-a669-a292271a76d7"> | 

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->


1. Log in to your WordPress dashboard.
2. From your WordPress dashboard, go to Appearance > Themes. Make sure you have a block-based theme installed and activated. If not, you can install one from the Add New option. Block-based themes include "Twenty-twenty Two," "Twenty-twenty Three," etc.
3. On the left-hand side menu, click on Appearance > Editor. This will open the Site Editor.
4. On the left-hand side menu, click on Templates. This will open the list of available templates.
5. Find and select the 'Single Product' template from the list.
6. When the Classic Product Template renders, click on Transform into Blocks. This will transform the Classic template in a block template if you haven't done it before.
7. On the top-right side, click on the Save button.
8. Visit a product that does not contain SKU.
9. Check that the inner blocks of the Product Meta block are correctly aligned

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Fix alignment of Product Meta inner blocks when the product does not have a SKU
