### PR TITLE
Fix image not rendering on the editor and empty styles

### DIFF
--- a/assets/js/atomic/blocks/product-elements/image/style.scss
+++ b/assets/js/atomic/blocks/product-elements/image/style.scss
@@ -60,8 +60,6 @@
 
 .wc-block-components-product-image {
 	margin: 0 0 $gap-small;
-	position: relative;
-	z-index: -1;
 }
 
 .wc-block-product-image__tools-panel .components-input-control {

--- a/src/BlockTypes/ProductImage.php
+++ b/src/BlockTypes/ProductImage.php
@@ -148,7 +148,16 @@ class ProductImage extends AbstractBlock {
 	private function render_image( $product, $attributes ) {
 		$image_size = 'single' === $attributes['imageSizing'] ? 'woocommerce_single' : 'woocommerce_thumbnail';
 
-		$image_style = sprintf( 'max-width:none; height:%s; width:%s; object-fit:%s;', $attributes['height'] ?? '', $attributes['width'] ?? '', $attributes['scale'] ?? '' );
+		$image_style = 'max-width:none;';
+		if ( ! empty( $attributes['height'] ) ) {
+			$image_style .= sprintf( 'height:%s;', $attributes['height'] );
+		}
+		if ( ! empty( $attributes['width'] ) ) {
+			$image_style .= sprintf( 'width:%s;', $attributes['width'] );
+		}
+		if ( ! empty( $attributes['scale'] ) ) {
+			$image_style .= sprintf( 'object-fit:%s;', $attributes['scale'] );
+		}
 
 		if ( ! $product->get_image_id() ) {
 			// The alt text is left empty on purpose, as it's considered a decorative image.


### PR DESCRIPTION
This PR fixes an issue with the `Product Image` not being visible in the editor, it was introduced in https://github.com/woocommerce/woocommerce-blocks/pull/10034
It also avoids adding some empty styles (width, height, object-fit).

### Testing

#### User-Facing Testing

1. Create a new page or post.
2. Insert the `Single Product` block.
3. Check the `Product Image` block is visible on the editor.
4. Save, go to the front-end, and check is visible there too.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
