### PR TITLE
Load product-query stylesheet when rendering the Products block

### DIFF
--- a/src/BlockTypes/ProductQuery.php
+++ b/src/BlockTypes/ProductQuery.php
@@ -71,6 +71,12 @@ class ProductQuery extends AbstractBlock {
 			10,
 			2
 		);
+		add_filter(
+			'render_block',
+			array( $this, 'enqueue_styles' ),
+			10,
+			2
+		);
 		add_filter( 'rest_product_query', array( $this, 'update_rest_query' ), 10, 2 );
 		add_filter( 'rest_product_collection_params', array( $this, 'extend_rest_query_allowed_params' ), 10, 1 );
 	}
@@ -116,6 +122,28 @@ class ProductQuery extends AbstractBlock {
 	public static function is_woocommerce_variation( $parsed_block ) {
 		return isset( $parsed_block['attrs']['namespace'] )
 		&& substr( $parsed_block['attrs']['namespace'], 0, 11 ) === 'woocommerce';
+	}
+
+	/**
+	 * Enqueues the variation styles when rendering the Product Query variation.
+	 *
+	 * @param string $block_content The block content.
+	 * @param array  $parsed_block  The full block, including name and attributes.
+	 *
+	 * @return string The block content.
+	 */
+	public function enqueue_styles( string $block_content, array $parsed_block ) {
+		if ( 'core/query' !== $parsed_block['blockName'] ) {
+			return $block_content;
+		}
+
+		$this->parsed_block = $parsed_block;
+
+		if ( self::is_woocommerce_variation( $parsed_block ) ) {
+			wp_enqueue_style( 'wc-blocks-style-product-query' );
+		}
+
+		return $block_content;
 	}
 
 	/**

--- a/src/BlockTypes/ProductQuery.php
+++ b/src/BlockTypes/ProductQuery.php
@@ -128,18 +128,12 @@ class ProductQuery extends AbstractBlock {
 	 * Enqueues the variation styles when rendering the Product Query variation.
 	 *
 	 * @param string $block_content The block content.
-	 * @param array  $parsed_block  The full block, including name and attributes.
+	 * @param array  $block         The full block, including name and attributes.
 	 *
 	 * @return string The block content.
 	 */
-	public function enqueue_styles( string $block_content, array $parsed_block ) {
-		if ( 'core/query' !== $parsed_block['blockName'] ) {
-			return $block_content;
-		}
-
-		$this->parsed_block = $parsed_block;
-
-		if ( self::is_woocommerce_variation( $parsed_block ) ) {
+	public function enqueue_styles( string $block_content, array $block ) {
+		if ( 'core/query' === $block['blockName'] && self::is_woocommerce_variation( $block ) ) {
 			wp_enqueue_style( 'wc-blocks-style-product-query' );
 		}
 


### PR DESCRIPTION
Fixes wrong spacing in the Products block introduced in #9831, discovered by @gigitux. I think the issue was that the stylesheet was not automatically imported because it's a variation instead of a block, so in this PR we are importing it manually.

### Testing

#### User Facing Testing

1. Add the Products (beta) block to a post or page.
2. Verify there is spacing between the price and the button:

Before | After
--- | ----
![imatge](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/bc3026d6-3544-44bf-aca0-9f4c410b6374) | ![imatge](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/8085a64f-cb3b-4c9e-bd91-944fb31d2c4b)

3. Now, create another page with the Query Loop block, displaying posts.
4. In the frontend, open the _Network_ tab of your browser devtools (<kbd>F12</kbd>) and verify there is no `product-query.css` stylesheet being loaded unnecessarily.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
