### PR TITLE
POC: prevent passing all product IDs to frontend filters and pass query instead

### DIFF
--- a/assets/js/base/context/hooks/collections/use-collection-data.ts
+++ b/assets/js/base/context/hooks/collections/use-collection-data.ts
@@ -3,7 +3,7 @@
  */
 import { useState, useEffect, useMemo } from '@wordpress/element';
 import { useDebounce } from 'use-debounce';
-import { isEmpty, objectHasProp } from '@woocommerce/types';
+import { objectHasProp } from '@woocommerce/types';
 import { sort } from 'fast-sort';
 import { useShallowEqual } from '@woocommerce/base-hooks';
 
@@ -56,7 +56,6 @@ export const useCollectionData = ( {
 	queryStock,
 	queryRating,
 	queryState,
-	productIds,
 	isEditor = false,
 }: UseCollectionDataProps ) => {
 	let context = useQueryStateContext();
@@ -166,7 +165,6 @@ export const useCollectionData = ( {
 			per_page: undefined,
 			orderby: undefined,
 			order: undefined,
-			...( ! isEmpty( productIds ) && { include: productIds } ),
 			...collectionDataQueryVars,
 		},
 		shouldSelect: debouncedShouldSelect,

--- a/assets/js/blocks/attribute-filter/block.tsx
+++ b/assets/js/blocks/attribute-filter/block.tsx
@@ -54,6 +54,7 @@ import {
 import { BlockAttributes, DisplayOption, GetNotice } from './types';
 import CheckboxFilter from './checkbox-filter';
 import { useSetWraperVisibility } from '../filter-wrapper/context';
+import { mapRawQueryToUseCollection } from '../filter-utils';
 
 /**
  * Component displaying an attribute filter.
@@ -92,7 +93,9 @@ const AttributeFilterBlock = ( {
 
 	const productsQuery = isEditor
 		? {}
-		: getSettingWithCoercion( 'products_block_query', {}, isObject );
+		: mapRawQueryToUseCollection(
+				getSettingWithCoercion( 'products_block_query', {}, isObject )
+		  );
 
 	const [ hasSetFilterDefaultsFromUrl, setHasSetFilterDefaultsFromUrl ] =
 		useState( false );

--- a/assets/js/blocks/attribute-filter/block.tsx
+++ b/assets/js/blocks/attribute-filter/block.tsx
@@ -22,6 +22,7 @@ import {
 	isAttributeQueryCollection,
 	isBoolean,
 	isString,
+	isObject,
 	objectHasProp,
 } from '@woocommerce/types';
 import { Icon, chevronDown } from '@wordpress/icons';
@@ -89,9 +90,9 @@ const AttributeFilterBlock = ( {
 		isString
 	);
 
-	const productIds = isEditor
-		? []
-		: getSettingWithCoercion( 'product_ids', [], Array.isArray );
+	const productsQuery = isEditor
+		? {}
+		: getSettingWithCoercion( 'products_block_query', {}, isObject );
 
 	const [ hasSetFilterDefaultsFromUrl, setHasSetFilterDefaultsFromUrl ] =
 		useState( false );
@@ -143,8 +144,8 @@ const AttributeFilterBlock = ( {
 			},
 			queryState: {
 				...queryState,
+				...productsQuery,
 			},
-			productIds,
 			isEditor,
 		} );
 

--- a/assets/js/blocks/filter-utils.tsx
+++ b/assets/js/blocks/filter-utils.tsx
@@ -1,0 +1,25 @@
+export const mapRawQueryToUseCollection = ( rawQuery ) => {
+	// @todo requires more advanced mapping and covering edge cases
+
+	// Handpicked Products
+	const { post__in: include } = rawQuery;
+
+	// Attributes
+	const attributes = rawQuery.tax_query.reduce(
+		( acc, { taxonomy, operator } ) => {
+			if ( taxonomy === 'pa_color' ) {
+				return [
+					...acc,
+					{
+						attribute: taxonomy,
+						operator: operator.toLowerCase(),
+						slug: 'red', // hardcoded for demo purposes, it requires changing term id into slug
+					},
+				];
+			}
+			return acc;
+		},
+		[]
+	);
+	return { include, attributes };
+};

--- a/assets/js/blocks/price-filter/block.tsx
+++ b/assets/js/blocks/price-filter/block.tsx
@@ -20,6 +20,7 @@ import {
 	CurrencyResponse,
 	isBoolean,
 	isString,
+	isObject,
 	objectHasProp,
 } from '@woocommerce/types';
 
@@ -99,9 +100,9 @@ const PriceFilterBlock = ( {
 		isBoolean
 	);
 
-	const productIds = isEditor
-		? []
-		: getSettingWithCoercion( 'product_ids', [], Array.isArray );
+	const productsQuery = isEditor
+		? {}
+		: getSettingWithCoercion( 'products_block_query', {}, isObject );
 
 	const [ hasSetFilterDefaultsFromUrl, setHasSetFilterDefaultsFromUrl ] =
 		useState( false );
@@ -111,8 +112,7 @@ const PriceFilterBlock = ( {
 	const [ queryState ] = useQueryStateByContext();
 	const { results, isLoading } = useCollectionData( {
 		queryPrices: true,
-		queryState,
-		productIds,
+		queryState: { ...queryState, ...productsQuery },
 		isEditor,
 	} );
 

--- a/assets/js/blocks/price-filter/block.tsx
+++ b/assets/js/blocks/price-filter/block.tsx
@@ -31,6 +31,7 @@ import usePriceConstraints from './use-price-constraints';
 import './style.scss';
 import { Attributes } from './types';
 import { useSetWraperVisibility } from '../filter-wrapper/context';
+import { mapRawQueryToUseCollection } from '../filter-utils';
 
 /**
  * Formats filter values into a string for the URL parameters needed for filtering PHP templates.
@@ -102,7 +103,9 @@ const PriceFilterBlock = ( {
 
 	const productsQuery = isEditor
 		? {}
-		: getSettingWithCoercion( 'products_block_query', {}, isObject );
+		: mapRawQueryToUseCollection(
+				getSettingWithCoercion( 'products_block_query', {}, isObject )
+		  );
 
 	const [ hasSetFilterDefaultsFromUrl, setHasSetFilterDefaultsFromUrl ] =
 		useState( false );

--- a/assets/js/blocks/stock-filter/block.tsx
+++ b/assets/js/blocks/stock-filter/block.tsx
@@ -43,6 +43,7 @@ import './style.scss';
 import { formatSlug, getActiveFilters, generateUniqueId } from './utils';
 import { Attributes, DisplayOption, Current } from './types';
 import { useSetWraperVisibility } from '../filter-wrapper/context';
+import { mapRawQueryToUseCollection } from '../filter-utils';
 
 export const QUERY_PARAM_KEY = PREFIX_QUERY_ARG_FILTER_TYPE + 'stock_status';
 
@@ -78,7 +79,9 @@ const StockStatusFilterBlock = ( {
 
 	const productQuery = isEditor
 		? []
-		: getSettingWithCoercion( 'products_block_query', {}, isObject );
+		: mapRawQueryToUseCollection(
+				getSettingWithCoercion( 'products_block_query', {}, isObject )
+		  );
 
 	const STOCK_STATUS_OPTIONS: { current: Current } = useRef(
 		getSetting( 'hideOutOfStockItems', false )

--- a/assets/js/blocks/stock-filter/block.tsx
+++ b/assets/js/blocks/stock-filter/block.tsx
@@ -26,7 +26,7 @@ import Label from '@woocommerce/base-components/filter-element-label';
 import FormTokenField from '@woocommerce/base-components/form-token-field';
 import isShallowEqual from '@wordpress/is-shallow-equal';
 import { decodeEntities } from '@wordpress/html-entities';
-import { isBoolean, objectHasProp } from '@woocommerce/types';
+import { isBoolean, isObject, objectHasProp } from '@woocommerce/types';
 import { addQueryArgs, removeQueryArgs } from '@wordpress/url';
 import {
 	changeUrl,
@@ -76,9 +76,9 @@ const StockStatusFilterBlock = ( {
 		{}
 	);
 
-	const productIds = isEditor
+	const productQuery = isEditor
 		? []
-		: getSettingWithCoercion( 'product_ids', [], Array.isArray );
+		: getSettingWithCoercion( 'products_block_query', {}, isObject );
 
 	const STOCK_STATUS_OPTIONS: { current: Current } = useRef(
 		getSetting( 'hideOutOfStockItems', false )
@@ -110,8 +110,7 @@ const StockStatusFilterBlock = ( {
 	const { results: filteredCounts, isLoading: filteredCountsLoading } =
 		useCollectionData( {
 			queryStock: true,
-			queryState,
-			productIds,
+			queryState: { ...queryState, ...productQuery },
 			isEditor,
 		} );
 

--- a/src/BlockTypes/ProductCollection.php
+++ b/src/BlockTypes/ProductCollection.php
@@ -150,10 +150,8 @@ class ProductCollection extends AbstractBlock {
 		];
 		$new_array          = array_merge( $frontend_query, $fields_to_override );
 
-		$products    = new \WP_Query( $new_array );
-		$product_ids = wp_list_pluck( $products->posts, 'ID' );
-		// Add the product ids to the asset data registry, so that filter blocks can use it.
-		$this->asset_data_registry->add( 'product_ids', $product_ids, true );
+		$this->asset_data_registry->add( 'products_block_query', $new_array, true, true );
+
 	}
 
 	/**

--- a/src/BlockTypes/ProductQuery.php
+++ b/src/BlockTypes/ProductQuery.php
@@ -157,7 +157,7 @@ class ProductQuery extends AbstractBlock {
 			// Set this so that our product filters can detect if it's a PHP template.
 			$this->asset_data_registry->add( 'has_filterable_products', true, true );
 			$this->asset_data_registry->add( 'is_rendering_php_template', true, true );
-			$this->asset_data_registry->add( 'product_ids', $this->get_products_ids_by_attributes( $parsed_block ), true );
+			$this->asset_data_registry->add( 'products_block_query', $this->get_query_to_store( $parsed_block ), true, true );
 			add_filter(
 				'query_loop_block_query_vars',
 				array( $this, 'build_query' ),
@@ -253,8 +253,8 @@ class ProductQuery extends AbstractBlock {
 	 * @param array $parsed_block The block being rendered.
 	 * @return array
 	 */
-	private function get_products_ids_by_attributes( $parsed_block ) {
-		$query = $this->merge_queries(
+	private function get_query_to_store( $parsed_block ) {
+		return $this->merge_queries(
 			array(
 				'post_type'      => 'product',
 				'post__in'       => array(),
@@ -266,11 +266,6 @@ class ProductQuery extends AbstractBlock {
 			$this->get_queries_by_custom_attributes( $parsed_block ),
 			$this->get_global_query( $parsed_block )
 		);
-
-		$products = new \WP_Query( $query );
-		$post_ids = wp_list_pluck( $products->posts, 'ID' );
-
-		return $post_ids;
 	}
 
 	/**


### PR DESCRIPTION
In order for filters to work correctly on the frontend we do the following:

1. In the backend within Products (Beta) and Product Collection blocks we fetch all of the products based on the query - the query is influenced by the inspector controls of the block.
    - Products (Beta) [here](https://github.com/woocommerce/woocommerce-blocks/blob/f89cecf069f5fa0ff171591bc2649f3134ac62b2/src/BlockTypes/ProductQuery.php#L270)
    - Product Collection [here](https://github.com/woocommerce/woocommerce-blocks/blob/f89cecf069f5fa0ff171591bc2649f3134ac62b2/src/BlockTypes/ProductCollection.php#L153)
2. Received products IDs are added to `asset_data_registry` under `product_ids` key:
    - Products (Beta) [here](https://github.com/woocommerce/woocommerce-blocks/blob/f89cecf069f5fa0ff171591bc2649f3134ac62b2/src/BlockTypes/ProductQuery.php#L160)
    - Product Collection [here](https://github.com/woocommerce/woocommerce-blocks/blob/f89cecf069f5fa0ff171591bc2649f3134ac62b2/src/BlockTypes/ProductCollection.php#L156)
3. Now this data is received in the frontend by filter blocks, to use it within `useCollectionData` so it can properly get the product counts for filters to display. Examples:
    - Stock Filter [here](https://github.com/woocommerce/woocommerce-blocks/blob/f89cecf069f5fa0ff171591bc2649f3134ac62b2/assets/js/blocks/stock-filter/block.tsx#L81)
    - Attribute Filter [here](https://github.com/woocommerce/woocommerce-blocks/blob/f89cecf069f5fa0ff171591bc2649f3134ac62b2/assets/js/blocks/attribute-filter/block.tsx#L94)

However, `useCollectionData` is query-based and only recently was extended with the `productIds` field specifically for the filters to work with Products (Beta) block (which can display limited scope of products): https://github.com/woocommerce/woocommerce-blocks/pull/7257.

The problem is that query from step 1 is highly inefficient and for big number of products may even cause a crash of the page.

This PR is a POC of the alternative solution. The idea is, instead of Product IDs, to pass a query object from backend to the frontend, so the filters can pass it to the `useCollectionData`, so the proper data is fetched from Store API.

For simplicity this PR covers only the simplest case:
- Handpicked products
- Color Attribute filter (but with the hardcoded color, because of lack of data handy).

Encountered problems:
- backend query is not compatible with the Store API query and requires mapping (example in the PR: `post__in` -> `include`)
- in some cases, we would need to map the query in the backend and pass more/different data to the frontend (example in the PR: when I tried to map attributes in the backend we operate using term IDs, while Store API expects slug, so I hardcoded slug `red`, just for demo purpose).\
- Products (Beta) and Product Collection seem to have different backend query. And also, Products (Beta) doesn't seem to work fine with filters at the moment.
- Filter by Attribute works based on ALL store's products (it's been changed recently)
- Filter by Rating seems to work based on ALL store's products as well

To check out how this POC works:
1. Go to the Editor, for example Product Catalog
2. Add "Product Filters" pattern
3. Add Product Collection block
4. Focus on Product Collection and in Inspector Controls choose Filters -> Three dots -> Hand-picked Products
5. Choose some products, for example, "Beanie" and "Beanie with Logo"
6. Save and go to the frontend
7. Expected: Price Range is adjusted to the products you've chosen
8. Expected: Filter by stock status shows number of products you've chosen (in this example 2)

<img width="793" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/20098064/ad5b1e31-94a1-42c6-86ad-2ea73787601d">

Required steps to finish this work:
- agree on the solution if filters should display number of products available in product grid (as in Filter by Stock Status) or ALL products in the store (as in Filter by Attribute)
- implement the full query mapping
