### PR TITLE
Product Rating block: Fix reviews count not showing on Single Product page

### DIFF
--- a/assets/js/atomic/blocks/product-elements/rating/style.scss
+++ b/assets/js/atomic/blocks/product-elements/rating/style.scss
@@ -44,14 +44,6 @@
 		}
 	}
 
-	&__link {
-		display: inline-block;
-		height: 1.618em;
-		width: 100%;
-		text-align: inherit;
-		@include font-size(small);
-	}
-
 	.wc-block-all-products & {
 		margin-top: 0;
 		margin-bottom: $gap-small;

--- a/assets/js/atomic/blocks/product-elements/rating/style.scss
+++ b/assets/js/atomic/blocks/product-elements/rating/style.scss
@@ -14,6 +14,10 @@
 		font-family: star;
 		font-weight: 400;
 
+		&.wc-block-grid__product-rating__stars {
+			margin: 0;
+		}
+
 		&::before {
 			content: "\53\53\53\53\53";
 			top: 0;
@@ -49,6 +53,12 @@
 		margin-bottom: $gap-small;
 	}
 
+	&__container {
+		display: flex;
+		align-items: center;
+		column-gap: $gap-smaller;
+	}
+
 	&__norating-container {
 		display: inline-flex;
 		flex-direction: row;
@@ -81,17 +91,6 @@
 	}
 }
 
-.wp-block-woocommerce-single-product {
-	.wc-block-components-product-rating__stars {
-		margin: 0;
-	}
-	.wc-block-components-product-rating__container {
-		display: flex;
-		align-items: center;
-		column-gap: $gap-smaller;
-	}
-}
-
 .wc-block-all-products,
 .wp-block-query {
 	.is-loading {
@@ -99,5 +98,13 @@
 			@include placeholder();
 			width: 7em;
 		}
+	}
+
+	.wc-block-components-product-rating__container {
+		display: block;
+	}
+
+	.wc-block-components-product-rating__stars.wc-block-grid__product-rating__stars {
+		margin: inherit;
 	}
 }

--- a/src/BlockTypes/ProductRating.php
+++ b/src/BlockTypes/ProductRating.php
@@ -64,6 +64,7 @@ class ProductRating extends AbstractBlock {
 			'isDescendentOfQueryLoop'          => false,
 			'textAlign'                        => '',
 			'isDescendentOfSingleProductBlock' => false,
+			'isDescendentOfSingleProductTemplate' => false,
 		);
 
 		return wp_parse_args( $attributes, $defaults );
@@ -109,6 +110,7 @@ class ProductRating extends AbstractBlock {
 			$product_rating                        = $product->get_average_rating();
 			$parsed_attributes                     = $this->parse_attributes( $attributes );
 			$is_descendent_of_single_product_block = $parsed_attributes['isDescendentOfSingleProductBlock'];
+			$is_descendent_of_single_product_template = $parsed_attributes['isDescendentOfSingleProductTemplate'];
 
 			$styles_and_classes            = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes );
 			$text_align_styles_and_classes = StyleAttributesUtils::get_text_align_class_and_style( $attributes );
@@ -121,7 +123,7 @@ class ProductRating extends AbstractBlock {
 			 * @param int    $count  Total number of ratings.
 			 * @return string
 			 */
-			$filter_rating_html = function( $html, $rating, $count ) use ( $product_rating, $product_reviews_count, $is_descendent_of_single_product_block ) {
+			$filter_rating_html = function( $html, $rating, $count ) use ( $product_rating, $product_reviews_count, $is_descendent_of_single_product_block, $is_descendent_of_single_product_template ) {
 				$product_permalink = get_permalink();
 				$reviews_count     = $count;
 				$average_rating    = $rating;
@@ -163,7 +165,7 @@ class ProductRating extends AbstractBlock {
 						',
 						esc_attr( $label ),
 						wc_get_star_rating_html( $average_rating, $reviews_count ),
-						$is_descendent_of_single_product_block ? $reviews_count_html : ''
+						$is_descendent_of_single_product_block || $is_descendent_of_single_product_template ? $reviews_count_html : ''
 					);
 				} else {
 					$html = '';


### PR DESCRIPTION
## Description

The Product Rating block is currently not showing the reviews count (it should appear after the rating stars). This PR addresses that by checking if the Product Rating block is being used inside the Single Product template, if so, the reviews count is displayed.

## Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1968c86</samp>
<samp>👨‍💻 Enhanced by @thealexandrelara </samp>

* Add a new attribute `isDescendentOfSingleProductTemplate` to the `ProductRating` block class, to determine if the block is rendered inside a single product template ([link](https://github.com/woocommerce/woocommerce-blocks/pull/9995/files?diff=unified&w=0#diff-9defe615963571610affb73341a43db364eeb7fc5616000176494510be3e8e70R67))
* Assign the value of the `isDescendentOfSingleProductTemplate` attribute to a local variable for easier access in the class methods ([link](https://github.com/woocommerce/woocommerce-blocks/pull/9995/files?diff=unified&w=0#diff-9defe615963571610affb73341a43db364eeb7fc5616000176494510be3e8e70R113))
* Pass the local variable to the anonymous function that filters the rating HTML output, using the `use` clause ([link](https://github.com/woocommerce/woocommerce-blocks/pull/9995/files?diff=unified&w=0#diff-9defe615963571610affb73341a43db364eeb7fc5616000176494510be3e8e70L124-R126))
* Modify the conditional logic that shows the reviews count HTML, to check both the single product block and the single product template cases ([link](https://github.com/woocommerce/woocommerce-blocks/pull/9995/files?diff=unified&w=0#diff-9defe615963571610affb73341a43db364eeb7fc5616000176494510be3e8e70L166-R168))

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #9994

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
| ![image](https://github.com/woocommerce/woocommerce-blocks/assets/20469356/ca8e63b4-3fbe-40fd-91f2-4e9e057327ae) | <img width="1173" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/20469356/f7e8fff5-bbcc-4424-b0ce-a1aeee927b4a"> |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Log in to your WordPress dashboard.
2. From your WordPress dashboard, go to Appearance > Themes. Make sure you have a block-based theme installed and activated. If not, you can install one from the Add New option. Block-based themes include "Twenty-twenty Two," "Twenty-twenty Three," etc.
3. On the left-hand side menu, click on Appearance > Editor. This will open the Site Editor.
4. On the left-hand side menu, click on Templates. This will open the list of available templates.
5. Find and select the 'Single Product' template from the list.
6. When the Classic Product Template renders, click on Transform into Blocks. This will transform the Classic template in a block template if you haven't done it before.
7. On the top-right side, click on the Save button.
8. Visit a product with at least 1 review and check that the Reviews count is being shown

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Fix reviews count not showing for the Product Rating block when inside the Single Product page
