### PR TITLE
Update the `Testimonials Single` pattern to have no opinionated styles

### DIFF
--- a/patterns/testimonials-single.php
+++ b/patterns/testimonials-single.php
@@ -17,17 +17,16 @@
 
 	<!-- wp:column {"layout":{"type":"default"}} -->
 	<div class="wp-block-column">
-		<!-- wp:heading {"level":4,"style":{"typography":{"textTransform":"none","fontSize":"18px"},"color":{"text":"#000000"}}} -->
-		<h4 class="wp-block-heading has-text-color" style="color:#000000;font-size:18px;text-transform:none"><strong>Great experience</strong></h4>
-		<!-- /wp:heading -->
-
-		<!-- wp:paragraph {"style":{"typography":{"fontSize":"18px"},"color":{"text":"#000000"}}} -->
-		<p class="has-text-color" style="color:#000000;font-size:18px">In the end the couch wasn't exactly what I was looking for but my experience with the Burrow team was excellent. First in providing a discount when the couch was delayed, then timely feedback and updates as the...
-		</p>
+		<!-- wp:paragraph -->
+		<p><strong><?php esc_attr_e( 'Great experience', 'woo-gutenberg-products-block' ); ?></strong></p>
 		<!-- /wp:paragraph -->
 
-		<!-- wp:paragraph {"style":{"typography":{"fontSize":"18px"},"color":{"text":"#646970"}}} -->
-		<p class="has-text-color" style="color:#646970;font-size:18px">~ Anna W.</p>
+		<!-- wp:paragraph -->
+		<p><?php esc_attr_e( 'In the end the couch wasn\'t exactly what I was looking for but my experience with the Burrow team was excellent. First in providing a discount when the couch was delayed, then timely feedback and updates as the...', 'woo-gutenberg-products-block' ); ?></p>
+		<!-- /wp:paragraph -->
+
+		<!-- wp:paragraph -->
+		<p>~ Anna W.</p>
 		<!-- /wp:paragraph -->
 	</div>
 	<!-- /wp:column -->

--- a/patterns/testimonials-single.php
+++ b/patterns/testimonials-single.php
@@ -18,11 +18,11 @@
 	<!-- wp:column {"layout":{"type":"default"}} -->
 	<div class="wp-block-column">
 		<!-- wp:paragraph -->
-		<p><strong><?php esc_attr_e( 'Great experience', 'woo-gutenberg-products-block' ); ?></strong></p>
+		<p><strong><?php esc_html_e( 'Great experience', 'woo-gutenberg-products-block' ); ?></strong></p>
 		<!-- /wp:paragraph -->
 
 		<!-- wp:paragraph -->
-		<p><?php esc_attr_e( 'In the end the couch wasn\'t exactly what I was looking for but my experience with the Burrow team was excellent. First in providing a discount when the couch was delayed, then timely feedback and updates as the...', 'woo-gutenberg-products-block' ); ?></p>
+		<p><?php esc_html_e( 'In the end the couch wasn\'t exactly what I was looking for but my experience with the Burrow team was excellent. First in providing a discount when the couch was delayed, then timely feedback and updates as the...', 'woo-gutenberg-products-block' ); ?></p>
 		<!-- /wp:paragraph -->
 
 		<!-- wp:paragraph -->


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-blocks/issues/10273
### Screenshots

<img width="1199" alt="Screenshot 2023-07-19 at 15 20 19" src="https://github.com/woocommerce/woocommerce-blocks/assets/186112/a627540e-ef0c-4540-81ea-026fa4880a4e">

### Testing
#### User Facing Testing

1. In the post editor or the site editor, add the `Testimonials Single` pattern.
2. Verify the text does not have opinionated styles (borders, colors, fonts, etc) and that the pattern looks like the screenshot above.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Updated "Testimonial Single" pattern to have no opinionated styles.
