### PR TITLE
Reference Mini Cart drawer preview dynamically

### DIFF
--- a/assets/js/blocks/mini-cart/edit.tsx
+++ b/assets/js/blocks/mini-cart/edit.tsx
@@ -26,6 +26,7 @@ import { select } from '@wordpress/data';
 import classNames from 'classnames';
 import { cartOutline, bag, bagAlt } from '@woocommerce/icons';
 import { Icon } from '@wordpress/icons';
+import { WC_BLOCKS_IMAGE_URL } from '@woocommerce/block-settings';
 
 /**
  * Internal dependencies
@@ -237,8 +238,8 @@ const Edit = ( {
 								className="wc-block-editor-mini-cart__drawer-image"
 								src={
 									isRTL()
-										? '/wp-content/plugins/woocommerce-blocks/images/blocks/mini-cart/cart-drawer-rtl.svg'
-										: '/wp-content/plugins/woocommerce-blocks/images/blocks/mini-cart/cart-drawer.svg'
+										? `${ WC_BLOCKS_IMAGE_URL }/blocks/mini-cart/cart-drawer-rtl.svg`
+										: `${ WC_BLOCKS_IMAGE_URL }/blocks/mini-cart/cart-drawer.svg`
 								}
 								alt=""
 							/>

--- a/assets/js/blocks/mini-cart/edit.tsx
+++ b/assets/js/blocks/mini-cart/edit.tsx
@@ -238,8 +238,8 @@ const Edit = ( {
 								className="wc-block-editor-mini-cart__drawer-image"
 								src={
 									isRTL()
-										? `${ WC_BLOCKS_IMAGE_URL }/blocks/mini-cart/cart-drawer-rtl.svg`
-										: `${ WC_BLOCKS_IMAGE_URL }/blocks/mini-cart/cart-drawer.svg`
+										? `${ WC_BLOCKS_IMAGE_URL }blocks/mini-cart/cart-drawer-rtl.svg`
+										: `${ WC_BLOCKS_IMAGE_URL }blocks/mini-cart/cart-drawer.svg`
 								}
 								alt=""
 							/>


### PR DESCRIPTION
Fixes #9910

In https://github.com/woocommerce/woocommerce-blocks/pull/9420, we introduced the Mini Cart drawer preview. In https://github.com/woocommerce/woocommerce-blocks/pull/9756, we added RTL support for the preview. While testing the 10.5.0 release, I noticed that the preview only works locally when the plugin slug is `woocommerce-blocks`. When using the plugin online, the plugin uses the old slug `woocommerce-gutenberg-products-block`. This leads to the fact that the preview is no longer visible.

In this PR, I replaced the hardcoded preview address with a dynamic one. This ensures that the preview can be loaded independent of the plugin slug.

### Screenshots

<table>
<tr>
<td valign="top">Before:
<br><br>

<img width="278" alt="Screenshot 2023-06-20 at 10 29 37" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/27c5ddf9-cb97-485b-9424-5d92500d1f80">
</td>
<td valign="top">After:
<br><br>

<img width="278" alt="Screenshot 2023-06-20 at 10 30 21" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/80aabe37-aa71-4812-95b5-18b8c6a7bae9">
</td>
</tr>
</table>

### Testing

#### User Facing Testing

1. Create an online site, e.g. using Jurassic Ninja.
2. [Download the testing ZIP file](https://wcblocks.wpcomstaging.com/wp-content/uploads/woocommerce-gutenberg-products-block-9912.zip) of this PR and install it on the test site.
3. Create a test page and add the Mini Cart block to it.
4. Select the Mini Cart block and verify that the Mini Cart drawer preview is visible in the sidebar.
5. Inspect the URL of the Mini Cart drawer preview  and verify that the plugin slug does not contain `woocommerce-blocks`.

* [x] Do not include in the Testing Notes

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental