### PR TITLE
e2e tests: Wait for cart to be removed from the DOM when emptied

### DIFF
--- a/tests/utils/shopper.js
+++ b/tests/utils/shopper.js
@@ -171,11 +171,10 @@ export const shopper = {
 				await uiUnblocked();
 			}
 
-			await page.waitForSelector( '.woocommerce-info' );
-			// eslint-disable-next-line jest/no-standalone-expect
-			await expect( page ).toMatchElement(
-				'.woocommerce-info.cart-empty'
-			);
+			// Wait for form to be hidden.
+			await page.waitForSelector( '.woocommerce-cart-form', {
+				hidden: true,
+			} );
 		},
 
 		placeOrder: async () => {


### PR DESCRIPTION
It's not yet clear if the removal of the notices in the shortcode cart were intentional in WC core, but it is breaking our tests. To workaround the issue we can wait for the cart form to be removed from the DOM, instead of waiting for a notice to be rendered.

This should be merged when/if e2e tests pass.