### PR TITLE
Revert "Fix image over content (#10092)"

### DIFF
--- a/assets/js/atomic/blocks/product-elements/image/style.scss
+++ b/assets/js/atomic/blocks/product-elements/image/style.scss
@@ -2,6 +2,7 @@
 .wc-block-components-product-image {
 	text-decoration: none;
 	display: block;
+	position: relative;
 
 	a {
 		border-radius: inherit;


### PR DESCRIPTION
This reverts commit 87b3f9556bb077182e300799fd4b7065547c28a4.

This PR reverts #10092. We noticed that #10092 introduces a regression on the sale badge that isn't anchored in the image but rendered on the top right of the page.


<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->


### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|![image](https://github.com/woocommerce/woocommerce-blocks/assets/4463174/efbcb0eb-320d-48ac-b075-5d822fc384ca)|![image](https://github.com/woocommerce/woocommerce-blocks/assets/4463174/d0d6738e-34a1-4d0f-af6d-3052bd3bc61b)|

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Ensure that you have the blockified Single Product Template.
2. Open the Benie product page.
3. Ensure that the sale badge is in the right position

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->
