### PR TITLE
Remove work-around code in EditableButton component to fix typing Space

### DIFF
--- a/assets/js/editor-components/editable-button/index.tsx
+++ b/assets/js/editor-components/editable-button/index.tsx
@@ -1,10 +1,8 @@
 /**
  * External dependencies
  */
-import { useEffect, useRef } from '@wordpress/element';
 import Button, { ButtonProps } from '@woocommerce/base-components/button';
 import { RichText } from '@wordpress/block-editor';
-import type { RefObject } from 'react';
 
 export interface EditableButtonProps
 	extends Omit< ButtonProps, 'onChange' | 'placeholder' | 'value' > {
@@ -28,59 +26,15 @@ const EditableButton = ( {
 	value,
 	...props
 }: EditableButtonProps ) => {
-	const button: RefObject< HTMLButtonElement > = useRef( null );
-
-	// Fix a bug in Firefox that didn't allow to type spaces in editable buttons.
-	// @see https://github.com/woocommerce/woocommerce-blocks/issues/8734
-	useEffect( () => {
-		const buttonEl = button?.current;
-
-		if ( ! buttonEl ) {
-			return;
-		}
-
-		const onKeyDown = ( event: KeyboardEvent ) => {
-			// If the user typed something different than space, do nothing.
-			if ( event.code !== 'Space' ) {
-				return;
-			}
-			event.preventDefault();
-			const selection = buttonEl.ownerDocument.getSelection();
-			if ( selection && selection.rangeCount > 0 ) {
-				// Get the caret position and insert a space.
-				const range = selection.getRangeAt( 0 );
-				range.deleteContents();
-				const textNode = document.createTextNode( ' ' );
-				range.insertNode( textNode );
-				// Set the caret position after the space.
-				range.setStartAfter( textNode );
-				range.setEndAfter( textNode );
-				selection.removeAllRanges();
-				selection.addRange( range );
-			}
-		};
-
-		buttonEl.addEventListener( 'keydown', onKeyDown );
-
-		return () => {
-			if ( ! buttonEl ) {
-				return;
-			}
-			buttonEl.removeEventListener( 'keydown', onKeyDown );
-		};
-	}, [ onChange, value ] );
-
 	return (
 		<Button { ...props }>
-			<span ref={ button }>
-				<RichText
-					multiline={ false }
-					allowedFormats={ [] }
-					value={ value }
-					placeholder={ placeholder }
-					onChange={ onChange }
-				/>
-			</span>
+			<RichText
+				multiline={ false }
+				allowedFormats={ [] }
+				value={ value }
+				placeholder={ placeholder }
+				onChange={ onChange }
+			/>
 		</Button>
 	);
 };


### PR DESCRIPTION
This PR removes some of the code added on https://github.com/woocommerce/woocommerce-blocks/pull/8777. In that PR, we worked-around an issue in Firefox that caused users not to be able to type <kbd>Space</kbd> in editable buttons. Since then, the [bug in Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1822860) has been fixed and shipped with Firefox 115, so we should be good to remove our work-around code.

### Testing

#### User Facing Testing

1. With Firefox 115 or later, add the Cart block to a post or page.
2. In the editor, press the _Proceed to Checkout_ button to edit the text to something like: _Go to payment_ (or any string containing spaces).
3. Verify the text is updated correctly and spaces are added as expected.
4. Preview the page in the frontend and verify the button text is correct as well.
5. Repeat steps 1-4 with the Checkout and Mini Cart blocks. (For the Mini Cart, you will need to edit its template part)
6. Repeat steps 1-4 with different browsers (Chrome, Safari, etc.).

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
