### PR TITLE
Product Collection: Add author filter in sidebar settings

### DIFF
--- a/assets/js/blocks/product-collection/inspector-controls/author-control.tsx
+++ b/assets/js/blocks/product-collection/inspector-controls/author-control.tsx
@@ -20,14 +20,11 @@ interface Author {
 	name: string;
 }
 
-interface AuthorsMapping {
+interface AuthorsInfo {
+	authors: Author[];
 	mapById: Map< number, Author >;
 	mapByName: Map< string, Author >;
 	names: string[];
-}
-
-interface AuthorsInfo extends AuthorsMapping {
-	authors: Author[];
 }
 
 interface AuthorControlProps {

--- a/assets/js/blocks/product-collection/inspector-controls/author-control.tsx
+++ b/assets/js/blocks/product-collection/inspector-controls/author-control.tsx
@@ -72,40 +72,33 @@ const getIdByValue = (
 };
 
 function AuthorControl( { value, setQueryAttribute }: AuthorControlProps ) {
-	const {
-		records: authorsList,
-		error,
-		hasResolved,
-	} = useEntityRecords< Author[] >( 'root', 'user', AUTHORS_QUERY );
+	const { records: authorsList, error } = useEntityRecords< Author[] >(
+		'root',
+		'user',
+		AUTHORS_QUERY
+	);
 
-	if ( ! hasResolved || error ) {
+	if ( error ) {
 		return (
 			<ToolsPanelItem
-				hasValue={ () => true }
 				label={ __( 'Authors', 'woo-gutenberg-products-block' ) }
+				hasValue={ () => true }
 			>
 				<FormTokenField
 					label={ __( 'Authors', 'woo-gutenberg-products-block' ) }
-					value={
-						error
-							? [
-									__(
-										'Error loading authors',
-										'woo-gutenberg-products-block'
-									),
-							  ]
-							: [
-									__(
-										'Loading authors…',
-										'woo-gutenberg-products-block'
-									),
-							  ]
-					}
+					value={ [
+						__(
+							'Error occurred while loading authors.',
+							'woo-gutenberg-products-block'
+						),
+					] }
 					disabled={ true }
 				/>
 			</ToolsPanelItem>
 		);
 	}
+
+	if ( ! authorsList ) return null;
 
 	const authorsInfo = getAuthorsInfo( authorsList as Author[] );
 

--- a/assets/js/blocks/product-collection/inspector-controls/author-control.tsx
+++ b/assets/js/blocks/product-collection/inspector-controls/author-control.tsx
@@ -1,0 +1,165 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useEntityRecords } from '@wordpress/core-data';
+import {
+	FormTokenField,
+	// @ts-expect-error Using experimental features
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToolsPanelItem as ToolsPanelItem,
+} from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { ProductCollectionQuery } from '../types';
+
+interface Author {
+	id: string;
+	name: string;
+}
+
+interface AuthorsMapping {
+	mapById: Map< number, Author >;
+	mapByName: Map< string, Author >;
+	names: string[];
+}
+
+interface AuthorsInfo extends AuthorsMapping {
+	authors: Author[];
+}
+
+interface AuthorControlProps {
+	value: string;
+	setQueryAttribute: ( value: Partial< ProductCollectionQuery > ) => void;
+}
+
+const AUTHORS_QUERY = {
+	who: 'authors',
+	per_page: -1,
+	_fields: 'id,name',
+	context: 'view',
+};
+
+export const getAuthorsInfo = ( authors: Author[] ): AuthorsInfo => {
+	const mapById = new Map< number, Author >();
+	const mapByName = new Map< string, Author >();
+	const names: string[] = [];
+
+	authors.forEach( ( author ) => {
+		mapById.set( Number( author.id ), author );
+		mapByName.set( author.name, author );
+		names.push( author.name );
+	} );
+
+	return {
+		authors,
+		mapById,
+		mapByName,
+		names,
+	};
+};
+
+const getIdByValue = (
+	entitiesMappedByName: Map< string, Author >,
+	authorValue: string | Author
+) => {
+	const id =
+		( authorValue as Author )?.id ||
+		entitiesMappedByName.get( authorValue as string )?.id;
+	if ( id ) return id;
+};
+
+function AuthorControl( { value, setQueryAttribute }: AuthorControlProps ) {
+	const {
+		records: authorsList,
+		error,
+		hasResolved,
+	} = useEntityRecords< Author[] >( 'root', 'user', AUTHORS_QUERY );
+
+	if ( ! hasResolved || error ) {
+		return (
+			<ToolsPanelItem
+				hasValue={ () => true }
+				label={ __( 'Authors', 'woo-gutenberg-products-block' ) }
+			>
+				<FormTokenField
+					label={ __( 'Authors', 'woo-gutenberg-products-block' ) }
+					value={
+						error
+							? [
+									__(
+										'Error loading authors',
+										'woo-gutenberg-products-block'
+									),
+							  ]
+							: [
+									__(
+										'Loading authors…',
+										'woo-gutenberg-products-block'
+									),
+							  ]
+					}
+					disabled={ true }
+				/>
+			</ToolsPanelItem>
+		);
+	}
+
+	const authorsInfo = getAuthorsInfo( authorsList as Author[] );
+
+	/**
+	 * We need to normalize the value because the block operates on a
+	 * comma(`,`) separated string value and `FormTokenFields` needs an
+	 * array.
+	 *
+	 * Returns only the existing authors ids. This prevents the component
+	 * from crashing in the editor, when non existing ids are provided.
+	 */
+	const sanitizedValue = value
+		? ( value
+				.split( ',' )
+				.map( ( authorId ) => {
+					const author = authorsInfo.mapById.get(
+						Number( authorId )
+					);
+					return author
+						? {
+								id: author.id,
+								value: author.name,
+						  }
+						: null;
+				} )
+				.filter( Boolean ) as { id: string; value: string }[] )
+		: [];
+
+	const onAuthorChange = ( newValue: string[] ) => {
+		const ids = Array.from(
+			newValue.reduce( ( accumulator: Set< string >, author: string ) => {
+				// Verify that new values point to existing entities.
+				const id = getIdByValue( authorsInfo.mapByName, author );
+				if ( id ) accumulator.add( id );
+				return accumulator;
+			}, new Set() )
+		);
+		setQueryAttribute( { author: ids.join( ',' ) } );
+	};
+
+	return (
+		<ToolsPanelItem
+			hasValue={ () => !! value }
+			label={ __( 'Authors', 'woo-gutenberg-products-block' ) }
+			onDeselect={ () => setQueryAttribute( { author: '' } ) }
+		>
+			<FormTokenField
+				label={ __( 'Authors', 'woo-gutenberg-products-block' ) }
+				value={ sanitizedValue }
+				suggestions={ authorsInfo.names }
+				onChange={ onAuthorChange }
+			/>
+		</ToolsPanelItem>
+	);
+}
+
+export default AuthorControl;

--- a/assets/js/blocks/product-collection/inspector-controls/index.tsx
+++ b/assets/js/blocks/product-collection/inspector-controls/index.tsx
@@ -25,6 +25,7 @@ import StockStatusControl from './stock-status-control';
 import KeywordControl from './keyword-control';
 import AttributesControl from './attributes-control';
 import TaxonomyControls from './taxonomy-controls';
+import AuthorControl from './author-control';
 
 const ProductCollectionInspectorControls = (
 	props: BlockEditProps< ProductCollectionAttributes >
@@ -82,6 +83,10 @@ const ProductCollectionInspectorControls = (
 					<TaxonomyControls
 						setQueryAttribute={ setQueryAttributeBind }
 						query={ query }
+					/>
+					<AuthorControl
+						value={ query.author }
+						setQueryAttribute={ setQueryAttributeBind }
 					/>
 				</ToolsPanel>
 			) : null }

--- a/src/BlockTypes/ProductCollection.php
+++ b/src/BlockTypes/ProductCollection.php
@@ -128,13 +128,15 @@ class ProductCollection extends AbstractBlock {
 		}
 
 		$block_context_query = $block->context['query'];
+		$offset              = $block_context_query['offset'] ?? 0;
+		$per_page            = $block_context_query['perPage'] ?? 9;
 
 		$common_query_values = array(
 			// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 			'meta_query'     => array(),
 			'posts_per_page' => $block_context_query['perPage'],
 			'order'          => $block_context_query['order'],
-			'offset'         => $block_context_query['offset'],
+			'offset'         => ( $per_page * ( $page - 1 ) ) + $offset,
 			'post__in'       => array(),
 			'post_status'    => 'publish',
 			'post_type'      => 'product',

--- a/src/BlockTypes/ProductCollection.php
+++ b/src/BlockTypes/ProductCollection.php
@@ -80,6 +80,7 @@ class ProductCollection extends AbstractBlock {
 		$on_sale            = $request->get_param( 'woocommerceOnSale' ) === 'true';
 		$stock_status       = $request->get_param( 'woocommerceStockStatus' );
 		$product_attributes = $request->get_param( 'woocommerceAttributes' );
+		$args['author']     = $request->get_param( 'author' ) ?? '';
 
 		return $this->get_final_query_args(
 			$args,
@@ -141,6 +142,7 @@ class ProductCollection extends AbstractBlock {
 			'tax_query'      => array(),
 			'paged'          => $page,
 			's'              => $block_context_query['search'],
+			'author'         => $block_context_query['author'] ?? '',
 		);
 
 		$is_on_sale       = $block_context_query['woocommerceOnSale'] ?? false;


### PR DESCRIPTION
This PR adds an author filter to the ProductCollection block
<img width="272" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/16707866/e63257e6-a752-4a09-9d08-c062edfaf7e1">


- A new file, `author-control.tsx`, has been created inside the `inspector-controls` directory of the `product-collection` block. This file contains the React component for the author filter, which fetches the list of authors from the WordPress database using `useEntityRecords`. The filter provides an interface for selecting authors whose products should be displayed in the ProductCollection block.

- The author filter is added to the main component of the `inspector-controls` in `index.tsx`.

- In `ProductCollection.php`, the 'author' parameter is now included in the product query. This allows products from a specific author to be displayed in the ProductCollection block, depending on the user's selection in the Gutenberg editor.

This addition enhances the functionality of the ProductCollection block by allowing site administrators to create more customized and targeted displays of products.

Fixes #9366

### Testing

##### Simplest path

1. Add a “Product Collection” block to your page.
2. Go to the “Filters” within the Inspector Controls and add “Authors”.
3. Start typing to select authors. If you don't have products with different authors then please add some for testing.
4. As you narrow down your selection, verify that the preview is updated accurately. Only products by selected authors should be visible. 
5. Select 'Publish' to apply the changes.
6. Ensure the front-end is correct.

##### Complex path

1. Repeat steps 1–4 above.
2. Add additional filters (such as “On sale”).
3. With these additional filters applied, ensure that the products continue to be filtered accurately based on the selected authors.

Here is a quick demo:

https://github.com/woocommerce/woocommerce-blocks/assets/16707866/c213648c-79df-4134-bc61-7d33231d8bdb

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [X] Experimental

### Changelog

> Product Collection: Add author filter in sidebar settings
