### PR TITLE
Fix the order of enqueued scripts in the Mini-Cart block

### DIFF
--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -333,7 +333,7 @@ class MiniCart extends AbstractBlock {
 		$wp_scripts = wp_scripts();
 
 		// This script and its dependencies have already been appended.
-		if ( ! $script || array_key_exists( $script->handle, $this->scripts_to_lazy_load ) || isset( $wp_scripts->queue[ $script->handle ] ) ) {
+		if ( ! $script || array_key_exists( $script->handle, $this->scripts_to_lazy_load ) || wp_script_is( $script->handle, 'enqueued' ) ) {
 			return;
 		}
 

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -71,8 +71,9 @@ class MiniCart extends AbstractBlock {
 		parent::initialize();
 		add_action( 'wp_loaded', array( $this, 'register_empty_cart_message_block_pattern' ) );
 		add_action( 'wp_print_footer_scripts', array( $this, 'enqueue_wc_settings' ), 1 );
-		// We need this action to run after the equivalent in AssetDataRegistry.
-		add_action( 'wp_print_footer_scripts', array( $this, 'print_lazy_load_scripts' ), 3 );
+		// We need this action to run after enqueue_wc_settings() and dequeue_wc_settings(),
+		// otherwise it might incorrectly consider wc_settings script to be enqueued.
+		add_action( 'wp_print_footer_scripts', array( $this, 'print_lazy_load_scripts' ), 4 );
 	}
 
 	/**
@@ -220,7 +221,7 @@ class MiniCart extends AbstractBlock {
 		// AssetDataRegistry knows it's going to load.
 		wp_enqueue_script( 'wc-settings' );
 		// After AssetDataRegistry function runs, we dequeue `wc-settings`.
-		add_action( 'wp_print_footer_scripts', array( $this, 'dequeue_wc_settings' ), 4 );
+		add_action( 'wp_print_footer_scripts', array( $this, 'dequeue_wc_settings' ), 3 );
 	}
 
 	/**


### PR DESCRIPTION
In https://github.com/woocommerce/woocommerce-blocks/pull/9586, we introduced a fix that made that if a script was already enqueued, it would not be added to the list of scripts to lazy load by the Mini-Cart block. That caused some issues so we needed to revert it in https://github.com/woocommerce/woocommerce-blocks/pull/9649.

The reason of the issues was that the order the code was running caused `wc-settings` to appear as enqueued even though it was not. The reason was that:

1. First, we were enqueuing `wc-settings`, that was required to make sure we include some PHP constants which are used by this script. https://github.com/woocommerce/woocommerce-blocks/blob/c378f9261aca1cca9bfe3c4f2a236511730ed18e/src/BlockTypes/MiniCart.php#L73
2. Then, we created the array of scripts to lazy load, which wouldn't include `wc-settings` and its dependencies because it had been enqueued in step 1. https://github.com/woocommerce/woocommerce-blocks/blob/c378f9261aca1cca9bfe3c4f2a236511730ed18e/src/BlockTypes/MiniCart.php#L75
3. Last, we were dequeuing `wc-settings` if it hasn't been enqueued by a 3rd-party, as the original idea was to lazy load it. https://github.com/woocommerce/woocommerce-blocks/blob/c378f9261aca1cca9bfe3c4f2a236511730ed18e/src/BlockTypes/MiniCart.php#L230

The bug came from the fact that step 3 assumed `wc-settings` would be lazy loaded, but step 2 was not adding it to the array of scripts to lazy load. So in the fronted, `wc-settings` and its dependencies were missing, causing the Mini-Cart to crash.

To solve it, I changed the order, so step 3 runs before step 2:

1. We enqueue `wc-settings`.
2. We dequeue `wc-settings` (if it hasn't been enqued by a 3rd-party).
3. Then, we run all the logic to prepare the array of scripts to lazy load.

So basically, what this PR does:

1. As mentioned, changes the order of the actions so when generating the array of scripts to lazy load, we correctly know if `wc-settings` is enqueued or not (f3322f48482e1eed947d4d54481d7c1cd17612f9).
2. Applies the fix from #9586 again. This should help prevent issues where the same script is loaded twice, which might happen when there is a plugin that concatenates scripts (17816e9051434610a4d560400dc7598f67399625).

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. Enable a block theme.
1. Add the Mini-Cart block to the header of your store.
1. Go to a page in the frontend that doesn't have any blocks besides the Mini-Cart you added to the header.
1. Open the Mini-Cart and verify there is no JS error.
1. Install the Page Optimize and Product Bundles plugins (no need to change anything in their configuration) and repeat the testing steps.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
