### PR TITLE
Remove styles from `Product Details Product Listing` pattern

### DIFF
--- a/patterns/product-details-listing.php
+++ b/patterns/product-details-listing.php
@@ -33,9 +33,9 @@ $product_id = $products ? $products[0] : null;
 			</div>
 			<!-- /wp:group -->
 
-			<!-- wp:post-title {"textAlign":"center","isLink":true,"style":{"typography":{"fontStyle":"normal","fontWeight":"700"},"elements":{"link":{"color":{"text":"#000000"}}},"color":{"text":"#000000"}},"fontSize":"x-large","__woocommerceNamespace":"woocommerce/product-query/product-title"} /-->
+			<!-- wp:post-title {"textAlign":"center","isLink":true,"style":{"typography":{"fontStyle":"normal","fontWeight":"700"}},"fontSize":"x-large","__woocommerceNamespace":"woocommerce/product-query/product-title"} /-->
 			<!-- wp:woocommerce/product-price {"textAlign":"center","isDescendentOfSingleProductBlock":true,"style":{"typography":{"fontSize":"28px","fontStyle":"normal","fontWeight":"700"}}} /-->
-			<!-- wp:woocommerce/product-button {"textAlign":"center","isDescendentOfSingleProductBlock":true,"style":{"color":{"background":"#000000","text":"#ffffff"},"typography":{"fontSize":"18px","fontStyle":"normal","fontWeight":"600"},"spacing":{"padding":{"top":"20px","bottom":"20px","right":"94px","left":"94px"},"margin":{"top":"15px"}}}} /-->
+			<!-- wp:woocommerce/product-button {"textAlign":"center","isDescendentOfSingleProductBlock":true} /-->
 		</div>
 		<!-- /wp:column -->
 	</div>

--- a/patterns/product-details-listing.php
+++ b/patterns/product-details-listing.php
@@ -33,9 +33,9 @@ $product_id = $products ? $products[0] : null;
 			</div>
 			<!-- /wp:group -->
 
-			<!-- wp:post-title {"textAlign":"center","isLink":true,"style":{"typography":{"fontStyle":"normal","fontWeight":"700"},"elements":{"link":{"color":{"text":"#000001"}}},"color":{"text":"#000001"}},"fontSize":"x-large","__woocommerceNamespace":"woocommerce/product-query/product-title"} /-->
+			<!-- wp:post-title {"textAlign":"center","isLink":true,"style":{"typography":{"fontStyle":"normal","fontWeight":"700"},"elements":{"link":{"color":{"text":"#000000"}}},"color":{"text":"#000000"}},"fontSize":"x-large","__woocommerceNamespace":"woocommerce/product-query/product-title"} /-->
 			<!-- wp:woocommerce/product-price {"textAlign":"center","isDescendentOfSingleProductBlock":true,"style":{"typography":{"fontSize":"28px","fontStyle":"normal","fontWeight":"700"}}} /-->
-			<!-- wp:woocommerce/product-button {"textAlign":"center","isDescendentOfSingleProductBlock":true,"style":{"color":{"background":"#000001","text":"#fffff1"},"typography":{"fontSize":"18px","fontStyle":"normal","fontWeight":"600"},"spacing":{"padding":{"top":"20px","bottom":"20px","right":"94px","left":"94px"},"margin":{"top":"15px"}}}} /-->
+			<!-- wp:woocommerce/product-button {"textAlign":"center","isDescendentOfSingleProductBlock":true,"style":{"color":{"background":"#000000","text":"#ffffff"},"typography":{"fontSize":"18px","fontStyle":"normal","fontWeight":"600"},"spacing":{"padding":{"top":"20px","bottom":"20px","right":"94px","left":"94px"},"margin":{"top":"15px"}}}} /-->
 		</div>
 		<!-- /wp:column -->
 	</div>


### PR DESCRIPTION
The PR removes the styles from the title & button of the pattern.

### Testing
#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Create a page or post.
2. Insert the `Product Details Product Listing`.
3. Click on the product title and in the styles tab check it has no colors.
4. Click on the product button and in the styles tab check it has no colors or other styles.

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> `Product Details Product Listing`: remove the styles on product title and button.
