### PR TITLE
Add order number to checkout schema

### DIFF
--- a/src/StoreApi/Schemas/V1/CheckoutSchema.php
+++ b/src/StoreApi/Schemas/V1/CheckoutSchema.php
@@ -83,6 +83,12 @@ class CheckoutSchema extends AbstractSchema {
 				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,
 			],
+			'order_number'      => [
+				'description' => __( 'Order number used to update order data.', 'woo-gutenberg-products-block' ),
+				'type'        => 'string',
+				'context'     => [ 'view', 'edit' ],
+				'readonly'    => true,
+			],
 			'customer_note'     => [
 				'description' => __( 'Note added to the order by the customer during checkout.', 'woo-gutenberg-products-block' ),
 				'type'        => 'string',
@@ -188,6 +194,7 @@ class CheckoutSchema extends AbstractSchema {
 			'order_id'          => $order->get_id(),
 			'status'            => $order->get_status(),
 			'order_key'         => $order->get_order_key(),
+			'order_number'      => $order->get_order_number(),
 			'customer_note'     => $order->get_customer_note(),
 			'customer_id'       => $order->get_customer_id(),
 			'billing_address'   => $this->billing_address_schema->get_item_response( $order ),

--- a/src/StoreApi/Schemas/V1/CheckoutSchema.php
+++ b/src/StoreApi/Schemas/V1/CheckoutSchema.php
@@ -84,7 +84,7 @@ class CheckoutSchema extends AbstractSchema {
 				'readonly'    => true,
 			],
 			'order_number'      => [
-				'description' => __( 'Order number used to update order data.', 'woo-gutenberg-products-block' ),
+				'description' => __( 'Order number used for display.', 'woo-gutenberg-products-block' ),
 				'type'        => 'string',
 				'context'     => [ 'view', 'edit' ],
 				'readonly'    => true,


### PR DESCRIPTION
The issue is the sequential order number plugin is not compatible with WooPay.  Because we don't pass the order number in the checkout endpoint so WooPay can only use the order id as the order number.


### Testing
1. Preserve log and go through the Block checkout
2. Find the checkout response and see the order number
3. Smoke test the blocks checkout to make sure nothing is broken



### Changelog

> Add order number to checkout schema.
