### PR TITLE
Product Filters > Fix Performance issue and Fatal error on stores with a high volume of products

### DIFF
--- a/src/BlockTypes/ProductCollection.php
+++ b/src/BlockTypes/ProductCollection.php
@@ -72,6 +72,13 @@ class ProductCollection extends AbstractBlock {
 			3
 		);
 
+		add_filter(
+			'pre_render_block',
+			array( $this, 'add_support_for_filter_blocks' ),
+			10,
+			2
+		);
+
 		// Update the query for Editor.
 		add_filter( 'rest_product_query', array( $this, 'update_rest_query_in_editor' ), 10, 2 );
 
@@ -109,6 +116,31 @@ class ProductCollection extends AbstractBlock {
 				'handpicked_products' => $handpicked_products,
 			)
 		);
+	}
+
+	/**
+	 * Add support for filter blocks:
+	 * - Price filter block
+	 * - Attributes filter block
+	 * - Rating filter block
+	 * - In stock filter block etc.
+	 *
+	 * @param array $pre_render   The pre-rendered block.
+	 * @param array $parsed_block The parsed block.
+	 */
+	public function add_support_for_filter_blocks( $pre_render, $parsed_block ) {
+		$is_product_collection_block = $parsed_block['attrs']['query']['isProductCollectionBlock'] ?? false;
+
+		if ( ! $is_product_collection_block ) {
+			return;
+		}
+
+		$this->asset_data_registry->add( 'has_filterable_products', true, true );
+		/**
+		 * It enables the page to refresh when a filter is applied, ensuring that the product collection block,
+		 * which is a server-side rendered (SSR) block, retrieves the products that match the filters.
+		 */
+		$this->asset_data_registry->add( 'is_rendering_php_template', true, true );
 	}
 
 	/**

--- a/src/BlockTypes/ProductCollection.php
+++ b/src/BlockTypes/ProductCollection.php
@@ -72,13 +72,6 @@ class ProductCollection extends AbstractBlock {
 			3
 		);
 
-		add_filter(
-			'pre_render_block',
-			array( $this, 'add_support_for_filter_blocks' ),
-			10,
-			2
-		);
-
 		// Update the query for Editor.
 		add_filter( 'rest_product_query', array( $this, 'update_rest_query_in_editor' ), 10, 2 );
 
@@ -116,44 +109,6 @@ class ProductCollection extends AbstractBlock {
 				'handpicked_products' => $handpicked_products,
 			)
 		);
-	}
-
-	/**
-	 * Add support for filter blocks:
-	 * - Price filter block
-	 * - Attributes filter block
-	 * - Rating filter block
-	 * - In stock filter block etc.
-	 *
-	 * @param array $pre_render   The pre-rendered block.
-	 * @param array $parsed_block The parsed block.
-	 */
-	public function add_support_for_filter_blocks( $pre_render, $parsed_block ) {
-		$is_product_collection_block = $parsed_block['attrs']['query']['isProductCollectionBlock'] ?? false;
-
-		if ( ! $is_product_collection_block ) {
-			return;
-		}
-
-		$this->asset_data_registry->add( 'has_filterable_products', true, true );
-		/**
-		 * It enables the page to refresh when a filter is applied, ensuring that the product collection block,
-		 * which is a server-side rendered (SSR) block, retrieves the products that match the filters.
-		 */
-		$this->asset_data_registry->add( 'is_rendering_php_template', true, true );
-
-		$frontend_query = $this->get_final_frontend_query( $parsed_block['attrs']['query'], null, true );
-		// Override the query to get all products.
-		$fields_to_override = [
-			'posts_per_page' => -1,
-			'paged'          => null,
-		];
-		$new_array          = array_merge( $frontend_query, $fields_to_override );
-
-		$products    = new \WP_Query( $new_array );
-		$product_ids = wp_list_pluck( $products->posts, 'ID' );
-		// Add the product ids to the asset data registry, so that filter blocks can use it.
-		$this->asset_data_registry->add( 'product_ids', $product_ids, true );
 	}
 
 	/**

--- a/src/BlockTypes/ProductQuery.php
+++ b/src/BlockTypes/ProductQuery.php
@@ -157,7 +157,6 @@ class ProductQuery extends AbstractBlock {
 			// Set this so that our product filters can detect if it's a PHP template.
 			$this->asset_data_registry->add( 'has_filterable_products', true, true );
 			$this->asset_data_registry->add( 'is_rendering_php_template', true, true );
-			$this->asset_data_registry->add( 'product_ids', $this->get_products_ids_by_attributes( $parsed_block ), true );
 			add_filter(
 				'query_loop_block_query_vars',
 				array( $this, 'build_query' ),
@@ -244,33 +243,6 @@ class ProductQuery extends AbstractBlock {
 		);
 
 		return $this->filter_query_to_only_include_ids( $merged_query, $handpicked_products );
-	}
-
-	/**
-	 * Return the product ids based on the attributes and global query.
-	 * This is used to allow the filter blocks to render data that matches with variations. More details here: https://github.com/woocommerce/woocommerce-blocks/issues/7245
-	 *
-	 * @param array $parsed_block The block being rendered.
-	 * @return array
-	 */
-	private function get_products_ids_by_attributes( $parsed_block ) {
-		$query = $this->merge_queries(
-			array(
-				'post_type'      => 'product',
-				'post__in'       => array(),
-				'post_status'    => 'publish',
-				'posts_per_page' => -1,
-				'meta_query'     => array(),
-				'tax_query'      => array(),
-			),
-			$this->get_queries_by_custom_attributes( $parsed_block ),
-			$this->get_global_query( $parsed_block )
-		);
-
-		$products = new \WP_Query( $query );
-		$post_ids = wp_list_pluck( $products->posts, 'ID' );
-
-		return $post_ids;
 	}
 
 	/**


### PR DESCRIPTION
This PR fixes the issue initially reported on pdnLyh-3VR-p2 by removing the SQL queries used to manipulate the product counts for filters in particular cases. These queries were triggered for 100% of the stores using the Products (Beta) or the Product Collection blocks, independent of their usage of the Product Filters. Consequently, they negatively affected all stores' performance and triggered memory exhaustion errors for big e-commerces with thousands of products.

## What these queries were used for?

A practical use-case example is: when adding the Products (beta) block on any post or page, it is possible to edit a setting under "Advanced Filters" that allows you to handpick specific products for display instead of showing all of them by default:

<img width="1303" alt="Screenshot 2023-07-13 at 19 33 58" src="https://github.com/woocommerce/woocommerce-blocks/assets/15730971/62a189b0-7dd6-4f19-af6d-e9bc2af66768">

If any user decided to use the Filter by Attribute, Filter by Rating, or the Filter by Stock blocks with the filter counts enabled (they are disabled by default) alongside the Products (Beta) block that is just rendering a handful of products, these queries would manipulate the product counts to match the displayed products, and not all available products in the store right before rendering the block.

In other words, these queries were modifying the native behavior of the filter counts, and as a consequence, they were [not aligned with the design decisions](https://github.com/woocommerce/woocommerce-blocks/discussions/9023) made a few cycles ago. With the changes introduced here, all filter counts now provide the same functionality across the board, independent of their use cases.

## Discussion

There's an ongoing internal discussion, opened by @kmanijak, to gather feedback from the design team in case we wanna open an exception for this use case in particular and deviate from the design decision made previously. Depending on the outcome of that discussion, more changes will follow. (ref. per0F9-Rh-p2 ) 

Its also important to note that these queries are not necessary for maintaining the functionality of the filters or the filter counts; the [get_attribute_counts](https://github.com/woocommerce/woocommerce-blocks/blob/0d809ee287e52d3a348448349be5bf094bdb88ae/src/StoreApi/Utilities/ProductQueryFilters.php#L167) method is.

## User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Make sure you have products in your store with attributes and stock status (You can do so by simply importing the sample products from the core of Woo).
2. Create a new post.
3. Insert the Products (Beta) block.
4. Insert the Filter by Attribute, Filter by Stock and Filter by Price
5. Make sure all filters have the "Display product count" setting enabled (it is disabled by default).

<img width="309" alt="Screenshot 2023-07-13 at 20 09 31" src="https://github.com/woocommerce/woocommerce-blocks/assets/15730971/749275ca-94f9-4990-99f2-f302aaa4aab0">
 
6. Save the post and go to the front-end
7. Make sure you can use all filters as expected and without any problems/errors: the product counts should match the number of existing products in the store with the filtered criteria, not just what is displayed on the page.
8. Repeat all steps from 2 to 7, but using the Products Collection block instead of Products (beta). Make sure all filters work as expected.

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

This update will positively impact performance as two heavy queries were removed from the codebase. Stores with a high volume of products should be able to use the Products Collection and Products (Beta) blocks without risking having memory exhaustion errors as a consequence.

### Changelog

> Improve performance and fix memory exhaustion errors that could be triggered for stores with a high volume of products using the Products (Beta) or Products Collection blocks.