### PR TITLE
All Reviews block: Fix error when adding the block to a store without reviews

### DIFF
--- a/assets/js/blocks/reviews/all-reviews/block.tsx
+++ b/assets/js/blocks/reviews/all-reviews/block.tsx
@@ -75,7 +75,7 @@ const AllReviewsEditor = ( {
 					/>
 				}
 				name={ __( 'All Reviews', 'woo-gutenberg-products-block' ) }
-				noReviewsPlaceholder={ NoReviewsPlaceholder() }
+				noReviewsPlaceholder={ NoReviewsPlaceholder }
 			/>
 		</>
 	);

--- a/assets/js/blocks/reviews/editor-container-block.js
+++ b/assets/js/blocks/reviews/editor-container-block.js
@@ -74,7 +74,7 @@ EditorContainerBlock.propTypes = {
 	attributes: PropTypes.object.isRequired,
 	icon: PropTypes.node.isRequired,
 	name: PropTypes.string.isRequired,
-	noReviewsPlaceholder: PropTypes.element.isRequired,
+	noReviewsPlaceholder: PropTypes.elementType.isRequired,
 	className: PropTypes.string,
 };
 


### PR DESCRIPTION
## Description
In this PR I fixed an error that was occurring when adding the All Reviews block to a store that has no product reviews.

## Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 07c035c</samp>

*  Fix bug where `NoReviewsPlaceholder` component was called as a function instead of being passed as a prop ([link](https://github.com/woocommerce/woocommerce-blocks/pull/9869/files?diff=unified&w=0#diff-b1d839d2a50cd82c1568183069e1c3807af800865185acaa53ae100ce5c74977L78-R78))
*  Update prop type validation for `noReviewsPlaceholder` prop in `EditorContainerBlock` component to accept any component type ([link](https://github.com/woocommerce/woocommerce-blocks/pull/9869/files?diff=unified&w=0#diff-bc45a00aef0729fa54ef63c480f8f161bfea6af408f659aed5acb65ece12be95L77-R77))

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
In this PR I fixed a PropType warning and also solved an error that was occurring when adding the Reviews by Category block to a store that has no product reviews.

<!-- Reference any related issues or PRs here -->

Fixes #9866 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
| ![image](https://github.com/woocommerce/woocommerce-blocks/assets/20469356/d4297f54-5b28-4eff-ae43-b10a9d75c4fa) | ![image](https://github.com/woocommerce/woocommerce-blocks/assets/20469356/f7ce077e-22d1-4696-835a-7f493b0ce30a) |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

```
Pre-requisites:
- Make sure your store has no reviews
``` 

1. Log in to your WordPress admin dashboard: To do this, go to your website's login URL, which typically looks something like www.yourwebsite.com/wp-admin.
2. Ensure you have WooCommerce and WooCommerce Blocks installed and activated: If you haven't done this yet, you can navigate to Plugins > Add New from your WordPress dashboard, search for WooCommerce and WooCommerce Blocks, install and activate both.
3. Create a new post: Navigate to Posts > Add New from the WordPress dashboard.
4. Add the All Reviews block: When you're in the new post editor, click on the plus icon (+) in the top left corner or within the post editor to add a new block. Type All Reviews in the search bar and click on it to add the block to your post.
5. Check that the block is inserted to the Editor without any errors

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> All Reviews block: Fix error when adding the block to a store without reviews.
