### PR TITLE
Temporarily skip PHP Unit Tests for PHP 8.1 and 8.2

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -56,6 +56,7 @@ jobs:
         php:
           - '7.4'
           - '8.0'
+          # Disabled temporary as docker-images for those cause the errors when pipeline is running
           # - '8.1'
           # - '8.2'
     

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -50,8 +50,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     if: ${{ github.repository == 'WooCommerce/WooCommerce-Blocks' || github.event_name == 'pull_request' }}
+    continue-on-error: true
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         php:
           - '7.4'

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -89,21 +89,29 @@ jobs:
       
       # Ensure that Composer installs the correct versions of packages.
       - name: Override PHP version in composer.json
+        # 8.1 and 8.2 are temporarily disabled as docker-images for those cause the errors when pipeline is running
+        if: ${{ matrix.php == '7.4' || matrix.php == '8.0' }}
         run: |
           composer config platform.php ${{ matrix.php }}
           composer update
 
       - name: Install npm dependencies
+        # 8.1 and 8.2 are temporarily disabled as docker-images for those cause the errors when pipeline is running
+        if: ${{ matrix.php == '7.4' || matrix.php == '8.0' }}
         run: |
           npm ci
           npm run build
           
       - name: Docker debug information
+        # 8.1 and 8.2 are temporarily disabled as docker-images for those cause the errors when pipeline is running
+        if: ${{ matrix.php == '7.4' || matrix.php == '8.0' }}
         run: |
           docker -v
           docker-compose -v
           
       - name: General debug information
+        # 8.1 and 8.2 are temporarily disabled as docker-images for those cause the errors when pipeline is running
+        if: ${{ matrix.php == '7.4' || matrix.php == '8.0' }}
         run: |
           npm --version
           node --version
@@ -113,12 +121,18 @@ jobs:
           locale -a
           
       - name: Start Docker environment
+        # 8.1 and 8.2 are temporarily disabled as docker-images for those cause the errors when pipeline is running
+        if: ${{ matrix.php == '7.4' || matrix.php == '8.0' }}
         run: npm run wp-env start --update
 
       - name: Log running Docker containers
+        # 8.1 and 8.2 are temporarily disabled as docker-images for those cause the errors when pipeline is running
+        if: ${{ matrix.php == '7.4' || matrix.php == '8.0' }}
         run: docker ps -a
 
       - name: Docker container debug information
+        # 8.1 and 8.2 are temporarily disabled as docker-images for those cause the errors when pipeline is running
+        if: ${{ matrix.php == '7.4' || matrix.php == '8.0' }}
         run: |
           npm run wp-env run tests-mysql mysql -- --version
           npm run wp-env run tests-wordpress "php --version"
@@ -127,4 +141,6 @@ jobs:
           npm run wp-env run tests-wordpress "locale -a"
           
       - name: Run PHPUnit tests
+        # 8.1 and 8.2 are temporarily disabled as docker-images for those cause the errors when pipeline is running
+        if: ${{ matrix.php == '7.4' || matrix.php == '8.0' }}
         run: npm run test:php

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -56,9 +56,8 @@ jobs:
         php:
           - '7.4'
           - '8.0'
-          # Disabled temporary as docker-images for those cause the errors when pipeline is running
-          # - '8.1'
-          # - '8.2'
+          - '8.1'
+          - '8.2'
     
     env:
       WP_ENV_PHP_VERSION: ${{ matrix.php }}
@@ -81,6 +80,8 @@ jobs:
       ##
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
+        # 8.1 and 8.2 are temporarily disabled as docker-images for those cause the errors when pipeline is running
+        if: ${{ matrix.php == '7.4' || matrix.php == '8.0' }}
         with:
           php-version: '${{ matrix.php }}'
           ini-file: development

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -50,9 +50,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     if: ${{ github.repository == 'WooCommerce/WooCommerce-Blocks' || github.event_name == 'pull_request' }}
-    continue-on-error: true
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         php:
           - '7.4'

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -57,8 +57,8 @@ jobs:
         php:
           - '7.4'
           - '8.0'
-          - '8.1'
-          - '8.2'
+          # - '8.1'
+          # - '8.2'
     
     env:
       WP_ENV_PHP_VERSION: ${{ matrix.php }}


### PR DESCRIPTION
Currently, PHP Unit Tests jobs are failing on every PR. This is most likely due the official WordPress docker images being recently updated (e.g. [WordPress 8.2 image](https://hub.docker.com/layers/library/wordpress/php8.2/images/sha256-49be2e34db386890752ae32edbfb26ccd574267193ac007fe837d26a2a83a7e4?context=explore)) and are now based on debian:12-slim.

That change affected multiple repositories, Gutenberg included. The https://github.com/WordPress/gutenberg/pull/51513 was provided to the @wordpress/env package that unblocks the pipelines for Gutenberg's trunk, but the change is not released yet, hence we cannot update wp-env and have no control over docker-image to apply the changes manually.

Having said that, this PR limits the PHP Unit Tests to only PHP 7.4 and 8.0 which are working fine. Versions 8.1 and 8.2 are skipped until `wp-env` patch is released containing the fix: check [a discussion](https://github.com/WordPress/gutenberg/pull/51513#issuecomment-1592721868). 

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. All pipelines should be green except for Unit Tests PHP 8.1 and 8.2 which are not run at all (however marked as expected - this cannot be changed on the repo level as it's controlled on an Organisation level)

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->
