### PR TITLE
Change the way of debug check of tests-mysql container

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -118,7 +118,7 @@ jobs:
 
       - name: Docker container debug information
         run: |
-          # npm run wp-env run tests-mysql "mysql --version"
+          npm run wp-env run tests-mysql mysql -- --version
           npm run wp-env run tests-wordpress "php --version"
           npm run wp-env run tests-wordpress "php -m"
           npm run wp-env run tests-wordpress "php -i"


### PR DESCRIPTION
Unit test PHP job on GitHub actions started to fail on 11 June.

That was due to debug check:

npm run wp-env run tests-mysql "mysql --version"

which resulted in the following:

```
OCI runtime exec failed: exec failed: unable to start container process: exec: "mysql": executable file not found in $PATH: unknown
✖ Command failed with exit code 126
Command failed with exit code 126
Error: Process completed with exit code 1.
```

That seems to match description provided in the Gutenberg PR: https://github.com/WordPress/gutenberg/pull/50559 [here](https://github.com/WordPress/gutenberg/blob/trunk/packages/env/README.md#wp-env-run-container-command):

> In some cases wp-env run may conflict with options that you are passing to the container. When this happens, wp-env will treat the option as its own and take action accordingly. For example, if you try wp-env run cli php --help, you will receive the wp-env help text.
> You can get around this by passing any conflicting options after a double dash. wp-env will not process anything after the double dash and will simply pass it on to the container. To get the PHP help text you would use wp-env run cli php -- --help.

And that's what I did in this PR. However, it's still a mystery to me why it started to fail.

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/9793