### PR TITLE
Product Collection - check the value before consuming it to avoid frontend warning

### DIFF
--- a/src/BlockTypes/ProductCollection.php
+++ b/src/BlockTypes/ProductCollection.php
@@ -174,7 +174,7 @@ class ProductCollection extends AbstractBlock {
 
 		$block_context_query = $block->context['query'];
 		// phpcs:ignore WordPress.DB.SlowDBQuery
-		$block_context_query['tax_query'] = $query['tax_query'];
+		$block_context_query['tax_query'] = ! empty( $query['tax_query'] ) ? $query['tax_query'] : array();
 
 		return $this->get_final_frontend_query( $block_context_query, $page );
 	}


### PR DESCRIPTION
Check if value exists before consuming it in Product Collection block as it resulted in warning on the frontend:

![image](https://github.com/woocommerce/woocommerce-blocks/assets/20098064/5b8af7e4-1cfc-4fa8-8028-417f5e842ead)

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Create new post
2. Add Product Collection block
3. Save and go to frontend
4. Expected: There's no warning rendered on the page

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental
