### PR TITLE
Shop by Price pattern: add price filters to buttons

### DIFF
--- a/patterns/shop-by-price.php
+++ b/patterns/shop-by-price.php
@@ -14,11 +14,11 @@
 			<span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim" style="background-color:#e09300"></span>
 			<div class="wp-block-cover__inner-container">
 				<!-- wp:paragraph {"align":"left","placeholder":"Write title…","style":{"typography":{"fontSize":"0.7em","lineHeight":"1"},"spacing":{"margin":{"top":"0px","bottom":"5px"}},"color":{"text":"#ffffff"},"elements":{"link":{"color":{"text":"var:preset|color|base"}}}}} -->
-				<p class="has-text-align-left has-text-color has-link-color" style="color:#ffffff;margin-top:0px;margin-bottom:5px;font-size:0.7em;line-height:1"><a style="text-decoration:none;" href="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>?rating_filter=5">Best</a></p>
+				<p class="has-text-align-left has-text-color has-link-color" style="color:#ffffff;margin-top:0px;margin-bottom:5px;font-size:0.7em;line-height:1"><a style="text-decoration:none;" href="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>?rating_filter=5">Highest</a></p>
 				<!-- /wp:paragraph -->
 
 				<!-- wp:paragraph {"style":{"typography":{"fontSize":"0.7em","lineHeight":"1"},"spacing":{"margin":{"top":"0px","bottom":"5px"}},"color":{"text":"#ffffff"},"elements":{"link":{"color":{"text":"var:preset|color|base"}}}},"fontSize":"large"} -->
-				<p class="has-text-color has-link-color has-large-font-size" style="color:#ffffff;margin-top:0px;margin-bottom:5px;font-size:0.7em;line-height:1"><strong><a style="text-decoration:none;" href="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>?rating_filter=5">sellers</a></strong></p>
+				<p class="has-text-color has-link-color has-large-font-size" style="color:#ffffff;margin-top:0px;margin-bottom:5px;font-size:0.7em;line-height:1"><strong><a style="text-decoration:none;" href="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>?rating_filter=5">rated</a></strong></p>
 				<!-- /wp:paragraph -->
 			</div>
 		</div>

--- a/patterns/shop-by-price.php
+++ b/patterns/shop-by-price.php
@@ -9,16 +9,16 @@
 <div class="wp-block-columns alignwide">
 	<!-- wp:column {"width":"25%","style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"},"blockGap":"10px"}},"layout":{"type":"default"}} -->
 	<div class="wp-block-column" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0;flex-basis:25%">
-		<!-- wp:cover {"customOverlayColor":"#e09300","minHeight":130,"minHeightUnit":"px","contentPosition":"top left","className":"has-background-color has-text-color","style":{"spacing":{"blockGap":"0em","padding":{"top":"0.8em"}}}} -->
+		<!-- wp:cover {"customOverlayColor":"#e09300","minHeight":130,"minHeightUnit":"px","contentPosition":"top left","isDark":false,"className":"is-light has-background-color has-text-color","style":{"spacing":{"blockGap":"0em","padding":{"top":"0.8em"}}}} -->
 		<div class="wp-block-cover is-light has-custom-content-position is-position-top-left has-background-color has-text-color" style="padding-top:0.8em;min-height:130px">
 			<span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim" style="background-color:#e09300"></span>
 			<div class="wp-block-cover__inner-container">
-				<!-- wp:paragraph {"align":"left","placeholder":"Write title…","style":{"typography":{"fontSize":"0.7em","lineHeight":"1"},"spacing":{"margin":{"top":"0px","bottom":"5px"}},"color":{"text":"#ffffff"}}} -->
-				<p class="has-text-align-left has-text-color" style="color:#ffffff;margin-top:0px;margin-bottom:5px;font-size:0.7em;line-height:1">Up to</p>
+				<!-- wp:paragraph {"align":"left","placeholder":"Write title…","style":{"typography":{"fontSize":"0.7em","lineHeight":"1"},"spacing":{"margin":{"top":"0px","bottom":"5px"}},"color":{"text":"#ffffff"},"elements":{"link":{"color":{"text":"var:preset|color|base"}}}}} -->
+				<p class="has-text-align-left has-text-color has-link-color" style="color:#ffffff;margin-top:0px;margin-bottom:5px;font-size:0.7em;line-height:1"><a style="text-decoration:none;" href="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>?rating_filter=5">Best</a></p>
 				<!-- /wp:paragraph -->
 
-				<!-- wp:paragraph {"style":{"typography":{"lineHeight":"1"},"spacing":{"margin":{"top":"4px","right":"0px","bottom":"0px","left":"0px"}},"color":{"text":"#ffffff"}},"fontSize":"large"} -->
-				<p class="has-text-color has-large-font-size" style="color:#ffffff;margin-top:4px;margin-right:0px;margin-bottom:0px;margin-left:0px;line-height:1"><strong>30% Off</strong></p>
+				<!-- wp:paragraph {"style":{"typography":{"fontSize":"0.7em","lineHeight":"1"},"spacing":{"margin":{"top":"0px","bottom":"5px"}},"color":{"text":"#ffffff"},"elements":{"link":{"color":{"text":"var:preset|color|base"}}}},"fontSize":"large"} -->
+				<p class="has-text-color has-link-color has-large-font-size" style="color:#ffffff;margin-top:0px;margin-bottom:5px;font-size:0.7em;line-height:1"><strong><a style="text-decoration:none;" href="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>?rating_filter=5">sellers</a></strong></p>
 				<!-- /wp:paragraph -->
 			</div>
 		</div>
@@ -28,7 +28,7 @@
 		<div class="wp-block-buttons">
 			<!-- wp:button {"textColor":"contrast","style":{"border":{"width":"0px","style":"none"},"spacing":{"padding":{"left":"0","right":"0","top":"0","bottom":"0"}}},"className":"is-style-outline","fontSize":"small"} -->
 			<div class="wp-block-button has-custom-font-size is-style-outline has-small-font-size">
-				<a class="wp-block-button__link has-contrast-color has-text-color wp-element-button" href="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>" style="border-style:none;border-width:0px;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><strong>Outdoor Furniture &amp; Accessories</strong></a>
+				<a class="wp-block-button__link has-contrast-color has-text-color wp-element-button" href="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>?rating_filter=5" style="border-style:none;border-width:0px;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><strong>Outdoor Furniture &amp; Accessories</strong></a>
 			</div>
 			<!-- /wp:button -->
 		</div>
@@ -42,12 +42,12 @@
 		<div class="wp-block-cover has-custom-content-position is-position-top-left has-background-color has-text-color" style="padding-top:0.8em;min-height:130px">
 			<span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim" style="background-color:#6f64f1"></span>
 			<div class="wp-block-cover__inner-container">
-				<!-- wp:paragraph {"align":"left","placeholder":"Write title…","style":{"typography":{"fontSize":"0.7em","lineHeight":"1"},"spacing":{"margin":{"top":"0px","bottom":"5px"}},"color":{"text":"#ffffff"}}} -->
-				<p class="has-text-align-left has-text-color" style="color:#ffffff;margin-top:0px;margin-bottom:5px;font-size:0.7em;line-height:1">Under</p>
+				<!-- wp:paragraph {"align":"left","placeholder":"Write title…","style":{"typography":{"fontSize":"0.7em","lineHeight":"1"},"spacing":{"margin":{"top":"0px","bottom":"5px"}},"color":{"text":"#ffffff"},"elements":{"link":{"color":{"text":"var:preset|color|base"}}}}} -->
+				<p class="has-text-align-left has-text-color has-link-color" style="color:#ffffff;margin-top:0px;margin-bottom:5px;font-size:0.7em;line-height:1"><a style="text-decoration:none;" href="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>?max_price=15">Under</a></p>
 				<!-- /wp:paragraph -->
 
-				<!-- wp:paragraph {"style":{"typography":{"lineHeight":"1"},"spacing":{"margin":{"top":"4px","right":"0px","bottom":"0px","left":"0px"}},"color":{"text":"#ffffff"}},"fontSize":"large"} -->
-				<p class="has-text-color has-large-font-size" style="color:#ffffff;margin-top:4px;margin-right:0px;margin-bottom:0px;margin-left:0px;line-height:1"><strong>$15</strong></p>
+				<!-- wp:paragraph {"style":{"typography":{"fontSize":"0.7em","lineHeight":"1"},"spacing":{"margin":{"top":"0px","bottom":"5px"}},"color":{"text":"#ffffff"},"elements":{"link":{"color":{"text":"var:preset|color|base"}}}},"fontSize":"large"} -->
+				<p class="has-text-color has-link-color has-large-font-size" style="color:#ffffff;margin-top:0px;margin-bottom:5px;font-size:0.7em;line-height:1"><strong><a style="text-decoration:none;" href="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>?max_price=15">$15</a></strong></p>
 				<!-- /wp:paragraph -->
 			</div>
 		</div>
@@ -73,12 +73,12 @@
 		<div class="wp-block-cover has-custom-content-position is-position-top-left has-background-color has-text-color" style="padding-top:0.8em;min-height:130px">
 			<span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim" style="background-color:#c1d21c"></span>
 			<div class="wp-block-cover__inner-container">
-				<!-- wp:paragraph {"align":"left","placeholder":"Write title…","style":{"typography":{"fontSize":"0.7em","lineHeight":"1"},"spacing":{"margin":{"top":"0px","bottom":"5px"}},"color":{"text":"#ffffff"}}} -->
-				<p class="has-text-align-left has-text-color" style="color:#ffffff;margin-top:0px;margin-bottom:5px;font-size:0.7em;line-height:1">Under</p>
+				<!-- wp:paragraph {"align":"left","placeholder":"Write title…","style":{"typography":{"fontSize":"0.7em","lineHeight":"1"},"spacing":{"margin":{"top":"0px","bottom":"5px"}},"color":{"text":"#ffffff"},"elements":{"link":{"color":{"text":"var:preset|color|base"}}}}} -->
+				<p class="has-text-align-left has-text-color has-link-color" style="color:#ffffff;margin-top:0px;margin-bottom:5px;font-size:0.7em;line-height:1"><a style="text-decoration:none;" href="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>?max_price=25">Under</a></p>
 				<!-- /wp:paragraph -->
 
-				<!-- wp:paragraph {"style":{"typography":{"lineHeight":"1"},"spacing":{"margin":{"top":"4px","right":"0px","bottom":"0px","left":"0px"}},"color":{"text":"#ffffff"}},"fontSize":"large"} -->
-				<p class="has-text-color has-large-font-size" style="color:#ffffff;margin-top:4px;margin-right:0px;margin-bottom:0px;margin-left:0px;line-height:1"><strong>$25</strong></p>
+				<!-- wp:paragraph {"style":{"typography":{"fontSize":"0.7em","lineHeight":"1"},"spacing":{"margin":{"top":"0px","bottom":"5px"}},"color":{"text":"#ffffff"},"elements":{"link":{"color":{"text":"var:preset|color|base"}}}},"fontSize":"large"} -->
+				<p class="has-text-color has-link-color has-large-font-size" style="color:#ffffff;margin-top:0px;margin-bottom:5px;font-size:0.7em;line-height:1"><strong><a style="text-decoration:none;" href="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>?max_price=25">$25</a></strong></p>
 				<!-- /wp:paragraph -->
 			</div>
 		</div>
@@ -104,13 +104,13 @@
 		<div class="wp-block-cover has-custom-content-position is-position-top-left has-background-color has-text-color" style="padding-top:0.8em;min-height:130px">
 			<span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim" style="background-color:#10ca99"></span>
 			<div class="wp-block-cover__inner-container">
-				<!-- wp:paragraph {"align":"left","placeholder":"Write title…","style":{"typography":{"fontSize":"0.7em","lineHeight":"1"},"spacing":{"margin":{"top":"0px","bottom":"5px"}},"color":{"text":"#ffffff"}}} -->
-				<p class="has-text-align-left has-text-color" style="color:#ffffff;margin-top:0px;margin-bottom:5px;font-size:0.7em;line-height:1">Under</p>
+				<!-- wp:paragraph {"align":"left","placeholder":"Write title…","style":{"typography":{"fontSize":"0.7em","lineHeight":"1"},"spacing":{"margin":{"top":"0px","bottom":"5px"}},"color":{"text":"#ffffff"},"elements":{"link":{"color":{"text":"var:preset|color|base"}}}}} -->
+				<p class="has-text-align-left has-text-color has-link-color" style="color:#ffffff;margin-top:0px;margin-bottom:5px;font-size:0.7em;line-height:1"><a style="text-decoration:none;" href="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>?max_price=20">Under</a></p>
 				<!-- /wp:paragraph -->
 
-				<!-- wp:paragraph {"style":{"typography":{"lineHeight":"1"},"spacing":{"margin":{"top":"4px","right":"0px","bottom":"0px","left":"0px"}},"color":{"text":"#ffffff"}},"fontSize":"large"} -->
-				<p class="has-text-color has-large-font-size" style="color:#ffffff;margin-top:4px;margin-right:0px;margin-bottom:0px;margin-left:0px;line-height:1"><strong>$20</strong></p>
-		<!-- /wp:paragraph -->
+				<!-- wp:paragraph {"style":{"typography":{"fontSize":"0.7em","lineHeight":"1"},"spacing":{"margin":{"top":"0px","bottom":"5px"}},"color":{"text":"#ffffff"},"elements":{"link":{"color":{"text":"var:preset|color|base"}}}},"fontSize":"large"} -->
+				<p class="has-text-color has-link-color has-large-font-size" style="color:#ffffff;margin-top:0px;margin-bottom:5px;font-size:0.7em;line-height:1"><strong><a style="text-decoration:none;" href="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>?max_price=20">$20</a></strong></p>
+				<!-- /wp:paragraph -->
 			</div>
 		</div>
 		<!-- /wp:cover -->

--- a/patterns/shop-by-price.php
+++ b/patterns/shop-by-price.php
@@ -27,8 +27,11 @@
 		<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center","verticalAlignment":"center"}} -->
 		<div class="wp-block-buttons">
 			<!-- wp:button {"textColor":"contrast","style":{"border":{"width":"0px","style":"none"},"spacing":{"padding":{"left":"0","right":"0","top":"0","bottom":"0"}}},"className":"is-style-outline","fontSize":"small"} -->
-			<div class="wp-block-button has-custom-font-size is-style-outline has-small-font-size"><a class="wp-block-button__link has-contrast-color has-text-color wp-element-button" href="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>" style="border-style:none;border-width:0px;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><strong>Outdoor Furniture &amp; Accessories</strong></a></div>
-			<!-- /wp:button --></div>
+			<div class="wp-block-button has-custom-font-size is-style-outline has-small-font-size">
+				<a class="wp-block-button__link has-contrast-color has-text-color wp-element-button" href="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>" style="border-style:none;border-width:0px;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><strong>Outdoor Furniture &amp; Accessories</strong></a>
+			</div>
+			<!-- /wp:button -->
+		</div>
 		<!-- /wp:buttons -->
 	</div>
 	<!-- /wp:column -->
@@ -53,8 +56,13 @@
 		<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center","verticalAlignment":"center"}} -->
 		<div class="wp-block-buttons">
 			<!-- wp:button {"textColor":"contrast","style":{"border":{"width":"0px","style":"none"},"spacing":{"padding":{"left":"0","right":"0","top":"0","bottom":"0"}}},"className":"is-style-outline","fontSize":"small"} -->
-			<div class="wp-block-button has-custom-font-size is-style-outline has-small-font-size"><a class="wp-block-button__link has-contrast-color has-text-color wp-element-button" href="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>" style="border-style:none;border-width:0px;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><strong>Summer Dinning</strong></a></div>
-			<!-- /wp:button --></div>
+			<div class="wp-block-button has-custom-font-size is-style-outline has-small-font-size">
+				<a class="wp-block-button__link has-contrast-color has-text-color wp-element-button" href="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>?max_price=15" style="border-style:none;border-width:0px;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">
+					<strong>Summer Dinning</strong>
+				</a>
+			</div>
+			<!-- /wp:button -->
+		</div>
 		<!-- /wp:buttons -->
 	</div>
 	<!-- /wp:column -->
@@ -79,8 +87,13 @@
 		<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center","verticalAlignment":"center"}} -->
 		<div class="wp-block-buttons">
 			<!-- wp:button {"textColor":"contrast","style":{"border":{"width":"0px","style":"none"},"spacing":{"padding":{"left":"0","right":"0","top":"0","bottom":"0"}}},"className":"is-style-outline","fontSize":"small"} -->
-			<div class="wp-block-button has-custom-font-size is-style-outline has-small-font-size"><a class="wp-block-button__link has-contrast-color has-text-color wp-element-button" href="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>" style="border-style:none;border-width:0px;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><strong>Women's Styles</strong></a></div>
-			<!-- /wp:button --></div>
+			<div class="wp-block-button has-custom-font-size is-style-outline has-small-font-size">
+				<a class="wp-block-button__link has-contrast-color has-text-color wp-element-button" href="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>?max_price=25" style="border-style:none;border-width:0px;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">
+					<strong>Women's Styles</strong>
+				</a>
+			</div>
+			<!-- /wp:button -->
+		</div>
 		<!-- /wp:buttons -->
 	</div>
 	<!-- /wp:column -->
@@ -105,8 +118,13 @@
 		<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center","verticalAlignment":"center"}} -->
 		<div class="wp-block-buttons">
 			<!-- wp:button {"textColor":"contrast","style":{"border":{"width":"0px","style":"none"},"spacing":{"padding":{"left":"0","right":"0","top":"0","bottom":"0"}}},"className":"is-style-outline","fontSize":"small"} -->
-			<div class="wp-block-button has-custom-font-size is-style-outline has-small-font-size"><a class="wp-block-button__link has-contrast-color has-text-color wp-element-button" href="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>" style="border-style:none;border-width:0px;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><strong>Kids' Styles</strong></a></div>
-			<!-- /wp:button --></div>
+			<div class="wp-block-button has-custom-font-size is-style-outline has-small-font-size">
+				<a class="wp-block-button__link has-contrast-color has-text-color wp-element-button" href="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>?max_price=20" style="border-style:none;border-width:0px;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">
+					<strong>Kids' Styles</strong>
+				</a>
+			</div>
+			<!-- /wp:button -->
+		</div>
 		<!-- /wp:buttons -->
 	</div>
 	<!-- /wp:column -->


### PR DESCRIPTION
This PR adds filter links to the 4 block titles and buttons.

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/9852

### Testing
#### User-Facing Testing

1. Create a new page or post.
2. Insert the `Shop by price` pattern and save.
3. Go to the front end and check the pattern looks like the image below.
4. Check that the link inside each of the squares corresponds to its title (highest rated filters by rating, under $X filters by price, etc).
5. Check that the link under each of the squares is the same as the one in the title.

<img width="1235" alt="Screenshot 2023-06-20 at 16 34 27" src="https://github.com/woocommerce/woocommerce-blocks/assets/186112/561aa7e7-be01-4617-abcd-ff7b71584a1c">


* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental


### Changelog

> Shop by price pattern: update titles and links to filter by price and rating. 
