### PR TITLE
Create a PayForOrder service class to implement authentication checks

### DIFF
--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -3,6 +3,7 @@ namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
 use Automattic\WooCommerce\StoreApi\Utilities\LocalPickupUtils;
 use Automattic\WooCommerce\Blocks\Utils\CartCheckoutUtils;
+use Automattic\WooCommerce\Blocks\Package;
 
 /**
  * Checkout class.
@@ -206,7 +207,10 @@ class Checkout extends AbstractBlock {
 	 * @return boolean
 	 */
 	protected function is_checkout_endpoint() {
-		return is_wc_endpoint_url( 'order-received' );
+		if ( Package::is_experimental_build() ) {
+			return is_wc_endpoint_url( 'order-received' );
+		}
+		return is_wc_endpoint_url( 'order-pay' ) || is_wc_endpoint_url( 'order-received' );
 	}
 
 	/**

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -206,7 +206,7 @@ class Checkout extends AbstractBlock {
 	 * @return boolean
 	 */
 	protected function is_checkout_endpoint() {
-		return is_wc_endpoint_url( 'order-pay' ) || is_wc_endpoint_url( 'order-received' );
+		return is_wc_endpoint_url( 'order-received' );
 	}
 
 	/**

--- a/src/Domain/Bootstrap.php
+++ b/src/Domain/Bootstrap.php
@@ -12,6 +12,7 @@ use Automattic\WooCommerce\Blocks\Domain\Services\Notices;
 use Automattic\WooCommerce\Blocks\Domain\Services\DraftOrders;
 use Automattic\WooCommerce\Blocks\Domain\Services\FeatureGating;
 use Automattic\WooCommerce\Blocks\Domain\Services\GoogleAnalytics;
+use Automattic\WooCommerce\Blocks\Domain\Services\PayForOrder;
 use Automattic\WooCommerce\Blocks\InboxNotifications;
 use Automattic\WooCommerce\Blocks\Installer;
 use Automattic\WooCommerce\Blocks\Migration;
@@ -131,6 +132,7 @@ class Bootstrap {
 		$this->container->get( Notices::class )->init();
 		$this->container->get( StoreApi::class )->init();
 		$this->container->get( GoogleAnalytics::class );
+		$this->container->get( PayForOrder::class )->init();
 		$this->container->get( BlockTypesController::class );
 		$this->container->get( BlockTemplatesController::class );
 		$this->container->get( ProductSearchResultsTemplate::class );
@@ -351,6 +353,12 @@ class Bootstrap {
 			Notices::class,
 			function( Container $container ) {
 				return new Notices( $container->get( Package::class ) );
+			}
+		);
+		$this->container->register(
+			PayForOrder::class,
+			function () {
+				return new PayForOrder();
 			}
 		);
 		$this->container->register(

--- a/src/Domain/Services/PayForOrder.php
+++ b/src/Domain/Services/PayForOrder.php
@@ -1,23 +1,47 @@
 <?php
 namespace Automattic\WooCommerce\Blocks\Domain\Services;
 
+use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
+use Automattic\WooCommerce\StoreApi\Utilities\OrderController;
+
 /**
  * Service class implementing authentication checks for pay-for-order checkout block.
  */
 class PayForOrder {
+	/**
+	 * Order controller class instance.
+	 *
+	 * @var OrderController
+	 */
+	protected $order_controller;
 
 	/**
 	 * Constructor.
 	 */
 	public function __construct() {
 		$this->init();
+		$this->order_controller = new OrderController();
+
 	}
 
 	/**
 	 * Hook into WP.
 	 */
 	public function init() {
-		add_filter( 'the_content', array( $this, 'check_authentication' ) );
+		add_filter( 'the_content', array( $this, 'maybe_render_authentication_form' ) );
+		add_action( 'init', array( $this, 'add_billing_email_to_url' ) );
+	}
+
+	/**
+	 * Check authentication for pay for order
+	 *
+	 * @param integer $order_id Order id.
+	 */
+	private function is_pay_for_order( $order_id ) {
+		if ( isset( $_GET['pay_for_order'], $_GET['key'] ) && $order_id ) { //phpcs:ignore WordPress.Security.NonceVerification
+			return true;
+		}
+		return false;
 	}
 
 	/**
@@ -25,26 +49,67 @@ class PayForOrder {
 	 *
 	 * @param string $content Content.
 	 */
-	public function check_authentication( $content ) {
+	public function maybe_render_authentication_form( $content ) {
 		global $wp;
+		$order_id      = ! empty( $wp->query_vars['order-pay'] ) ? absint( $wp->query_vars['order-pay'] ) : null;
+		$order         = wc_get_order( $order_id );
+		$billing_email = isset( $_GET['billing_email'] ) ? sanitize_text_field( wp_unslash( $_GET['billing_email'] ) ) : ''; //phpcs:ignore WordPress.Security.NonceVerification
+		$order_key     = isset( $_GET['key'] ) ? sanitize_text_field( wp_unslash( $_GET['key'] ) ) : ''; //phpcs:ignore WordPress.Security.NonceVerification
 
-		$order_id = ! empty( $wp->query_vars['order-pay'] ) ? $wp->query_vars['order-pay'] : null;
-
-		if ( isset( $_GET['pay_for_order'], $_GET['key'] ) && $order_id ) { // phpcs:ignore WordPress.Security.NonceVerification
-			if ( ! current_user_can( 'pay_for_order', $order_id ) && ! is_user_logged_in() ) {
-				$order = wc_get_order( $order_id );
+		if ( $this->is_pay_for_order( $order_id ) ) {
+			try {
+				$this->order_controller->validate_order( $order_id, $order_key, $billing_email );
+			} catch ( RouteException $error ) {
+				if ( 'woocommerce_rest_invalid_user' === $error->error_code && ! is_user_logged_in() ) {
+					ob_start();
+					wc_print_notice( esc_html__( 'Please log in to your account below to continue to the payment form.', 'woo-gutenberg-products-block' ), 'notice' );
+					woocommerce_login_form(
+						array(
+							'redirect' => $order->get_checkout_payment_url(),
+						)
+					);
+					return ob_get_clean();
+				} else {
+					// For guest orders, request they verify their email address (unless we can identify them via the active user session).
+					ob_start();
+					wc_get_template(
+						'checkout/form-verify-email.php',
+						array(
+							'failed_submission' => ! empty( $_GET['billing_email'] ), //phpcs:ignore WordPress.Security.NonceVerification
+							'verify_url'        => '',
+						)
+					);
+					return ob_get_clean();
+				}
 
 				ob_start();
-				wc_print_notice( esc_html__( 'Please log in to your account below to continue to the payment form.', 'woo-gutenberg-products-block' ), 'notice' );
-				woocommerce_login_form(
-					array(
-						'redirect' => $order->get_checkout_payment_url(),
-					)
-				);
+				wc_print_notice( esc_html__( 'This order cannot be paid for. Please contact us if you need assistance.', 'woo-gutenberg-products-block' ), 'error' );
 				return ob_get_clean();
 			}
 		}
 
 		return $content;
+	}
+
+	/**
+	 * Add the request email to the url param billing email
+	 */
+	public function add_billing_email_to_url() {
+		global $wp;
+		$order_id = ! empty( $wp->query_vars['order-pay'] ) ? $wp->query_vars['order-pay'] : null;
+
+		if ( $this->is_pay_for_order( $order_id ) ) {
+			return;
+		}
+
+		// Move the form email to a billing_email param in the URL.
+		//phpcs:ignore WordPress.Security.NonceVerification
+		$guest_email = isset( $_POST['email'] ) ? sanitize_text_field( wp_unslash( $_POST['email'] ) ) : null;
+		if ( $guest_email ) {
+			$url = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : null;
+			$url = add_query_arg( array( 'billing_email' => $guest_email ), $url );
+			wp_safe_redirect( $url );
+			exit;
+		}
 	}
 }

--- a/src/Domain/Services/PayForOrder.php
+++ b/src/Domain/Services/PayForOrder.php
@@ -1,0 +1,51 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\Domain\Services;
+
+/**
+ * Service class implementing authentication checks for pay-for-order checkout block.
+ */
+class PayForOrder {
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->init();
+	}
+
+	/**
+	 * Hook into WP.
+	 */
+	public function init() {
+		add_filter( 'the_content', array( $this, 'check_authentication' ) );
+	}
+
+	/**
+	 * Check authentication for pay for order
+	 *
+	 * @param string $content Content.
+	 */
+	public function check_authentication( $content ) {
+		global $wp;
+
+		$order_id = ! empty( $wp->query_vars['order-pay'] ) ? $wp->query_vars['order-pay'] : null;
+
+		if ( isset( $_GET['pay_for_order'], $_GET['key'] ) && $order_id ) { // phpcs:ignore WordPress.Security.NonceVerification
+			$order = wc_get_order( $order_id );
+
+			// Logged out customer does not have permission to pay for this order.
+			if ( ! current_user_can( 'pay_for_order', $order_id ) && ! is_user_logged_in() ) {
+				ob_start();
+				wc_print_notice( esc_html__( 'Please log in to your account below to continue to the payment form.', 'woo-gutenberg-products-block' ), 'notice' );
+				woocommerce_login_form(
+					array(
+						'redirect' => $order->get_checkout_payment_url(),
+					)
+				);
+				return ob_get_clean();
+			}
+		}
+
+		return $content;
+	}
+}

--- a/src/Domain/Services/PayForOrder.php
+++ b/src/Domain/Services/PayForOrder.php
@@ -31,10 +31,9 @@ class PayForOrder {
 		$order_id = ! empty( $wp->query_vars['order-pay'] ) ? $wp->query_vars['order-pay'] : null;
 
 		if ( isset( $_GET['pay_for_order'], $_GET['key'] ) && $order_id ) { // phpcs:ignore WordPress.Security.NonceVerification
-			$order = wc_get_order( $order_id );
-
-			// Logged out customer does not have permission to pay for this order.
 			if ( ! current_user_can( 'pay_for_order', $order_id ) && ! is_user_logged_in() ) {
+				$order = wc_get_order( $order_id );
+
 				ob_start();
 				wc_print_notice( esc_html__( 'Please log in to your account below to continue to the payment form.', 'woo-gutenberg-products-block' ), 'notice' );
 				woocommerce_login_form(

--- a/src/StoreApi/Utilities/OrderAuthorizationTrait.php
+++ b/src/StoreApi/Utilities/OrderAuthorizationTrait.php
@@ -1,7 +1,6 @@
 <?php
 namespace Automattic\WooCommerce\StoreApi\Utilities;
 
-use Automattic\WooCommerce\StoreApi\Utilities\OrderController;
 use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
 
 /**
@@ -24,16 +23,7 @@ trait OrderAuthorizationTrait {
 		$billing_email = sanitize_text_field( wp_unslash( $request->get_param( 'billing_email' ) ) );
 
 		try {
-			// In this context, pay_for_order capability checks that the current user ID matches the customer ID stored
-			// within the order, or if the order was placed by a guest.
-			// See https://github.com/woocommerce/woocommerce/blob/abcedbefe02f9e89122771100c42ff588da3e8e0/plugins/woocommerce/includes/wc-user-functions.php#L458.
-			if ( ! current_user_can( 'pay_for_order', $order_id ) ) {
-				throw new RouteException( 'woocommerce_rest_invalid_user', __( 'This order belongs to a different customer.', 'woo-gutenberg-products-block' ), 403 );
-			}
-			if ( get_current_user_id() === 0 ) {
-				$this->order_controller->validate_order_key( $order_id, $order_key );
-				$this->validate_billing_email_matches_order( $order_id, $billing_email );
-			}
+			$this->order_controller->validate_order( $order_id, $order_key, $billing_email );
 		} catch ( RouteException $error ) {
 			return new \WP_Error(
 				$error->getErrorCode(),


### PR DESCRIPTION
Create a `PayForOrder` service class to implement authentication checks for the pay-for-order checkout block.

Fixes #9400 

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| | Before log-in | After log-in |
| ------ | ----- | ----- |
| Customer |<img width="642" alt="Screen Shot 2023-07-25 at 9 57 16 PM" src="https://github.com/woocommerce/woocommerce-blocks/assets/56378160/c342a403-dcc3-4dbc-9515-415127577725">|<img width="707" alt="Screen Shot 2023-05-08 at 10 27 33 PM" src="https://user-images.githubusercontent.com/56378160/237002178-e5b5faa8-0069-4d62-a9c4-2a14549a6874.png">|
| | Before verify | After verify |
| Guest |<img width="533" alt="guest" src="https://github.com/woocommerce/woocommerce-blocks/assets/56378160/ed4b248c-3256-41d6-b952-4faabc5ba10e">|<img width="707" alt="Screen Shot 2023-05-08 at 10 27 33 PM" src="https://user-images.githubusercontent.com/56378160/237002178-e5b5faa8-0069-4d62-a9c4-2a14549a6874.png">|

### Testing
1. Create a pay-for-order order as a guest
1. Go to WC -> Orders -> find the order you just created
1. Click on the `Customer payment page` and copy the URL to incognito
1. See asking to verify the email address
2. Use the billing email in the order you just created
3. See `billing_email` added in to the URL and empty cart
4. Go back to the order you just created
5. Change `Customer` to an existing customer
6. Go back to the `Your cart is currently empty!`  page and refresh
7. See the login form
8. Log in as user and see empty cart

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests
 
### Changelog

> Create a `PayForOrder` service class to implement authentication checks
