### PR TITLE
Invalidate script data cache when site URL, scheme, or plugin name changes

### DIFF
--- a/src/Assets/Api.php
+++ b/src/Assets/Api.php
@@ -143,7 +143,9 @@ class Api {
 			empty( $transient_value ) ||
 			empty( $transient_value['script_data'] ) ||
 			empty( $transient_value['version'] ) ||
-			$transient_value['version'] !== $this->package->get_version()
+			$transient_value['version'] !== $this->package->get_version() ||
+			empty( $transient_value['hash'] ) ||
+			$transient_value['hash'] !== $this->script_data_hash
 		) {
 			return [];
 		}

--- a/src/Assets/Api.php
+++ b/src/Assets/Api.php
@@ -138,12 +138,7 @@ class Api {
 
 		$transient_value = json_decode( (string) get_transient( $this->script_data_transient_key ), true );
 
-		// If the data in the cache is somehow corrupt and causes a JSON error, just ignore it.
-		if ( json_last_error() !== JSON_ERROR_NONE ) {
-			return [];
-		}
-
-		if ( empty( $transient_value ) || empty( $transient_value['script_data'] ) || empty( $transient_value['version'] ) || $transient_value['version'] !== $this->package->get_version() ) {
+		if ( json_last_error() !== JSON_ERROR_NONE || empty( $transient_value ) || empty( $transient_value['script_data'] ) || empty( $transient_value['version'] ) || $transient_value['version'] !== $this->package->get_version() ) {
 			return [];
 		}
 

--- a/src/Assets/Api.php
+++ b/src/Assets/Api.php
@@ -93,6 +93,17 @@ class Api {
 	}
 
 	/**
+	 * Generates a hash containing the site url, plugin version and package path.
+	 *
+	 * Moving the plugin, changing the version, or changing the site url will result in a new hash and the cache will be invalidated.
+	 *
+	 * @return string The generated hash.
+	 */
+	private function get_script_data_hash() {
+		return md5( get_option( 'siteurl', '' ) . $this->package->get_version() . $this->package->get_path() );
+	}
+
+	/**
 	 * Initialize and load cached script data from the transient cache.
 	 *
 	 * @return array

--- a/src/Assets/Api.php
+++ b/src/Assets/Api.php
@@ -158,6 +158,7 @@ class Api {
 				array(
 					'script_data' => $this->script_data,
 					'version'     => $this->package->get_version(),
+					'hash'        => $this->script_data_hash,
 				)
 			),
 			DAY_IN_SECONDS * 30

--- a/src/Assets/Api.php
+++ b/src/Assets/Api.php
@@ -138,7 +138,13 @@ class Api {
 
 		$transient_value = json_decode( (string) get_transient( $this->script_data_transient_key ), true );
 
-		if ( json_last_error() !== JSON_ERROR_NONE || empty( $transient_value ) || empty( $transient_value['script_data'] ) || empty( $transient_value['version'] ) || $transient_value['version'] !== $this->package->get_version() ) {
+		if (
+			json_last_error() !== JSON_ERROR_NONE ||
+			empty( $transient_value ) ||
+			empty( $transient_value['script_data'] ) ||
+			empty( $transient_value['version'] ) ||
+			$transient_value['version'] !== $this->package->get_version()
+		) {
 			return [];
 		}
 

--- a/src/Assets/Api.php
+++ b/src/Assets/Api.php
@@ -136,7 +136,7 @@ class Api {
 			return [];
 		}
 
-		$transient_value = json_decode( (string) get_transient( 'woocommerce_blocks_asset_api_script_data' ), true );
+		$transient_value = json_decode( (string) get_transient( $this->script_data_transient_key ), true );
 
 		if ( empty( $transient_value ) || empty( $transient_value['script_data'] ) || empty( $transient_value['version'] ) || $transient_value['version'] !== $this->package->get_version() ) {
 			return [];
@@ -153,7 +153,7 @@ class Api {
 			return;
 		}
 		set_transient(
-			'woocommerce_blocks_asset_api_script_data',
+			$this->script_data_transient_key,
 			wp_json_encode(
 				array(
 					'script_data' => $this->script_data,

--- a/src/Assets/Api.php
+++ b/src/Assets/Api.php
@@ -33,6 +33,13 @@ class Api {
 	private $script_data = null;
 
 	/**
+	 * Stores the hash for the script data, made up of the site url, plugin version and package path.
+	 *
+	 * @var string
+	 */
+	private $script_data_hash;
+
+	/**
 	 * Reference to the Package instance
 	 *
 	 * @var Package
@@ -47,6 +54,10 @@ class Api {
 	public function __construct( Package $package ) {
 		$this->package       = $package;
 		$this->disable_cache = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) || ! $this->package->feature()->is_production_environment();
+
+		if ( ! $this->disable_cache ) {
+			$this->script_data_hash = $this->get_script_data_hash();
+		}
 		add_action( 'shutdown', array( $this, 'update_script_data_cache' ), 20 );
 	}
 

--- a/src/Assets/Api.php
+++ b/src/Assets/Api.php
@@ -138,6 +138,11 @@ class Api {
 
 		$transient_value = json_decode( (string) get_transient( $this->script_data_transient_key ), true );
 
+		// If the data in the cache is somehow corrupt and causes a JSON error, just ignore it.
+		if ( json_last_error() !== JSON_ERROR_NONE ) {
+			return [];
+		}
+
 		if ( empty( $transient_value ) || empty( $transient_value['script_data'] ) || empty( $transient_value['version'] ) || $transient_value['version'] !== $this->package->get_version() ) {
 			return [];
 		}

--- a/src/Assets/Api.php
+++ b/src/Assets/Api.php
@@ -40,6 +40,13 @@ class Api {
 	private $script_data_hash;
 
 	/**
+	 * Stores the transient key used to cache the script data. This will change if the site is accessed via HTTPS or HTTP.
+	 *
+	 * @var string
+	 */
+	private $script_data_transient_key = 'woocommerce_blocks_asset_api_script_data';
+
+	/**
 	 * Reference to the Package instance
 	 *
 	 * @var Package
@@ -55,6 +62,11 @@ class Api {
 		$this->package       = $package;
 		$this->disable_cache = ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) || ! $this->package->feature()->is_production_environment();
 
+		// If the site is accessed via HTTPS, change the transient key. This is to prevent the script URLs being cached
+		// with the first scheme they are accessed on after cache expiry.
+		if ( is_ssl() ) {
+			$this->script_data_transient_key .= '_ssl';
+		}
 		if ( ! $this->disable_cache ) {
 			$this->script_data_hash = $this->get_script_data_hash();
 		}


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

This PR adds a hash to the value of the `woocommerce_blocks_asset_api_script_data` transient. The hash is constructed based on the site URL, plugin version, and plugin path.

The plugin path is used to check whether we're loading from WC Core or the WC Blocks feature plugin.

This PR also introduces a new transient, `woocommerce_blocks_asset_api_script_data_ssl`. If the site is loaded using HTTPS the script data will be loaded from this transient, if it is loaded using HTTP it will get it from the original value.

This is required because, if a site is accessible by both HTTP and HTTPS, the URLs to the scripts would be cached with whatever scheme was used when the value was cached. While uncommon it has the potential to break sites so I would prefer to be safe at the expense of additional database storage.

<!-- Reference any related issues or PRs here -->

Fixes #10221

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->


#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. Load up your site, ensuring WooCommerce Blocks is active. Visit a page with the Cart or Checkout block on it.
2. Disable and delete the WooCommerce Blocks plugin from your site.
3. Load up the page from Step 1 and ensure it loads correctly.

##### Internal testing - Do not include in the Testing Notes

0. Ensure caching is disabled, go to [this line](https://github.com/woocommerce/woocommerce-blocks/blob/4a19873db1ed2b77c80ef5005616452757639d36/src/Assets/Api.php#L63) and set `$this->disable_cache` to `false`;
1. Set your site up to use both HTTPS and HTTP, it shouldn't redirect to one or the other, but should use whatever you access it by.
2. Open the network tab of dev tools
3. Load the HTTP version first. Load a page with Cart/Checkout blocks.
4. Load the HTTPS version next, load the same page and ensure the blocks render correctly, open the console.
5. Change the URL you use to access your site in your dev environment.
6. Change your site url (WordPress -> Settings -> General) to use the new site name.
7. Load the Cart/Checkout blocks and ensure they're working
8. Open your `wp_options` table search for
```sql
select *
FROM `wp_options`
where `option_name` LIKE '%woocommerce_blocks_asset_api_script_data%'
```
9. Ensure you see two transients, one for HTTPs and one for HTTP and they contain the correct URL for each.
10. Edit the transient values, make them invalid JSON.
11. Reload the page and ensure the scripts load correctly.
12. Re-query the database and ensure the invalid JSON you changed is gone and replaced with correctly formatted script data.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->
Small increase in database storage due to new transient. This is an acceptable tradeoff because it prevents sites allowing access via HTTP and HTTPs from breaking based on who accesses the site first after the cache becomes invalid.

### Changelog

> Ensure cached script data is refreshed following a site URL change, version change, or when switching between the WooCommerce Blocks feature plugin and WooCommerce Core.
