### PR TITLE
Return null or object for ImageAttachmentSchema response

### DIFF
--- a/src/StoreApi/Schemas/V1/ImageAttachmentSchema.php
+++ b/src/StoreApi/Schemas/V1/ImageAttachmentSchema.php
@@ -70,7 +70,7 @@ class ImageAttachmentSchema extends AbstractSchema {
 	 * Convert a WooCommerce product into an object suitable for the response.
 	 *
 	 * @param int $attachment_id Image attachment ID.
-	 * @return array|null
+	 * @return object|null
 	 */
 	public function get_item_response( $attachment_id ) {
 		if ( ! $attachment_id ) {

--- a/src/StoreApi/Schemas/V1/ImageAttachmentSchema.php
+++ b/src/StoreApi/Schemas/V1/ImageAttachmentSchema.php
@@ -80,12 +80,12 @@ class ImageAttachmentSchema extends AbstractSchema {
 		$attachment = wp_get_attachment_image_src( $attachment_id, 'full' );
 
 		if ( ! is_array( $attachment ) ) {
-			return [];
+			return null;
 		}
 
 		$thumbnail = wp_get_attachment_image_src( $attachment_id, 'woocommerce_thumbnail' );
 
-		return [
+		return (object) [
 			'id'        => (int) $attachment_id,
 			'src'       => current( $attachment ),
 			'thumbnail' => current( $thumbnail ),


### PR DESCRIPTION
Fixes #9908

In #9908, @whywilson reported:
> _"The return image of product categories should be null or object, but on some categories, it is an empty array. The same issues happened on the image of /wp-json/wc/store/products/categories request."_

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [ ] E2E tests

The affected unit test can be executed using the following commands:
```sh
npm run wp-env start
npm run test:php -- tests/php/StoreApi/Routes/Products.php
```

#### User Facing Testing

1. Make sure to have two test product categories. One test product category should have an image, the other one should not have an image.
2. Open `[YOUR-URL]/wp-json/wc/store/products/categories` and replace `[YOUR-URL]` with the URL of your test site.
3. Alternatively, open `[YOUR-URL]/wp-json/wc/store/products/categories/[ID]` and replace `[ID]` with the ID of the test product category.
4. Verify that the response for the test product category without image is
```json
{
	...
	"image": null,
	...
}
```
5. Verify that the response for the test product category with image is
```json
{
   ...
   "images": { ... },
   ...
}
```

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix: Return null or object for ImageAttachmentSchema response.
