### PR TITLE
Product by Category block: Fix error when adding the block to a store without reviews

### DIFF
--- a/assets/js/blocks/reviews/editor-container-block.js
+++ b/assets/js/blocks/reviews/editor-container-block.js
@@ -74,7 +74,7 @@ EditorContainerBlock.propTypes = {
 	attributes: PropTypes.object.isRequired,
 	icon: PropTypes.node.isRequired,
 	name: PropTypes.string.isRequired,
-	noReviewsPlaceholder: PropTypes.element.isRequired,
+	noReviewsPlaceholder: PropTypes.elementType.isRequired,
 	className: PropTypes.string,
 };
 

--- a/assets/js/blocks/reviews/reviews-by-category/block.tsx
+++ b/assets/js/blocks/reviews/reviews-by-category/block.tsx
@@ -160,7 +160,7 @@ const ReviewsByCategoryEditor = ( {
 					'Reviews by Category',
 					'woo-gutenberg-products-block'
 				) }
-				noReviewsPlaceholder={ NoReviewsPlaceholder() }
+				noReviewsPlaceholder={ NoReviewsPlaceholder }
 			/>
 		</>
 	);


### PR DESCRIPTION
## Description
In this PR I fixed a PropType warning and also solved an error that was occurring when adding the Reviews by Category block to a store that has no product reviews.

## Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4d660a5</samp>

*  Fix prop type validation warning for `noReviewsPlaceholder` prop in `EditorContainerBlock` component ([link](https://github.com/woocommerce/woocommerce-blocks/pull/9868/files?diff=unified&w=0#diff-bc45a00aef0729fa54ef63c480f8f161bfea6af408f659aed5acb65ece12be95L77-R77))
*  Pass `NoReviewsPlaceholder` component as a render prop to `EditorContainerBlock` component in `reviews-by-category` block ([link](https://github.com/woocommerce/woocommerce-blocks/pull/9868/files?diff=unified&w=0#diff-292c2d256daa978cada261808ea8b988e39eb84c4eb562771eef3f785904ae01L163-R163))

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #9867 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
| ![image](https://github.com/woocommerce/woocommerce-blocks/assets/20469356/7444c66f-8c86-4444-a1ee-419b38eeba25)  |  ![image](https://github.com/woocommerce/woocommerce-blocks/assets/20469356/da76db67-6d7d-460d-8737-be1a6201b06d)  |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->
```
Pre-requisites:
- Make sure your store has no reviews
``` 

Steps to reproduce the behavior:

1. Log in to your WordPress admin dashboard: This can be done by visiting your website's login URL, which typically looks like www.yourwebsite.com/wp-admin.
2. Verify WooCommerce and WooCommerce Blocks installation: Before you proceed, make sure you have both WooCommerce and WooCommerce Blocks installed and activated. If you haven't, navigate to Plugins > Add New from your WordPress dashboard, search for WooCommerce and WooCommerce Blocks, install and activate them.
3. Create a new post: To do this, navigate to Posts > Add New from the WordPress dashboard.
4. Add the Reviews by Category block: Inside the new post editor, click on the plus icon (+) at the top left corner or within the post editor to add a new block. In the search bar that appears, type Reviews by Category and click on it to add the block to your post.
5. Configure the Reviews by Category block: Now, you can configure the block based on your needs. Select the category you want to display reviews from using the dropdown in the block selector.
6. Check that the block is inserted to the Editor and no error appears

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Fix error when adding the Reviews by Category block to a store without any product reviews
