### PR TITLE
Temporary disable PHP Unit Tests job until wp-env release containing the docker image fix 

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -53,15 +53,15 @@ jobs:
     # if: ${{ github.repository == 'WooCommerce/WooCommerce-Blocks' || github.event_name == 'pull_request' }}
     strategy:
       fail-fast: true
-      matrix:
-        php:
-          - '7.4'
-          - '8.0'
-          - '8.1'
-          - '8.2'
+      # matrix:
+        # php:
+          # - '7.4'
+          # - '8.0'
+          # - '8.1'
+          # - '8.2'
     
     env:
-      WP_ENV_PHP_VERSION: ${{ matrix.php }}
+      # WP_ENV_PHP_VERSION: ${{ matrix.php }}
     
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -49,7 +49,8 @@ jobs:
     name: PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    if: ${{ github.repository == 'WooCommerce/WooCommerce-Blocks' || github.event_name == 'pull_request' }}
+    if: ${{ false }}  # disable for now
+    # if: ${{ github.repository == 'WooCommerce/WooCommerce-Blocks' || github.event_name == 'pull_request' }}
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -49,7 +49,7 @@ jobs:
     name: PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    if: ${{ false }}  # disable for now
+    if: ${{ false }}  # Disable temporary
     # if: ${{ github.repository == 'WooCommerce/WooCommerce-Blocks' || github.event_name == 'pull_request' }}
     strategy:
       fail-fast: true

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -60,7 +60,7 @@ jobs:
           # - '8.1'
           # - '8.2'
     
-    env:
+    # env:
       # WP_ENV_PHP_VERSION: ${{ matrix.php }}
     
     steps:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -53,15 +53,15 @@ jobs:
     # if: ${{ github.repository == 'WooCommerce/WooCommerce-Blocks' || github.event_name == 'pull_request' }}
     strategy:
       fail-fast: true
-      # matrix:
-        # php:
-          # - '7.4'
-          # - '8.0'
-          # - '8.1'
-          # - '8.2'
+      matrix:
+        php:
+          - '7.4'
+          - '8.0'
+          - '8.1'
+          - '8.2'
     
-    # env:
-      # WP_ENV_PHP_VERSION: ${{ matrix.php }}
+    env:
+      WP_ENV_PHP_VERSION: ${{ matrix.php }}
     
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Currently, PHP Unit Tests jobs are failing on every PR. This is most likely due the official WordPress docker images being recently updated (e.g. [WordPress 8.2 image](https://hub.docker.com/layers/library/wordpress/php8.2/images/sha256-49be2e34db386890752ae32edbfb26ccd574267193ac007fe837d26a2a83a7e4?context=explore)) and are now based on debian:12-slim.

That change affected multiple repositories, Gutenberg included. The https://github.com/WordPress/gutenberg/pull/51513 was provided to the @wordpress/env package that unblocks the pipelines for Gutenberg's trunk, but the change is not released yet, hence we cannot update wp-env and have no control over docker-image to apply the changes manually.

Having said that, this PR disables the PHP Unit Tests job.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. PHP Unit tests should not be fired on this PR and pipeline should be green ✅ 

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->