### PR TITLE
Fix margin issue with the Proceed to checkout button on the site editor

### DIFF
--- a/assets/js/blocks/cart/inner-blocks/cart-express-payment-block/editor.scss
+++ b/assets/js/blocks/cart/inner-blocks/cart-express-payment-block/editor.scss
@@ -13,6 +13,11 @@
 	}
 }
 
+.block-editor-block-list__layout .wp-block-woocommerce-proceed-to-checkout-block {
+	margin-bottom: 28px;
+	margin-top: 28px;
+}
+
 .wp-block-woocommerce-checkout-express-payment-block-placeholder {
 	* {
 		pointer-events: all; // Overrides parent disabled component in editor context

--- a/assets/js/blocks/cart/inner-blocks/cart-express-payment-block/editor.scss
+++ b/assets/js/blocks/cart/inner-blocks/cart-express-payment-block/editor.scss
@@ -13,7 +13,7 @@
 	}
 }
 
-.block-editor-block-list__layout .wp-block-woocommerce-proceed-to-checkout-block {
+.wp-block-woocommerce-proceed-to-checkout-block {
 	margin-bottom: 28px;
 	margin-top: 28px;
 }


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This fixes a bug with the Proceed to Checkout button on the Cart block, where it looses its margins, only in the site editor. The reason being that for the classic block editor, the stylesheet ads a 28px border around every wp block. 

```
.editor-styles-wrapper .wp-block {
    margin-left: auto;
    margin-right: auto;
}
```

This doesn't apply to the site editor so the Proceed to Checkout button looses its margins. The solution here is to explicitly set the margins on the Proceed to Checkout button so that it keeps them on both the site editor and the classic block editor.

<!-- Reference any related issues or PRs here -->

Partly Fixes #10177

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before                                                                                                                                      	| After                                                                                                                                       	|
|---------------------------------------------------------------------------------------------------------------------------------------------	|---------------------------------------------------------------------------------------------------------------------------------------------	|
| ![Screenshot 2023-07-12 at 09 59 20](https://github.com/woocommerce/woocommerce-blocks/assets/3966773/6130d5bc-9e9b-487d-a2a3-9d2a46ced417) 	| ![Screenshot 2023-07-12 at 12 57 32](https://github.com/woocommerce/woocommerce-blocks/assets/3966773/48681cef-6517-4c52-af71-7d78d0dbd02e) 	|

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Install and activate a block theme (e.g. Twenty Twenty Three)
2. Edit the Cart page
3. Check the Proceed to Checkout button has some padding around it
4. Switch to a non block theme page (e.g. Storefront)
5. Check that the Proceed to Checkout button has the same padding around it

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix a visual bug with margins around the Proceed to Checkout button on the Cart block
