### PR TITLE
Update the `Footer with Simple Menu and Cart` pattern to have no opinionated styles

### DIFF
--- a/patterns/footer-simple-menu-and-cart.php
+++ b/patterns/footer-simple-menu-and-cart.php
@@ -15,17 +15,8 @@
 		<div class="wp-block-column is-vertically-aligned-center">
 			<!-- wp:group {"style":{"spacing":{"blockGap":"32px"}},"layout":{"type":"flex","flexWrap":"wrap"}} -->
 			<div class="wp-block-group">
-				<!-- wp:group {"style":{"border":{"top":{"width":"1px","style":"solid"},"right":{"width":"1px","style":"solid"},"bottom":{"width":"1px","style":"solid"},"left":{"width":"1px","style":"solid"}}},"layout":{"type":"flex","orientation":"vertical"}} -->
-				<div class="wp-block-group" style="border-top-style:solid;border-top-width:1px;border-right-style:solid;border-right-width:1px;border-bottom-style:solid;border-bottom-width:1px;border-left-style:solid;border-left-width:1px">
-					<!-- wp:search {"label":"Search","showLabel":false,"placeholder":"Search our store","width":250,"widthUnit":"px","buttonText":"Search","buttonUseIcon":true,"query":{"post_type":"product"},"style":{"border":{"top":{"width":"0px","style":"none"},"right":{"width":"0px","style":"none"},"bottom":{"width":"0px","style":"none"},"left":{"width":"0px","style":"none"}}},"backgroundColor":"background","textColor":"foreground"} /-->
-				</div>
-				<!-- /wp:group -->
-
-				<!-- wp:group {"style":{"spacing":{"blockGap":"8px"}},"layout":{"type":"flex","orientation":"vertical","flexWrap":"nowrap"}} -->
-				<div class="wp-block-group">
-					<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"horizontal","justifyContent":"left","flexWrap":"wrap"},"style":{"spacing":{"blockGap":"35px"}}} /-->
-				</div>
-				<!-- /wp:group -->
+				<!-- wp:search {"label":"<?php esc_html_e( 'Search', 'woo-gutenberg-products-block' ); ?>","showLabel":false,"placeholder":"<?php esc_html_e( 'Search our store', 'woo-gutenberg-products-block' ); ?>","buttonText":"<?php esc_html_e( 'Search our store', 'woo-gutenberg-products-block' ); ?>","buttonUseIcon":true,"query":{"post_type":"product"}} /-->
+				<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"horizontal","justifyContent":"left","flexWrap":"wrap"},"style":{"spacing":{"blockGap":"35px"}}} /-->
 			</div>
 			<!-- /wp:group -->
 		</div>
@@ -39,16 +30,16 @@
 	</div>
 	<!-- /wp:columns -->
 
-	<!-- wp:separator {"className":"is-style-wide"} -->
-	<hr class="wp-block-separator has-alpha-channel-opacity is-style-wide"/>
+	<!-- wp:separator {"style":{"spacing":{"margin":{"top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}},"className":"is-style-wide"} -->
+	<hr class="wp-block-separator has-alpha-channel-opacity is-style-wide" style="margin-top:var(--wp--preset--spacing--40);margin-bottom:var(--wp--preset--spacing--40)"/>
 	<!-- /wp:separator -->
 
 	<!-- wp:group {"style":{"spacing":{"blockGap":"5px"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"center","orientation":"vertical"}} -->
 	<div class="wp-block-group">
-		<!-- wp:site-title {"textAlign":"center","style":{"typography":{"fontSize":"14px","fontStyle":"normal","fontWeight":"700"}}} /-->
+		<!-- wp:site-title {"textAlign":"center"} /-->
 
-		<!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"12px"}}} -->
-		<p class="has-text-align-center" style="font-size:12px">
+		<!-- wp:paragraph {"align":"center"} -->
+		<p class="has-text-align-center">
 			<?php
 				/* translators: 1: WordPress link, 2: WooCommerce link */
 				echo wp_kses( sprintf( __( 'Powered by %1$s with %2$s', 'woo-gutenberg-products-block' ), '<a href="https://wordpress.org">WordPress</a>', '<a href="https://woocommerce.com">WooCommerce</a>' ), array() );


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-blocks/issues/10304
### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
| <img width="2023" alt="Screenshot 2023-07-21 at 12 54 00" src="https://github.com/woocommerce/woocommerce-blocks/assets/186112/de6c4f77-77a8-42fe-8009-91b614fa5ba4">|<img width="2021" alt="Screenshot 2023-07-21 at 12 56 29" src="https://github.com/woocommerce/woocommerce-blocks/assets/186112/a705e319-27b4-49a7-a0e3-51bae429f1ca">|

### Testing
#### User Facing Testing

1. In the post editor or the site editor, add the `Footer with Simple Menu and Cart` pattern.
2. Verify there are no opinionated styles (borders, colors, fonts, etc) - except the margin on the separator - and the pattern looks like the After screenshot above.


* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog
> Updated "Footer with Simple Menu and Cart" pattern to have no opinionated styles.
