### PR TITLE
Add tests in Playwright for Mini-Cart drawer closing

### DIFF
--- a/tests/e2e-pw/tests/mini-cart/mini-cart.block_theme.spec.ts
+++ b/tests/e2e-pw/tests/mini-cart/mini-cart.block_theme.spec.ts
@@ -10,6 +10,7 @@ const blockData: BlockData = {
 	selectors: {
 		frontend: {
 			drawer: '.wc-block-mini-cart__drawer',
+			drawerCloseButton: 'button[aria-label="Close"]',
 		},
 		editor: {},
 	},
@@ -53,12 +54,15 @@ test.describe( `${ blockData.name } Block`, () => {
 			).toHaveText( 'Your cart is currently empty!' );
 
 			// Wait for the drawer to fully open.
-			await page.waitForTimeout( 500 );
+			await page.waitForSelector(
+				blockData.selectors.frontend.drawerCloseButton
+			);
 
-			const closeButton = await page.getByRole( 'button', {
-				name: 'Close',
-			} );
-			await closeButton.click();
+			const closeButton = await page.$(
+				blockData.selectors.frontend.drawerCloseButton
+			);
+
+			await closeButton?.click();
 
 			// Wait for the drawer to fully close.
 			await page.waitForTimeout( 500 );
@@ -82,7 +86,9 @@ test.describe( `${ blockData.name } Block`, () => {
 			).toHaveText( 'Your cart is currently empty!' );
 
 			// Wait for the drawer to fully open.
-			await page.waitForTimeout( 500 );
+			await page.waitForSelector(
+				blockData.selectors.frontend.drawerCloseButton
+			);
 
 			await page.mouse.click( 50, 200 );
 

--- a/tests/e2e-pw/tests/mini-cart/mini-cart.block_theme.spec.ts
+++ b/tests/e2e-pw/tests/mini-cart/mini-cart.block_theme.spec.ts
@@ -15,6 +15,10 @@ const blockData: BlockData = {
 	},
 };
 
+const getMiniCartButton = async ( { page } ) => {
+	return await page.getByLabel( '0 items in cart, total price of $0.00' );
+};
+
 test.describe( `${ blockData.name } Block`, () => {
 	test.describe( `standalone`, () => {
 		test.beforeEach( async ( { admin, page, editor } ) => {
@@ -28,17 +32,68 @@ test.describe( `${ blockData.name } Block`, () => {
 		} );
 
 		test( 'should open the empty cart drawer', async ( { page } ) => {
-			const miniCartButton = await page.getByLabel(
-				'0 items in cart, total price of $0.00'
-			);
+			const miniCartButton = await getMiniCartButton( { page } );
 
 			await miniCartButton.click();
 
 			await expect(
-				page
-					.locator( blockData.selectors.frontend.drawer as string )
-					.first()
+				page.locator( blockData.selectors.frontend.drawer ).first()
 			).toHaveText( 'Your cart is currently empty!' );
+		} );
+
+		test( 'should close the drawer when clicking on the close button', async ( {
+			page,
+		} ) => {
+			const miniCartButton = await getMiniCartButton( { page } );
+
+			await miniCartButton.click();
+
+			await expect(
+				page.locator( blockData.selectors.frontend.drawer ).first()
+			).toHaveText( 'Your cart is currently empty!' );
+
+			// Wait for the drawer to fully open.
+			await page.waitForTimeout( 500 );
+
+			const closeButton = await page.getByRole( 'button', {
+				name: 'Close',
+			} );
+			await closeButton.click();
+
+			// Wait for the drawer to fully close.
+			await page.waitForTimeout( 500 );
+
+			expect(
+				await page
+					.locator( blockData.selectors.frontend.drawer )
+					.count()
+			).toEqual( 0 );
+		} );
+
+		test( 'should close the drawer when clicking outside the drawer', async ( {
+			page,
+		} ) => {
+			const miniCartButton = await getMiniCartButton( { page } );
+
+			await miniCartButton.click();
+
+			await expect(
+				page.locator( blockData.selectors.frontend.drawer ).first()
+			).toHaveText( 'Your cart is currently empty!' );
+
+			// Wait for the drawer to fully open.
+			await page.waitForTimeout( 500 );
+
+			await page.mouse.click( 50, 200 );
+
+			// Wait for the drawer to fully close.
+			await page.waitForTimeout( 500 );
+
+			expect(
+				await page
+					.locator( blockData.selectors.frontend.drawer )
+					.count()
+			).toEqual( 0 );
 		} );
 	} );
 
@@ -55,9 +110,7 @@ test.describe( `${ blockData.name } Block`, () => {
 		} );
 
 		test( 'should open the filled cart drawer', async ( { page } ) => {
-			const miniCartButton = await page.getByLabel(
-				'0 items in cart, total price of $0.00'
-			);
+			const miniCartButton = await getMiniCartButton( { page } );
 
 			await page.waitForLoadState( 'networkidle' );
 			await page.click( 'text=Add to cart' );

--- a/tests/e2e-pw/tests/mini-cart/mini-cart.block_theme.spec.ts
+++ b/tests/e2e-pw/tests/mini-cart/mini-cart.block_theme.spec.ts
@@ -65,7 +65,9 @@ test.describe( `${ blockData.name } Block`, () => {
 			await closeButton?.click();
 
 			// Wait for the drawer to fully close.
-			await page.waitForTimeout( 500 );
+			await page.waitForSelector( blockData.selectors.frontend.drawer, {
+				state: 'detached',
+			} );
 
 			expect(
 				await page
@@ -93,7 +95,9 @@ test.describe( `${ blockData.name } Block`, () => {
 			await page.mouse.click( 50, 200 );
 
 			// Wait for the drawer to fully close.
-			await page.waitForTimeout( 500 );
+			await page.waitForSelector( blockData.selectors.frontend.drawer, {
+				state: 'detached',
+			} );
 
 			expect(
 				await page

--- a/tests/e2e-pw/types/block-data.ts
+++ b/tests/e2e-pw/types/block-data.ts
@@ -1,5 +1,5 @@
 export type BlockData< T = unknown > = {
 	name: string;
 	mainClass: string;
-	selectors: Record< 'editor' | 'frontend', Record< string, unknown > >;
+	selectors: Record< 'editor' | 'frontend', Record< string, string > >;
 } & ( T extends undefined ? Record< string, never > : T );

--- a/tests/e2e/specs/shopper/mini-cart.test.js
+++ b/tests/e2e/specs/shopper/mini-cart.test.js
@@ -114,62 +114,6 @@ describe( 'Shopper → Mini-Cart', () => {
 		} );
 	} );
 
-	describe( 'Drawer', () => {
-		it( 'The drawer opens when shopper clicks on the Mini-Cart icon', async () => {
-			await clickMiniCartButton();
-
-			await expect( page ).toMatchElement(
-				'.wc-block-mini-cart__drawer',
-				{
-					text: 'Start shopping',
-				}
-			);
-		} );
-
-		it( 'The drawer closes when shopper clicks on the drawer close button', async () => {
-			await clickMiniCartButton();
-
-			await expect( page ).toMatchElement(
-				'.wc-block-mini-cart__drawer',
-				{
-					text: 'Start shopping',
-				}
-			);
-
-			// Wait for the drawer to fully open.
-			await page.waitForTimeout( 500 );
-
-			await page.click( '.wc-block-components-drawer__close' );
-
-			await expect( page ).not.toMatchElement(
-				'.wc-block-mini-cart__drawer',
-				{
-					text: 'Start shopping',
-				}
-			);
-		} );
-
-		it( 'The drawer closes when shopper clicks outside the drawer', async () => {
-			await clickMiniCartButton();
-
-			await expect( page ).toMatchElement(
-				'.wc-block-mini-cart__drawer',
-				{
-					text: 'Start shopping',
-				}
-			);
-
-			await page.mouse.click( 50, 200 );
-
-			await expect( page ).not.toMatchElement(
-				'.wc-block-mini-cart__drawer',
-				{
-					text: 'Start shopping',
-				}
-			);
-		} );
-	} );
-
 	describe( 'Empty Mini-Cart', () => {
 		it( 'When the cart is empty, the Mini-Cart Drawer show empty cart message and start shopping button', async () => {
 			await clickMiniCartButton();


### PR DESCRIPTION
This PR adds two new Playwright tests for the Mini-Cart block, to detect that the drawer can be closed. I also removed the equivalent tests from Puppeteer.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests

#### User Facing Testing

1. Verify Playwright e2e tests pass. If running them locally, you can run `npm run test:e2e-pw -- tests/e2e-pw/tests/mini-cart/mini-cart.block_theme.spec.ts`.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
