### PR TITLE
Fix filter count display toggle

### DIFF
--- a/assets/js/blocks/attribute-filter/index.tsx
+++ b/assets/js/blocks/attribute-filter/index.tsx
@@ -49,12 +49,7 @@ registerBlockType( metadata, {
 				{ ...useBlockProps.save( {
 					className: classNames( 'is-loading', className ),
 				} ) }
-			>
-				<span
-					aria-hidden
-					className="wc-block-product-attribute-filter__placeholder"
-				/>
-			</div>
+			/>
 		);
 	},
 	deprecated,

--- a/assets/js/blocks/attribute-filter/utils.ts
+++ b/assets/js/blocks/attribute-filter/utils.ts
@@ -127,7 +127,7 @@ export const parseAttributes = ( data: Record< string, unknown > ) => {
 			isString( data?.attributeId ) ? data.attributeId : '0',
 			10
 		),
-		showCounts: data?.showCounts !== 'false',
+		showCounts: data?.showCounts === 'true',
 		queryType:
 			( isString( data?.queryType ) && data.queryType ) ||
 			metadata.attributes.queryType.default,

--- a/assets/js/blocks/rating-filter/index.tsx
+++ b/assets/js/blocks/rating-filter/index.tsx
@@ -36,12 +36,7 @@ registerBlockType( metadata, {
 				{ ...useBlockProps.save( {
 					className: classNames( 'is-loading', className ),
 				} ) }
-			>
-				<span
-					aria-hidden
-					className="wc-block-product-rating-filter__placeholder"
-				/>
-			</div>
+			/>
 		);
 	},
 	deprecated,

--- a/assets/js/blocks/rating-filter/utils.ts
+++ b/assets/js/blocks/rating-filter/utils.ts
@@ -38,7 +38,7 @@ export const formatSlug = ( slug: string ) =>
 export const parseAttributes = ( data: Record< string, unknown > ) => {
 	return {
 		showFilterButton: data?.showFilterButton === 'true',
-		showCounts: data?.showCounts !== 'false',
+		showCounts: data?.showCounts === 'true',
 		isPreview: false,
 		displayStyle:
 			( isString( data?.displayStyle ) && data.displayStyle ) ||

--- a/assets/js/blocks/stock-filter/index.tsx
+++ b/assets/js/blocks/stock-filter/index.tsx
@@ -38,12 +38,7 @@ registerBlockType( metadata, {
 				{ ...useBlockProps.save( {
 					className: classNames( 'is-loading', className ),
 				} ) }
-			>
-				<span
-					aria-hidden
-					className="wc-block-product-stock-filter__placeholder"
-				/>
-			</div>
+			/>
 		);
 	},
 	deprecated,

--- a/assets/js/blocks/stock-filter/utils.ts
+++ b/assets/js/blocks/stock-filter/utils.ts
@@ -48,7 +48,7 @@ export const parseAttributes = ( data: Record< string, unknown > ) => {
 				parseInt( data.headingLevel, 10 ) ) ||
 			metadata.attributes.headingLevel.default,
 		showFilterButton: data?.showFilterButton === 'true',
-		showCounts: data?.showCounts !== 'false',
+		showCounts: data?.showCounts === 'true',
 		isPreview: false,
 		displayStyle:
 			( isString( data?.displayStyle ) && data.displayStyle ) ||


### PR DESCRIPTION
This PR is a follow-up of #9833. After the last refactor, a regression has been introduced. The counter was displayed/hidden correctly based on the toggle on the editor side. Instead, the counter was always visible on the frontend side.

When the `showCounts` is false, it isn't saved as an attribute. So I changed the check in the `utils.ts`. 

Also, I improved the `save` method since it isn't necessary anymore to use the inner HTML.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Before checking out this branch, check out `release/10.5.0` branch, add post/page, and test the following blocks Filter by Attributes, Filter by Stock and Filter by Rating along with Products (beta) block. Just leave all default settings and publish post/page.
2. Now checkout this PR and load the post/page you created in step 1 and ensure there are no block validation errors in the console.
3. Add the 3 blocks again. Check that in each of the blocks, Display product count option is set to false/off.
Ensure you can toggle Display product count and it will hide/show the product counts in editor and frontend.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->


