### PR TITLE
Remove opinionated styles from Hero Product 3 Split pattern

### DIFF
--- a/patterns/hero-product-3-split.php
+++ b/patterns/hero-product-3-split.php
@@ -16,18 +16,18 @@
 				<!-- wp:group {"style":{"spacing":{"margin":{"top":"20px","bottom":"20px"}}},"layout":{"type":"flex","orientation":"vertical"}} -->
 				<div class="wp-block-group" style="margin-top:20px;margin-bottom:20px;">
 					<!-- wp:heading -->
-					<h2 class="wp-block-heading">Endless Tee's</h2>
+					<h2 class="wp-block-heading"><?php esc_attr_e( "Endless Tee's", 'woo-gutenberg-products-block' ); ?></h2>
 					<!-- /wp:heading -->
 
 					<!-- wp:paragraph -->
-					<p>With high-quality materials and expert craftsmanship, our products are built to last and exceed your expectations.</p>
+					<p><?php esc_attr_e( 'With high-quality materials and expert craftsmanship, our products are built to last and exceed your expectations.', 'woo-gutenberg-products-block' ); ?></p>
 					<!-- /wp:paragraph -->
 
 					<!-- wp:buttons -->
 					<div class="wp-block-buttons">
 						<!-- wp:button {"textAlign":"left","style":{"color":{"background":"#ffffff","text":"#000000"}}} -->
 						<div class="wp-block-button has-custom-font-size">
-							<a class="wp-block-button__link has-text-color has-background has-text-align-left wp-element-button" href="<?php echo esc_url( get_permalink( wc_get_page_id( 'shop' ) ) ); ?>" style="color:#000000;background-color:#ffffff">Shop now</a>
+							<a class="wp-block-button__link has-text-color has-background has-text-align-left wp-element-button" href="<?php echo esc_url( get_permalink( wc_get_page_id( 'shop' ) ) ); ?>" style="color:#000000;background-color:#ffffff"><?php esc_attr_e( 'Shop now', 'woo-gutenberg-products-block' ); ?></a>
 						</div>
 						<!-- /wp:button -->
 					</div>
@@ -46,23 +46,11 @@
 	<!-- wp:column {"verticalAlignment":"center","width":"33.33%"} -->
 	<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:33.33%">
 		<!-- wp:paragraph -->
-		<p><strong>Waterproof Membrane</strong></p>
+		<p><strong><?php esc_attr_e( 'Waterproof Membrane', 'woo-gutenberg-products-block' ); ?></strong></p>
 		<!-- /wp:paragraph -->
 
 		<!-- wp:paragraph -->
-		<p>Never worry about the weather again. Keep yourself dry, warm, and looking stylish.</p>
-		<!-- /wp:paragraph -->
-
-		<!-- wp:separator {"className":"is-style-wide"} -->
-		<hr class="wp-block-separator has-alpha-channel-opacity is-style-wide" />
-		<!-- /wp:separator -->
-
-		<!-- wp:paragraph -->
-		<p><strong>Expert Craftsmanship</strong></p>
-		<!-- /wp:paragraph -->
-
-		<!-- wp:paragraph -->
-		<p>Our products are made with expert craftsmanship and attention to detail, ensuring that every stitch and seam is perfect.</p>
+		<p><?php esc_attr_e( 'Never worry about the weather again. Keep yourself dry, warm, and looking stylish.', 'woo-gutenberg-products-block' ); ?></p>
 		<!-- /wp:paragraph -->
 
 		<!-- wp:separator {"className":"is-style-wide"} -->
@@ -70,11 +58,11 @@
 		<!-- /wp:separator -->
 
 		<!-- wp:paragraph -->
-		<p><strong>Durable Fabric</strong></p>
+		<p><strong><?php esc_attr_e( 'Expert Craftsmanship', 'woo-gutenberg-products-block' ); ?></strong></p>
 		<!-- /wp:paragraph -->
 
 		<!-- wp:paragraph -->
-		<p>We use only the highest-quality materials in our products, ensuring that they look great and last for years to come.</p>
+		<p><?php esc_attr_e( 'Our products are made with expert craftsmanship and attention to detail, ensuring that every stitch and seam is perfect.', 'woo-gutenberg-products-block' ); ?></p>
 		<!-- /wp:paragraph -->
 
 		<!-- wp:separator {"className":"is-style-wide"} -->
@@ -82,11 +70,23 @@
 		<!-- /wp:separator -->
 
 		<!-- wp:paragraph -->
-		<p><strong>Sustainable Dyes</strong></p>
+		<p><strong><?php esc_attr_e( 'Durable Fabric', 'woo-gutenberg-products-block' ); ?></strong></p>
 		<!-- /wp:paragraph -->
 
 		<!-- wp:paragraph -->
-		<p>From bold prints and colors to intricate details and textures, our products are a perfect combination of style and function.</p>
+		<p><?php esc_attr_e( 'We use only the highest-quality materials in our products, ensuring that they look great and last for years to come.', 'woo-gutenberg-products-block' ); ?></p>
+		<!-- /wp:paragraph -->
+
+		<!-- wp:separator {"className":"is-style-wide"} -->
+		<hr class="wp-block-separator has-alpha-channel-opacity is-style-wide" />
+		<!-- /wp:separator -->
+
+		<!-- wp:paragraph -->
+		<p><strong><?php esc_attr_e( 'Sustainable Dyes', 'woo-gutenberg-products-block' ); ?></strong></p>
+		<!-- /wp:paragraph -->
+
+		<!-- wp:paragraph -->
+		<p><?php esc_attr_e( 'From bold prints and colors to intricate details and textures, our products are a perfect combination of style and function.', 'woo-gutenberg-products-block' ); ?></p>
 		<!-- /wp:paragraph -->
 	</div>
 	<!-- /wp:column -->

--- a/patterns/hero-product-3-split.php
+++ b/patterns/hero-product-3-split.php
@@ -6,27 +6,27 @@
  */
 ?>
 
-<!-- wp:columns {"align":"wide","style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"},"blockGap":{"top":"0","left":"0"}}}} -->
+<!-- wp:columns {"align":"wide","style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"}}}} -->
 <div class="wp-block-columns alignwide" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">
 	<!-- wp:column {"width":"66.66%"} -->
 	<div class="wp-block-column" style="flex-basis:66.66%">
 		<!-- wp:media-text {"mediaPosition":"right","mediaId":1,"mediaLink":"<?php echo esc_url( plugins_url( 'images/pattern-placeholders/hand-guitar-finger-tshirt-clothing-rack.png', dirname( __FILE__ ) ) ); ?>","mediaType":"image","style":{"color":{"background":"#000000","text":"#ffffff"}}} -->
 		<div class="wp-block-media-text alignwide has-media-on-the-right is-stacked-on-mobile has-text-color has-background" style="color:#ffffff;background-color:#000000">
 			<div class="wp-block-media-text__content">
-				<!-- wp:group {"style":{"spacing":{"padding":{"top":"0","left":"20px","right":"20px"},"margin":{"top":"20px","bottom":"20px"}}},"layout":{"type":"flex","orientation":"vertical"}} -->
-				<div class="wp-block-group" style="margin-top:20px;margin-bottom:20px;padding-top:0;padding-right:20px;padding-left:20px">
-					<!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"large"} -->
-					<h2 class="wp-block-heading has-large-font-size" style="font-style:normal;font-weight:700">Endless Tee's</h2>
+				<!-- wp:group {"style":{"spacing":{"margin":{"top":"20px","bottom":"20px"}}},"layout":{"type":"flex","orientation":"vertical"}} -->
+				<div class="wp-block-group" style="margin-top:20px;margin-bottom:20px;">
+					<!-- wp:heading -->
+					<h2 class="wp-block-heading">Endless Tee's</h2>
 					<!-- /wp:heading -->
 
-					<!-- wp:paragraph {"fontSize":"small"} -->
-					<p class="has-small-font-size">With high-quality materials and expert craftsmanship, our products are built to last and exceed your expectations.</p>
+					<!-- wp:paragraph -->
+					<p>With high-quality materials and expert craftsmanship, our products are built to last and exceed your expectations.</p>
 					<!-- /wp:paragraph -->
 
 					<!-- wp:buttons -->
 					<div class="wp-block-buttons">
-						<!-- wp:button {"textAlign":"left","style":{"typography":{"fontSize":"16px"},"color":{"background":"#ffffff","text":"#000000"}}} -->
-						<div class="wp-block-button has-custom-font-size" style="font-size:16px">
+						<!-- wp:button {"textAlign":"left","style":{"color":{"background":"#ffffff","text":"#000000"}}} -->
+						<div class="wp-block-button has-custom-font-size">
 							<a class="wp-block-button__link has-text-color has-background has-text-align-left wp-element-button" href="<?php echo esc_url( get_permalink( wc_get_page_id( 'shop' ) ) ); ?>" style="color:#000000;background-color:#ffffff">Shop now</a>
 						</div>
 						<!-- /wp:button -->
@@ -43,50 +43,50 @@
 	</div>
 	<!-- /wp:column -->
 
-	<!-- wp:column {"verticalAlignment":"center","width":"25%","style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"}}}} -->
-	<div class="wp-block-column is-vertically-aligned-center" style="padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px;flex-basis:25%">
-		<!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"700","fontSize":"15px"},"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}}} -->
-		<h2 class="wp-block-heading" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0;font-size:15px;font-style:normal;font-weight:700">Waterproof Membrane</h2>
-		<!-- /wp:heading -->
-
-		<!-- wp:paragraph {"style":{"typography":{"fontSize":"12px"},"spacing":{"margin":{"top":"10px","right":"0","bottom":"0","left":"0"}}}} -->
-		<p style="margin-top:10px;margin-right:0;margin-bottom:0;margin-left:0;font-size:12px">Never worry about the weather again. Keep yourself dry, warm, and looking stylish.</p>
+	<!-- wp:column {"verticalAlignment":"center","width":"33.33%"} -->
+	<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:33.33%">
+		<!-- wp:paragraph -->
+		<p><strong>Waterproof Membrane</strong></p>
 		<!-- /wp:paragraph -->
 
-		<!-- wp:separator {"style":{"spacing":{"margin":{"top":"20px","bottom":"20px"}}},"className":"is-style-wide"} -->
-		<hr class="wp-block-separator has-alpha-channel-opacity is-style-wide" style="margin-top:20px;margin-bottom:20px" />
-		<!-- /wp:separator -->
-
-		<!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"700","fontSize":"15px"},"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}}} -->
-		<h2 class="wp-block-heading" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0;font-size:15px;font-style:normal;font-weight:700">Expert Craftsmanship</h2>
-		<!-- /wp:heading -->
-
-		<!-- wp:paragraph {"style":{"typography":{"fontSize":"12px"},"spacing":{"margin":{"top":"10px","right":"0","bottom":"0","left":"0"}}}} -->
-		<p style="margin-top:10px;margin-right:0;margin-bottom:0;margin-left:0;font-size:12px">Our products are made with expert craftsmanship and attention to detail, ensuring that every stitch and seam is perfect.</p>
+		<!-- wp:paragraph -->
+		<p>Never worry about the weather again. Keep yourself dry, warm, and looking stylish.</p>
 		<!-- /wp:paragraph -->
 
-		<!-- wp:separator {"style":{"spacing":{"margin":{"top":"20px","bottom":"20px"}}},"className":"is-style-wide"} -->
-		<hr class="wp-block-separator has-alpha-channel-opacity is-style-wide" style="margin-top:20px;margin-bottom:20px" />
+		<!-- wp:separator {"className":"is-style-wide"} -->
+		<hr class="wp-block-separator has-alpha-channel-opacity is-style-wide" />
 		<!-- /wp:separator -->
 
-		<!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"700","fontSize":"15px"},"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}}} -->
-		<h2 class="wp-block-heading" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0;font-size:15px;font-style:normal;font-weight:700">Durable Fabric</h2>
-		<!-- /wp:heading -->
-
-		<!-- wp:paragraph {"style":{"typography":{"fontSize":"12px"},"spacing":{"margin":{"top":"10px","right":"0","bottom":"0","left":"0"}}}} -->
-		<p style="margin-top:10px;margin-right:0;margin-bottom:0;margin-left:0;font-size:12px">We use only the highest-quality materials in our products, ensuring that they look great and last for years to come.</p>
+		<!-- wp:paragraph -->
+		<p><strong>Expert Craftsmanship</strong></p>
 		<!-- /wp:paragraph -->
 
-		<!-- wp:separator {"style":{"spacing":{"margin":{"top":"20px","bottom":"20px"}}},"className":"is-style-wide"} -->
-		<hr class="wp-block-separator has-alpha-channel-opacity is-style-wide" style="margin-top:20px;margin-bottom:20px" />
+		<!-- wp:paragraph -->
+		<p>Our products are made with expert craftsmanship and attention to detail, ensuring that every stitch and seam is perfect.</p>
+		<!-- /wp:paragraph -->
+
+		<!-- wp:separator {"className":"is-style-wide"} -->
+		<hr class="wp-block-separator has-alpha-channel-opacity is-style-wide" />
 		<!-- /wp:separator -->
 
-		<!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"700","fontSize":"15px"},"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}}}} -->
-		<h2 class="wp-block-heading" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0;font-size:15px;font-style:normal;font-weight:700">Sustainable Dyes</h2>
-		<!-- /wp:heading -->
+		<!-- wp:paragraph -->
+		<p><strong>Durable Fabric</strong></p>
+		<!-- /wp:paragraph -->
 
-		<!-- wp:paragraph {"style":{"typography":{"fontSize":"12px"},"spacing":{"margin":{"top":"10px","right":"0","bottom":"0","left":"0"}}}} -->
-		<p style="margin-top:10px;margin-right:0;margin-bottom:0;margin-left:0;font-size:12px">From bold prints and colors to intricate details and textures, our products are a perfect combination of style and function.</p>
+		<!-- wp:paragraph -->
+		<p>We use only the highest-quality materials in our products, ensuring that they look great and last for years to come.</p>
+		<!-- /wp:paragraph -->
+
+		<!-- wp:separator {"className":"is-style-wide"} -->
+		<hr class="wp-block-separator has-alpha-channel-opacity is-style-wide" />
+		<!-- /wp:separator -->
+
+		<!-- wp:paragraph -->
+		<p><strong>Sustainable Dyes</strong></p>
+		<!-- /wp:paragraph -->
+
+		<!-- wp:paragraph -->
+		<p>From bold prints and colors to intricate details and textures, our products are a perfect combination of style and function.</p>
 		<!-- /wp:paragraph -->
 	</div>
 	<!-- /wp:column -->


### PR DESCRIPTION
Fixes #10217.

### Testing

#### User Facing Testing

1. In the post editor or the site editor, add the Hero Product 3 Split pattern.
3. Verify it looks like the _After_ patterns in screenshot below (styles adapt to the theme) and it matches the design (see https://github.com/woocommerce/woocommerce-blocks/issues/10217).

Desktop | Mobile
--- | ---
![Captura de pantalla feta el 2023-07-18 a les 17 21 47](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/cac2b052-3469-408c-b442-24bc494a36fa) | ![Captura de pantalla feta el 2023-07-18 a les 17 22 10](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/2b5c57a7-fc86-44b3-970a-8cd73e39c6a3)

* [ ] Do not include in the Testing Notes

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Updated Product Hero pattern to have no opinionated styles.
