### PR TITLE
Mini Cart: Remove template part from the block inserter

### DIFF
--- a/assets/js/blocks/mini-cart/index.tsx
+++ b/assets/js/blocks/mini-cart/index.tsx
@@ -7,6 +7,7 @@ import { Icon } from '@wordpress/icons';
 import { registerBlockType } from '@wordpress/blocks';
 import type { BlockConfiguration } from '@wordpress/blocks';
 import { isFeaturePluginBuild } from '@woocommerce/block-settings';
+import { addFilter } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -99,3 +100,28 @@ const settings: BlockConfiguration = {
 };
 
 registerBlockType( 'woocommerce/mini-cart', settings );
+
+// Remove the Mini Cart template part from the block inserter.
+addFilter(
+	'blocks.registerBlockType',
+	'woocommerce/mini-cart',
+	function ( blockSettings, blockName ) {
+		if ( blockName === 'core/template-part' ) {
+			return {
+				...blockSettings,
+				variations: blockSettings.variations.map(
+					( variation: { name: string } ) => {
+						if ( variation.name === 'instance_mini-cart' ) {
+							return {
+								...variation,
+								scope: [],
+							};
+						}
+						return variation;
+					}
+				),
+			};
+		}
+		return blockSettings;
+	}
+);


### PR DESCRIPTION
This PR removes the Mini Cart template part from the block inserter, as it is not meant to be inserted inside templates.

Fixes #9753 

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|<img width="991" alt="before_mini_cart_template_part" src="https://github.com/woocommerce/woocommerce-blocks/assets/905781/0b869815-c070-496d-afc3-110cfcdad300">|<img width="976" alt="after_mini_cart_template_part" src="https://github.com/woocommerce/woocommerce-blocks/assets/905781/a43551ea-2163-4e29-82f0-3cf232f4db16">|

### Testing

#### User Facing Testing

1. Add a `mini-cart.html` file to the `parts` folder of your (block) theme, representing the Mini-Cart template part.
2. Go to Appearance > Editor > Templates > Single Product and search for blocks with name _Mini-Cart_.
3. Make sure only the Mini-Cart block is available and the Mini-Cart template part doesn't come up.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Mini-Cart: Remove the Mini-Cart template part from the block inserter.
