### PR TITLE
Add patterns for localisation of cart templates

### DIFF
--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -24,6 +24,52 @@ class Cart extends AbstractBlock {
 	protected $chunks_folder = 'cart-blocks';
 
 	/**
+	 * Initialize this block type.
+	 *
+	 * - Hook into WP lifecycle.
+	 * - Register the block with WordPress.
+	 */
+	protected function initialize() {
+		parent::initialize();
+		add_action( 'wp_loaded', array( $this, 'register_patterns' ) );
+	}
+
+	/**
+	 * Register block pattern for Empty Cart Message to make it translatable.
+	 */
+	public function register_patterns() {
+		$shop_permalink = wc_get_page_id( 'shop' ) ? get_permalink( wc_get_page_id( 'shop' ) ) : '';
+
+		register_block_pattern(
+			'woocommerce/cart-cross-sells-message',
+			array(
+				'title'    => '',
+				'inserter' => false,
+				'content'  => '<!-- wp:heading {"fontSize":"large"} --><h2 class="wp-block-heading has-large-font-size">' . esc_html__( 'You may be interested in…', 'woo-gutenberg-products-block' ) . '</h2><!-- /wp:heading -->',
+			)
+		);
+		register_block_pattern(
+			'woocommerce/cart-empty-message',
+			array(
+				'title'    => '',
+				'inserter' => false,
+				'content'  => '
+					<!-- wp:heading {"textAlign":"center","className":"with-empty-cart-icon wc-block-cart__empty-cart__title"} --><h2 class="wp-block-heading has-text-align-center with-empty-cart-icon wc-block-cart__empty-cart__title">' . esc_html__( 'Your cart is currently empty!', 'woo-gutenberg-products-block' ) . '</h2><!-- /wp:heading -->
+					<!-- wp:paragraph {"align":"center"} --><p class="has-text-align-center"><a href="' . esc_attr( esc_url( $shop_permalink ) ) . '">' . esc_html__( 'Browse store', 'woo-gutenberg-products-block' ) . '</a></p><!-- /wp:paragraph -->
+				',
+			)
+		);
+		register_block_pattern(
+			'woocommerce/cart-new-in-store-message',
+			array(
+				'title'    => '',
+				'inserter' => false,
+				'content'  => '<!-- wp:heading {"textAlign":"center"} --><h2 class="wp-block-heading has-text-align-center">' . esc_html__( 'New in store', 'woo-gutenberg-products-block' ) . '</h2><!-- /wp:heading -->',
+			)
+		);
+	}
+
+	/**
 	 * Get the editor script handle for this block type.
 	 *
 	 * @param string $key Data to get, or default to everything.

--- a/templates/templates/blockified/cart.html
+++ b/templates/templates/blockified/cart.html
@@ -1,26 +1,31 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 <!-- wp:group {"layout":{"inherit":true,"type":"constrained"}} -->
 <div class="wp-block-group"><!-- wp:woocommerce/cart -->
-	<div class="wp-block-woocommerce-cart alignwide is-loading"><!-- wp:woocommerce/filled-cart-block {"align":"wide"} -->
-		<div class="wp-block-woocommerce-filled-cart-block alignwide"><!-- wp:woocommerce/cart-items-block -->
-			<div class="wp-block-woocommerce-cart-items-block"><!-- wp:woocommerce/cart-line-items-block -->
+	<div class="wp-block-woocommerce-cart alignwide is-loading">
+		<!-- wp:woocommerce/filled-cart-block {"align":"wide"} -->
+		<div class="wp-block-woocommerce-filled-cart-block alignwide">
+			<!-- wp:woocommerce/cart-items-block -->
+			<div class="wp-block-woocommerce-cart-items-block">
+				<!-- wp:woocommerce/cart-line-items-block -->
 				<div class="wp-block-woocommerce-cart-line-items-block"></div>
 				<!-- /wp:woocommerce/cart-line-items-block -->
 
 				<!-- wp:woocommerce/cart-cross-sells-block -->
-				<div class="wp-block-woocommerce-cart-cross-sells-block"><!-- wp:heading {"fontSize":"large"} -->
-					<h2 class="wp-block-heading has-large-font-size">You may be interested in…</h2>
-					<!-- /wp:heading -->
-
+				<div class="wp-block-woocommerce-cart-cross-sells-block">
+					<!-- wp:pattern {"slug":"woocommerce/cart-cross-sells-message"} /-->
 					<!-- wp:woocommerce/cart-cross-sells-products-block -->
 					<div class="wp-block-woocommerce-cart-cross-sells-products-block"></div>
-					<!-- /wp:woocommerce/cart-cross-sells-products-block --></div>
-				<!-- /wp:woocommerce/cart-cross-sells-block --></div>
+					<!-- /wp:woocommerce/cart-cross-sells-products-block -->
+				</div>
+				<!-- /wp:woocommerce/cart-cross-sells-block -->
+			</div>
 			<!-- /wp:woocommerce/cart-items-block -->
 
 			<!-- wp:woocommerce/cart-totals-block -->
-			<div class="wp-block-woocommerce-cart-totals-block"><!-- wp:woocommerce/cart-order-summary-block -->
-				<div class="wp-block-woocommerce-cart-order-summary-block"><!-- wp:woocommerce/cart-order-summary-heading-block -->
+			<div class="wp-block-woocommerce-cart-totals-block">
+				<!-- wp:woocommerce/cart-order-summary-block -->
+				<div class="wp-block-woocommerce-cart-order-summary-block">
+					<!-- wp:woocommerce/cart-order-summary-heading-block -->
 					<div class="wp-block-woocommerce-cart-order-summary-heading-block"></div>
 					<!-- /wp:woocommerce/cart-order-summary-heading-block -->
 
@@ -46,7 +51,8 @@
 
 					<!-- wp:woocommerce/cart-order-summary-taxes-block -->
 					<div class="wp-block-woocommerce-cart-order-summary-taxes-block"></div>
-					<!-- /wp:woocommerce/cart-order-summary-taxes-block --></div>
+					<!-- /wp:woocommerce/cart-order-summary-taxes-block -->
+				</div>
 				<!-- /wp:woocommerce/cart-order-summary-block -->
 
 				<!-- wp:woocommerce/cart-express-payment-block -->
@@ -59,36 +65,44 @@
 
 				<!-- wp:woocommerce/cart-accepted-payment-methods-block -->
 				<div class="wp-block-woocommerce-cart-accepted-payment-methods-block"></div>
-				<!-- /wp:woocommerce/cart-accepted-payment-methods-block --></div>
-			<!-- /wp:woocommerce/cart-totals-block --></div>
+				<!-- /wp:woocommerce/cart-accepted-payment-methods-block -->
+			</div>
+			<!-- /wp:woocommerce/cart-totals-block -->
+		</div>
 		<!-- /wp:woocommerce/filled-cart-block -->
 
 		<!-- wp:woocommerce/empty-cart-block {"align":"wide"} -->
-		<div class="wp-block-woocommerce-empty-cart-block alignwide"><!-- wp:woocommerce/filled-cart-block -->
-			<div class="wp-block-woocommerce-filled-cart-block"><!-- wp:woocommerce/cart-items-block -->
-				<div class="wp-block-woocommerce-cart-items-block"><!-- wp:woocommerce/cart-line-items-block -->
+		<div class="wp-block-woocommerce-empty-cart-block alignwide">
+			<!-- wp:woocommerce/filled-cart-block -->
+			<div class="wp-block-woocommerce-filled-cart-block">
+				<!-- wp:woocommerce/cart-items-block -->
+				<div class="wp-block-woocommerce-cart-items-block">
+					<!-- wp:woocommerce/cart-line-items-block -->
 					<div class="wp-block-woocommerce-cart-line-items-block"></div>
 					<!-- /wp:woocommerce/cart-line-items-block -->
 
 					<!-- wp:woocommerce/cart-cross-sells-block -->
-					<div class="wp-block-woocommerce-cart-cross-sells-block"><!-- wp:heading {"fontSize":"large"} -->
-						<h2 class="wp-block-heading has-large-font-size">You may be interested in…</h2>
-						<!-- /wp:heading -->
-
+					<div class="wp-block-woocommerce-cart-cross-sells-block">
+						<!-- wp:pattern {"slug":"woocommerce/cart-cross-sells-message"} /-->
 						<!-- wp:woocommerce/cart-cross-sells-products-block -->
 						<div class="wp-block-woocommerce-cart-cross-sells-products-block"></div>
-						<!-- /wp:woocommerce/cart-cross-sells-products-block --></div>
-					<!-- /wp:woocommerce/cart-cross-sells-block --></div>
+						<!-- /wp:woocommerce/cart-cross-sells-products-block -->
+					</div>
+					<!-- /wp:woocommerce/cart-cross-sells-block -->
+				</div>
 				<!-- /wp:woocommerce/cart-items-block -->
 
 				<!-- wp:woocommerce/cart-totals-block -->
-				<div class="wp-block-woocommerce-cart-totals-block"><!-- wp:woocommerce/cart-order-summary-block -->
-					<div class="wp-block-woocommerce-cart-order-summary-block"><!-- wp:woocommerce/cart-order-summary-heading-block -->
+				<div class="wp-block-woocommerce-cart-totals-block">
+					<!-- wp:woocommerce/cart-order-summary-block -->
+					<div class="wp-block-woocommerce-cart-order-summary-block">
+						<!-- wp:woocommerce/cart-order-summary-heading-block -->
 						<div class="wp-block-woocommerce-cart-order-summary-heading-block"></div>
 						<!-- /wp:woocommerce/cart-order-summary-heading-block -->
 
 						<!-- wp:woocommerce/cart-order-summary-coupon-form-block -->
-						<div class="wp-block-woocommerce-cart-order-summary-coupon-form-block"></div>
+						<div class="wp-block-woocommerce-cart-order-summary-coupon-form-block">
+						</div>
 						<!-- /wp:woocommerce/cart-order-summary-coupon-form-block -->
 
 						<!-- wp:woocommerce/cart-order-summary-subtotal-block -->
@@ -109,7 +123,8 @@
 
 						<!-- wp:woocommerce/cart-order-summary-taxes-block -->
 						<div class="wp-block-woocommerce-cart-order-summary-taxes-block"></div>
-						<!-- /wp:woocommerce/cart-order-summary-taxes-block --></div>
+						<!-- /wp:woocommerce/cart-order-summary-taxes-block -->
+					</div>
 					<!-- /wp:woocommerce/cart-order-summary-block -->
 
 					<!-- wp:woocommerce/cart-express-payment-block -->
@@ -122,31 +137,28 @@
 
 					<!-- wp:woocommerce/cart-accepted-payment-methods-block -->
 					<div class="wp-block-woocommerce-cart-accepted-payment-methods-block"></div>
-					<!-- /wp:woocommerce/cart-accepted-payment-methods-block --></div>
-				<!-- /wp:woocommerce/cart-totals-block --></div>
+					<!-- /wp:woocommerce/cart-accepted-payment-methods-block -->
+				</div>
+				<!-- /wp:woocommerce/cart-totals-block -->
+			</div>
 			<!-- /wp:woocommerce/filled-cart-block -->
 
 			<!-- wp:woocommerce/empty-cart-block -->
-			<div class="wp-block-woocommerce-empty-cart-block"><!-- wp:heading {"textAlign":"center","className":"with-empty-cart-icon wc-block-cart__empty-cart__title"} -->
-				<h2 class="wp-block-heading has-text-align-center with-empty-cart-icon wc-block-cart__empty-cart__title">
-					Your cart is currently empty!</h2>
-				<!-- /wp:heading -->
-
-				<!-- wp:paragraph {"align":"center"} -->
-				<p class="has-text-align-center"><a href="http://localhost/shop/">Browse store</a></p>
-				<!-- /wp:paragraph -->
+			<div class="wp-block-woocommerce-empty-cart-block">
+				<!-- wp:pattern {"slug":"woocommerce/cart-empty-message"} /-->
 
 				<!-- wp:separator {"className":"is-style-dots"} -->
-				<hr class="wp-block-separator has-alpha-channel-opacity is-style-dots"/>
+				<hr class="wp-block-separator has-alpha-channel-opacity is-style-dots" />
 				<!-- /wp:separator -->
 
-				<!-- wp:heading {"textAlign":"center"} -->
-				<h2 class="wp-block-heading has-text-align-center">New in store</h2>
-				<!-- /wp:heading -->
-
-				<!-- wp:woocommerce/product-new {"rows":1} /--></div>
-			<!-- /wp:woocommerce/empty-cart-block --></div>
-		<!-- /wp:woocommerce/empty-cart-block --></div>
-	<!-- /wp:woocommerce/cart --></div>
+				<!-- wp:pattern {"slug":"woocommerce/cart-new-in-store-message"} /-->
+				<!-- wp:woocommerce/product-new {"rows":1} /-->
+			</div>
+			<!-- /wp:woocommerce/empty-cart-block -->
+		</div>
+		<!-- /wp:woocommerce/empty-cart-block -->
+	</div>
+	<!-- /wp:woocommerce/cart -->
+</div>
 <!-- /wp:group -->
 <!-- wp:template-part {"slug":"footer"} /-->

--- a/templates/templates/cart.html
+++ b/templates/templates/cart.html
@@ -1,26 +1,31 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 <!-- wp:group {"layout":{"inherit":true,"type":"constrained"}} -->
 <div class="wp-block-group"><!-- wp:woocommerce/cart -->
-	<div class="wp-block-woocommerce-cart alignwide is-loading"><!-- wp:woocommerce/filled-cart-block {"align":"wide"} -->
-		<div class="wp-block-woocommerce-filled-cart-block alignwide"><!-- wp:woocommerce/cart-items-block -->
-			<div class="wp-block-woocommerce-cart-items-block"><!-- wp:woocommerce/cart-line-items-block -->
+	<div class="wp-block-woocommerce-cart alignwide is-loading">
+		<!-- wp:woocommerce/filled-cart-block {"align":"wide"} -->
+		<div class="wp-block-woocommerce-filled-cart-block alignwide">
+			<!-- wp:woocommerce/cart-items-block -->
+			<div class="wp-block-woocommerce-cart-items-block">
+				<!-- wp:woocommerce/cart-line-items-block -->
 				<div class="wp-block-woocommerce-cart-line-items-block"></div>
 				<!-- /wp:woocommerce/cart-line-items-block -->
 
 				<!-- wp:woocommerce/cart-cross-sells-block -->
-				<div class="wp-block-woocommerce-cart-cross-sells-block"><!-- wp:heading {"fontSize":"large"} -->
-					<h2 class="wp-block-heading has-large-font-size">You may be interested in…</h2>
-					<!-- /wp:heading -->
-
+				<div class="wp-block-woocommerce-cart-cross-sells-block">
+					<!-- wp:pattern {"slug":"woocommerce/cart-cross-sells-message"} /-->
 					<!-- wp:woocommerce/cart-cross-sells-products-block -->
 					<div class="wp-block-woocommerce-cart-cross-sells-products-block"></div>
-					<!-- /wp:woocommerce/cart-cross-sells-products-block --></div>
-				<!-- /wp:woocommerce/cart-cross-sells-block --></div>
+					<!-- /wp:woocommerce/cart-cross-sells-products-block -->
+				</div>
+				<!-- /wp:woocommerce/cart-cross-sells-block -->
+			</div>
 			<!-- /wp:woocommerce/cart-items-block -->
 
 			<!-- wp:woocommerce/cart-totals-block -->
-			<div class="wp-block-woocommerce-cart-totals-block"><!-- wp:woocommerce/cart-order-summary-block -->
-				<div class="wp-block-woocommerce-cart-order-summary-block"><!-- wp:woocommerce/cart-order-summary-heading-block -->
+			<div class="wp-block-woocommerce-cart-totals-block">
+				<!-- wp:woocommerce/cart-order-summary-block -->
+				<div class="wp-block-woocommerce-cart-order-summary-block">
+					<!-- wp:woocommerce/cart-order-summary-heading-block -->
 					<div class="wp-block-woocommerce-cart-order-summary-heading-block"></div>
 					<!-- /wp:woocommerce/cart-order-summary-heading-block -->
 
@@ -46,7 +51,8 @@
 
 					<!-- wp:woocommerce/cart-order-summary-taxes-block -->
 					<div class="wp-block-woocommerce-cart-order-summary-taxes-block"></div>
-					<!-- /wp:woocommerce/cart-order-summary-taxes-block --></div>
+					<!-- /wp:woocommerce/cart-order-summary-taxes-block -->
+				</div>
 				<!-- /wp:woocommerce/cart-order-summary-block -->
 
 				<!-- wp:woocommerce/cart-express-payment-block -->
@@ -59,36 +65,44 @@
 
 				<!-- wp:woocommerce/cart-accepted-payment-methods-block -->
 				<div class="wp-block-woocommerce-cart-accepted-payment-methods-block"></div>
-				<!-- /wp:woocommerce/cart-accepted-payment-methods-block --></div>
-			<!-- /wp:woocommerce/cart-totals-block --></div>
+				<!-- /wp:woocommerce/cart-accepted-payment-methods-block -->
+			</div>
+			<!-- /wp:woocommerce/cart-totals-block -->
+		</div>
 		<!-- /wp:woocommerce/filled-cart-block -->
 
 		<!-- wp:woocommerce/empty-cart-block {"align":"wide"} -->
-		<div class="wp-block-woocommerce-empty-cart-block alignwide"><!-- wp:woocommerce/filled-cart-block -->
-			<div class="wp-block-woocommerce-filled-cart-block"><!-- wp:woocommerce/cart-items-block -->
-				<div class="wp-block-woocommerce-cart-items-block"><!-- wp:woocommerce/cart-line-items-block -->
+		<div class="wp-block-woocommerce-empty-cart-block alignwide">
+			<!-- wp:woocommerce/filled-cart-block -->
+			<div class="wp-block-woocommerce-filled-cart-block">
+				<!-- wp:woocommerce/cart-items-block -->
+				<div class="wp-block-woocommerce-cart-items-block">
+					<!-- wp:woocommerce/cart-line-items-block -->
 					<div class="wp-block-woocommerce-cart-line-items-block"></div>
 					<!-- /wp:woocommerce/cart-line-items-block -->
 
 					<!-- wp:woocommerce/cart-cross-sells-block -->
-					<div class="wp-block-woocommerce-cart-cross-sells-block"><!-- wp:heading {"fontSize":"large"} -->
-						<h2 class="wp-block-heading has-large-font-size">You may be interested in…</h2>
-						<!-- /wp:heading -->
-
+					<div class="wp-block-woocommerce-cart-cross-sells-block">
+						<!-- wp:pattern {"slug":"woocommerce/cart-cross-sells-message"} /-->
 						<!-- wp:woocommerce/cart-cross-sells-products-block -->
 						<div class="wp-block-woocommerce-cart-cross-sells-products-block"></div>
-						<!-- /wp:woocommerce/cart-cross-sells-products-block --></div>
-					<!-- /wp:woocommerce/cart-cross-sells-block --></div>
+						<!-- /wp:woocommerce/cart-cross-sells-products-block -->
+					</div>
+					<!-- /wp:woocommerce/cart-cross-sells-block -->
+				</div>
 				<!-- /wp:woocommerce/cart-items-block -->
 
 				<!-- wp:woocommerce/cart-totals-block -->
-				<div class="wp-block-woocommerce-cart-totals-block"><!-- wp:woocommerce/cart-order-summary-block -->
-					<div class="wp-block-woocommerce-cart-order-summary-block"><!-- wp:woocommerce/cart-order-summary-heading-block -->
+				<div class="wp-block-woocommerce-cart-totals-block">
+					<!-- wp:woocommerce/cart-order-summary-block -->
+					<div class="wp-block-woocommerce-cart-order-summary-block">
+						<!-- wp:woocommerce/cart-order-summary-heading-block -->
 						<div class="wp-block-woocommerce-cart-order-summary-heading-block"></div>
 						<!-- /wp:woocommerce/cart-order-summary-heading-block -->
 
 						<!-- wp:woocommerce/cart-order-summary-coupon-form-block -->
-						<div class="wp-block-woocommerce-cart-order-summary-coupon-form-block"></div>
+						<div class="wp-block-woocommerce-cart-order-summary-coupon-form-block">
+						</div>
 						<!-- /wp:woocommerce/cart-order-summary-coupon-form-block -->
 
 						<!-- wp:woocommerce/cart-order-summary-subtotal-block -->
@@ -109,7 +123,8 @@
 
 						<!-- wp:woocommerce/cart-order-summary-taxes-block -->
 						<div class="wp-block-woocommerce-cart-order-summary-taxes-block"></div>
-						<!-- /wp:woocommerce/cart-order-summary-taxes-block --></div>
+						<!-- /wp:woocommerce/cart-order-summary-taxes-block -->
+					</div>
 					<!-- /wp:woocommerce/cart-order-summary-block -->
 
 					<!-- wp:woocommerce/cart-express-payment-block -->
@@ -122,31 +137,28 @@
 
 					<!-- wp:woocommerce/cart-accepted-payment-methods-block -->
 					<div class="wp-block-woocommerce-cart-accepted-payment-methods-block"></div>
-					<!-- /wp:woocommerce/cart-accepted-payment-methods-block --></div>
-				<!-- /wp:woocommerce/cart-totals-block --></div>
+					<!-- /wp:woocommerce/cart-accepted-payment-methods-block -->
+				</div>
+				<!-- /wp:woocommerce/cart-totals-block -->
+			</div>
 			<!-- /wp:woocommerce/filled-cart-block -->
 
 			<!-- wp:woocommerce/empty-cart-block -->
-			<div class="wp-block-woocommerce-empty-cart-block"><!-- wp:heading {"textAlign":"center","className":"with-empty-cart-icon wc-block-cart__empty-cart__title"} -->
-				<h2 class="wp-block-heading has-text-align-center with-empty-cart-icon wc-block-cart__empty-cart__title">
-					Your cart is currently empty!</h2>
-				<!-- /wp:heading -->
-
-				<!-- wp:paragraph {"align":"center"} -->
-				<p class="has-text-align-center"><a href="http://localhost/shop/">Browse store</a></p>
-				<!-- /wp:paragraph -->
+			<div class="wp-block-woocommerce-empty-cart-block">
+				<!-- wp:pattern {"slug":"woocommerce/cart-empty-message"} /-->
 
 				<!-- wp:separator {"className":"is-style-dots"} -->
-				<hr class="wp-block-separator has-alpha-channel-opacity is-style-dots"/>
+				<hr class="wp-block-separator has-alpha-channel-opacity is-style-dots" />
 				<!-- /wp:separator -->
 
-				<!-- wp:heading {"textAlign":"center"} -->
-				<h2 class="wp-block-heading has-text-align-center">New in store</h2>
-				<!-- /wp:heading -->
-
-				<!-- wp:woocommerce/product-new {"rows":1} /--></div>
-			<!-- /wp:woocommerce/empty-cart-block --></div>
-		<!-- /wp:woocommerce/empty-cart-block --></div>
-	<!-- /wp:woocommerce/cart --></div>
+				<!-- wp:pattern {"slug":"woocommerce/cart-new-in-store-message"} /-->
+				<!-- wp:woocommerce/product-new {"rows":1} /-->
+			</div>
+			<!-- /wp:woocommerce/empty-cart-block -->
+		</div>
+		<!-- /wp:woocommerce/empty-cart-block -->
+	</div>
+	<!-- /wp:woocommerce/cart -->
+</div>
 <!-- /wp:group -->
 <!-- wp:template-part {"slug":"footer"} /-->


### PR DESCRIPTION
This PR introduces some block patterns to inject into the default cart templates that allow the text to be localised instead of hardcoded.

Fixes #9865

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. Go to Appearance > Editor
2. Select Pages > Cart and edit the template. Make some small changes and save.
3. (important) Exit the editor back to WP admin.
4. Go to Appearance > Editor
5. Select Pages > Cart and edit the template. This time, in the inspector there are 3 dots. Click here and "reset customisations". Ensure all headings, blocks, and content are present.

![Screenshot 2023-06-19 at 15 28 26](https://github.com/woocommerce/woocommerce-blocks/assets/90977/29adf880-c252-43bc-900d-6db1ce6d9167)

To be completely certain this is working you can also modify one of the `register_block_pattern` calls in this PR and use some unique text you can identify after resetting the templates.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->
