### PR TITLE
Style checkout fields without floats to fix validation error appearance

### DIFF
--- a/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/style.scss
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/style.scss
@@ -15,23 +15,15 @@
 	.wc-block-checkout__shipping-fields,
 	.wc-block-checkout__billing-fields {
 		.wc-block-components-address-form {
-			margin-left: #{-$gap-small * 0.5};
-			margin-right: #{-$gap-small * 0.5};
-
-			&::after {
-				content: "";
-				clear: both;
-				display: block;
-			}
+			display: flex;
+			flex-wrap: wrap;
+			justify-content: space-between;
 
 			.wc-block-components-text-input,
 			.wc-block-components-country-input,
 			.wc-block-components-state-input {
-				float: left;
-				margin-left: #{$gap-small * 0.5};
-				margin-right: #{$gap-small * 0.5};
-				position: relative;
-				width: calc(50% - #{$gap-small});
+				flex: 0 0 calc(50% - #{$gap-small});
+				box-sizing: border-box;
 
 				&:nth-of-type(2),
 				&:first-of-type {
@@ -42,11 +34,7 @@
 			.wc-block-components-address-form__company,
 			.wc-block-components-address-form__address_1,
 			.wc-block-components-address-form__address_2 {
-				width: calc(100% - #{$gap-small});
-			}
-
-			.wc-block-components-checkbox {
-				clear: both;
+				flex: 0 0 100%;
 			}
 		}
 	}


### PR DESCRIPTION
This PR fixes the styling of checkout fields when validation errors are displayed.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
| ![Screenshot 2023-07-21 at 16 00 15](https://github.com/woocommerce/woocommerce-blocks/assets/90977/531bc056-b65f-4ed8-954e-829f5f33cf8d) | ![Screenshot 2023-07-21 at 16 02 55](https://github.com/woocommerce/woocommerce-blocks/assets/90977/cd8118b5-06d7-44fc-ae63-193612e45aaf) |

### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Open a private/incognito session
2. Add an item to the cart
3. Go to the checkout
4. Enter something in the "city" field. A validation error will appear below country.
5. Confirm fields are styled correctly.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fixed appearance of checkout fields when validation errors are shown.
