### PR TITLE
`Featured Products 5-item grid` fix alignment

### DIFF
--- a/patterns/featured-products-5-cols.php
+++ b/patterns/featured-products-5-cols.php
@@ -16,8 +16,9 @@
 <div class="wp-block-query alignwide">
 	<!-- wp:post-template {"__woocommerceNamespace":"woocommerce/product-query/product-template"} -->
 
-		<!-- wp:cover {"useFeaturedImage":true,"dimRatio":0,"minHeight":190,"minHeightUnit":"px","contentPosition":"top right","isDark":false,"align":"right","style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}}} -->
-		<div class="wp-block-cover alignright is-light has-custom-content-position is-position-top-right" style="margin-bottom:var(--wp--preset--spacing--40);min-height:190px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span>
+		<!-- wp:cover {"useFeaturedImage":true,"dimRatio":0,"minHeight":190,"minHeightUnit":"px","contentPosition":"top right","isDark":false,"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}}} -->
+		<div class="wp-block-cover is-light has-custom-content-position is-position-top-right" style="margin-bottom:var(--wp--preset--spacing--40);min-height:190px">
+			<span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span>
 			<div class="wp-block-cover__inner-container">
 				<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"right"}} -->
 				<div class="wp-block-group">

--- a/patterns/hero-product-3-split.php
+++ b/patterns/hero-product-3-split.php
@@ -10,11 +10,11 @@
 <div class="wp-block-columns alignwide" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">
 	<!-- wp:column {"width":"66.66%"} -->
 	<div class="wp-block-column" style="flex-basis:66.66%">
-		<!-- wp:media-text {"mediaPosition":"right","mediaId":3800,"mediaLink":"https://store.local/p/image/","mediaType":"image","style":{"color":{"background":"#000000","text":"#ffffff"}}} -->
+		<!-- wp:media-text {"mediaPosition":"right","mediaId":1,"mediaLink":"<?php echo esc_url( plugins_url( 'images/pattern-placeholders/hand-guitar-finger-tshirt-clothing-rack.png', dirname( __FILE__ ) ) ); ?>","mediaType":"image","style":{"color":{"background":"#000000","text":"#ffffff"}}} -->
 		<div class="wp-block-media-text alignwide has-media-on-the-right is-stacked-on-mobile has-text-color has-background" style="color:#ffffff;background-color:#000000">
 			<div class="wp-block-media-text__content">
-				<!-- wp:group {"style":{"spacing":{"padding":{"top":"0","left":"20px","right":"20px"}}},"layout":{"type":"flex","orientation":"vertical"}} -->
-				<div class="wp-block-group" style="padding-top:0;padding-right:20px;padding-left:20px">
+				<!-- wp:group {"style":{"spacing":{"padding":{"top":"0","left":"20px","right":"20px"},"margin":{"top":"20px","bottom":"20px"}}},"layout":{"type":"flex","orientation":"vertical"}} -->
+				<div class="wp-block-group" style="margin-top:20px;margin-bottom:20px;padding-top:0;padding-right:20px;padding-left:20px">
 					<!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"large"} -->
 					<h2 class="wp-block-heading has-large-font-size" style="font-style:normal;font-weight:700">Endless Tee's</h2>
 					<!-- /wp:heading -->
@@ -25,9 +25,9 @@
 
 					<!-- wp:buttons -->
 					<div class="wp-block-buttons">
-						<!-- wp:button {"style":{"color":{"background":"#ffffff","text":"#000000"}}} -->
-						<div class="wp-block-button">
-							<a class="wp-block-button__link has-text-color has-background wp-element-button" style="color:#000000;background-color:#ffffff">Shop now</a>
+						<!-- wp:button {"textAlign":"left","style":{"typography":{"fontSize":"16px"},"color":{"background":"#ffffff","text":"#000000"}}} -->
+						<div class="wp-block-button has-custom-font-size" style="font-size:16px">
+							<a class="wp-block-button__link has-text-color has-background has-text-align-left wp-element-button" href="<?php echo esc_url( get_permalink( wc_get_page_id( 'shop' ) ) ); ?>" style="color:#000000;background-color:#ffffff">Shop now</a>
 						</div>
 						<!-- /wp:button -->
 					</div>
@@ -36,7 +36,7 @@
 				<!-- /wp:group -->
 			</div>
 			<figure class="wp-block-media-text__media">
-				<img src="<?php echo esc_url( plugins_url( 'images/pattern-placeholders/hand-guitar-finger-tshirt-clothing-rack.png', dirname( __FILE__ ) ) ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent a product being showcased in a hero section.', 'woo-gutenberg-products-block' ); ?>" class="wp-image-3800 size-full" />
+				<img src="<?php echo esc_url( plugins_url( 'images/pattern-placeholders/hand-guitar-finger-tshirt-clothing-rack.png', dirname( __FILE__ ) ) ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent a product being showcased in a hero section.', 'woo-gutenberg-products-block' ); ?>" class="wp-image-1 size-full" />
 			</figure>
 		</div>
 		<!-- /wp:media-text -->


### PR DESCRIPTION
This PR fixes the alignment on the `Featured Products 5-item grid` in small viewport screens.

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/9851

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
| ![foo-1687250343520](https://github.com/woocommerce/woocommerce-blocks/assets/186112/99080fa1-0039-4936-b7ee-0fbd7bdda561) | ![foo-1687250240100](https://github.com/woocommerce/woocommerce-blocks/assets/186112/7930ca9e-895a-45f3-b098-b2a85c33c9c9) |

### Testing
#### User-Facing Testing

1. Create a new page or post.
2. Insert the `Featured Products 5-item grid` pattern.
3. Change the screen size to a smaller viewport and check the pattern looks like the `After` image above (there's no whitespace at the right of the image).

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Featured Products 5-item grid: fix extra whitespace in small viewports.
