### PR TITLE
Remove opinionated styles from Product Hero pattern

### DIFF
--- a/patterns/product-hero.php
+++ b/patterns/product-hero.php
@@ -19,25 +19,25 @@ $product_id = $products ? $products[0] : null;
 
 <!-- wp:woocommerce/single-product {"productId":<?php echo esc_attr( $product_id ); ?>,"align":"wide"} -->
 <div class="wp-block-woocommerce-single-product alignwide">
-	<!-- wp:columns {"style":{"color":{"background":"#6b7ba8"},"elements":{"link":{"color":{"text":"var:preset|color|base"}}},"spacing":{"padding":{"left":"20px"}}},"textColor":"base"} -->
-	<div class="wp-block-columns has-base-color has-text-color has-background has-link-color" style="background-color:#6b7ba8;padding-left:20px">
-		<!-- wp:column {"width":"40%","style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"}}}} -->
-		<div class="wp-block-column" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0;flex-basis:40%">
+	<!-- wp:columns -->
+	<div class="wp-block-columns">
+		<!-- wp:column {"width":"40%","style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"}}},"verticalAlignment":"center"} -->
+		<div class="wp-block-column is-vertically-aligned-center" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0;flex-basis:40%">
 			<!-- wp:woocommerce/product-image {"showSaleBadge":false,"isDescendentOfSingleProductBlock":true,"height":"300px"} /-->
 		</div>
 		<!-- /wp:column -->
 
-		<!-- wp:column {"style":{"spacing":{"padding":{"top":"1.5em","bottom":"1.5em"}}}} -->
-		<div class="wp-block-column" style="padding-top:1.5em;padding-bottom:1.5em">
-			<!-- wp:post-title {"textAlign":"","isLink":true,"style":{"typography":{"fontStyle":"normal","fontWeight":"400"},"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}},"fontSize":"large","__woocommerceNamespace":"woocommerce/product-query/product-title"} /-->
+		<!-- wp:column {"verticalAlignment":"center"} -->
+		<div class="wp-block-column is-vertically-aligned-center">
+			<!-- wp:post-title {"textAlign":"","isLink":true,"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}},"__woocommerceNamespace":"woocommerce/product-query/product-title"} /-->
 
-			<!-- wp:woocommerce/product-price {"isDescendentOfSingleProductBlock":true,"style":{"typography":{"fontStyle":"normal","fontWeight":"700","fontSize":"16px","lineHeight":"0.1"}}} /-->
+			<!-- wp:woocommerce/product-price {"isDescendentOfSingleProductBlock":true} /-->
 
-			<!-- wp:woocommerce/product-button {"style":{"color":{"background":"#000001","text":"#fffff1"},"spacing":{"padding":{"left":"30px","right":"30px"},"margin":{"top":"15px"}},"typography":{"fontSize":"15px"}}} -->
-			<div class="wp-block-woocommerce-product-button is-loading" style="font-size:15px"></div>
+			<!-- wp:woocommerce/product-button -->
+			<div class="wp-block-woocommerce-product-button is-loading"></div>
 			<!-- /wp:woocommerce/product-button -->
 
-			<!-- wp:post-excerpt {"style":{"typography":{"fontSize":"14px"}},"__woocommerceNamespace":"woocommerce/product-query/product-summary"} /-->
+			<!-- wp:post-excerpt {"__woocommerceNamespace":"woocommerce/product-query/product-summary"} /-->
 		</div>
 		<!-- /wp:column -->
 	</div>


### PR DESCRIPTION
Fixes #10216.

Some comments:

1. I didn't consider margins/paddings of 0 as opinionated-styles.
2. I centered columns vertically as we can't use opinionated paddings and I think that way it matches the design better.

### Testing

#### User Facing Testing

1. In the post editor or the site editor, add the Product Hero pattern.
3. Verify it looks like the _After_ patterns in screenshot below (styles adapt to the theme) and it matches the design (see https://github.com/woocommerce/woocommerce-blocks/issues/10216).

Desktop | Mobile
--- | ---
![imatge](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/8c320dea-bd0c-4a6c-af10-12121b3784f4) | ![imatge](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/ee00385b-4752-4f5f-b44c-5549f8b2b604)

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Updated Product Hero pattern to have no opinionated styles.
