### PR TITLE
Template Part Handling: Check for `gutenberg_render_block_core_template_part`

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -88,7 +88,11 @@ class BlockTemplatesController {
 			add_filter(
 				'block_type_metadata_settings',
 				function( $settings, $metadata ) {
-					if ( isset( $metadata['name'], $settings['render_callback'] ) && 'core/template-part' === $metadata['name'] && 'render_block_core_template_part' === $settings['render_callback'] ) {
+					if (
+						isset( $metadata['name'], $settings['render_callback'] ) &&
+						'core/template-part' === $metadata['name'] &&
+						in_array( $settings['render_callback'], [ 'render_block_core_template_part', 'gutenberg_render_block_core_template_part' ], true )
+					) {
 						$settings['render_callback'] = [ $this, 'render_woocommerce_template_part' ];
 					}
 					return $settings;
@@ -113,7 +117,7 @@ class BlockTemplatesController {
 				return do_blocks( $template_part->content );
 			}
 		}
-		return \render_block_core_template_part( $attributes );
+		return function_exists( '\gutenberg_render_block_core_template_part' ) ? \gutenberg_render_block_core_template_part( $attributes ) : \render_block_core_template_part( $attributes );
 	}
 
 	/**


### PR DESCRIPTION
With the Gutenberg plugin active, the render callback gets a `gutenberg_` prefix. This prevents our in built template part handling logic from functioning.

### Testing

#### User Facing Testing

1. Ensure you're using a blocks theme and the new checkout template (under Appearance > Edit > Templates > Checkout).
2. Enable the Gutenberg plugin. 
3. Go to the checkout on the frontend and confirm the header template part loads successfully. 

Before applying this PR you'll see a template loading error with Gutenberg active w/ a block theme like TT3.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental