### PR TITLE
CI: Ensure that the CI fails if PHP code doesn't respect phpcs configuration

### DIFF
--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -61,4 +61,4 @@ jobs:
               run: phpcs -i
 
             - name: Run PHPCS on all files
-              run: phpcs ./src -q -n --report=checkstyle | cs2pr
+              run: phpcs ./src -n --report=checkstyle | cs2pr


### PR DESCRIPTION
I noticed that the CI doesn't fail if the PHP code doesn't respect the phpcs configuration. This PR fixes this behavior.

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->


### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Create a new branch from this one.
2. Introduce a PHP lint error in the codebase.
3. Create a PR .
4. Ensure that the CI fails.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->


