### PR TITLE
Disable the debug check of tests-mysql to let PHP unit tests pass

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -118,7 +118,7 @@ jobs:
 
       - name: Docker container debug information
         run: |
-          npm run wp-env run tests-mysql "mysql --version"
+          # npm run wp-env run tests-mysql "mysql --version"
           npm run wp-env run tests-wordpress "php --version"
           npm run wp-env run tests-wordpress "php -m"
           npm run wp-env run tests-wordpress "php -i"


### PR DESCRIPTION
## Temporary change

Disable the debug check of tests-mysql to let PHP unit tests pass. This is due to the job failing with:

```
OCI runtime exec failed: exec failed: unable to start container process: exec: "mysql": executable file not found in $PATH: unknown
✖ Command failed with exit code 126
Command failed with exit code 126
Error: Process completed with exit code 1.
```

and that prevents PHP unit tests to run.

[Example job](https://github.com/woocommerce/woocommerce-blocks/actions/runs/5242874662/jobs/9466956419?pr=9788)