### PR TITLE
Fix notice banner links for Legacy notices

### DIFF
--- a/assets/js/base/components/notice-banner/style.scss
+++ b/assets/js/base/components/notice-banner/style.scss
@@ -43,7 +43,7 @@
 		}
 
 		// Legacy notice compatibility.
-		.wc-forward.wp-element-button {
+		.wc-forward {
 			float: right;
 			color: $gray-800 !important;
 			background: transparent;
@@ -52,6 +52,8 @@
 			border: 0;
 			appearance: none;
 			opacity: 0.6;
+			text-decoration-line: underline;
+			text-underline-position: under;
 
 			&:hover,
 			&:focus,


### PR DESCRIPTION
A few third-party plugins were still using the `wc-forward` class instead of `wp-element-button` that was causing the links in the notice banner to appear on the left and link buttons. With this PR, we're  making the banner links compatible for Legacy notices by just focusing on `wc-forward` class. 

Fixes #9609 & #9134

Also added the underline to the links present in notice banner as per the figma design: hqyJB5F38BOXTrOyxehUZH-fi-2141%3A6588
### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|<img width="100%" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/11503784/4338beb1-2a72-4129-bebf-e01a0c7dc5ad">|![image](https://github.com/woocommerce/woocommerce-blocks/assets/11503784/0f864388-d605-46cc-8749-041dca830eb3)|




### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Install Back in Stock Notifications plugin.
2. Visit an out-of-stock product.
3. Click the “Notify me” button.
4. Confirm the notice banner link is displayed correctly.

![image](https://github.com/woocommerce/woocommerce-blocks/assets/11503784/0f864388-d605-46cc-8749-041dca830eb3)


* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Fix notice banner links for Legacy notices