### PR TITLE
Move sale badge to top right of product image

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -152,7 +152,10 @@
 	text-transform: uppercase;
 	font-weight: 600;
 	z-index: 9;
-	position: relative;
+	position: absolute;
+	top: 4px;
+	right: 4px;
+	left: auto;
 }
 
 // Element spacing.

--- a/src/BlockTypes/AbstractProductGrid.php
+++ b/src/BlockTypes/AbstractProductGrid.php
@@ -513,10 +513,10 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 			'woocommerce_blocks_product_grid_item_html',
 			"<li class=\"wc-block-grid__product\">
 				<a href=\"{$data->permalink}\" class=\"wc-block-grid__product-link\">
+					{$data->badge}
 					{$data->image}
 					{$data->title}
 				</a>
-				{$data->badge}
 				{$data->price}
 				{$data->rating}
 				{$data->button}


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/10253

This PR relocates the `Sale` badge to be on top right of the product image. This makes it consistent with our latest `Product Collection` block.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|![file.png](https://github.com/woocommerce/woocommerce-blocks/assets/2132595/fcaa104e-dea0-4b17-b289-2d4b29fda06a)        |![file.png](https://github.com/woocommerce/woocommerce-blocks/assets/2132595/5925108e-4e2c-48f4-8a4a-4988cc0dc7da)       |

### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Add the following blocks to a post/page. `Hand-picked Products`,  `Best Selling Products`, `Products by Category`, `Newest Products`, `On Sale Products`, `Products by Attribute`, `Products by Tag`, `Top Rated Products`.
2. For each of these blocks, ensure the `Sale` badge is on the top right of the product image as seen in the `After` screenshot above.
3. Save the post/page and ensure it shows the same in the frontend.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Relocate sale badge to be consistent for products