### PR TITLE
Fix `Product Rating` styles & alignment

### DIFF
--- a/assets/js/atomic/blocks/product-elements/rating/block.tsx
+++ b/assets/js/atomic/blocks/product-elements/rating/block.tsx
@@ -11,6 +11,11 @@ import { useStyleProps } from '@woocommerce/base-hooks';
 import { withProductDataContext } from '@woocommerce/shared-hocs';
 import { isNumber, ProductResponseItem } from '@woocommerce/types';
 
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
 type RatingProps = {
 	reviews: number;
 	rating: number;

--- a/assets/js/atomic/blocks/product-elements/rating/style.scss
+++ b/assets/js/atomic/blocks/product-elements/rating/style.scss
@@ -1,0 +1,12 @@
+.wc-block-components-product-rating {
+	.wc-block-components-product-rating__container {
+		> * {
+			vertical-align: middle;
+		}
+	}
+
+	.wc-block-components-product-rating__stars {
+		display: inline-block;
+		margin: 0;
+	}
+}

--- a/assets/js/base/components/product-rating/style.scss
+++ b/assets/js/base/components/product-rating/style.scss
@@ -54,9 +54,13 @@
 	}
 
 	&__container {
-		display: flex;
-		align-items: center;
-		column-gap: $gap-smaller;
+		> * {
+			vertical-align: middle;
+		}
+	}
+
+	&__reviews_count {
+		margin-left: $gap-smaller;
 	}
 
 	&__norating-container {

--- a/src/BlockTypes/ProductRating.php
+++ b/src/BlockTypes/ProductRating.php
@@ -86,7 +86,7 @@ class ProductRating extends AbstractBlock {
 	 * @return null
 	 */
 	protected function get_block_type_style() {
-		return null;
+		return array_merge( parent::get_block_type_style(), [ 'wc-blocks-packages-style' ] );
 	}
 
 	/**


### PR DESCRIPTION
This PR fixes a couple of issues with the `Product Rating` block:
- Alignment setting not working
- Regression on front-end style caused by https://github.com/woocommerce/woocommerce-blocks/pull/9831

### Testing
#### User Facing Testing

1. Create a new page or post.
2. Insert a `Single Product` block with a product with reviews.
3. Select the `Product Rating` block and change the alignment to right or center.
4. Make sure the alignment works fine in the editor.
5. Save and make sure it renders the same in the front-end.
6. Repeat the same steps with the `Single Product` template in the `Site Editor`.

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Product Rating: fix alignment settings.
