### PR TITLE
Enable declaration-block-no-duplicate-properties stylelint rule

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -4,7 +4,6 @@
 		"at-rule-empty-line-before": null,
 		"at-rule-no-unknown": null,
 		"comment-empty-line-before": null,
-		"declaration-block-no-duplicate-properties": null,
 		"font-weight-notation": null,
 		"max-line-length": null,
 		"no-descending-specificity": null,

--- a/assets/css/abstracts/_mixins.scss
+++ b/assets/css/abstracts/_mixins.scss
@@ -92,7 +92,6 @@ $fontSizes: (
 	word-wrap: normal !important;
 	padding: 0;
 	position: absolute !important;
-	width: 1px;
 }
 
 @mixin visually-hidden-focus-reveal() {

--- a/assets/js/base/components/price-slider/style.scss
+++ b/assets/js/base/components/price-slider/style.scss
@@ -169,7 +169,6 @@
 	width: 100%;
 	height: 0;
 	display: block;
-	position: relative;
 	pointer-events: none;
 	outline: none !important;
 	position: absolute;
@@ -366,7 +365,6 @@
 	@include ie11() {
 		.wc-block-components-price-slider__range-input-wrapper {
 			border: 0;
-			height: auto;
 			position: relative;
 			height: 50px;
 		}

--- a/assets/js/base/components/snackbar-list/style.scss
+++ b/assets/js/base/components/snackbar-list/style.scss
@@ -14,7 +14,6 @@
 		display: inline-flex;
 		width: auto;
 		max-width: 600px;
-		margin: 0;
 		pointer-events: all;
 		border: 1px solid transparent;
 		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);

--- a/assets/js/blocks/active-filters/style.scss
+++ b/assets/js/blocks/active-filters/style.scss
@@ -160,7 +160,6 @@
 		height: 16px;
 		width: 16px;
 		line-height: 16px;
-		padding: 0;
 		margin: 0 0.5em 0 0;
 		color: currentColor;
 

--- a/assets/js/blocks/product-categories/style.scss
+++ b/assets/js/blocks/product-categories/style.scss
@@ -31,7 +31,6 @@
 		margin: 0;
 		margin-right: 0.5em;
 		margin-left: -60px;
-		position: relative;
 		vertical-align: middle;
 		border: 1px solid #eee;
 

--- a/assets/js/editor-components/tag/style.scss
+++ b/assets/js/editor-components/tag/style.scss
@@ -29,7 +29,6 @@
 
 	.woocommerce-tag__remove {
 		cursor: pointer;
-		height: inherit;
 		padding: 0 2px;
 		border-radius: 0 12px 12px 0;
 		color: $gray-700;


### PR DESCRIPTION
This PR enables the  `declaration-block-no-duplicate-properties` rule. In this way, we can catch easily when the same property has multiple declarations.

Kudos to @erikyo (a member of the WP Italian community) for catching this!


#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Ensure that the job about the CSS lint is green.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
