### PR TITLE
Fix incorrect filter application in Product Collection

### DIFF
--- a/assets/js/blocks/product-collection/inspector-controls/index.tsx
+++ b/assets/js/blocks/product-collection/inspector-controls/index.tsx
@@ -18,6 +18,7 @@ import {
 /**
  * Internal dependencies
  */
+import metadata from '../block.json';
 import { ProductCollectionAttributes } from '../types';
 import { setQueryAttribute } from '../utils';
 import { DEFAULT_FILTERS, getDefaultSettings } from '../constants';
@@ -107,7 +108,7 @@ export default ProductCollectionInspectorControls;
 
 const isProductCollection = (
 	block: EditorBlock< ProductCollectionAttributes >
-) => block.name === 'woocommerce/product-collection';
+) => block.name === metadata.name;
 
 export const withUpgradeNoticeControls =
 	< T extends EditorBlock< T > >( BlockEdit: ElementType ) =>

--- a/assets/js/blocks/product-collection/inspector-controls/index.tsx
+++ b/assets/js/blocks/product-collection/inspector-controls/index.tsx
@@ -105,14 +105,17 @@ const ProductCollectionInspectorControls = (
 
 export default ProductCollectionInspectorControls;
 
+const isProductCollection = (
+	block: EditorBlock< ProductCollectionAttributes >
+) => block.name === 'woocommerce/product-collection';
+
 export const withUpgradeNoticeControls =
 	< T extends EditorBlock< T > >( BlockEdit: ElementType ) =>
-	( props: BlockEditProps< ProductCollectionAttributes > ) => {
-		const { displayUpgradeNotice } = props.attributes;
-		return (
+	( props: EditorBlock< ProductCollectionAttributes > ) => {
+		return isProductCollection( props ) ? (
 			<>
 				<InspectorControls>
-					{ displayUpgradeNotice && (
+					{ props.attributes.displayUpgradeNotice && (
 						<UpgradeNotice
 							{ ...props }
 							revertMigration={
@@ -123,6 +126,8 @@ export const withUpgradeNoticeControls =
 				</InspectorControls>
 				<BlockEdit { ...props } />
 			</>
+		) : (
+			<BlockEdit { ...props } />
 		);
 	};
 


### PR DESCRIPTION
In scope of https://github.com/woocommerce/woocommerce-blocks/pull/10139 I added a Upgrade Notice to the Product Collection block. It was added through filter ([code here](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/assets/js/blocks/product-collection/inspector-controls/index.tsx#L129)):

```
addFilter(
	'editor.BlockEdit',
	'woocommerce/product-collection',
	withUpgradeNoticeControls
);
```

The `withUpgradeNoticeControls` function is run for every block in the editor, hence the logic of the function was incorrect as it should be called ONLY for `woocommerce/product-collection` block.

The outcome of this function wasn't noticed as there was no additional content rendered on the page, only empty `<InspectorControl>` tag was returned, which is then merged to other Inspector Controls and eventually ignored as empty. Also, the Product Collection block is experimental hence this code is not included in the production build, so it's not influencing customers. But still, it deserves to be fixed.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Edit `withUpgradeNoticeControls` in `assets/js/blocks/product-collection/inspector-controls/index.tsx` and replace lines 119-126:

```
					{ props.attributes.displayUpgradeNotice && (
						<UpgradeNotice
							{ ...props }
							revertMigration={
								replaceProductCollectionWithProducts
							}
						/>
					) }
```

with

```
<h2>Custom content</h2>
```

so custom content is displayed unconditionally on Product Collection.
3. Go to Editor
4. Add Product Collection and some other blocks, for example Products (Beta) and Columns
5. Focus on each of them
6. Expected: There's Custom Content displayed in Inspector Controls for Product Collection 
7. Expected: There's no Custom Content (or any other custom content) displayed in Inspector Controls for other blocks like Products (Beta) or Columns

Product Collection | Other blocks
-- | --
<img width="285" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/20098064/30afe443-0531-4694-85c5-b71150f0444d"> | <img width="280" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/20098064/f98e37c3-7ce9-462b-8c4d-aa329c17234a">

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental

