### PR TITLE
Avoid usage of __experimentalUseFocusOutside

### DIFF
--- a/assets/js/base/components/drawer/index.tsx
+++ b/assets/js/base/components/drawer/index.tsx
@@ -146,6 +146,8 @@ const UnforwardedDrawer = (
 			) }
 			onKeyDown={ handleEscapeKeyDown }
 			onClick={ ( e ) => {
+				// If click was done directly in the overlay element and not one
+				// of its descendants, close the drawer.
 				if ( e.target === ref.current ) {
 					onRequestClose();
 				}

--- a/assets/js/base/components/drawer/index.tsx
+++ b/assets/js/base/components/drawer/index.tsx
@@ -19,8 +19,6 @@ import { close } from '@wordpress/icons';
 import {
 	useFocusReturn,
 	useFocusOnMount,
-	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
-	__experimentalUseFocusOutside as useFocusOutside,
 	useConstrainedTabbing,
 	useMergeRefs,
 } from '@wordpress/compose';
@@ -93,7 +91,6 @@ const UnforwardedDrawer = (
 	const focusOnMountRef = useFocusOnMount();
 	const constrainedTabbingRef = useConstrainedTabbing();
 	const focusReturnRef = useFocusReturn();
-	const focusOutsideProps = useFocusOutside( onRequestClose );
 	const contentRef = useRef< HTMLDivElement >( null );
 
 	useEffect( () => {
@@ -148,6 +145,11 @@ const UnforwardedDrawer = (
 				}
 			) }
 			onKeyDown={ handleEscapeKeyDown }
+			onClick={ ( e ) => {
+				if ( e.target === ref.current ) {
+					onRequestClose();
+				}
+			} }
 		>
 			<div
 				className={ classNames(
@@ -157,7 +159,6 @@ const UnforwardedDrawer = (
 				ref={ drawerRef }
 				role="dialog"
 				tabIndex={ -1 }
-				{ ...focusOutsideProps }
 			>
 				<div
 					className="wc-block-components-drawer__content"

--- a/assets/js/base/components/quantity-selector/index.tsx
+++ b/assets/js/base/components/quantity-selector/index.tsx
@@ -6,7 +6,6 @@ import { speak } from '@wordpress/a11y';
 import classNames from 'classnames';
 import { useCallback, useLayoutEffect, useRef } from '@wordpress/element';
 import { DOWN, UP } from '@wordpress/keycodes';
-import { usePrevious } from '@woocommerce/base-hooks';
 import { useDebouncedCallback } from 'use-debounce';
 
 /**
@@ -75,45 +74,6 @@ const QuantitySelector = ( {
 	const canDecrease = ! disabled && quantity - step >= minimum;
 	const canIncrease =
 		! disabled && ( ! hasMaximum || quantity + step <= maximum );
-	const previousCanDecrease = usePrevious( canDecrease );
-	const previousCanIncrease = usePrevious( canIncrease );
-
-	// When the increase or decrease buttons get disabled, the focus
-	// gets moved to the `<body>` element. This was causing weird
-	// issues in the Mini-Cart block, as the drawer expects focus to be
-	// inside.
-	// To fix this, we move the focus to the text input after the
-	// increase or decrease buttons get disabled. We only do that if
-	// the focus is on the button or the body element.
-	// See https://github.com/woocommerce/woocommerce-blocks/pull/9345
-	useLayoutEffect( () => {
-		// Refs are not available yet, so abort.
-		if (
-			! inputRef.current ||
-			! decreaseButtonRef.current ||
-			! increaseButtonRef.current
-		) {
-			return;
-		}
-
-		const currentDocument = inputRef.current.ownerDocument;
-		if (
-			previousCanDecrease &&
-			! canDecrease &&
-			( currentDocument.activeElement === decreaseButtonRef.current ||
-				currentDocument.activeElement === currentDocument.body )
-		) {
-			inputRef.current.focus();
-		}
-		if (
-			previousCanIncrease &&
-			! canIncrease &&
-			( currentDocument.activeElement === increaseButtonRef.current ||
-				currentDocument.activeElement === currentDocument.body )
-		) {
-			inputRef.current.focus();
-		}
-	}, [ previousCanDecrease, previousCanIncrease, canDecrease, canIncrease ] );
 
 	/**
 	 * The goal of this function is to normalize what was inserted,


### PR DESCRIPTION
This PR refactors how the Drawer component gets closed and, instead of relying on the `__experimentalUseFocusOutside` utility from Gutenberg, we now simply check for a click to the overlay. This has some benefits:

* We remove a usage of an experimental dependency.
* We can remove the weird fix introduced in https://github.com/woocommerce/woocommerce-blocks/pull/9345#issuecomment-1547638759 that programmatically moved the focus after a Quantity Selector button became disabled focus (commit 689acc6a1b7561e7cfcb4f468d3ddbf6d2c5d606).
* I don't have exact reproducible steps, but with the previous approach, there were some cases where the Mini-Cart wouldn't open in Chrome, or it would open but wouldn't be closed until refocus in Firefox.

### Testing

#### User Facing Testing

1. Add the Mini Cart block to the header of your site via (Appearance > Editor). 
2. In the frontend and with the Cart empty, open the Mini Cart drawer, verify you can open and close the drawer without problems. Test closing the drawer by clicking on the overlay that appears above the rest of the page.
3. Add some products to your cart and open the Mini Cart drawer again. Verify you can open and close it, you can change the products' quantity, etc.
4. Now repeat steps 1-3 with another browser. Ideally test Chrome, Firefox and a Webkit-based browser (like Safari or GNOME Web).

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
