### PR TITLE
Prevent Mini-Cart template part preview in Site Editor being too high

### DIFF
--- a/assets/js/blocks/mini-cart/mini-cart-contents/edit.tsx
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/edit.tsx
@@ -47,18 +47,7 @@ const Edit = ( {
 }: Props ): ReactElement => {
 	const { currentView, width } = attributes;
 
-	const blockProps = useBlockProps( {
-		/**
-		 * This is a workaround for the Site Editor to calculate the
-		 * correct height of the Mini-Cart template part on the first load.
-		 *
-		 * @see https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5825
-		 */
-		style: {
-			minHeight: '100vh',
-			width,
-		},
-	} );
+	const blockProps = useBlockProps();
 
 	const defaultTemplate = [
 		[ 'woocommerce/filled-mini-cart-contents-block', {}, [] ],

--- a/assets/js/blocks/mini-cart/mini-cart-contents/editor.scss
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/editor.scss
@@ -88,12 +88,6 @@
 	}
 }
 
-.editor-styles-wrapper .wp-block-woocommerce-mini-cart-contents,
-.editor-styles-wrapper .wp-block-woocommerce-filled-mini-cart-contents-block {
-	height: auto;
-	min-height: 500px;
-}
-
 /* Site Editor preview */
 .block-editor-block-preview__content-iframe .editor-styles-wrapper {
 	.wp-block-woocommerce-mini-cart-contents,

--- a/assets/js/blocks/mini-cart/mini-cart-contents/editor.scss
+++ b/assets/js/blocks/mini-cart/mini-cart-contents/editor.scss
@@ -93,3 +93,13 @@
 	height: auto;
 	min-height: 500px;
 }
+
+/* Site Editor preview */
+.block-editor-block-preview__content-iframe .editor-styles-wrapper {
+	.wp-block-woocommerce-mini-cart-contents,
+	.wp-block-woocommerce-filled-mini-cart-contents-block,
+	.wp-block-woocommerce-empty-mini-cart-contents-block {
+		height: 800px;
+		min-height: none;
+	}
+}


### PR DESCRIPTION
This PR fixes the Mini-Cart template part height in the Site Editor preview. It also removes the code added in https://github.com/woocommerce/woocommerce-blocks/pull/5825 (it seems like it's no longer needed) and the code from https://github.com/woocommerce/woocommerce-blocks/pull/8458 (the block is no longer visible in the Story Book, so we can remove that CSS).

### Testing

#### User Facing Testing

1. With WP 6.3 and a block theme, go to Appearance > Editor > Patterns.
2. Open the General template part area.
3. Scroll down to see the Mini-Cart template part.
4. Verify its size doesn't occupy the entire window height.

Before | After
--- | ---
![imatge](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/ddb310f0-c33e-453f-881f-5bd146051d90) | ![imatge](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/f2f73bff-9ad9-4919-9c14-ec5caed35a20)

5. Click on it and verify that, when opened, it does take the entire height as always.

![imatge](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/ab9b2b6f-07b6-4202-8a6b-a986bee1ddd4)

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Prevent Mini-Cart template part preview in Site Editor being too high
