### PR TITLE
Fix Classic Template block in Single Product custom templates

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -590,7 +590,13 @@ class BlockTemplatesController {
 		if (
 			is_singular( 'product' ) && $this->block_template_is_available( 'single-product' )
 		) {
-			$templates = get_block_templates( array( 'slug__in' => array( 'single-product' ) ) );
+			global $post;
+
+			$valid_slugs = [ 'single-product' ];
+			if ( 'product' === $post->post_type && $post->post_name ) {
+				$valid_slugs = array_merge( $valid_slugs, [ 'single-product-' . $post->post_name ] );
+			}
+			$templates = get_block_templates( array( 'slug__in' => $valid_slugs ) );
 
 			if ( isset( $templates[0] ) && BlockTemplateUtils::template_has_legacy_template_block( $templates[0] ) ) {
 				add_filter( 'woocommerce_disable_compatibility_layer', '__return_true' );

--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -594,7 +594,7 @@ class BlockTemplatesController {
 
 			$valid_slugs = [ 'single-product' ];
 			if ( 'product' === $post->post_type && $post->post_name ) {
-				$valid_slugs = array_merge( $valid_slugs, [ 'single-product-' . $post->post_name ] );
+				$valid_slugs[] = 'single-product-' . $post->post_name;
 			}
 			$templates = get_block_templates( array( 'slug__in' => $valid_slugs ) );
 

--- a/src/BlockTypes/ClassicTemplate.php
+++ b/src/BlockTypes/ClassicTemplate.php
@@ -9,7 +9,7 @@ use WC_Shortcode_Checkout;
 use WC_Frontend_Scripts;
 
 /**
- * Classic Single Product class
+ * Classic Template class
  *
  * @internal
  */
@@ -91,7 +91,7 @@ class ClassicTemplate extends AbstractDynamicBlock {
 			return $this->render_order_received();
 		}
 
-		if ( 'single-product' === $attributes['template'] ) {
+		if ( is_product() ) {
 			return $this->render_single_product();
 		}
 

--- a/src/Templates/SingleProductTemplateCompatibility.php
+++ b/src/Templates/SingleProductTemplateCompatibility.php
@@ -269,7 +269,6 @@ class SingleProductTemplateCompatibility extends AbstractTemplateCompatibility {
 		$wrapped_blocks = self::wrap_single_product_template( $template_content );
 		$template       = self::inject_custom_attributes_to_first_and_last_block_single_product_template( $wrapped_blocks );
 		return self::serialize_blocks( $template );
-
 	}
 
 	/**


### PR DESCRIPTION
Fixes an issue that caused the Classic Template block not to render properly in Single Product templates created by the user.

### Testing

#### User Facing Testing

1. Go to Appearance > Editor > Templates and create a Product template:

<img src="https://github.com/woocommerce/woocommerce-blocks/assets/3616980/32660cc4-c2f8-4c38-8f00-ad108690d3eb" alt="" width="556" />

3. Choose one of the products and create a custom template for it.
4. Remove all blocks from the template (except header and footer) and, as a replacement, add the WooCommerce Classic Template block.

<img src="https://github.com/woocommerce/woocommerce-blocks/assets/3616980/a82da4b2-c94b-445f-a4da-45064963ad66" alt="" width="556" />

6. Visit the page of that product in the frontend.
7. Verify it renders the product details properly.

Before | After
--- | ---
![imatge](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/fd660ef9-cc35-4c96-824e-cd3e776ca7b6) | ![imatge](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/cef3d706-92c6-47fe-ab5c-17077fe764a2)

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix Classic Template block not rendering in Single Product custom templates
