### PR TITLE
Single Product Block: avoid to register incompatibility blocks with the Single Product Block on the post/page editor

### DIFF
--- a/assets/js/atomic/blocks/product-elements/add-to-cart-form/index.tsx
+++ b/assets/js/atomic/blocks/product-elements/add-to-cart-form/index.tsx
@@ -30,4 +30,5 @@ registerBlockSingleProductTemplate( {
 	blockName: metadata.name,
 	blockMetadata: metadata,
 	blockSettings,
+	isAvailableOnPostEditor: true,
 } );

--- a/assets/js/atomic/blocks/product-elements/product-details/index.tsx
+++ b/assets/js/atomic/blocks/product-elements/product-details/index.tsx
@@ -25,6 +25,6 @@ registerBlockSingleProductTemplate( {
 			),
 		},
 		edit,
-		ancestor: [ 'woocommerce/single-product' ],
 	},
+	isAvailableOnPostEditor: false,
 } );

--- a/assets/js/atomic/blocks/product-elements/product-image-gallery/index.ts
+++ b/assets/js/atomic/blocks/product-elements/product-image-gallery/index.ts
@@ -19,6 +19,6 @@ registerBlockSingleProductTemplate( {
 		icon,
 		// @ts-expect-error `edit` can be extended to include other attributes
 		edit,
-		ancestor: [ 'woocommerce/single-product' ],
 	},
+	isAvailableOnPostEditor: false,
 } );

--- a/assets/js/atomic/blocks/product-elements/product-meta/index.tsx
+++ b/assets/js/atomic/blocks/product-elements/product-meta/index.tsx
@@ -29,4 +29,5 @@ registerBlockSingleProductTemplate( {
 		},
 		ancestor: [ 'woocommerce/single-product' ],
 	},
+	isAvailableOnPostEditor: true,
 } );

--- a/assets/js/atomic/blocks/product-elements/product-reviews/index.tsx
+++ b/assets/js/atomic/blocks/product-elements/product-reviews/index.tsx
@@ -15,6 +15,6 @@ registerBlockSingleProductTemplate( {
 	blockMetadata: metadata,
 	blockSettings: {
 		edit,
-		ancestor: [ 'woocommerce/single-product' ],
 	},
+	isAvailableOnPostEditor: false,
 } );

--- a/assets/js/atomic/blocks/product-elements/rating/index.ts
+++ b/assets/js/atomic/blocks/product-elements/rating/index.ts
@@ -30,4 +30,5 @@ registerBlockSingleProductTemplate( {
 	blockName: 'woocommerce/product-rating',
 	blockMetadata: metadata,
 	blockSettings: blockConfig,
+	isAvailableOnPostEditor: true,
 } );

--- a/assets/js/atomic/blocks/product-elements/related-products/index.tsx
+++ b/assets/js/atomic/blocks/product-elements/related-products/index.tsx
@@ -19,6 +19,6 @@ registerBlockSingleProductTemplate( {
 		icon,
 		edit,
 		save,
-		ancestor: [ 'woocommerce/single-product' ],
 	},
+	isAvailableOnPostEditor: false,
 } );

--- a/assets/js/atomic/utils/register-block-single-product-template.ts
+++ b/assets/js/atomic/utils/register-block-single-product-template.ts
@@ -26,10 +26,12 @@ export const registerBlockSingleProductTemplate = ( {
 	blockSettings,
 	isVariationBlock = false,
 	variationName,
+	isAvailableOnPostEditor,
 }: {
 	blockName: string;
 	blockMetadata: Partial< BlockConfiguration >;
 	blockSettings: Partial< BlockConfiguration >;
+	isAvailableOnPostEditor: boolean;
 	isVariationBlock?: boolean;
 	variationName?: string;
 } ) => {
@@ -97,7 +99,7 @@ export const registerBlockSingleProductTemplate = ( {
 		// This subscribe callback could be invoked with the core/blocks store
 		// which would cause infinite registration loops because of the `registerBlockType` call.
 		// This local cache helps prevent that.
-		if ( ! isBlockRegistered ) {
+		if ( ! isBlockRegistered && isAvailableOnPostEditor ) {
 			if ( isVariationBlock ) {
 				blocksRegistered.add( variationName );
 				registerBlockVariation(


### PR DESCRIPTION
This PR avoids some blocks that are available on the Post Editor and can create a fatal error.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Open the Single Product Template and ensure you have the blockified version.
2. Ensure that all the blocks are visible.
3. Open the post editor and add the Single Product Block.
4. Follow the table below and ensure that only the blocks with the 🟢  are available as ancestor the Single Product Block


| Block Name | Available as the ancestor of the Single Product Block |
|--------|--------|
| Add to Cart with Option | 🟢   |
| Product Details | 🔴  |
| Product Image Gallery | 🔴  | 
| Product Meta | 🟢  |
| Product Reviews | 🔴  |
| Product Rating | 🟢   |
| Related Products | 🔴  |


* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental


### Changelog

> Single Product Block: avoid to register incompatibility blocks with the Single Product Block on the post/page editor
