### PR TITLE
Convert product-orderby-control to use typescript

### DIFF
--- a/assets/js/editor-components/product-orderby-control/index.tsx
+++ b/assets/js/editor-components/product-orderby-control/index.tsx
@@ -3,7 +3,11 @@
  */
 import { __ } from '@wordpress/i18n';
 import { SelectControl } from '@wordpress/components';
-import PropTypes from 'prop-types';
+
+/**
+ * Internal dependencies
+ */
+import type { ProductOrderbyControlProps } from './types';
 
 /**
  * A pre-configured SelectControl for product orderby settings.
@@ -12,7 +16,10 @@ import PropTypes from 'prop-types';
  * @param {string}            props.value
  * @param {function(any):any} props.setAttributes Setter for block attributes.
  */
-const ProductOrderbyControl = ( { value, setAttributes } ) => {
+const ProductOrderbyControl = ( {
+	value,
+	setAttributes,
+}: ProductOrderbyControlProps ) => {
 	return (
 		<SelectControl
 			label={ __( 'Order products by', 'woo-gutenberg-products-block' ) }
@@ -68,17 +75,6 @@ const ProductOrderbyControl = ( { value, setAttributes } ) => {
 			onChange={ ( orderby ) => setAttributes( { orderby } ) }
 		/>
 	);
-};
-
-ProductOrderbyControl.propTypes = {
-	/**
-	 * Callback to update the order setting.
-	 */
-	setAttributes: PropTypes.func.isRequired,
-	/**
-	 * The selected order setting.
-	 */
-	value: PropTypes.string.isRequired,
 };
 
 export default ProductOrderbyControl;

--- a/assets/js/editor-components/product-orderby-control/types.ts
+++ b/assets/js/editor-components/product-orderby-control/types.ts
@@ -1,0 +1,4 @@
+export interface ProductOrderbyControlProps {
+	value: string;
+	setAttributes: ( attributes: Record< string, unknown > ) => void;
+}


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/9536

This PR converts `product-orderby-control` component to use typescript.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

