### PR TITLE
 Check if WordPress version is higher than 6.2.2 to make Products block compatible with Gutenberg 16+

### DIFF
--- a/src/BlockTypes/ProductQuery.php
+++ b/src/BlockTypes/ProductQuery.php
@@ -2,6 +2,7 @@
 namespace Automattic\WooCommerce\Blocks\BlockTypes;
 
 use WP_Query;
+use Automattic\WooCommerce\Blocks\Utils\Utils;
 
 // phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 // phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_query
@@ -88,7 +89,7 @@ class ProductQuery extends AbstractBlock {
 	 * - https://github.com/woocommerce/woocommerce-blocks/pull/10360
 	 */
 	private function check_if_post_template_has_support_for_grid_view() {
-		if ( version_compare( $GLOBALS['wp_version'], '6.2.2', '>' ) ) {
+		if ( Utils::wp_version_compare( '6.3', '>=' ) ) {
 			return true;
 		}
 

--- a/src/BlockTypes/ProductQuery.php
+++ b/src/BlockTypes/ProductQuery.php
@@ -91,6 +91,14 @@ class ProductQuery extends AbstractBlock {
 	protected function enqueue_data( array $attributes = [] ) {
 		parent::enqueue_data( $attributes );
 
+		if ( version_compare( $GLOBALS['wp_version'], '6.2.2', '>' ) ) {
+			$this->asset_data_registry->add(
+				'post_template_has_support_for_grid_view',
+				true
+			);
+			return;
+		}
+
 		$gutenberg_version = '';
 
 		if ( is_plugin_active( 'gutenberg/gutenberg.php' ) ) {

--- a/src/BlockTypes/ProductQuery.php
+++ b/src/BlockTypes/ProductQuery.php
@@ -82,26 +82,19 @@ class ProductQuery extends AbstractBlock {
 	}
 
 	/**
-	 * Extra data passed through from server to client for block.
-	 *
-	 * @param array $attributes  Any attributes that currently are available from the block.
-	 *                           Note, this will be empty in the editor context when the block is
-	 *                           not in the post content on editor load.
+	 * Post Template support for grid view was introduced in Gutenberg 16 / WordPress 6.3
+	 * Fixed in:
+	 * - https://github.com/woocommerce/woocommerce-blocks/pull/9916
+	 * - https://github.com/woocommerce/woocommerce-blocks/pull/10360
 	 */
-	protected function enqueue_data( array $attributes = [] ) {
-		parent::enqueue_data( $attributes );
-
+	private function check_if_post_template_has_support_for_grid_view() {
 		if ( version_compare( $GLOBALS['wp_version'], '6.2.2', '>' ) ) {
-			$this->asset_data_registry->add(
-				'post_template_has_support_for_grid_view',
-				true
-			);
-			return;
+			return true;
 		}
 
-		$gutenberg_version = '';
-
 		if ( is_plugin_active( 'gutenberg/gutenberg.php' ) ) {
+			$gutenberg_version = '';
+
 			if ( defined( 'GUTENBERG_VERSION' ) ) {
 				$gutenberg_version = GUTENBERG_VERSION;
 			}
@@ -113,11 +106,27 @@ class ProductQuery extends AbstractBlock {
 				);
 				$gutenberg_version = $gutenberg_data['Version'];
 			}
+			return version_compare( $gutenberg_version, '16.0', '>=' );
 		}
+
+		return false;
+	}
+
+	/**
+	 * Extra data passed through from server to client for block.
+	 *
+	 * @param array $attributes  Any attributes that currently are available from the block.
+	 *                           Note, this will be empty in the editor context when the block is
+	 *                           not in the post content on editor load.
+	 */
+	protected function enqueue_data( array $attributes = [] ) {
+		parent::enqueue_data( $attributes );
+
+		$post_template_has_support_for_grid_view = $this->check_if_post_template_has_support_for_grid_view();
 
 		$this->asset_data_registry->add(
 			'post_template_has_support_for_grid_view',
-			version_compare( $gutenberg_version, '16.0', '>=' )
+			$post_template_has_support_for_grid_view
 		);
 	}
 

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -7,7 +7,10 @@ namespace Automattic\WooCommerce\Blocks\Utils;
 class Utils {
 
 	/**
-	 * Compare the current WordPress version with a given version.
+	 * Compare the current WordPress version with a given version. It's a wrapper around `version-compare`
+	 * that additionally takes into account the suffix (like `-RC1`).
+	 * For example: version 6.3 is considered lower than 6.3-RC2, so you can do
+	 * wp_version_compare( '6.3', '>=' ) and that will return true for 6.3-RC2.
 	 *
 	 * @param string      $version The version to compare against.
 	 * @param string|null $operator Optional. The comparison operator. Defaults to null.


### PR DESCRIPTION
In Gutenberg 16+ the layout attributes of Query block has been moved from `core/query` to `core/post-template`. Products (Beta) and Product Template blocks are variations of the mentioned blocks, hence we had to adjust to this logic (issue: https://github.com/woocommerce/woocommerce-blocks/issues/9884).

In https://github.com/woocommerce/woocommerce-blocks/pull/9916 we fixed this, but the change is applied based on the Gutenberg version. When Gutenberg was not installed or disabled we didn't apply the adjusting logic.
However, Gutenberg 16+ is included in WordPress 6.3, so we have to apply the fix also in the case of WordPress 6.3+.

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/10367

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before - no layout option is chosen, which defaults to list | After  - grid option is chosen by default|
| ------ | ----- |
|   <img width="688" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/20098064/4859c40f-fea7-4fbf-83b8-e2deadf2709b">     |   <img width="688" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/20098064/7c139c5c-1977-460a-afce-cf7489cb9a37">    |

### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

Check below steps in following configurations:
- WordPress 6.2:
    - [ ] Gutenberg 16 enabled
    - [ ] Gutenberg 16 disabled
- WordPress 6.3:
    - [ ] Gutenberg 16 enabled
    - [ ] Gutenberg 16 disabled

1. Create new post
2. Add Products (Beta) block
3. **Expected**: It has grid layout applied by default

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Products: fix the incorrect layout with WordPress 6.3+ without Gutenberg
