### PR TITLE
Replace sanitization functions to enforce string values

### DIFF
--- a/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
+++ b/src/StoreApi/Schemas/V1/AbstractAddressSchema.php
@@ -92,16 +92,16 @@ abstract class AbstractAddressSchema extends AbstractSchema {
 		$validation_util = new ValidationUtils();
 
 		$address               = array_merge( array_fill_keys( array_keys( $this->get_properties() ), '' ), (array) $address );
-		$address['country']    = wc_strtoupper( wc_clean( wp_unslash( $address['country'] ) ) );
-		$address['first_name'] = wc_clean( wp_unslash( $address['first_name'] ) );
-		$address['last_name']  = wc_clean( wp_unslash( $address['last_name'] ) );
-		$address['company']    = wc_clean( wp_unslash( $address['company'] ) );
-		$address['address_1']  = wc_clean( wp_unslash( $address['address_1'] ) );
-		$address['address_2']  = wc_clean( wp_unslash( $address['address_2'] ) );
-		$address['city']       = wc_clean( wp_unslash( $address['city'] ) );
-		$address['state']      = $validation_util->format_state( wc_clean( wp_unslash( $address['state'] ) ), $address['country'] );
-		$address['postcode']   = $address['postcode'] ? wc_format_postcode( wc_clean( wp_unslash( $address['postcode'] ) ), $address['country'] ) : '';
-		$address['phone']      = wc_clean( wp_unslash( $address['phone'] ) );
+		$address['country']    = wc_strtoupper( sanitize_text_field( wp_unslash( $address['country'] ) ) );
+		$address['first_name'] = sanitize_text_field( wp_unslash( $address['first_name'] ) );
+		$address['last_name']  = sanitize_text_field( wp_unslash( $address['last_name'] ) );
+		$address['company']    = sanitize_text_field( wp_unslash( $address['company'] ) );
+		$address['address_1']  = sanitize_text_field( wp_unslash( $address['address_1'] ) );
+		$address['address_2']  = sanitize_text_field( wp_unslash( $address['address_2'] ) );
+		$address['city']       = sanitize_text_field( wp_unslash( $address['city'] ) );
+		$address['state']      = $validation_util->format_state( sanitize_text_field( wp_unslash( $address['state'] ) ), $address['country'] );
+		$address['postcode']   = $address['postcode'] ? wc_format_postcode( sanitize_text_field( wp_unslash( $address['postcode'] ) ), $address['country'] ) : '';
+		$address['phone']      = sanitize_text_field( wp_unslash( $address['phone'] ) );
 		return $address;
 	}
 

--- a/src/StoreApi/Schemas/V1/BillingAddressSchema.php
+++ b/src/StoreApi/Schemas/V1/BillingAddressSchema.php
@@ -54,7 +54,7 @@ class BillingAddressSchema extends AbstractAddressSchema {
 	 */
 	public function sanitize_callback( $address, $request, $param ) {
 		$address          = parent::sanitize_callback( $address, $request, $param );
-		$address['email'] = wc_clean( wp_unslash( $address['email'] ) );
+		$address['email'] = sanitize_text_field( wp_unslash( $address['email'] ) );
 		return $address;
 	}
 

--- a/tests/php/StoreApi/Routes/Checkout.php
+++ b/tests/php/StoreApi/Routes/Checkout.php
@@ -19,6 +19,8 @@ use Mockery\Adapter\Phpunit\MockeryTestCase;
 
 /**
  * Checkout Controller Tests.
+ *
+ * phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_print_r, WooCommerce.Commenting.CommentHooks.MissingHookComment
  */
 class Checkout extends MockeryTestCase {
 	/**
@@ -384,5 +386,51 @@ class Checkout extends MockeryTestCase {
 
 		$customer = get_user_by( 'id', $data['customer_id'] );
 		$this->assertEquals( $customer->user_email, 'testaccount@test.com' );
+	}
+
+	/**
+	 * Test account creation options.
+	 */
+	public function test_checkout_invalid_address_data() {
+		$request = new \WP_REST_Request( 'POST', '/wc/store/v1/checkout' );
+		$request->set_header( 'Nonce', wp_create_nonce( 'wc_store_api' ) );
+		$request->set_body_params(
+			array(
+				'billing_address'  => (object) array(
+					'first_name' => 'test',
+					'last_name'  => array(
+						'invalid' => 'invalid_data',
+					),
+					'company'    => '',
+					'address_1'  => 'test',
+					'address_2'  => '',
+					'city'       => 'test',
+					'state'      => '',
+					'postcode'   => 'cb241ab',
+					'country'    => 'GB',
+					'phone'      => '',
+					'email'      => 'testaccount@test.com',
+				),
+				'shipping_address' => (object) array(
+					'first_name' => 'test',
+					'last_name'  => 'test',
+					'company'    => '',
+					'address_1'  => 'test',
+					'address_2'  => '',
+					'city'       => 'test',
+					'state'      => '',
+					'postcode'   => 'cb241ab',
+					'country'    => 'GB',
+					'phone'      => '',
+				),
+				'payment_method'   => 'bacs',
+			)
+		);
+
+		$response = rest_get_server()->dispatch( $request );
+		$status   = $response->get_status();
+		$data     = $response->get_data();
+
+		$this->assertEquals( 400, $status, print_r( $data, true ) );
 	}
 }


### PR DESCRIPTION
This PR ensures that address data posted to the Store API is correctly formatted as a string.

Previously data was sanitized by `wc_clean` which supports arrays of data also. In this case, we need to enforce string values to match the Store API schema, so the fix here is to instead use `sanitize_text_field` directly.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [ ] E2E tests

#### User Facing Testing

To test, use a rest API client to add something to your cart and then post the following to the wp-json/wc/store/checkout endpoint:

```json
{
	"billing_address": {
		"first_name": "Steve",
		"last_name": {
			"Guest": "test"
    		},
		"email": "test@test.com",
		"address_1": "41 Some Street",
		"city": "Townford",
		"postcode": "CB25 6FG",
		"country": "GB"
	},
	"payment_method": "bacs"
}
```

This should come back with a 400 bad request after this PR is merged. I have added a unit test to confirm this.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fixed formatting for addresses sent to the Store API.
