### PR TITLE
Hero Split pattern: add shop link to the button

### DIFF
--- a/patterns/hero-product-split.php
+++ b/patterns/hero-product-split.php
@@ -17,7 +17,7 @@
 		<div class="wp-block-buttons" style="margin-bottom:var(--wp--preset--spacing--40)">
 		<!-- wp:button {"style":{"color":{"text":"#000000","background":"#ffffff"}}} -->
 		<div class="wp-block-button">
-			<a class="wp-block-button__link has-text-color has-background wp-element-button" style="color:#000000;background-color:#ffffff;"><?php esc_html_e( 'Shop now', 'woo-gutenberg-products-block' ); ?></a>
+			<a href="<?php echo esc_url( get_permalink( wc_get_page_id( 'shop' ) ) ); ?>" class="wp-block-button__link has-text-color has-background wp-element-button" style="color:#000000;background-color:#ffffff;"><?php esc_html_e( 'Shop now', 'woo-gutenberg-products-block' ); ?></a>
 		</div>
 		<!-- /wp:button -->
 		</div>


### PR DESCRIPTION
This PR adds the link to the `shop` page to the Hero Split pattern.

In the issue there's also this task 👇 but it cannot be addressed, check: https://github.com/woocommerce/woocommerce-blocks/pull/9879#issuecomment-1596974161
> Address the lack of a :hover state for the button.

### Testing

#### User-Facing Testing

1. Create a new page or post.
2. Insert the `Hero Product - Split` pattern and save.
3. Go to the front end and check the `Shop now` button links to the shop.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Hero Product – Split pattern: add link to the shop page to the button.
