### PR TITLE
Create Mini-Cart template part area

### DIFF
--- a/assets/js/blocks/mini-cart/index.tsx
+++ b/assets/js/blocks/mini-cart/index.tsx
@@ -61,10 +61,7 @@ addFilter(
 				...blockSettings,
 				variations: blockSettings.variations.map(
 					( variation: { name: string } ) => {
-						if (
-							variation.name === 'instance_mini-cart' ||
-							variation.name === 'mini-cart'
-						) {
+						if ( variation.name === 'mini-cart' ) {
 							return {
 								...variation,
 								scope: [],

--- a/assets/js/blocks/mini-cart/index.tsx
+++ b/assets/js/blocks/mini-cart/index.tsx
@@ -61,7 +61,10 @@ addFilter(
 				...blockSettings,
 				variations: blockSettings.variations.map(
 					( variation: { name: string } ) => {
-						if ( variation.name === 'mini-cart' ) {
+						if (
+							variation.name === 'instance_mini-cart' ||
+							variation.name === 'mini-cart'
+						) {
 							return {
 								...variation,
 								scope: [],

--- a/assets/js/blocks/mini-cart/index.tsx
+++ b/assets/js/blocks/mini-cart/index.tsx
@@ -61,7 +61,7 @@ addFilter(
 				...blockSettings,
 				variations: blockSettings.variations.map(
 					( variation: { name: string } ) => {
-						if ( variation.name === 'instance_mini-cart' ) {
+						if ( variation.name === 'mini-cart' ) {
 							return {
 								...variation,
 								scope: [],

--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -68,6 +68,7 @@ class BlockTemplatesController {
 	 * Initialization method.
 	 */
 	protected function init() {
+		add_filter( 'default_wp_template_part_areas', array( $this, 'register_mini_cart_template_part_area' ), 10, 1 );
 		add_action( 'template_redirect', array( $this, 'render_block_template' ) );
 		add_filter( 'pre_get_block_template', array( $this, 'get_block_template_fallback' ), 10, 3 );
 		add_filter( 'pre_get_block_file_template', array( $this, 'get_block_file_template' ), 10, 3 );
@@ -101,6 +102,23 @@ class BlockTemplatesController {
 				2
 			);
 		}
+	}
+
+	/**
+	 * Add Mini-Cart to the default template part areas.
+	 *
+	 * @param array $default_area_definitions An array of supported area objects.
+	 * @return array The supported template part areas including the Mini-Cart one.
+	 */
+	public function register_mini_cart_template_part_area( $default_area_definitions ) {
+		$mini_cart_template_part_area = [
+			'area'        => 'mini-cart',
+			'label'       => 'Mini-Cart',
+			'description' => 'The Mini-Cart template allows shoppers to see their cart items and provides access to the Cart and Checkout pages.',
+			'icon'        => 'mini-cart',
+			'area_tag'    => 'mini-cart',
+		];
+		return array_merge( $default_area_definitions, [ $mini_cart_template_part_area ] );
 	}
 
 	/**

--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -114,7 +114,7 @@ class BlockTemplatesController {
 		$mini_cart_template_part_area = [
 			'area'        => 'mini-cart',
 			'label'       => __( 'Mini-Cart', 'woo-gutenberg-products-block' ),
-			'description' => 'The Mini-Cart template allows shoppers to see their cart items and provides access to the Cart and Checkout pages.',
+			'description' => __( 'The Mini-Cart template allows shoppers to see their cart items and provides access to the Cart and Checkout pages.', 'woo-gutenberg-products-block' ),
 			'icon'        => 'mini-cart',
 			'area_tag'    => 'mini-cart',
 		];

--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -113,7 +113,7 @@ class BlockTemplatesController {
 	public function register_mini_cart_template_part_area( $default_area_definitions ) {
 		$mini_cart_template_part_area = [
 			'area'        => 'mini-cart',
-			'label'       => 'Mini-Cart',
+			'label'       => __( 'Mini-Cart', 'woo-gutenberg-products-block' ),
 			'description' => 'The Mini-Cart template allows shoppers to see their cart items and provides access to the Cart and Checkout pages.',
 			'icon'        => 'mini-cart',
 			'area_tag'    => 'mini-cart',

--- a/src/Utils/BlockTemplateUtils.php
+++ b/src/Utils/BlockTemplateUtils.php
@@ -219,6 +219,11 @@ class BlockTemplateUtils {
 		$template->is_custom      = false; // Templates loaded from the filesystem aren't custom, ones that have been edited and loaded from the DB are.
 		$template->post_types     = array(); // Don't appear in any Edit Post template selector dropdown.
 		$template->area           = 'uncategorized';
+
+		// Force the Mini-Cart template part to be in the Mini-Cart template part area.
+		if ( 'wp_template_part' === $template_type && 'mini-cart' === $template_file->slug ) {
+			$template->area = 'mini-cart';
+		}
 		return $template;
 	}
 


### PR DESCRIPTION
This PR registers a Mini-Cart template part area, so in WP 6.3, the Mini-Cart template part is listed separately from the other template parts.

### Testing

#### User Facing Testing

1. With WP 6.3 and a block theme, go to Appearance > Editor > Patterns.
2. Verify there is a Mini-Cart template part area containing the Mini-Cart template part.

Before | After
--- | ---
![imatge](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/687cf682-6670-4e5a-a9e5-0318813e59ab) | ![imatge](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/222cf40b-3b6d-42e0-85b4-2bb1e2d0b679)

* [ ] Do not include in the Testing Notes

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Register a Mini-Cart template part area, so in WP 6.3, the Mini-Cart template part is listed separately from the other template parts.
