### PR TITLE
Render Checkout on Pay for Order for FSE themes with checkout flow templates

### DIFF
--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -237,7 +237,14 @@ class Cart extends AbstractBlock {
 	 * Hydrate the cart block with data from the API.
 	 */
 	protected function hydrate_from_api() {
+		// Cache existing notices now, otherwise they are caught by the Cart Controller and converted to exceptions.
+		$old_notices = WC()->session->get( 'wc_notices', array() );
+		wc_clear_notices();
+
 		$this->asset_data_registry->hydrate_api_request( '/wc/store/v1/cart' );
+
+		// Restore notices.
+		WC()->session->set( 'wc_notices', $old_notices );
 	}
 	/**
 	 * Register script and style assets for the block type before it is registered.

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -88,7 +88,7 @@ class Checkout extends AbstractBlock {
 		if ( $this->is_checkout_endpoint() ) {
 			// Note: Currently the block only takes care of the main checkout form -- if an endpoint is set, refer to the
 			// legacy shortcode instead and do not render block.
-			return '[woocommerce_checkout]';
+			return wc_current_theme_is_fse_theme() ? do_shortcode( '[woocommerce_checkout]' ) : '[woocommerce_checkout]';
 		}
 
 		// Deregister core checkout scripts and styles.

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -361,17 +361,19 @@ class Checkout extends AbstractBlock {
 	 * Hydrate the checkout block with data from the API.
 	 */
 	protected function hydrate_from_api() {
+		// Cache existing notices now, otherwise they are caught by the Cart Controller and converted to exceptions.
+		$old_notices = WC()->session->get( 'wc_notices', array() );
+		wc_clear_notices();
+
 		$this->asset_data_registry->hydrate_api_request( '/wc/store/v1/cart' );
 
-		// Print existing notices now, otherwise they are caught by the Cart
-		// Controller and converted to exceptions.
-		wc_print_notices();
 		add_filter( 'woocommerce_store_api_disable_nonce_check', '__return_true' );
-
 		$rest_preload_api_requests = rest_preload_api_request( [], '/wc/store/v1/checkout' );
 		$this->asset_data_registry->add( 'checkoutData', $rest_preload_api_requests['/wc/store/v1/checkout']['body'] ?? [] );
-
 		remove_filter( 'woocommerce_store_api_disable_nonce_check', '__return_true' );
+
+		// Restore notices.
+		WC()->session->set( 'wc_notices', $old_notices );
 	}
 
 	/**

--- a/src/StoreApi/Utilities/CartController.php
+++ b/src/StoreApi/Utilities/CartController.php
@@ -442,11 +442,6 @@ class CartController {
 		remove_action( 'woocommerce_check_cart_items', array( $cart, 'check_cart_items' ), 1 );
 		remove_action( 'woocommerce_check_cart_items', array( $cart, 'check_cart_coupons' ), 1 );
 
-		if ( ! wc()->is_rest_api_request() ) {
-			// Also backup existing notices--this API call may be made to hydrate blocks on regular pages, so we don't want to destroy notices that existed beforehand.
-			$old_notices = WC()->session->get( 'wc_notices', array() );
-		}
-
 		/**
 		 * Fires when cart items are being validated.
 		 *
@@ -462,11 +457,6 @@ class CartController {
 		do_action( 'woocommerce_check_cart_items' );
 
 		$cart_errors = NoticeHandler::convert_notices_to_wp_errors( 'woocommerce_rest_cart_item_error' );
-
-		if ( ! wc()->is_rest_api_request() ) {
-			// Restore notices.
-			WC()->session->set( 'wc_notices', $old_notices );
-		}
 
 		if ( $cart_errors->has_errors() ) {
 			throw new InvalidCartException(

--- a/src/Templates/CheckoutTemplate.php
+++ b/src/Templates/CheckoutTemplate.php
@@ -36,7 +36,7 @@ class CheckoutTemplate extends AbstractPageTemplate {
 	}
 
 	/**
-	 * True when viewing the cart page or cart endpoint.
+	 * True when viewing the checkout page or checkout endpoint.
 	 *
 	 * @return boolean
 	 */

--- a/src/Templates/OrderConfirmationTemplate.php
+++ b/src/Templates/OrderConfirmationTemplate.php
@@ -26,7 +26,7 @@ class OrderConfirmationTemplate extends AbstractPageTemplate {
 	}
 
 	/**
-	 * True when viewing the cart page or cart endpoint.
+	 * True when viewing the Order Received endpoint.
 	 *
 	 * @return boolean
 	 */


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

Fixed rendering checkout on Pay For Order on a FSE theme

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. On a block based theme Place an order
2. Leave the confirmation open
3. Edit the order and set status to failed
4. Now refresh the confirmation
5. Click “Pay” to be taken to the Pay Page
6. Checkout should render (TT3 Pay for Order view looks bad, constrained and left aligned)
7. Ensure you have a "terms and conditions" checkbox, otherwise enable it in WC > Settings >Advanced
8. Try to pay without checking the box. See a notice appear.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### Changelog

> n/a