### PR TITLE
Add to Cart Form: Fix broken styles for the block when using inside the Single Product Block

### DIFF
--- a/assets/js/atomic/blocks/product-elements/add-to-cart-form/index.tsx
+++ b/assets/js/atomic/blocks/product-elements/add-to-cart-form/index.tsx
@@ -9,6 +9,8 @@ import { Icon, button } from '@wordpress/icons';
  */
 import metadata from './block.json';
 import edit from './edit';
+import './style.scss';
+import './editor.scss';
 
 const blockSettings = {
 	edit,

--- a/bin/webpack-entries.js
+++ b/bin/webpack-entries.js
@@ -133,6 +133,8 @@ const entries = {
 			'./assets/js/atomic/blocks/product-elements/product-reviews/index.tsx',
 		'product-details':
 			'./assets/js/atomic/blocks/product-elements/product-details/index.tsx',
+		'add-to-cart-form':
+			'./assets/js/atomic/blocks/product-elements/add-to-cart-form/index.tsx',
 		...getBlockEntries( '{index,block,frontend}.{t,j}s{,x}' ),
 	},
 	core: {

--- a/src/BlockTypes/AddToCartForm.php
+++ b/src/BlockTypes/AddToCartForm.php
@@ -96,7 +96,7 @@ class AddToCartForm extends AbstractBlock {
 
 		$classname          = $attributes['className'] ?? '';
 		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes );
-		$product_classname = $is_descendent_of_single_product_block ? 'product': '';
+		$product_classname = $is_descendent_of_single_product_block ? 'product' : '';
 
 		$form = sprintf(
 			'<div class="wp-block-add-to-cart-form %1$s %2$s %3$s" style="%4$s">%5$s</div>',

--- a/src/BlockTypes/AddToCartForm.php
+++ b/src/BlockTypes/AddToCartForm.php
@@ -96,11 +96,13 @@ class AddToCartForm extends AbstractBlock {
 
 		$classname          = $attributes['className'] ?? '';
 		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes );
+		$product_classname = $is_descendent_of_single_product_block ? 'product': '';
 
 		$form = sprintf(
-			'<div class="wp-block-add-to-cart-form %1$s %2$s" style="%3$s">%4$s</div>',
+			'<div class="wp-block-add-to-cart-form %1$s %2$s %3$s" style="%4$s">%5$s</div>',
 			esc_attr( $classes_and_styles['classes'] ),
 			esc_attr( $classname ),
+			esc_attr( $product_classname ),
 			esc_attr( $classes_and_styles['styles'] ),
 			$product
 		);
@@ -182,7 +184,7 @@ class AddToCartForm extends AbstractBlock {
 	 * @return null
 	 */
 	protected function get_block_type_style() {
-		return null;
+		return array_merge( parent::get_block_type_style(), [ 'wc-blocks-packages-style' ] );
 	}
 
 	/**


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

While testing the Single Product block with WordPress 6.3 I noticed that the styles for the Add to Cart Form block were not being applied correctly. The input was too small and there was a line break between the input and the button.

## Walkthrough

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1e60e1f</samp>

* Refactor the add-to-cart-form block to use TypeScript and React instead of PHP and HTML ([link](https://github.com/woocommerce/woocommerce-blocks/pull/10282/files?diff=unified&w=0#diff-2f4d3497e82c66c00f3a9077edfccbde0109326c9abc378b1b3dcb3b570588d8R12-R13),                                                         F0

<!-- Reference any related issues or PRs here -->

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Log in to your WordPress dashboard.
2. From your WordPress dashboard, go to Appearance > Themes. Make sure you have a block-based theme installed and activated. If not, you can install one from the Add New option. Block-based themes include "Twenty-twenty Two," "Twenty-twenty Three," etc.
3. On the left-hand side menu, click on Pages > Add New.
4. Inside the Page editor, click on the '+' button, usually found at the top left of the editing space or within the content area itself, to add a new block.
5. In the block library that pops up, search for the 'Single Product' block. Click on it to add the block to the template.
6. On the top-right side, click on the Save button.
7. Visit a product and check if the Single Product block is shown and the Add to Cart Form block is correctly being displayed

| Before | After |
| ------ | ----- |
| <img width="649" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/20469356/80a249d6-4a0c-41fe-8b1c-c71c69112717">  | <img width="674" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/20469356/436f48ae-9a9e-467c-95a6-1935a8ff3c11"> |

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Fix styles for the Add to Cart Form block when used together with the Single Product block
