### PR TITLE
Prevent prefetched Cart payload causing wrong values with cached Mini-Cart block

### DIFF
--- a/assets/js/blocks/mini-cart/block.tsx
+++ b/assets/js/blocks/mini-cart/block.tsx
@@ -14,7 +14,7 @@ import {
 	getCurrencyFromPriceResponse,
 } from '@woocommerce/price-format';
 import { getSettingWithCoercion } from '@woocommerce/settings';
-import { isBoolean, isString } from '@woocommerce/types';
+import { isBoolean, isString, isCartResponseTotals } from '@woocommerce/types';
 import {
 	unmountComponentAtNode,
 	useCallback,
@@ -178,13 +178,16 @@ const MiniCartBlock = ( attributes: Props ): JSX.Element => {
 
 	const taxLabel = getSettingWithCoercion( 'taxLabel', '', isString );
 
+	const cartTotals =
+		cartIsLoadingForTheFirstTime.current ||
+		! isCartResponseTotals( initialCartTotals )
+			? initialCartTotals
+			: cartTotalsFromApi;
+
 	const cartItemsCount = cartIsLoadingForTheFirstTime.current
 		? initialCartItemsCount
 		: cartItemsCountFromApi;
 
-	const cartTotals = cartIsLoadingForTheFirstTime.current
-		? initialCartTotals
-		: cartTotalsFromApi;
 	const subTotal = showIncludingTax
 		? parseInt( cartTotals.total_items, 10 ) +
 		  parseInt( cartTotals.total_items_tax, 10 )
@@ -239,7 +242,7 @@ const MiniCartBlock = ( attributes: Props ): JSX.Element => {
 						) }
 					</span>
 				) }
-				{ taxLabel !== '' && subTotal > 0 && ! hasHiddenPrice && (
+				{ taxLabel !== '' && subTotal !== 0 && ! hasHiddenPrice && (
 					<small
 						className="wc-block-mini-cart__tax-label"
 						style={ { color: priceColorValue } }

--- a/assets/js/blocks/mini-cart/block.tsx
+++ b/assets/js/blocks/mini-cart/block.tsx
@@ -14,7 +14,12 @@ import {
 	getCurrencyFromPriceResponse,
 } from '@woocommerce/price-format';
 import { getSettingWithCoercion } from '@woocommerce/settings';
-import { isBoolean, isString, isCartResponseTotals } from '@woocommerce/types';
+import {
+	isBoolean,
+	isString,
+	isCartResponseTotals,
+	isNumber,
+} from '@woocommerce/types';
 import {
 	unmountComponentAtNode,
 	useCallback,
@@ -179,14 +184,16 @@ const MiniCartBlock = ( attributes: Props ): JSX.Element => {
 	const taxLabel = getSettingWithCoercion( 'taxLabel', '', isString );
 
 	const cartTotals =
-		cartIsLoadingForTheFirstTime.current ||
-		! isCartResponseTotals( initialCartTotals )
+		cartIsLoadingForTheFirstTime.current &&
+		isCartResponseTotals( initialCartTotals )
 			? initialCartTotals
 			: cartTotalsFromApi;
 
-	const cartItemsCount = cartIsLoadingForTheFirstTime.current
-		? initialCartItemsCount
-		: cartItemsCountFromApi;
+	const cartItemsCount =
+		cartIsLoadingForTheFirstTime.current &&
+		isNumber( initialCartItemsCount )
+			? initialCartItemsCount
+			: cartItemsCountFromApi;
 
 	const subTotal = showIncludingTax
 		? parseInt( cartTotals.total_items, 10 ) +

--- a/assets/js/blocks/mini-cart/block.tsx
+++ b/assets/js/blocks/mini-cart/block.tsx
@@ -77,6 +77,24 @@ const MiniCartBlock = ( attributes: Props ): JSX.Element => {
 		}
 	}, [ cartIsLoading, cartIsLoadingForTheFirstTime ] );
 
+	useEffect( () => {
+		if (
+			! cartIsLoading &&
+			isCartResponseTotals( cartTotalsFromApi ) &&
+			isNumber( cartItemsCountFromApi )
+		) {
+			// Save server data to local storage, so we can re-fetch it faster
+			// on the next page load.
+			localStorage.setItem(
+				'wc-blocks_mini_cart_totals',
+				JSON.stringify( {
+					totals: cartTotalsFromApi,
+					itemsCount: cartItemsCountFromApi,
+				} )
+			);
+		}
+	} );
+
 	const [ isOpen, setIsOpen ] = useState< boolean >( isInitiallyOpen );
 	// We already rendered the HTML drawer placeholder, so we want to skip the
 	// slide in animation.

--- a/assets/js/blocks/mini-cart/component-frontend.tsx
+++ b/assets/js/blocks/mini-cart/component-frontend.tsx
@@ -37,9 +37,9 @@ const renderMiniCartFrontend = () => {
 					.replace( 'wc-block-mini-cart__button', '' );
 
 				return {
-					initialCartSubtotal: button.dataset.cartSubtotal
-						? button.dataset.cartSubtotal
-						: '',
+					initialCartTotals: button.dataset.cartTotals
+						? JSON.parse( button.dataset.cartTotals )
+						: 0,
 					initialCartItemsCount: button.dataset.cartItemsCount
 						? parseInt( button.dataset.cartItemsCount, 10 )
 						: 0,

--- a/assets/js/blocks/mini-cart/component-frontend.tsx
+++ b/assets/js/blocks/mini-cart/component-frontend.tsx
@@ -29,28 +29,37 @@ const renderMiniCartFrontend = () => {
 		selector: '.wc-block-mini-cart',
 		Block: MiniCartBlock,
 		getProps: ( el ) => {
-			let colorClassNames = '';
 			const button = el.querySelector( '.wc-block-mini-cart__button' );
-			if ( button !== null ) {
-				colorClassNames = button.classList
+
+			if ( button instanceof HTMLButtonElement ) {
+				const colorClassNames = button.classList
 					.toString()
 					.replace( 'wc-block-mini-cart__button', '' );
+
+				return {
+					initialCartSubtotal: button.dataset.cartSubtotal
+						? button.dataset.cartSubtotal
+						: '',
+					initialCartItemsCount: button.dataset.cartItemsCount
+						? parseInt( button.dataset.cartItemsCount, 10 )
+						: 0,
+					isInitiallyOpen: el.dataset.isInitiallyOpen === 'true',
+					colorClassNames,
+					style: el.dataset.style
+						? JSON.parse( el.dataset.style )
+						: {},
+					miniCartIcon: el.dataset.miniCartIcon,
+					addToCartBehaviour: el.dataset.addToCartBehaviour || 'none',
+					hasHiddenPrice: el.dataset.hasHiddenPrice,
+					priceColorValue: el.dataset.priceColorValue,
+					iconColorValue: el.dataset.iconColorValue,
+					productCountColorValue: el.dataset.productCountColorValue,
+					contents:
+						el.querySelector( '.wc-block-mini-cart__template-part' )
+							?.innerHTML ?? '',
+				};
 			}
-			return {
-				isDataOutdated: el.dataset.isDataOutdated,
-				isInitiallyOpen: el.dataset.isInitiallyOpen === 'true',
-				colorClassNames,
-				style: el.dataset.style ? JSON.parse( el.dataset.style ) : {},
-				miniCartIcon: el.dataset.miniCartIcon,
-				addToCartBehaviour: el.dataset.addToCartBehaviour || 'none',
-				hasHiddenPrice: el.dataset.hasHiddenPrice,
-				priceColorValue: el.dataset.priceColorValue,
-				iconColorValue: el.dataset.iconColorValue,
-				productCountColorValue: el.dataset.productCountColorValue,
-				contents:
-					el.querySelector( '.wc-block-mini-cart__template-part' )
-						?.innerHTML ?? '',
-			};
+			return {};
 		},
 	} );
 

--- a/assets/js/blocks/mini-cart/component-frontend.tsx
+++ b/assets/js/blocks/mini-cart/component-frontend.tsx
@@ -29,37 +29,34 @@ const renderMiniCartFrontend = () => {
 		selector: '.wc-block-mini-cart',
 		Block: MiniCartBlock,
 		getProps: ( el ) => {
+			let colorClassNames = '';
 			const button = el.querySelector( '.wc-block-mini-cart__button' );
 
 			if ( button instanceof HTMLButtonElement ) {
-				const colorClassNames = button.classList
+				colorClassNames = button.classList
 					.toString()
 					.replace( 'wc-block-mini-cart__button', '' );
-
-				return {
-					initialCartTotals: button.dataset.cartTotals
-						? JSON.parse( button.dataset.cartTotals )
-						: 0,
-					initialCartItemsCount: button.dataset.cartItemsCount
-						? parseInt( button.dataset.cartItemsCount, 10 )
-						: 0,
-					isInitiallyOpen: el.dataset.isInitiallyOpen === 'true',
-					colorClassNames,
-					style: el.dataset.style
-						? JSON.parse( el.dataset.style )
-						: {},
-					miniCartIcon: el.dataset.miniCartIcon,
-					addToCartBehaviour: el.dataset.addToCartBehaviour || 'none',
-					hasHiddenPrice: el.dataset.hasHiddenPrice,
-					priceColorValue: el.dataset.priceColorValue,
-					iconColorValue: el.dataset.iconColorValue,
-					productCountColorValue: el.dataset.productCountColorValue,
-					contents:
-						el.querySelector( '.wc-block-mini-cart__template-part' )
-							?.innerHTML ?? '',
-				};
 			}
-			return {};
+			return {
+				initialCartTotals: el.dataset.cartTotals
+					? JSON.parse( el.dataset.cartTotals )
+					: null,
+				initialCartItemsCount: el.dataset.cartItemsCount
+					? parseInt( el.dataset.cartItemsCount, 10 )
+					: 0,
+				isInitiallyOpen: el.dataset.isInitiallyOpen === 'true',
+				colorClassNames,
+				style: el.dataset.style ? JSON.parse( el.dataset.style ) : {},
+				miniCartIcon: el.dataset.miniCartIcon,
+				addToCartBehaviour: el.dataset.addToCartBehaviour || 'none',
+				hasHiddenPrice: el.dataset.hasHiddenPrice,
+				priceColorValue: el.dataset.priceColorValue,
+				iconColorValue: el.dataset.iconColorValue,
+				productCountColorValue: el.dataset.productCountColorValue,
+				contents:
+					el.querySelector( '.wc-block-mini-cart__template-part' )
+						?.innerHTML ?? '',
+			};
 		},
 	} );
 

--- a/assets/js/blocks/mini-cart/frontend.ts
+++ b/assets/js/blocks/mini-cart/frontend.ts
@@ -150,12 +150,10 @@ window.addEventListener( 'load', () => {
 		};
 
 		const openDrawerWithRefresh = () => {
-			miniCartBlock.dataset.isDataOutdated = 'true';
 			openDrawer();
 		};
 
 		const loadContentsWithRefresh = () => {
-			miniCartBlock.dataset.isDataOutdated = 'true';
 			miniCartBlock.dataset.isInitiallyOpen = 'false';
 			loadContents();
 		};

--- a/assets/js/blocks/mini-cart/test/block.js
+++ b/assets/js/blocks/mini-cart/test/block.js
@@ -58,6 +58,15 @@ const mockFullCart = () => {
 	} );
 };
 
+const initializeLocalStorage = () => {
+	Object.defineProperty( window, 'localStorage', {
+		value: {
+			setItem: jest.fn(),
+		},
+		writable: true,
+	} );
+};
+
 describe( 'Testing Mini-Cart', () => {
 	beforeEach( () => {
 		act( () => {
@@ -173,6 +182,21 @@ describe( 'Testing Mini-Cart', () => {
 			expect(
 				screen.getByLabelText( /3 items in cart/i )
 			).toBeInTheDocument()
+		);
+	} );
+
+	it( 'updates local storage when cart finishes loading', async () => {
+		initializeLocalStorage();
+		mockFullCart();
+		render( <MiniCartBlock /> );
+		await waitFor( () => expect( fetchMock ).toHaveBeenCalled() );
+
+		// Assert we saved the values returned to the localStorage.
+		await waitFor( () =>
+			expect(
+				JSON.parse( window.localStorage.setItem.mock.calls[ 0 ][ 1 ] )
+					.itemsCount
+			).toEqual( 3 )
 		);
 	} );
 

--- a/assets/js/blocks/mini-cart/types.ts
+++ b/assets/js/blocks/mini-cart/types.ts
@@ -6,8 +6,8 @@ import { CartResponseTotals } from '@woocommerce/types';
 export type IconType = 'cart' | 'bag' | 'bag-alt' | undefined;
 
 export interface BlockAttributes {
-	initialCartItemsCount: number;
-	initialCartTotals: CartResponseTotals;
+	initialCartItemsCount?: number;
+	initialCartTotals?: CartResponseTotals;
 	isInitiallyOpen?: boolean;
 	colorClassNames?: string;
 	style?: Record< string, Record< string, string > >;

--- a/assets/js/blocks/mini-cart/types.ts
+++ b/assets/js/blocks/mini-cart/types.ts
@@ -1,8 +1,13 @@
+/**
+ * External dependencies
+ */
+import { CartResponseTotals } from '@woocommerce/types';
+
 export type IconType = 'cart' | 'bag' | 'bag-alt' | undefined;
 
 export interface BlockAttributes {
 	initialCartItemsCount: number;
-	initialCartSubtotal: string;
+	initialCartTotals: CartResponseTotals;
 	isInitiallyOpen?: boolean;
 	colorClassNames?: string;
 	style?: Record< string, Record< string, string > >;

--- a/assets/js/blocks/mini-cart/types.ts
+++ b/assets/js/blocks/mini-cart/types.ts
@@ -1,6 +1,8 @@
 export type IconType = 'cart' | 'bag' | 'bag-alt' | undefined;
 
 export interface BlockAttributes {
+	initialCartItemsCount: number;
+	initialCartSubtotal: string;
 	isInitiallyOpen?: boolean;
 	colorClassNames?: string;
 	style?: Record< string, Record< string, string > >;

--- a/assets/js/blocks/mini-cart/utils/data.ts
+++ b/assets/js/blocks/mini-cart/utils/data.ts
@@ -25,12 +25,12 @@ const getPrice = ( totals: CartResponseTotals, showIncludingTax: boolean ) => {
 };
 
 export const updateTotals = (
-	cart: [ CartResponseTotals, number ] | undefined
+	cartData: [ CartResponseTotals, number ] | undefined
 ) => {
-	if ( ! cart ) {
+	if ( ! cartData ) {
 		return;
 	}
-	const [ totals, quantity ] = cart;
+	const [ totals, quantity ] = cartData;
 	const showIncludingTax = getSettingWithCoercion(
 		'displayCartPricesIncludingTax',
 		false,
@@ -54,36 +54,34 @@ export const updateTotals = (
 			'.wc-block-mini-cart__button'
 		);
 
-		if ( miniCartButton instanceof HTMLButtonElement ) {
-			miniCartButton.setAttribute(
-				'aria-label',
-				miniCartBlock.dataset.hasHiddenPrice
-					? sprintf(
-							/* translators: %s number of products in cart. */
-							_n(
-								'%1$d item in cart',
-								'%1$d items in cart',
-								quantity,
-								'woo-gutenberg-products-block'
-							),
-							quantity
-					  )
-					: sprintf(
-							/* translators: %1$d is the number of products in the cart. %2$s is the cart total */
-							_n(
-								'%1$d item in cart, total price of %2$s',
-								'%1$d items in cart, total price of %2$s',
-								quantity,
-								'woo-gutenberg-products-block'
-							),
+		miniCartButton?.setAttribute(
+			'aria-label',
+			miniCartBlock.dataset.hasHiddenPrice
+				? sprintf(
+						/* translators: %s number of products in cart. */
+						_n(
+							'%1$d item in cart',
+							'%1$d items in cart',
 							quantity,
-							amount
-					  )
-			);
+							'woo-gutenberg-products-block'
+						),
+						quantity
+				  )
+				: sprintf(
+						/* translators: %1$d is the number of products in the cart. %2$s is the cart total */
+						_n(
+							'%1$d item in cart, total price of %2$s',
+							'%1$d items in cart, total price of %2$s',
+							quantity,
+							'woo-gutenberg-products-block'
+						),
+						quantity,
+						amount
+				  )
+		);
 
-			miniCartButton.dataset.cartTotals = JSON.stringify( totals );
-			miniCartButton.dataset.cartItemsCount = quantity.toString();
-		}
+		miniCartBlock.dataset.cartTotals = JSON.stringify( totals );
+		miniCartBlock.dataset.cartItemsCount = quantity.toString();
 	} );
 	miniCartQuantities.forEach( ( miniCartQuantity ) => {
 		if ( quantity > 0 || miniCartQuantity.textContent !== '' ) {

--- a/assets/js/blocks/mini-cart/utils/data.ts
+++ b/assets/js/blocks/mini-cart/utils/data.ts
@@ -112,8 +112,8 @@ export const getMiniCartTotalsFromLocalStorage = ():
 	if ( ! rawMiniCartTotals ) {
 		return undefined;
 	}
-	const miniCartTotals = JSON.parse( rawMiniCartTotals );
-	return [ miniCartTotals, miniCartTotals.itemsCount ] as [
+	const cartData = JSON.parse( rawMiniCartTotals );
+	return [ cartData.totals, cartData.itemsCount ] as [
 		CartResponseTotals,
 		number
 	];

--- a/assets/js/blocks/mini-cart/utils/data.ts
+++ b/assets/js/blocks/mini-cart/utils/data.ts
@@ -43,31 +43,36 @@ export const updateTotals = ( totals: [ string, number ] | undefined ) => {
 			'.wc-block-mini-cart__button'
 		);
 
-		miniCartButton?.setAttribute(
-			'aria-label',
-			miniCartBlock.dataset.hasHiddenPrice
-				? sprintf(
-						/* translators: %s number of products in cart. */
-						_n(
-							'%1$d item in cart',
-							'%1$d items in cart',
+		if ( miniCartButton instanceof HTMLButtonElement ) {
+			miniCartButton.setAttribute(
+				'aria-label',
+				miniCartBlock.dataset.hasHiddenPrice
+					? sprintf(
+							/* translators: %s number of products in cart. */
+							_n(
+								'%1$d item in cart',
+								'%1$d items in cart',
+								quantity,
+								'woo-gutenberg-products-block'
+							),
+							quantity
+					  )
+					: sprintf(
+							/* translators: %1$d is the number of products in the cart. %2$s is the cart total */
+							_n(
+								'%1$d item in cart, total price of %2$s',
+								'%1$d items in cart, total price of %2$s',
+								quantity,
+								'woo-gutenberg-products-block'
+							),
 							quantity,
-							'woo-gutenberg-products-block'
-						),
-						quantity
-				  )
-				: sprintf(
-						/* translators: %1$d is the number of products in the cart. %2$s is the cart total */
-						_n(
-							'%1$d item in cart, total price of %2$s',
-							'%1$d items in cart, total price of %2$s',
-							quantity,
-							'woo-gutenberg-products-block'
-						),
-						quantity,
-						amount
-				  )
-		);
+							amount
+					  )
+			);
+
+			miniCartButton.dataset.cartSubtotal = amount;
+			miniCartButton.dataset.cartItemsCount = quantity.toString();
+		}
 	} );
 	miniCartQuantities.forEach( ( miniCartQuantity ) => {
 		if ( quantity > 0 || miniCartQuantity.textContent !== '' ) {

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -137,20 +137,6 @@ class MiniCart extends AbstractBlock {
 				$this->tax_label,
 				''
 			);
-
-			$cart_payload = $this->get_cart_payload();
-
-			$this->asset_data_registry->add(
-				'cartTotals',
-				isset( $cart_payload['totals'] ) ? $cart_payload['totals'] : null,
-				null
-			);
-
-			$this->asset_data_registry->add(
-				'cartItemsCount',
-				isset( $cart_payload['items_count'] ) ? $cart_payload['items_count'] : null,
-				null
-			);
 		}
 
 		$this->asset_data_registry->add(
@@ -560,22 +546,6 @@ class MiniCart extends AbstractBlock {
 			'tax_label'                         => '',
 			'display_cart_prices_including_tax' => false,
 		);
-	}
-
-	/**
-	 * Get Cart Payload.
-	 *
-	 * @return object;
-	 */
-	protected function get_cart_payload() {
-		$notices = wc_get_notices(); // Backup the notices because StoreAPI will remove them.
-		$payload = WC()->api->get_endpoint_data( '/wc/store/cart' );
-
-		if ( ! empty( $notices ) ) {
-			wc_set_notices( $notices ); // Restore the notices.
-		}
-
-		return $payload;
 	}
 
 	/**


### PR DESCRIPTION
In https://github.com/woocommerce/woocommerce-blocks/pull/9493, we updated the Mini-Cart block to support caching plugins. However, there was still an issue when hovering the button: cached values were displayed for a small period of time. That was caused by the prefetching we did of the `/cart/` endpoint, this PR removes that and updates the Mini-Cart block button to always display the correct values.

### Testing

#### User Facing Testing

**With your admin user:**

1. Install _[WP-Optimize - Clean, Compress, Cache](https://wordpress.org/plugins/wp-optimize/)_ or a similar caching plugin.
2. Go to WP-Optimize > Settings > Cache and enable page caching.

**In a private/incognito window without being logged in:**

3. In the frontend visit any page. This will cache the page without products in the cart.

**With your admin user:**

4. Add some products to your cart.
5. Visit the same page from step 3.
6. Notice the Mini Cart totals do include the products you added in step 4, even though it's serving the cached version of step 3.
7. Hover the Mini-Cart button and verify the totals are still correct.

Before | After
--- | ---
[before.webm](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/a7bed8d6-13d4-4b8a-b775-eea8feab9d32) | [after.webm](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/c3b75b3b-60fb-4683-be6a-3bc9d108dd42)

8. Add another product to your cart.
9. Verify Mini-Cart totals updated correctly.
10. Navigate to any other page.
11. Verify Mini-Cart values are always correct and at no moment they render incorrect data.

* [ ] Do not include in the Testing Notes

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Prevent prefetched Cart payload causing wrong values with cached Mini-Cart block
