### PR TITLE
Update rating filter test to match the new logic

### DIFF
--- a/tests/e2e/specs/backend/rating-filter.test.js
+++ b/tests/e2e/specs/backend/rating-filter.test.js
@@ -36,13 +36,13 @@ describe( `${ block.name } Block`, () => {
 		} );
 
 		it( 'product count can be toggled', async () => {
-			await expect( page ).toMatchElement(
+			await expect( page ).not.toMatchElement(
 				'.wc-block-components-product-rating-count'
 			);
 			await expect( page ).toClick( 'label', {
 				text: 'Display product count',
 			} );
-			await expect( page ).not.toMatchElement(
+			await expect( page ).toMatchElement(
 				'.wc-block-components-product-rating-count'
 			);
 			// reset


### PR DESCRIPTION
This PR fixes the test regarding the rating filter count. The logic was recently changed here https://github.com/woocommerce/woocommerce-blocks/pull/9833 and the default state for the `showCounts` attribute is now `false`. The test was expecting it to be visible by default.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests

#### User Facing Testing
Make sure the `tests/e2e/specs/backend/rating-filter.test.js` test is passing on CI.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
