### PR TITLE
Fix capitalization in Product Collections: Newest Arrivals pattern

### DIFF
--- a/patterns/product-collections-newest-arrivals.php
+++ b/patterns/product-collections-newest-arrivals.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Title: Product collections: Newest Arrivals
+ * Title: Product Collections: Newest Arrivals
  * Slug: woocommerce-blocks/product-collections-newest-arrivals
  * Categories: WooCommerce
  * Block Types: core/query/woocommerce/product-query


### PR DESCRIPTION
Small PR that updates the _Product Collections: Newest Arrivals_ pattern name so it's capitalized like the other patterns.

### Testing

#### User Facing Testing

1. Create a post or page and open the _Patterns_ tab in the inserter.
2. Search for `product collections`.
3. Verify the word _Collections_ is capitalized in all the available patterns.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix capitalization in Product Collections: Newest Arrivals pattern
