### PR TITLE
Remove unneeded testing step for 10198

### DIFF
--- a/docs/internal-developers/testing/releases/1061.md
+++ b/docs/internal-developers/testing/releases/1061.md
@@ -17,7 +17,6 @@ Zip file for testing: [woocommerce-gutenberg-products-block.zip](https://github.
 
 6. Save the post and go to the front-end
 7. Make sure you can use all filters as expected and without any problems/errors: the product counts should match the number of existing products in the store with the filtered criteria, not just what is displayed on the page.
-8. Repeat all steps from 2 to 7, but using the Products Collection block instead of Products (beta). Make sure all filters work as expected.
 
 ### Stop reading Product IDs from asset store in filter blocks [#10195](https://github.com/woocommerce/woocommerce-blocks/pull/10195)
 


### PR DESCRIPTION
Remove unneeded testing step for https://github.com/woocommerce/woocommerce-blocks/pull/10198 as that step is for an experimental block.