### PR TITLE
Product Image: use WC Core function to render image

### DIFF
--- a/assets/js/atomic/blocks/product-elements/image/style.scss
+++ b/assets/js/atomic/blocks/product-elements/image/style.scss
@@ -16,6 +16,7 @@
 		border-radius: inherit;
 		vertical-align: middle;
 		width: 100%;
+		height: auto;
 
 		&[hidden] {
 			display: none;

--- a/src/BlockTypes/ProductImage.php
+++ b/src/BlockTypes/ProductImage.php
@@ -145,21 +145,16 @@ class ProductImage extends AbstractBlock {
 	 * @return string
 	 */
 	private function render_image( $product, $attributes ) {
-		$image_type = 'single' === $attributes['imageSizing'] ? 'woocommerce_single' : 'woocommerce_thumbnail';
-		$image_info = wp_get_attachment_image_src( get_post_thumbnail_id( $product->get_id() ), $image_type );
+		$image_size = 'single' === $attributes['imageSizing'] ? 'woocommerce_single' : 'woocommerce_thumbnail';
 
-		if ( ! isset( $image_info[0] ) ) {
+		if ( ! $product->get_image_id() ) {
 			// The alt text is left empty on purpose, as it's considered a decorative image.
 			// More can be found here: https://www.w3.org/WAI/tutorials/images/decorative/.
 			// Github discussion for a context: https://github.com/woocommerce/woocommerce-blocks/pull/7651#discussion_r1019560494.
-			return sprintf( '<img src="%s" alt="" />', wc_placeholder_img_src( $image_type ) );
+			return wc_placeholder_img( $image_size, array( 'alt' => '' ) );
 		}
 
-		return sprintf(
-			'<img data-testid="product-image" alt="%s" src="%s">',
-			$product->get_title(),
-			$image_info[0]
-		);
+		return $product->get_image( $image_size, array( 'alt' => $product->get_title() ) );
 	}
 
 	/**

--- a/src/BlockTypes/ProductImage.php
+++ b/src/BlockTypes/ProductImage.php
@@ -154,7 +154,13 @@ class ProductImage extends AbstractBlock {
 			return wc_placeholder_img( $image_size, array( 'alt' => '' ) );
 		}
 
-		return $product->get_image( $image_size, array( 'alt' => $product->get_title() ) );
+		return $product->get_image(
+			$image_size,
+			array(
+				'alt'         => $product->get_title(),
+				'data-testid' => 'product-image',
+			)
+		);
 	}
 
 	/**


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

This PR refactors the image render function of the Product Image block to use WC Core functions. 

<!-- Reference any related issues or PRs here -->

Fixes #9979 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Add a Products (Beta) block to a page.
2. Save and check the page on the front end.
3. See `<img>` elements have `loading`, `srcset`, `size` attributes.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

N/a
<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Add loading and responsive image attribute to image element of Product Image block.