### PR TITLE
Remove styles from `Newest arrivals` pattern

### DIFF
--- a/patterns/product-collections-newest-arrivals.php
+++ b/patterns/product-collections-newest-arrivals.php
@@ -9,10 +9,10 @@
 
 <!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignwide">
-	<!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-	<div class="wp-block-group alignfull">
-		<!-- wp:heading {"level":1,"style":{"typography":{"fontSize":"48px"}}} -->
-		<h1 class="wp-block-heading" style="font-size:48px">Our newest arrivals</h1>
+	<!-- wp:group {"align":"wide","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+	<div class="wp-block-group alignwide">
+		<!-- wp:heading {"level":3} -->
+		<h3 class="wp-block-heading">Our newest arrivals</h3>
 		<!-- /wp:heading -->
 
 		<!-- wp:buttons -->
@@ -27,19 +27,13 @@
 	</div>
 	<!-- /wp:group -->
 
-	<!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"nowrap"}} -->
-	<div class="wp-block-group alignfull">
-		<!-- wp:query {"query":{"perPage":"4","pages":0,"offset":0,"postType":"product","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"__woocommerceAttributes":[],"__woocommerceStockStatus":["instock","onbackorder"]},"displayLayout":{"type":"flex","columns":4},"namespace":"woocommerce/product-query"} -->
+	<!-- wp:group {"align":"wide","layout":{"type":"flex","flexWrap":"nowrap"}} -->
+	<div class="wp-block-group alignwide">
+		<!-- wp:query {"queryId":9,"query":{"perPage":"4","pages":0,"offset":0,"postType":"product","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"__woocommerceAttributes":[],"__woocommerceStockStatus":["instock","onbackorder"]},"displayLayout":{"type":"flex","columns":4},"namespace":"woocommerce/product-query"} -->
 		<div class="wp-block-query">
-			<!-- wp:post-template {"__woocommerceNamespace":"woocommerce/product-query/product-template"} -->
-
-				<!-- wp:group {"style":{"border":{"radius":"4px","top":{"color":"#dddddd","style":"solid","width":"1px"},"right":{"color":"#dddddd","style":"solid","width":"1px"},"bottom":{"color":"#dddddd","style":"solid","width":"1px"},"left":{"color":"#dddddd","style":"solid","width":"1px"}},"spacing":{"padding":{"right":"20px","bottom":"10px","left":"20px","top":"20px"}}},"textColor":"contrast","layout":{"type":"flex","orientation":"vertical","verticalAlignment":"center","justifyContent":"center"}} -->
-				<div class="wp-block-group has-contrast-color has-text-color" style="border-radius:4px;border-top-color:#dddddd;border-top-style:solid;border-top-width:1px;border-right-color:#dddddd;border-right-style:solid;border-right-width:1px;border-bottom-color:#dddddd;border-bottom-style:solid;border-bottom-width:1px;border-left-color:#dddddd;border-left-style:solid;border-left-width:1px;padding-top:20px;padding-right:20px;padding-bottom:10px;padding-left:20px">
-					<!-- wp:woocommerce/product-image {"imageSizing":"thumbnail","isDescendentOfQueryLoop":true} /-->
-					<!-- wp:post-title {"level":3,"isLink":true,"style":{"spacing":{"margin":{"bottom":"0.75rem","top":"0"}},"typography":{"fontStyle":"normal","fontWeight":"300","textDecoration":"underline"}},"textColor":"contrast","fontSize":"small","__woocommerceNamespace":"woocommerce/product-query/product-title"} /-->
-				</div>
-				<!-- /wp:group -->
-
+			<!-- wp:post-template {"className":"products-block-post-template","__woocommerceNamespace":"woocommerce/product-query/product-template"} -->
+			<!-- wp:woocommerce/product-image {"imageSizing":"thumbnail","isDescendentOfQueryLoop":true,"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","right":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20"}}}} /-->
+			<!-- wp:post-title {"textAlign":"center","level":3,"isLink":true,"style":{"spacing":{"margin":{"bottom":"0.75rem","top":"0"}}},"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-query/product-title"} /-->
 			<!-- /wp:post-template -->
 		</div>
 		<!-- /wp:query -->

--- a/patterns/product-collections-newest-arrivals.php
+++ b/patterns/product-collections-newest-arrivals.php
@@ -14,7 +14,8 @@
 		<!-- wp:column -->
 		<div class="wp-block-column">
 			<!-- wp:heading {"level":3} -->
-			<h3 class="wp-block-heading">Our newest arrivals</h3>
+
+			<h3 class="wp-block-heading"><?php esc_attr_e( 'Our newest arrivals', 'woo-gutenberg-products-block' ); ?></h3>
 			<!-- /wp:heading -->
 		</div>
 		<!-- /wp:column -->

--- a/patterns/product-collections-newest-arrivals.php
+++ b/patterns/product-collections-newest-arrivals.php
@@ -26,7 +26,9 @@
 			<div class="wp-block-buttons">
 				<!-- wp:button -->
 				<div class="wp-block-button">
-					<a class="wp-block-button__link wp-element-button" href="<?php echo esc_url( get_permalink( wc_get_page_id( 'shop' ) ) ); ?>">More new products</a>
+					<a class="wp-block-button__link wp-element-button" href="<?php echo esc_url( get_permalink( wc_get_page_id( 'shop' ) ) ); ?>">
+						<?php esc_attr_e( 'More new products', 'woo-gutenberg-products-block' ); ?>
+					</a>
 				</div>
 				<!-- /wp:button -->
 			</div>

--- a/patterns/product-collections-newest-arrivals.php
+++ b/patterns/product-collections-newest-arrivals.php
@@ -29,7 +29,7 @@
 
 	<!-- wp:group {"align":"wide","layout":{"type":"flex","flexWrap":"nowrap"}} -->
 	<div class="wp-block-group alignwide">
-		<!-- wp:query {"queryId":9,"query":{"perPage":"4","pages":0,"offset":0,"postType":"product","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"__woocommerceAttributes":[],"__woocommerceStockStatus":["instock","onbackorder"]},"displayLayout":{"type":"flex","columns":4},"namespace":"woocommerce/product-query"} -->
+		<!-- wp:query {"query":{"perPage":"4","pages":0,"offset":0,"postType":"product","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"__woocommerceAttributes":[],"__woocommerceStockStatus":["instock","onbackorder"]},"displayLayout":{"type":"flex","columns":4},"namespace":"woocommerce/product-query"} -->
 		<div class="wp-block-query">
 			<!-- wp:post-template {"className":"products-block-post-template","__woocommerceNamespace":"woocommerce/product-query/product-template"} -->
 			<!-- wp:woocommerce/product-image {"imageSizing":"thumbnail","isDescendentOfQueryLoop":true,"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","right":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20"}}}} /-->

--- a/patterns/product-collections-newest-arrivals.php
+++ b/patterns/product-collections-newest-arrivals.php
@@ -9,23 +9,31 @@
 
 <!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignwide">
-	<!-- wp:group {"align":"wide","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-	<div class="wp-block-group alignwide">
-		<!-- wp:heading {"level":3} -->
-		<h3 class="wp-block-heading">Our newest arrivals</h3>
-		<!-- /wp:heading -->
-
-		<!-- wp:buttons -->
-		<div class="wp-block-buttons">
-			<!-- wp:button -->
-			<div class="wp-block-button">
-				<a class="wp-block-button__link wp-element-button" href="<?php echo esc_url( get_permalink( wc_get_page_id( 'shop' ) ) ); ?>">More new products</a>
-			</div>
-			<!-- /wp:button -->
+	<!-- wp:columns {"align":"wide"} -->
+	<div class="wp-block-columns alignwide">
+		<!-- wp:column -->
+		<div class="wp-block-column">
+			<!-- wp:heading {"level":3} -->
+			<h3 class="wp-block-heading">Our newest arrivals</h3>
+			<!-- /wp:heading -->
 		</div>
-		<!-- /wp:buttons -->
+		<!-- /wp:column -->
+
+		<!-- wp:column -->
+		<div class="wp-block-column">
+			<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"right"}} -->
+			<div class="wp-block-buttons">
+				<!-- wp:button -->
+				<div class="wp-block-button">
+					<a class="wp-block-button__link wp-element-button" href="<?php echo esc_url( get_permalink( wc_get_page_id( 'shop' ) ) ); ?>">More new products</a>
+				</div>
+				<!-- /wp:button -->
+			</div>
+			<!-- /wp:buttons -->
+		</div>
+		<!-- /wp:column -->
 	</div>
-	<!-- /wp:group -->
+	<!-- /wp:columns -->
 
 	<!-- wp:group {"align":"wide","layout":{"type":"flex","flexWrap":"nowrap"}} -->
 	<div class="wp-block-group alignwide">


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-blocks/issues/10215
### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
| <img width="975" alt="Screenshot 2023-07-18 at 15 42 55" src="https://github.com/woocommerce/woocommerce-blocks/assets/186112/59b5d98a-e7f0-4e30-ae90-368157d421a5">| <img width="1049" alt="Screenshot 2023-07-18 at 15 42 30" src="https://github.com/woocommerce/woocommerce-blocks/assets/186112/2af96065-94c6-4da7-b3a2-d5a551abfb5a"> |

### Testing

#### User Facing Testing

1. In the post editor or the site editor, add the `Product Collections Newest Arrivals` pattern.
2. Verify there are no opinionated styles (borders, colors, fonts, etc) and the pattern looks like the `After` screenshot above.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Updated Product Collections Newest Arrivals patterns to have no opinionated styles.
