### PR TITLE
Update Featured Category Cover Image pattern

### DIFF
--- a/patterns/featured-category-cover-image.php
+++ b/patterns/featured-category-cover-image.php
@@ -9,20 +9,17 @@
 <div class="wp-block-cover alignwide has-custom-content-position is-position-top-left" style="padding-top:2em;padding-right:2.25em;padding-bottom:2.25em;padding-left:2.25em">
 	<span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span>
 	<img class="wp-block-cover__image-background wp-image-1" alt="<?php esc_attr_e( 'Placeholder image used to represent products being showcased in a featured category section.', 'woo-gutenberg-products-block' ); ?>" src="<?php echo esc_url( plugins_url( 'images/pattern-placeholders/wood-leather-fur-shop-jeans-shelf.png', dirname( __FILE__ ) ) ); ?>" style="object-position:0% 0%" data-object-fit="cover" data-object-position="0% 0%"/>
-
 	<div class="wp-block-cover__inner-container">
-		<!-- wp:paragraph {"align":"left","placeholder":"Write title…","style":{"typography":{"lineHeight":"1.5","fontSize":"2.2em","textColor":"background"},"color":{"text":"#ffffff"},"spacing":{"margin":{"bottom":"0px","top":"0px"}}}} -->
-		<p class="has-text-align-left has-text-color" style="color:#ffffff;margin-top:0px;margin-bottom:0px;font-size:2.2em;line-height:1.5"><strong>100% natural denim</strong></p>
-		<!-- /wp:paragraph -->
-
-		<!-- wp:paragraph {"style":{"typography":{"lineHeight":"1.5"},"color":{"text":"#ffffff"},"spacing":{"margin":{"top":"0px","bottom":"0px"}}}} -->
+		<!-- wp:heading {"textAlign":"left","style":{"color":{"text":"#ffffff"}}} -->
+		<h2 class="wp-block-heading has-text-align-left has-text-color" style="color:#ffffff;"><strong>100% natural denim</strong></h2>
+		<!-- /wp:heading -->
+		<!-- wp:paragraph {"style":{"color":{"text":"#ffffff"},"spacing":{"margin":{"top":"0px","bottom":"0px"}}}} -->
 		<p class="has-text-color" style="color:#ffffff;margin-top:0px;margin-bottom:0px;line-height:1.5">Only the finest goes into our products. You deserve it.</p>
 		<!-- /wp:paragraph -->
-
 		<!-- wp:buttons {"style":{"spacing":{"margin":{"top":"30px"}}}} -->
 		<div class="wp-block-buttons" style="margin-top:30px">
-			<!-- wp:button {"style":{"border":{"width":"0px","style":"none"},"color":{"text":"#000000","background":"#ffffff"}},"className":"is-style-fill"} -->
-			<div class="wp-block-button is-style-fill"><a href="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>" class="wp-block-button__link has-text-color has-background wp-element-button" style="border-style:none;border-width:0px;color:#000000;background-color:#ffffff">Shop jeans</a></div>
+			<!-- wp:button -->
+			<div class="wp-block-button"><a href="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>" class="wp-block-button__link wp-element-button">Shop jeans</a></div>
 			<!-- /wp:button --></div>
 		<!-- /wp:buttons --></div>
 </div>

--- a/patterns/featured-category-cover-image.php
+++ b/patterns/featured-category-cover-image.php
@@ -5,21 +5,22 @@
  * Categories: WooCommerce
  */
 ?>
-<!-- wp:cover {"url":"<?php echo esc_url( plugins_url( 'images/pattern-placeholders/wood-leather-fur-shop-jeans-shelf.png', dirname( __FILE__ ) ) ); ?>","id":1,"dimRatio":0,"focalPoint":{"x":0,"y":0},"contentPosition":"top left","align":"wide","style":{"spacing":{"padding":{"top":"2em","right":"2.25em","bottom":"2.25em","left":"2.25em"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-cover alignwide has-custom-content-position is-position-top-left" style="padding-top:2em;padding-right:2.25em;padding-bottom:2.25em;padding-left:2.25em">
-	<span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span>
+<!-- wp:cover {"url":"<?php echo esc_url( plugins_url( 'images/pattern-placeholders/wood-leather-fur-shop-jeans-shelf.png', dirname( __FILE__ ) ) ); ?>","id":1,"dimRatio":30,"customOverlayColor":"#000000","focalPoint":{"x":0,"y":0},"contentPosition":"center center","align":"wide","style":{"spacing":{"padding":{"top":"2em","right":"2.25em","bottom":"2.25em","left":"2.25em"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-cover alignwide has-custom-content-position" style="padding-top:2em;padding-right:2.25em;padding-bottom:2.25em;padding-left:2.25em">
+	<span aria-hidden="true" class="wp-block-cover__background has-background-dim-30 has-background-dim" style="background-color:#000000"></span>
 	<img class="wp-block-cover__image-background wp-image-1" alt="<?php esc_attr_e( 'Placeholder image used to represent products being showcased in a featured category section.', 'woo-gutenberg-products-block' ); ?>" src="<?php echo esc_url( plugins_url( 'images/pattern-placeholders/wood-leather-fur-shop-jeans-shelf.png', dirname( __FILE__ ) ) ); ?>" style="object-position:0% 0%" data-object-fit="cover" data-object-position="0% 0%"/>
 	<div class="wp-block-cover__inner-container">
-		<!-- wp:heading {"textAlign":"left","style":{"color":{"text":"#ffffff"}}} -->
-		<h2 class="wp-block-heading has-text-align-left has-text-color" style="color:#ffffff;"><strong>100% natural denim</strong></h2>
+		<!-- wp:heading {"textAlign":"center","style":{"color":{"text":"#ffffff"}}} -->
+		<h2 class="wp-block-heading has-text-align-center has-text-color" style="color:#ffffff;"><strong>100% natural denim</strong></h2>
 		<!-- /wp:heading -->
-		<!-- wp:paragraph {"style":{"color":{"text":"#ffffff"},"spacing":{"margin":{"top":"0px","bottom":"0px"}}}} -->
-		<p class="has-text-color" style="color:#ffffff;margin-top:0px;margin-bottom:0px;line-height:1.5">Only the finest goes into our products. You deserve it.</p>
+
+		<!-- wp:paragraph {"align":"center","style":{"color":{"text":"#ffffff"},"spacing":{"margin":{"top":"0px","bottom":"0px"}}}} -->
+		<p class="has-text-align-center has-text-color" style="color:#ffffff;margin-top:0px;margin-bottom:0px">Only the finest goes into our products. You deserve it.</p>
 		<!-- /wp:paragraph -->
-		<!-- wp:buttons {"style":{"spacing":{"margin":{"top":"30px"}}}} -->
+		<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"},"style":{"spacing":{"margin":{"top":"30px"}}}} -->
 		<div class="wp-block-buttons" style="margin-top:30px">
-			<!-- wp:button -->
-			<div class="wp-block-button"><a href="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>" class="wp-block-button__link wp-element-button">Shop jeans</a></div>
+			<!-- wp:button {"textAlign":"center"} -->
+			<div class="wp-block-button"><a href="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>" class="wp-block-button__link has-text-align-center wp-element-button">Shop jeans</a></div>
 			<!-- /wp:button --></div>
 		<!-- /wp:buttons --></div>
 </div>

--- a/patterns/featured-category-cover-image.php
+++ b/patterns/featured-category-cover-image.php
@@ -11,16 +11,27 @@
 	<img class="wp-block-cover__image-background wp-image-1" alt="<?php esc_attr_e( 'Placeholder image used to represent products being showcased in a featured category section.', 'woo-gutenberg-products-block' ); ?>" src="<?php echo esc_url( plugins_url( 'images/pattern-placeholders/wood-leather-fur-shop-jeans-shelf.png', dirname( __FILE__ ) ) ); ?>" style="object-position:0% 0%" data-object-fit="cover" data-object-position="0% 0%"/>
 	<div class="wp-block-cover__inner-container">
 		<!-- wp:heading {"textAlign":"center","style":{"color":{"text":"#ffffff"}}} -->
-		<h2 class="wp-block-heading has-text-align-center has-text-color" style="color:#ffffff;"><strong>100% natural denim</strong></h2>
+		<h2 class="wp-block-heading has-text-align-center has-text-color" style="color:#ffffff;"><strong>
+		<?php
+		esc_attr_e(
+			'100% natural denim',
+			'woo-gutenberg-products-block'
+		);
+		?>
+		</strong></h2>
 		<!-- /wp:heading -->
 
 		<!-- wp:paragraph {"align":"center","style":{"color":{"text":"#ffffff"},"spacing":{"margin":{"top":"0px","bottom":"0px"}}}} -->
-		<p class="has-text-align-center has-text-color" style="color:#ffffff;margin-top:0px;margin-bottom:0px">Only the finest goes into our products. You deserve it.</p>
+		<p class="has-text-align-center has-text-color" style="color:#ffffff;margin-top:0px;margin-bottom:0px">
+		<?php
+		esc_attr_e( 'Only the finest goes into our products. You deserve it.', 'woo-gutenberg-products-block' );
+		?>
+		</p>
 		<!-- /wp:paragraph -->
 		<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"},"style":{"spacing":{"margin":{"top":"30px"}}}} -->
 		<div class="wp-block-buttons" style="margin-top:30px">
 			<!-- wp:button {"textAlign":"center"} -->
-			<div class="wp-block-button"><a href="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>" class="wp-block-button__link has-text-align-center wp-element-button">Shop jeans</a></div>
+			<div class="wp-block-button"><a href="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>" class="wp-block-button__link has-text-align-center wp-element-button"><?php esc_attr_e( 'Shop jeans', 'woo-gutenberg-products-block' ); ?></a></div>
 			<!-- /wp:button --></div>
 		<!-- /wp:buttons --></div>
 </div>

--- a/patterns/featured-category-cover-image.php
+++ b/patterns/featured-category-cover-image.php
@@ -11,14 +11,14 @@
 	<img class="wp-block-cover__image-background wp-image-1" alt="<?php esc_attr_e( 'Placeholder image used to represent products being showcased in a featured category section.', 'woo-gutenberg-products-block' ); ?>" src="<?php echo esc_url( plugins_url( 'images/pattern-placeholders/wood-leather-fur-shop-jeans-shelf.png', dirname( __FILE__ ) ) ); ?>" style="object-position:0% 0%" data-object-fit="cover" data-object-position="0% 0%"/>
 	<div class="wp-block-cover__inner-container">
 		<!-- wp:heading {"textAlign":"center","style":{"color":{"text":"#ffffff"}}} -->
-		<h2 class="wp-block-heading has-text-align-center has-text-color" style="color:#ffffff;"><strong>
+		<h2 class="wp-block-heading has-text-align-center has-text-color" style="color:#ffffff;">
 		<?php
 		esc_attr_e(
 			'100% natural denim',
 			'woo-gutenberg-products-block'
 		);
 		?>
-		</strong></h2>
+		</h2>
 		<!-- /wp:heading -->
 
 		<!-- wp:paragraph {"align":"center","style":{"color":{"text":"#ffffff"},"spacing":{"margin":{"top":"0px","bottom":"0px"}}}} -->


### PR DESCRIPTION
Fixes woocommerce/woocommerce-blocks#10214.

### Testing

#### User Facing Testing

1. In the post editor or the site editor, add the Featured Category Cover Image pattern.
2. Verify there are no opinionated styles: ie font size, line heading, button color, etc. follow theme styles.
3. Also verify the pattern matches the new designs (see screenshots below or Figma file: [F5AAbRJOGbTeEweXPFtHgf-fi-2242_36099](https://href.li/?https://www.figma.com/file/F5AAbRJOGbTeEweXPFtHgf/?node-id=2242-36099)).

Desktop | Mobile
--- | ---
![imatge](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/c6600dd1-8caa-4f30-8fd7-07d719d43105) | ![imatge](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/d261c3d8-097d-4f0e-80ad-f4dda835cb1b)

* [ ] Do not include in the Testing Notes

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Update Featured Category Cover Image pattern styles and make it localizable
