### PR TITLE
Fix `Product Image` inconsistent style between Editor and front end

### DIFF
--- a/assets/js/atomic/blocks/product-elements/image/style.scss
+++ b/assets/js/atomic/blocks/product-elements/image/style.scss
@@ -2,7 +2,6 @@
 .wc-block-components-product-image {
 	text-decoration: none;
 	display: block;
-	position: relative;
 
 	a {
 		border-radius: inherit;


### PR DESCRIPTION
This PR fixes a different behavior in the editor and in the front end in the `Product Image` block.
When inserted in a column, if the image is wider than the column it shows **under** the second column content in the editor, but **over** it in the front-end.

### Screenshots

| Before | After |
| ------ | ----- |
| <img width="653" alt="Screenshot 2023-07-04 at 13 10 19" src="https://github.com/woocommerce/woocommerce-blocks/assets/186112/000a2b94-fbf7-432a-88b9-1d355d1e3856"> | <img width="640" alt="Screenshot 2023-07-04 at 13 10 37" src="https://github.com/woocommerce/woocommerce-blocks/assets/186112/106828fe-7d15-46fc-b7d3-4ccd1c6c027d"> |

### Testing

#### User-Facing Testing

1. Create a new page or post.
2. Insert a `Single Product` block.
3. Select the `Product Image` block and set the width to a value wider than its column.
4. Notice the image is shown **under** the right column blocks in the Editor.
5. Save and go to the front end and notice the image is shown also **under** the right column blocks.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> "Product Image": fix inconsistent style between Editor and front end.
