### PR TITLE
Add styles to align last element of product card at the bottom at all times

### DIFF
--- a/assets/js/blocks/product-template/editor.scss
+++ b/assets/js/blocks/product-template/editor.scss
@@ -9,7 +9,7 @@ ul.products-block-post-template {
 			display: flex;
 			flex-direction: column;
 
-			> :last-child {
+			.wc-block-components-product-button {
 				margin-top: auto;
 			}
 		}

--- a/assets/js/blocks/product-template/editor.scss
+++ b/assets/js/blocks/product-template/editor.scss
@@ -1,5 +1,19 @@
-ul.wc-block-product-template {
+ul.wc-block-product-template,
+ul.products-block-post-template {
 	padding-left: 0;
 	margin-left: 0;
 	list-style: none;
+
+	&.is-flex-container {
+		> li {
+			display: flex;
+			flex-direction: column;
+
+			.wp-block-woocommerce-product-button {
+				margin-top: auto;
+				margin-left: auto;
+				margin-right: auto;
+			}
+		}
+	}
 }

--- a/assets/js/blocks/product-template/editor.scss
+++ b/assets/js/blocks/product-template/editor.scss
@@ -9,10 +9,8 @@ ul.products-block-post-template {
 			display: flex;
 			flex-direction: column;
 
-			.wp-block-woocommerce-product-button {
+			> :last-child {
 				margin-top: auto;
-				margin-left: auto;
-				margin-right: auto;
 			}
 		}
 	}

--- a/assets/js/blocks/product-template/style.scss
+++ b/assets/js/blocks/product-template/style.scss
@@ -31,7 +31,7 @@ $break-small: 600px;
 			display: flex;
 			flex-direction: column;
 
-			> :last-child {
+			.wc-block-components-product-button {
 				margin-top: auto;
 			}
 		}

--- a/assets/js/blocks/product-template/style.scss
+++ b/assets/js/blocks/product-template/style.scss
@@ -31,10 +31,8 @@ $break-small: 600px;
 			display: flex;
 			flex-direction: column;
 
-			.wc-block-components-product-button {
+			> :last-child {
 				margin-top: auto;
-				margin-left: auto;
-				margin-right: auto;
 			}
 		}
 

--- a/assets/js/blocks/product-template/style.scss
+++ b/assets/js/blocks/product-template/style.scss
@@ -6,7 +6,8 @@ $break-small: 600px;
 	}
 }
 
-.wc-block-product-template {
+.wc-block-product-template,
+.products-block-post-template {
 	margin-top: 0;
 	margin-bottom: 0;
 	max-width: 100%;
@@ -27,6 +28,14 @@ $break-small: 600px;
 		> li {
 			margin: 0;
 			width: 100%;
+			display: flex;
+			flex-direction: column;
+
+			.wc-block-components-product-button {
+				margin-top: auto;
+				margin-left: auto;
+				margin-right: auto;
+			}
 		}
 
 		@include break-small {


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

This PR pushes the `Add to cart` button to always be at the bottom filling up the height of the column to the tallest column available. This is so that the row won't look misaligned in height.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|![file.png](https://github.com/woocommerce/woocommerce-blocks/assets/2132595/1295383d-46d9-4126-b499-fcdc1970f698)        |![file.png](https://github.com/woocommerce/woocommerce-blocks/assets/2132595/c15555fd-fb44-4cc0-9be8-ce3bb9a88025)       |

### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Add a post/page and add the `Products (beta)` block.
2. Add a `Product rating` block inbetween the product title and price. ( this is just to push the content down ).
3. Save/update and go to the frontend and ensure the `Add to cart` button is aligned at the bottom on each row.
4. Test this also in the editor. You can use the developer tools to edit the product title to something long which will force it to wrap down. Ensure the `Add to cart` button still stays at the bottom in alignment with other buttons.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Update product grid styling to align the last element on each product card to the bottom