### PR TITLE
Mini Cart block > Update block registration to rely on a metadata file.

### DIFF
--- a/assets/js/blocks/mini-cart/block.json
+++ b/assets/js/blocks/mini-cart/block.json
@@ -1,0 +1,70 @@
+{
+	"name": "woocommerce/mini-cart",
+	"version": "1.0.0",
+	"title": "Mini-Cart",
+	"icon": "miniCartAlt",
+	"description": "Display a button for shoppers to quickly view their cart.",
+	"category": "woocommerce",
+	"keywords": [ "WooCommerce" ],
+	"textdomain": "woo-gutenberg-products-block",
+	"providesContext": {
+		"priceColorValue": "priceColorValue",
+		"iconColorValue": "iconColorValue",
+		"productCountColorValue": "productCountColorValue"
+	},
+	"supports": {
+		"html": false,
+		"multiple": false,
+		"typography": {
+			"fontSize": true
+		}
+	},
+	"example": {
+		"attributes": {
+			"isPreview": true,
+			"className": "wc-block-mini-cart--preview"
+		}
+	},
+	"attributes": {
+		"isPreview": {
+			"type": "boolean",
+			"default": false
+		},
+		"miniCartIcon": {
+			"type": "string",
+			"default": "cart"
+		},
+		"addToCartBehaviour": {
+			"type": "string",
+			"default": "none"
+		},
+		"hasHiddenPrice": {
+			"type": "boolean",
+			"default": false
+		},
+		"cartAndCheckoutRenderStyle": {
+			"type": "string",
+			"default": "hidden"
+		},
+		"priceColor": {
+			"type": "string"
+		},
+		"priceColorValue": {
+			"type": "string"
+		},
+		"iconColor": {
+			"type": "string"
+		},
+		"iconColorValue": {
+			"type": "string"
+		},
+		"productCountColor": {
+			"type": "string"
+		},
+		"productCountColorValue": {
+			"type": "string"
+		}
+	},
+	"apiVersion": 2,
+	"$schema": "https://schemas.wp.org/trunk/block.json"
+}

--- a/assets/js/blocks/mini-cart/index.tsx
+++ b/assets/js/blocks/mini-cart/index.tsx
@@ -1,22 +1,30 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { miniCartAlt } from '@woocommerce/icons';
 import { Icon } from '@wordpress/icons';
 import { registerBlockType } from '@wordpress/blocks';
-import type { BlockConfiguration } from '@wordpress/blocks';
 import { isFeaturePluginBuild } from '@woocommerce/block-settings';
 import { addFilter } from '@wordpress/hooks';
-
 /**
  * Internal dependencies
  */
+import metadata from './block.json';
 import edit from './edit';
+import './style.scss';
 
-const settings: BlockConfiguration = {
-	apiVersion: 2,
-	title: __( 'Mini-Cart', 'woo-gutenberg-products-block' ),
+const featurePluginSupport = {
+	...metadata.supports,
+	...( isFeaturePluginBuild() && {
+		typography: {
+			...metadata.supports.typography,
+			__experimentalFontFamily: true,
+			__experimentalFontWeight: true,
+		},
+	} ),
+};
+
+registerBlockType( metadata, {
 	icon: {
 		src: (
 			<Icon
@@ -25,81 +33,23 @@ const settings: BlockConfiguration = {
 			/>
 		),
 	},
-	category: 'woocommerce',
-	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
-	description: __(
-		'Display a button for shoppers to quickly view their cart.',
-		'woo-gutenberg-products-block'
-	),
 	providesContext: {
-		priceColorValue: 'priceColorValue',
-		iconColorValue: 'iconColorValue',
-		productCountColorValue: 'productCountColorValue',
+		...metadata.providesContext,
 	},
 	supports: {
-		html: false,
-		multiple: false,
-		typography: {
-			fontSize: true,
-			...( isFeaturePluginBuild() && {
-				__experimentalFontFamily: true,
-				__experimentalFontWeight: true,
-			} ),
-		},
+		...featurePluginSupport,
 	},
 	example: {
-		attributes: {
-			isPreview: true,
-			className: 'wc-block-mini-cart--preview',
-		},
+		...metadata.example,
 	},
 	attributes: {
-		isPreview: {
-			type: 'boolean',
-			default: false,
-		},
-		miniCartIcon: {
-			type: 'string',
-			default: 'cart',
-		},
-		addToCartBehaviour: {
-			type: 'string',
-			default: 'none',
-		},
-		hasHiddenPrice: {
-			type: 'boolean',
-			default: false,
-		},
-		cartAndCheckoutRenderStyle: {
-			type: 'string',
-			default: 'hidden',
-		},
-		priceColor: {
-			type: 'string',
-		},
-		priceColorValue: {
-			type: 'string',
-		},
-		iconColor: {
-			type: 'string',
-		},
-		iconColorValue: {
-			type: 'string',
-		},
-		productCountColor: {
-			type: 'string',
-		},
-		productCountColorValue: {
-			type: 'string',
-		},
+		...metadata.attributes,
 	},
 	edit,
 	save() {
 		return null;
 	},
-};
-
-registerBlockType( 'woocommerce/mini-cart', settings );
+} );
 
 // Remove the Mini Cart template part from the block inserter.
 addFilter(


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

Ensure the mini-cart block uses the `block.json` metadata file as the canonical way to register the block type with both PHP (server-side) and JavaScript (client-side) as this has been the [recommended approach for registering blocks ](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/) since WordPress 5.8.

The benefits of this change are highlighted in [this post](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-metadata/#benefits-using-the-metadata-file), which includes:

* The block definition allows code sharing between JavaScript, PHP, and other languages when processing block types stored as JSON, and registering blocks with the block.json metadata file provides multiple benefits on top of it.

* From a performance perspective, when themes support lazy loading assets, blocks registered with block.json will have their asset enqueuing optimized out of the box. The frontend CSS and JavaScript assets listed in the style or script properties will only be enqueued when the block is present on the page, resulting in reduced page sizes.

* Furthermore, because the [Block Type REST API Endpoint](https://developer.wordpress.org/rest-api/reference/block-types/) can only list blocks registered on the server, registering blocks server-side is recommended; using the `block.json` file simplifies this registration.

* The [WordPress Plugins Directory](https://wordpress.org/plugins/) can detect `block.json` files, highlight blocks included in plugins, and extract their metadata.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Create a new post
2. Make sure the mini-cart block is available for insertion
3. Insert the block, make changes to its settings and save
4. On the frontend, make sure everything works as expected: you can add/remove products from the cart and the style changes made in the editor are visible on the frontend.

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Modernize the block registration for the Mini Cart block.
