### PR TITLE
Add local state to address-form to reduce number of server pushes

### DIFF
--- a/assets/js/base/components/cart-checkout/address-form/address-form.tsx
+++ b/assets/js/base/components/cart-checkout/address-form/address-form.tsx
@@ -10,12 +10,13 @@ import {
 	BillingStateInput,
 	ShippingStateInput,
 } from '@woocommerce/base-components/state-input';
-import { useEffect, useMemo } from '@wordpress/element';
+import { useEffect, useMemo, useState } from '@wordpress/element';
 import { withInstanceId } from '@wordpress/compose';
-import { useShallowEqual } from '@woocommerce/base-hooks';
+import { useShallowEqual, usePrevious } from '@woocommerce/base-hooks';
 import { defaultAddressFields } from '@woocommerce/settings';
-import { useDispatch, dispatch } from '@wordpress/data';
+import { select } from '@wordpress/data';
 import { VALIDATION_STORE_KEY } from '@woocommerce/block-data';
+import isShallowEqual from '@wordpress/is-shallow-equal';
 
 /**
  * Internal dependencies
@@ -30,7 +31,7 @@ const defaultFields = Object.keys(
 ) as unknown as FieldType[];
 
 /**
- * Checkout address form.
+ * Checkout address form. Holds local state while fields are not yet complete.
  */
 const AddressForm = ( {
 	id = '',
@@ -39,48 +40,78 @@ const AddressForm = ( {
 	instanceId,
 	onChange,
 	type = 'shipping',
-	values,
+	values: initialValues,
 }: AddressFormProps ): JSX.Element => {
-	const { clearValidationError } = useDispatch( VALIDATION_STORE_KEY );
+	// Holds local state of the field values.
+	const [ values, setValues ] = useState( initialValues );
+	const previousInitialValues = usePrevious( initialValues );
 
+	// Memoize the address form fields passed in from the parent component.
 	const currentFields = useShallowEqual( fields );
-
 	const addressFormFields = useMemo( () => {
-		return prepareAddressFields(
+		const preparedFields = prepareAddressFields(
 			currentFields,
 			fieldConfig,
 			values.country
 		);
+		return {
+			fields: preparedFields,
+			requiredFields: preparedFields.filter(
+				( field ) => field.required
+			),
+			hiddenFields: preparedFields.filter( ( field ) => field.hidden ),
+		};
 	}, [ currentFields, fieldConfig, values.country ] );
+
+	// Push when all values of required fields are complete.
+	useEffect( () => {
+		if ( ! isShallowEqual( values, initialValues ) ) {
+			// Check required fields have values.
+			const isComplete = addressFormFields.requiredFields.every(
+				( field ) => {
+					return values[ field.key ] !== '';
+				}
+			);
+			if ( ! isComplete ) {
+				return;
+			}
+			// Check if any fields have errors.
+			const hasErrors = addressFormFields.fields.some( ( field ) => {
+				const errorId = `${ type }_${ field.key }`;
+				const validationError =
+					select( VALIDATION_STORE_KEY ).getValidationError(
+						errorId
+					);
+				const hasError = validationError?.message;
+				return !! hasError;
+			} );
+			if ( hasErrors ) {
+				return;
+			}
+			onChange( values );
+		}
+	}, [ values, initialValues, onChange, addressFormFields, type ] );
 
 	// Clear values for hidden fields.
 	useEffect( () => {
-		addressFormFields.forEach( ( field ) => {
-			if ( field.hidden && values[ field.key ] ) {
-				onChange( {
-					...values,
-					[ field.key ]: '',
-				} );
-			}
+		const newValues = { ...values };
+		addressFormFields.hiddenFields.forEach( ( field ) => {
+			newValues[ field.key ] = '';
 		} );
-	}, [ addressFormFields, onChange, values ] );
+		if ( ! isShallowEqual( values, newValues ) ) {
+			setValues( newValues );
+		}
+	}, [ addressFormFields.hiddenFields, onChange, values ] );
 
-	// Clear postcode validation error if postcode is not required.
+	// Sync incoming values with local state.
 	useEffect( () => {
-		addressFormFields.forEach( ( field ) => {
-			if ( field.key === 'postcode' && field.required === false ) {
-				const store = dispatch( 'wc/store/validation' );
-
-				if ( type === 'shipping' ) {
-					store.clearValidationError( 'shipping_postcode' );
-				}
-
-				if ( type === 'billing' ) {
-					store.clearValidationError( 'billing_postcode' );
-				}
-			}
-		} );
-	}, [ addressFormFields, type, clearValidationError ] );
+		if (
+			previousInitialValues &&
+			! isShallowEqual( initialValues, previousInitialValues )
+		) {
+			setValues( initialValues );
+		}
+	}, [ initialValues, previousInitialValues ] );
 
 	// Maybe validate country when other fields change so user is notified that it's required.
 	useEffect( () => {
@@ -93,7 +124,7 @@ const AddressForm = ( {
 
 	return (
 		<div id={ id } className="wc-block-components-address-form">
-			{ addressFormFields.map( ( field ) => {
+			{ addressFormFields.fields.map( ( field ) => {
 				if ( field.hidden ) {
 					return null;
 				}
@@ -120,7 +151,7 @@ const AddressForm = ( {
 							{ ...fieldProps }
 							value={ values.country }
 							onChange={ ( newValue ) =>
-								onChange( {
+								setValues( {
 									...values,
 									country: newValue,
 									state: '',
@@ -142,7 +173,7 @@ const AddressForm = ( {
 							country={ values.country }
 							value={ values.state }
 							onChange={ ( newValue ) =>
-								onChange( {
+								setValues( {
 									...values,
 									state: newValue,
 								} )
@@ -157,7 +188,7 @@ const AddressForm = ( {
 						{ ...fieldProps }
 						value={ values[ field.key ] }
 						onChange={ ( newValue: string ) =>
-							onChange( {
+							setValues( {
 								...values,
 								[ field.key ]: newValue,
 							} )

--- a/assets/js/base/components/cart-checkout/address-form/test/index.js
+++ b/assets/js/base/components/cart-checkout/address-form/test/index.js
@@ -21,19 +21,28 @@ const renderInCheckoutProvider = ( ui, options = {} ) => {
 // Countries used in testing addresses must be in the wcSettings global.
 // See: tests/js/setup-globals.js
 const primaryAddress = {
+	firstName: 'John',
+	lastName: 'Doe',
+	address1: '123 Main St',
 	country: 'United Kingdom',
 	countryKey: 'GB',
 	city: 'London',
 	state: 'Greater London',
-	postcode: 'ABCD',
+	postcode: 'AB10 2AB',
 };
 const secondaryAddress = {
+	firstName: 'John',
+	lastName: 'Doe',
+	address1: '123 Main St',
 	country: 'Austria', // We use Austria because it doesn't have states.
 	countryKey: 'AU',
 	city: 'Vienna',
 	postcode: 'DCBA',
 };
 const tertiaryAddress = {
+	firstName: 'John',
+	lastName: 'Doe',
+	address1: '123 Main St',
 	country: 'Canada', // We use Canada because it has a select for the state.
 	countryKey: 'CA',
 	city: 'Toronto',
@@ -45,8 +54,14 @@ const countryRegExp = /country/i;
 const cityRegExp = /city/i;
 const stateRegExp = /county|province|state/i;
 const postalCodeRegExp = /postal code|postcode|zip/i;
+const address1RegExp = /address/i;
+const firstNameRegExp = /first name/i;
+const lastNameRegExp = /last name/i;
 
 const inputAddress = async ( {
+	firstName = null,
+	lastName = null,
+	address1 = null,
 	country = null,
 	city = null,
 	state = null,
@@ -76,6 +91,18 @@ const inputAddress = async ( {
 	if ( postcode ) {
 		const postcodeInput = screen.getByLabelText( postalCodeRegExp );
 		userEvent.type( postcodeInput, postcode );
+	}
+	if ( address1 ) {
+		const address1Input = screen.getByLabelText( address1RegExp );
+		userEvent.type( address1Input, address1 );
+	}
+	if ( firstName ) {
+		const firstNameInput = screen.getByLabelText( firstNameRegExp );
+		userEvent.type( firstNameInput, firstName );
+	}
+	if ( lastName ) {
+		const lastNameInput = screen.getByLabelText( lastNameRegExp );
+		userEvent.type( lastNameInput, lastName );
 	}
 };
 


### PR DESCRIPTION
This is split from https://github.com/woocommerce/woocommerce-blocks/pull/10279 and resolves part of https://github.com/woocommerce/woocommerce-blocks/issues/9444

This PR introduces a local state within the `AddressForm` component. This allows to prevent pushes to the global data store and the server when the address is incomplete. To do this is checks against required fields, as well as checking for validation errors throughout the form. 

By doing this we reduce the number of server pushes and thus should improve performance in general.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. Open up a new incognito session 
2. Add some items to your cart
3. Go to checkout
4. Keep an eye on the sidebar where your shipping address is displayed. As you fill out the form, notice that unlike before, this section does not update.
5. Once you've completed the address form fields (the required ones) this section will update and shipping rates will be shown.
6. If you enter an invalid field, for example, an invalid postcode, notice the address display in the sidebar does not refresh with your invalid changes. If you correct the mistake, it will update as normal.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

Reduces number of server pushes when updating address fields.

### Changelog

> Improved checkout performance by reducing the number of pushes to the server while the address form is completed by a shopper.
