### PR TITLE
Prepend CSS src with correct url scheme

### DIFF
--- a/src/BlockTypes/ClassicTemplate.php
+++ b/src/BlockTypes/ClassicTemplate.php
@@ -6,6 +6,7 @@ use Automattic\WooCommerce\Blocks\Templates\ProductSearchResultsTemplate;
 use Automattic\WooCommerce\Blocks\Templates\OrderConfirmationTemplate;
 use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
 use WC_Shortcode_Checkout;
+use WC_Frontend_Scripts;
 
 /**
  * Classic Single Product class
@@ -47,10 +48,17 @@ class ClassicTemplate extends AbstractDynamicBlock {
 	public function enqueue_block_assets() {
 		// Ensures frontend styles for blocks exist in the site editor iframe.
 		if ( class_exists( 'WC_Frontend_Scripts' ) && is_admin() ) {
-			$frontend_scripts = new \WC_Frontend_Scripts();
+			$frontend_scripts = new WC_Frontend_Scripts();
 			$styles           = $frontend_scripts::get_styles();
+
 			foreach ( $styles as $handle => $style ) {
-				wp_enqueue_style( $handle, $style['src'], $style['deps'], $style['version'], $style['media'] );
+				wp_enqueue_style(
+					$handle,
+					substr( $style['src'], 0, 2 ) === '//' ? 'https:' . $style['src'] : $style['src'],
+					$style['deps'],
+					$style['version'],
+					$style['media']
+				);
 			}
 		}
 	}
@@ -75,7 +83,7 @@ class ClassicTemplate extends AbstractDynamicBlock {
 		 * @see https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/5328#issuecomment-989013447
 		 */
 		if ( class_exists( 'WC_Frontend_Scripts' ) ) {
-			$frontend_scripts = new \WC_Frontend_Scripts();
+			$frontend_scripts = new WC_Frontend_Scripts();
 			$frontend_scripts::load_scripts();
 		}
 

--- a/src/BlockTypes/ClassicTemplate.php
+++ b/src/BlockTypes/ClassicTemplate.php
@@ -54,7 +54,7 @@ class ClassicTemplate extends AbstractDynamicBlock {
 			foreach ( $styles as $handle => $style ) {
 				wp_enqueue_style(
 					$handle,
-					substr( $style['src'], 0, 2 ) === '//' ? 'https:' . $style['src'] : $style['src'],
+					set_url_scheme( $style['src'] ),
 					$style['deps'],
 					$style['version'],
 					$style['media']


### PR DESCRIPTION
Styles from themes (2023 for example) were not working in the editor because the src began with `//`. This fixes the issue by ensuring there is a `https://` prefix.

Fixes #10170

### Screenshots

![Screenshot 2023-07-17 at 15 04 50](https://github.com/woocommerce/woocommerce-blocks/assets/90977/80d42fb9-fd83-45fd-94d0-2effd159c308)

### Testing

#### User Facing Testing

1. With Twenty Twenty Three theme and Gutenberg plugin active, go to the site editor
2. Edit Templates > Order Confirmation
3. Check that styles match the screenshot above taking note of the borders around tables, and the lack of bullets next to list items.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### Changelog

> Fixed classic template appearance in the editor with some of the default themes
