### PR TITLE
Single Product Template: fix compatibility layer logic when the blocks aren't wrapped in a group block

### DIFF
--- a/src/Templates/SingleProductTemplateCompatibility.php
+++ b/src/Templates/SingleProductTemplateCompatibility.php
@@ -259,19 +259,16 @@ class SingleProductTemplateCompatibility extends AbstractTemplateCompatibility {
 	 * @return string
 	 */
 	public static function add_compatibility_layer( $template_content ) {
+		$parsed_blocks = parse_blocks( $template_content );
+
+		if ( ! self::has_single_product_template_blocks( $parsed_blocks ) ) {
+			$template = self::inject_custom_attributes_to_first_and_last_block_single_product_template( $parsed_blocks );
+			return self::serialize_blocks( $template );
+		}
+
 		$wrapped_blocks = self::wrap_single_product_template( $template_content );
 		$template       = self::inject_custom_attributes_to_first_and_last_block_single_product_template( $wrapped_blocks );
-
-		return array_reduce(
-			$template,
-			function( $carry, $item ) {
-				if ( is_array( $item ) ) {
-					return $carry . serialize_blocks( $item );
-				}
-				return $carry . serialize_block( $item );
-			},
-			''
-		);
+		return self::serialize_blocks( $template );
 
 	}
 
@@ -286,15 +283,13 @@ class SingleProductTemplateCompatibility extends AbstractTemplateCompatibility {
 		$parsed_blocks  = parse_blocks( $template_content );
 		$grouped_blocks = self::group_blocks( $parsed_blocks );
 
-		$single_product_template_blocks = array( 'woocommerce/product-image-gallery', 'woocommerce/product-details', 'woocommerce/add-to-cart-form', 'woocommerce/product-meta', 'woocommerce/product-price', 'woocommerce/breadcrumbs' );
-
 		$wrapped_blocks = array_map(
-			function( $blocks ) use ( $single_product_template_blocks ) {
+			function( $blocks ) {
 				if ( 'core/template-part' === $blocks[0]['blockName'] ) {
 					return $blocks;
 				}
 
-				$has_single_product_template_blocks = self::has_single_product_template_blocks( $blocks, $single_product_template_blocks );
+				$has_single_product_template_blocks = self::has_single_product_template_blocks( $blocks );
 
 				if ( $has_single_product_template_blocks ) {
 					$wrapped_block = self::create_wrap_block_group( $blocks );
@@ -320,7 +315,8 @@ class SingleProductTemplateCompatibility extends AbstractTemplateCompatibility {
 
 				$index          = $carry['index'];
 				$carry['index'] = $carry['index'] + 1;
-				$block          = $item[0];
+				// If the block is a child of a group block, we need to get the first block of the group.
+				$block = isset( $item[0] ) ? $item[0] : $item;
 
 				if ( 'core/template-part' === $block['blockName'] || self::is_custom_html( $block ) ) {
 					$carry['template'][] = $block;
@@ -396,10 +392,11 @@ class SingleProductTemplateCompatibility extends AbstractTemplateCompatibility {
 	 * woocommerce/product-gallery-image, woocommerce/product-details, woocommerce/add-to-cart-form]
 	 *
 	 * @param array $parsed_blocks Array of parsed block objects.
-	 * @param array $single_product_template_blocks Array of single product template blocks.
 	 * @return bool True if the template has a single product template block, false otherwise.
 	 */
-	private static function has_single_product_template_blocks( $parsed_blocks, $single_product_template_blocks ) {
+	private static function has_single_product_template_blocks( $parsed_blocks ) {
+		$single_product_template_blocks = array( 'woocommerce/product-image-gallery', 'woocommerce/product-details', 'woocommerce/add-to-cart-form', 'woocommerce/product-meta', 'woocommerce/product-price', 'woocommerce/breadcrumbs' );
+
 		$found = false;
 
 		foreach ( $parsed_blocks as $block ) {
@@ -477,5 +474,24 @@ class SingleProductTemplateCompatibility extends AbstractTemplateCompatibility {
 	 */
 	private static function is_custom_html( $block ) {
 		return empty( $block['blockName'] ) && ! empty( $block['innerHTML'] );
+	}
+
+	/**
+	 * Serialize template.
+	 *
+	 * @param array $parsed_blocks Parsed blocks.
+	 * @return string
+	 */
+	private static function serialize_blocks( $parsed_blocks ) {
+		return array_reduce(
+			$parsed_blocks,
+			function( $carry, $item ) {
+				if ( is_array( $item ) ) {
+					return $carry . serialize_blocks( $item );
+				}
+				return $carry . serialize_block( $item );
+			},
+			''
+		);
 	}
 }

--- a/tests/php/Templates/SingleProductTemplateCompatibilityTests.php
+++ b/tests/php/Templates/SingleProductTemplateCompatibilityTests.php
@@ -364,4 +364,43 @@ class SingleProductTemplateCompatibilityTests extends WP_UnitTestCase {
 
 		$this->assertEquals( $result_without_withespace, $expected_single_product_template_without_whitespace, '' );
 	}
+
+		/**
+		 *  @group failing
+		 * Test that the Single Product Template doesn't remove any blocks if those aren't grouped in a a core/group block
+		 */
+	public function test_add_compatibility_layer_if_contains_blocks_not_related_to_the_single_product_template_and_not_grouped() {
+		$default_single_product_template = '
+		<!-- wp:template-part {"slug":"header","theme":"twentytwentythree","tagName":"header"} /-->
+		<!-- wp:paragraph -->
+		<p>hello</p>
+		<!-- /wp:paragraph -->
+		<!-- wp:paragraph -->
+		<p>hello1</p>
+		<!-- /wp:paragraph -->
+		<!-- wp:paragraph -->
+		<p>hello2</p>
+		<!-- /wp:paragraph -->
+		<!-- wp:template-part {"slug":"footer","theme":"twentytwentythree","tagName":"footer"} /-->';
+
+		$expected_single_product_template = '
+		<!-- wp:template-part {"slug":"header","theme":"twentytwentythree","tagName":"header"} /-->
+		<!-- wp:paragraph {"__wooCommerceIsFirstBlock":true} -->
+		<p>hello</p>
+		<!-- /wp:paragraph -->
+		<!-- wp:paragraph -->
+		<p>hello1</p>
+		<!-- /wp:paragraph -->
+		<!-- wp:paragraph {"__wooCommerceIsLastBlock":true} -->
+		<p>hello2</p>
+		<!-- /wp:paragraph -->
+		<!-- wp:template-part {"slug":"footer","theme":"twentytwentythree","tagName":"footer"} /-->';
+
+		$result = SingleProductTemplateCompatibility::add_compatibility_layer( $default_single_product_template );
+
+		$result_without_withespace                           = preg_replace( '/\s+/', '', $result );
+		$expected_single_product_template_without_whitespace = preg_replace( '/\s+/', '', $expected_single_product_template );
+
+		$this->assertEquals( $result_without_withespace, $expected_single_product_template_without_whitespace, '' );
+	}
 }


### PR DESCRIPTION
This PR fixes woocommerce/woocommerce-blocks#9922. In this PR, I revisit the logic of the Compatibility Layer: It isn't necessary to wrap the blocks inside a div with the class `woocommerce` if any block related to the Single Product Template is used. In this way, it has been easier to fix the issue.


<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes woocommerce/woocommerce-blocks#9922

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Edit the Single Product Template.
2. Remove all the blocks.
3. Add three paragraph blocks.
4. Save it.
5. Visit a product.
6. Ensure that all three paragraph blocks are visible.


* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Single Product Template Compatibility Layer: fix some blocks that don't show on the frontend side in a specific case.
