### PR TITLE
Add new `Discount banner` pattern

### DIFF
--- a/patterns/discount-banner.php
+++ b/patterns/discount-banner.php
@@ -10,25 +10,23 @@
 <div class="wp-block-columns are-vertically-aligned-center">
 	<!-- wp:column {"verticalAlignment":"center","width":"400px","style":{"color":{"background":"#254094"},"spacing":{"padding":{"top":"25px","right":"40px","bottom":"40px","left":"40px"}}}} -->
 	<div class="wp-block-column is-vertically-aligned-center has-background" style="background-color:#254094;padding-top:25px;padding-right:40px;padding-bottom:40px;padding-left:40px;flex-basis:400px">
-		<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"500","fontSize":"45px"}},"textColor":"base"} -->
-		<p class="has-base-color has-text-color" style="font-size:45px;font-style:normal;font-weight:500">UP TO</p>
+		<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"500","fontSize":"45px"},"color":{"text":"#ffffff"}}} -->
+		<p class="has-text-color" style="color:#ffffff;font-size:45px;font-style:normal;font-weight:500">UP TO</p>
 		<!-- /wp:paragraph -->
 
-		<!-- wp:paragraph {"style":{"color":{"text":"#fdf251"},"typography":{"fontStyle":"normal","fontWeight":"800","fontSize":"90px","lineHeight":"0"}}} -->
-		<p class="has-text-color" style="color:#fdf251;font-size:90px;font-style:normal;font-weight:800;line-height:0">
-			40% off
-		</p>
+		<!-- wp:paragraph {"style":{"color":{"text":"#fdf251"},"typography":{"fontStyle":"normal","fontWeight":"800","fontSize":"90px","lineHeight":"0.1"}}} -->
+		<p class="has-text-color" style="color:#fdf251;font-size:90px;font-style:normal;font-weight:800;line-height:0.1">40% off</p>
 		<!-- /wp:paragraph -->
 
-		<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"300","fontSize":"35px"}},"textColor":"base"} -->
-		<p class="has-base-color has-text-color" style="font-size:35px;font-style:normal;font-weight:300">Select products</p>
+		<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"300","fontSize":"35px"},"color":{"text":"#ffffff"}}} -->
+		<p class="has-text-color" style="color:#ffffff;font-size:35px;font-style:normal;font-weight:300">Select products</p>
 		<!-- /wp:paragraph -->
 
 		<!-- wp:buttons -->
 		<div class="wp-block-buttons">
-			<!-- wp:button {"style":{"color":{"background":"#ff7179"},"border":{"radius":"40px"},"spacing":{"padding":{"top":"10px","bottom":"10px","left":"30px","right":"30px"}}}} -->
+			<!-- wp:button {"style":{"color":{"background":"#ff7179","text":"#ffffff"},"border":{"radius":"40px"},"spacing":{"padding":{"top":"10px","bottom":"10px","left":"30px","right":"30px"}}}} -->
 			<div class="wp-block-button">
-				<a href="<?php echo esc_url( get_permalink( wc_get_page_id( 'shop' ) ) ); ?>" class="wp-block-button__link has-background wp-element-button" style="border-radius:40px;background-color:#ff7179;padding-top:10px;padding-right:30px;padding-bottom:10px;padding-left:30px">
+				<a href="<?php echo esc_url( get_permalink( wc_get_page_id( 'shop' ) ) ); ?>" class="wp-block-button__link has-text-color has-background wp-element-button" style="border-radius:40px;color:#ffffff;background-color:#ff7179;padding-top:10px;padding-right:30px;padding-bottom:10px;padding-left:30px">
 					Shop now
 				</a>
 			</div>

--- a/patterns/discount-banner.php
+++ b/patterns/discount-banner.php
@@ -21,7 +21,7 @@
 		<!-- /wp:paragraph -->
 
 		<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"300","fontSize":"35px"}},"textColor":"base"} -->
-		<p class="has-base-color has-text-color" style="font-size:35px;font-style:normal;font-weight:300">Select product</p>
+		<p class="has-base-color has-text-color" style="font-size:35px;font-style:normal;font-weight:300">Select products</p>
 		<!-- /wp:paragraph -->
 
 		<!-- wp:buttons -->

--- a/patterns/discount-banner.php
+++ b/patterns/discount-banner.php
@@ -28,7 +28,7 @@
 		<div class="wp-block-buttons">
 			<!-- wp:button {"style":{"color":{"background":"#ff7179"},"border":{"radius":"40px"},"spacing":{"padding":{"top":"10px","bottom":"10px","left":"30px","right":"30px"}}}} -->
 			<div class="wp-block-button">
-				<a class="wp-block-button__link has-background wp-element-button" style="border-radius:40px;background-color:#ff7179;padding-top:10px;padding-right:30px;padding-bottom:10px;padding-left:30px">
+				<a href="<?php echo esc_url( get_permalink( wc_get_page_id( 'shop' ) ) ); ?>" class="wp-block-button__link has-background wp-element-button" style="border-radius:40px;background-color:#ff7179;padding-top:10px;padding-right:30px;padding-bottom:10px;padding-left:30px">
 					Shop now
 				</a>
 			</div>

--- a/patterns/discount-banner.php
+++ b/patterns/discount-banner.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Title: Discount Banner
+ * Slug: woocommerce-blocks/discount-banner
+ * Categories: WooCommerce
+ */
+?>
+
+<!-- wp:columns {"verticalAlignment":"center"} -->
+<div class="wp-block-columns are-vertically-aligned-center">
+	<!-- wp:column {"verticalAlignment":"center","width":"400px","style":{"color":{"background":"#254094"},"spacing":{"padding":{"top":"25px","right":"40px","bottom":"40px","left":"40px"}}}} -->
+	<div class="wp-block-column is-vertically-aligned-center has-background" style="background-color:#254094;padding-top:25px;padding-right:40px;padding-bottom:40px;padding-left:40px;flex-basis:400px">
+		<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"500","fontSize":"45px"}},"textColor":"base"} -->
+		<p class="has-base-color has-text-color" style="font-size:45px;font-style:normal;font-weight:500">UP TO</p>
+		<!-- /wp:paragraph -->
+
+		<!-- wp:paragraph {"style":{"color":{"text":"#fdf251"},"typography":{"fontStyle":"normal","fontWeight":"800","fontSize":"90px","lineHeight":"0"}}} -->
+		<p class="has-text-color" style="color:#fdf251;font-size:90px;font-style:normal;font-weight:800;line-height:0">
+			40% off
+		</p>
+		<!-- /wp:paragraph -->
+
+		<!-- wp:paragraph {"style":{"typography":{"fontStyle":"normal","fontWeight":"300","fontSize":"35px"}},"textColor":"base"} -->
+		<p class="has-base-color has-text-color" style="font-size:35px;font-style:normal;font-weight:300">Select product</p>
+		<!-- /wp:paragraph -->
+
+		<!-- wp:buttons -->
+		<div class="wp-block-buttons">
+			<!-- wp:button {"style":{"color":{"background":"#ff7179"},"border":{"radius":"40px"},"spacing":{"padding":{"top":"10px","bottom":"10px","left":"30px","right":"30px"}}}} -->
+			<div class="wp-block-button">
+				<a class="wp-block-button__link has-background wp-element-button" style="border-radius:40px;background-color:#ff7179;padding-top:10px;padding-right:30px;padding-bottom:10px;padding-left:30px">
+					Shop now
+				</a>
+			</div>
+			<!-- /wp:button -->
+		</div>
+		<!-- /wp:buttons -->
+	</div>
+	<!-- /wp:column -->
+</div>
+<!-- /wp:columns -->
+


### PR DESCRIPTION
This PRs adds the new `Discount banner` pattern.

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/9930

### Screenshots
<img width="481" alt="Screenshot 2023-06-21 at 15 31 03" src="https://user-images.githubusercontent.com/186112/247502460-9ff3235a-7770-4ff4-ac58-ef533737731e.png">

### Testing

#### User-Facing Testing

1. Create a new post or page.
2. Insert the `Discount banner` pattern and save.
3. In the front end, check the pattern looks like the image above and the `Shop now` button links to the shop page.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Add the new `Banner discount` pattern.
