### PR TITLE
Remove the word ‘beta’ from the compatibility notice

### DIFF
--- a/assets/js/editor-components/sidebar-compatibility-notice/index.tsx
+++ b/assets/js/editor-components/sidebar-compatibility-notice/index.tsx
@@ -21,7 +21,7 @@ export const CartCheckoutSidebarCompatibilityNotice = ( {
 
 	const noticeText = createInterpolateElement(
 		__(
-			'The Cart & Checkout Blocks are a feature to optimize for faster checkout. To make sure this feature is right for your store, <a>review the list of compatible extensions</a>.',
+			'The Cart & Checkout Blocks are built to optimize for faster checkout. To make sure this feature is right for your store, <a>review the list of compatible extensions</a>.',
 			'woo-gutenberg-products-block'
 		),
 		{

--- a/assets/js/editor-components/sidebar-compatibility-notice/index.tsx
+++ b/assets/js/editor-components/sidebar-compatibility-notice/index.tsx
@@ -21,7 +21,7 @@ export const CartCheckoutSidebarCompatibilityNotice = ( {
 
 	const noticeText = createInterpolateElement(
 		__(
-			'The Cart & Checkout Blocks are a beta feature to optimize for faster checkout. To make sure this feature is right for your store, <a>review the list of compatible extensions</a>.',
+			'The Cart & Checkout Blocks are a feature to optimize for faster checkout. To make sure this feature is right for your store, <a>review the list of compatible extensions</a>.',
 			'woo-gutenberg-products-block'
 		),
 		{


### PR DESCRIPTION
Currently, we’re showing the following message in some places in the Cart and Checkout blocks:

> The Cart & Checkout Blocks are a beta feature to optimize for faster checkout. To make sure this feature is right for your store, [review the list of compatible extensions](https://woocommerce.com/document/cart-checkout-blocks-support-status/#section-3)

The word `beta` might prevent merchants from switching to the Cart and the Checkout blocks as it creates the impression that these blocks are not production ready. This PR aims to remove the word `beta` from the compatibility notice, but keep the rest of the compatibility notice as it is.

Fixes #10009 

### Screenshots

<table>
<tr>
<td valign="top">Before:
<br><br>

<img width="293" alt="Screenshot 2023-06-29 at 15 24 19" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/5a95ea1d-7e52-4699-9cfd-937005315dde">
</td>
<td valign="top">After:
<br><br>

<img width="291" alt="Screenshot 2023-06-29 at 15 12 14" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/ee2e903b-8a63-4c2f-b6b6-4c6a1066d4a7">
</td>
</tr>
</table>

> **Note**
> After placing the screenshots, the wording had been adjusted from 
_"The Cart & Checkout Blocks are **a feature** to [...]"_
to
_"The Cart & Checkout Blocks are **built** to [...]"_.

### Testing

#### User Facing Testing

1. Create a fresh site.
2. Create a test page and add the Cart block to it.
3. Select the Cart block and verify that the notice reads:
> _"The Cart & Checkout Blocks are built to optimize for faster checkout. To make sure this feature is right for your store, [review the list of compatible extensions](https://woocommerce.com/document/cart-checkout-blocks-support-status/#section-3)."_
5. Create a test page and add the Checkout block to it.
6. Select the Checkout block and verify that the notice reads:
> _"The Cart & Checkout Blocks are built to optimize for faster checkout. To make sure this feature is right for your store, [review the list of compatible extensions](https://woocommerce.com/document/cart-checkout-blocks-support-status/#section-3)."_

---

> **Note**
> When testing this on an existing testing site:
> - Make sure that there's no incompatible payment gateway is installed, as the incompatible payment gateway notice prevents the compatibility notice  from appearing.
> - Make sure that there's no key called `wc-blocks_dismissed_sidebar_compatibility_notices` stored in local storage, as this also prevents the compatibility notice from appearing.

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

* Enhancement: Adjust compatibility notice to highlight that the Cart and Checkout blocks are no longer a beta feature.