### PR TITLE
docs: add link to batching cart item

### DIFF
--- a/src/StoreApi/docs/cart-items.md
+++ b/src/StoreApi/docs/cart-items.md
@@ -303,6 +303,8 @@ curl --request POST https://example-store.com/wp-json/wc/store/v1/cart/items?id=
 
 For an example response, see [Single Cart Item](#single-cart-item).
 
+If you're looking to add multiple items to the cart at once, please take a look at [batching](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/src/StoreApi/docs/cart.md#add-item).
+
 ## Edit Single Cart Item
 
 Edit an item in the cart.


### PR DESCRIPTION
Discussion reference: https://github.com/woocommerce/woocommerce-blocks/discussions/9775
