### PR TITLE
Mark order confirmation template E2E test as to fix

### DIFF
--- a/tests/e2e-pw/tests/templates/order-confirmation.block_theme.spec.ts
+++ b/tests/e2e-pw/tests/templates/order-confirmation.block_theme.spec.ts
@@ -7,7 +7,7 @@ const permalink = '/checkout/order-received';
 const templatePath = 'woocommerce/woocommerce//order-confirmation';
 const templateType = 'wp_template';
 
-test.describe( 'Test the order confirmation template', async () => {
+test.fixme( 'Test the order confirmation template', async () => {
 	test( 'Template can be opened in the site editor', async ( {
 		page,
 		editorUtils,


### PR DESCRIPTION
This PR marks the order confirmation template E2E test introduced with   https://github.com/woocommerce/woocommerce-blocks/pull/9301 to fix.

https://github.com/woocommerce/woocommerce/issues/42322 for more details

### Testing


1. Ensure that PW E2E tests pass.


