### PR TITLE
Remove styles from the `Testimonials 3 cols` pattern

### DIFF
--- a/patterns/testimonials-3-columns.php
+++ b/patterns/testimonials-3-columns.php
@@ -11,11 +11,11 @@
 	<!-- wp:column -->
 	<div class="wp-block-column">
 		<!-- wp:paragraph -->
-		<p><strong>Great experience</strong></p>
+		<p><strong><?php esc_attr_e( 'Great experience', 'woo-gutenberg-products-block' ); ?></strong></p>
 		<!-- /wp:paragraph -->
 
 		<!-- wp:paragraph -->
-		<p>In the end the couch wasn't exactly what I was looking for but my experience with the Burrow team was excellent. First in providing a discount when the couch was delayed, then timely feedback and updates as the…</p>
+		<p><?php esc_attr_e( 'In the end the couch wasn\'t exactly what I was looking for but my experience with the Burrow team was excellent. First in providing a discount when the couch was delayed, then timely feedback and updates as the…', 'woo-gutenberg-products-block' ); ?></p>
 		<!-- /wp:paragraph -->
 
 		<!-- wp:paragraph -->
@@ -27,11 +27,12 @@
 	<!-- wp:column -->
 	<div class="wp-block-column">
 		<!-- wp:paragraph -->
-		<p><strong>LOVE IT</strong></p>
+
+		<p><strong><?php esc_attr_e( 'LOVE IT', 'woo-gutenberg-products-block' ); ?></strong></p>
 		<!-- /wp:paragraph -->
 
 		<!-- wp:paragraph -->
-		<p>Great couch. color as advertise. seat is nice and firm. Easy to put together. Versatile. Bought one for my mother in law as well. And she loves hers!</p>
+		<p><?php esc_attr_e( 'Great couch. color as advertise. seat is nice and firm. Easy to put together. Versatile. Bought one for my mother in law as well. And she loves hers!', 'woo-gutenberg-products-block' ); ?></p>
 		<!-- /wp:paragraph -->
 
 		<!-- wp:paragraph -->
@@ -43,11 +44,11 @@
 	<!-- wp:column -->
 	<div class="wp-block-column">
 		<!-- wp:paragraph -->
-		<p><strong>Awesome couch and great buying experience</strong></p>
+		<p><strong><?php esc_attr_e( 'Awesome couch and great buying experience', 'woo-gutenberg-products-block' ); ?></strong></p>
 		<!-- /wp:paragraph -->
 
 		<!-- wp:paragraph -->
-		<p>I got the kind sofa. The look and feel is high quality, and I enjoy that it is a medium level of firmness. Assembly took a little longer than I expected, and it came in 4 boxes. I am excited about the time / st…</p>
+		<p><?php esc_attr_e( 'I got the kind sofa. The look and feel is high quality, and I enjoy that it is a medium level of firmness. Assembly took a little longer than I expected, and it came in 4 boxes. I am excited about the time / st…', 'woo-gutenberg-products-block' ); ?></p>
 		<!-- /wp:paragraph -->
 
 		<!-- wp:paragraph -->

--- a/patterns/testimonials-3-columns.php
+++ b/patterns/testimonials-3-columns.php
@@ -10,46 +10,50 @@
 <div class="wp-block-columns alignfull">
 	<!-- wp:column -->
 	<div class="wp-block-column">
-		<!-- wp:heading {"level":4,"style":{"typography":{"textTransform":"none","fontSize":"18px"}}} -->
-		<h4 class="wp-block-heading" style="font-size:18px;text-transform:none"><strong>Great experience</strong></h4>
-		<!-- /wp:heading -->
-
-		<!-- wp:paragraph {"style":{"typography":{"fontSize":"18px"}}} -->
-		<p style="font-size:18px">In the end the couch wasn’t exactly what I was looking for but my experience with the Burrow team was excellent. First in providing a discount when the couch was delayed, then timely feedback and updates as the…</p>
+		<!-- wp:paragraph -->
+		<p><strong>Great experience</strong></p>
 		<!-- /wp:paragraph -->
 
-		<!-- wp:paragraph {"style":{"typography":{"fontSize":"18px"},"color":{"text":"#646970"}}} -->
-		<p class="has-text-color" style="color:#646970;font-size:18px">~ Tanner P.</p>
-		<!-- /wp:paragraph --></div>
+		<!-- wp:paragraph -->
+		<p>In the end the couch wasn't exactly what I was looking for but my experience with the Burrow team was excellent. First in providing a discount when the couch was delayed, then timely feedback and updates as the…</p>
+		<!-- /wp:paragraph -->
+
+		<!-- wp:paragraph -->
+		<p>~ Tanner P.</p>
+		<!-- /wp:paragraph -->
+	</div>
 	<!-- /wp:column -->
 
 	<!-- wp:column -->
 	<div class="wp-block-column">
-		<!-- wp:heading {"level":4,"style":{"typography":{"textTransform":"none","fontSize":"18px"}}} -->
-		<h4 class="wp-block-heading" style="font-size:18px;text-transform:none"><strong>LOVE IT</strong></h4>
-		<!-- /wp:heading -->
-
-		<!-- wp:paragraph {"style":{"typography":{"fontSize":"18px"}}} -->
-		<p style="font-size:18px">Great couch. color as advertise. seat is nice and firm. Easy to put together. Versatile. Bought one for my mother in law as well. And she loves hers!</p>
+		<!-- wp:paragraph -->
+		<p><strong>LOVE IT</strong></p>
 		<!-- /wp:paragraph -->
 
-		<!-- wp:paragraph {"style":{"typography":{"fontSize":"18px"},"color":{"text":"#646970"}}} -->
-		<p class="has-text-color" style="color:#646970;font-size:18px">~ Abigail N.</p>
-		<!-- /wp:paragraph --></div>
+		<!-- wp:paragraph -->
+		<p>Great couch. color as advertise. seat is nice and firm. Easy to put together. Versatile. Bought one for my mother in law as well. And she loves hers!</p>
+		<!-- /wp:paragraph -->
+
+		<!-- wp:paragraph -->
+		<p>~ Abigail N.</p>
+		<!-- /wp:paragraph -->
+	</div>
 	<!-- /wp:column -->
 
 	<!-- wp:column -->
 	<div class="wp-block-column">
-		<!-- wp:heading {"level":4,"style":{"typography":{"textTransform":"none","fontSize":"18px"}}} -->
-		<h4 class="wp-block-heading" style="font-size:18px;text-transform:none"><strong>Awesome couch and great buying experience</strong></h4>
-		<!-- /wp:heading -->
-
-		<!-- wp:paragraph {"style":{"typography":{"fontSize":"18px"}}} -->
-		<p style="font-size:18px">I got the kind sofa. The look and feel is high quality, and I enjoy that it is a medium level of firmness. Assembly took a little longer than I expected, and it came in 4 boxes. I am excited about the time / st…</p>
+		<!-- wp:paragraph -->
+		<p><strong>Awesome couch and great buying experience</strong></p>
 		<!-- /wp:paragraph -->
 
-		<!-- wp:paragraph {"style":{"typography":{"fontSize":"18px"},"color":{"text":"#646970"}}} -->
-		<p class="has-text-color" style="color:#646970;font-size:18px">~ Albert L.</p>
-		<!-- /wp:paragraph --></div>
-	<!-- /wp:column --></div>
+		<!-- wp:paragraph -->
+		<p>I got the kind sofa. The look and feel is high quality, and I enjoy that it is a medium level of firmness. Assembly took a little longer than I expected, and it came in 4 boxes. I am excited about the time / st…</p>
+		<!-- /wp:paragraph -->
+
+		<!-- wp:paragraph -->
+		<p>~ Albert L.</p>
+		<!-- /wp:paragraph -->
+	</div>
+	<!-- /wp:column -->
+</div>
 <!-- /wp:columns -->


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-blocks/issues/10218

### Screenshots

| Before | After |
| ------ | ----- |
| <img width="1678" alt="Screenshot 2023-07-18 at 16 18 49" src="https://github.com/woocommerce/woocommerce-blocks/assets/186112/ee16bc83-5316-44ba-a0b6-5ed766e493db"> | <img width="1701" alt="Screenshot 2023-07-18 at 16 18 25" src="https://github.com/woocommerce/woocommerce-blocks/assets/186112/26894af6-0d1c-4a34-9f51-3d3977c371e7"> |

### Testing

#### User Facing Testing

1. In the post editor or the site editor, add the `Testimonials 3 columns` pattern.
2. Verify there are no opinionated styles (borders, colors, fonts, etc) and the pattern looks like the `After` screenshot above.


* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Updated Testimonial 3 columns pattern to have no opinionated styles.
