### PR TITLE
Remove unnecessary white space from Testimonials 3 Columns pattern

### DIFF
--- a/patterns/testimonials-3-columns.php
+++ b/patterns/testimonials-3-columns.php
@@ -15,11 +15,7 @@
 		<!-- /wp:heading -->
 
 		<!-- wp:paragraph {"style":{"typography":{"fontSize":"18px"}}} -->
-		<p style="font-size:18px">
-			In the end the couch wasn’t exactly what I was looking for but my experience with the
-			Burrow team was excellent. First in providing a discount when the couch was delayed, then timely feedback
-			and updates as the…
-		</p>
+		<p style="font-size:18px">In the end the couch wasn’t exactly what I was looking for but my experience with the Burrow team was excellent. First in providing a discount when the couch was delayed, then timely feedback and updates as the…</p>
 		<!-- /wp:paragraph -->
 
 		<!-- wp:paragraph {"style":{"typography":{"fontSize":"18px"},"color":{"text":"#646970"}}} -->
@@ -34,10 +30,7 @@
 		<!-- /wp:heading -->
 
 		<!-- wp:paragraph {"style":{"typography":{"fontSize":"18px"}}} -->
-		<p style="font-size:18px">
-			Great couch. color as advertise. seat is nice and firm. Easy to put together.
-			Versatile. Bought one for my mother in law as well. And she loves hers!
-		</p>
+		<p style="font-size:18px">Great couch. color as advertise. seat is nice and firm. Easy to put together. Versatile. Bought one for my mother in law as well. And she loves hers!</p>
 		<!-- /wp:paragraph -->
 
 		<!-- wp:paragraph {"style":{"typography":{"fontSize":"18px"},"color":{"text":"#646970"}}} -->
@@ -52,11 +45,7 @@
 		<!-- /wp:heading -->
 
 		<!-- wp:paragraph {"style":{"typography":{"fontSize":"18px"}}} -->
-		<p style="font-size:18px">
-			I got the kind sofa. The look and feel is high quality, and I enjoy that it is a
-			medium level of firmness. Assembly took a little longer than I expected, and it came in 4 boxes. I am
-			excited about the time / st…
-		</p>
+		<p style="font-size:18px">I got the kind sofa. The look and feel is high quality, and I enjoy that it is a medium level of firmness. Assembly took a little longer than I expected, and it came in 4 boxes. I am excited about the time / st…</p>
 		<!-- /wp:paragraph -->
 
 		<!-- wp:paragraph {"style":{"typography":{"fontSize":"18px"},"color":{"text":"#646970"}}} -->


### PR DESCRIPTION
Fixes an issue discovered by @verofasulo.

### Testing

#### User Facing Testing

1. Create a post or page.
2. Add the _Testimonials 3 Columns_ pattern.
3. Verify there is no white space at the beginning of each paragraph.

Before | After
--- | ---
![imatge](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/d212291d-6aaf-4642-847d-62a336cbc922) | ![imatge](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/509f25b6-788a-46b2-95e2-2dc74b92d59b)

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Remove unnecessary white space from Testimonials 3 Columns pattern
