### PR TITLE
Add order confirmation wrapper block

### DIFF
--- a/assets/js/blocks/classic-template/order-confirmation.tsx
+++ b/assets/js/blocks/classic-template/order-confirmation.tsx
@@ -30,6 +30,10 @@ const getBlockifiedTemplate = ( inheritedAttributes: InheritedAttributes ) =>
 			'woocommerce/order-confirmation-totals',
 			inheritedAttributes
 		),
+		createBlock(
+			'order-confirmation-billing-wrapper',
+			inheritedAttributes
+		),
 		createBlock( 'core/columns', inheritedAttributes, [
 			createBlock( 'core/column', inheritedAttributes, [
 				createBlock( 'core/heading', {

--- a/assets/js/blocks/classic-template/order-confirmation.tsx
+++ b/assets/js/blocks/classic-template/order-confirmation.tsx
@@ -30,21 +30,10 @@ const getBlockifiedTemplate = ( inheritedAttributes: InheritedAttributes ) =>
 			'woocommerce/order-confirmation-totals',
 			inheritedAttributes
 		),
-		createBlock(
-			'woocommerce/order-confirmation-billing-wrapper',
-			inheritedAttributes
-		),
 		createBlock( 'core/columns', inheritedAttributes, [
 			createBlock( 'core/column', inheritedAttributes, [
-				createBlock( 'core/heading', {
-					level: 3,
-					content: __(
-						'Billing Address',
-						'woo-gutenberg-products-block'
-					),
-				} ),
 				createBlock(
-					'woocommerce/order-confirmation-billing-address',
+					'woocommerce/order-confirmation-billing-wrapper',
 					inheritedAttributes
 				),
 			] ),

--- a/assets/js/blocks/classic-template/order-confirmation.tsx
+++ b/assets/js/blocks/classic-template/order-confirmation.tsx
@@ -31,7 +31,7 @@ const getBlockifiedTemplate = ( inheritedAttributes: InheritedAttributes ) =>
 			inheritedAttributes
 		),
 		createBlock(
-			'order-confirmation-billing-wrapper',
+			'woocommerce/order-confirmation-billing-wrapper',
 			inheritedAttributes
 		),
 		createBlock( 'core/columns', inheritedAttributes, [

--- a/assets/js/blocks/order-confirmation/billing-address/block.json
+++ b/assets/js/blocks/order-confirmation/billing-address/block.json
@@ -16,6 +16,7 @@
 		}
 	},
 	"textdomain": "woo-gutenberg-products-block",
+	"parent": [ "woocommerce/order-confirmation-billing-wrapper" ],
 	"apiVersion": 2,
 	"$schema": "https://schemas.wp.org/trunk/block.json"
 }

--- a/assets/js/blocks/order-confirmation/billing-address/block.json
+++ b/assets/js/blocks/order-confirmation/billing-address/block.json
@@ -16,7 +16,6 @@
 		}
 	},
 	"textdomain": "woo-gutenberg-products-block",
-	"parent": [ "woocommerce/order-confirmation-billing-wrapper" ],
 	"apiVersion": 2,
 	"$schema": "https://schemas.wp.org/trunk/block.json"
 }

--- a/assets/js/blocks/order-confirmation/billing-address/index.tsx
+++ b/assets/js/blocks/order-confirmation/billing-address/index.tsx
@@ -2,8 +2,7 @@
  * External dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
-import { Icon } from '@wordpress/icons';
-import { totals } from '@woocommerce/icons';
+import { Icon, mapMarker } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -16,7 +15,7 @@ registerBlockType( metadata, {
 	icon: {
 		src: (
 			<Icon
-				icon={ totals }
+				icon={ mapMarker }
 				className="wc-block-editor-components-block-icon"
 			/>
 		),

--- a/assets/js/blocks/order-confirmation/billing-wrapper/attributes.tsx
+++ b/assets/js/blocks/order-confirmation/billing-wrapper/attributes.tsx
@@ -1,0 +1,11 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export default {
+	heading: {
+		type: 'string',
+		default: __( 'Billing address', 'woo-gutenberg-products-block' ),
+	},
+};

--- a/assets/js/blocks/order-confirmation/billing-wrapper/block.json
+++ b/assets/js/blocks/order-confirmation/billing-wrapper/block.json
@@ -1,7 +1,8 @@
 {
 	"name": "woocommerce/order-confirmation-billing-wrapper",
 	"version": "1.0.0",
-	"title": "Billing wrapper",
+	"title": "Order Confirmation Billing wrapper",
+	"description": "Display the order confirmation billing wrapper.",
 	"category": "woocommerce",
 	"keywords": [ "WooCommerce" ],
 	"attributes": {

--- a/assets/js/blocks/order-confirmation/billing-wrapper/block.json
+++ b/assets/js/blocks/order-confirmation/billing-wrapper/block.json
@@ -1,7 +1,7 @@
 {
 	"name": "woocommerce/order-confirmation-billing-wrapper",
 	"version": "1.0.0",
-	"title": "Order Confirmation Billing section",
+	"title": "Order Confirmation Billing Section",
 	"description": "Display the order confirmation billing section.",
 	"category": "woocommerce",
 	"keywords": [ "WooCommerce" ],

--- a/assets/js/blocks/order-confirmation/billing-wrapper/block.json
+++ b/assets/js/blocks/order-confirmation/billing-wrapper/block.json
@@ -1,0 +1,18 @@
+{
+	"name": "woocommerce/order-confirmation-billing-wrapper",
+	"version": "1.0.0",
+	"title": "Billing wrapper",
+	"category": "woocommerce",
+	"keywords": [ "WooCommerce" ],
+	"attributes": {
+		"filterType": {
+			"type": "string"
+		},
+		"heading": {
+			"type": "string"
+		}
+	},
+	"textdomain": "woo-gutenberg-products-block",
+	"apiVersion": 2,
+	"$schema": "https://schemas.wp.org/trunk/block.json"
+}

--- a/assets/js/blocks/order-confirmation/billing-wrapper/block.json
+++ b/assets/js/blocks/order-confirmation/billing-wrapper/block.json
@@ -1,8 +1,8 @@
 {
 	"name": "woocommerce/order-confirmation-billing-wrapper",
 	"version": "1.0.0",
-	"title": "Order Confirmation Billing wrapper",
-	"description": "Display the order confirmation billing wrapper.",
+	"title": "Order Confirmation Billing section",
+	"description": "Display the order confirmation billing section.",
 	"category": "woocommerce",
 	"keywords": [ "WooCommerce" ],
 	"attributes": {

--- a/assets/js/blocks/order-confirmation/billing-wrapper/edit.tsx
+++ b/assets/js/blocks/order-confirmation/billing-wrapper/edit.tsx
@@ -2,14 +2,16 @@
  * External dependencies
  */
 import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
-import type { BlockEditProps } from '@wordpress/blocks';
 
-/**
- * Internal dependencies
- */
-import { Attributes } from './types';
-
-const Edit = ( { attributes }: BlockEditProps< Attributes > ) => {
+const Edit = ( {
+	attributes,
+	setAttributes,
+}: {
+	attributes: {
+		heading: string;
+	};
+	setAttributes: ( attributes: Record< string, unknown > ) => void;
+} ) => {
 	const blockProps = useBlockProps();
 
 	return (
@@ -19,7 +21,12 @@ const Edit = ( { attributes }: BlockEditProps< Attributes > ) => {
 				template={ [
 					[
 						'core/heading',
-						{ level: 3, content: attributes.heading || '' },
+						{
+							level: 3,
+							content: attributes.heading || '',
+							onChangeContent: ( value: string ) =>
+								setAttributes( { heading: value } ),
+						},
 					],
 					[
 						'woocommerce/order-confirmation-billing-address',

--- a/assets/js/blocks/order-confirmation/billing-wrapper/edit.tsx
+++ b/assets/js/blocks/order-confirmation/billing-wrapper/edit.tsx
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
+import type { BlockEditProps } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { Attributes } from './types';
+
+const Edit = ( { attributes }: BlockEditProps< Attributes > ) => {
+	const blockProps = useBlockProps();
+
+	return (
+		<div { ...blockProps }>
+			<InnerBlocks
+				allowedBlocks={ [ 'core/heading' ] }
+				template={ [
+					[
+						'core/heading',
+						{ level: 3, content: attributes.heading || '' },
+					],
+					[
+						'woocommerce/order-confirmation-billing-address',
+						{
+							heading: '',
+							lock: {
+								remove: true,
+							},
+						},
+					],
+				] }
+			/>
+		</div>
+	);
+};
+
+export default Edit;

--- a/assets/js/blocks/order-confirmation/billing-wrapper/index.tsx
+++ b/assets/js/blocks/order-confirmation/billing-wrapper/index.tsx
@@ -9,6 +9,7 @@ import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
  */
 import edit from './edit';
 import metadata from './block.json';
+import attributes from './attributes';
 
 registerBlockType( metadata, {
 	edit,
@@ -19,4 +20,5 @@ registerBlockType( metadata, {
 			</div>
 		);
 	},
+	attributes,
 } );

--- a/assets/js/blocks/order-confirmation/billing-wrapper/index.tsx
+++ b/assets/js/blocks/order-confirmation/billing-wrapper/index.tsx
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
+import metadata from './block.json';
+
+registerBlockType( metadata, {
+	edit,
+	save() {
+		return (
+			<div { ...useBlockProps.save() }>
+				<InnerBlocks.Content />
+			</div>
+		);
+	},
+} );

--- a/assets/js/blocks/order-confirmation/billing-wrapper/index.tsx
+++ b/assets/js/blocks/order-confirmation/billing-wrapper/index.tsx
@@ -3,6 +3,7 @@
  */
 import { registerBlockType } from '@wordpress/blocks';
 import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
+import { Icon, mapMarker } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -12,6 +13,14 @@ import metadata from './block.json';
 import attributes from './attributes';
 
 registerBlockType( metadata, {
+	icon: {
+		src: (
+			<Icon
+				icon={ mapMarker }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
+	},
 	edit,
 	save() {
 		return (

--- a/bin/webpack-entries.js
+++ b/bin/webpack-entries.js
@@ -100,6 +100,9 @@ const blocks = {
 	'order-confirmation-shipping-address': {
 		customDir: 'order-confirmation/shipping-address',
 	},
+	'order-confirmation-billing-wrapper': {
+		customDir: 'order-confirmation/billing-wrapper',
+	},
 	'order-confirmation-status': {
 		customDir: 'order-confirmation/status',
 	},

--- a/src/BlockTypes/OrderConfirmation/BillingWrapper.php
+++ b/src/BlockTypes/OrderConfirmation/BillingWrapper.php
@@ -53,6 +53,8 @@ class BillingWrapper extends AbstractOrderConfirmationBlock {
 	 * This renders the content of the billing wrapper.
 	 *
 	 * @param \WC_Order $order Order object.
+	 * @param string    $permission Permission level for viewing order details.
+	 * @param array     $attributes Block attributes.
 	 */
-	protected function render_content( $order ) {}
+	protected function render_content( $order, $permission = false, $attributes = [] ) {}
 }

--- a/src/BlockTypes/OrderConfirmation/BillingWrapper.php
+++ b/src/BlockTypes/OrderConfirmation/BillingWrapper.php
@@ -51,7 +51,7 @@ class BillingWrapper extends AbstractOrderConfirmationBlock {
 	 * @return string
 	 */
 	protected function render_content( $order ) {
-		$heading = esc_html_( 'Billing address', 'woo-gutenberg-products-block' );
+		$heading = esc_html__( 'Billing address', 'woo-gutenberg-products-block' );
 
 		return '
 			<div class="woocommerce-column woocommerce-column--1 woocommerce-column--billing-address col-1">

--- a/src/BlockTypes/OrderConfirmation/BillingWrapper.php
+++ b/src/BlockTypes/OrderConfirmation/BillingWrapper.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Automattic\WooCommerce\Blocks\BlockTypes\OrderConfirmation;
+
+use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
+
+/**
+ * BillingWrapper class.
+ */
+class BillingWrapper extends AbstractOrderConfirmationBlock {
+
+	/**
+	 * Block name.
+	 *
+	 * @var string
+	 */
+	protected $block_name = 'order-confirmation-billing-wrapper';
+
+	/**
+	 * Render the block.
+	 *
+	 * @param array    $attributes Block attributes.
+	 * @param string   $content Block content.
+	 * @param WP_Block $block Block instance.
+	 *
+	 * @return string | void Rendered block output.
+	 */
+	protected function render( $attributes, $content, $block ) {
+		$order              = $this->get_order();
+		$content            = $order && $this->is_current_customer_order( $order ) ? $this->render_content( $order ) : '';
+		$classname          = $attributes['className'] ?? '';
+		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes );
+
+		if ( isset( $attributes['align'] ) ) {
+			$classname .= " align{$attributes['align']}";
+		}
+
+		return sprintf(
+			'<div class="wc-block-%4$s %1$s %2$s">%3$s</div>',
+			esc_attr( $classes_and_styles['classes'] ),
+			esc_attr( $classname ),
+			$content,
+			esc_attr( $this->block_name )
+		);
+	}
+
+	/**
+	 * This renders the content of the billing wrapper.
+	 *
+	 * @return string
+	 */
+	protected function render_content() {
+		$heading = esc_html_( 'Billing address', 'woo-gutenberg-products-block' );
+
+		return '
+			<div class="woocommerce-column woocommerce-column--1 woocommerce-column--billing-address col-1">
+				<h2 class="woocommerce-order-details">
+					' . wp_kses_post( $heading ) . '
+				</h2>
+			</div>
+		';
+	}
+
+	/**
+	 * This is what gets rendered when the order does not exist.
+	 *
+	 * @return string
+	 */
+	protected function render_content_fallback() {
+		return '-';
+	}
+}

--- a/src/BlockTypes/OrderConfirmation/BillingWrapper.php
+++ b/src/BlockTypes/OrderConfirmation/BillingWrapper.php
@@ -3,6 +3,7 @@
 namespace Automattic\WooCommerce\Blocks\BlockTypes\OrderConfirmation;
 
 use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
+use Automattic\WooCommerce\Blocks\BlockTypes\OrderConfirmation\BillingAddress;
 
 /**
  * BillingWrapper class.
@@ -51,6 +52,10 @@ class BillingWrapper extends AbstractOrderConfirmationBlock {
 	 * @return string
 	 */
 	protected function render_content( $order ) {
+		if ( ! $order->has_billing_address() ) {
+			return '';
+		}
+
 		$heading = esc_html__( 'Billing address', 'woo-gutenberg-products-block' );
 
 		return '
@@ -58,6 +63,7 @@ class BillingWrapper extends AbstractOrderConfirmationBlock {
 				<h2 class="woocommerce-order-details">
 					' . wp_kses_post( $heading ) . '
 				</h2>
+				' . BillingAddress::render_content( $order ) . '
 			</div>
 		';
 	}

--- a/src/BlockTypes/OrderConfirmation/BillingWrapper.php
+++ b/src/BlockTypes/OrderConfirmation/BillingWrapper.php
@@ -47,9 +47,10 @@ class BillingWrapper extends AbstractOrderConfirmationBlock {
 	/**
 	 * This renders the content of the billing wrapper.
 	 *
+	 * @param \WC_Order $order Order object.
 	 * @return string
 	 */
-	protected function render_content() {
+	protected function render_content( $order ) {
 		$heading = esc_html_( 'Billing address', 'woo-gutenberg-products-block' );
 
 		return '

--- a/src/BlockTypes/OrderConfirmation/BillingWrapper.php
+++ b/src/BlockTypes/OrderConfirmation/BillingWrapper.php
@@ -27,8 +27,12 @@ class BillingWrapper extends AbstractOrderConfirmationBlock {
 	 * @return string | void Rendered block output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		$order              = $this->get_order();
-		$content            = $order && $this->is_current_customer_order( $order ) ? $this->render_content( $order ) : '';
+		$order = $this->get_order();
+
+		if ( ! $order || ! $this->is_current_customer_order( $order ) || ! $order->has_billing_address() ) {
+			return '';
+		}
+
 		$classname          = $attributes['className'] ?? '';
 		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes );
 
@@ -49,31 +53,6 @@ class BillingWrapper extends AbstractOrderConfirmationBlock {
 	 * This renders the content of the billing wrapper.
 	 *
 	 * @param \WC_Order $order Order object.
-	 * @return string
 	 */
-	protected function render_content( $order ) {
-		if ( ! $order->has_billing_address() ) {
-			return '';
-		}
-
-		$heading = esc_html__( 'Billing address', 'woo-gutenberg-products-block' );
-
-		return '
-			<div class="woocommerce-column woocommerce-column--1 woocommerce-column--billing-address col-1">
-				<h2 class="woocommerce-order-details">
-					' . wp_kses_post( $heading ) . '
-				</h2>
-				' . BillingAddress::render_content( $order ) . '
-			</div>
-		';
-	}
-
-	/**
-	 * This is what gets rendered when the order does not exist.
-	 *
-	 * @return string
-	 */
-	protected function render_content_fallback() {
-		return '-';
-	}
+	protected function render_content( $order ) {}
 }

--- a/src/BlockTypesController.php
+++ b/src/BlockTypesController.php
@@ -235,6 +235,7 @@ final class BlockTypesController {
 			$block_types[] = 'OrderConfirmation\Totals';
 			$block_types[] = 'OrderConfirmation\Downloads';
 			$block_types[] = 'OrderConfirmation\BillingAddress';
+			$block_types[] = 'OrderConfirmation\BillingWrapper';
 			$block_types[] = 'OrderConfirmation\ShippingAddress';
 		}
 


### PR DESCRIPTION
This PR introduces a parent Block for the Billing Address Block. In this parent Block, we are conditionally displaying the Billing Address Block and the heading. We also updated the titles, descriptions, and icons of the Billing Address and the wrapper Blocks. 

Fixes #10094, #10054

#### User Facing Testing

1. Select a block theme (e.g., Twenty Twenty-Three)
2. Go to `Editor -> Templates -> Order Confirmation`
3. Select the `Order Confirmation Block` and click on `transform into blocks`
4. Check the `Order Confirmation Order Billing Wrapper` Block. Ensure it has a heading and `Billing Address` as Inner Blocks.
5. Update the `billing address` block heading and refresh the page. Ensure the changes are applied on the edit and frontend sides.

* [x] Do not include in the Testing Notes

### WooCommerce Visibility

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental

