### PR TITLE
Add table styles for order details

### DIFF
--- a/assets/js/blocks/order-confirmation/status/block.json
+++ b/assets/js/blocks/order-confirmation/status/block.json
@@ -25,6 +25,7 @@
 		"color": {
 			"background": true,
 			"text": true,
+			"gradients": true,
 			"__experimentalDefaultControls": {
 				"background": true,
 				"text": true

--- a/assets/js/blocks/order-confirmation/summary/block.json
+++ b/assets/js/blocks/order-confirmation/summary/block.json
@@ -25,6 +25,7 @@
 		"color": {
 			"background": true,
 			"text": true,
+			"gradients": true,
 			"__experimentalDefaultControls": {
 				"background": true,
 				"text": true

--- a/assets/js/blocks/order-confirmation/totals/block.json
+++ b/assets/js/blocks/order-confirmation/totals/block.json
@@ -15,6 +15,7 @@
 			"__experimentalFontFamily": true,
 			"__experimentalTextDecoration": true,
 			"__experimentalFontStyle": true,
+			"__experimentalFontWeight": true,
 			"__experimentalLetterSpacing": true,
 			"__experimentalTextTransform": true,
 			"__experimentalDefaultControls": {

--- a/assets/js/blocks/order-confirmation/totals/block.json
+++ b/assets/js/blocks/order-confirmation/totals/block.json
@@ -25,6 +25,7 @@
 		"color": {
 			"background": true,
 			"text": true,
+			"link": true,
 			"gradients": true,
 			"__experimentalDefaultControls": {
 				"background": true,

--- a/assets/js/blocks/order-confirmation/totals/block.json
+++ b/assets/js/blocks/order-confirmation/totals/block.json
@@ -7,7 +7,50 @@
 	"keywords": [ "WooCommerce" ],
 	"supports": {
 		"multiple": false,
-		"align": [ "wide", "full" ]
+		"align": [ "wide", "full" ],
+		"html": false,
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalFontStyle": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalTextTransform": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
+		},
+		"color": {
+			"background": true,
+			"text": true,
+			"gradients": true,
+			"__experimentalDefaultControls": {
+				"background": true,
+				"text": true
+			},
+			"__experimentalSkipSerialization": true
+		},
+		"spacing": {
+			"padding": true,
+			"margin": true,
+			"__experimentalDefaultControls": {
+				"margin": false,
+				"padding": false
+			}
+		},
+		"__experimentalBorder": {
+			"color": true,
+			"style": true,
+			"width": true,
+			"__experimentalDefaultControls": {
+				"color": true,
+				"style": true,
+				"width": true
+			},
+			"__experimentalSkipSerialization": true
+		},
+		"__experimentalSelector": ".wp-block-woocommerce-order-confirmation-totals table"
 	},
 	"attributes": {
 		"align": {

--- a/assets/js/blocks/order-confirmation/totals/style.scss
+++ b/assets/js/blocks/order-confirmation/totals/style.scss
@@ -1,26 +1,36 @@
 .wc-block-order-confirmation-totals {
-	.woocommerce-order-details table,
-	.woocommerce-order-details table.shop_table {
+	table {
 		width: 100%;
 		border: 1px solid currentColor;
-		border-bottom: 0;
-
-		thead {
-			text-transform: uppercase;
-		}
-
-		th {
-			font-weight: bold;
-		}
-
+		border-collapse: collapse;
 		th,
 		td {
-			border-style: solid;
-			border-color: currentColor;
-			border-width: 0 0 1px 0;
-			padding: $gap-small;
+			border: 1px solid currentColor;
+			border-right-width: 0;
+			border-left-width: 0;
+			padding: $gap;
 			margin: 0;
 			text-align: left;
+			font-weight: inherit;
+		}
+		thead {
+			font-weight: bold;
+		}
+		.wc-block-order-confirmation-totals__total {
+			font-variant-numeric: tabular-nums;
+			text-align: right;
+		}
+	}
+	table[style*="border-width"] {
+		> *,
+		tr,
+		th,
+		td {
+			border-style: inherit;
+			border-width: inherit;
+			border-color: inherit;
+			border-right-width: 0;
+			border-left-width: 0;
 		}
 	}
 }

--- a/src/BlockTypes/OrderConfirmation/Totals.php
+++ b/src/BlockTypes/OrderConfirmation/Totals.php
@@ -64,6 +64,26 @@ class Totals extends AbstractOrderConfirmationBlock {
 	}
 
 	/**
+	 * Enqueue frontend assets for this block, just in time for rendering.
+	 *
+	 * @param array $attributes  Any attributes that currently are available from the block.
+	 */
+	protected function enqueue_assets( array $attributes ) {
+		parent::enqueue_assets( $attributes );
+
+		$link_classes_and_styles       = StyleAttributesUtils::get_link_color_class_and_style( $attributes );
+		$link_hover_classes_and_styles = StyleAttributesUtils::get_link_hover_color_class_and_style( $attributes );
+
+		wp_add_inline_style(
+			'wc-blocks-style',
+			'
+			.wc-block-order-confirmation-totals__table a {' . $link_classes_and_styles['style'] . '}
+			.wc-block-order-confirmation-totals__table a:hover, .wc-block-order-confirmation-totals__table a:focus {' . $link_hover_classes_and_styles['style'] . '}
+			'
+		);
+	}
+
+	/**
 	 * This renders the content of the block within the wrapper.
 	 *
 	 * @param \WC_Order $order Order object.

--- a/src/BlockTypes/OrderConfirmation/Totals.php
+++ b/src/BlockTypes/OrderConfirmation/Totals.php
@@ -36,18 +36,19 @@ class Totals extends AbstractOrderConfirmationBlock {
 			}
 		}
 
-		$content            = $order ? $this->render_content( $order ) : $this->render_content_fallback();
+		$content            = $order ? $this->render_content( $order, $attributes ) : $this->render_content_fallback();
+		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, [], [ 'border_color', 'border_radius', 'border_width', 'background_color', 'text_color' ] );
 		$classname          = $attributes['className'] ?? '';
-		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes );
 
 		if ( isset( $attributes['align'] ) ) {
 			$classname .= " align{$attributes['align']}";
 		}
 
 		return sprintf(
-			'<div class="wc-block-%4$s %1$s %2$s">%3$s</div>',
+			'<div class="wc-block-%5$s %1$s %2$s" style="%3$s">%4$s</div>',
 			esc_attr( $classes_and_styles['classes'] ),
 			esc_attr( $classname ),
+			esc_attr( $classes_and_styles['styles'] ),
 			$content,
 			esc_attr( $this->block_name )
 		);
@@ -66,31 +67,31 @@ class Totals extends AbstractOrderConfirmationBlock {
 	 * This renders the content of the block within the wrapper.
 	 *
 	 * @param \WC_Order $order Order object.
+	 * @param array     $attributes Block attributes.
 	 * @return string
 	 */
-	protected function render_content( $order ) {
-		return '
-			<section class="woocommerce-order-details">
-				' . $this->get_hook_content( 'woocommerce_order_details_before_order_table', [ $order ] ) . '
-				<table class="woocommerce-table woocommerce-table--order-details shop_table order_details" cellspacing="0">
-					<thead>
-						<tr>
-							<th class="woocommerce-table__product-name product-name">' . esc_html__( 'Product', 'woo-gutenberg-products-block' ) . '</th>
-							<th class="woocommerce-table__product-table product-total">' . esc_html__( 'Total', 'woo-gutenberg-products-block' ) . '</th>
-						</tr>
-					</thead>
-					<tbody>
-						' . $this->get_hook_content( 'woocommerce_order_details_before_order_table_items', [ $order ] ) . '
-						' . $this->render_order_details_table_items( $order ) . '
-						' . $this->get_hook_content( 'woocommerce_order_details_after_order_table_items', [ $order ] ) . '
-					</tbody>
-					<tfoot>
-						' . $this->render_order_details_table_totals( $order ) . '
-						' . $this->render_order_details_table_customer_note( $order ) . '
-					</tfoot>
-				</table>
-				' . $this->get_hook_content( 'woocommerce_order_details_after_order_table', [ $order ] ) . '
-			</section>
+	protected function render_content( $order, $attributes = [] ) {
+		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, [ 'border_color', 'border_radius', 'border_width', 'background_color', 'text_color' ] );
+
+		return $this->get_hook_content( 'woocommerce_order_details_before_order_table', [ $order ] ) . '
+			<table cellspacing="0" class="wc-block-order-confirmation-totals__table ' . esc_attr( $classes_and_styles['classes'] ) . '" style="' . esc_attr( $classes_and_styles['styles'] ) . '">
+				<thead>
+					<tr>
+						<th class="wc-block-order-confirmation-totals__product">' . esc_html__( 'Product', 'woo-gutenberg-products-block' ) . '</th>
+						<th class="wc-block-order-confirmation-totals__total">' . esc_html__( 'Total', 'woo-gutenberg-products-block' ) . '</th>
+					</tr>
+				</thead>
+				<tbody>
+					' . $this->get_hook_content( 'woocommerce_order_details_before_order_table_items', [ $order ] ) . '
+					' . $this->render_order_details_table_items( $order ) . '
+					' . $this->get_hook_content( 'woocommerce_order_details_after_order_table_items', [ $order ] ) . '
+				</tbody>
+				<tfoot>
+					' . $this->render_order_details_table_totals( $order ) . '
+					' . $this->render_order_details_table_customer_note( $order ) . '
+				</tfoot>
+			</table>
+			' . $this->get_hook_content( 'woocommerce_order_details_after_order_table', [ $order ] ) . '
 			' . $this->get_hook_content( 'woocommerce_after_order_details', [ $order ] ) . '
 		';
 	}
@@ -156,7 +157,7 @@ class Totals extends AbstractOrderConfirmationBlock {
 
 		return '
 			<tr class="' . esc_attr( $row_class ) . '">
-				<td class="woocommerce-table__product-name product-name">
+				<th scope="row" class="wc-block-order-confirmation-totals__product">
 					' . wp_kses_post( $item_name ) . '&nbsp;
 					' . wp_kses_post( $item_qty ) . '
 					' . $this->get_hook_content( 'woocommerce_order_item_meta_start', [ $item_id, $item, $order, false ] ) . '
@@ -164,7 +165,7 @@ class Totals extends AbstractOrderConfirmationBlock {
 					' . $this->get_hook_content( 'woocommerce_order_item_meta_end', [ $item_id, $item, $order, false ] ) . '
 					' . $this->render_order_details_table_item_purchase_note( $order, $product ) . '
 				</td>
-				<td class="woocommerce-table__product-total product-total">
+				<td class="wc-block-order-confirmation-totals__total">
 					' . wp_kses_post( $order->get_formatted_line_subtotal( $item ) ) . '
 				</td>
 			</tr>
@@ -193,13 +194,22 @@ class Totals extends AbstractOrderConfirmationBlock {
 	 * @return string
 	 */
 	protected function render_order_details_table_totals( $order ) {
-		$return = '';
+		add_filter( 'woocommerce_order_shipping_to_display_shipped_via', '__return_empty_string' );
 
-		foreach ( $order->get_order_item_totals() as $total ) {
+		$return     = '';
+		$total_rows = array_diff_key(
+			$order->get_order_item_totals(),
+			array(
+				'cart_subtotal'  => '',
+				'payment_method' => '',
+			)
+		);
+
+		foreach ( $total_rows as $total ) {
 			$return .= '
 				<tr>
-					<th scope="row">' . esc_html( $total['label'] ) . '</th>
-					<td>' . wp_kses_post( $total['value'] ) . '</td>
+					<th class="wc-block-order-confirmation-totals__label" scope="row">' . esc_html( $total['label'] ) . '</th>
+					<td class="wc-block-order-confirmation-totals__total">' . wp_kses_post( $total['value'] ) . '</td>
 				</tr>
 			';
 		}
@@ -219,8 +229,8 @@ class Totals extends AbstractOrderConfirmationBlock {
 		}
 
 		return '<tr>
-			<th>' . esc_html__( 'Note:', 'woo-gutenberg-products-block' ) . '</th>
-			<td>' . wp_kses_post( nl2br( wptexturize( $order->get_customer_note() ) ) ) . '</td>
+			<th class="wc-block-order-confirmation-totals__label" scope="row">' . esc_html__( 'Note:', 'woo-gutenberg-products-block' ) . '</th>
+			<td class="wc-block-order-confirmation-totals__note">' . wp_kses_post( nl2br( wptexturize( $order->get_customer_note() ) ) ) . '</td>
 		</tr>';
 	}
 }

--- a/src/Utils/StyleAttributesUtils.php
+++ b/src/Utils/StyleAttributesUtils.php
@@ -6,6 +6,13 @@ namespace Automattic\WooCommerce\Blocks\Utils;
  */
 class StyleAttributesUtils {
 
+	// Empty style array.
+	const EMPTY_STYLE = [
+		'class' => '',
+		'style' => '',
+		'value' => '',
+	];
+
 	/**
 	 * If color value is in preset format, convert it to a CSS var. Else return same value
 	 * For example:
@@ -60,16 +67,10 @@ class StyleAttributesUtils {
 	 * Get class and style for align from attributes.
 	 *
 	 * @param array $attributes Block attributes.
-	 *
-	 * @return (array | null)
+	 * @return array
 	 */
 	public static function get_align_class_and_style( $attributes ) {
-
 		$align_attribute = $attributes['align'] ?? null;
-
-		if ( ! $align_attribute ) {
-			return null;
-		}
 
 		if ( 'wide' === $align_attribute ) {
 			return array(
@@ -106,7 +107,7 @@ class StyleAttributesUtils {
 			);
 		}
 
-		return null;
+		return self::EMPTY_STYLE;
 	}
 
 	/**
@@ -168,8 +169,7 @@ class StyleAttributesUtils {
 	 * Unlinked - custom color: $attributes['style']['border']['top']['color'] => '#681228'.
 	 *
 	 * @param array $attributes Block attributes.
-	 *
-	 * @return (array | null)
+	 * @return array
 	 */
 	public static function get_border_color_class_and_style( $attributes ) {
 
@@ -198,7 +198,7 @@ class StyleAttributesUtils {
 		}
 
 		if ( ! $border_color_class && ! $border_color_css ) {
-			return null;
+			return self::EMPTY_STYLE;
 		}
 
 		return array(
@@ -211,15 +211,14 @@ class StyleAttributesUtils {
 	 * Get class and style for border-radius from attributes.
 	 *
 	 * @param array $attributes Block attributes.
-	 *
-	 * @return (array | null)
+	 * @return array
 	 */
 	public static function get_border_radius_class_and_style( $attributes ) {
 
 		$custom_border_radius = $attributes['style']['border']['radius'] ?? '';
 
 		if ( '' === $custom_border_radius ) {
-			return null;
+			return self::EMPTY_STYLE;
 		}
 
 		$border_radius_css = '';
@@ -253,15 +252,14 @@ class StyleAttributesUtils {
 	 * Get class and style for border width from attributes.
 	 *
 	 * @param array $attributes Block attributes.
-	 *
-	 * @return (array | null)
+	 * @return array
 	 */
 	public static function get_border_width_class_and_style( $attributes ) {
 
 		$custom_border = $attributes['style']['border'] ?? '';
 
 		if ( '' === $custom_border ) {
-			return null;
+			return self::EMPTY_STYLE;
 		}
 
 		$border_width_css = '';
@@ -302,8 +300,7 @@ class StyleAttributesUtils {
 	 * Get class and style for font-family from attributes.
 	 *
 	 * @param array $attributes Block attributes.
-	 *
-	 * @return (array | null)
+	 * @return array
 	 */
 	public static function get_font_family_class_and_style( $attributes ) {
 
@@ -315,15 +312,14 @@ class StyleAttributesUtils {
 				'style' => null,
 			);
 		}
-		return null;
+		return self::EMPTY_STYLE;
 	}
 
 	/**
 	 * Get class and style for font-size from attributes.
 	 *
 	 * @param array $attributes Block attributes.
-	 *
-	 * @return (array | null)
+	 * @return array
 	 */
 	public static function get_font_size_class_and_style( $attributes ) {
 
@@ -332,7 +328,7 @@ class StyleAttributesUtils {
 		$custom_font_size = $attributes['style']['typography']['fontSize'] ?? '';
 
 		if ( ! $font_size && '' === $custom_font_size ) {
-			return null;
+			return self::EMPTY_STYLE;
 		}
 
 		if ( $font_size ) {
@@ -346,15 +342,15 @@ class StyleAttributesUtils {
 				'style' => sprintf( 'font-size: %s;', $custom_font_size ),
 			);
 		}
-		return null;
+
+		return self::EMPTY_STYLE;
 	}
 
 	/**
 	 * Get class and style for font-style from attributes.
 	 *
 	 * @param array $attributes Block attributes.
-	 *
-	 * @return (array | null)
+	 * @return array
 	 */
 	public static function get_font_style_class_and_style( $attributes ) {
 
@@ -366,15 +362,14 @@ class StyleAttributesUtils {
 				'style' => sprintf( 'font-style: %s;', $custom_font_style ),
 			);
 		}
-		return null;
+		return self::EMPTY_STYLE;
 	}
 
 	/**
 	 * Get class and style for font-weight from attributes.
 	 *
 	 * @param array $attributes Block attributes.
-	 *
-	 * @return (array | null)
+	 * @return array
 	 */
 	public static function get_font_weight_class_and_style( $attributes ) {
 
@@ -386,15 +381,14 @@ class StyleAttributesUtils {
 				'style' => sprintf( 'font-weight: %s;', $custom_font_weight ),
 			);
 		}
-		return null;
+		return self::EMPTY_STYLE;
 	}
 
 	/**
 	 * Get class and style for letter-spacing from attributes.
 	 *
 	 * @param array $attributes Block attributes.
-	 *
-	 * @return (array | null)
+	 * @return array
 	 */
 	public static function get_letter_spacing_class_and_style( $attributes ) {
 
@@ -406,22 +400,21 @@ class StyleAttributesUtils {
 				'style' => sprintf( 'letter-spacing: %s;', $custom_letter_spacing ),
 			);
 		}
-		return null;
+		return self::EMPTY_STYLE;
 	}
 
 	/**
 	 * Get class and style for line height from attributes.
 	 *
 	 * @param array $attributes Block attributes.
-	 *
-	 * @return (array | null)
+	 * @return array
 	 */
 	public static function get_line_height_class_and_style( $attributes ) {
 
 		$line_height = $attributes['style']['typography']['lineHeight'] ?? '';
 
 		if ( ! $line_height ) {
-			return null;
+			return self::EMPTY_STYLE;
 		}
 
 		return array(
@@ -431,53 +424,94 @@ class StyleAttributesUtils {
 	}
 
 	/**
+	 * Get a value from an array based on a path e.g style.elements.link
+	 *
+	 * @param array  $array Target array.
+	 * @param string $path Path joined by delimiter.
+	 * @param string $delimiter Chosen delimiter defaults to ".".
+	 * @return mixed
+	 */
+	protected static function array_get_value_by_path( array &$array, $path, $delimiter = '.' ) {
+		$array_path = explode( $delimiter, $path );
+		$ref        = &$array;
+
+		foreach ( $array_path as $key ) {
+			if ( is_array( $ref ) && array_key_exists( $key, $ref ) ) {
+				$ref = &$ref[ $key ];
+			} else {
+				return null;
+			}
+		}
+		return $ref;
+	}
+
+	/**
 	 * Get class and style for link-color from attributes.
 	 *
 	 * @param array $attributes Block attributes.
-	 *
-	 * @return (array | null)
+	 * @return array
 	 */
 	public static function get_link_color_class_and_style( $attributes ) {
+		$link_color = self::array_get_value_by_path( $attributes, 'style.elements.link.color.text' );
 
-		if ( ! isset( $attributes['style']['elements']['link']['color']['text'] ) ) {
-			return null;
+		if ( empty( $link_color ) ) {
+			return self::EMPTY_STYLE;
 		}
-
-		$link_color = $attributes['style']['elements']['link']['color']['text'];
 
 		// If the link color is selected from the theme color picker, the value of $link_color is var:preset|color|slug.
 		// If the link color is selected from the core color picker, the value of $link_color is an hex value.
 		// When the link color is a string var:preset|color|slug we parsed it for get the slug, otherwise we use the hex value.
-		$index_named_link_color = strrpos( $link_color, '|' );
-
-		if ( ! empty( $index_named_link_color ) ) {
-			$parsed_named_link_color = substr( $link_color, $index_named_link_color + 1 );
-			return array(
-				'class' => 'has-link-color',
-				'style' => sprintf( 'color: %s;', self::get_preset_value( $parsed_named_link_color ) ),
-				'value' => self::get_preset_value( $parsed_named_link_color ),
-			);
-		} else {
-			return array(
-				'class' => 'has-link-color',
-				'style' => sprintf( 'color: %s;', $link_color ),
-				'value' => $link_color,
-			);
+		if ( strstr( $link_color, '|' ) ) {
+			$link_color_parts = explode( '|', $link_color );
+			$link_color       = self::get_preset_value( end( $link_color_parts ) );
 		}
+
+		return array(
+			'class' => 'has-link-color',
+			'style' => sprintf( 'color: %s;', $link_color ),
+			'value' => $link_color,
+		);
+	}
+
+	/**
+	 * Get class and style for link-hover-color from attributes.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return array
+	 */
+	public static function get_link_hover_color_class_and_style( $attributes ) {
+		$link_color = self::array_get_value_by_path( $attributes, 'style.elements.link.:hover.color.text' );
+
+		if ( empty( $link_color ) ) {
+			return self::EMPTY_STYLE;
+		}
+
+		// If the link color is selected from the theme color picker, the value of $link_color is var:preset|color|slug.
+		// If the link color is selected from the core color picker, the value of $link_color is an hex value.
+		// When the link color is a string var:preset|color|slug we parsed it for get the slug, otherwise we use the hex value.
+		if ( strstr( $link_color, '|' ) ) {
+			$link_color_parts = explode( '|', $link_color );
+			$link_color       = self::get_preset_value( end( $link_color_parts ) );
+		}
+
+		return array(
+			'class' => 'has-link-color',
+			'style' => sprintf( 'color: %s;', $link_color ),
+			'value' => $link_color,
+		);
 	}
 
 	/**
 	 * Get class and style for margin from attributes.
 	 *
 	 * @param array $attributes Block attributes.
-	 *
-	 * @return (array | null)
+	 * @return array
 	 */
 	public static function get_margin_class_and_style( $attributes ) {
 		$margin = $attributes['style']['spacing']['margin'] ?? null;
 
 		if ( ! $margin ) {
-			return null;
+			return self::EMPTY_STYLE;
 		}
 
 		$spacing_values_css = '';
@@ -497,13 +531,13 @@ class StyleAttributesUtils {
 	 *
 	 * @param array $attributes Block attributes.
 	 *
-	 * @return (array | null)
+	 * @return array
 	 */
 	public static function get_padding_class_and_style( $attributes ) {
 		$padding = $attributes['style']['spacing']['padding'] ?? null;
 
 		if ( ! $padding ) {
-			return null;
+			return self::EMPTY_STYLE;
 		}
 
 		$spacing_values_css = '';
@@ -536,11 +570,9 @@ class StyleAttributesUtils {
 	 * Get class and style for text align from attributes.
 	 *
 	 * @param array $attributes Block attributes.
-	 *
-	 * @return (array | null)
+	 * @return array
 	 */
 	public static function get_text_align_class_and_style( $attributes ) {
-
 		if ( isset( $attributes['textAlign'] ) ) {
 			return array(
 				'class' => 'has-text-align-' . $attributes['textAlign'],
@@ -548,15 +580,14 @@ class StyleAttributesUtils {
 			);
 		}
 
-		return null;
+		return self::EMPTY_STYLE;
 	}
 
 	/**
 	 * Get class and style for text-color from attributes.
 	 *
 	 * @param array $attributes Block attributes.
-	 *
-	 * @return (array | null)
+	 * @return array
 	 */
 	public static function get_text_color_class_and_style( $attributes ) {
 
@@ -565,7 +596,7 @@ class StyleAttributesUtils {
 		$custom_text_color = $attributes['style']['color']['text'] ?? '';
 
 		if ( ! $text_color && ! $custom_text_color ) {
-			return null;
+			return self::EMPTY_STYLE;
 		}
 
 		if ( $text_color ) {
@@ -581,7 +612,8 @@ class StyleAttributesUtils {
 				'value' => $custom_text_color,
 			);
 		}
-		return null;
+
+		return self::EMPTY_STYLE;
 	}
 
 	/**
@@ -589,7 +621,7 @@ class StyleAttributesUtils {
 	 *
 	 * @param array $attributes Block attributes.
 	 *
-	 * @return (array | null)
+	 * @return array
 	 */
 	public static function get_text_decoration_class_and_style( $attributes ) {
 
@@ -601,15 +633,15 @@ class StyleAttributesUtils {
 				'style' => sprintf( 'text-decoration: %s;', $custom_text_decoration ),
 			);
 		}
-		return null;
+
+		return self::EMPTY_STYLE;
 	}
 
 	/**
 	 * Get class and style for text-transform from attributes.
 	 *
 	 * @param array $attributes Block attributes.
-	 *
-	 * @return (array | null)
+	 * @return array
 	 */
 	public static function get_text_transform_class_and_style( $attributes ) {
 
@@ -621,7 +653,7 @@ class StyleAttributesUtils {
 				'style' => sprintf( 'text-transform: %s;', $custom_text_transform ),
 			);
 		}
-		return null;
+		return self::EMPTY_STYLE;
 	}
 
 	/**
@@ -646,6 +678,7 @@ class StyleAttributesUtils {
 			'letter_spacing'   => self::get_letter_spacing_class_and_style( $attributes ),
 			'line_height'      => self::get_line_height_class_and_style( $attributes ),
 			'link_color'       => self::get_link_color_class_and_style( $attributes ),
+			'link_hover_color' => self::get_link_hover_color_class_and_style( $attributes ),
 			'margin'           => self::get_margin_class_and_style( $attributes ),
 			'padding'          => self::get_padding_class_and_style( $attributes ),
 			'text_align'       => self::get_text_align_class_and_style( $attributes ),


### PR DESCRIPTION
Adds styles for the totals block. This also removes legacy classnames so the new styles can apply without conflicts.

Fixes #10119

### Screenshots

![Screenshot 2023-07-12 at 15 00 10](https://github.com/woocommerce/woocommerce-blocks/assets/90977/993728f0-8750-4615-8391-cf9f6a202803)
![Screenshot 2023-07-12 at 15 00 30](https://github.com/woocommerce/woocommerce-blocks/assets/90977/252a6971-c37f-4d59-9101-690fa16c99bc)

### Testing

1. Go to Appearance > Editor > Templates > Order Confirmation
2. Convert the legacy order confirmation block to individual blocks using the button if you didn't already do so
3. Select the "totals" block
4. In the inspector, adjust styles (color, type, padding) and save. Note, padding should apply around the table, not within, which mimics the table block.
5. Go to the frontend and place a new order
6. Confirm the confirmation page matches your selected styling

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental
