### PR TITLE
Product Collection: Hand picked products control in sidebar settings

### DIFF
--- a/assets/js/blocks/product-collection/constants.ts
+++ b/assets/js/blocks/product-collection/constants.ts
@@ -49,6 +49,7 @@ export const DEFAULT_QUERY: ProductCollectionQuery = {
 	woocommerceOnSale: false,
 	woocommerceStockStatus: getDefaultStockStatuses(),
 	woocommerceAttributes: [],
+	woocommerceHandPickedProducts: [],
 };
 
 export const DEFAULT_ATTRIBUTES: Partial< ProductCollectionAttributes > = {
@@ -73,9 +74,10 @@ export const getDefaultSettings = (
 	},
 } );
 
-export const DEFAULT_FILTERS = {
+export const DEFAULT_FILTERS: Partial< ProductCollectionQuery > = {
 	woocommerceOnSale: DEFAULT_QUERY.woocommerceOnSale,
 	woocommerceStockStatus: getDefaultStockStatuses(),
 	woocommerceAttributes: [],
 	taxQuery: DEFAULT_QUERY.taxQuery,
+	woocommerceHandPickedProducts: [],
 };

--- a/assets/js/blocks/product-collection/inspector-controls/hand-picked-products-control.tsx
+++ b/assets/js/blocks/product-collection/inspector-controls/hand-picked-products-control.tsx
@@ -1,0 +1,132 @@
+/**
+ * External dependencies
+ */
+import { getProducts } from '@woocommerce/editor-components/utils';
+import { ProductResponseItem } from '@woocommerce/types';
+import { useState, useEffect, useCallback, useMemo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import {
+	FormTokenField,
+	// @ts-expect-error Using experimental features
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToolsPanelItem as ToolsPanelItem,
+} from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { ProductCollectionQuery } from '../types';
+
+interface HandPickedProductsControlProps {
+	setQueryAttribute: ( value: Partial< ProductCollectionQuery > ) => void;
+	selectedProductIds?: string[] | undefined;
+}
+
+/**
+ * Returns:
+ * - productsMap: Map of products by id and name.
+ * - productsList: List of products retrieved.
+ */
+function useProducts() {
+	// Creating a map for fast lookup of products by id or name.
+	const [ productsMap, setProductsMap ] = useState<
+		Map< number | string, ProductResponseItem >
+	>( new Map() );
+
+	// List of products retrieved
+	const [ productsList, setProductsList ] = useState< ProductResponseItem[] >(
+		[]
+	);
+
+	useEffect( () => {
+		getProducts( { selected: [] } ).then( ( results ) => {
+			const newProductsMap = new Map();
+			( results as ProductResponseItem[] ).forEach( ( product ) => {
+				newProductsMap.set( product.id, product );
+				newProductsMap.set( product.name, product );
+			} );
+
+			setProductsList( results as ProductResponseItem[] );
+			setProductsMap( newProductsMap );
+		} );
+	}, [] );
+
+	return { productsMap, productsList };
+}
+
+export const HandPickedProductsControl = ( {
+	selectedProductIds,
+	setQueryAttribute,
+}: HandPickedProductsControlProps ) => {
+	const { productsMap, productsList } = useProducts();
+
+	const onTokenChange = useCallback(
+		( values: string[] ) => {
+			// Map the tokens to product ids.
+			const newHandPickedProducts = values.reduce( ( acc, nameOrId ) => {
+				const product =
+					productsMap.get( nameOrId ) ||
+					productsMap.get( Number( nameOrId ) );
+				if ( product ) acc.push( String( product.id ) );
+				return acc;
+			}, [] as string[] );
+
+			setQueryAttribute( {
+				woocommerceHandPickedProducts: newHandPickedProducts,
+			} );
+		},
+		[ setQueryAttribute, productsMap ]
+	);
+
+	const suggestions = useMemo( () => {
+		return productsList.map( ( product ) => product.name );
+	}, [ productsList ] );
+
+	// Transform the token to a product name while displaying in the input field.
+	const displayTransform = ( token: string ) => {
+		const parsedToken = Number( token );
+
+		if ( Number.isNaN( parsedToken ) ) {
+			return token;
+		}
+
+		const product = productsMap.get( parsedToken );
+
+		return product?.name || '';
+	};
+
+	return (
+		<ToolsPanelItem
+			label={ __(
+				'Hand-picked Products',
+				'woo-gutenberg-products-block'
+			) }
+			hasValue={ () => !! selectedProductIds?.length }
+			onDeselect={ () => {
+				setQueryAttribute( {
+					woocommerceHandPickedProducts: [],
+				} );
+			} }
+		>
+			<FormTokenField
+				disabled={ ! productsMap.size }
+				displayTransform={ displayTransform }
+				label={ __(
+					'Pick some products',
+					'woo-gutenberg-products-block'
+				) }
+				onChange={ onTokenChange }
+				suggestions={ suggestions }
+				// @ts-expect-error Using experimental features
+				__experimentalValidateInput={ ( value: string ) =>
+					productsMap.has( value )
+				}
+				value={
+					! productsMap.size
+						? [ __( 'Loading…', 'woo-gutenberg-products-block' ) ]
+						: selectedProductIds || []
+				}
+			/>
+		</ToolsPanelItem>
+	);
+};

--- a/assets/js/blocks/product-collection/inspector-controls/hand-picked-products-control.tsx
+++ b/assets/js/blocks/product-collection/inspector-controls/hand-picked-products-control.tsx
@@ -54,7 +54,7 @@ function useProducts() {
 	return { productsMap, productsList };
 }
 
-export const HandPickedProductsControl = ( {
+const HandPickedProductsControl = ( {
 	selectedProductIds,
 	setQueryAttribute,
 }: HandPickedProductsControlProps ) => {
@@ -142,3 +142,5 @@ export const HandPickedProductsControl = ( {
 		</ToolsPanelItem>
 	);
 };
+
+export default HandPickedProductsControl;

--- a/assets/js/blocks/product-collection/inspector-controls/hand-picked-products-control.tsx
+++ b/assets/js/blocks/product-collection/inspector-controls/hand-picked-products-control.tsx
@@ -63,27 +63,39 @@ export const HandPickedProductsControl = ( {
 	const onTokenChange = useCallback(
 		( values: string[] ) => {
 			// Map the tokens to product ids.
-			const newHandPickedProducts = values.reduce( ( acc, nameOrId ) => {
-				const product =
-					productsMap.get( nameOrId ) ||
-					productsMap.get( Number( nameOrId ) );
-				if ( product ) acc.push( String( product.id ) );
-				return acc;
-			}, [] as string[] );
+			const newHandPickedProductsSet = values.reduce(
+				( acc, nameOrId ) => {
+					const product =
+						productsMap.get( nameOrId ) ||
+						productsMap.get( Number( nameOrId ) );
+					if ( product ) acc.add( String( product.id ) );
+					return acc;
+				},
+				new Set< string >()
+			);
 
 			setQueryAttribute( {
-				woocommerceHandPickedProducts: newHandPickedProducts,
+				woocommerceHandPickedProducts: Array.from(
+					newHandPickedProductsSet
+				),
 			} );
 		},
 		[ setQueryAttribute, productsMap ]
 	);
 
 	const suggestions = useMemo( () => {
-		return productsList.map( ( product ) => product.name );
-	}, [ productsList ] );
+		return (
+			productsList
+				// Filter out products that are already selected.
+				.filter(
+					( product ) =>
+						! selectedProductIds?.includes( String( product.id ) )
+				)
+				.map( ( product ) => product.name )
+		);
+	}, [ productsList, selectedProductIds ] );
 
-	// Transform the token to a product name while displaying in the input field.
-	const displayTransform = ( token: string ) => {
+	const transformTokenIntoProductName = ( token: string ) => {
 		const parsedToken = Number( token );
 
 		if ( Number.isNaN( parsedToken ) ) {
@@ -110,7 +122,7 @@ export const HandPickedProductsControl = ( {
 		>
 			<FormTokenField
 				disabled={ ! productsMap.size }
-				displayTransform={ displayTransform }
+				displayTransform={ transformTokenIntoProductName }
 				label={ __(
 					'Pick some products',
 					'woo-gutenberg-products-block'

--- a/assets/js/blocks/product-collection/inspector-controls/index.tsx
+++ b/assets/js/blocks/product-collection/inspector-controls/index.tsx
@@ -25,7 +25,7 @@ import StockStatusControl from './stock-status-control';
 import KeywordControl from './keyword-control';
 import AttributesControl from './attributes-control';
 import TaxonomyControls from './taxonomy-controls';
-import { HandPickedProductsControl } from './hand-picked-products-control';
+import HandPickedProductsControl from './hand-picked-products-control';
 import AuthorControl from './author-control';
 
 const ProductCollectionInspectorControls = (

--- a/assets/js/blocks/product-collection/inspector-controls/index.tsx
+++ b/assets/js/blocks/product-collection/inspector-controls/index.tsx
@@ -25,6 +25,7 @@ import StockStatusControl from './stock-status-control';
 import KeywordControl from './keyword-control';
 import AttributesControl from './attributes-control';
 import TaxonomyControls from './taxonomy-controls';
+import { HandPickedProductsControl } from './hand-picked-products-control';
 
 const ProductCollectionInspectorControls = (
 	props: BlockEditProps< ProductCollectionAttributes >
@@ -72,6 +73,12 @@ const ProductCollectionInspectorControls = (
 				>
 					<OnSaleControl { ...props } />
 					<StockStatusControl { ...props } />
+					<HandPickedProductsControl
+						setQueryAttribute={ setQueryAttributeBind }
+						selectedProductIds={
+							query.woocommerceHandPickedProducts
+						}
+					/>
 					<KeywordControl { ...props } />
 					<AttributesControl
 						woocommerceAttributes={

--- a/assets/js/blocks/product-collection/types.ts
+++ b/assets/js/blocks/product-collection/types.ts
@@ -52,6 +52,7 @@ export interface ProductCollectionQuery {
 	woocommerceStockStatus?: string[];
 	woocommerceAttributes?: AttributeMetadata[];
 	isProductCollectionBlock?: boolean;
+	woocommerceHandPickedProducts?: string[];
 }
 
 export type TProductCollectionOrder = 'asc' | 'desc';

--- a/src/BlockTypes/ProductCollection.php
+++ b/src/BlockTypes/ProductCollection.php
@@ -76,18 +76,20 @@ class ProductCollection extends AbstractBlock {
 			return $args;
 		}
 
-		$orderby            = $request->get_param( 'orderBy' );
-		$on_sale            = $request->get_param( 'woocommerceOnSale' ) === 'true';
-		$stock_status       = $request->get_param( 'woocommerceStockStatus' );
-		$product_attributes = $request->get_param( 'woocommerceAttributes' );
+		$orderby             = $request->get_param( 'orderBy' );
+		$on_sale             = $request->get_param( 'woocommerceOnSale' ) === 'true';
+		$stock_status        = $request->get_param( 'woocommerceStockStatus' );
+		$product_attributes  = $request->get_param( 'woocommerceAttributes' );
+		$handpicked_products = $request->get_param( 'woocommerceHandPickedProducts' );
 
 		return $this->get_final_query_args(
 			$args,
 			array(
-				'orderby'            => $orderby,
-				'on_sale'            => $on_sale,
-				'stock_status'       => $stock_status,
-				'product_attributes' => $product_attributes,
+				'orderby'             => $orderby,
+				'on_sale'             => $on_sale,
+				'stock_status'        => $stock_status,
+				'product_attributes'  => $product_attributes,
+				'handpicked_products' => $handpicked_products,
 			)
 		);
 	}
@@ -99,15 +101,18 @@ class ProductCollection extends AbstractBlock {
 	 * @param array $query               Query from block context.
 	 */
 	private function get_final_query_args( $common_query_values, $query ) {
-		$orderby_query    = $query['orderby'] ? $this->get_custom_orderby_query( $query['orderby'] ) : [];
-		$on_sale_query    = $this->get_on_sale_products_query( $query['on_sale'] );
-		$stock_query      = $this->get_stock_status_query( $query['stock_status'] );
-		$visibility_query = is_array( $query['stock_status'] ) ? $this->get_product_visibility_query( $stock_query ) : [];
-		$attributes_query = $this->get_product_attributes_query( $query['product_attributes'] );
-		$taxonomies_query = $query['taxonomies_query'] ?? [];
-		$tax_query        = $this->merge_tax_queries( $visibility_query, $attributes_query, $taxonomies_query );
+		$handpicked_products = $query['handpicked_products'] ?? [];
+		$orderby_query       = $query['orderby'] ? $this->get_custom_orderby_query( $query['orderby'] ) : [];
+		$on_sale_query       = $this->get_on_sale_products_query( $query['on_sale'] );
+		$stock_query         = $this->get_stock_status_query( $query['stock_status'] );
+		$visibility_query    = is_array( $query['stock_status'] ) ? $this->get_product_visibility_query( $stock_query ) : [];
+		$attributes_query    = $this->get_product_attributes_query( $query['product_attributes'] );
+		$taxonomies_query    = $query['taxonomies_query'] ?? [];
+		$tax_query           = $this->merge_tax_queries( $visibility_query, $attributes_query, $taxonomies_query );
 
-		return $this->merge_queries( $common_query_values, $orderby_query, $on_sale_query, $stock_query, $tax_query );
+		$merged_query = $this->merge_queries( $common_query_values, $orderby_query, $on_sale_query, $stock_query, $tax_query );
+
+		return $this->filter_query_to_only_include_ids( $merged_query, $handpicked_products );
 	}
 
 	/**
@@ -143,17 +148,19 @@ class ProductCollection extends AbstractBlock {
 			's'              => $block_context_query['search'],
 		);
 
-		$is_on_sale       = $block_context_query['woocommerceOnSale'] ?? false;
-		$taxonomies_query = $this->get_filter_by_taxonomies_query( $query['tax_query'] ?? [] );
+		$is_on_sale          = $block_context_query['woocommerceOnSale'] ?? false;
+		$taxonomies_query    = $this->get_filter_by_taxonomies_query( $query['tax_query'] ?? [] );
+		$handpicked_products = $block_context_query['woocommerceHandPickedProducts'] ?? [];
 
 		return $this->get_final_query_args(
 			$common_query_values,
 			array(
-				'on_sale'            => $is_on_sale,
-				'stock_status'       => $block_context_query['woocommerceStockStatus'],
-				'orderby'            => $block_context_query['orderBy'],
-				'product_attributes' => $block_context_query['woocommerceAttributes'],
-				'taxonomies_query'   => $taxonomies_query,
+				'on_sale'             => $is_on_sale,
+				'stock_status'        => $block_context_query['woocommerceStockStatus'],
+				'orderby'             => $block_context_query['orderBy'],
+				'product_attributes'  => $block_context_query['woocommerceAttributes'],
+				'taxonomies_query'    => $taxonomies_query,
+				'handpicked_products' => $handpicked_products,
 			)
 		);
 	}
@@ -536,5 +543,22 @@ class ProductCollection extends AbstractBlock {
 
 		// phpcs:ignore WordPress.DB.SlowDBQuery
 		return ! empty( $result ) ? [ 'tax_query' => $result ] : [];
+	}
+
+	/**
+	 * Apply the query only to a subset of products
+	 *
+	 * @param array $query  The query.
+	 * @param array $ids  Array of selected product ids.
+	 *
+	 * @return array
+	 */
+	private function filter_query_to_only_include_ids( $query, $ids ) {
+		if ( ! empty( $ids ) ) {
+			$query['post__in'] = empty( $query['post__in'] ) ?
+				$ids : array_intersect( $ids, $query['post__in'] );
+		}
+
+		return $query;
 	}
 }


### PR DESCRIPTION
This PR introduces the ability to manually select specific products in the Product Collection block.
<img width="269" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/16707866/a535113c-9c8c-4e1f-b7ff-eaaa1f2adade">

Changes include:
- Added `woocommerceHandPickedProducts` to the `ProductCollectionQuery` and `DEFAULT_FILTERS` in `constants.ts`.
- Created a new control file `hand-picked-products-control.tsx` which introduces a token field where the user can search for and select specific products.
- Included `HandPickedProductsControl` in the Product Collection block's inspector controls in `index.tsx`.
- Updated `ProductCollectionQuery` in `types.ts` to accommodate handpicked products.
- Updated the PHP `ProductCollection` class to handle the hand-picked products query parameters.

These changes allow users to hand-pick products to be displayed in the Product Collection block. This allows for greater customization of the products shown in the block.

Fixes #9722

### Testing

##### Simplest path

1. Add a “Product Collection” block to your page.
2. Go to the “Filters” within the Inspector Controls and add “Hand-picked Products”.
3. Start typing to select some products.
4. Ensure the preview is correctly updated as you narrow down your selection.
5. Click Publish.
6. Ensure the front-end is correct.

##### Complex path

1. Repeat steps 1–4 above.
2. Add additional filters (such as “On sale”).
3. Ensure the block only applies the subsequent filters to the subset of products you have selected.

Here is a quick demo:


https://github.com/woocommerce/woocommerce-blocks/assets/16707866/562efcdb-932c-41d7-8f73-572d73b9c54d



* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [X] Experimental


### Changelog

> Product Collection: Add a filter to allow merchants to hand-pick a subset of products.
