### PR TITLE
Render express payment methods in full in the editor

### DIFF
--- a/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment-methods.js
+++ b/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment-methods.js
@@ -138,12 +138,13 @@ const ExpressPaymentMethods = () => {
 	const content =
 		entries.length > 0 ? (
 			entries.map( ( [ id, paymentMethod ] ) => {
-				const expressPaymentMethod = isEditor
-					? paymentMethod.edit
-					: paymentMethod.content;
-				return isValidElement( expressPaymentMethod ) ? (
-					<li key={ id } id={ `express-payment-method-${ id }` }>
-						{ cloneElement( expressPaymentMethod, {
+				return isValidElement( paymentMethod.content ) ? (
+					<li
+						key={ id }
+						id={ `express-payment-method-${ id }` }
+						style={ { pointerEvents: isEditor ? 'none' : 'auto' } } // disable click in the editor
+					>
+						{ cloneElement( paymentMethod.content, {
 							...paymentMethodInterface,
 							onClick: onExpressPaymentClick( id ),
 							onClose: onExpressPaymentClose,


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
When registering an express payment method, a third party plugin will provide an object with a `content` and an `edit` property. They both contain react components. The `content` property contains the component to display on the front-end, and the `edit` property contains the component to display in the editor.

As part of woocommerce/woocommerce#42353, we want to make the editor experience as close to the front end experience as possible. There is a discussion on the issue for reference but the gist of it is that it's difficult to get parity between editor and front-end, as the express payment buttons depend on the local environment (browser, logged in status). As a starting point, this PR renders the `content` component in the editor as well, for consistency but disables the clicking of it.

There is a concern that @opr pointed out that the component specified as the `edit` property may have additional controls, and by replacing this we may be removing those. I haven't found a solution to this yet but it is a genuine concern. We are also changing the public facing api by removing the need for the `edit` property. It's not a breaking change, but relevant plugin authors should be notified.

As the conversation is ongoing on woocommerce/woocommerce#42353, I will leave this as draft for the time being.

There is also another branch (9668/show-enabled-express-methods-detect-button-render) with some code that detects if any express payment buttons are rendered. We could potentially display a placeholder for the merchant if there are no express payment buttons rendered.

### Screenshots

### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Open up the Checkout block in the editor in Chrome
2. If you are signed into your Google account, and you have a valid payment method in your wallet, you should see the Google Pay button
3. If you are not, then you should see an aqua Link button
4. You should not be able to click these buttons
5. Add some items to your cart and go to the Checkout on the front-end
6. Make sure you see the same button, and that it is clickable
7. Continue the Checkout process with the express payment method you are using and make sure you can check out successfully


* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Express payment methods show in the editor rather than a preview
