### PR TITLE
WooCommerce Classic Template block: Fix error on clearing customizations on Woo Templates

### DIFF
--- a/assets/js/blocks/classic-template/index.tsx
+++ b/assets/js/blocks/classic-template/index.tsx
@@ -351,6 +351,8 @@ const registerClassicTemplateBlock = ( {
  * This function replaces the 'core/missing' block with the original Classic Template block that failed
  * to render, allowing the block to be displayed correctly.
  *
+ * @see {@link https://github.com/woocommerce/woocommerce-blocks/issues/9637|Issue: Block error is displayed on clearing customizations for Woo Templates}
+ *
  */
 const tryToRecoverClassicTemplateBlockWhenItFailsToRender = debounce( () => {
 	const blocks = select( 'core/block-editor' ).getBlocks();

--- a/assets/js/blocks/classic-template/index.tsx
+++ b/assets/js/blocks/classic-template/index.tsx
@@ -7,6 +7,7 @@ import {
 	getBlockType,
 	registerBlockType,
 	unregisterBlockType,
+	parse,
 } from '@wordpress/blocks';
 import type { BlockEditProps } from '@wordpress/blocks';
 import { WC_BLOCKS_IMAGE_URL } from '@woocommerce/block-settings';
@@ -18,10 +19,17 @@ import {
 import { Button, Placeholder, Popover } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { box, Icon } from '@wordpress/icons';
-import { useDispatch, subscribe, useSelect, select } from '@wordpress/data';
+import {
+	useDispatch,
+	subscribe,
+	useSelect,
+	select,
+	dispatch,
+} from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
 import { store as noticesStore } from '@wordpress/notices';
 import { useEntityRecord } from '@wordpress/core-data';
+import { debounce } from '@woocommerce/base-utils';
 
 /**
  * Internal dependencies
@@ -333,6 +341,42 @@ const registerClassicTemplateBlock = ( {
 	} );
 };
 
+/**
+ * Attempts to recover the Classic Template block if it fails to render on the Single Product template
+ * due to the user resetting customizations without refreshing the page.
+ *
+ * When the Classic Template block fails to render, it is replaced by the 'core/missing' block, which
+ * displays an error message stating that the WooCommerce Classic template block is unsupported.
+ *
+ * This function replaces the 'core/missing' block with the original Classic Template block that failed
+ * to render, allowing the block to be displayed correctly.
+ *
+ */
+const tryToRecoverClassicTemplateBlockWhenItFailsToRender = debounce( () => {
+	const blocks = select( 'core/block-editor' ).getBlocks();
+	const blocksIncludingInnerBlocks = blocks.flatMap( ( block ) => [
+		block,
+		...block.innerBlocks,
+	] );
+	const classicTemplateThatFailedToRender = blocksIncludingInnerBlocks.find(
+		( block ) =>
+			block.name === 'core/missing' &&
+			block.attributes.originalName === BLOCK_SLUG
+	);
+
+	if ( classicTemplateThatFailedToRender ) {
+		const blockToReplaceClassicTemplateBlockThatFailedToRender = parse(
+			classicTemplateThatFailedToRender.attributes.originalContent
+		);
+		if ( blockToReplaceClassicTemplateBlockThatFailedToRender ) {
+			dispatch( 'core/block-editor' ).replaceBlock(
+				classicTemplateThatFailedToRender.clientId,
+				blockToReplaceClassicTemplateBlockThatFailedToRender
+			);
+		}
+	}
+}, 100 );
+
 // @todo Refactor when there will be possible to show a block according on a template/post with a Gutenberg API. https://github.com/WordPress/gutenberg/pull/41718
 
 let currentTemplateId: string | undefined;
@@ -341,11 +385,6 @@ subscribe( () => {
 	const previousTemplateId = currentTemplateId;
 	const store = select( 'core/edit-site' );
 	currentTemplateId = store?.getEditedPostId() as string | undefined;
-
-	if ( previousTemplateId === currentTemplateId ) {
-		return;
-	}
-
 	const parsedTemplate = currentTemplateId?.split( '//' )[ 1 ];
 
 	if ( parsedTemplate === null || parsedTemplate === undefined ) {
@@ -353,9 +392,21 @@ subscribe( () => {
 	}
 
 	const block = getBlockType( BLOCK_SLUG );
+	const isBlockRegistered = Boolean( block );
 
 	if (
-		block !== undefined &&
+		isBlockRegistered &&
+		hasTemplateSupportForClassicTemplateBlock( parsedTemplate, TEMPLATES )
+	) {
+		tryToRecoverClassicTemplateBlockWhenItFailsToRender();
+	}
+
+	if ( previousTemplateId === currentTemplateId ) {
+		return;
+	}
+
+	if (
+		isBlockRegistered &&
 		( ! hasTemplateSupportForClassicTemplateBlock(
 			parsedTemplate,
 			TEMPLATES
@@ -371,7 +422,7 @@ subscribe( () => {
 	}
 
 	if (
-		block === undefined &&
+		! isBlockRegistered &&
 		hasTemplateSupportForClassicTemplateBlock( parsedTemplate, TEMPLATES )
 	) {
 		registerClassicTemplateBlock( {
@@ -379,4 +430,4 @@ subscribe( () => {
 			inserter: true,
 		} );
 	}
-} );
+}, 'core/blocks-editor' );


### PR DESCRIPTION
## Description
When the user clears the customizations made on the Single Product template and visits the template page without refreshing the page, an error was occurring that prevented the WooCommerce Classic Template block from being rendered on the Editor.

This PR fixes that error by replacing the 'core/missing' block with the original block (WooCommerce Classic Template) when the template has support to the classic block and the block is already registered.


## Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b78ab3d</samp>

* Import `parse` function to parse block content into block object ([link](https://github.com/woocommerce/woocommerce-blocks/pull/9759/files?diff=unified&w=0#diff-49cf8439043f78ee9f68b6374ef821be0b59c5804fec85e9aecf528d7fe9bcecR10))
* Import `dispatch` and `debounce` functions to dispatch actions and limit function calls ([link](https://github.com/woocommerce/woocommerce-blocks/pull/9759/files?diff=unified&w=0#diff-49cf8439043f78ee9f68b6374ef821be0b59c5804fec85e9aecf528d7fe9bcecL21-R32))
* Define and export `tryToRecoverClassicTemplateBlockWhenItFailsToRender` function to replace 'core/missing' block with original Classic Template block if it fails to render ([link](https://github.com/woocommerce/woocommerce-blocks/pull/9759/files?diff=unified&w=0#diff-49cf8439043f78ee9f68b6374ef821be0b59c5804fec85e9aecf528d7fe9bcecR344-R379))
* Remove unnecessary condition that checked previous template ID ([link](https://github.com/woocommerce/woocommerce-blocks/pull/9759/files?diff=unified&w=0#diff-49cf8439043f78ee9f68b6374ef821be0b59c5804fec85e9aecf528d7fe9bcecL344-L348))
* Replace condition that checked block undefined with variable that checked block registered and add condition that calls `tryToRecoverClassicTemplateBlockWhenItFailsToRender` if block registered and template supports Classic Template block ([link](https://github.com/woocommerce/woocommerce-blocks/pull/9759/files?diff=unified&w=0#diff-49cf8439043f78ee9f68b6374ef821be0b59c5804fec85e9aecf528d7fe9bcecL356-R409), [link](https://github.com/woocommerce/woocommerce-blocks/pull/9759/files?diff=unified&w=0#diff-49cf8439043f78ee9f68b6374ef821be0b59c5804fec85e9aecf528d7fe9bcecL374-R425))
* Wrap `subscribe` function with namespace argument of 'core/blocks-editor' to limit subscription scope to block editor store ([link](https://github.com/woocommerce/woocommerce-blocks/pull/9759/files?diff=unified&w=0#diff-49cf8439043f78ee9f68b6374ef821be0b59c5804fec85e9aecf528d7fe9bcecL382-R433))

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #9637 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|  ![image](https://github.com/woocommerce/woocommerce-blocks/assets/20469356/2b0c034d-60e0-4fd8-bcc1-77e6cb6853d2)  |  ![image](https://github.com/woocommerce/woocommerce-blocks/assets/20469356/dbad4c57-e844-480b-91ff-9e44263eaa76) |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Log in to your WordPress dashboard.
2. From your WordPress dashboard, go to Appearance > Themes. Make sure you have a block-based theme installed and activated. If not, you can install one from the Add New option. Block-based themes include "Twenty-twenty Two," "Twenty-twenty Three", etc.
3. On the left-hand side menu, click on Appearance > Editor. This will open the Site Editor.
4. On the left-hand side menu, click on Templates. This will open the list of available templates.
5. Find and select the Single Product template from the list.
6. When the template renders, modify it by adding or removing blocks. Once you finish customizing it, on the top right side, click on Save;
7. On the top left side, click on the WordPress logo;
8. On the menu, click on the "Left Arrow" icon to go back to the list of templates;
9. Click on Manage all Templates;
10. Locate the Single Product template on the list. Click on the three vertical dots and select Clear customizations
11. Wait for the message confirming that the template was reverted successfully;
12. On the templates list, click on the Single Product template;
13. Make sure that the Unsupported block is not rendered, and the WooCommerce Classic Template block is rendered instead.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->
Before the changes, the code was subscribing to all events from the `@wordpress/data`, but now the subscription is restricted to the changes on the 'core/block-editor' storage so possible the performance will be better after merging these changes.

### Changelog

> Fix error on clearing customizations on Woo Templates that prevented WooCommerce Classic Template block from being displayed
