### PR TITLE
Account for classic theme support of template parts

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -295,7 +295,7 @@ class BlockTemplatesController {
 	 * @return array
 	 */
 	public function add_block_templates( $query_result, $query, $template_type ) {
-		if ( ! BlockTemplateUtils::supports_block_templates() ) {
+		if ( ! BlockTemplateUtils::supports_block_templates( 'wp_template_part' === $template_type ) ) {
 			return $query_result;
 		}
 

--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -295,7 +295,7 @@ class BlockTemplatesController {
 	 * @return array
 	 */
 	public function add_block_templates( $query_result, $query, $template_type ) {
-		if ( ! BlockTemplateUtils::supports_block_templates( 'wp_template_part' ) ) {
+		if ( ! BlockTemplateUtils::supports_block_templates( $template_type ) ) {
 			return $query_result;
 		}
 

--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -295,7 +295,7 @@ class BlockTemplatesController {
 	 * @return array
 	 */
 	public function add_block_templates( $query_result, $query, $template_type ) {
-		if ( ! BlockTemplateUtils::supports_block_templates( 'wp_template_part' === $template_type ) ) {
+		if ( ! BlockTemplateUtils::supports_block_templates( 'wp_template_part' ) ) {
 			return $query_result;
 		}
 

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -155,7 +155,7 @@ class MiniCart extends AbstractBlock {
 
 		if (
 			current_user_can( 'edit_theme_options' ) &&
-			wc_current_theme_is_fse_theme()
+			( wc_current_theme_is_fse_theme() || current_theme_supports( 'block-template-parts' ) )
 		) {
 			$theme_slug = BlockTemplateUtils::theme_has_template_part( 'mini-cart' ) ? wp_get_theme()->get_stylesheet() : BlockTemplateUtils::PLUGIN_SLUG;
 

--- a/src/Utils/BlockTemplateUtils.php
+++ b/src/Utils/BlockTemplateUtils.php
@@ -440,17 +440,21 @@ class BlockTemplateUtils {
 	/**
 	 * Checks to see if they are using a compatible version of WP, or if not they have a compatible version of the Gutenberg plugin installed.
 	 *
+	 * @param  boolean $template_part Whether we are checking for a template part or not.
 	 * @return boolean
 	 */
-	public static function supports_block_templates() {
-		if (
-			! wc_current_theme_is_fse_theme() &&
-			( ! function_exists( 'gutenberg_supports_block_templates' ) || ! gutenberg_supports_block_templates() )
-		) {
-			return false;
+	public static function supports_block_templates( $template_part = false ) {
+		if ( (bool) $template_part && ( wc_current_theme_is_fse_theme() || current_theme_supports( 'block-template-parts' ) ) ) {
+				return true;
+		} else {
+			if (
+				! wc_current_theme_is_fse_theme() &&
+				( ! function_exists( 'gutenberg_supports_block_templates' ) || ! gutenberg_supports_block_templates() )
+			) {
+				return false;
+			}
+			return true;
 		}
-
-		return true;
 	}
 
 	/**

--- a/src/Utils/BlockTemplateUtils.php
+++ b/src/Utils/BlockTemplateUtils.php
@@ -446,16 +446,11 @@ class BlockTemplateUtils {
 	 */
 	public static function supports_block_templates( $template_type = 'wp_template' ) {
 		if ( 'wp_template_part' === $template_type && ( wc_current_theme_is_fse_theme() || current_theme_supports( 'block-template-parts' ) ) ) {
-				return true;
-		} else {
-			if (
-				! wc_current_theme_is_fse_theme() &&
-				( ! function_exists( 'gutenberg_supports_block_templates' ) || ! gutenberg_supports_block_templates() )
-			) {
-				return false;
-			}
+			return true;
+		} elseif ( 'wp_template' === $template_type && wc_current_theme_is_fse_theme() ) {
 			return true;
 		}
+		return false;
 	}
 
 	/**

--- a/src/Utils/BlockTemplateUtils.php
+++ b/src/Utils/BlockTemplateUtils.php
@@ -440,11 +440,12 @@ class BlockTemplateUtils {
 	/**
 	 * Checks to see if they are using a compatible version of WP, or if not they have a compatible version of the Gutenberg plugin installed.
 	 *
-	 * @param  boolean $template_part Whether we are checking for a template part or not.
+	 * @param string $template_type Optional. Template type: `wp_template` or `wp_template_part`.
+	 *                              Default `wp_template`.
 	 * @return boolean
 	 */
-	public static function supports_block_templates( $template_part = false ) {
-		if ( (bool) $template_part && ( wc_current_theme_is_fse_theme() || current_theme_supports( 'block-template-parts' ) ) ) {
+	public static function supports_block_templates( $template_type = 'wp_template' ) {
+		if ( 'wp_template_part' === $template_type && ( wc_current_theme_is_fse_theme() || current_theme_supports( 'block-template-parts' ) ) ) {
 				return true;
 		} else {
 			if (
@@ -461,8 +462,8 @@ class BlockTemplateUtils {
 	 * Retrieves a single unified template object using its id.
 	 *
 	 * @param string $id            Template unique identifier (example: theme_slug//template_slug).
-	 * @param string $template_type Optional. Template type: `'wp_template'` or '`wp_template_part'`.
-	 *                             Default `'wp_template'`.
+	 * @param string $template_type Optional. Template type: `wp_template` or 'wp_template_part`.
+	 *                              Default `wp_template`.
 	 *
 	 * @return WP_Block_Template|null Template.
 	 */

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -7,7 +7,7 @@
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain:  woo-gutenberg-products-block
- * Requires at least: 6.2
+ * Requires at least: 6.1
  * Requires PHP: 7.3
  * WC requires at least: 7.7
  * WC tested up to: 7.8
@@ -18,7 +18,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-$minimum_wp_version = '6.2';
+$minimum_wp_version = '6.1';
 
 if ( ! defined( 'WC_BLOCKS_IS_FEATURE_PLUGIN' ) ) {
 	define( 'WC_BLOCKS_IS_FEATURE_PLUGIN', true );


### PR DESCRIPTION
Classic themes are able to register support for template parts, so it'd be good to account for that with our registration of custom Woo Template Parts such as what is utilized for the Mini-Cart block.

### Testing

#### User Facing Testing

User testing requires utilizing a classic WordPress theme which has implemented support for template parts (commonly via adding `add_theme_support( 'block-template-parts' );` to the themes `functions.php` file via a callback on the `after_setup_theme` action hook:

```PHP
 add_action( 'after_setup_theme', function() {
 	add_theme_support( 'block-template-parts' );
 } );
```

Once that is in place...

1. Go to the Appearance -> Template Parts menu page
2. The Mini-Cart template part should be available in the list.
3. Load the Mini-Cart template part and you should be able to edit and save any changes.
4. Now, create a new post and add the Mini-Cart block.
5. View the post in the frontend and click on the Mini-Cart button. Verify that the changes you did to the Mini-Cart template part are visible.

* [x] Do not include in the Testing Notes

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Enable WooCommerce custom template part support for classic themes that support block template parts.
