### PR TITLE
Adjust the Dependabot GitHub username

### DIFF
--- a/.github/workflows/scripts/is-community-contributor.js
+++ b/.github/workflows/scripts/is-community-contributor.js
@@ -6,7 +6,7 @@ const core = require( '@actions/core' );
 // this won't work.
 const octokit = new Octokit();
 
-const ignoredUsernames = [ 'dependabot' ];
+const ignoredUsernames = [ 'dependabot[bot]' ];
 const checkIfIgnoredUsername = ( username ) =>
 	ignoredUsernames.includes( username );
 


### PR DESCRIPTION
In https://github.com/woocommerce/woocommerce-blocks/pull/9254 I added the logic to exclude Dependabot from the Community Contribution label.

However, that doesn't work and for example in [this job](https://github.com/woocommerce/woocommerce-blocks/actions/runs/5314605610/jobs/9622004667) Dependabot update was still marked as Community Contribution.

Based on:
- [this docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions):
    > For workflows initiated by Dependabot (github.actor == 'dependabot[bot]') using the pull_request_target event, if the base ref of the pull request was created by Dependabot (github.actor == 'dependabot[bot]')
- [other repo code](https://github.com/Particular/NServiceBus.Persistence.AzureTable/actions/runs/1554854810/workflow#L19)
    > `github.event.pull_request.user.login == 'dependabot[bot]'`

it is most likely caused by the wrong username.

This PR changes `dependabot` username to `dependabot[bot]` username.

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/9819
