### PR TITLE
Refactor Store API hydration logic and prevent fatal errors from session class usage

### DIFF
--- a/src/Assets/AssetDataRegistry.php
+++ b/src/Assets/AssetDataRegistry.php
@@ -2,7 +2,7 @@
 namespace Automattic\WooCommerce\Blocks\Assets;
 
 use Automattic\WooCommerce\Blocks\Package;
-use  Automattic\WooCommerce\Blocks\Domain\Services\Hydration;
+use Automattic\WooCommerce\Blocks\Domain\Services\Hydration;
 use Exception;
 use InvalidArgumentException;
 

--- a/src/Assets/AssetDataRegistry.php
+++ b/src/Assets/AssetDataRegistry.php
@@ -2,7 +2,7 @@
 namespace Automattic\WooCommerce\Blocks\Assets;
 
 use Automattic\WooCommerce\Blocks\Package;
-
+use  Automattic\WooCommerce\Blocks\Domain\Services\Hydration;
 use Exception;
 use InvalidArgumentException;
 
@@ -317,14 +317,38 @@ class AssetDataRegistry {
 	}
 
 	/**
-	 * Hydrate from API.
+	 * Hydrate from the API.
 	 *
 	 * @param string $path REST API path to preload.
 	 */
 	public function hydrate_api_request( $path ) {
 		if ( ! isset( $this->preloaded_api_requests[ $path ] ) ) {
-			$this->preloaded_api_requests = rest_preload_api_request( $this->preloaded_api_requests, $path );
+			$this->preloaded_api_requests[ $path ] = Package::container()->get( Hydration::class )->get_rest_api_response_data( $path );
 		}
+	}
+
+	/**
+	 * Hydrate some data from the API.
+	 *
+	 * @param string  $key  The key used to reference the data being registered.
+	 * @param string  $path REST API path to preload.
+	 * @param boolean $check_key_exists If set to true, duplicate data will be ignored if the key exists.
+	 *                                  If false, duplicate data will cause an exception.
+	 *
+	 * @throws InvalidArgumentException  Only throws when site is in debug mode. Always logs the error.
+	 */
+	public function hydrate_data_from_api_request( $key, $path, $check_key_exists = false ) {
+		$this->add(
+			$key,
+			function() use ( $path ) {
+				if ( isset( $this->preloaded_api_requests[ $path ], $this->preloaded_api_requests[ $path ]['body'] ) ) {
+					return $this->preloaded_api_requests[ $path ]['body'];
+				}
+				$response = Package::container()->get( Hydration::class )->get_rest_api_response_data( $path );
+				return $response['body'] ?? '';
+			},
+			$check_key_exists
+		);
 	}
 
 	/**

--- a/src/BlockTypes/AllProducts.php
+++ b/src/BlockTypes/AllProducts.php
@@ -31,18 +31,10 @@ class AllProducts extends AbstractBlock {
 		$this->asset_data_registry->add( 'max_rows', wc_get_theme_support( 'product_blocks::max_rows', 6 ), true );
 		$this->asset_data_registry->add( 'default_rows', wc_get_theme_support( 'product_blocks::default_rows', 3 ), true );
 
-		// Hydrate the following data depending on admin or frontend context.
+		// Hydrate the All Product block with data from the API. This is for the add to cart buttons which show current quantity in cart, and events.
 		if ( ! is_admin() && ! WC()->is_rest_api_request() ) {
-			$this->hydrate_from_api();
+			$this->asset_data_registry->hydrate_api_request( '/wc/store/v1/cart' );
 		}
-	}
-
-	/**
-	 * Hydrate the All Product block with data from the API. This is for the add to cart buttons which show current
-	 * quantity in cart, and events.
-	 */
-	protected function hydrate_from_api() {
-		$this->asset_data_registry->hydrate_api_request( '/wc/store/v1/cart' );
 	}
 
 	/**

--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -239,7 +239,7 @@ class Cart extends AbstractBlock {
 
 		// Hydrate the following data depending on admin or frontend context.
 		if ( ! is_admin() && ! WC()->is_rest_api_request() ) {
-			$this->hydrate_from_api();
+			$this->asset_data_registry->hydrate_api_request( '/wc/store/v1/cart' );
 		}
 
 		/**
@@ -250,19 +250,6 @@ class Cart extends AbstractBlock {
 		do_action( 'woocommerce_blocks_cart_enqueue_data' );
 	}
 
-	/**
-	 * Hydrate the cart block with data from the API.
-	 */
-	protected function hydrate_from_api() {
-		// Cache existing notices now, otherwise they are caught by the Cart Controller and converted to exceptions.
-		$old_notices = WC()->session->get( 'wc_notices', array() );
-		wc_clear_notices();
-
-		$this->asset_data_registry->hydrate_api_request( '/wc/store/v1/cart' );
-
-		// Restore notices.
-		WC()->session->set( 'wc_notices', $old_notices );
-	}
 	/**
 	 * Register script and style assets for the block type before it is registered.
 	 *

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -323,7 +323,8 @@ class Checkout extends AbstractBlock {
 		}
 
 		if ( ! is_admin() && ! WC()->is_rest_api_request() ) {
-			$this->hydrate_from_api();
+			$this->asset_data_registry->hydrate_api_request( '/wc/store/v1/cart' );
+			$this->asset_data_registry->hydrate_data_from_api_request( 'checkoutData', '/wc/store/v1/checkout' );
 			$this->hydrate_customer_payment_methods();
 		}
 
@@ -389,25 +390,6 @@ class Checkout extends AbstractBlock {
 			$payment_methods
 		);
 		remove_filter( 'woocommerce_payment_methods_list_item', [ $this, 'include_token_id_with_payment_methods' ], 10, 2 );
-	}
-
-	/**
-	 * Hydrate the checkout block with data from the API.
-	 */
-	protected function hydrate_from_api() {
-		// Cache existing notices now, otherwise they are caught by the Cart Controller and converted to exceptions.
-		$old_notices = WC()->session->get( 'wc_notices', array() );
-		wc_clear_notices();
-
-		$this->asset_data_registry->hydrate_api_request( '/wc/store/v1/cart' );
-
-		add_filter( 'woocommerce_store_api_disable_nonce_check', '__return_true' );
-		$rest_preload_api_requests = rest_preload_api_request( [], '/wc/store/v1/checkout' );
-		$this->asset_data_registry->add( 'checkoutData', $rest_preload_api_requests['/wc/store/v1/checkout']['body'] ?? [] );
-		remove_filter( 'woocommerce_store_api_disable_nonce_check', '__return_true' );
-
-		// Restore notices.
-		WC()->session->set( 'wc_notices', $old_notices );
 	}
 
 	/**

--- a/src/BlockTypesController.php
+++ b/src/BlockTypesController.php
@@ -1,7 +1,6 @@
 <?php
 namespace Automattic\WooCommerce\Blocks;
 
-use Automattic\WooCommerce\Blocks\BlockTypes\AtomicBlock;
 use Automattic\WooCommerce\Blocks\Package;
 use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
 use Automattic\WooCommerce\Blocks\Assets\Api as AssetApi;
@@ -61,10 +60,10 @@ final class BlockTypesController {
 		$block_types = $this->get_block_types();
 
 		foreach ( $block_types as $block_type ) {
-			$block_type_class    = __NAMESPACE__ . '\\BlockTypes\\' . $block_type;
-			$block_type_instance = new $block_type_class( $this->asset_api, $this->asset_data_registry, new IntegrationRegistry() );
-		}
+			$block_type_class = __NAMESPACE__ . '\\BlockTypes\\' . $block_type;
 
+			new $block_type_class( $this->asset_api, $this->asset_data_registry, new IntegrationRegistry() );
+		}
 	}
 
 	/**

--- a/src/Domain/Bootstrap.php
+++ b/src/Domain/Bootstrap.php
@@ -12,6 +12,7 @@ use Automattic\WooCommerce\Blocks\Domain\Services\Notices;
 use Automattic\WooCommerce\Blocks\Domain\Services\DraftOrders;
 use Automattic\WooCommerce\Blocks\Domain\Services\FeatureGating;
 use Automattic\WooCommerce\Blocks\Domain\Services\GoogleAnalytics;
+use Automattic\WooCommerce\Blocks\Domain\Services\Hydration;
 use Automattic\WooCommerce\Blocks\InboxNotifications;
 use Automattic\WooCommerce\Blocks\Installer;
 use Automattic\WooCommerce\Blocks\Migration;
@@ -351,6 +352,12 @@ class Bootstrap {
 			Notices::class,
 			function( Container $container ) {
 				return new Notices( $container->get( Package::class ) );
+			}
+		);
+		$this->container->register(
+			Hydration::class,
+			function( Container $container ) {
+				return new Hydration( $container->get( AssetDataRegistry::class ) );
 			}
 		);
 		$this->container->register(

--- a/src/Domain/Services/Hydration.php
+++ b/src/Domain/Services/Hydration.php
@@ -1,0 +1,97 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\Domain\Services;
+
+use Automattic\WooCommerce\Blocks\Assets\AssetDataRegistry;
+
+/**
+ * Service class that handles hydration of API data for blocks.
+ */
+class Hydration {
+	/**
+	 * Instance of the asset data registry.
+	 *
+	 * @var AssetDataRegistry
+	 */
+	protected $asset_data_registry;
+
+	/**
+	 * Cached notices to restore after hydrating the API.
+	 *
+	 * @var array
+	 */
+	protected $cached_store_notices = [];
+
+	/**
+	 * Constructor.
+	 *
+	 * @param AssetDataRegistry $asset_data_registry Instance of the asset data registry.
+	 */
+	public function __construct( AssetDataRegistry $asset_data_registry ) {
+		$this->asset_data_registry = $asset_data_registry;
+	}
+
+	/**
+	 * Hydrates the asset data registry with data from the API. Disables notices and nonces so requests contain valid
+	 * data that is not polluted by the current session.
+	 *
+	 * @param array $path API paths to hydrate e.g. '/wc/store/v1/cart'.
+	 * @return array Response data.
+	 */
+	public function get_rest_api_response_data( $path = '' ) {
+		$this->cache_store_notices();
+		$this->disable_nonce_check();
+
+		// Preload the request and add it to the array. It will be $preloaded_requests['path']  and contain 'body' and 'headers'.
+		$preloaded_requests = rest_preload_api_request( [], $path );
+
+		$this->restore_cached_store_notices();
+		$this->restore_nonce_check();
+
+		// Returns just the single preloaded request.
+		return $preloaded_requests[ $path ];
+	}
+
+	/**
+	 * Disable the nonce check temporarily.
+	 */
+	protected function disable_nonce_check() {
+		add_filter( 'woocommerce_store_api_disable_nonce_check', [ $this, 'disable_nonce_check_callback' ] );
+	}
+
+	/**
+	 * Callback to disable the nonce check. While we could use `__return_true`, we use a custom named callback so that
+	 * we can remove it later without affecting other filters.
+	 */
+	public function disable_nonce_check_callback() {
+		return true;
+	}
+
+	/**
+	 * Restore the nonce check.
+	 */
+	protected function restore_nonce_check() {
+		remove_filter( 'woocommerce_store_api_disable_nonce_check', [ $this, 'disable_nonce_check_callback' ] );
+	}
+
+	/**
+	 * Cache notices before hydrating the API if the customer has a session.
+	 */
+	protected function cache_store_notices() {
+		if ( ! did_action( 'woocommerce_init' ) || null === WC()->session ) {
+			return;
+		}
+		$this->cached_store_notices = WC()->session->get( 'wc_notices', array() );
+		WC()->session->set( 'wc_notices', null );
+	}
+
+	/**
+	 * Restore notices into current session from cache.
+	 */
+	protected function restore_cached_store_notices() {
+		if ( ! did_action( 'woocommerce_init' ) || null === WC()->session ) {
+			return;
+		}
+		WC()->session->set( 'wc_notices', $this->cached_store_notices );
+		$this->cached_store_notices = [];
+	}
+}


### PR DESCRIPTION
This is a refactor of the hydration logic so we have a shared service class for preloading requests. This shared service class handles removing nonces, and caching store notices only when a customer session object is present. This mitigates the issues in #10350.

Fixes #10350

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [x] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. Test the full shop->cart->checkout flow and look out for errors.
2. When loading the cart page, have the network inspector open and ensure there are no requests to the Store API on page load. This will confirm the hydration is still functional. 

The original issue mentioned rendering blocks via cron jobs but I don't think this is easily testable. https://github.com/woocommerce/woocommerce-blocks/issues/10350 The check for `WC()->session` being `null` is the fix for this.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Prevent a conflict with 3rd party plugins caused by using the session class too early.
