### PR TITLE
Add global styles for order confirmation summary block

### DIFF
--- a/assets/js/blocks/order-confirmation/summary/block.json
+++ b/assets/js/blocks/order-confirmation/summary/block.json
@@ -18,7 +18,6 @@
 			"__experimentalFontWeight": true,
 			"__experimentalLetterSpacing": true,
 			"__experimentalTextTransform": true,
-			"__experimentalWritingMode": true,
 			"__experimentalDefaultControls": {
 				"fontSize": true
 			}

--- a/assets/js/blocks/order-confirmation/summary/block.json
+++ b/assets/js/blocks/order-confirmation/summary/block.json
@@ -7,7 +7,38 @@
 	"keywords": [ "WooCommerce" ],
 	"supports": {
 		"multiple": false,
-		"align": [ "wide", "full" ]
+		"align": [ "wide", "full" ],
+		"html": false,
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalFontStyle": true,
+			"__experimentalFontWeight": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalTextTransform": true,
+			"__experimentalWritingMode": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
+		},
+		"color": {
+			"background": true,
+			"text": true,
+			"__experimentalDefaultControls": {
+				"background": true,
+				"text": true
+			}
+		},
+		"spacing": {
+			"padding": true,
+			"margin": true,
+			"__experimentalDefaultControls": {
+				"margin": false,
+				"padding": false
+			}
+		}
 	},
 	"attributes": {
 		"align": {

--- a/assets/js/blocks/order-confirmation/summary/edit.tsx
+++ b/assets/js/blocks/order-confirmation/summary/edit.tsx
@@ -20,7 +20,8 @@ interface Props {
 
 const Edit = ( props: Props ): JSX.Element => {
 	const { attributes, name } = props;
-	const blockProps = useBlockProps( {
+	// Remove style because its handled by the server-side render.
+	const { style, ...blockProps } = useBlockProps( {
 		className: 'wc-block-order-confirmation-summary',
 	} );
 

--- a/assets/js/blocks/order-confirmation/summary/style.scss
+++ b/assets/js/blocks/order-confirmation/summary/style.scss
@@ -4,21 +4,20 @@
 		list-style: none outside;
 		display: flex;
 		flex-direction: row;
-		margin: 0 0 $gap-largest;
+		margin: 0;
 		padding: 0;
 		gap: 1em;
+		flex-wrap: wrap;
 
 		li {
 			flex: 1 1 auto;
 
 			> span {
-				text-transform: uppercase;
-				@include font-size(smaller);
+				@include font-size(small);
 			}
 			> strong {
-				font-weight: bold;
+				font-weight: inherit;
 				display: block;
-				@include font-size(small);
 			}
 		}
 	}

--- a/src/BlockTypes/OrderConfirmation/Summary.php
+++ b/src/BlockTypes/OrderConfirmation/Summary.php
@@ -45,9 +45,10 @@ class Summary extends AbstractOrderConfirmationBlock {
 		}
 
 		return sprintf(
-			'<div class="wc-block-%4$s %1$s %2$s">%3$s</div>',
+			'<div class="wc-block-%5$s %1$s %2$s" style="%3$s">%4$s</div>',
 			esc_attr( $classes_and_styles['classes'] ),
 			esc_attr( $classname ),
+			esc_attr( $classes_and_styles['styles'] ),
 			$content,
 			esc_attr( $this->block_name )
 		);


### PR DESCRIPTION
Adds style controls to the order summary block.

Fixes #10118

### Screenshots

![Screenshot 2023-07-12 at 11 31 30](https://github.com/woocommerce/woocommerce-blocks/assets/90977/ae340fa6-7ef6-42c1-9b3c-b644e78d9a08)

### Testing

1. Go to Appearance > Editor > Templates > Order Confirmation
2. If not already blockified, click the button to convert legacy block to individual blocks
3. Select the "summary" block
4. In the inspector, adjust styles (color, type, padding) and save
5. Go to the frontend and place a new order
6. Confirm the confirmation page matches your selected styling

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental
