### PR TITLE
Render the single product title as an h1 when transforming from classic template

### DIFF
--- a/assets/js/blocks/classic-template/single-product.ts
+++ b/assets/js/blocks/classic-template/single-product.ts
@@ -33,6 +33,7 @@ const getBlockifiedTemplate = () =>
 				createBlock( 'core/column', {}, [
 					createBlock( 'core/post-title', {
 						__woocommerceNamespace: PRODUCT_TITLE_VARIATION_NAME,
+						level: 1,
 					} ),
 					createBlock( 'woocommerce/product-rating' ),
 					createBlock( 'woocommerce/product-price', {


### PR DESCRIPTION
When transforming from the classic template, the title block will be rendered as `h1`.
It was missing from this PR https://github.com/woocommerce/woocommerce-blocks/pull/9698

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. Ensure that the Single Product Template doesn't have any customization.
2. Edit it.
3. Transform it to the blockified version.
4. Focus on the Product Title.
5. Ensure that it renders as an h1.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Blockified Single Product Template: use h1 for the Product Title when transforming from Classic template.
