### PR TITLE
Store Customization > Hero Product Split pattern - Update the pattern to become wireframed

### DIFF
--- a/patterns/hero-product-split.php
+++ b/patterns/hero-product-split.php
@@ -7,7 +7,7 @@
 ?>
 
 <!-- wp:media-text {"align":"full","mediaPosition":"right","mediaType":"image","mediaSizeSlug":"full","imageFill":false} -->
-<div class="wp-block-media-text alignfull has-media-on-the-right is-stacked-on-mobile has-text-color has-background">
+<div class="wp-block-media-text alignfull has-media-on-the-right is-stacked-on-mobile">
 	<div class="wp-block-media-text__content">
 		<!-- wp:heading -->
 		<h2 class="wp-block-heading"><?php esc_html_e( 'Get cozy this fall with knit sweaters', 'woo-gutenberg-products-block' ); ?></h2>

--- a/patterns/hero-product-split.php
+++ b/patterns/hero-product-split.php
@@ -6,18 +6,18 @@
  */
 ?>
 
-<!-- wp:media-text {"align":"full","mediaPosition":"right","mediaType":"image","mediaSizeSlug":"full","imageFill":false,"style":{"color":{"background":"#000000","text":"#ffffff"}}} -->
-<div class="wp-block-media-text alignfull has-media-on-the-right is-stacked-on-mobile has-text-color has-background" style="color:#ffffff;background-color:#000000">
+<!-- wp:media-text {"align":"full","mediaPosition":"right","mediaType":"image","mediaSizeSlug":"full","imageFill":false} -->
+<div class="wp-block-media-text alignfull has-media-on-the-right is-stacked-on-mobile has-text-color has-background">
 	<div class="wp-block-media-text__content">
-		<!-- wp:heading {"style":{"color":{"text":"#ffffff"}}} -->
-		<h2 class="wp-block-heading has-text-color" style="color:#ffffff;"><?php esc_html_e( 'Get cozy this fall with knit sweaters', 'woo-gutenberg-products-block' ); ?></h2>
+		<!-- wp:heading -->
+		<h2 class="wp-block-heading"><?php esc_html_e( 'Get cozy this fall with knit sweaters', 'woo-gutenberg-products-block' ); ?></h2>
 		<!-- /wp:heading -->
 
 		<!-- wp:buttons {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}}} -->
 		<div class="wp-block-buttons" style="margin-bottom:var(--wp--preset--spacing--40)">
-		<!-- wp:button {"style":{"color":{"text":"#000000","background":"#ffffff"}}} -->
+		<!-- wp:button -->
 		<div class="wp-block-button">
-			<a href="<?php echo esc_url( get_permalink( wc_get_page_id( 'shop' ) ) ); ?>" class="wp-block-button__link has-text-color has-background wp-element-button" style="color:#000000;background-color:#ffffff;"><?php esc_html_e( 'Shop now', 'woo-gutenberg-products-block' ); ?></a>
+			<a href="<?php echo esc_url( get_permalink( wc_get_page_id( 'shop' ) ) ); ?>" class="wp-block-button__link wp-element-button"><?php esc_html_e( 'Shop now', 'woo-gutenberg-products-block' ); ?></a>
 		</div>
 		<!-- /wp:button -->
 		</div>


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

Ensure the Hero Product Split pattern is wireframed (doesn't have any custom font colors, background, or button colors).

<!-- Reference any related issues or PRs here -->

Fixes #10211

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|  <img width="987" alt="Screenshot 2023-07-19 at 12 02 36" src="https://github.com/woocommerce/woocommerce-blocks/assets/15730971/0c73123e-7cec-42e6-839d-ad0f5f5dfa85"> <img width="308" alt="Screenshot 2023-07-19 at 12 03 24" src="https://github.com/woocommerce/woocommerce-blocks/assets/15730971/a55b5817-9111-4e1e-9312-f787f0c7e6bc"> | <img width="987" alt="Screenshot 2023-07-19 at 12 02 51" src="https://github.com/woocommerce/woocommerce-blocks/assets/15730971/4c8f2926-2711-4e91-9002-ddffb0a2418e"> <img width="310" alt="Screenshot 2023-07-19 at 12 03 07" src="https://github.com/woocommerce/woocommerce-blocks/assets/15730971/064260ea-8c33-4177-9e5a-4cad364b0c7a"> |

### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Create a new post
2. Insert the Hero Product Split pattern and save
3. Make sure it works as expected and is correctly rendered on the front end: the design should match the one demonstrated on the screenshots of this PR.

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Remove opinionated styles from the Hero Product Split pattern.
