### PR TITLE
Products block: Improve stability E2E tests

### DIFF
--- a/tests/e2e-pw/tests/products/products.block_theme.side_effects.spec.ts
+++ b/tests/e2e-pw/tests/products/products.block_theme.side_effects.spec.ts
@@ -151,11 +151,12 @@ for ( const {
 				parentClientId
 			);
 
-			await editor.saveSiteEditorEntities();
-
-			await page.waitForResponse( ( response ) =>
-				response.url().includes( 'wp-json/wp/v2/templates/' )
-			);
+			await Promise.all( [
+				editor.saveSiteEditorEntities(),
+				page.waitForResponse( ( response ) =>
+					response.url().includes( 'wp-json/wp/v2/templates/' )
+				),
+			] );
 
 			// @todo This is a workaround to wait for the save button to be enabled. It works only without Gutenberg enabled. We have to refactor this.
 			await page


### PR DESCRIPTION
This PR improves the stability of some E2E tests about the Products block.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Ensure that E2E tests pass


* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

