### PR TITLE
Add missing page titles in Cart and Checkout templates

### DIFF
--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -41,6 +41,14 @@ class Cart extends AbstractBlock {
 		$shop_permalink = wc_get_page_id( 'shop' ) ? get_permalink( wc_get_page_id( 'shop' ) ) : '';
 
 		register_block_pattern(
+			'woocommerce/cart-heading',
+			array(
+				'title'    => '',
+				'inserter' => false,
+				'content'  => '<!-- wp:heading {"align":"wide", "level":1} --><h1 class="wp-block-heading alignwide">' . esc_html__( 'Cart', 'woo-gutenberg-products-block' ) . '</h1><!-- /wp:heading -->',
+			)
+		);
+		register_block_pattern(
 			'woocommerce/cart-cross-sells-message',
 			array(
 				'title'    => '',

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -25,6 +25,31 @@ class Checkout extends AbstractBlock {
 	protected $chunks_folder = 'checkout-blocks';
 
 	/**
+	 * Initialize this block type.
+	 *
+	 * - Hook into WP lifecycle.
+	 * - Register the block with WordPress.
+	 */
+	protected function initialize() {
+		parent::initialize();
+		add_action( 'wp_loaded', array( $this, 'register_patterns' ) );
+	}
+
+	/**
+	 * Register block pattern for Empty Cart Message to make it translatable.
+	 */
+	public function register_patterns() {
+		register_block_pattern(
+			'woocommerce/checkout-heading',
+			array(
+				'title'    => '',
+				'inserter' => false,
+				'content'  => '<!-- wp:heading {"align":"wide", "level":1} --><h1 class="wp-block-heading alignwide">' . esc_html__( 'Checkout', 'woo-gutenberg-products-block' ) . '</h1><!-- /wp:heading -->',
+			)
+		);
+	}
+
+	/**
 	 * Get the editor script handle for this block type.
 	 *
 	 * @param string $key Data to get, or default to everything.

--- a/templates/templates/blockified/cart.html
+++ b/templates/templates/blockified/cart.html
@@ -1,4 +1,5 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
 <!-- wp:group {"layout":{"inherit":true,"type":"constrained"}} -->
 <div class="wp-block-group">
 	<!-- wp:pattern {"slug":"woocommerce/cart-heading"} /-->
@@ -164,4 +165,5 @@
 	<!-- /wp:woocommerce/cart -->
 </div>
 <!-- /wp:group -->
+
 <!-- wp:template-part {"slug":"footer"} /-->

--- a/templates/templates/blockified/cart.html
+++ b/templates/templates/blockified/cart.html
@@ -1,6 +1,9 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 <!-- wp:group {"layout":{"inherit":true,"type":"constrained"}} -->
-<div class="wp-block-group"><!-- wp:woocommerce/cart -->
+<div class="wp-block-group">
+	<!-- wp:pattern {"slug":"woocommerce/cart-heading"} /-->
+
+	<!-- wp:woocommerce/cart -->
 	<div class="wp-block-woocommerce-cart alignwide is-loading">
 		<!-- wp:woocommerce/filled-cart-block {"align":"wide"} -->
 		<div class="wp-block-woocommerce-filled-cart-block alignwide">

--- a/templates/templates/blockified/checkout.html
+++ b/templates/templates/blockified/checkout.html
@@ -1,4 +1,5 @@
 <!-- wp:template-part {"slug":"checkout-header","theme":"woocommerce/woocommerce"} /-->
+
 <!-- wp:group {"layout":{"inherit":true,"type":"constrained"}} -->
 <div class="wp-block-group">
 	<!-- wp:pattern {"slug":"woocommerce/checkout-heading"} /-->

--- a/templates/templates/blockified/checkout.html
+++ b/templates/templates/blockified/checkout.html
@@ -1,7 +1,11 @@
 <!-- wp:template-part {"slug":"checkout-header","theme":"woocommerce/woocommerce"} /-->
 <!-- wp:group {"layout":{"inherit":true,"type":"constrained"}} -->
-<div class="wp-block-group"><!-- wp:woocommerce/checkout {"className":"wc-block-checkout"} -->
-	<div class="wp-block-woocommerce-checkout alignwide wc-block-checkout is-loading"><!-- wp:woocommerce/checkout-fields-block -->
+<div class="wp-block-group">
+	<!-- wp:pattern {"slug":"woocommerce/checkout-heading"} /-->
+
+	<!-- wp:woocommerce/checkout {"className":"wc-block-checkout"} -->
+	<div class="wp-block-woocommerce-checkout alignwide wc-block-checkout is-loading">
+		<!-- wp:woocommerce/checkout-fields-block -->
 		<div class="wp-block-woocommerce-checkout-fields-block"><!-- wp:woocommerce/checkout-express-payment-block -->
 			<div class="wp-block-woocommerce-checkout-express-payment-block"></div>
 			<!-- /wp:woocommerce/checkout-express-payment-block -->
@@ -44,12 +48,14 @@
 
 			<!-- wp:woocommerce/checkout-actions-block -->
 			<div class="wp-block-woocommerce-checkout-actions-block"></div>
-			<!-- /wp:woocommerce/checkout-actions-block --></div>
+			<!-- /wp:woocommerce/checkout-actions-block -->
+		</div>
 		<!-- /wp:woocommerce/checkout-fields-block -->
 
 		<!-- wp:woocommerce/checkout-totals-block -->
 		<div class="wp-block-woocommerce-checkout-totals-block"><!-- wp:woocommerce/checkout-order-summary-block -->
-			<div class="wp-block-woocommerce-checkout-order-summary-block"><!-- wp:woocommerce/checkout-order-summary-cart-items-block -->
+			<div class="wp-block-woocommerce-checkout-order-summary-block">
+				<!-- wp:woocommerce/checkout-order-summary-cart-items-block -->
 				<div class="wp-block-woocommerce-checkout-order-summary-cart-items-block"></div>
 				<!-- /wp:woocommerce/checkout-order-summary-cart-items-block -->
 
@@ -75,8 +81,12 @@
 
 				<!-- wp:woocommerce/checkout-order-summary-taxes-block -->
 				<div class="wp-block-woocommerce-checkout-order-summary-taxes-block"></div>
-				<!-- /wp:woocommerce/checkout-order-summary-taxes-block --></div>
-			<!-- /wp:woocommerce/checkout-order-summary-block --></div>
-		<!-- /wp:woocommerce/checkout-totals-block --></div>
-	<!-- /wp:woocommerce/checkout --></div>
+				<!-- /wp:woocommerce/checkout-order-summary-taxes-block -->
+			</div>
+			<!-- /wp:woocommerce/checkout-order-summary-block -->
+		</div>
+		<!-- /wp:woocommerce/checkout-totals-block -->
+	</div>
+	<!-- /wp:woocommerce/checkout -->
+</div>
 <!-- /wp:group -->

--- a/templates/templates/cart.html
+++ b/templates/templates/cart.html
@@ -2,7 +2,7 @@
 <!-- wp:group {"layout":{"inherit":true,"type":"constrained"}} -->
 <div class="wp-block-group">
 	<!-- wp:heading {"align":"wide"} -->
-	<h2 class="wp-block-heading alignwide">Cart</h2>
+	<h1 class="wp-block-heading alignwide">Cart</h1>
 	<!-- /wp:heading -->
 
 	<!-- wp:woocommerce/cart -->
@@ -12,7 +12,8 @@
 			<!-- wp:woocommerce/cart-items-block -->
 			<div class="wp-block-woocommerce-cart-items-block">
 				<!-- wp:woocommerce/cart-line-items-block -->
-				<div class="wp-block-woocommerce-cart-line-items-block"></div>				<!-- /wp:woocommerce/cart-line-items-block -->
+				<div class="wp-block-woocommerce-cart-line-items-block"></div>
+				<!-- /wp:woocommerce/cart-line-items-block -->
 
 				<!-- wp:woocommerce/cart-cross-sells-block -->
 				<div class="wp-block-woocommerce-cart-cross-sells-block">

--- a/templates/templates/cart.html
+++ b/templates/templates/cart.html
@@ -1,14 +1,18 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 <!-- wp:group {"layout":{"inherit":true,"type":"constrained"}} -->
-<div class="wp-block-group"><!-- wp:woocommerce/cart -->
+<div class="wp-block-group">
+	<!-- wp:heading {"align":"wide"} -->
+	<h2 class="wp-block-heading alignwide">Cart</h2>
+	<!-- /wp:heading -->
+
+	<!-- wp:woocommerce/cart -->
 	<div class="wp-block-woocommerce-cart alignwide is-loading">
 		<!-- wp:woocommerce/filled-cart-block {"align":"wide"} -->
 		<div class="wp-block-woocommerce-filled-cart-block alignwide">
 			<!-- wp:woocommerce/cart-items-block -->
 			<div class="wp-block-woocommerce-cart-items-block">
 				<!-- wp:woocommerce/cart-line-items-block -->
-				<div class="wp-block-woocommerce-cart-line-items-block"></div>
-				<!-- /wp:woocommerce/cart-line-items-block -->
+				<div class="wp-block-woocommerce-cart-line-items-block"></div>				<!-- /wp:woocommerce/cart-line-items-block -->
 
 				<!-- wp:woocommerce/cart-cross-sells-block -->
 				<div class="wp-block-woocommerce-cart-cross-sells-block">

--- a/templates/templates/cart.html
+++ b/templates/templates/cart.html
@@ -1,9 +1,7 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 <!-- wp:group {"layout":{"inherit":true,"type":"constrained"}} -->
 <div class="wp-block-group">
-	<!-- wp:heading {"align":"wide"} -->
-	<h1 class="wp-block-heading alignwide">Cart</h1>
-	<!-- /wp:heading -->
+	<!-- wp:pattern {"slug":"woocommerce/cart-heading"} /-->
 
 	<!-- wp:woocommerce/cart -->
 	<div class="wp-block-woocommerce-cart alignwide is-loading">

--- a/templates/templates/cart.html
+++ b/templates/templates/cart.html
@@ -1,4 +1,5 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
 <!-- wp:group {"layout":{"inherit":true,"type":"constrained"}} -->
 <div class="wp-block-group">
 	<!-- wp:pattern {"slug":"woocommerce/cart-heading"} /-->
@@ -164,4 +165,5 @@
 	<!-- /wp:woocommerce/cart -->
 </div>
 <!-- /wp:group -->
+
 <!-- wp:template-part {"slug":"footer"} /-->

--- a/templates/templates/checkout.html
+++ b/templates/templates/checkout.html
@@ -1,4 +1,5 @@
 <!-- wp:template-part {"slug":"checkout-header","theme":"woocommerce/woocommerce"} /-->
+
 <!-- wp:group {"layout":{"inherit":true,"type":"constrained"}} -->
 <div class="wp-block-group">
 	<!-- wp:pattern {"slug":"woocommerce/checkout-heading"} /-->

--- a/templates/templates/checkout.html
+++ b/templates/templates/checkout.html
@@ -2,7 +2,7 @@
 <!-- wp:group {"layout":{"inherit":true,"type":"constrained"}} -->
 <div class="wp-block-group">
 	<!-- wp:heading {"align":"wide"} -->
-	<h2 class="wp-block-heading alignwide">Checkout</h2>
+	<h1 class="wp-block-heading alignwide">Checkout</h1>
 	<!-- /wp:heading -->
 
 	<!-- wp:woocommerce/checkout {"className":"wc-block-checkout"} -->

--- a/templates/templates/checkout.html
+++ b/templates/templates/checkout.html
@@ -1,9 +1,7 @@
 <!-- wp:template-part {"slug":"checkout-header","theme":"woocommerce/woocommerce"} /-->
 <!-- wp:group {"layout":{"inherit":true,"type":"constrained"}} -->
 <div class="wp-block-group">
-	<!-- wp:heading {"align":"wide"} -->
-	<h1 class="wp-block-heading alignwide">Checkout</h1>
-	<!-- /wp:heading -->
+	<!-- wp:pattern {"slug":"woocommerce/checkout-heading"} /-->
 
 	<!-- wp:woocommerce/checkout {"className":"wc-block-checkout"} -->
 	<div class="wp-block-woocommerce-checkout alignwide wc-block-checkout is-loading">
@@ -50,12 +48,14 @@
 
 			<!-- wp:woocommerce/checkout-actions-block -->
 			<div class="wp-block-woocommerce-checkout-actions-block"></div>
-			<!-- /wp:woocommerce/checkout-actions-block --></div>
+			<!-- /wp:woocommerce/checkout-actions-block -->
+		</div>
 		<!-- /wp:woocommerce/checkout-fields-block -->
 
 		<!-- wp:woocommerce/checkout-totals-block -->
 		<div class="wp-block-woocommerce-checkout-totals-block"><!-- wp:woocommerce/checkout-order-summary-block -->
-			<div class="wp-block-woocommerce-checkout-order-summary-block"><!-- wp:woocommerce/checkout-order-summary-cart-items-block -->
+			<div class="wp-block-woocommerce-checkout-order-summary-block">
+				<!-- wp:woocommerce/checkout-order-summary-cart-items-block -->
 				<div class="wp-block-woocommerce-checkout-order-summary-cart-items-block"></div>
 				<!-- /wp:woocommerce/checkout-order-summary-cart-items-block -->
 
@@ -81,8 +81,12 @@
 
 				<!-- wp:woocommerce/checkout-order-summary-taxes-block -->
 				<div class="wp-block-woocommerce-checkout-order-summary-taxes-block"></div>
-				<!-- /wp:woocommerce/checkout-order-summary-taxes-block --></div>
-			<!-- /wp:woocommerce/checkout-order-summary-block --></div>
-		<!-- /wp:woocommerce/checkout-totals-block --></div>
-	<!-- /wp:woocommerce/checkout --></div>
+				<!-- /wp:woocommerce/checkout-order-summary-taxes-block -->
+			</div>
+			<!-- /wp:woocommerce/checkout-order-summary-block -->
+		</div>
+		<!-- /wp:woocommerce/checkout-totals-block -->
+	</div>
+	<!-- /wp:woocommerce/checkout -->
+</div>
 <!-- /wp:group -->

--- a/templates/templates/checkout.html
+++ b/templates/templates/checkout.html
@@ -1,7 +1,13 @@
 <!-- wp:template-part {"slug":"checkout-header","theme":"woocommerce/woocommerce"} /-->
 <!-- wp:group {"layout":{"inherit":true,"type":"constrained"}} -->
-<div class="wp-block-group"><!-- wp:woocommerce/checkout {"className":"wc-block-checkout"} -->
-	<div class="wp-block-woocommerce-checkout alignwide wc-block-checkout is-loading"><!-- wp:woocommerce/checkout-fields-block -->
+<div class="wp-block-group">
+	<!-- wp:heading {"align":"wide"} -->
+	<h2 class="wp-block-heading alignwide">Checkout</h2>
+	<!-- /wp:heading -->
+
+	<!-- wp:woocommerce/checkout {"className":"wc-block-checkout"} -->
+	<div class="wp-block-woocommerce-checkout alignwide wc-block-checkout is-loading">
+		<!-- wp:woocommerce/checkout-fields-block -->
 		<div class="wp-block-woocommerce-checkout-fields-block"><!-- wp:woocommerce/checkout-express-payment-block -->
 			<div class="wp-block-woocommerce-checkout-express-payment-block"></div>
 			<!-- /wp:woocommerce/checkout-express-payment-block -->


### PR DESCRIPTION
Fixes #10171

In WooCommerce Blocks 10.6.0, we introduced the Cart and Checkout templates. Initially, we introduced them without the page title. This led to failing e2e tests and confusion as other pages do have a page title. This PR aims to add the page titles to the Cart and Checkout templates.

### Screenshots

<table>
<tr>
<td>Cart template (EN) - before:
<br><br>

<img width="1512" alt="Screenshot 2023-07-19 at 19 14 51" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/7027813d-83bf-427e-9d4d-18324be0cbed">
</td>
<td>Cart template (EN) - after:
<br><br>

<img width="1512" alt="Screenshot 2023-07-19 at 19 13 20" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/7d060bd5-e455-4dfc-a870-79f210b14f9f">
</td>
<td>Cart template (NL) - after:
<br><br>

<img width="1512" alt="Screenshot 2023-07-20 at 12 40 21" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/eedb9060-b1ec-42a4-b2ab-e5b1b83bcace">
</td>
</tr>
<tr>
<td>Checkout template (EN) - before:
<br><br>

<img width="1512" alt="Screenshot 2023-07-19 at 19 15 19" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/4ea05fda-e1cb-471e-8798-78762adfadeb">
</td>
<td>Checkout template (EN) - after:
<br><br>

<img width="1512" alt="Screenshot 2023-07-19 at 19 13 40" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/9e614530-763f-4c64-848d-ba8059a9d7e1">
</td>
<td>Checkout template (NL) - after:
<br><br>

<img width="1512" alt="Screenshot 2023-07-20 at 12 40 42" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/6cc88e87-7056-47c7-8e10-6b5e13d6c6f0">
</td>
</tr>
</table>

### Testing

#### User Facing Testing » Verify that page titles are visible

1. Install a block-theme, e.g. [Twenty Twenty-Three](https://wordpress.org/themes/twentytwentythree/).
2. Go to WP Admin » Appearance » Editor » Templates.
3. Open the Cart template and verify that it has the page title `Cart`.
4. Open the Checkout template and verify that it has the page title `Checkout`. 
5. Go to the frontend and add a product to the cart.
6. Go to the Cart page and verify that it has the page title `Cart`.
7. Go to the Checkout page and verify that it has the page title `Checkout`.

#### User Facing Testing » Verify that page titles are translatable

1. Go to `/wp-admin/options-general.php` and switch the language to `Nederlands`.
2. Go to `/wp-admin/update-core.php` and fetch the available translations.
3. Open the Cart template and verify that it has the page title `Winkelwagen`.
4. Open the Checkout template and verify that it has the page title `Afrekenen`. 
5. Go to the frontend and add a product to the cart.
6. Go to the Cart page and verify that it has the page title `Winkelwagen`.
7. Go to the Checkout page and verify that it has the page title `Afrekenen`.

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix: Add missing page titles to the Cart and the Checkout templates.
