### PR TITLE
Replace Automated tests badge with E2E and Unit tests badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 [![View](https://img.shields.io/badge/Project%20Components-brightgreen.svg?style=flat)](https://woocommerce.github.io/woocommerce-blocks/)
 ![JavaScript and CSS Linting](https://github.com/woocommerce/woocommerce-gutenberg-products-block/workflows/JavaScript%20and%20CSS%20Linting/badge.svg?branch=trunk)
 ![PHP Coding Standards](https://github.com/woocommerce/woocommerce-gutenberg-products-block/workflows/PHP%20Coding%20Standards/badge.svg?branch=trunk)
-![Automated tests](https://github.com/woocommerce/woocommerce-gutenberg-products-block/workflows/Automated%20tests/badge.svg?branch=trunk)
+![Unit Tests](https://github.com/woocommerce/woocommerce-blocks/workflows/E2E%20tests/badge.svg?branch=trunk)
+![E2E Tests](https://github.com/woocommerce/woocommerce-blocks/workflows/Unit%20Tests/badge.svg?branch=trunk)
 
 This is the feature plugin for WooCommerce + Gutenberg. This plugin serves as a space to iterate and explore new Blocks and updates to existing blocks for WooCommerce, and how WooCommerce might work with the block editor.
 


### PR DESCRIPTION
Replace the "Automated tests" workflow badge with:
- E2E tests https://github.com/woocommerce/woocommerce-blocks/workflows/E2E%20tests/badge.svg?branch=trunk
- Unit tests https://github.com/woocommerce/woocommerce-blocks/workflows/Unit%20Tests/badge.svg?branch=trunk

"Automated tests" badge started to return 404 as it seems the workflow has been renamed or changed:
https://github.com/woocommerce/woocommerce-blocks/workflows/Automated%20tests/badge.svg?branch=trunk which was causing `markdown-link-check` job to fail.

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. It's expected that `markdown-link-check` job will pass for this job.
2. Check the badges "E2E tests" and "Unit tests" are displayed in [README.md](https://github.com/woocommerce/woocommerce-blocks/blob/8c3f9245fc646d3db05689e4c4809c7deceafe74/README.md)

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->