### PR TITLE
Cleanup code to lazy-load wc-settings in the Mini-Cart block

### DIFF
--- a/src/Assets/AssetDataRegistry.php
+++ b/src/Assets/AssetDataRegistry.php
@@ -67,7 +67,7 @@ class AssetDataRegistry {
 	 */
 	protected function init() {
 		add_action( 'init', array( $this, 'register_data_script' ) );
-		add_action( is_admin() ? 'admin_print_footer_scripts' : 'wp_print_footer_scripts', array( $this, 'enqueue_asset_data' ), 2 );
+		add_action( is_admin() ? 'admin_print_footer_scripts' : 'wp_print_footer_scripts', array( $this, 'enqueue_asset_data' ), 1 );
 	}
 
 	/**

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -70,10 +70,7 @@ class MiniCart extends AbstractBlock {
 	protected function initialize() {
 		parent::initialize();
 		add_action( 'wp_loaded', array( $this, 'register_empty_cart_message_block_pattern' ) );
-		add_action( 'wp_print_footer_scripts', array( $this, 'enqueue_wc_settings' ), 1 );
-		// We need this action to run after enqueue_wc_settings() and dequeue_wc_settings(),
-		// otherwise it might incorrectly consider wc_settings script to be enqueued.
-		add_action( 'wp_print_footer_scripts', array( $this, 'print_lazy_load_scripts' ), 4 );
+		add_action( 'wp_print_footer_scripts', array( $this, 'print_lazy_load_scripts' ), 2 );
 	}
 
 	/**
@@ -205,30 +202,6 @@ class MiniCart extends AbstractBlock {
 		 * @since 5.8.0
 		 */
 		do_action( 'woocommerce_blocks_cart_enqueue_data' );
-	}
-
-	/**
-	 * Function to enqueue `wc-settings` script and dequeue it later on so when
-	 * AssetDataRegistry runs, it appears enqueued- This allows the necessary
-	 * data to be printed to the page.
-	 */
-	public function enqueue_wc_settings() {
-		// Return early if another block has already enqueued `wc-settings`.
-		if ( wp_script_is( 'wc-settings', 'enqueued' ) ) {
-			return;
-		}
-		// We are lazy-loading `wc-settings`, but we need to enqueue it here so
-		// AssetDataRegistry knows it's going to load.
-		wp_enqueue_script( 'wc-settings' );
-		// After AssetDataRegistry function runs, we dequeue `wc-settings`.
-		add_action( 'wp_print_footer_scripts', array( $this, 'dequeue_wc_settings' ), 3 );
-	}
-
-	/**
-	 * Function to dequeue `wc-settings` script.
-	 */
-	public function dequeue_wc_settings() {
-		wp_dequeue_script( 'wc-settings' );
 	}
 
 	/**


### PR DESCRIPTION
This PR removes some code added in #8703. In that PR, we added some logic to lazy-load `wc-settings` in the Mini-Cart block to improve performance. However, since we did the Mini-Cart block work with caching plugins, [`wc-settings` is a dependency](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/assets/js/blocks/mini-cart/utils/data.ts#L10) that can't be lazy-loaded, so [this line](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/src/BlockTypes/MiniCart.php#L217) would always return early, and thus the code would never run.

### Testing

#### User Facing Testing

This PR doesn't add any new feature, so testing mostly refers to smoke testing that there are no regressions.

1. Add the Mini Cart block to the header of your store.
2. In the frontend, verify you can open it, interact with its inner blocks (ie: change the quantity of a product, remove a product, etc.).

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
