### PR TITLE
Prevent showing edit product details link when in multiple products c…

### DIFF
--- a/assets/js/editor-components/edit-product-link/index.tsx
+++ b/assets/js/editor-components/edit-product-link/index.tsx
@@ -22,7 +22,7 @@ const EditProductLink = ( props: EditProductLinkProps ): JSX.Element | null => {
 	const product = productDataContext.product || {};
 	const productId = product.id || props.productId || 0;
 
-	if ( ! productId ) {
+	if ( ! productId || productId === 1 ) {
 		return null;
 	}
 


### PR DESCRIPTION
…ontext

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/8931

This PR adds a check if the `productId` is `1` (which is the default item number and not an actual product), will assume it is in a context of multiple products block which means it should not show the `Edit this product's details` link.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| All Products | Single Product |
| ------ | ----- |
| ![file.png](https://github.com/woocommerce/woocommerce-blocks/assets/2132595/08961be4-28eb-4acf-a5b3-5cec28db2bcf)       | ![file.png](https://github.com/woocommerce/woocommerce-blocks/assets/2132595/bb0b9853-03c5-4afd-8604-3eece1c7a748)      |

### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Go to a post/page and add the `All Products` block.
2. Click on `Edit` in the block toolbar.
3. Add the `Product SKU` block.
4. In the inspector controls, ensure the link `Edit this product's details...` does not show.
5. Add the `Single product` block.
6. In the inspector controls, ensure the link `Edit this product's details...` does show.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Hide edit product detail link from Product SKU block in multi product context