### PR TITLE
Keep change address button visible even if prefersCollection is true

### DIFF
--- a/assets/js/base/components/cart-checkout/totals/shipping/shipping-address.tsx
+++ b/assets/js/base/components/cart-checkout/totals/shipping/shipping-address.tsx
@@ -48,7 +48,7 @@ export const ShippingAddress = ( {
 			) : (
 				<ShippingLocation formattedLocation={ formattedLocation } />
 			) }
-			{ showCalculator && ! prefersCollection ? (
+			{ showCalculator && (
 				<CalculatorButton
 					label={ __(
 						'Change address',
@@ -57,7 +57,7 @@ export const ShippingAddress = ( {
 					isShippingCalculatorOpen={ isShippingCalculatorOpen }
 					setIsShippingCalculatorOpen={ setIsShippingCalculatorOpen }
 				/>
-			) : null }
+			) }
 		</>
 	);
 };


### PR DESCRIPTION
When testing #9785 I discovered an issue where you can lock yourself out of changing rates in the cart. 

The cart page shows a mix of local pickup and regular shipping rates, but right now if a local pickup rate is selected, the "Change Address" button is hidden, even if there could potentially be other rates to display.

This PR just removes the check so that the "Change Address" button is always visible.

### Screenshots

![Screenshot 2023-06-13 at 14 18 51](https://github.com/woocommerce/woocommerce-blocks/assets/90977/69156833-3cba-461d-bec6-a4d07fc6bf50)

### Testing

1. Ensure you are using the Cart block.
2. Go to /wp-admin/profile.php and ensure your test account has a (shipping) address.
3. Ensure you have an item in the cart that needs shipping, and a mixture of pickup and flat rates.
4. Select the local pickup shipping method.
5. Confirm the “change address” button is still shown.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### Changelog

> Ensure the "Change Address" button is visible in the cart even if local pickup is selected.