### PR TITLE
Single Product Template > Ensure extensions can't trigger fatal errors on templates without any post content blocks

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -373,6 +373,15 @@ class BlockTemplatesController {
 							}
 						);
 
+						global $product;
+
+						if ( ! $product instanceof \WC_Product ) {
+							$product_id = get_the_ID();
+							if ( $product_id ) {
+								wc_setup_product_data( $product_id );
+							}
+						}
+
 						$new_content       = SingleProductTemplateCompatibility::add_compatibility_layer( $template->content );
 						$template->content = $new_content;
 					}


### PR DESCRIPTION
Fixes #10126

When plugin developers add a callback function to an action or filter hook within the Single Product template, it is not uncommon for them to assume the `global $product` variable is always available and an instance of `WC_Product`. 

While this assumption is not ideal (plugin developers should be guarding against fatal errors), this has been a relatively "safe" practice for the classic Product Template, as the core of WooCommerce ensures this variable is properly set via the [`woocommerce_content`](https://github.com/Automattic/woocommerce/blob/security/plugins/woocommerce/includes/wc-template-functions.php#L975-L978), which calls the `the_post()` function. When `the_post` is called, WooCommerce then puts product data into a global via [`wc_setup_product_data`](https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/includes/wc-template-functions.php#L139).  

With the blockified version of the Single Product template, though, the presence of the global `$product` as an instance of `WC_Product` is not reliable, as it currently depends on the presence of at least one block that invokes the `the_post()` to work as expected. 

In other words, **by simply removing both the Product Details and the Related Products blocks from the blockified template**, the global `$product` variable is not available as an object anymore, resulting in a fatal error for any extensions with callback functions that assume the global `$product` is a `WC_Product`. 

## Changes introduced by this PR

To solve the problem, it is now ensured the `$product` global variable is an instance of the `WC_Product` right before adding the compatibility layer for the single product template.

## Discussion

Since the value set for the global `$product` matches the one expected for it within the context of the Single Product template, the variable is not restored to its original value after. I believe this is a safe assumption, considering this is what the core of WooCommerce does for this template as well, but opening the topic for discussion in case folks have any concerns.

### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Make sure you have a block theme enabled, such as Twenty-twenty three.
2. Head over to Edit Site > Templates > Single Product
3. Make sure you have the blockyified version of this template up and running: if you don't, click on the "Transform into blocks" button. Delete/remove both the `Product Details` and the `Related Products` blocks and save.
4. Within any active plugin (e.g. within the `woocommerce-gutenberg-products-block.php` file), add the following:

```php
add_action( 'woocommerce_single_product_summary', function () {
	global $product;

	$product->get_title();
} );
```
5. Access any Single Product on the front end and ensure everything works as expected: no Fatal Errors should be triggered.

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Single Product Template > Ensure extensions can't trigger fatal errors on customized single product templates without any post content blocks.
