### PR TITLE
Fix: Frontend Category Filtering in Product Collection Block

### DIFF
--- a/src/BlockTypes/ProductCollection.php
+++ b/src/BlockTypes/ProductCollection.php
@@ -173,6 +173,9 @@ class ProductCollection extends AbstractBlock {
 		}
 
 		$block_context_query = $block->context['query'];
+		// phpcs:ignore WordPress.DB.SlowDBQuery
+		$block_context_query['tax_query'] = $query['tax_query'];
+
 		return $this->get_final_frontend_query( $block_context_query, $page );
 	}
 

--- a/tests/e2e-pw/tests/product-collection/product-collection.block_theme.spec.ts
+++ b/tests/e2e-pw/tests/product-collection/product-collection.block_theme.spec.ts
@@ -147,38 +147,37 @@ test.describe( 'Product Collection', () => {
 			await expect( pageObject.productTitles ).toHaveText( [ 'Cap' ] );
 		} );
 
-		test.fixme(
-			'Products can be filtered based on category.',
-			async ( { pageObject } ) => {
-				const filterName = 'Product categories';
-				await pageObject.addFilter( 'Show Taxonomies' );
-				await pageObject.setFilterComboboxValue( filterName, [
-					'Clothing',
-				] );
-				await expect( pageObject.productTitles ).toHaveText( [
-					'Logo Collection',
-				] );
+		test( 'Products can be filtered based on category.', async ( {
+			pageObject,
+		} ) => {
+			const filterName = 'Product categories';
+			await pageObject.addFilter( 'Show Taxonomies' );
+			await pageObject.setFilterComboboxValue( filterName, [
+				'Clothing',
+			] );
+			await expect( pageObject.productTitles ).toHaveText( [
+				'Logo Collection',
+			] );
 
-				await pageObject.setFilterComboboxValue( filterName, [
-					'Accessories',
-				] );
-				const accessoriesProductNames = [
-					'Beanie',
-					'Beanie with Logo',
-					'Belt',
-					'Cap',
-					'Sunglasses',
-				];
-				await expect( pageObject.productTitles ).toHaveText(
-					accessoriesProductNames
-				);
+			await pageObject.setFilterComboboxValue( filterName, [
+				'Accessories',
+			] );
+			const accessoriesProductNames = [
+				'Beanie',
+				'Beanie with Logo',
+				'Belt',
+				'Cap',
+				'Sunglasses',
+			];
+			await expect( pageObject.productTitles ).toHaveText(
+				accessoriesProductNames
+			);
 
-				await pageObject.publishAndGoToFrontend();
-				await expect( pageObject.productTitles ).toHaveText(
-					accessoriesProductNames
-				);
-			}
-		);
+			await pageObject.publishAndGoToFrontend();
+			await expect( pageObject.productTitles ).toHaveText(
+				accessoriesProductNames
+			);
+		} );
 
 		test( 'Products can be filtered based on product attributes like color, size etc.', async ( {
 			pageObject,


### PR DESCRIPTION
This Pull Request addresses an issue where products were not being filtered correctly by category on the frontend, despite appearing correctly in the Editor.


Fixes #10131

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Testing

1. Add a product collection block in the Editor.
2. Add a category to filter the products. The products should be filtered correctly in the Editor based on the chosen category.
3. Publish the post and go to the frontend. The products should now be correctly filtered by the chosen category on the frontend.


* [X] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [X] Experimental

### Changelog

> Fix: Align frontend category filtering with Editor in Product Collection block.
