### PR TITLE
Remove opinionated font sizes from Essential Header patterns

### DIFF
--- a/patterns/header-essential-dark.php
+++ b/patterns/header-essential-dark.php
@@ -16,10 +16,10 @@
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:group {"style":{"spacing":{"blockGap":"8px"},"typography":{"fontSize":"18px"},"layout":{"selfStretch":"fill","flexSize":null}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"right"}} -->
-	<div class="wp-block-group" style="font-size:18px">
+	<!-- wp:group {"style":{"spacing":{"blockGap":"8px"},"layout":{"selfStretch":"fill","flexSize":null}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"right"}} -->
+	<div class="wp-block-group">
 		<!-- wp:woocommerce/customer-account {"displayStyle":"icon_only","iconStyle":"alt","iconClass":"wc-block-customer-account__account-icon"} /-->
-		<!-- wp:woocommerce/mini-cart {"textColor":"background","style":{"typography":{"fontSize":"14px"}}} /-->
+		<!-- wp:woocommerce/mini-cart {"textColor":"background"} /-->
 	</div>
 	<!-- /wp:group -->
 </div>

--- a/patterns/header-essential.php
+++ b/patterns/header-essential.php
@@ -16,10 +16,10 @@
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:group {"style":{"spacing":{"blockGap":"8px"},"typography":{"fontSize":"18px"},"layout":{"selfStretch":"fill","flexSize":null}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"right"}} -->
-	<div class="wp-block-group" style="font-size:18px">
+	<!-- wp:group {"style":{"spacing":{"blockGap":"8px"},"layout":{"selfStretch":"fill","flexSize":null}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"right"}} -->
+	<div class="wp-block-group">
 		<!-- wp:woocommerce/customer-account {"displayStyle":"icon_only","iconStyle":"alt","iconClass":"wc-block-customer-account__account-icon"} /-->
-		<!-- wp:woocommerce/mini-cart {"style":{"typography":{"fontSize":"14px"}}} /-->
+		<!-- wp:woocommerce/mini-cart /-->
 	</div>
 	<!-- /wp:group -->
 </div>


### PR DESCRIPTION
Fixes #10208.

### Testing

#### User Facing Testing

1. In the post editor or the site editor, add the Essential Header pattern.
2. Verify it looks like the screenshot below (font-sizes adapt to the theme).
3. Repeat 1-2 with the Essential Header Dark pattern.

![imatge](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/d8502340-89c5-43d8-9231-0fafd9d6c9a4)

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Updated Essential Header patterns to have no opinionated font sizes.
