### PR TITLE
Removed proptypes from feedback-promt

### DIFF
--- a/assets/js/editor-components/feedback-prompt/index.tsx
+++ b/assets/js/editor-components/feedback-prompt/index.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import PropTypes from 'prop-types';
 import { Icon, commentContent, external } from '@wordpress/icons';
 import { useEffect, useState } from '@wordpress/element';
 
@@ -10,7 +9,11 @@ import { useEffect, useState } from '@wordpress/element';
  * Internal dependencies
  */
 import './style.scss';
-
+interface FeedbackPromptProps {
+	text: string;
+	title?: string;
+	url?: string;
+}
 /**
  * Component to render a Feedback prompt in the sidebar.
  *
@@ -23,7 +26,7 @@ const FeedbackPrompt = ( {
 	text,
 	title = __( 'Feedback?', 'woo-gutenberg-products-block' ),
 	url = 'https://ideas.woocommerce.com/forums/133476-woocommerce?category_id=384565',
-} ) => {
+}: FeedbackPromptProps ) => {
 	// By returning false we ensure that this component is not entered into the InspectorControls
 	// (which is a slot fill), children array on first render, on the second render when the state
 	// gets updated this component does get put into the InspectorControls children array but as the
@@ -34,31 +37,30 @@ const FeedbackPrompt = ( {
 	}, [] );
 
 	return (
-		isVisible && (
-			<div className="wc-block-feedback-prompt">
-				<Icon icon={ commentContent } />
-				<h2 className="wc-block-feedback-prompt__title">{ title }</h2>
-				<p className="wc-block-feedback-prompt__text">{ text }</p>
-				<a
-					href={ url }
-					className="wc-block-feedback-prompt__link"
-					rel="noreferrer noopener"
-					target="_blank"
-				>
-					{ __(
-						'Give us your feedback.',
-						'woo-gutenberg-products-block'
-					) }
-					<Icon icon={ external } size={ 16 } />
-				</a>
-			</div>
-		)
+		<>
+			{ isVisible && (
+				<div className="wc-block-feedback-prompt">
+					<Icon icon={ commentContent } />
+					<h2 className="wc-block-feedback-prompt__title">
+						{ title }
+					</h2>
+					<p className="wc-block-feedback-prompt__text">{ text }</p>
+					<a
+						href={ url }
+						className="wc-block-feedback-prompt__link"
+						rel="noreferrer noopener"
+						target="_blank"
+					>
+						{ __(
+							'Give us your feedback.',
+							'woo-gutenberg-products-block'
+						) }
+						<Icon icon={ external } size={ 16 } />
+					</a>
+				</div>
+			) }
+		</>
 	);
-};
-
-FeedbackPrompt.propTypes = {
-	text: PropTypes.string,
-	url: PropTypes.string,
 };
 
 export default FeedbackPrompt;


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #9528 

### Changes in the PR:
Removed propTypes definitions from price filters.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->
### Testing

#### Automated Tests
* [x] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [x] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
