### PR TITLE
Convert grid-layout-control to use Typescript

### DIFF
--- a/assets/js/editor-components/grid-layout-control/index.tsx
+++ b/assets/js/editor-components/grid-layout-control/index.tsx
@@ -2,10 +2,13 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import PropTypes from 'prop-types';
 import { RangeControl, ToggleControl } from '@wordpress/components';
 
-const clamp = ( number, boundOne, boundTwo ) => {
+interface ClampProps {
+	( number: number, boundOne: number, boundTwo?: number ): number;
+}
+
+const clamp: ClampProps = ( number, boundOne, boundTwo ) => {
 	if ( ! boundTwo ) {
 		return Math.max( number, boundOne ) === boundOne ? number : boundOne;
 	} else if ( Math.min( number, boundOne ) === number ) {
@@ -15,6 +18,17 @@ const clamp = ( number, boundOne, boundTwo ) => {
 	}
 	return number;
 };
+
+interface GridLayoutControlProps {
+	columns: number;
+	rows: number;
+	setAttributes: ( attributes: Record< string, unknown > ) => void;
+	alignButtons: boolean;
+	minColumns?: number;
+	maxColumns?: number;
+	minRows?: number;
+	maxRows?: number;
+}
 
 /**
  * A combination of range controls for product grid layout settings.
@@ -38,13 +52,13 @@ const GridLayoutControl = ( {
 	maxColumns = 6,
 	minRows = 1,
 	maxRows = 6,
-} ) => {
+}: GridLayoutControlProps ) => {
 	return (
 		<>
 			<RangeControl
 				label={ __( 'Columns', 'woo-gutenberg-products-block' ) }
 				value={ columns }
-				onChange={ ( value ) => {
+				onChange={ ( value: number ) => {
 					const newValue = clamp( value, minColumns, maxColumns );
 					setAttributes( {
 						columns: Number.isNaN( newValue ) ? '' : newValue,
@@ -56,7 +70,7 @@ const GridLayoutControl = ( {
 			<RangeControl
 				label={ __( 'Rows', 'woo-gutenberg-products-block' ) }
 				value={ rows }
-				onChange={ ( value ) => {
+				onChange={ ( value: number ) => {
 					const newValue = clamp( value, minRows, maxRows );
 					setAttributes( {
 						rows: Number.isNaN( newValue ) ? '' : newValue,
@@ -88,24 +102,6 @@ const GridLayoutControl = ( {
 			/>
 		</>
 	);
-};
-
-GridLayoutControl.propTypes = {
-	// The current columns count.
-	columns: PropTypes.oneOfType( [ PropTypes.number, PropTypes.string ] )
-		.isRequired,
-	// The current rows count.
-	rows: PropTypes.oneOfType( [ PropTypes.number, PropTypes.string ] )
-		.isRequired,
-	// Whether or not buttons are aligned horizontally across items.
-	alignButtons: PropTypes.bool.isRequired,
-	// Callback to update the layout settings.
-	setAttributes: PropTypes.func.isRequired,
-	// Min and max constraints.
-	minColumns: PropTypes.number,
-	maxColumns: PropTypes.number,
-	minRows: PropTypes.number,
-	maxRows: PropTypes.number,
 };
 
 export default GridLayoutControl;


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/9535

This PR converts the `grid-layout-control` to use Typescript.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Add a post/page with `All Products` block. This block utilizes the `grid-layout-control` component.
2. Try changing the columns/rows in the inspector controls.
3. Ensure everything works as expected.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Convert the grid-layout-control component to use Typescript
