### PR TITLE
Cart and Checkout Page Migration: Inherit Page template and fix rendering

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -779,6 +779,29 @@ class BlockTemplatesController {
 	}
 
 	/**
+	 * Prepare default page template.
+	 *
+	 * @param \WP_Post $page Page object.
+	 * @return string
+	 */
+	protected function get_default_migrate_page_template( $page ) {
+		$default_template_content  = $this->get_block_template_part( 'header' );
+		$default_template_content .= '
+			<!-- wp:group {"layout":{"inherit":true}} -->
+			<div class="wp-block-group">
+				<!-- wp:heading {"level":1} -->
+				<h1 class="wp-block-heading">' . wp_kses_post( $page->post_title ) . '</h1>
+				<!-- /wp:heading -->
+				' . wp_kses_post( $page->post_content ) . '
+			</div>
+			<!-- /wp:group -->
+		';
+		$default_template_content .= $this->get_block_template_part( 'footer' );
+
+		return $default_template_content;
+	}
+
+	/**
 	 * Migrates a page to a template if needed.
 	 *
 	 * @param string   $page_id Page ID.
@@ -790,20 +813,27 @@ class BlockTemplatesController {
 			return;
 		}
 
+		// Use the page template if it exists, which we'll use over our default template if found.
+		$existing_page_template = BlockTemplateUtils::get_block_template( get_stylesheet() . '//page', 'wp_template' );
+
+		if ( $existing_page_template && ! empty( $existing_page_template->content ) ) {
+			// Massage the original content into something we can use. Replace post content with a group block.
+			$pattern          = '/(<!--\s*)wp:post-content(.*?)(\/-->)/';
+			$replacement      = '
+				<!-- wp:group $2 -->
+				<div class="wp-block-group">' . wp_kses_post( $page->post_content ) . '</div>
+				<!-- /wp:group -->
+			';
+			$template_content = preg_replace( $pattern, $replacement, $existing_page_template->content );
+		} else {
+			$template_content = $this->get_default_migrate_page_template( $page );
+		}
+
 		$request = new \WP_REST_Request( 'POST', '/wp/v2/templates/woocommerce/woocommerce//' . $page_id );
 		$request->set_body_params(
 			[
 				'id'      => 'woocommerce/woocommerce//' . $page_id,
-				'content' => $this->get_block_template_part( 'header' ) .
-					'<!-- wp:group {"layout":{"inherit":true}} -->
-					<div class="wp-block-group">
-						<!-- wp:heading {"level":1} -->
-						<h1 class="wp-block-heading">' . wp_kses_post( $page->post_title ) . '</h1>
-						<!-- /wp:heading -->
-						' . wp_kses_post( $page->post_content ) . '
-					</div>
-					<!-- /wp:group -->' .
-					$this->get_block_template_part( 'footer' ),
+				'content' => $template_content,
 			]
 		);
 		rest_get_server()->dispatch( $request );
@@ -818,7 +848,7 @@ class BlockTemplatesController {
 	 * @return string
 	 */
 	protected function get_block_template_part( $part ) {
-		$template_part = get_block_template( get_stylesheet() . '//' . $part, 'wp_template_part' );
+		$template_part = BlockTemplateUtils::get_block_template( get_stylesheet() . '//' . $part, 'wp_template_part' );
 		if ( ! $template_part || empty( $template_part->content ) ) {
 			return '';
 		}


### PR DESCRIPTION
This PR resolves the styling issues reporting in #10357, and the template migration issue reported in #10181. Both are related to how content is migrated, and how content renders after migration.

@wavvves @ralucaStan 

## Issue causes

- #10357 Shortcode blocks work differently in templates than they do in pages. The rendered shortcode is ran though `wpautop` which introduces unwanted `<br>` and `<p>` tags around and within the rendered shortcode content. This is a know WP 6.2 issue (see trac links below).
- #10181 When the page content was migrated from a page to a new template, the new template had custom headers, footers, and content wrappers. This ignored any changes made by the merchant, or theme, to the original Page template.

Refs:

- https://core.trac.wordpress.org/ticket/58366 Trac issue for the shortcode `wpautop` issue, with some workarounds. The fix I employed is similar but more specific so as not to affect other shortcodes.
- https://core.trac.wordpress.org/ticket/58333 Original trac issue about shortcodes being broken after a security fix. This had media coverage, and was supposed to be fixed in 6.2.2, however some issues remain.
- https://wordpress.org/support/topic/wordpress-v6-2-1-breaks-the-shortcode-block-in-templates/page/5/
- https://wptavern.com/wordpress-6-2-1-update-breaks-shortcode-support-in-block-templates

Fixes #10357
Fixes #10181

### Testing

#### User Facing Testing

To setup your environment for testing:

1. Switch to a non-block theme, such as Twenty Nineteen
2. Edit the Cart Page. Ensure there is some content inside, as well as a **shortcode block** containing `[woocommerce_cart]`
3. Delete WP options which may have been added already due to a past migration called `has_migrated_cart` and `has_migrated_checkout`. If you're using Local WP, you can use the Adminer tool it provides to access your DB.

![](https://files.slack.com/files-pri/T024FN1V2-F05JY4WLQ0M/screenshot_2023-07-27_at_13.03.50.png)

Testing steps:

1. Switch from your non-block theme to Twenty Twenty Three theme
2. Visit the cart page on the frontend
3. Ensure the layout of your cart page matches other pages, and that the styles look correct, for example, the "proceed to checkout" button should have no extra padding caused by an erroneous `<br>` tag.
4. Repeat for the Checkout page.
5. Edit the cart page. You'll be redirected to the template editor.
6. Replace the shortcode block with a real Cart Block and save.
7. Go back to the frontend cart page and see the block working.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

Not needed as this feature has not landed yet.
