### PR TITLE
Product Collection - refactor inspector controls props

### DIFF
--- a/assets/js/blocks/product-collection/constants.ts
+++ b/assets/js/blocks/product-collection/constants.ts
@@ -13,8 +13,6 @@ import {
 	TProductCollectionOrderBy,
 	ProductCollectionQuery,
 	ProductCollectionDisplayLayout,
-	DisplayLayoutObject,
-	QueryObject,
 } from './types';
 
 export const STOCK_STATUS_OPTIONS = getSetting< Record< string, string > >(
@@ -65,25 +63,21 @@ export const DEFAULT_ATTRIBUTES: Partial< ProductCollectionAttributes > = {
 
 export const getDefaultQuery = (
 	currentQuery: ProductCollectionQuery
-): QueryObject => ( {
-	query: {
-		...currentQuery,
-		orderBy: DEFAULT_QUERY.orderBy as TProductCollectionOrderBy,
-		order: DEFAULT_QUERY.order as TProductCollectionOrder,
-		inherit: DEFAULT_QUERY.inherit,
-	},
+): ProductCollectionQuery => ( {
+	...currentQuery,
+	orderBy: DEFAULT_QUERY.orderBy as TProductCollectionOrderBy,
+	order: DEFAULT_QUERY.order as TProductCollectionOrder,
+	inherit: DEFAULT_QUERY.inherit,
 } );
 
-export const getDefaultDisplayLayout = (): DisplayLayoutObject => ( {
-	displayLayout:
-		DEFAULT_ATTRIBUTES.displayLayout as ProductCollectionDisplayLayout,
-} );
+export const getDefaultDisplayLayout = () =>
+	DEFAULT_ATTRIBUTES.displayLayout as ProductCollectionDisplayLayout;
 
 export const getDefaultSettings = (
 	currentAttributes: ProductCollectionAttributes
 ): Partial< ProductCollectionAttributes > => ( {
-	...getDefaultDisplayLayout(),
-	...getDefaultQuery( currentAttributes.query ),
+	displayLayout: getDefaultDisplayLayout(),
+	query: getDefaultQuery( currentAttributes.query ),
 } );
 
 export const DEFAULT_FILTERS: Partial< ProductCollectionQuery > = {

--- a/assets/js/blocks/product-collection/constants.ts
+++ b/assets/js/blocks/product-collection/constants.ts
@@ -14,6 +14,7 @@ import {
 	ProductCollectionQuery,
 	ProductCollectionDisplayLayout,
 	DisplayLayoutObject,
+	QueryObject,
 } from './types';
 
 export const STOCK_STATUS_OPTIONS = getSetting< Record< string, string > >(
@@ -62,11 +63,11 @@ export const DEFAULT_ATTRIBUTES: Partial< ProductCollectionAttributes > = {
 	},
 };
 
-export const getDefaultSettings = (
-	currentAttributes: ProductCollectionAttributes
-): Partial< ProductCollectionAttributes > => ( {
+export const getDefaultQuery = (
+	currentQuery: ProductCollectionQuery
+): QueryObject => ( {
 	query: {
-		...currentAttributes.query,
+		...currentQuery,
 		orderBy: DEFAULT_QUERY.orderBy as TProductCollectionOrderBy,
 		order: DEFAULT_QUERY.order as TProductCollectionOrder,
 		inherit: DEFAULT_QUERY.inherit,
@@ -76,6 +77,13 @@ export const getDefaultSettings = (
 export const getDefaultDisplayLayout = (): DisplayLayoutObject => ( {
 	displayLayout:
 		DEFAULT_ATTRIBUTES.displayLayout as ProductCollectionDisplayLayout,
+} );
+
+export const getDefaultSettings = (
+	currentAttributes: ProductCollectionAttributes
+): Partial< ProductCollectionAttributes > => ( {
+	...getDefaultDisplayLayout(),
+	...getDefaultQuery( currentAttributes.query ),
 } );
 
 export const DEFAULT_FILTERS: Partial< ProductCollectionQuery > = {

--- a/assets/js/blocks/product-collection/constants.ts
+++ b/assets/js/blocks/product-collection/constants.ts
@@ -13,6 +13,7 @@ import {
 	TProductCollectionOrderBy,
 	ProductCollectionQuery,
 	ProductCollectionDisplayLayout,
+	DisplayLayoutObject,
 } from './types';
 
 export const STOCK_STATUS_OPTIONS = getSetting< Record< string, string > >(
@@ -64,14 +65,17 @@ export const DEFAULT_ATTRIBUTES: Partial< ProductCollectionAttributes > = {
 export const getDefaultSettings = (
 	currentAttributes: ProductCollectionAttributes
 ): Partial< ProductCollectionAttributes > => ( {
-	displayLayout:
-		DEFAULT_ATTRIBUTES.displayLayout as ProductCollectionDisplayLayout,
 	query: {
 		...currentAttributes.query,
 		orderBy: DEFAULT_QUERY.orderBy as TProductCollectionOrderBy,
 		order: DEFAULT_QUERY.order as TProductCollectionOrder,
 		inherit: DEFAULT_QUERY.inherit,
 	},
+} );
+
+export const getDefaultDisplayLayout = (): DisplayLayoutObject => ( {
+	displayLayout:
+		DEFAULT_ATTRIBUTES.displayLayout as ProductCollectionDisplayLayout,
 } );
 
 export const DEFAULT_FILTERS: Partial< ProductCollectionQuery > = {

--- a/assets/js/blocks/product-collection/inspector-controls/attributes-control.tsx
+++ b/assets/js/blocks/product-collection/inspector-controls/attributes-control.tsx
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import ProductAttributeTermControl from '@woocommerce/editor-components/product-attribute-term-control';
-import { AttributeMetadata } from '@woocommerce/types';
 import { SearchListItem } from '@woocommerce/editor-components/search-list-control/types';
 import { ADMIN_URL } from '@woocommerce/settings';
 import {
@@ -16,19 +15,15 @@ import {
 /**
  * Internal dependencies
  */
-import { ProductCollectionQuery } from '../types';
+import { QueryControlProps } from '../types';
 
 const EDIT_ATTRIBUTES_URL = `${ ADMIN_URL }edit.php?post_type=product&page=product_attributes`;
 
-interface AttributesControlProps {
-	woocommerceAttributes?: AttributeMetadata[];
-	setQueryAttribute: ( value: Partial< ProductCollectionQuery > ) => void;
-}
-
 const AttributesControl = ( {
-	woocommerceAttributes,
+	query,
 	setQueryAttribute,
-}: AttributesControlProps ) => {
+}: QueryControlProps ) => {
+	const woocommerceAttributes = query.woocommerceAttributes || [];
 	const selectedAttributes = woocommerceAttributes?.map(
 		( { termId: id } ) => ( {
 			id,

--- a/assets/js/blocks/product-collection/inspector-controls/author-control.tsx
+++ b/assets/js/blocks/product-collection/inspector-controls/author-control.tsx
@@ -13,7 +13,7 @@ import {
 /**
  * Internal dependencies
  */
-import { ProductCollectionQuery } from '../types';
+import { QueryControlProps } from '../types';
 
 interface Author {
 	id: string;
@@ -25,11 +25,6 @@ interface AuthorsInfo {
 	mapById: Map< number, Author >;
 	mapByName: Map< string, Author >;
 	names: string[];
-}
-
-interface AuthorControlProps {
-	value: string;
-	setQueryAttribute: ( value: Partial< ProductCollectionQuery > ) => void;
 }
 
 const AUTHORS_QUERY = {
@@ -68,7 +63,8 @@ const getIdByValue = (
 	if ( id ) return id;
 };
 
-function AuthorControl( { value, setQueryAttribute }: AuthorControlProps ) {
+function AuthorControl( { query, setQueryAttribute }: QueryControlProps ) {
+	const value = query.author;
 	const { records: authorsList, error } = useEntityRecords< Author[] >(
 		'root',
 		'user',

--- a/assets/js/blocks/product-collection/inspector-controls/columns-control.tsx
+++ b/assets/js/blocks/product-collection/inspector-controls/columns-control.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { BlockEditProps } from '@wordpress/blocks';
 import {
 	RangeControl,
 	// @ts-expect-error Using experimental features
@@ -13,32 +12,26 @@ import {
 /**
  * Internal dependencies
  */
-import {
-	ProductCollectionAttributes,
-	ProductCollectionDisplayLayout,
-} from '../types';
-import { getDefaultSettings } from '../constants';
+import { ColumnsControlProps } from '../types';
+import { getDefaultDisplayLayout } from '../constants';
 
-const ColumnsControl = (
-	props: BlockEditProps< ProductCollectionAttributes >
-) => {
-	const { type, columns } = props.attributes.displayLayout;
+const ColumnsControl = ( props: ColumnsControlProps ) => {
+	const { type, columns } = props.displayLayout;
 	const showColumnsControl = type === 'flex';
 
-	const defaultSettings = getDefaultSettings( props.attributes );
+	const { displayLayout: defaultLayout } = getDefaultDisplayLayout();
 
 	return showColumnsControl ? (
 		<ToolsPanelItem
 			label={ __( 'Columns', 'woo-gutenberg-products-block' ) }
 			hasValue={ () =>
-				defaultSettings.displayLayout?.columns !== columns ||
-				defaultSettings.displayLayout?.type !== type
+				defaultLayout?.columns !== columns ||
+				defaultLayout?.type !== type
 			}
 			isShownByDefault
 			onDeselect={ () => {
 				props.setAttributes( {
-					displayLayout:
-						defaultSettings.displayLayout as ProductCollectionDisplayLayout,
+					displayLayout: defaultLayout,
 				} );
 			} }
 		>
@@ -48,7 +41,7 @@ const ColumnsControl = (
 				onChange={ ( value: number ) =>
 					props.setAttributes( {
 						displayLayout: {
-							...props.attributes.displayLayout,
+							...props.displayLayout,
 							columns: value,
 						},
 					} )

--- a/assets/js/blocks/product-collection/inspector-controls/columns-control.tsx
+++ b/assets/js/blocks/product-collection/inspector-controls/columns-control.tsx
@@ -12,14 +12,14 @@ import {
 /**
  * Internal dependencies
  */
-import { ColumnsControlProps } from '../types';
+import { DisplayLayoutControlProps } from '../types';
 import { getDefaultDisplayLayout } from '../constants';
 
-const ColumnsControl = ( props: ColumnsControlProps ) => {
+const ColumnsControl = ( props: DisplayLayoutControlProps ) => {
 	const { type, columns } = props.displayLayout;
 	const showColumnsControl = type === 'flex';
 
-	const { displayLayout: defaultLayout } = getDefaultDisplayLayout();
+	const defaultLayout = getDefaultDisplayLayout();
 
 	return showColumnsControl ? (
 		<ToolsPanelItem

--- a/assets/js/blocks/product-collection/inspector-controls/display-layout-control.tsx
+++ b/assets/js/blocks/product-collection/inspector-controls/display-layout-control.tsx
@@ -8,15 +8,10 @@ import { list, grid } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import { ProductCollectionDisplayLayout } from '../types';
-
-type DisplayLayoutObject = {
-	displayLayout: ProductCollectionDisplayLayout;
-};
-
-type DisplayLayoutControlProps = DisplayLayoutObject & {
-	setAttributes: ( attrs: DisplayLayoutObject ) => void;
-};
+import {
+	DisplayLayoutControlProps,
+	ProductCollectionDisplayLayout,
+} from '../types';
 
 const DisplayLayoutControl = ( props: DisplayLayoutControlProps ) => {
 	const { type, columns } = props.displayLayout;

--- a/assets/js/blocks/product-collection/inspector-controls/hand-picked-products-control.tsx
+++ b/assets/js/blocks/product-collection/inspector-controls/hand-picked-products-control.tsx
@@ -15,12 +15,7 @@ import {
 /**
  * Internal dependencies
  */
-import { ProductCollectionQuery } from '../types';
-
-interface HandPickedProductsControlProps {
-	setQueryAttribute: ( value: Partial< ProductCollectionQuery > ) => void;
-	selectedProductIds?: string[] | undefined;
-}
+import { QueryControlProps } from '../types';
 
 /**
  * Returns:
@@ -55,9 +50,10 @@ function useProducts() {
 }
 
 const HandPickedProductsControl = ( {
-	selectedProductIds,
+	query,
 	setQueryAttribute,
-}: HandPickedProductsControlProps ) => {
+}: QueryControlProps ) => {
+	const selectedProductIds = query.woocommerceHandPickedProducts;
 	const { productsMap, productsList } = useProducts();
 
 	const onTokenChange = useCallback(

--- a/assets/js/blocks/product-collection/inspector-controls/index.tsx
+++ b/assets/js/blocks/product-collection/inspector-controls/index.tsx
@@ -100,7 +100,10 @@ const ProductCollectionInspectorControls = (
 							query.woocommerceHandPickedProducts
 						}
 					/>
-					<KeywordControl { ...props } />
+					<KeywordControl
+						setAttributes={ props.setAttributes }
+						query={ query }
+					/>
 					<AttributesControl
 						woocommerceAttributes={
 							query.woocommerceAttributes || []

--- a/assets/js/blocks/product-collection/inspector-controls/index.tsx
+++ b/assets/js/blocks/product-collection/inspector-controls/index.tsx
@@ -16,12 +16,12 @@ import {
  * Internal dependencies
  */
 import { ProductCollectionAttributes } from '../types';
+import { setQueryAttribute } from '../utils';
+import { DEFAULT_FILTERS, getDefaultSettings } from '../constants';
 import ColumnsControl from './columns-control';
 import InheritQueryControl from './inherit-query-control';
 import OrderByControl from './order-by-control';
 import OnSaleControl from './on-sale-control';
-import { setQueryAttribute } from '../utils';
-import { DEFAULT_FILTERS, getDefaultSettings } from '../constants';
 import StockStatusControl from './stock-status-control';
 import KeywordControl from './keyword-control';
 import AttributesControl from './attributes-control';

--- a/assets/js/blocks/product-collection/inspector-controls/index.tsx
+++ b/assets/js/blocks/product-collection/inspector-controls/index.tsx
@@ -90,6 +90,10 @@ const ProductCollectionInspectorControls = (
 						setAttributes={ props.setAttributes }
 						query={ query }
 					/>
+					<StockStatusControl
+						setAttributes={ props.setAttributes }
+						query={ query }
+					/>
 					<HandPickedProductsControl
 						setQueryAttribute={ setQueryAttributeBind }
 						selectedProductIds={

--- a/assets/js/blocks/product-collection/inspector-controls/index.tsx
+++ b/assets/js/blocks/product-collection/inspector-controls/index.tsx
@@ -59,7 +59,10 @@ const ProductCollectionInspectorControls = (
 					props.setAttributes( defaultSettings );
 				} }
 			>
-				<ColumnsControl { ...props } />
+				<ColumnsControl
+					displayLayout={ props.attributes.displayLayout }
+					setAttributes={ props.setAttributes }
+				/>
 				<InheritQueryControl
 					setQueryAttribute={ setQueryAttributeBind }
 					query={ query }

--- a/assets/js/blocks/product-collection/inspector-controls/index.tsx
+++ b/assets/js/blocks/product-collection/inspector-controls/index.tsx
@@ -68,7 +68,10 @@ const ProductCollectionInspectorControls = (
 					query={ query }
 				/>
 				{ displayQueryControls ? (
-					<OrderByControl { ...props } />
+					<OrderByControl
+						setAttributes={ props.setAttributes }
+						query={ query }
+					/>
 				) : null }
 			</ToolsPanel>
 

--- a/assets/js/blocks/product-collection/inspector-controls/index.tsx
+++ b/assets/js/blocks/product-collection/inspector-controls/index.tsx
@@ -86,24 +86,11 @@ const ProductCollectionInspectorControls = (
 				>
 					<OnSaleControl { ...queryControlProps } />
 					<StockStatusControl { ...queryControlProps } />
-					<HandPickedProductsControl
-						setQueryAttribute={ setQueryAttributeBind }
-						selectedProductIds={
-							query.woocommerceHandPickedProducts
-						}
-					/>
+					<HandPickedProductsControl { ...queryControlProps } />
 					<KeywordControl { ...queryControlProps } />
-					<AttributesControl
-						woocommerceAttributes={
-							query.woocommerceAttributes || []
-						}
-						setQueryAttribute={ setQueryAttributeBind }
-					/>
+					<AttributesControl { ...queryControlProps } />
 					<TaxonomyControls { ...queryControlProps } />
-					<AuthorControl
-						setQueryAttribute={ setQueryAttributeBind }
-						value={ query.author }
-					/>
+					<AuthorControl { ...queryControlProps } />
 				</ToolsPanel>
 			) : null }
 			<ProductCollectionFeedbackPrompt />

--- a/assets/js/blocks/product-collection/inspector-controls/index.tsx
+++ b/assets/js/blocks/product-collection/inspector-controls/index.tsx
@@ -86,8 +86,10 @@ const ProductCollectionInspectorControls = (
 					} }
 					className="wc-block-editor-product-collection-inspector-toolspanel__filters"
 				>
-					<OnSaleControl { ...props } />
-					<StockStatusControl { ...props } />
+					<OnSaleControl
+						setAttributes={ props.setAttributes }
+						query={ query }
+					/>
 					<HandPickedProductsControl
 						setQueryAttribute={ setQueryAttributeBind }
 						selectedProductIds={

--- a/assets/js/blocks/product-collection/inspector-controls/index.tsx
+++ b/assets/js/blocks/product-collection/inspector-controls/index.tsx
@@ -42,13 +42,20 @@ const ProductCollectionInspectorControls = (
 		[ props ]
 	);
 
+	const displayControlProps = {
+		setAttributes: props.setAttributes,
+		displayLayout: props.attributes.displayLayout,
+	};
+
+	const queryControlProps = {
+		setQueryAttribute: setQueryAttributeBind,
+		query,
+	};
+
 	return (
 		<InspectorControls>
 			<BlockControls>
-				<DisplayLayoutControl
-					displayLayout={ props.attributes.displayLayout }
-					setAttributes={ props.setAttributes }
-				/>
+				<DisplayLayoutControl { ...displayControlProps } />
 			</BlockControls>
 			<ToolsPanel
 				label={ __( 'Settings', 'woo-gutenberg-products-block' ) }
@@ -59,19 +66,10 @@ const ProductCollectionInspectorControls = (
 					props.setAttributes( defaultSettings );
 				} }
 			>
-				<ColumnsControl
-					displayLayout={ props.attributes.displayLayout }
-					setAttributes={ props.setAttributes }
-				/>
-				<InheritQueryControl
-					setQueryAttribute={ setQueryAttributeBind }
-					query={ query }
-				/>
+				<ColumnsControl { ...displayControlProps } />
+				<InheritQueryControl { ...queryControlProps } />
 				{ displayQueryControls ? (
-					<OrderByControl
-						setAttributes={ props.setAttributes }
-						query={ query }
-					/>
+					<OrderByControl { ...queryControlProps } />
 				) : null }
 			</ToolsPanel>
 
@@ -86,37 +84,25 @@ const ProductCollectionInspectorControls = (
 					} }
 					className="wc-block-editor-product-collection-inspector-toolspanel__filters"
 				>
-					<OnSaleControl
-						setAttributes={ props.setAttributes }
-						query={ query }
-					/>
-					<StockStatusControl
-						setAttributes={ props.setAttributes }
-						query={ query }
-					/>
+					<OnSaleControl { ...queryControlProps } />
+					<StockStatusControl { ...queryControlProps } />
 					<HandPickedProductsControl
 						setQueryAttribute={ setQueryAttributeBind }
 						selectedProductIds={
 							query.woocommerceHandPickedProducts
 						}
 					/>
-					<KeywordControl
-						setAttributes={ props.setAttributes }
-						query={ query }
-					/>
+					<KeywordControl { ...queryControlProps } />
 					<AttributesControl
 						woocommerceAttributes={
 							query.woocommerceAttributes || []
 						}
 						setQueryAttribute={ setQueryAttributeBind }
 					/>
-					<TaxonomyControls
-						setQueryAttribute={ setQueryAttributeBind }
-						query={ query }
-					/>
+					<TaxonomyControls { ...queryControlProps } />
 					<AuthorControl
-						value={ query.author }
 						setQueryAttribute={ setQueryAttributeBind }
+						value={ query.author }
 					/>
 				</ToolsPanel>
 			) : null }

--- a/assets/js/blocks/product-collection/inspector-controls/keyword-control.tsx
+++ b/assets/js/blocks/product-collection/inspector-controls/keyword-control.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { BlockEditProps } from '@wordpress/blocks';
 import { useEffect, useState } from '@wordpress/element';
 import { useDebounce } from '@wordpress/compose';
 import {
@@ -15,18 +14,20 @@ import {
 /**
  * Internal dependencies
  */
-import { ProductCollectionAttributes } from '../types';
-import { setQueryAttribute } from '../utils';
+import { KeywordControlProps } from '../types';
 
-const KeywordControl = (
-	props: BlockEditProps< ProductCollectionAttributes >
-) => {
-	const { query } = props.attributes;
+const KeywordControl = ( props: KeywordControlProps ) => {
+	const { query, setAttributes } = props;
 	const [ querySearch, setQuerySearch ] = useState( query.search );
 
 	const onChangeDebounced = useDebounce( () => {
 		if ( query.search !== querySearch ) {
-			setQueryAttribute( props, { search: querySearch } );
+			setAttributes( {
+				query: {
+					...query,
+					search: querySearch,
+				},
+			} );
 		}
 	}, 250 );
 

--- a/assets/js/blocks/product-collection/inspector-controls/keyword-control.tsx
+++ b/assets/js/blocks/product-collection/inspector-controls/keyword-control.tsx
@@ -14,9 +14,9 @@ import {
 /**
  * Internal dependencies
  */
-import { KeywordControlProps } from '../types';
+import { QueryControlProps } from '../types';
 
-const KeywordControl = ( props: KeywordControlProps ) => {
+const KeywordControl = ( props: QueryControlProps ) => {
 	const { query, setAttributes } = props;
 	const [ querySearch, setQuerySearch ] = useState( query.search );
 

--- a/assets/js/blocks/product-collection/inspector-controls/keyword-control.tsx
+++ b/assets/js/blocks/product-collection/inspector-controls/keyword-control.tsx
@@ -17,16 +17,13 @@ import {
 import { QueryControlProps } from '../types';
 
 const KeywordControl = ( props: QueryControlProps ) => {
-	const { query, setAttributes } = props;
+	const { query, setQueryAttribute } = props;
 	const [ querySearch, setQuerySearch ] = useState( query.search );
 
 	const onChangeDebounced = useDebounce( () => {
 		if ( query.search !== querySearch ) {
-			setAttributes( {
-				query: {
-					...query,
-					search: querySearch,
-				},
+			setQueryAttribute( {
+				search: querySearch,
 			} );
 		}
 	}, 250 );

--- a/assets/js/blocks/product-collection/inspector-controls/on-sale-control.tsx
+++ b/assets/js/blocks/product-collection/inspector-controls/on-sale-control.tsx
@@ -12,9 +12,9 @@ import {
 /**
  * Internal dependencies
  */
-import { OnSaleControlProps } from '../types';
+import { QueryControlProps } from '../types';
 
-const OnSaleControl = ( props: OnSaleControlProps ) => {
+const OnSaleControl = ( props: QueryControlProps ) => {
 	const { query, setAttributes } = props;
 
 	return (

--- a/assets/js/blocks/product-collection/inspector-controls/on-sale-control.tsx
+++ b/assets/js/blocks/product-collection/inspector-controls/on-sale-control.tsx
@@ -15,7 +15,7 @@ import {
 import { QueryControlProps } from '../types';
 
 const OnSaleControl = ( props: QueryControlProps ) => {
-	const { query, setAttributes } = props;
+	const { query, setQueryAttribute } = props;
 
 	return (
 		<ToolsPanelItem
@@ -23,11 +23,8 @@ const OnSaleControl = ( props: QueryControlProps ) => {
 			hasValue={ () => query.woocommerceOnSale === true }
 			isShownByDefault
 			onDeselect={ () => {
-				setAttributes( {
-					query: {
-						...query,
-						woocommerceOnSale: false,
-					},
+				setQueryAttribute( {
+					woocommerceOnSale: false,
 				} );
 			} }
 		>
@@ -38,11 +35,8 @@ const OnSaleControl = ( props: QueryControlProps ) => {
 				) }
 				checked={ query.woocommerceOnSale || false }
 				onChange={ ( woocommerceOnSale ) => {
-					setAttributes( {
-						query: {
-							...query,
-							woocommerceOnSale,
-						},
+					setQueryAttribute( {
+						woocommerceOnSale,
 					} );
 				} }
 			/>

--- a/assets/js/blocks/product-collection/inspector-controls/on-sale-control.tsx
+++ b/assets/js/blocks/product-collection/inspector-controls/on-sale-control.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { BlockEditProps } from '@wordpress/blocks';
 import {
 	ToggleControl,
 	// @ts-expect-error Using experimental features
@@ -13,13 +12,10 @@ import {
 /**
  * Internal dependencies
  */
-import { ProductCollectionAttributes } from '../types';
-import { setQueryAttribute } from '../utils';
+import { OnSaleControlProps } from '../types';
 
-const OnSaleControl = (
-	props: BlockEditProps< ProductCollectionAttributes >
-) => {
-	const { query } = props.attributes;
+const OnSaleControl = ( props: OnSaleControlProps ) => {
+	const { query, setAttributes } = props;
 
 	return (
 		<ToolsPanelItem
@@ -27,8 +23,11 @@ const OnSaleControl = (
 			hasValue={ () => query.woocommerceOnSale === true }
 			isShownByDefault
 			onDeselect={ () => {
-				setQueryAttribute( props, {
-					woocommerceOnSale: false,
+				setAttributes( {
+					query: {
+						...query,
+						woocommerceOnSale: false,
+					},
 				} );
 			} }
 		>
@@ -39,8 +38,11 @@ const OnSaleControl = (
 				) }
 				checked={ query.woocommerceOnSale || false }
 				onChange={ ( woocommerceOnSale ) => {
-					setQueryAttribute( props, {
-						woocommerceOnSale,
+					setAttributes( {
+						query: {
+							...query,
+							woocommerceOnSale,
+						},
 					} );
 				} }
 			/>

--- a/assets/js/blocks/product-collection/inspector-controls/order-by-control.tsx
+++ b/assets/js/blocks/product-collection/inspector-controls/order-by-control.tsx
@@ -47,8 +47,9 @@ const orderOptions = [
 ];
 
 const OrderByControl = ( props: QueryControlProps ) => {
-	const { order, orderBy } = props.query;
-	const { query: defaultQuery } = getDefaultQuery( props.query );
+	const { query, setQueryAttribute } = props;
+	const { order, orderBy } = query;
+	const { query: defaultQuery } = getDefaultQuery( query );
 
 	return (
 		<ToolsPanelItem
@@ -59,12 +60,7 @@ const OrderByControl = ( props: QueryControlProps ) => {
 			}
 			isShownByDefault
 			onDeselect={ () => {
-				props.setAttributes( {
-					query: {
-						...props.query,
-						...defaultQuery,
-					},
-				} );
+				setQueryAttribute( defaultQuery );
 			} }
 		>
 			<SelectControl
@@ -73,12 +69,9 @@ const OrderByControl = ( props: QueryControlProps ) => {
 				label={ __( 'Order by', 'woo-gutenberg-products-block' ) }
 				onChange={ ( value ) => {
 					const [ newOrderBy, newOrder ] = value.split( '/' );
-					props.setAttributes( {
-						query: {
-							...props.query,
-							order: newOrder as TProductCollectionOrder,
-							orderBy: newOrderBy as TProductCollectionOrderBy,
-						},
+					setQueryAttribute( {
+						order: newOrder as TProductCollectionOrder,
+						orderBy: newOrderBy as TProductCollectionOrderBy,
 					} );
 				} }
 			/>

--- a/assets/js/blocks/product-collection/inspector-controls/order-by-control.tsx
+++ b/assets/js/blocks/product-collection/inspector-controls/order-by-control.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { BlockEditProps } from '@wordpress/blocks';
 import {
 	SelectControl,
 	// @ts-expect-error Using experimental features
@@ -14,11 +13,11 @@ import {
  * Internal dependencies
  */
 import {
-	ProductCollectionAttributes,
 	TProductCollectionOrder,
 	TProductCollectionOrderBy,
+	OrderByControlProps,
 } from '../types';
-import { getDefaultSettings } from '../constants';
+import { getDefaultQuery } from '../constants';
 
 const orderOptions = [
 	{
@@ -47,25 +46,23 @@ const orderOptions = [
 	},
 ];
 
-const OrderByControl = (
-	props: BlockEditProps< ProductCollectionAttributes >
-) => {
-	const { order, orderBy } = props.attributes.query;
-	const defaultSettings = getDefaultSettings( props.attributes );
+const OrderByControl = ( props: OrderByControlProps ) => {
+	const { order, orderBy } = props.query;
+	const { query: defaultQuery } = getDefaultQuery( props.query );
 
 	return (
 		<ToolsPanelItem
 			label={ __( 'Order by', 'woo-gutenberg-products-block' ) }
 			hasValue={ () =>
-				order !== defaultSettings.query?.order ||
-				orderBy !== defaultSettings.query?.orderBy
+				order !== defaultQuery?.order ||
+				orderBy !== defaultQuery?.orderBy
 			}
 			isShownByDefault
 			onDeselect={ () => {
 				props.setAttributes( {
 					query: {
-						...props.attributes.query,
-						...defaultSettings.query,
+						...props.query,
+						...defaultQuery,
 					},
 				} );
 			} }
@@ -78,7 +75,7 @@ const OrderByControl = (
 					const [ newOrderBy, newOrder ] = value.split( '/' );
 					props.setAttributes( {
 						query: {
-							...props.attributes.query,
+							...props.query,
 							order: newOrder as TProductCollectionOrder,
 							orderBy: newOrderBy as TProductCollectionOrderBy,
 						},

--- a/assets/js/blocks/product-collection/inspector-controls/order-by-control.tsx
+++ b/assets/js/blocks/product-collection/inspector-controls/order-by-control.tsx
@@ -15,7 +15,7 @@ import {
 import {
 	TProductCollectionOrder,
 	TProductCollectionOrderBy,
-	OrderByControlProps,
+	QueryControlProps,
 } from '../types';
 import { getDefaultQuery } from '../constants';
 
@@ -46,7 +46,7 @@ const orderOptions = [
 	},
 ];
 
-const OrderByControl = ( props: OrderByControlProps ) => {
+const OrderByControl = ( props: QueryControlProps ) => {
 	const { order, orderBy } = props.query;
 	const { query: defaultQuery } = getDefaultQuery( props.query );
 

--- a/assets/js/blocks/product-collection/inspector-controls/order-by-control.tsx
+++ b/assets/js/blocks/product-collection/inspector-controls/order-by-control.tsx
@@ -49,7 +49,7 @@ const orderOptions = [
 const OrderByControl = ( props: QueryControlProps ) => {
 	const { query, setQueryAttribute } = props;
 	const { order, orderBy } = query;
-	const { query: defaultQuery } = getDefaultQuery( query );
+	const defaultQuery = getDefaultQuery( query );
 
 	return (
 		<ToolsPanelItem

--- a/assets/js/blocks/product-collection/inspector-controls/stock-status-control.tsx
+++ b/assets/js/blocks/product-collection/inspector-controls/stock-status-control.tsx
@@ -34,7 +34,7 @@ function getStockStatusIdByLabel( statusLabel: FormTokenField.Value ) {
 }
 
 const StockStatusControl = ( props: QueryControlProps ) => {
-	const { query, setAttributes } = props;
+	const { query, setQueryAttribute } = props;
 
 	return (
 		<ToolsPanelItem
@@ -46,11 +46,8 @@ const StockStatusControl = ( props: QueryControlProps ) => {
 				)
 			}
 			onDeselect={ () => {
-				setAttributes( {
-					query: {
-						...query,
-						woocommerceStockStatus: getDefaultStockStatuses(),
-					},
+				setQueryAttribute( {
+					woocommerceStockStatus: getDefaultStockStatuses(),
 				} );
 			} }
 			isShownByDefault
@@ -62,11 +59,8 @@ const StockStatusControl = ( props: QueryControlProps ) => {
 						.map( getStockStatusIdByLabel )
 						.filter( Boolean ) as string[];
 
-					setAttributes( {
-						query: {
-							...query,
-							woocommerceStockStatus,
-						},
+					setQueryAttribute( {
+						woocommerceStockStatus,
 					} );
 				} }
 				suggestions={ Object.values( STOCK_STATUS_OPTIONS ) }

--- a/assets/js/blocks/product-collection/inspector-controls/stock-status-control.tsx
+++ b/assets/js/blocks/product-collection/inspector-controls/stock-status-control.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { BlockEditProps } from '@wordpress/blocks';
 import fastDeepEqual from 'fast-deep-equal/es6';
 import {
 	FormTokenField,
@@ -14,8 +13,7 @@ import {
 /**
  * Internal dependencies
  */
-import { ProductCollectionAttributes } from '../types';
-import { setQueryAttribute } from '../utils';
+import { StockStatusControlProps } from '../types';
 import { STOCK_STATUS_OPTIONS, getDefaultStockStatuses } from '../constants';
 
 /**
@@ -35,10 +33,9 @@ function getStockStatusIdByLabel( statusLabel: FormTokenField.Value ) {
 	)?.[ 0 ];
 }
 
-const StockStatusControl = (
-	props: BlockEditProps< ProductCollectionAttributes >
-) => {
-	const { query } = props.attributes;
+const StockStatusControl = ( props: StockStatusControlProps ) => {
+	const { query, setAttributes } = props;
+
 	return (
 		<ToolsPanelItem
 			label={ __( 'Stock status', 'woo-gutenberg-products-block' ) }
@@ -49,8 +46,11 @@ const StockStatusControl = (
 				)
 			}
 			onDeselect={ () => {
-				setQueryAttribute( props, {
-					woocommerceStockStatus: getDefaultStockStatuses(),
+				setAttributes( {
+					query: {
+						...query,
+						woocommerceStockStatus: getDefaultStockStatuses(),
+					},
 				} );
 			} }
 			isShownByDefault
@@ -62,8 +62,11 @@ const StockStatusControl = (
 						.map( getStockStatusIdByLabel )
 						.filter( Boolean ) as string[];
 
-					setQueryAttribute( props, {
-						woocommerceStockStatus,
+					setAttributes( {
+						query: {
+							...query,
+							woocommerceStockStatus,
+						},
 					} );
 				} }
 				suggestions={ Object.values( STOCK_STATUS_OPTIONS ) }

--- a/assets/js/blocks/product-collection/inspector-controls/stock-status-control.tsx
+++ b/assets/js/blocks/product-collection/inspector-controls/stock-status-control.tsx
@@ -13,7 +13,7 @@ import {
 /**
  * Internal dependencies
  */
-import { StockStatusControlProps } from '../types';
+import { QueryControlProps } from '../types';
 import { STOCK_STATUS_OPTIONS, getDefaultStockStatuses } from '../constants';
 
 /**
@@ -33,7 +33,7 @@ function getStockStatusIdByLabel( statusLabel: FormTokenField.Value ) {
 	)?.[ 0 ];
 }
 
-const StockStatusControl = ( props: StockStatusControlProps ) => {
+const StockStatusControl = ( props: QueryControlProps ) => {
 	const { query, setAttributes } = props;
 
 	return (

--- a/assets/js/blocks/product-collection/types.ts
+++ b/assets/js/blocks/product-collection/types.ts
@@ -66,9 +66,14 @@ export type DisplayLayoutObject = {
 	displayLayout: ProductCollectionDisplayLayout;
 };
 
+export type QueryObject = {
+	query: ProductCollectionQuery;
+};
+
 export type SetAttributes = {
 	setAttributes: ( attrs: Partial< ProductCollectionAttributes > ) => void;
 };
 
 export type DisplayLayoutControlProps = DisplayLayoutObject & SetAttributes;
 export type ColumnsControlProps = DisplayLayoutObject & SetAttributes;
+export type OrderByControlProps = QueryObject & SetAttributes;

--- a/assets/js/blocks/product-collection/types.ts
+++ b/assets/js/blocks/product-collection/types.ts
@@ -75,8 +75,4 @@ export type SetAttributes = {
 };
 
 export type DisplayLayoutControlProps = DisplayLayoutObject & SetAttributes;
-export type ColumnsControlProps = DisplayLayoutObject & SetAttributes;
-export type OrderByControlProps = QueryObject & SetAttributes;
-export type OnSaleControlProps = QueryObject & SetAttributes;
-export type StockStatusControlProps = QueryObject & SetAttributes;
-export type KeywordControlProps = QueryObject & SetAttributes;
+export type QueryControlProps = QueryObject & SetAttributes;

--- a/assets/js/blocks/product-collection/types.ts
+++ b/assets/js/blocks/product-collection/types.ts
@@ -61,3 +61,14 @@ export type TProductCollectionOrderBy =
 	| 'title'
 	| 'popularity'
 	| 'rating';
+
+export type DisplayLayoutObject = {
+	displayLayout: ProductCollectionDisplayLayout;
+};
+
+export type SetAttributes = {
+	setAttributes: ( attrs: Partial< ProductCollectionAttributes > ) => void;
+};
+
+export type DisplayLayoutControlProps = DisplayLayoutObject & SetAttributes;
+export type ColumnsControlProps = DisplayLayoutObject & SetAttributes;

--- a/assets/js/blocks/product-collection/types.ts
+++ b/assets/js/blocks/product-collection/types.ts
@@ -74,5 +74,9 @@ export type SetAttributes = {
 	setAttributes: ( attrs: Partial< ProductCollectionAttributes > ) => void;
 };
 
+export type SetQueryAttributes = {
+	setQueryAttribute: ( attrs: Partial< ProductCollectionQuery > ) => void;
+};
+
 export type DisplayLayoutControlProps = DisplayLayoutObject & SetAttributes;
-export type QueryControlProps = QueryObject & SetAttributes;
+export type QueryControlProps = QueryObject & SetQueryAttributes;

--- a/assets/js/blocks/product-collection/types.ts
+++ b/assets/js/blocks/product-collection/types.ts
@@ -62,21 +62,11 @@ export type TProductCollectionOrderBy =
 	| 'popularity'
 	| 'rating';
 
-export type DisplayLayoutObject = {
+export type DisplayLayoutControlProps = {
 	displayLayout: ProductCollectionDisplayLayout;
-};
-
-export type QueryObject = {
-	query: ProductCollectionQuery;
-};
-
-export type SetAttributes = {
 	setAttributes: ( attrs: Partial< ProductCollectionAttributes > ) => void;
 };
-
-export type SetQueryAttributes = {
+export type QueryControlProps = {
+	query: ProductCollectionQuery;
 	setQueryAttribute: ( attrs: Partial< ProductCollectionQuery > ) => void;
 };
-
-export type DisplayLayoutControlProps = DisplayLayoutObject & SetAttributes;
-export type QueryControlProps = QueryObject & SetQueryAttributes;

--- a/assets/js/blocks/product-collection/types.ts
+++ b/assets/js/blocks/product-collection/types.ts
@@ -78,3 +78,5 @@ export type DisplayLayoutControlProps = DisplayLayoutObject & SetAttributes;
 export type ColumnsControlProps = DisplayLayoutObject & SetAttributes;
 export type OrderByControlProps = QueryObject & SetAttributes;
 export type OnSaleControlProps = QueryObject & SetAttributes;
+export type StockStatusControlProps = QueryObject & SetAttributes;
+export type KeywordControlProps = QueryObject & SetAttributes;

--- a/assets/js/blocks/product-collection/types.ts
+++ b/assets/js/blocks/product-collection/types.ts
@@ -77,3 +77,4 @@ export type SetAttributes = {
 export type DisplayLayoutControlProps = DisplayLayoutObject & SetAttributes;
 export type ColumnsControlProps = DisplayLayoutObject & SetAttributes;
 export type OrderByControlProps = QueryObject & SetAttributes;
+export type OnSaleControlProps = QueryObject & SetAttributes;


### PR DESCRIPTION
This PR is a result of a code review comment ([here](https://github.com/woocommerce/woocommerce-blocks/pull/10145#discussion_r1257783990)), to avoid passing all `props` to each of the Inspector Controls of Product Collection.

This PR:
- divides Inspector Controls into two types: those controlling Query and those controlling Display Layout
- unifies the props passed to each of the types (and related types)
- unifies the way query attributes are set (previously there were three ways)

I decided to unify the props passed to Query Controls in the form of `query` object to improve the readability. If you think it's better to pass very specific query attributes to each of them, please raise that in code review.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Go to Editor
2. Add Product Collection block
3. Disable "Inherit query from template" option
4. Change the filters and make sure there's an expected outcome:
    - change "Columns" - layout changes
    - change "Order By" - Expected: ordering changes
    - enable/disable "Show only products on sale" - Expected: shows only products on sale
    - change "Stock Status" - for example remove "In Stock" - Expected: only "On Backorder" and "Out of Stock" products are shown (it's possible "No results found" will be displayed"). Bring "In Stock" back
    - choose some products in "PICK SOME PRODUCTS" - Expected: Only these products should show up (keep in mind other filters are still applied to you may want to disable them before)
    - choose some "Keyword" e.g. "Hoodie" - Expected: Only hoodies are displayed
    - choose some "Attributes" e.g. Color: "Red" - Expected: Only products with red option are displayed
    - choose some "Product Categories" e.g. "Tshirts" - Expected: Only t-shirts are displayed
    - choose some "Product Tags" (you may need to create some tags if you don't use them already) - Expected: Only products assigned to the tag are displayed
    - choose some "Authors" (you may need to create new user and create product as one) - Expected: Only products created by the author are displayed

⚠️ Note: makes sense to merge this AFTER https://github.com/woocommerce/woocommerce-blocks/pull/10090 where E2E tests related to multiple Inspector Controls were added!

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental
