### PR TITLE
Fix PHP CS warnings in src/BlockTypesAddToCartForm.php

### DIFF
--- a/src/BlockTypes/AddToCartForm.php
+++ b/src/BlockTypes/AddToCartForm.php
@@ -90,9 +90,9 @@ class AddToCartForm extends AbstractBlock {
 			return '';
 		}
 
-		$parsed_attributes = $this->parse_attributes( $attributes );
+		$parsed_attributes                     = $this->parse_attributes( $attributes );
 		$is_descendent_of_single_product_block = $parsed_attributes['isDescendentOfSingleProductBlock'];
-		$product = $this->add_is_descendent_of_single_product_block_hidden_input_to_product_form( $product, $is_descendent_of_single_product_block );
+		$product                               = $this->add_is_descendent_of_single_product_block_hidden_input_to_product_form( $product, $is_descendent_of_single_product_block );
 
 		$classname          = $attributes['className'] ?? '';
 		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes );
@@ -124,7 +124,7 @@ class AddToCartForm extends AbstractBlock {
 			'<input type="hidden" name="is-descendent-of-single-product-block" value="%1$s">',
 			$is_descendent_of_single_product_block ? 'true' : 'false'
 		);
-		$regex_pattern = '/<button\s+type="submit"[^>]*>.*?<\/button>/i';
+		$regex_pattern                                      = '/<button\s+type="submit"[^>]*>.*?<\/button>/i';
 
 		preg_match( $regex_pattern, $product, $input_matches );
 


### PR DESCRIPTION
When testing https://github.com/woocommerce/woocommerce-blocks/pull/9837 I found there are other 3 PHP lint warnings:

```
FILE: /Users/karolm/automattic/repositories/woocommerce-blocks/src/BlockTypes/AddToCartForm.php
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 3 WARNINGS AFFECTING 3 LINES
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  93 | WARNING | [x] Equals sign not aligned with surrounding assignments; expected 21 spaces but found 1 space
     |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
  95 | WARNING | [x] Equals sign not aligned with surrounding assignments; expected 31 spaces but found 1 space
     |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
 127 | WARNING | [x] Equals sign not aligned with surrounding assignments; expected 38 spaces but found 1 space
     |         |     (Generic.Formatting.MultipleStatementAlignment.NotSameWarning)
```

This PR's fixing them.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Run `npm run lint:php`
2. Expect no warnings in src/BlockTypesAddToCartForm.php file

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
