### PR TITLE
Mini Cart Block > Fix deprecation error on WordPress 6.3 for print_inline_script

### DIFF
--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -322,11 +322,24 @@ class MiniCart extends AbstractBlock {
 
 		$site_url = site_url() ?? wp_guess_url();
 
+		$current_wp_version = get_bloginfo( 'version' );
+		if ( preg_match( '/^([0-9]+\.[0-9]+)/', $current_wp_version, $matches ) ) {
+			$current_wp_version = (float) $matches[1];
+		}
+
+		if ( version_compare( $current_wp_version, '6.3', 'ge' ) ) {
+			$before = $wp_scripts->get_inline_script_data( $script->handle, 'before' );
+			$after  = $wp_scripts->get_inline_script_data( $script->handle );
+		} else {
+			$before = $wp_scripts->print_inline_script( $script->handle, 'before', false );
+			$after  = $wp_scripts->print_inline_script( $script->handle, 'after', false );
+		}
+
 		$this->scripts_to_lazy_load[ $script->handle ] = array(
 			'src'          => preg_match( '|^(https?:)?//|', $script->src ) ? $script->src : $site_url . $script->src,
 			'version'      => $script->ver,
-			'before'       => $wp_scripts->get_inline_script_data( $script->handle, 'before' ),
-			'after'        => $wp_scripts->get_inline_script_data( $script->handle ),
+			'before'       => $before,
+			'after'        => $after,
 			'translations' => $wp_scripts->print_translations( $script->handle, false ),
 		);
 	}

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -325,8 +325,8 @@ class MiniCart extends AbstractBlock {
 		$this->scripts_to_lazy_load[ $script->handle ] = array(
 			'src'          => preg_match( '|^(https?:)?//|', $script->src ) ? $script->src : $site_url . $script->src,
 			'version'      => $script->ver,
-			'before'       => $wp_scripts->print_inline_script( $script->handle, 'before', false ),
-			'after'        => $wp_scripts->print_inline_script( $script->handle, 'after', false ),
+			'before'       => $wp_scripts->get_inline_script_data( $script->handle, 'before' ),
+			'after'        => $wp_scripts->get_inline_script_data( $script->handle ),
 			'translations' => $wp_scripts->print_translations( $script->handle, false ),
 		);
 	}


### PR DESCRIPTION
Ensure the mini-cart block doesn't rely on `WP_Scripts::print_inline_script()` for printing inline scripts registered for a specific handle on WordPress 6.3, as this function is deprecated in favor of `WP_Scripts::get_inline_script_data()` and `WP_Scripts::get_inline_script_tag()`.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

0. In your local install, make sure WP Debug mode is enabled (Instructions on how to enable it are [available here](https://wordpress.org/documentation/article/debugging-in-wordpress/)).
1. Make sure you have a WordPress install running the latest version of WordPress (6.2)
2. Create a new post, insert the Mini-Cart block and save (you can also just add the mini-cart to the header of your site)
3. Confirm everything is working as expected: e.g. you can add/remove products from the mini-cart and customize it in the editor.
4. Now update your WordPress core version to 6.3. You can do so via WP-CLI by running: `wp core download --version=nightly --force`
5. Update the DB via user interface or via WP-CLI as well by running: `wp core update-db`
6. Access your Dashboard and make sure you are indeed running the nightly version of WordPress, which currently is version `6.3-beta4-56222`.
7. Access the same post where you added the mini-cart block previously and make sure everything is working as expected as well.
8. Make sure you see no PHP Deprecate errors in your site.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Mini-cart block: clear out deprecation error for the WP_Scripts::print_inline_script method on WordPress 6.3
