### PR TITLE
Mini-Cart: don't include shipping price

### DIFF
--- a/assets/js/blocks/mini-cart/utils/data.ts
+++ b/assets/js/blocks/mini-cart/utils/data.ts
@@ -10,11 +10,15 @@ import { CartResponse, isBoolean } from '@woocommerce/types';
 import { getSettingWithCoercion } from '@woocommerce/settings';
 
 const getPrice = ( cartResponse: CartResponse, showIncludingTax: boolean ) => {
-	const currency = getCurrencyFromPriceResponse( cartResponse.totals );
+	const { totals } = cartResponse;
+	const currency = getCurrencyFromPriceResponse( totals );
 
-	return showIncludingTax
-		? formatPrice( cartResponse.totals.total_price, currency )
-		: formatPrice( cartResponse.totals.total_items, currency );
+	const subTotal = showIncludingTax
+		? parseInt( totals.total_items, 10 ) +
+		  parseInt( totals.total_items_tax, 10 )
+		: parseInt( totals.total_items, 10 );
+
+	return formatPrice( subTotal, currency );
 };
 
 export const updateTotals = ( totals: [ string, number ] | undefined ) => {

--- a/assets/js/blocks/mini-cart/utils/test/data.ts
+++ b/assets/js/blocks/mini-cart/utils/test/data.ts
@@ -19,8 +19,9 @@ const responseMock = {
 	ok: true,
 	json: async () => ( {
 		totals: {
-			total_price: '1600',
+			total_price: '1800',
 			total_items: '1400',
+			total_items_tax: '200',
 			currency_code: 'USD',
 			currency_symbol: '$',
 			currency_minor_unit: 2,
@@ -34,8 +35,9 @@ const responseMock = {
 } as Response;
 const localStorageMock = {
 	totals: {
-		total_price: '1600',
+		total_price: '1800',
 		total_items: '1400',
+		total_items_tax: '200',
 		currency_code: 'USD',
 		currency_symbol: '$',
 		currency_minor_unit: 2,


### PR DESCRIPTION
This PR modifies the calculation added in https://github.com/woocommerce/woocommerce-blocks/pull/9878, so we use `total_items` + `total_items_tax` instead of using `total_price`, which might include shipping or other values. This is aligned with what we are doing in the Mini-Cart block TSX code:

https://github.com/woocommerce/woocommerce-blocks/blob/d7652f35fdfd528146787c761061c0d27ac7da57/assets/js/blocks/mini-cart/block.tsx#L207-L210

### Testing

#### User Facing Testing

These testing notes override the ones from https://github.com/woocommerce/woocommerce-blocks/pull/9878.

1. Open the WooCommerce Settings via WooCommerce > Settings from the sidebar menu of the WP-Admin.
2. Enable the option "Enable tax rates and calculations".
3. Click on the "Tax" tab.
4. Click on "Standard Rates" and configure a tax rate. Save.
5. Click on the "Tax" tab.
6. Set the "Display prices during cart and checkout" option to "Including Tax".
7. Now set up a Shipping method going to WooCommerce > Settings > Shipping > Add shipping zone. Create the zone and add a shipping method with a price different from 0.
8.  With the Site Editor adds the Mini Cart in the header.
9. On the front end, add a product to the cart and go to the Cart page, so shipping price is calculated.
10. Go back to the Shop page
11. Ensure that the Mini Cart shows the price including the tax, but not including the Shipping prive.
12. Hover the Mini Cart.
13. Ensure that the Mini Cart shows always the same price.
14. Open the WooCommerce Settings.
15. Click on the "Tax" tab.
16. Set the "Display prices during cart and checkout" option to "Excluding Tax".
17. On the front end, add a product to the cart.
18. Refresh the page.
19. Ensure that the Mini Cart shows the price excluding the tax. 
20. Hover the Mini Cart.
21. Ensure that the Mini Cart shows always the same price.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
