### PR TITLE
Styling and improvements

### DIFF
--- a/patterns/hero-product-3-split.php
+++ b/patterns/hero-product-3-split.php
@@ -10,11 +10,11 @@
 <div class="wp-block-columns alignwide" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">
 	<!-- wp:column {"width":"66.66%"} -->
 	<div class="wp-block-column" style="flex-basis:66.66%">
-		<!-- wp:media-text {"mediaPosition":"right","mediaId":3800,"mediaLink":"https://store.local/p/image/","mediaType":"image","style":{"color":{"background":"#000000","text":"#ffffff"}}} -->
+		<!-- wp:media-text {"mediaPosition":"right","mediaId":1,"mediaLink":"<?php echo esc_url( plugins_url( 'images/pattern-placeholders/hand-guitar-finger-tshirt-clothing-rack.png', dirname( __FILE__ ) ) ); ?>","mediaType":"image","style":{"color":{"background":"#000000","text":"#ffffff"}}} -->
 		<div class="wp-block-media-text alignwide has-media-on-the-right is-stacked-on-mobile has-text-color has-background" style="color:#ffffff;background-color:#000000">
 			<div class="wp-block-media-text__content">
-				<!-- wp:group {"style":{"spacing":{"padding":{"top":"0","left":"20px","right":"20px"}}},"layout":{"type":"flex","orientation":"vertical"}} -->
-				<div class="wp-block-group" style="padding-top:0;padding-right:20px;padding-left:20px">
+				<!-- wp:group {"style":{"spacing":{"padding":{"top":"0","left":"20px","right":"20px"},"margin":{"top":"20px","bottom":"20px"}}},"layout":{"type":"flex","orientation":"vertical"}} -->
+				<div class="wp-block-group" style="margin-top:20px;margin-bottom:20px;padding-top:0;padding-right:20px;padding-left:20px">
 					<!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"large"} -->
 					<h2 class="wp-block-heading has-large-font-size" style="font-style:normal;font-weight:700">Endless Tee's</h2>
 					<!-- /wp:heading -->
@@ -25,9 +25,9 @@
 
 					<!-- wp:buttons -->
 					<div class="wp-block-buttons">
-						<!-- wp:button {"style":{"color":{"background":"#ffffff","text":"#000000"}}} -->
-						<div class="wp-block-button">
-							<a class="wp-block-button__link has-text-color has-background wp-element-button" style="color:#000000;background-color:#ffffff">Shop now</a>
+						<!-- wp:button {"textAlign":"left","style":{"typography":{"fontSize":"16px"},"color":{"background":"#ffffff","text":"#000000"}}} -->
+						<div class="wp-block-button has-custom-font-size" style="font-size:16px">
+							<a class="wp-block-button__link has-text-color has-background has-text-align-left wp-element-button" href="<?php echo esc_url( get_permalink( wc_get_page_id( 'shop' ) ) ); ?>" style="color:#000000;background-color:#ffffff">Shop now</a>
 						</div>
 						<!-- /wp:button -->
 					</div>
@@ -36,7 +36,7 @@
 				<!-- /wp:group -->
 			</div>
 			<figure class="wp-block-media-text__media">
-				<img src="<?php echo esc_url( plugins_url( 'images/pattern-placeholders/hand-guitar-finger-tshirt-clothing-rack.png', dirname( __FILE__ ) ) ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent a product being showcased in a hero section.', 'woo-gutenberg-products-block' ); ?>" class="wp-image-3800 size-full" />
+				<img src="<?php echo esc_url( plugins_url( 'images/pattern-placeholders/hand-guitar-finger-tshirt-clothing-rack.png', dirname( __FILE__ ) ) ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent a product being showcased in a hero section.', 'woo-gutenberg-products-block' ); ?>" class="wp-image-1 size-full" />
 			</figure>
 		</div>
 		<!-- /wp:media-text -->


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/9847

This PR hardcodes the `Shop Now` button to white background with black text. We're being opinionated here because the design itself has a black background and for this reason we don't want themes to override the button with global styles which may make the button hard to see.

I've also adding some margins to the text within the black background area so that in smaller viewport, it isn't bumped up against the edges.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|![file.png](https://github.com/woocommerce/woocommerce-blocks/assets/2132595/ace58cc2-b7a1-4c5d-9448-1fc8d38a1e59)        |![file.png](https://github.com/woocommerce/woocommerce-blocks/assets/2132595/f2645087-31d0-4836-aa9e-76acc753bd4d)       |

### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Add `Hero Product 3 Split` pattern to a post/page.
2. Check that the `Shop Now` button has a specific background/text color. Test with different block themes like Tsubaki and TT3 and make sure the button is white and text is black.
3. Check in the front end and reduce the browser viewport to smallest possible and ensure the block of text in the area of the black background that there are margins all around so it is not bumping up to the edges.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Update `Hero Product 3 Split` pattern with opinionated button styling and margin adjustments