### PR TITLE
Product Rating: append #reviews on the Single Product Block

### DIFF
--- a/src/BlockTypes/ProductRating.php
+++ b/src/BlockTypes/ProductRating.php
@@ -150,7 +150,11 @@ class ProductRating extends AbstractBlock {
 						esc_html( $reviews_count )
 					);
 
-					$customer_reviews_count = '<a class="woocommerce-review-link" rel="nofollow" href="' . esc_url( $product_permalink ) . '#reviews">' . $customer_reviews_count . '</a>';
+					if ( $is_descendent_of_single_product_block ) {
+						$customer_reviews_count = '<a href="' . esc_url( $product_permalink ) . '#reviews">' . $customer_reviews_count . '</a>';
+					} elseif ( $is_descendent_of_single_product_template ) {
+						$customer_reviews_count = '<a class="woocommerce-review-link" rel="nofollow" href="#reviews">' . $customer_reviews_count . '</a>';
+					}
 
 					$reviews_count_html = sprintf( '<span class="wc-block-components-product-rating__reviews_count">%1$s</span>', $customer_reviews_count );
 					$html               = sprintf(

--- a/src/BlockTypes/ProductRating.php
+++ b/src/BlockTypes/ProductRating.php
@@ -150,12 +150,7 @@ class ProductRating extends AbstractBlock {
 						esc_html( $reviews_count )
 					);
 
-					if ( $is_descendent_of_single_product_block ) {
-						$customer_reviews_count = '<a href="' . esc_url( $product_permalink ) . '">' . $customer_reviews_count . '</a>';
-					} elseif ( $is_descendent_of_single_product_template ) {
-						$product_permalink      = untrailingslashit( $product_permalink );
-						$customer_reviews_count = '<a href="' . esc_url( $product_permalink ) . '#reviews">' . $customer_reviews_count . '</a>';
-					}
+					$customer_reviews_count = '<a class="woocommerce-review-link" rel="nofollow" href="' . esc_url( $product_permalink ) . '#reviews">' . $customer_reviews_count . '</a>';
 
 					$reviews_count_html = sprintf( '<span class="wc-block-components-product-rating__reviews_count">%1$s</span>', $customer_reviews_count );
 					$html               = sprintf(


### PR DESCRIPTION
This PR is a follow-up of #9998. It:
- adds `#reviews` anchor to the Single Product Block
- ensure that when the user clicks on **"X customer review(s)"**, the review tab is focused.


### Testing



#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Create a new post
2. Add the Single Product block to the post (with a product with reviews) and save.
3. Notice how the "(X customer reviews)" text links to the relevant single product template.
4. Click on it.
5. Ensure that the review tab is focused.
6. Now head over to Edit site > Templates > Single Product and make you are using the blockified version of the Single Product Template with the Product Rating block in place. Edit and save the template if you made any changes to ensure this criteria.
7. Now access any Single Product on the front end and make sure the **"X customer review(s)"** text is linked to the relevant section.
8. Click on it.
9. Ensure that the review tab is focused.
* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental


