### PR TITLE
Add to cart form: Fix fatal error when missing `product` param in add_to_cart_redirect_filter

### DIFF
--- a/src/BlockTypes/AddToCartForm.php
+++ b/src/BlockTypes/AddToCartForm.php
@@ -157,7 +157,6 @@ class AddToCartForm extends AbstractBlock {
 	 * is clicked.
 	 *
 	 * @param string $url The URL to redirect to after the product is added to the cart.
-	 * @param object $product The product being added to the cart.
 	 * @return string The filtered redirect URL.
 	 */
 	public function add_to_cart_redirect_filter( $url ) {

--- a/src/BlockTypes/AddToCartForm.php
+++ b/src/BlockTypes/AddToCartForm.php
@@ -160,7 +160,7 @@ class AddToCartForm extends AbstractBlock {
 	 * @param object $product The product being added to the cart.
 	 * @return string The filtered redirect URL.
 	 */
-	public function add_to_cart_redirect_filter( $url, $product ) {
+	public function add_to_cart_redirect_filter( $url, $product = null ) {
 		// phpcs:ignore
 		if ( isset( $_POST['is-descendent-of-single-product-block'] ) && 'true' == $_POST['is-descendent-of-single-product-block'] ) {
 			return wp_validate_redirect( wp_get_referer(), $url );

--- a/src/BlockTypes/AddToCartForm.php
+++ b/src/BlockTypes/AddToCartForm.php
@@ -29,7 +29,7 @@ class AddToCartForm extends AbstractBlock {
 	protected function initialize() {
 		parent::initialize();
 		add_filter( 'wc_add_to_cart_message_html', array( $this, 'add_to_cart_message_html_filter' ), 10, 2 );
-		add_filter( 'woocommerce_add_to_cart_redirect', array( $this, 'add_to_cart_redirect_filter' ), 10, 2 );
+		add_filter( 'woocommerce_add_to_cart_redirect', array( $this, 'add_to_cart_redirect_filter' ), 10, 1 );
 	}
 
 	/**
@@ -144,6 +144,11 @@ class AddToCartForm extends AbstractBlock {
 	 * @param string $message Message to be displayed when product is added to the cart.
 	 */
 	public function add_to_cart_message_html_filter( $message ) {
+		$value = apply_filters(
+			'woocommerce_add_to_cart_redirect',
+			'http://woo.local/cart/'
+		);
+
 		// phpcs:ignore
 		if ( isset( $_POST['is-descendent-of-single-product-block'] ) && 'true' === $_POST['is-descendent-of-single-product-block'] ) {
 			return false;
@@ -160,7 +165,7 @@ class AddToCartForm extends AbstractBlock {
 	 * @param object $product The product being added to the cart.
 	 * @return string The filtered redirect URL.
 	 */
-	public function add_to_cart_redirect_filter( $url, $product = null ) {
+	public function add_to_cart_redirect_filter( $url ) {
 		// phpcs:ignore
 		if ( isset( $_POST['is-descendent-of-single-product-block'] ) && 'true' == $_POST['is-descendent-of-single-product-block'] ) {
 			return wp_validate_redirect( wp_get_referer(), $url );

--- a/src/BlockTypes/AddToCartForm.php
+++ b/src/BlockTypes/AddToCartForm.php
@@ -144,11 +144,6 @@ class AddToCartForm extends AbstractBlock {
 	 * @param string $message Message to be displayed when product is added to the cart.
 	 */
 	public function add_to_cart_message_html_filter( $message ) {
-		$value = apply_filters(
-			'woocommerce_add_to_cart_redirect',
-			'http://woo.local/cart/'
-		);
-
 		// phpcs:ignore
 		if ( isset( $_POST['is-descendent-of-single-product-block'] ) && 'true' === $_POST['is-descendent-of-single-product-block'] ) {
 			return false;


### PR DESCRIPTION
This PR fixes a fatal error that was occurring when some plugins were applying the `woocommerce_add_to_cart_redirect` filter without including all arguments. (ref: p1689956599964279-slack-C7YPW6K40)
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

## Walkthrough
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7451d9a</samp>

*  Simplify `woocommerce_add_to_cart_redirect` filter hook to accept only `$url` parameter and remove unused `$product` parameter from `add_to_cart_redirect_filter` method ([link](https://github.com/woocommerce/woocommerce-blocks/pull/10316/files?diff=unified&w=0#diff-b6dbf51b98c926a1ad3723993ddcb154b608d8abdda4d6282e38d325aa4f5ea8L32-R32), [link](https://github.com/woocommerce/woocommerce-blocks/pull/10316/files?diff=unified&w=0#diff-b6dbf51b98c926a1ad3723993ddcb154b608d8abdda4d6282e38d325aa4f5ea8L163-R163)) in `src/BlockTypes/AddToCartForm.php`

<!-- Reference any related issues or PRs here -->

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Log in to your WordPress dashboard.
2. From your WordPress dashboard, go to Appearance > Themes. Make sure you have a block-based theme installed and activated. If not, you can install one from the Add New option. Block-based themes include "Twenty-twenty Two," "Twenty-twenty Three," etc.
3. On the left-hand side menu, click on Appearance > Editor > Templates
5. Find and select the 'Single Product' template from the list.
6. When the Classic Product Template renders, click on Transform into Blocks. This will transform the Classic template in a block template if you haven't done it before.
7. On the top-right side, click on the Save button.
8. In the project's code, go to the file `src/BlockTypes/AddToCartForm.php`. Modify the `add_to_cart_message_html_filter` function and include the following piece of code (the reason for this is because we want to simulate what is causing the fatal error). Make sure to modify the `http://yoursite.local/cart/` with the url of your local site, for example: `http://woodev.local/cart/`:
```
$value = apply_filters(
    'woocommerce_add_to_cart_redirect',
    'http://yoursite.local/cart/'
  );
```

The expected code should be like this:
```
public function add_to_cart_message_html_filter( $message ) {
  $value = apply_filters(
    'woocommerce_add_to_cart_redirect',
    'http://yoursite.local/cart/'
  );
 
  // phpcs:ignore
  if ( isset( $_POST['is-descendent-of-single-product-block'] ) && 'true' === $_POST['is-descendent-of-single-product-block'] ) {
    return false;
  }
  return $message;
}
 ```
9. Visit a product page and click on add to cart. Make sure that no fatal error occurs on the page

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Fix an error occurring due to missing parameters in the `woocommerce_add_to_cart_redirect` filter.