### PR TITLE
Fix cart and checkout conditionals when using a block based theme and templates

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -14,6 +14,7 @@ import '../css/editor.scss';
 import '../css/style.scss';
 import './filters/block-list-block';
 import './filters/get-block-attributes';
+import './base/components/notice-banner/style.scss';
 
 setCategories( [
 	...getCategories().filter(

--- a/src/Domain/Services/Notices.php
+++ b/src/Domain/Services/Notices.php
@@ -2,6 +2,7 @@
 namespace Automattic\WooCommerce\Blocks\Domain\Services;
 
 use Automattic\WooCommerce\Blocks\Domain\Package;
+use Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils;
 
 /**
  * Service class for adding new-style Notices to WooCommerce core.
@@ -41,15 +42,7 @@ class Notices {
 	 * is using the new block based cart/checkout.
 	 */
 	public function init() {
-		// Core page IDs.
-		$cart_page_id     = wc_get_page_id( 'cart' );
-		$checkout_page_id = wc_get_page_id( 'checkout' );
-
-		// Checks a specific page (by ID) to see if it contains the named block.
-		$has_block_cart     = $cart_page_id && has_block( 'woocommerce/cart', $cart_page_id );
-		$has_block_checkout = $checkout_page_id && has_block( 'woocommerce/checkout', $checkout_page_id );
-
-		if ( $has_block_cart || $has_block_checkout ) {
+		if ( CartCheckoutUtils::is_cart_block_default() || CartCheckoutUtils::is_checkout_block_default() ) {
 			add_filter( 'woocommerce_kses_notice_allowed_tags', [ $this, 'add_kses_notice_allowed_tags' ] );
 			add_filter( 'wc_get_template', [ $this, 'get_notices_template' ], 10, 5 );
 			add_action(

--- a/src/Utils/CartCheckoutUtils.php
+++ b/src/Utils/CartCheckoutUtils.php
@@ -12,6 +12,21 @@ class CartCheckoutUtils {
 	 * @return bool true if the WC cart page is using the Cart block.
 	 */
 	public static function is_cart_block_default() {
+		if ( wc_current_theme_is_fse_theme() ) {
+			// Ignore the pages and check the templates.
+			$templates_from_db = BlockTemplateUtils::get_block_templates_from_db( array( 'cart' ), 'wp_template' );
+
+			// If there is no template file, we're using default which does use the block.
+			if ( empty( $templates_from_db ) ) {
+				return true;
+			}
+
+			foreach ( $templates_from_db as $template ) {
+				if ( has_block( 'woocommerce/cart', $template->content ) ) {
+					return true;
+				}
+			}
+		}
 		$cart_page_id = wc_get_page_id( 'cart' );
 		return $cart_page_id && has_block( 'woocommerce/cart', $cart_page_id );
 	}
@@ -22,6 +37,21 @@ class CartCheckoutUtils {
 	 * @return bool true if the WC checkout page is using the Checkout block.
 	 */
 	public static function is_checkout_block_default() {
+		if ( wc_current_theme_is_fse_theme() ) {
+			// Ignore the pages and check the templates.
+			$templates_from_db = BlockTemplateUtils::get_block_templates_from_db( array( 'checkout' ), 'wp_template' );
+
+			// If there is no template file, we're using default which does use the block.
+			if ( empty( $templates_from_db ) ) {
+				return true;
+			}
+
+			foreach ( $templates_from_db as $template ) {
+				if ( has_block( 'woocommerce/checkout', $template->content ) ) {
+					return true;
+				}
+			}
+		}
 		$checkout_page_id = wc_get_page_id( 'checkout' );
 		return $checkout_page_id && has_block( 'woocommerce/checkout', $checkout_page_id );
 	}


### PR DESCRIPTION
This PR fixes both new notice styling, and some shipping settings, that were relying on the cart and checkout pages to see if those features should be enabled. This adds a check to instead see if there is a FSE theme in use, in which case it checks the templates instead.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. Active a non-blocks theme e.g. 2019
2. Go to Settings > Advanced and set the cart and checkout pages to pages that **do not contain blocks.** For example, set them to pages using the cart and checkout shortcodes
3. Save settings. Then switch to a block based theme, e.g. TT3
4. Go to the store and view a product page.
5. Add to cart. Check that the notice styling is using the new design:

![Screenshot 2023-07-05 at 11 37 57](https://github.com/woocommerce/woocommerce-blocks/assets/90977/c8fb8bc5-abd6-43e2-8e3c-1748497aa0f7)

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->
