### PR TITLE
Order confirmation: transform to blocks

### DIFF
--- a/assets/js/blocks/classic-template/order-confirmation.tsx
+++ b/assets/js/blocks/classic-template/order-confirmation.tsx
@@ -1,11 +1,88 @@
 /**
  * External dependencies
  */
-
+import { createBlock, type BlockInstance } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import type { OnClickCallbackParameter, InheritedAttributes } from './types';
+
 const isConversionPossible = () => {
-	return false;
+	return true;
+};
+
+const getButtonLabel = () =>
+	__( 'Transform into blocks', 'woo-gutenberg-products-block' );
+
+const getBlockifiedTemplate = ( inheritedAttributes: InheritedAttributes ) =>
+	[
+		createBlock(
+			'woocommerce/order-confirmation-status',
+			inheritedAttributes
+		),
+		createBlock(
+			'woocommerce/order-confirmation-summary',
+			inheritedAttributes
+		),
+		createBlock(
+			'woocommerce/order-confirmation-details',
+			inheritedAttributes
+		),
+		createBlock( 'core/columns', inheritedAttributes, [
+			createBlock( 'core/column', inheritedAttributes, [
+				createBlock( 'core/heading', {
+					level: 3,
+					content: __(
+						'Billing Address',
+						'woo-gutenberg-products-block'
+					),
+				} ),
+				createBlock(
+					'woocommerce/order-confirmation-billing-address',
+					inheritedAttributes
+				),
+			] ),
+			createBlock( 'core/column', inheritedAttributes, [
+				createBlock( 'core/heading', {
+					level: 3,
+					content: __(
+						'Shipping Address',
+						'woo-gutenberg-products-block'
+					),
+				} ),
+				createBlock(
+					'woocommerce/order-confirmation-shipping-address',
+					inheritedAttributes
+				),
+			] ),
+		] ),
+	].filter( Boolean ) as BlockInstance[];
+
+const onClickCallback = ( {
+	clientId,
+	attributes,
+	getBlocks,
+	replaceBlock,
+	selectBlock,
+}: OnClickCallbackParameter ) => {
+	replaceBlock( clientId, getBlockifiedTemplate( attributes ) );
+
+	const blocks = getBlocks();
+
+	const groupBlock = blocks.find(
+		( block ) =>
+			block.name === 'core/group' &&
+			block.innerBlocks.some(
+				( innerBlock ) =>
+					innerBlock.name === 'woocommerce/store-notices'
+			)
+	);
+
+	if ( groupBlock ) {
+		selectBlock( groupBlock.clientId );
+	}
 };
 
 const getDescription = () => {
@@ -150,4 +227,10 @@ const getSkeleton = () => {
 	);
 };
 
-export { isConversionPossible, getDescription, getSkeleton };
+const blockifyConfig = {
+	getButtonLabel,
+	onClickCallback,
+	getBlockifiedTemplate,
+};
+
+export { blockifyConfig, isConversionPossible, getDescription, getSkeleton };


### PR DESCRIPTION
Adds the functionality to convert the legacy template into blocks. Note: The template may be changed in the final feature branch, but for now this makes use of the existing blocks already created.

Fixes #10052

### Screenshots

![Screenshot 2023-07-03 at 12 32 17](https://github.com/woocommerce/woocommerce-blocks/assets/90977/08f3a825-246e-4aea-9317-cc9894ddd503)

### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Go to Appearance > Edit > Templates > Order Confirmation
2. Click to edit and select the legacy order confirmation block
3. Hover over the "transform into blocks" button. Check the preview looks accurate.
4. Click the button. Confirm the blocks replaced the legacy block successfully.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->
