### PR TITLE
Get latest cart when triggering checkout events

### DIFF
--- a/assets/js/base/context/hooks/use-store-events.ts
+++ b/assets/js/base/context/hooks/use-store-events.ts
@@ -2,12 +2,8 @@
  * External dependencies
  */
 import { doAction } from '@wordpress/hooks';
-import { useCallback, useRef, useEffect } from '@wordpress/element';
-
-/**
- * Internal dependencies
- */
-import { useStoreCart } from './cart/use-store-cart';
+import { select } from '@wordpress/data';
+import { useCallback } from '@wordpress/element';
 
 type StoreEvent = (
 	eventName: string,
@@ -21,15 +17,6 @@ export const useStoreEvents = (): {
 	dispatchStoreEvent: StoreEvent;
 	dispatchCheckoutEvent: StoreEvent;
 } => {
-	const storeCart = useStoreCart();
-	const currentStoreCart = useRef( storeCart );
-
-	// Track the latest version of the cart so we can use the current value in our callback function below without triggering
-	// other useEffect hooks using dispatchCheckoutEvent as a dependency.
-	useEffect( () => {
-		currentStoreCart.current = storeCart;
-	}, [ storeCart ] );
-
 	const dispatchStoreEvent = useCallback( ( eventName, eventParams = {} ) => {
 		try {
 			doAction(
@@ -50,7 +37,7 @@ export const useStoreEvents = (): {
 					`experimental__woocommerce_blocks-checkout-${ eventName }`,
 					{
 						...eventParams,
-						storeCart: currentStoreCart.current,
+						storeCart: select( 'wc/store/cart' ).getCartData(),
 					}
 				);
 			} catch ( e ) {


### PR DESCRIPTION
Makes `dispatchCheckoutEvent` get the current value of the cart from the data store, rather than a stale ref.

Fixes #8863

### Testing

Go to the checkout page and type this in your browser console:

```
wp.hooks.addAction(
	"experimental__woocommerce_blocks-checkout-set-email-address",
	"test-plugin",
	({storeCart}) => {
		console.log("set-email-address", storeCart.billingAddress.email);
	}
);
```

Now start typing in the email field. When you type, check the log. The logged value should match the current value of the email input.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### Changelog

> Made checkout event hooks reflect the current state of the cart.
