### PR TITLE
Optimise imports of Product Query variation

### DIFF
--- a/assets/js/blocks/classic-template/archive-product.ts
+++ b/assets/js/blocks/classic-template/archive-product.ts
@@ -13,6 +13,7 @@ import {
 	QUERY_DEFAULT_ATTRIBUTES as productsQueryDefaultAttributes,
 	PRODUCT_QUERY_VARIATION_NAME as productsVariationName,
 } from '@woocommerce/blocks/product-query/constants';
+
 /**
  * Internal dependencies
  */

--- a/assets/js/blocks/classic-template/archive-product.ts
+++ b/assets/js/blocks/classic-template/archive-product.ts
@@ -8,15 +8,14 @@ import {
 } from '@wordpress/blocks';
 import { isWpVersion } from '@woocommerce/settings';
 import { __, sprintf } from '@wordpress/i18n';
-
-/**
- * Internal dependencies
- */
 import {
 	INNER_BLOCKS_TEMPLATE as productsInnerBlocksTemplate,
 	QUERY_DEFAULT_ATTRIBUTES as productsQueryDefaultAttributes,
-} from '../product-query/constants';
-import { VARIATION_NAME as productsVariationName } from '../product-query/variations/product-query';
+	PRODUCT_QUERY_VARIATION_NAME as productsVariationName,
+} from '@woocommerce/blocks/product-query/constants';
+/**
+ * Internal dependencies
+ */
 import { createArchiveTitleBlock, createRowBlock } from './utils';
 import { OnClickCallbackParameter, type InheritedAttributes } from './types';
 

--- a/assets/js/blocks/classic-template/product-search-results.ts
+++ b/assets/js/blocks/classic-template/product-search-results.ts
@@ -9,15 +9,15 @@ import {
 } from '@wordpress/blocks';
 import { isWpVersion } from '@woocommerce/settings';
 import { __, sprintf } from '@wordpress/i18n';
+import {
+	INNER_BLOCKS_TEMPLATE as productsInnerBlocksTemplate,
+	QUERY_DEFAULT_ATTRIBUTES as productsQueryDefaultAttributes,
+	PRODUCT_QUERY_VARIATION_NAME as productsVariationName,
+} from '@woocommerce/blocks/product-query/constants';
 
 /**
  * Internal dependencies
  */
-import {
-	INNER_BLOCKS_TEMPLATE as productsInnerBlocksTemplate,
-	QUERY_DEFAULT_ATTRIBUTES as productsQueryDefaultAttributes,
-} from '../product-query/constants';
-import { VARIATION_NAME as productsVariationName } from '../product-query/variations/product-query';
 import { createArchiveTitleBlock, createRowBlock } from './utils';
 import { OnClickCallbackParameter, type InheritedAttributes } from './types';
 

--- a/assets/js/blocks/product-query/constants.ts
+++ b/assets/js/blocks/product-query/constants.ts
@@ -16,6 +16,8 @@ import { ImageSizing } from '../../atomic/blocks/product-elements/image/types';
 export const AUTO_REPLACE_PRODUCTS_WITH_PRODUCT_COLLECTION = false;
 export const MANUAL_REPLACE_PRODUCTS_WITH_PRODUCT_COLLECTION = false;
 
+export const PRODUCT_QUERY_VARIATION_NAME = 'woocommerce/product-query';
+
 export const EDIT_ATTRIBUTES_URL =
 	'/wp-admin/edit.php?post_type=product&page=product_attributes';
 

--- a/assets/js/blocks/product-query/variations/product-query.tsx
+++ b/assets/js/blocks/product-query/variations/product-query.tsx
@@ -17,13 +17,12 @@ import { isSiteEditorPage } from '@woocommerce/utils';
  * Internal dependencies
  */
 import {
+	PRODUCT_QUERY_VARIATION_NAME,
 	DEFAULT_ALLOWED_CONTROLS,
 	INNER_BLOCKS_TEMPLATE,
 	QUERY_DEFAULT_ATTRIBUTES,
 	QUERY_LOOP_ID,
 } from '../constants';
-
-export const VARIATION_NAME = 'woocommerce/product-query';
 
 const ARCHIVE_PRODUCT_TEMPLATES = [
 	'woocommerce/woocommerce//archive-product',
@@ -39,11 +38,11 @@ const registerProductsBlock = ( attributes: QueryBlockAttributes ) => {
 			'A block that displays a selection of products in your store.',
 			'woo-gutenberg-products-block'
 		),
-		name: VARIATION_NAME,
+		name: PRODUCT_QUERY_VARIATION_NAME,
 		/* translators: “Products“ is the name of the block. */
 		title: __( 'Products (Beta)', 'woo-gutenberg-products-block' ),
 		isActive: ( blockAttributes ) =>
-			blockAttributes.namespace === VARIATION_NAME,
+			blockAttributes.namespace === PRODUCT_QUERY_VARIATION_NAME,
 		icon: (
 			<Icon
 				icon={ stacks }
@@ -52,7 +51,7 @@ const registerProductsBlock = ( attributes: QueryBlockAttributes ) => {
 		),
 		attributes: {
 			...attributes,
-			namespace: VARIATION_NAME,
+			namespace: PRODUCT_QUERY_VARIATION_NAME,
 		},
 		// Gutenberg doesn't support this type yet, discussion here:
 		// https://github.com/WordPress/gutenberg/pull/43632
@@ -84,7 +83,10 @@ if ( isWpVersion( '6.1', '>=' ) ) {
 				},
 			};
 
-			unregisterBlockVariation( QUERY_LOOP_ID, VARIATION_NAME );
+			unregisterBlockVariation(
+				QUERY_LOOP_ID,
+				PRODUCT_QUERY_VARIATION_NAME
+			);
 
 			registerProductsBlock( queryAttributes );
 		}


### PR DESCRIPTION
When working on https://github.com/woocommerce/woocommerce-blocks/pull/10267 I encountered a problem that Product Query logic was initialized twice in Editor and that included the subscription to the store changes [here](https://github.com/woocommerce/woocommerce-blocks/blob/55cc42e761a5c509bb2c5fae95cd241c497c213d/assets/js/blocks/product-query/variations/product-query.tsx#L69).

In scope of https://github.com/woocommerce/woocommerce-blocks/pull/10267 I [subscribe](https://github.com/woocommerce/woocommerce-blocks/pull/10267/files#diff-fa82d441c906b216eeee63983ce3d4f90dbfda4a6270bc86e983e72e44a763abR230) to the `'core/block-editor'` store changes and it's important to have single `unsubscribe` function returned from it. Unexpectedly the module was loaded twice and importing the `unsubscribe` was undeterministic.

Product Query [is marked with `sideEffect`](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/package.json#L28) hence tree shaking is not applied when importing `VARIATION_NAME` from Product Query variation file which happened within `classic-template`. So it actually included the whole module because of the `sideEffects`.

This PR overcomes the problem by moving the variable to `constants` which can be tree shaken when imported within `classic-template` and `product-query` modules.

Summarizing this PR, it:
- reduces the size of `legacy-template` module
- prevents running the `product-query` module twice.
<img width="833" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/20098064/d05ea24e-c58d-4682-811f-86e26633dd38">


Part of https://github.com/woocommerce/woocommerce-blocks/issues/9703

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Add `console.log( 'Subscribing' )` before the subscription happens in `product-query` [here](https://github.com/woocommerce/woocommerce-blocks/blob/55cc42e761a5c509bb2c5fae95cd241c497c213d/assets/js/blocks/product-query/variations/product-query.tsx#L68). (Adding breakpoint doesn't help here, as it's caught only once. I think it's because of the source maps that resolve to the single file anyway, hence the easiest is to actually use `console.log`).
2. Enter the Editor and edit any template
3. Open DevTools and console
4. "Subscribing" is logged just once, not twice like on `trunk`

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

It reduces the size of `legacy-template` module

### Changelog

> Products: Improve performance by preventing running the Product Query logic twice in Editor.
