### PR TITLE
Store API: Prevent notices due to missing properties with PHP 8.2

### DIFF
--- a/src/StoreApi/Schemas/V1/OrderSchema.php
+++ b/src/StoreApi/Schemas/V1/OrderSchema.php
@@ -38,6 +38,55 @@ class OrderSchema extends AbstractSchema {
 	protected $order_controller;
 
 	/**
+	 * Coupon schema instance.
+	 *
+	 * @var OrderCouponSchema
+	 */
+	public $coupon_schema;
+
+	/**
+	 * Product item schema instance representing cross-sell items.
+	 *
+	 * @var ProductSchema
+	 */
+	public $cross_sells_item_schema;
+
+	/**
+	 * Fee schema instance.
+	 *
+	 * @var OrderFeeSchema
+	 */
+	public $fee_schema;
+
+	/**
+	 * Shipping rates schema instance.
+	 *
+	 * @var CartShippingRateSchema
+	 */
+	public $shipping_rate_schema;
+
+	/**
+	 * Shipping address schema instance.
+	 *
+	 * @var ShippingAddressSchema
+	 */
+	public $shipping_address_schema;
+
+	/**
+	 * Billing address schema instance.
+	 *
+	 * @var BillingAddressSchema
+	 */
+	public $billing_address_schema;
+
+	/**
+	 * Error schema instance.
+	 *
+	 * @var ErrorSchema
+	 */
+	public $error_schema;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param ExtendSchema     $extend Rest Extending instance.


### PR DESCRIPTION
Fixes some notice/warnings under PHP 8.2 due to using dynamic properties. 

### Testing

Tests should cover regressions, its a minor change that only fixes deprecation notices under PHP 8.2 with debug enabled.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental