### PR TITLE
Add back filter blocks frontend scripts

### DIFF
--- a/assets/js/blocks/attribute-filter/frontend.ts
+++ b/assets/js/blocks/attribute-filter/frontend.ts
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import { renderFrontend } from '@woocommerce/base-utils';
+
+/**
+ * Internal dependencies
+ */
+import Block from './block';
+import { parseAttributes } from './utils';
+
+const getProps = ( el: HTMLElement ) => {
+	return {
+		isEditor: false,
+		attributes: parseAttributes( el.dataset ),
+	};
+};
+
+renderFrontend( {
+	selector: '.wp-block-woocommerce-attribute-filter',
+	Block,
+	getProps,
+} );

--- a/assets/js/blocks/price-filter/frontend.ts
+++ b/assets/js/blocks/price-filter/frontend.ts
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import { renderFrontend } from '@woocommerce/base-utils';
+
+/**
+ * Internal dependencies
+ */
+import Block from './block';
+import { parseAttributes } from './utils';
+
+const getProps = ( el: HTMLElement ) => {
+	return {
+		attributes: parseAttributes( el.dataset ),
+		isEditor: false,
+	};
+};
+
+renderFrontend( {
+	selector: '.wp-block-woocommerce-price-filter',
+	Block,
+	getProps,
+} );

--- a/assets/js/blocks/stock-filter/frontend.ts
+++ b/assets/js/blocks/stock-filter/frontend.ts
@@ -1,0 +1,23 @@
+/**
+ * External dependencies
+ */
+import { renderFrontend } from '@woocommerce/base-utils';
+
+/**
+ * Internal dependencies
+ */
+import Block from './block';
+import { parseAttributes } from './utils';
+
+const getProps = ( el: HTMLElement ) => {
+	return {
+		attributes: parseAttributes( el.dataset ),
+		isEditor: false,
+	};
+};
+
+renderFrontend( {
+	selector: '.wp-block-woocommerce-stock-filter',
+	Block,
+	getProps,
+} );

--- a/src/BlockTypes/AttributeFilter.php
+++ b/src/BlockTypes/AttributeFilter.php
@@ -25,13 +25,4 @@ class AttributeFilter extends AbstractBlock {
 		parent::enqueue_data( $attributes );
 		$this->asset_data_registry->add( 'attributes', array_values( wc_get_attribute_taxonomies() ), true );
 	}
-
-	/**
-	 * Get the frontend script handle for this block type.
-	 *
-	 * @param string $key Data to get, or default to everything.
-	 */
-	protected function get_block_type_script( $key = null ) {
-		return null;
-	}
 }

--- a/src/BlockTypes/PriceFilter.php
+++ b/src/BlockTypes/PriceFilter.php
@@ -14,13 +14,4 @@ class PriceFilter extends AbstractBlock {
 	protected $block_name     = 'price-filter';
 	const MIN_PRICE_QUERY_VAR = 'min_price';
 	const MAX_PRICE_QUERY_VAR = 'max_price';
-
-	/**
-	 * Get the frontend script handle for this block type.
-	 *
-	 * @param string $key Data to get, or default to everything.
-	 */
-	protected function get_block_type_script( $key = null ) {
-		return null;
-	}
 }

--- a/src/BlockTypes/StockFilter.php
+++ b/src/BlockTypes/StockFilter.php
@@ -33,13 +33,4 @@ class StockFilter extends AbstractBlock {
 	public static function get_stock_status_query_var_values() {
 		return array_keys( wc_get_product_stock_status_options() );
 	}
-
-	/**
-	 * Get the frontend script handle for this block type.
-	 *
-	 * @param string $key Data to get, or default to everything.
-	 */
-	protected function get_block_type_script( $key = null ) {
-		return null;
-	}
 }


### PR DESCRIPTION
This PR adds back the Filter block frontend scripts that were removed in #9251.

You will notice the fix is only applied to the Filter by Attribute, Filter by Price and Filter by Stock blocks. If I'm not wrong, these are the only ones that need it, as the Filter by Rating block was released _after_ the Filter Wrapper was created, so there are no instances of the "old markup" for it.

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/9870.
Fixes https://github.com/woocommerce/woocommerce-blocks/issues/9949.

### Testing

#### User Facing Testing

Test that the old markup of filter blocks still works (#9949):

1. Add Filter blocks with the old markup next to the All Products block. You can use this snippet:

```HTML
<!-- wp:columns -->
<div class="wp-block-columns"><!-- wp:column {"width":"33.33%"} -->
<div class="wp-block-column" style="flex-basis:33.33%"><!-- wp:woocommerce/price-filter -->
<div class="wp-block-woocommerce-price-filter is-loading" data-showinputfields="true" data-showfilterbutton="false" data-heading="Filter by price" data-heading-level="3"><span aria-hidden="true" class="wc-block-product-categories__placeholder"></span></div>
<!-- /wp:woocommerce/price-filter -->

<!-- wp:woocommerce/attribute-filter {"attributeId":1,"displayStyle":"dropdown","heading":"Filter by Color"} -->
<div class="wp-block-woocommerce-attribute-filter is-loading" data-attribute-id="1" data-show-counts="true" data-query-type="or" data-heading="Filter by Color" data-heading-level="3" data-display-style="dropdown"><span aria-hidden="true" class="wc-block-product-attribute-filter__placeholder"></span></div>
<!-- /wp:woocommerce/attribute-filter -->

<!-- wp:woocommerce/attribute-filter {"attributeId":2,"heading":"Filter by Size"} -->
<div class="wp-block-woocommerce-attribute-filter is-loading" data-attribute-id="2" data-show-counts="true" data-query-type="or" data-heading="Filter by Size" data-heading-level="3"><span aria-hidden="true" class="wc-block-product-attribute-filter__placeholder"></span></div>
<!-- /wp:woocommerce/attribute-filter -->

<!-- wp:woocommerce/active-filters -->
<div class="wp-block-woocommerce-active-filters is-loading" data-display-style="list" data-heading="Active filters" data-heading-level="3"><span aria-hidden="true" class="wc-block-active-product-filters__placeholder"></span></div>
<!-- /wp:woocommerce/active-filters -->

<!-- wp:woocommerce/stock-filter -->
<div class="wp-block-woocommerce-stock-filter is-loading" data-show-counts="true" data-heading="Filter by stock status" data-heading-level="3"><span aria-hidden="true" class="wc-block-product-stock-filter__placeholder"></span></div>
<!-- /wp:woocommerce/stock-filter --></div>
<!-- /wp:column -->

<!-- wp:column {"width":"66.66%"} -->
<div class="wp-block-column" style="flex-basis:66.66%"><!-- wp:woocommerce/all-products {"columns":3,"rows":3,"alignButtons":false,"contentVisibility":{"orderBy":true},"orderby":"date","layoutConfig":[["woocommerce/product-image"],["woocommerce/product-title"],["woocommerce/product-price"],["woocommerce/product-rating"],["woocommerce/product-button"]]} -->
<div class="wp-block-woocommerce-all-products wc-block-all-products" data-attributes="{&quot;alignButtons&quot;:false,&quot;columns&quot;:3,&quot;contentVisibility&quot;:{&quot;orderBy&quot;:true},&quot;isPreview&quot;:false,&quot;layoutConfig&quot;:[[&quot;woocommerce/product-image&quot;],[&quot;woocommerce/product-title&quot;],[&quot;woocommerce/product-price&quot;],[&quot;woocommerce/product-rating&quot;],[&quot;woocommerce/product-button&quot;]],&quot;orderby&quot;:&quot;date&quot;,&quot;rows&quot;:3}"></div>
<!-- /wp:woocommerce/all-products --></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->
```
2. Go to the frontend.
3. Verify filter blocks are rendered correctly. Interact with them and verify they work properly.

Before | After
--- | ---
![imatge](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/534ddab8-9bd2-4dde-a41c-7655ab88f265) | ![imatge](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/67992042-c508-48c7-884a-2dfdb75fdc3b)



Test that filter blocks translations are loaded correctly (#9870):

1. Change your store language to a locale that has translations (ie: Spanish).
2. Add the Filter by Attribute, Filter by Price, Filter by Stock and Filter by Rating blocks to a post or page, alongside the Active Filters and Products (beta) blocks.
3. In the frontend, interact with the filter blocks and verify they all work properly.
4. Verify translations are loaded correctly. Ie: Filter by Attribute shows "Seleccionar" instead of "Select" in the input field.

Before | After
--- | ---
![imatge](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/db3c0465-bbb9-4098-8338-3a7418de0284) | ![imatge](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/aec0a8d7-0af2-4166-b0a1-68f1f2d62e01)

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix filter blocks using the old markup not rendering and fix missing translations in those blocks.
