### PR TITLE
Add Mini-Cart block Playwright e2e tests

### DIFF
--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -274,8 +274,6 @@ class MiniCart extends AbstractBlock {
 			$mini_cart_dependencies_script,
 			'before'
 		);
-		wp_deregister_script( 'wc-settings' );
-		wp_dequeue_script( 'wc-settings' );
 	}
 
 	/**

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -274,6 +274,8 @@ class MiniCart extends AbstractBlock {
 			$mini_cart_dependencies_script,
 			'before'
 		);
+		wp_deregister_script( 'wc-settings' );
+		wp_dequeue_script( 'wc-settings' );
 	}
 
 	/**

--- a/tests/e2e-pw/tests/mini-cart/mini-cart.block_theme.spec.ts
+++ b/tests/e2e-pw/tests/mini-cart/mini-cart.block_theme.spec.ts
@@ -1,0 +1,72 @@
+/**
+ * External dependencies
+ */
+import { BlockData } from '@woocommerce/e2e-types';
+import { test, expect } from '@woocommerce/e2e-playwright-utils';
+
+const blockData: BlockData = {
+	name: 'woocommerce/mini-cart',
+	mainClass: '.wc-block-mini-cart',
+	selectors: {
+		frontend: {
+			drawer: '.wc-block-mini-cart__drawer',
+		},
+		editor: {},
+	},
+};
+
+test.describe( `${ blockData.name } Block`, () => {
+	test.describe( `standalone`, () => {
+		test.beforeEach( async ( { admin, page, editor } ) => {
+			await admin.createNewPost();
+			await editor.insertBlock( { name: blockData.name } );
+			await editor.publishPost();
+			await page.waitForLoadState( 'networkidle' );
+			const url = new URL( page.url() );
+			const postId = url.searchParams.get( 'post' );
+			await page.goto( `/?p=${ postId }`, { waitUntil: 'networkidle' } );
+		} );
+
+		test( 'should open the empty cart drawer', async ( { page } ) => {
+			const miniCartButton = await page.getByLabel(
+				'0 items in cart, total price of $0.00'
+			);
+
+			await miniCartButton.click();
+
+			await expect(
+				page
+					.locator( blockData.selectors.frontend.drawer as string )
+					.first()
+			).toHaveText( 'Your cart is currently empty!' );
+		} );
+	} );
+
+	test.describe( `with All products Block`, () => {
+		test.beforeEach( async ( { admin, page, editor } ) => {
+			await admin.createNewPost();
+			await editor.insertBlock( { name: blockData.name } );
+			await editor.insertBlock( { name: 'woocommerce/all-products' } );
+			await editor.publishPost();
+			await page.waitForLoadState( 'networkidle' );
+			const url = new URL( page.url() );
+			const postId = url.searchParams.get( 'post' );
+			await page.goto( `/?p=${ postId }`, { waitUntil: 'networkidle' } );
+		} );
+
+		test( 'should open the filled cart drawer', async ( { page } ) => {
+			const miniCartButton = await page.getByLabel(
+				'0 items in cart, total price of $0.00'
+			);
+
+			await page.waitForLoadState( 'networkidle' );
+			await page.click( 'text=Add to cart' );
+
+			await miniCartButton.click();
+
+			await expect(
+				page.locator( '.wc-block-mini-cart__title' ).first()
+			).toHaveText( 'Your cart (1 item)' );
+		} );
+	} );
+} );

--- a/tests/e2e-pw/tests/permalink-settings/permalink-settings.block_theme.spec.ts
+++ b/tests/e2e-pw/tests/permalink-settings/permalink-settings.block_theme.spec.ts
@@ -63,7 +63,9 @@ test.describe(
 				await page.goto( '/updated-cart-permalink', {
 					waitUntil: 'networkidle',
 				} );
-				const cartText = await page.getByText( 'Proceed to checkout' );
+				const cartText = await page.getByRole( 'link', {
+					name: 'Proceed to Checkout',
+				} );
 				expect( cartText ).toBeVisible();
 			} );
 


### PR DESCRIPTION
This PR adds two Playwright tests for the Mini-Cart block. They simply test that the drawer opens with the correct context when the cart is empty or filled. They test the Mini-Cart block alone, without any other blocks in the page, that would catch issues with missing dependencies (see _Verify tests fail_ commit: 47f666657d8a37bb486a4510ece44fd4d82c031d).

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests

#### User Facing Testing

1. Verify tests pass in this PR.
2. Verify tests failed in the commit _Verify tests fail_: 47f666657d8a37bb486a4510ece44fd4d82c031d.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
