### PR TITLE
Add E2E tests for 'Inherit query from template' control in Product Co…

### DIFF
--- a/assets/js/blocks/product-collection/inspector-controls/inherit-query-control.tsx
+++ b/assets/js/blocks/product-collection/inspector-controls/inherit-query-control.tsx
@@ -67,6 +67,7 @@ const InheritQueryControl = ( {
 			} }
 		>
 			<ToggleControl
+				className="wc-block-product-collection__inherit-query-control"
 				label={ label }
 				help={ __(
 					'Toggle to use the global query context that is set with the current template, such as an archive or search. Disable to customize the settings independently.',


### PR DESCRIPTION
This PR adds comprehensive end-to-end (E2E) tests for the 'Inherit query from template' control within the Product Collection block. In addition, it adds a CSS class to the toggle control to assist with these tests and updates existing E2E test code to improve code quality and readability.

Part of https://github.com/woocommerce/woocommerce-blocks/issues/9783

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Testing

1. Start the development environment by running the command: `npm run env:start`.
2. Install the necessary dependencies using Playwright with the command: `npx playwright install`.
3. Execute tests: `npx playwright test --config=tests/e2e-pw/playwright.config.ts "./tests/e2e-pw/tests/product-collection"`
4. Confirm that the test completes successfully and passes all assertions.

**Note:** Also verify that Playwright CI is green.

* [X] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [X] Experimental

### Changelog

> Product Collection - Add E2E tests for 'Inherit query from template' control
