### PR TITLE
Remove opinionated styles from Alternating Image and Text pattern

### DIFF
--- a/patterns/store-info-alt-image-and-text.php
+++ b/patterns/store-info-alt-image-and-text.php
@@ -5,29 +5,29 @@
  * Categories: WooCommerce
  */
 ?>
-<!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"4vh","padding":{"top":"8vh","bottom":"8vh"}}}} -->
-<div class="wp-block-group alignwide" style="padding-top:8vh;padding-bottom:8vh"><!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":"40px"}}} -->
-<div class="wp-block-columns alignwide"><!-- wp:column {"width":"50%"} -->
-<div class="wp-block-column" style="flex-basis:50%"><!-- wp:image -->
+<!-- wp:group {"align":"wide"} -->
+<div class="wp-block-group alignwide"><!-- wp:columns {"align":"wide"} -->
+<div class="wp-block-columns alignwide"><!-- wp:column {"verticalAlignment":"center","width":"50%"} -->
+<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%"><!-- wp:image -->
 <figure class="wp-block-image"><img alt=""/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:column -->
 
-<!-- wp:column {"width":"50%","style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
-<div class="wp-block-column" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px;flex-basis:50%"><!-- wp:paragraph {"placeholder":"Content…","fontSize":"small"} -->
-<p class="has-small-font-size"><?php esc_html_e( 'THE GOODS', 'woo-gutenberg-products-block' ); ?></p>
+<!-- wp:column {"width":"50%"} -->
+<div class="wp-block-column" style="flex-basis:50%"><!-- wp:paragraph {"placeholder":"Content…","style":{"typography":{"textTransform":"uppercase"}}} -->
+<p style="text-transform:uppercase"><?php esc_html_e( 'The goods', 'woo-gutenberg-products-block' ); ?></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:heading {"style":{"typography":{"lineHeight":"1.3"},"spacing":{"margin":{"top":"var:preset|spacing|20","right":"0","bottom":"0","left":"0"}}},"fontSize":"x-large"} -->
-<h2 class="has-x-large-font-size" id="all-items-are-100-hand-made-using-the-potter-s-wheel-or-traditional-techniques-created-with-love-and-care-in-australia" style="margin-top:var(--wp--preset--spacing--20);margin-right:0;margin-bottom:0;margin-left:0;line-height:1.3"><?php esc_html_e( 'Created with love and care in Australia.', 'woo-gutenberg-products-block' ); ?></h2>
+<!-- wp:heading {"style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} -->
+<h2 id="all-items-are-100-hand-made-using-the-potter-s-wheel-or-traditional-techniques-created-with-love-and-care-in-australia" style="margin-top:0;margin-bottom:0"><?php esc_html_e( 'Created with love and care in Australia.', 'woo-gutenberg-products-block' ); ?></h2>
 <!-- /wp:heading -->
 
-<!-- wp:paragraph {"style":{"typography":{"lineHeight":"1.65"}}} -->
-<p style="line-height:1.65"><?php esc_html_e( 'All items are 100% hand-made, using the potter’s wheel or traditional techniques.', 'woo-gutenberg-products-block' ); ?></p>
+<!-- wp:paragraph -->
+<p><?php esc_html_e( 'All items are 100% hand-made, using the potter’s wheel or traditional techniques.', 'woo-gutenberg-products-block' ); ?></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:list {"style":{"typography":{"lineHeight":"2"}}} -->
-<ul style="line-height:2"><!-- wp:list-item -->
+<!-- wp:list -->
+<ul><!-- wp:list-item -->
 <li><?php esc_html_e( 'Timeless style.', 'woo-gutenberg-products-block' ); ?></li>
 <!-- /wp:list-item -->
 
@@ -46,29 +46,29 @@
 <!-- /wp:column --></div>
 <!-- /wp:columns -->
 
-<!-- wp:columns {"align":"wide","style":{"spacing":{"blockGap":"40px"}}} -->
+<!-- wp:columns {"align":"wide"} -->
 <div class="wp-block-columns alignwide"><!-- wp:column {"width":"50%"} -->
-<div class="wp-block-column" style="flex-basis:50%"><!-- wp:paragraph {"placeholder":"Content…","fontSize":"small"} -->
-<p class="has-small-font-size"><?php esc_html_e( 'ABOUT US', 'woo-gutenberg-products-block' ); ?></p>
+<div class="wp-block-column" style="flex-basis:50%"><!-- wp:paragraph {"placeholder":"Content…","style":{"typography":{"textTransform":"uppercase"}}} -->
+<p style="text-transform:uppercase"><?php esc_html_e( 'About us', 'woo-gutenberg-products-block' ); ?></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:heading {"style":{"typography":{"lineHeight":"1.3"},"spacing":{"margin":{"top":"var:preset|spacing|20"}}},"fontSize":"x-large"} -->
-<h2 class="has-x-large-font-size" id="all-items-are-100-hand-made-using-the-potter-s-wheel-or-traditional-techniques-created-with-love-and-care-in-australia" style="margin-top:var(--wp--preset--spacing--20);line-height:1.3"><?php esc_html_e( 'Marl is an independent studio and artisanal gallery.', 'woo-gutenberg-products-block' ); ?></h2>
+<!-- wp:heading {"style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} -->
+<h2 id="all-items-are-100-hand-made-using-the-potter-s-wheel-or-traditional-techniques-created-with-love-and-care-in-australia" style="margin-top:0;margin-bottom:0"><?php esc_html_e( 'Marl is an independent studio and artisanal gallery.', 'woo-gutenberg-products-block' ); ?></h2>
 <!-- /wp:heading -->
 
-<!-- wp:paragraph {"style":{"typography":{"fontSize":"18px"}}} -->
-<p style="font-size:18px"><?php esc_html_e( 'We specialize in limited collections of handmade tableware. We collaborate with restaurants and cafes to create unique items that complement the menu perfectly. Please get in touch if you want to know more about our process and pricing.', 'woo-gutenberg-products-block' ); ?></p>
+<!-- wp:paragraph -->
+<p><?php esc_html_e( 'We specialize in limited collections of handmade tableware. We collaborate with restaurants and cafes to create unique items that complement the menu perfectly. Please get in touch if you want to know more about our process and pricing.', 'woo-gutenberg-products-block' ); ?></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:buttons {"style":{"spacing":{"margin":{"top":"20px","bottom":"20px"}}}} -->
-<div class="wp-block-buttons" style="margin-top:20px;margin-bottom:20px"><!-- wp:button {"style":{"border":{"radius":"100px"},"spacing":{"padding":{"top":"6px","bottom":"6px","left":"36px","right":"36px"}}},"className":"is-style-outline","fontSize":"small"} -->
-<div class="wp-block-button has-custom-font-size is-style-outline has-small-font-size"><a class="wp-block-button__link wp-element-button" style="border-radius:100px;padding-top:6px;padding-right:36px;padding-bottom:6px;padding-left:36px"><?php esc_html_e( 'LEARN MORE', 'woo-gutenberg-products-block' ); ?></a></div>
+<!-- wp:buttons -->
+<div class="wp-block-buttons"><!-- wp:button {"className":"is-style-outline"} -->
+<div class="wp-block-button is-style-outline"><a class="wp-block-button__link wp-element-button"><?php esc_html_e( 'Learn more', 'woo-gutenberg-products-block' ); ?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons --></div>
 <!-- /wp:column -->
 
-<!-- wp:column {"width":"50%"} -->
-<div class="wp-block-column" style="flex-basis:50%"><!-- wp:image -->
+<!-- wp:column {"verticalAlignment":"center","width":"50%"} -->
+<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%"><!-- wp:image -->
 <figure class="wp-block-image"><img alt=""/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:column --></div>

--- a/patterns/store-info-alt-image-and-text.php
+++ b/patterns/store-info-alt-image-and-text.php
@@ -13,8 +13,8 @@
 <!-- /wp:image --></div>
 <!-- /wp:column -->
 
-<!-- wp:column {"width":"50%"} -->
-<div class="wp-block-column" style="flex-basis:50%"><!-- wp:paragraph {"placeholder":"Content…","style":{"typography":{"textTransform":"uppercase"}}} -->
+<!-- wp:column {"verticalAlignment":"center","width":"50%"} -->
+<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%"><!-- wp:paragraph {"placeholder":"Content…","style":{"typography":{"textTransform":"uppercase"}}} -->
 <p style="text-transform:uppercase"><?php esc_html_e( 'The goods', 'woo-gutenberg-products-block' ); ?></p>
 <!-- /wp:paragraph -->
 
@@ -47,8 +47,8 @@
 <!-- /wp:columns -->
 
 <!-- wp:columns {"align":"wide"} -->
-<div class="wp-block-columns alignwide"><!-- wp:column {"width":"50%"} -->
-<div class="wp-block-column" style="flex-basis:50%"><!-- wp:paragraph {"placeholder":"Content…","style":{"typography":{"textTransform":"uppercase"}}} -->
+<div class="wp-block-columns alignwide"><!-- wp:column {"verticalAlignment":"center","width":"50%"} -->
+<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%"><!-- wp:paragraph {"placeholder":"Content…","style":{"typography":{"textTransform":"uppercase"}}} -->
 <p style="text-transform:uppercase"><?php esc_html_e( 'About us', 'woo-gutenberg-products-block' ); ?></p>
 <!-- /wp:paragraph -->
 


### PR DESCRIPTION
Fixes #10290.

### Testing

#### User Facing Testing

1. In the post editor or the site editor, add the Alternating Image and Text pattern.
2. Click on the image placeholders and add images to the pattern.
3. Visit the frontend of your site.
4. Verify the patterns looks like the _After_ patterns in screenshots below.

Desktop:

Before | After
--- | ---
![imatge](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/5019313c-c1e1-4c63-bac8-3da49f8722fb) | ![imatge](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/3d7787b5-ec8b-4b1c-afd3-bb0cc1930915)

* [ ] Do not include in the Testing Notes

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Updated Product Hero pattern to have no opinionated styles.
