### PR TITLE
Change custom toolbar item to use toolbar button

### DIFF
--- a/assets/js/blocks/featured-items/block-controls.tsx
+++ b/assets/js/blocks/featured-items/block-controls.tsx
@@ -11,7 +11,6 @@ import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
 import { crop } from '@wordpress/icons';
 import { WP_REST_API_Category } from 'wp-types';
 import { ProductResponseItem } from '@woocommerce/types';
-import TextToolbarButton from '@woocommerce/editor-components/text-toolbar-button';
 import type { ComponentType, Dispatch, SetStateAction } from 'react';
 import type { BlockAlignment } from '@wordpress/blocks';
 
@@ -112,13 +111,13 @@ export const BlockControls = ( {
 					allowedTypes={ [ 'image' ] }
 				/>
 				{ backgroundImageId && mediaSrc ? (
-					<TextToolbarButton
+					<ToolbarButton
 						onClick={ () =>
 							setAttributes( { mediaId: 0, mediaSrc: '' } )
 						}
 					>
 						{ __( 'Reset', 'woo-gutenberg-products-block' ) }
-					</TextToolbarButton>
+					</ToolbarButton>
 				) : null }
 			</ToolbarGroup>
 			<ToolbarGroup


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/9244

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Create a post and add `Featured Category` and `Featured Product` block to the page and have your developer console opened.
2. Click on each of the block so that you can see the toolbar popup for each block.
3. In your developer console, ensure you don't see the warning `Using custom components as toolbar controls is deprecated since version 5.6. Please use ToolbarItem, ToolbarButton or ToolbarDropdownMenu components instead.`.
4. Ensure each of the toolbar items are still functioning as expected.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Fix deprecated warning for featured category and product block
