### PR TITLE
Fix SearchListControl styles (II)

### DIFF
--- a/assets/js/editor-components/search-list-control/style.scss
+++ b/assets/js/editor-components/search-list-control/style.scss
@@ -94,196 +94,202 @@
 	}
 }
 
-.editor-styles-wrapper {
-	.woocommerce-search-list__list {
-		border: 1px solid $gray-200;
-		margin: 0;
-		padding: 0;
-		max-height: 17em;
-		overflow-x: hidden;
-		overflow-y: auto;
+.woocommerce-search-list__list {
+	border: 1px solid $gray-200;
+	margin: 0;
+	padding: 0;
+	max-height: 17em;
+	overflow-x: hidden;
+	overflow-y: auto;
 
-		li {
-			margin-bottom: 0;
+	li {
+		margin-bottom: 0;
+	}
+
+	&.is-not-found {
+		padding: $gap-small 0;
+		text-align: center;
+		border: none;
+
+		.woocommerce-search-list__not-found-icon,
+		.woocommerce-search-list__not-found-text {
+			display: inline-block;
 		}
 
-		&.is-not-found {
-			padding: $gap-small 0;
-			text-align: center;
-			border: none;
+		.woocommerce-search-list__not-found-icon {
+			margin-right: $gap;
 
-			.woocommerce-search-list__not-found-icon,
-			.woocommerce-search-list__not-found-text {
-				display: inline-block;
-			}
-
-			.woocommerce-search-list__not-found-icon {
-				margin-right: $gap;
-
-				.gridicon {
-					vertical-align: top;
-					margin-top: -1px;
-				}
-			}
-		}
-
-		.components-spinner {
-			float: none;
-			margin: 0 auto;
-		}
-
-		.components-menu-group__label {
-			@include visually-hidden;
-		}
-
-		> [role="menu"] {
-			border: 1px solid $gray-100;
-			border-bottom: none;
-		}
-
-		.woocommerce-search-list__item {
-			display: flex;
-			align-items: center;
-			margin-bottom: 0;
-			padding: $gap-small $gap;
-			background: $studio-white;
-			// !important to keep the border around on hover
-			border-bottom: 1px solid $gray-100;
-			color: $gray-700;
-
-			&:hover,
-			&:active,
-			&:focus {
-				background: $gray-100;
-			}
-
-			&:active,
-			&:focus {
-				box-shadow: none;
-			}
-
-			&.has-children {
-				cursor: pointer;
-
-				&::after {
-					background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z" fill="#{encode-color($gray-700)}" /></svg>');
-					background-position: center right;
-					background-repeat: no-repeat;
-					background-size: contain;
-					content: "";
-					height: $gap-large;
-					margin-left: $gap-smaller;
-					width: $gap-large;
-				}
-
-				&[disabled]::after {
-					background: none;
-					margin-left: 0;
-					width: auto;
-				}
-
-				&.is-expanded::after {
-					background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z" fill="#{encode-color($gray-700)}" /></svg>');
-				}
-			}
-
-			.woocommerce-search-list__item-input[type="radio"] {
-				margin: 0 $gap-smaller 0 0;
-			}
-
-			.woocommerce-search-list__item-label {
-				display: flex;
-				flex: 1;
-			}
-
-			&.depth-0 + .depth-1 {
-				// Hide the border on the preceding list item
+			.gridicon {
+				vertical-align: top;
 				margin-top: -1px;
 			}
+		}
+	}
 
-			&:not(.depth-0) {
-				border-bottom: 0 !important;
-			}
+	.components-spinner {
+		float: none;
+		margin: 0 auto;
+	}
 
-			&:not(.depth-0) + .depth-0 {
-				border-top: 1px solid $gray-100;
-			}
+	.components-menu-group__label {
+		@include visually-hidden;
+	}
 
-			// Anything deeper than 5 levels will use this fallback depth
-			&[class*="depth-"] .woocommerce-search-list__item-label::before {
-				margin-right: $gap-smallest;
-				content: str-repeat("— ", 5);
-			}
+	> [role="menu"] {
+		border: 1px solid $gray-100;
+		border-bottom: none;
+	}
 
-			&.depth-0 .woocommerce-search-list__item-label::before {
-				margin-right: 0;
+	.woocommerce-search-list__item {
+		display: flex;
+		align-items: center;
+		margin-bottom: 0;
+		padding: $gap-small $gap;
+		background: $studio-white;
+		// !important to keep the border around on hover
+		border-bottom: 1px solid $gray-100;
+		color: $gray-700;
+
+		&:hover,
+		&:active,
+		&:focus {
+			background: $gray-100;
+		}
+
+		&:active,
+		&:focus {
+			box-shadow: none;
+		}
+
+		&.has-children {
+			cursor: pointer;
+
+			&::after {
+				background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z" fill="#{encode-color($gray-700)}" /></svg>');
+				background-position: center right;
+				background-repeat: no-repeat;
+				background-size: contain;
 				content: "";
+				height: $gap-large;
+				margin-left: $gap-smaller;
+				width: $gap-large;
 			}
 
-			@for $i from 1 to 5 {
-				&.depth-#{$i} {
-					padding-left: $gap * ( $i + 1 );
-				}
-
-				&.depth-#{$i} .woocommerce-search-list__item-label::before {
-					content: str-repeat("— ", $i);
-				}
+			&[disabled]::after {
+				background: none;
+				margin-left: 0;
+				width: auto;
 			}
 
-			.woocommerce-search-list__item-name {
+			&.is-expanded::after {
+				background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z" fill="#{encode-color($gray-700)}" /></svg>');
+			}
+		}
+
+		.woocommerce-search-list__item-input {
+			margin: 0;
+		}
+
+		.woocommerce-search-list__item-input[type="radio"] {
+			margin-right: $gap-smaller;
+		}
+
+		.components-base-control__field {
+			margin: 0;
+		}
+
+		.woocommerce-search-list__item-label {
+			display: flex;
+			flex: 1;
+		}
+
+		&.depth-0 + .depth-1 {
+			// Hide the border on the preceding list item
+			margin-top: -1px;
+		}
+
+		&:not(.depth-0) {
+			border-bottom: 0 !important;
+		}
+
+		&:not(.depth-0) + .depth-0 {
+			border-top: 1px solid $gray-100;
+		}
+
+		// Anything deeper than 5 levels will use this fallback depth
+		&[class*="depth-"] .woocommerce-search-list__item-label::before {
+			margin-right: $gap-smallest;
+			content: str-repeat("— ", 5);
+		}
+
+		&.depth-0 .woocommerce-search-list__item-label::before {
+			margin-right: 0;
+			content: "";
+		}
+
+		@for $i from 1 to 5 {
+			&.depth-#{$i} {
+				padding-left: $gap * ( $i + 1 );
+			}
+
+			&.depth-#{$i} .woocommerce-search-list__item-label::before {
+				content: str-repeat("— ", $i);
+			}
+		}
+
+		.woocommerce-search-list__item-name {
+			display: inline-block;
+		}
+
+		.woocommerce-search-list__item-prefix {
+			display: none;
+			color: $gray-700;
+		}
+
+		&.is-searching,
+		&.is-skip-level {
+			.woocommerce-search-list__item-label {
+				// Un-flex the label, so the prefix (breadcrumbs) and name are aligned.
 				display: inline-block;
 			}
 
 			.woocommerce-search-list__item-prefix {
-				display: none;
-				color: $gray-700;
-			}
+				display: inline;
 
-			&.is-searching,
-			&.is-skip-level {
-				.woocommerce-search-list__item-label {
-					// Un-flex the label, so the prefix (breadcrumbs) and name are aligned.
-					display: inline-block;
+				&::after {
+					margin-right: $gap-smallest;
+					content: " ›";
 				}
-
-				.woocommerce-search-list__item-prefix {
-					display: inline;
-
-					&::after {
-						margin-right: $gap-smallest;
-						content: " ›";
-					}
-				}
-			}
-
-			&.is-searching {
-				.woocommerce-search-list__item-name {
-					color: $gray-900;
-				}
-			}
-
-			&.has-count {
-				> .components-menu-item__item {
-					width: 100%;
-				}
-			}
-
-			.woocommerce-search-list__item-count {
-				flex: 0 1 auto;
-				padding: math.div($gap-smallest, 2) $gap-smaller;
-				border: 1px solid $gray-100;
-				border-radius: 12px;
-				font-size: 0.8em;
-				line-height: 1.4;
-				margin-left: auto;
-				color: $gray-700;
-				background: $studio-white;
-				white-space: nowrap;
 			}
 		}
 
-		li:last-child .woocommerce-search-list__item {
-			border-bottom: none;
+		&.is-searching {
+			.woocommerce-search-list__item-name {
+				color: $gray-900;
+			}
 		}
+
+		&.has-count {
+			> .components-menu-item__item {
+				width: 100%;
+			}
+		}
+
+		.woocommerce-search-list__item-count {
+			flex: 0 1 auto;
+			padding: math.div($gap-smallest, 2) $gap-smaller;
+			border: 1px solid $gray-100;
+			border-radius: 12px;
+			font-size: 0.8em;
+			line-height: 1.4;
+			margin-left: auto;
+			color: $gray-700;
+			background: $studio-white;
+			white-space: nowrap;
+		}
+	}
+
+	li:last-child .woocommerce-search-list__item {
+		border-bottom: none;
 	}
 }


### PR DESCRIPTION
This is a follow-up PR of https://github.com/woocommerce/woocommerce-blocks/pull/10192, fixing the `SearchListControl` styles in the sidebar and adding some more minor CSS fixes.

Note for the reviewer: it might be easier to review disabling the whitespace diff.

### Testing

#### User Facing Testing

1. Create a new post or page and add the Single Product, Products by Category and Newest Products blocks.
2.  In all of them, check that the list control UI looks correct; that's the UI that lets you choose the product/category:

Single Product (no change):

Before | After
--- | ---
![imatge](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/9ba6b525-7250-4bc1-a2bf-883438c88a1c) | ![imatge](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/9e7822f1-2c99-40f7-a149-59e86b885c42)

Products by Category (slight margin change):

Before | After
--- | ---
![imatge](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/7ada606c-ec28-4311-a090-522ff28a4614) | ![imatge](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/02304ce5-2454-4f4a-bb42-e9250be8987b)

Newest Products (broken UI fixed):

Before | After 
--- | ---
<img src="https://github.com/woocommerce/woocommerce-blocks/assets/3616980/45389590-fef5-41b2-9be8-c7a768b2fc15" alt="" width="304" /> | <img src="https://github.com/woocommerce/woocommerce-blocks/assets/3616980/6836c343-ad95-47d1-a850-5d7ea9c3b204" alt="" width="304" />

:point_up: this UI is displayed in the sidebar, under the Filter by Category panel.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix some styling issues in the product or category selector of some blocks.
