### PR TITLE
Fix Checkout Order Route markdown link

### DIFF
--- a/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md
+++ b/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md
@@ -43,7 +43,7 @@ The majority of our feature flagging is blocks, this is a list of them:
 -   Product Rating Counter ([PHP flag](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/src/BlockTypesController.php#L229) | [webpack flag](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/bin/webpack-entries.js#L71-L73))
 -   ⚛️ Add to cart ([JS flag](https://github.com/woocommerce/woocommerce-blocks/blob/dfd2902bd8a247b5d048577db6753c5e901fc60f/assets/js/atomic/blocks/product-elements/add-to-cart/index.ts#L26-L29)).
 -   Order Route ([PHP flag](https://github.com/woocommerce/woocommerce-blocks/blob/b4a9dc9334f82c09f533b0f88c947b5c34e4e546/src/StoreApi/RoutesController.php#L65-L67))
--   Checkout Order Route ([PHP flag](https://github.com/woocommerce/woocommerce-blocks/blob/add/an-endpoint-for-process-pay-for-order-orders/src/StoreApi/RoutesController.php#L67))
+-   Checkout Order Route ([PHP flag](https://github.com/woocommerce/woocommerce-blocks/blob/b4ba06a6242cbb6a64d2ec554a263ebe60d8d3af/src/StoreApi/RoutesController.php#L67))
 
 ## Features behind flags
 


### PR DESCRIPTION
Fix a markdown link that broke after a branch was deleted.

### Testing

#### User Facing Testing

1. Verify the _Check Markdown links_ automation passes.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->
