### PR TITLE
Remove attributes data from save function for filter by price

### DIFF
--- a/assets/js/blocks/price-filter/deprecated.tsx
+++ b/assets/js/blocks/price-filter/deprecated.tsx
@@ -1,40 +1,41 @@
 /**
  * External dependencies
  */
-import { registerBlockType } from '@wordpress/blocks';
 import classNames from 'classnames';
-import { Icon, currencyDollar } from '@wordpress/icons';
 import { useBlockProps } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
-import edit from './edit';
 import metadata from './block.json';
 import { blockAttributes } from './attributes';
-import deprecated from './deprecated';
+import type { Attributes } from './types';
 
-registerBlockType( metadata, {
-	icon: {
-		src: (
-			<Icon
-				icon={ currencyDollar }
-				className="wc-block-editor-components-block-icon"
-			/>
-		),
-	},
+const v1 = {
 	attributes: {
 		...metadata.attributes,
 		...blockAttributes,
 	},
-	edit,
-	save( { attributes } ) {
-		const { className } = attributes;
+	save: ( { attributes }: { attributes: Attributes } ) => {
+		const {
+			className,
+			showInputFields,
+			showFilterButton,
+			heading,
+			headingLevel,
+		} = attributes;
+		const data = {
+			'data-showinputfields': showInputFields,
+			'data-showfilterbutton': showFilterButton,
+			'data-heading': heading,
+			'data-heading-level': headingLevel,
+		};
 		return (
 			<div
 				{ ...useBlockProps.save( {
 					className: classNames( 'is-loading', className ),
 				} ) }
+				{ ...data }
 			>
 				<span
 					aria-hidden
@@ -43,5 +44,8 @@ registerBlockType( metadata, {
 			</div>
 		);
 	},
-	deprecated,
-} );
+};
+
+const deprecated = [ v1 ];
+
+export default deprecated;


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/9960

This PR removes the data attributes from being saved into HTML as it is not needed. A deprecation has been also implemented to prevent block validation errors on existing blocks.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Log in to your WordPress dashboard.
2. Create a new post / page. 
3. Click on the "+" button in the top left corner of the editor to add a new block. Search and add the following blocks to the editor: `Products (beta)` and `Filter by Price`.
4. On the top-right side, click on the Save button.
5. Visit the post/page that you just created and check that filter by price is working correctly and changes made to it is reflected on the Products (beta) block.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Remove attributes data from saving in HTML for Filter by Price block
