### PR TITLE
Add global styles for order confirmation status block

### DIFF
--- a/assets/js/blocks/order-confirmation/status/block.json
+++ b/assets/js/blocks/order-confirmation/status/block.json
@@ -18,7 +18,6 @@
 			"__experimentalFontWeight": true,
 			"__experimentalLetterSpacing": true,
 			"__experimentalTextTransform": true,
-			"__experimentalWritingMode": true,
 			"__experimentalDefaultControls": {
 				"fontSize": true
 			}

--- a/assets/js/blocks/order-confirmation/status/block.json
+++ b/assets/js/blocks/order-confirmation/status/block.json
@@ -7,7 +7,38 @@
 	"keywords": [ "WooCommerce" ],
 	"supports": {
 		"multiple": false,
-		"align": [ "wide", "full" ]
+		"align": [ "wide", "full" ],
+		"html": false,
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalFontStyle": true,
+			"__experimentalFontWeight": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalTextTransform": true,
+			"__experimentalWritingMode": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
+		},
+		"color": {
+			"background": true,
+			"text": true,
+			"__experimentalDefaultControls": {
+				"background": true,
+				"text": true
+			}
+		},
+		"spacing": {
+			"padding": true,
+			"margin": true,
+			"__experimentalDefaultControls": {
+				"margin": false,
+				"padding": false
+			}
+		}
 	},
 	"attributes": {
 		"align": {

--- a/assets/js/blocks/order-confirmation/status/edit.tsx
+++ b/assets/js/blocks/order-confirmation/status/edit.tsx
@@ -16,7 +16,7 @@ const Edit = (): JSX.Element => {
 
 	return (
 		<div { ...blockProps }>
-			<p className="woocommerce-thankyou-order-received">
+			<p>
 				{ __(
 					'Thank you. Your order has been received.',
 					'woo-gutenberg-products-block'

--- a/assets/js/blocks/order-confirmation/status/style.scss
+++ b/assets/js/blocks/order-confirmation/status/style.scss
@@ -1,7 +1,16 @@
 .wc-block-order-confirmation-status {
 	margin: $gap 0;
 	p {
-		@include font-size(large);
 		margin: 0;
+	}
+	.wc-block-order-confirmation-status__actions {
+		margin-top: $gap;
+
+		a {
+			margin-right: $gap;
+		}
+		a.has-link-color {
+			color: inherit;
+		}
 	}
 }

--- a/src/BlockTypes/OrderConfirmation/Status.php
+++ b/src/BlockTypes/OrderConfirmation/Status.php
@@ -36,9 +36,10 @@ class Status extends AbstractOrderConfirmationBlock {
 		}
 
 		return sprintf(
-			'<div class="wc-block-%4$s %1$s %2$s">%3$s</div>',
+			'<div class="wc-block-%5$s %1$s %2$s" style="%3$s">%4$s</div>',
 			esc_attr( $classes_and_styles['classes'] ),
 			esc_attr( $classname ),
+			esc_attr( $classes_and_styles['styles'] ),
 			$content,
 			esc_attr( $this->block_name )
 		);
@@ -57,7 +58,7 @@ class Status extends AbstractOrderConfirmationBlock {
 		// Unlike the core handling, this includes some extra messaging for completed orders to the text is appropriate for other order statuses.
 		switch ( $status ) {
 			case 'cancelled':
-				$content .= '<p class="woocommerce-thankyou-order-received">' . wp_kses_post(
+				$content .= '<p>' . wp_kses_post(
 						// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 					apply_filters(
 						'woocommerce_thankyou_order_received_text',
@@ -67,7 +68,7 @@ class Status extends AbstractOrderConfirmationBlock {
 				) . '</p>';
 				break;
 			case 'refunded':
-					$content .= '<p class="woocommerce-thankyou-order-received">' . wp_kses_post(
+					$content .= '<p>' . wp_kses_post(
 						sprintf(
 							// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 							apply_filters(
@@ -81,16 +82,12 @@ class Status extends AbstractOrderConfirmationBlock {
 					) . '</p>';
 				break;
 			case 'completed':
-				$content .= '<p class="woocommerce-thankyou-order-received">' . wp_kses_post(
-					sprintf(
-						// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
-						apply_filters(
-							'woocommerce_thankyou_order_received_text',
-							// translators: %s: date and time of the order completion.
-							esc_html__( 'Your order has been processed and was marked complete %s.', 'woo-gutenberg-products-block' ),
-							$order
-						),
-						wc_format_datetime( $order->get_date_completed() )
+				$content .= '<p>' . wp_kses_post(
+					// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+					apply_filters(
+						'woocommerce_thankyou_order_received_text',
+						esc_html__( 'Thank you. Your order has been fulfilled.', 'woo-gutenberg-products-block' ),
+						$order
 					)
 				) . '</p>';
 				break;
@@ -100,18 +97,18 @@ class Status extends AbstractOrderConfirmationBlock {
 				$actions             = '';
 
 				if ( $this->is_current_customer_order( $order ) ) {
-					$actions .= '<a href="' . esc_url( $order->get_checkout_payment_url() ) . '" class="button pay">' . esc_html__( 'Try again', 'woo-gutenberg-products-block' ) . '</a> ';
+					$actions .= '<a href="' . esc_url( $order->get_checkout_payment_url() ) . '" class="button">' . esc_html__( 'Try again', 'woo-gutenberg-products-block' ) . '</a> ';
 				}
 
-				$actions .= '<a href="' . esc_url( wc_get_page_permalink( 'myaccount' ) ) . '" class="button pay">' . esc_html_e( 'My account', 'woo-gutenberg-products-block' ) . '</a> ';
+				$actions .= '<a href="' . esc_url( wc_get_page_permalink( 'myaccount' ) ) . '" class="button">' . esc_html__( 'My account', 'woo-gutenberg-products-block' ) . '</a> ';
 
 				$content .= '
-				<p class="woocommerce-thankyou-order-failed">' . $order_received_text . '</p>
-				<p class="woocommerce-thankyou-order-failed-actions">' . $actions . '</p>
+				<p>' . $order_received_text . '</p>
+				<p class="wc-block-order-confirmation-status__actions">' . $actions . '</p>
 			';
 				break;
 			default:
-				$content .= '<p class="woocommerce-thankyou-order-received">' . wp_kses_post(
+				$content .= '<p>' . wp_kses_post(
 					// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 					apply_filters(
 						'woocommerce_thankyou_order_received_text',

--- a/src/Utils/StyleAttributesUtils.php
+++ b/src/Utils/StyleAttributesUtils.php
@@ -437,13 +437,13 @@ class StyleAttributesUtils {
 		if ( ! empty( $index_named_link_color ) ) {
 			$parsed_named_link_color = substr( $link_color, $index_named_link_color + 1 );
 			return array(
-				'class' => null,
+				'class' => 'has-link-color',
 				'style' => sprintf( 'color: %s;', self::get_preset_value( $parsed_named_link_color ) ),
 				'value' => self::get_preset_value( $parsed_named_link_color ),
 			);
 		} else {
 			return array(
-				'class' => null,
+				'class' => 'has-link-color',
 				'style' => sprintf( 'color: %s;', $link_color ),
 				'value' => $link_color,
 			);
@@ -659,7 +659,11 @@ class StyleAttributesUtils {
 			function( $item ) {
 				return $item['style'];
 			},
-			$classes_and_styles
+			// Exclude link color styles from parent to avoid conflict with text color.
+			array_diff_key(
+				$classes_and_styles,
+				array_flip( array( 'link_color' ) )
+			)
 		);
 
 		$classes = array_filter( $classes );


### PR DESCRIPTION
Adds styles for the status block. This also removes legacy classnames so the new styles can apply without conflicts.

Fixes #10117

### Screenshots

![Screenshot 2023-07-11 at 13 06 20](https://github.com/woocommerce/woocommerce-blocks/assets/90977/e97fa8f4-1dea-4908-a2e4-39159c891e87)
![Screenshot 2023-07-11 at 13 06 14](https://github.com/woocommerce/woocommerce-blocks/assets/90977/60a1bf0a-b35c-4fe6-8109-03ed44337df6)

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. Go to Appearance > Editor > Templates > Order Confirmation
2. Select the "status" block
3. In the inspector, adjust styles (color, type, padding) and save
4. Go to the frontend and place a new order
5. Confirm the confirmation page matches your selected styling

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental