### PR TITLE
Adjust Banner Pattern Column Padding

### DIFF
--- a/patterns/banner.php
+++ b/patterns/banner.php
@@ -8,8 +8,8 @@
 
 <!-- wp:columns {"verticalAlignment":null,"align":"wide","style":{"color":{"background":"#caf0fa"}}} -->
 <div class="wp-block-columns alignwide has-background" style="background-color:#caf0fa">
-	<!-- wp:column {"verticalAlignment":"center","style":{"spacing":{"padding":{"top":"var:preset|spacing|30","right":"var:preset|spacing|60","bottom":"var:preset|spacing|30","left":"var:preset|spacing|60"}}}} -->
-	<div class="wp-block-column is-vertically-aligned-center" style="padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--60)">
+	<!-- wp:column {"verticalAlignment":"center","style":{"spacing":{"padding":{"top":"var:preset|spacing|30","right":"clamp(1.5rem, 5vw, 2rem)","bottom":"var:preset|spacing|30","left":"clamp(1.5rem, 5vw, 2rem)"}}}} -->
+	<div class="wp-block-column is-vertically-aligned-center" style="padding-top:var(--wp--preset--spacing--30);padding-right:clamp(1.5rem, 5vw, 2rem);padding-bottom:var(--wp--preset--spacing--30);padding-left:clamp(1.5rem, 5vw, 2rem)">
 		<!-- wp:paragraph {"style":{"color":{"text":"#005cc9"},"typography":{"fontSize":"18px"},"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}}} -->
 		<p class="has-text-color" style="color:#005cc9;margin-top:0;margin-right:0;margin-bottom:0;margin-left:0;font-size:18px"><strong>HOLIDAY SALE</strong> </p>
 		<!-- /wp:paragraph -->


### PR DESCRIPTION
This PR brings the horizontal padding in the text column of the `Banner` pattern.

As suggested in #10103, this new alignment setting strikes a better balance on both the mobile and desktop views.

<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes #10103 

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->


### Screenshots (taken from #10103)

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
| ![banner-padding-before](https://github.com/woocommerce/woocommerce-blocks/assets/481776/e0e98b14-6f36-4cfd-9f73-b80d637a2ce6) | ![banner-padding-after](https://github.com/woocommerce/woocommerce-blocks/assets/481776/7fa7fe6c-c9f7-466e-928a-60865ed9dfa0) |


### Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. From the editor (post, page, etc.) apply the `Banner` pattern.
2. Select the first column in the pattern (can use the editor's List View).
3. From the Styles tab in the Settings panel, confirm that the horizontal padding is set to 1.
4. Confirm the image matches the "After" version in the screenshot above in both the admin and the front end.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Add suggested changelog entry here.
