### PR TITLE
ProductButton: Add animation

### DIFF
--- a/assets/js/atomic/blocks/product-elements/button/frontend.tsx
+++ b/assets/js/atomic/blocks/product-elements/button/frontend.tsx
@@ -18,6 +18,7 @@ type Context = {
 		quantityToAdd: number;
 		temporaryNumberOfItems: number;
 		animationStatus: AnimationStatus;
+		isAddedClassVisible: boolean | undefined;
 	};
 };
 
@@ -104,6 +105,9 @@ const productButtonSelectors = {
 			);
 			return product?.quantity || 0;
 		},
+		isAddedClassVisible: ( { context }: Store ) => {
+			return context.woocommerce.isAddedClassVisible;
+		},
 		slideOutAnimation: ( { context }: Store ) =>
 			context.woocommerce.animationStatus === AnimationStatus.SLIDE_OUT,
 		slideInAnimation: ( { context }: Store ) =>
@@ -182,6 +186,7 @@ interactivityStore(
 						// eslint-disable-next-line no-console
 						console.error( error );
 					} finally {
+						context.woocommerce.isAddedClassVisible = true;
 						context.woocommerce.displayViewCart = true;
 						context.woocommerce.isLoading = false;
 					}

--- a/assets/js/atomic/blocks/product-elements/button/frontend.tsx
+++ b/assets/js/atomic/blocks/product-elements/button/frontend.tsx
@@ -21,6 +21,7 @@ type Context = {
 		shouldStartAnimation: boolean | undefined;
 		slideOutStatus: AnimationStatus;
 		slideInStatus: AnimationStatus;
+		quantityToAdd: number;
 	};
 };
 
@@ -267,11 +268,13 @@ interactivityStore(
 					try {
 						await dispatch( storeKey ).addItemToCart(
 							context.woocommerce.productId,
-							1
+							context.woocommerce.quantityToAdd
 						);
 						context.woocommerce.isLoading = false;
 						context.woocommerce.displayViewCart = true;
-						context.woocommerce.numberOfItems++;
+						context.woocommerce.numberOfItems =
+							context.woocommerce.numberOfItems +
+							context.woocommerce.quantityToAdd;
 						context.woocommerce.shouldStartAnimation = undefined;
 					} catch ( error ) {
 						const domNode = document.querySelector(

--- a/assets/js/atomic/blocks/product-elements/button/frontend.tsx
+++ b/assets/js/atomic/blocks/product-elements/button/frontend.tsx
@@ -237,7 +237,8 @@ interactivityStore(
 		},
 	},
 	{
-		afterLoad: ( { state }: { state: State } ) => {
+		afterLoad: ( store: Store ) => {
+			const { state, selectors } = store;
 			// Subscribe to changes in Cart data.
 			subscribe( () => {
 				const cartData = select( storeKey ).getCartData();
@@ -251,7 +252,9 @@ interactivityStore(
 			// This selector triggers a fetch of the Cart data. It is done in a
 			// `requestIdleCallback` to avoid potential performance issues.
 			requestIdleCallback( () => {
-				select( storeKey ).getCartData();
+				if ( ! selectors.woocommerce.hasCartLoaded( store ) ) {
+					select( storeKey ).getCartData();
+				}
 			} );
 		},
 	}

--- a/assets/js/atomic/blocks/product-elements/button/frontend.tsx
+++ b/assets/js/atomic/blocks/product-elements/button/frontend.tsx
@@ -18,7 +18,6 @@ type Context = {
 		quantityToAdd: number;
 		temporaryNumberOfItems: number;
 		animationStatus: AnimationStatus;
-		isAddedClassVisible: boolean | undefined;
 	};
 };
 
@@ -183,7 +182,6 @@ interactivityStore(
 						// eslint-disable-next-line no-console
 						console.error( error );
 					} finally {
-						context.woocommerce.isAddedClassVisible = true;
 						context.woocommerce.displayViewCart = true;
 						context.woocommerce.isLoading = false;
 					}

--- a/assets/js/atomic/blocks/product-elements/button/frontend.tsx
+++ b/assets/js/atomic/blocks/product-elements/button/frontend.tsx
@@ -105,9 +105,6 @@ const productButtonSelectors = {
 			);
 			return product?.quantity || 0;
 		},
-		isAddedClassVisible: ( { context }: Store ) => {
-			return context.woocommerce.isAddedClassVisible;
-		},
 		slideOutAnimation: ( { context }: Store ) =>
 			context.woocommerce.animationStatus === AnimationStatus.SLIDE_OUT,
 		slideInAnimation: ( { context }: Store ) =>

--- a/assets/js/atomic/blocks/product-elements/button/frontend.tsx
+++ b/assets/js/atomic/blocks/product-elements/button/frontend.tsx
@@ -85,7 +85,8 @@ const productButtonSelectors = {
 				return getTextButton( {
 					addToCartText: context.woocommerce.addToCartText,
 					inTheCartText: state.woocommerce.inTheCartText,
-					numberOfItems: selectors.woocommerce.numberOfItems( store ),
+					numberOfItems:
+						selectors.woocommerce.getNumberOfItems( store ),
 				} );
 			}
 
@@ -93,7 +94,7 @@ const productButtonSelectors = {
 				addToCartText: context.woocommerce.addToCartText,
 				inTheCartText: state.woocommerce.inTheCartText,
 				numberOfItems:
-					selectors.woocommerce.numberOfItems( store ) !==
+					selectors.woocommerce.getNumberOfItems( store ) !==
 					context.woocommerce.initialNumberOfItems
 						? context.woocommerce.numberOfItems
 						: context.woocommerce.initialNumberOfItems,
@@ -137,7 +138,7 @@ const productButtonSelectors = {
 		hasCartLoaded: ( { state }: { state: State } ) => {
 			return state.woocommerce.cart !== undefined;
 		},
-		numberOfItems: ( {
+		getNumberOfItems: ( {
 			state,
 			context,
 		}: {
@@ -152,11 +153,10 @@ const productButtonSelectors = {
 
 			return product?.quantity || 0;
 		},
-		numberOfItemsPrev: ( {
+		getNumberOfItemsPrev: ( {
 			state,
 			context,
 		}: {
-			selecotrs: any;
 			state: State;
 			context: Context;
 		} ) => {
@@ -175,20 +175,21 @@ const productButtonSelectors = {
 		} ) => {
 			const { context, selectors } = store;
 
+			const numberOfItems =
+				selectors.woocommerce.getNumberOfItems( store );
+
+			const prevNumberOfItems =
+				selectors.woocommerce.getNumberOfItemsPrev( store );
+
 			const isFreshLoad =
 				selectors.woocommerce.hasCartLoaded( store ) &&
-				context.woocommerce.initialNumberOfItems !==
-					selectors.woocommerce.numberOfItems( store ) &&
-				context.woocommerce.numberOfItems !==
-					selectors.woocommerce.numberOfItems( store );
+				context.woocommerce.initialNumberOfItems !== numberOfItems &&
+				context.woocommerce.numberOfItems !== numberOfItems;
 
 			const isFromCart =
-				selectors.woocommerce.numberOfItemsPrev( store ) !==
-					undefined &&
-				selectors.woocommerce.numberOfItemsPrev( store ) !==
-					selectors.woocommerce.numberOfItems( store ) &&
-				selectors.woocommerce.numberOfItems( store ) !==
-					context.woocommerce.numberOfItems;
+				prevNumberOfItems !== undefined &&
+				prevNumberOfItems !== numberOfItems &&
+				numberOfItems !== context.woocommerce.numberOfItems;
 
 			const isFromUserAction =
 				! isFreshLoad &&

--- a/assets/js/atomic/blocks/product-elements/button/frontend.tsx
+++ b/assets/js/atomic/blocks/product-elements/button/frontend.tsx
@@ -14,6 +14,7 @@ type Context = {
 		productId: number;
 		numberOfItems: number;
 		productPermalink: string;
+		displayViewCart: boolean;
 	};
 };
 
@@ -27,7 +28,6 @@ type State = {
 const getProductById = ( cartState: Cart | undefined, productId: number ) => {
 	return cartState?.items.find( ( item ) => item.id === productId );
 };
-
 let isCartStateFirstLoad = true;
 
 const productButtonSelectors = {
@@ -106,7 +106,9 @@ const productButtonSelectors = {
 			context: Context;
 			state: State;
 		} ) => {
-			if ( ! state.woocommerce?.cart ) {
+			const cartState = state.woocommerce.cart;
+
+			if ( cartState === undefined ) {
 				return context.woocommerce.numberOfItems > 0;
 			}
 			const product = getProductById(
@@ -127,10 +129,12 @@ const productButtonSelectors = {
 			selectors: any;
 			state: State;
 		} ) => {
-			return selectors.woocommerce.isThereMoreThanOneItem( {
-				context,
-				state,
-			} );
+			return (
+				selectors.woocommerce.isThereMoreThanOneItem( {
+					context,
+					state,
+				} ) && context.woocommerce.displayViewCart
+			);
 		},
 	},
 };
@@ -179,6 +183,7 @@ store(
 						);
 						context.woocommerce.numberOfItems++;
 						context.woocommerce.isLoading = false;
+						context.woocommerce.displayViewCart = true;
 					} catch ( error ) {
 						const domNode = document.querySelector(
 							'.wc-block-store-notices'

--- a/assets/js/atomic/blocks/product-elements/button/style.scss
+++ b/assets/js/atomic/blocks/product-elements/button/style.scss
@@ -67,7 +67,7 @@
 		span {
 
 			&.wc-block-slide-out {
-				animation: slideOut 0.1s linear 1 normal;
+				animation: slideOut 0.1s linear 1 normal forwards;
 			}
 			&.wc-block-slide-in {
 				animation: slideIn 0.1s linear 1 normal;

--- a/assets/js/atomic/blocks/product-elements/button/style.scss
+++ b/assets/js/atomic/blocks/product-elements/button/style.scss
@@ -18,15 +18,6 @@
 			opacity: 0.25;
 		}
 
-		&.added::after {
-			font-family: WooCommerce; /* stylelint-disable-line */
-			content: "\e017";
-			margin-left: 0.5em;
-			display: inline-block;
-			width: auto;
-			height: auto;
-		}
-
 		&.loading::after {
 			font-family: WooCommerce; /* stylelint-disable-line */
 			content: "\e031";
@@ -42,6 +33,26 @@
 		display: none;
 	}
 
+	@keyframes scrollToUp {
+		from {
+			transform: translateY(0);
+		}
+		to {
+			transform: translateY(-60%);
+		}
+	}
+
+	@keyframes scrollFromDown {
+		from {
+			transform: translateY(90%);
+			opacity: 0;
+		}
+		to {
+			transform: translate(0);
+			opacity: 1;
+		}
+	}
+
 	.wc-block-components-product-button__button {
 		border-style: none;
 		display: inline-flex;
@@ -50,6 +61,17 @@
 		margin-left: auto;
 		white-space: normal;
 		word-break: break-word;
+		width: 150px;
+
+		span {
+
+			&.wc-block-scrollToUp {
+				animation: scrollToUp 0.1s linear 1 normal;
+			}
+			&.wc-block-scrollFromDown {
+				animation: scrollFromDown 0.1s linear 1 normal;
+			}
+		}
 	}
 
 	.wc-block-components-product-button__button--placeholder {

--- a/assets/js/atomic/blocks/product-elements/button/style.scss
+++ b/assets/js/atomic/blocks/product-elements/button/style.scss
@@ -1,12 +1,14 @@
 .wp-block-button.wc-block-components-product-button {
 	word-break: break-word;
 	white-space: normal;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	gap: $gap-small;
 
 	.wp-block-button__link {
 		word-break: break-word;
 		white-space: normal;
-		margin-right: auto !important;
-		margin-left: auto !important;
 		display: inline-flex;
 		justify-content: center;
 		text-align: center;
@@ -57,8 +59,6 @@
 		border-style: none;
 		display: inline-flex;
 		justify-content: center;
-		margin-right: auto;
-		margin-left: auto;
 		white-space: normal;
 		word-break: break-word;
 		width: 150px;

--- a/assets/js/atomic/blocks/product-elements/button/style.scss
+++ b/assets/js/atomic/blocks/product-elements/button/style.scss
@@ -35,7 +35,7 @@
 		display: none;
 	}
 
-	@keyframes scrollToUp {
+	@keyframes slideOut {
 		from {
 			transform: translateY(0);
 		}
@@ -44,7 +44,7 @@
 		}
 	}
 
-	@keyframes scrollFromDown {
+	@keyframes slideIn {
 		from {
 			transform: translateY(90%);
 			opacity: 0;
@@ -62,14 +62,15 @@
 		white-space: normal;
 		word-break: break-word;
 		width: 150px;
+		overflow: hidden;
 
 		span {
 
-			&.wc-block-scrollToUp {
-				animation: scrollToUp 0.1s linear 1 normal;
+			&.wc-block-slide-out {
+				animation: slideOut 0.1s linear 1 normal;
 			}
-			&.wc-block-scrollFromDown {
-				animation: scrollFromDown 0.1s linear 1 normal;
+			&.wc-block-slide-in {
+				animation: slideIn 0.1s linear 1 normal;
 			}
 		}
 	}

--- a/assets/js/atomic/blocks/product-elements/button/style.scss
+++ b/assets/js/atomic/blocks/product-elements/button/style.scss
@@ -40,7 +40,7 @@
 			transform: translateY(0);
 		}
 		to {
-			transform: translateY(-60%);
+			transform: translateY(-100%);
 		}
 	}
 

--- a/src/BlockTypes/ProductButton.php
+++ b/src/BlockTypes/ProductButton.php
@@ -153,16 +153,17 @@ class ProductButton extends AbstractBlock {
 			if ( isset( $args['attributes']['aria-label'] ) ) {
 				$args['attributes']['aria-label'] = wp_strip_all_tags( $args['attributes']['aria-label'] );
 			}
-			
+
 			if ( isset( WC()->cart ) && ! WC()->cart->is_empty() ) {
 				$this->prevent_cache();
 			}
 
-			$div_directives    = 'data-wc-context=\'' . wp_json_encode( $context, JSON_NUMERIC_CHECK ) . '\'';
+			$div_directives = 'data-wc-context=\'' . wp_json_encode( $context, JSON_NUMERIC_CHECK ) . '\'';
 
 			$button_directives = '
 				data-wc-on--click="actions.woocommerce.addToCart"
 				data-wc-class--loading="context.woocommerce.isLoading"
+				data-wc-class--added="context.woocommerce.isAddedClassVisible"
 			';
 
 			$span_button_directives = '
@@ -172,8 +173,6 @@ class ProductButton extends AbstractBlock {
 				data-wc-effect="effects.woocommerce.startAnimation"
 				data-wc-on--animationend="actions.woocommerce.handleAnimationEnd"
 			';
-
-			
 
 			/**
 			 * Filters the add to cart button class.

--- a/src/BlockTypes/ProductButton.php
+++ b/src/BlockTypes/ProductButton.php
@@ -163,7 +163,6 @@ class ProductButton extends AbstractBlock {
 			$button_directives = '
 				data-wc-on--click="actions.woocommerce.addToCart"
 				data-wc-class--loading="context.woocommerce.isLoading"
-				data-wc-class--added="context.woocommerce.isAddedClassVisible"
 			';
 
 			$span_button_directives = '

--- a/src/BlockTypes/ProductButton.php
+++ b/src/BlockTypes/ProductButton.php
@@ -112,6 +112,8 @@ class ProductButton extends AbstractBlock {
 				)
 			);
 
+			$default_quantity = 1;
+
 			$context = array(
 				'woocommerce' => array(
 					'isLoading'            => false,
@@ -119,6 +121,15 @@ class ProductButton extends AbstractBlock {
 					'productId'            => $product->get_id(),
 					'addToCartText'        => null !== $product->add_to_cart_text() ? $product->add_to_cart_text() : __( 'Add to cart', 'woo-gutenberg-products-block' ),
 					'initialNumberOfItems' => $number_of_items_in_cart,
+					/**
+					* Filters the change the quantity to add to cart.
+					*
+					* @since $VID:$
+					* @param number $default_quantity The default quantity.
+					* @param number $product_id The product id.
+					*/
+					'quantityToAdd'        => apply_filters( 'woocommerce_add_to_cart_quantity', $default_quantity, $product->get_id() ),
+
 				),
 			);
 

--- a/src/BlockTypes/ProductButton.php
+++ b/src/BlockTypes/ProductButton.php
@@ -152,7 +152,7 @@ class ProductButton extends AbstractBlock {
 				data-wc-class--added="selectors.woocommerce.isThereMoreThanOneItem"
 			';
 
-			$span_button_directives = 'data-wc-text="selectors.woocommerce.addToCartText" data-wc-class--wc-block-slide-out="selectors.woocommerce.shouldSlideOutAnimationStart" " data-wc-class--wc-block-slide-in="selectors.woocommerce.shouldSlideInAnimationStart" data-wc-on--animationend="actions.woocommerce.handleAnimationEnd"';
+			$span_button_directives = 'data-wc-text="selectors.woocommerce.addToCartText" data-wc-class--wc-block-slide-out="selectors.woocommerce.shouldSlideOutAnimationStart" data-wc-class--wc-block-slide-in="selectors.woocommerce.shouldSlideInAnimationStart" data-wc-on--animationstart="actions.woocommerce.handleAnimationStart" data-wc-on--animationend="actions.woocommerce.handleAnimationEnd"';
 
 			if ( isset( WC()->cart ) && WC()->cart->is_empty() ) {
 				$context['woocommerce']['numberOfItems'] = 0;

--- a/src/BlockTypes/ProductButton.php
+++ b/src/BlockTypes/ProductButton.php
@@ -257,6 +257,7 @@ class ProductButton extends AbstractBlock {
 				>
 				<span {span_button_directives}> {add_to_cart_text} </span>
 				</{html_element}>
+				{view_cart_html}
 			</div>',
 				array(
 					'{classes}'                => esc_attr( $text_align_styles_and_classes['class'] ?? '' ),
@@ -270,10 +271,32 @@ class ProductButton extends AbstractBlock {
 					'{div_directives}'         => $is_ajax_button ? $div_directives : '',
 					'{button_directives}'      => $is_ajax_button ? $button_directives : '',
 					'{span_button_directives}' => $is_ajax_button ? $span_button_directives : '',
+					'{view_cart_html}'         => $is_ajax_button ? $this->get_view_cart_html() : '',
 				)
 			),
 			$product,
 			$args
+		);
+	}
+
+	/**
+	 * Get the view cart link html.
+	 *
+	 * @return string The view cart html.
+	 */
+	private function get_view_cart_html() {
+		return sprintf(
+			'<span hidden data-wc-bind--hidden="!selectors.woocommerce.isAdded">
+				<a
+					href="%1$s"
+					class="added_to_cart wc_forward"
+					title="%2$s"
+				>
+					%2$s
+				</a>
+			</span>',
+			wc_get_cart_url(),
+			__( 'View cart', 'woo-gutenberg-products-block' )
 		);
 	}
 }


### PR DESCRIPTION
This PR implements the animation discussed into https://github.com/woocommerce/woocommerce-blocks/discussions/10153#discussioncomment-6475505.

| Cached Page | Not Cached Page |
|--------|--------|
|<video src=https://github.com/woocommerce/woocommerce-blocks/assets/4463174/3da139cf-7cd6-4b14-8e80-41af607b0e39 />|<video src=https://github.com/woocommerce/woocommerce-blocks/assets/4463174/f8b16c63-49a7-4448-8553-3c81b8d85844 />| 




### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Install the plugin [WP Optimize](https://wordpress.org/plugins/wp-optimize/).
2. Ensure that your cart is empty.
3. Ensure that you have the Mini Cart block in the header.
4. Enable the cache.
5. Visit the page with the Products block.
6. Refresh the page.
7. Add a product.
8. Refresh the page.
9. Ensure that the counter is updated with a smoother animation.
10. Open the Mini Cart block and change the quantity of the product in the cart.
11. Ensure that the counter inside the button is updated with a smoother animation.
12. Disable the plugin.
13. Visit the page with the Products block.
14. Open the Mini Cart block and change the quantity of the product in the cart.
15. Ensure that the counter inside the button is updated with a smoother animation.
16. Ensure that there isn't any regression.
