### PR TITLE
Unify links to WordPress and WooCommerce websites in patterns

### DIFF
--- a/patterns/footer-large-dark.php
+++ b/patterns/footer-large-dark.php
@@ -80,14 +80,10 @@
 		<!-- wp:paragraph -->
 		<p><em>
 			<?php
-			echo wp_kses(
-				sprintf(
-					/* translators: %1$s is a link to WooCommerce.com, %2$s is the name of the plugin. */
-					__( 'Built with <a href="%1$s" target="_blank">%2$s</a>', 'woo-gutenberg-products-block' ),
-					'https://woocommerce.com/',
-					'WooCommerce'
-				),
-				array( 'a' => array_fill_keys( array( 'href', 'target' ), true ) )
+			echo sprintf(
+				/* translators: %s WooCommerce link */
+				esc_html__( 'Built with %s', 'woo-gutenberg-products-block' ),
+				'<a href="https://woocommerce.com/" target="_blank" rel="noreferrer nofollow">WooCommerce</a>'
 			);
 			?>
 		</em></p>

--- a/patterns/footer-large.php
+++ b/patterns/footer-large.php
@@ -79,14 +79,10 @@
 		<!-- wp:paragraph -->
 		<p><em>
 			<?php
-			echo wp_kses(
-				sprintf(
-					/* translators: %1$s is a link to WooCommerce.com, %2$s is the name of the plugin. */
-					__( 'Built with <a href="%1$s" target="_blank">%2$s</a>', 'woo-gutenberg-products-block' ),
-					'https://woocommerce.com/',
-					'WooCommerce'
-				),
-				array( 'a' => array_fill_keys( array( 'href', 'target' ), true ) )
+			echo sprintf(
+					/* translators: %s WooCommerce link */
+				esc_html__( 'Built with %s', 'woo-gutenberg-products-block' ),
+				'<a href="https://woocommerce.com/" target="_blank" rel="noreferrer nofollow">WooCommerce</a>'
 			);
 			?>
 		</em></p>

--- a/patterns/footer-simple-dark.php
+++ b/patterns/footer-simple-dark.php
@@ -50,7 +50,15 @@
 		<!-- /wp:group -->
 
 		<!-- wp:paragraph {"style":{"typography":{"fontSize":"14px"}}} -->
-		<p style="font-size:14px"><em>Built with <a href="https://woocommerce.com/">WooCommerce</a> </em></p>
+		<p style="font-size:14px"><em>
+			<?php
+			echo sprintf(
+				/* translators: %s WooCommerce link */
+				esc_html__( 'Built with %s', 'woo-gutenberg-products-block' ),
+				'<a href="https://woocommerce.com/" target="_blank" rel="noreferrer nofollow">WooCommerce</a>'
+			);
+			?>
+		</em></p>
 		<!-- /wp:paragraph -->
 	</div>
 	<!-- /wp:group -->

--- a/patterns/footer-simple-menu-and-cart.php
+++ b/patterns/footer-simple-menu-and-cart.php
@@ -42,7 +42,7 @@
 		<p class="has-text-align-center">
 			<?php
 				/* translators: 1: WordPress link, 2: WooCommerce link */
-				echo wp_kses( sprintf( __( 'Powered by %1$s with %2$s', 'woo-gutenberg-products-block' ), '<a href="https://wordpress.org">WordPress</a>', '<a href="https://woocommerce.com">WooCommerce</a>' ), array() );
+				echo sprintf( esc_html__( 'Powered by %1$s with %2$s', 'woo-gutenberg-products-block' ), '<a href="https://wordpress.org" target="_blank" rel="noreferrer nofollow">WordPress</a>', '<a href="https://woocommerce.com" target="_blank" rel="noreferrer nofollow">WooCommerce</a>' );
 			?>
 		</p>
 		<!-- /wp:paragraph -->

--- a/patterns/footer-simple.php
+++ b/patterns/footer-simple.php
@@ -50,7 +50,15 @@
 		<!-- /wp:group -->
 
 		<!-- wp:paragraph {"style":{"typography":{"fontSize":"14px"}}} -->
-		<p style="font-size:14px"><em>Built with <a href="https://woocommerce.com/">WooCommerce</a> </em></p>
+		<p style="font-size:14px"><em>
+			<?php
+			echo sprintf(
+				/* translators: %s WooCommerce link */
+				esc_html__( 'Built with %s', 'woo-gutenberg-products-block' ),
+				'<a href="https://woocommerce.com/" target="_blank" rel="noreferrer nofollow">WooCommerce</a>'
+			);
+			?>
+		</em></p>
 		<!-- /wp:paragraph -->
 	</div>
 	<!-- /wp:group -->

--- a/patterns/footer-with-2-menus-dark.php
+++ b/patterns/footer-with-2-menus-dark.php
@@ -75,7 +75,7 @@
 				'<a href="https://woocommerce.com/" target="_blank" rel="noreferrer nofollow">WooCommerce</a>'
 			);
 			?>
-		</p>
+		</em></p>
 		<!-- /wp:paragraph -->
 	</div>
 	<!-- /wp:group -->

--- a/patterns/footer-with-2-menus-dark.php
+++ b/patterns/footer-with-2-menus-dark.php
@@ -67,7 +67,15 @@
 		<!-- /wp:group -->
 
 		<!-- wp:paragraph {"style":{"typography":{"fontSize":"14px"}}} -->
-		<p style="font-size:14px"><em>Built with <a href="https://woocommerce.com/">WooCommerce</a> </em></p>
+		<p style="font-size:14px"><em>
+			<?php
+			echo sprintf(
+					/* translators: %s WooCommerce link */
+				esc_html__( 'Built with %s', 'woo-gutenberg-products-block' ),
+				'<a href="https://woocommerce.com/" target="_blank" rel="noreferrer nofollow">WooCommerce</a>'
+			);
+			?>
+		</p>
 		<!-- /wp:paragraph -->
 	</div>
 	<!-- /wp:group -->

--- a/patterns/footer-with-2-menus.php
+++ b/patterns/footer-with-2-menus.php
@@ -66,7 +66,15 @@
 		<!-- /wp:group -->
 
 		<!-- wp:paragraph {"style":{"typography":{"fontSize":"14px"}}} -->
-		<p style="font-size:14px"><em>Built with <a href="https://woocommerce.com/">WooCommerce</a> </em></p>
+		<p style="font-size:14px"><em>
+			<?php
+			echo sprintf(
+					/* translators: %s WooCommerce link */
+				esc_html__( 'Built with %s', 'woo-gutenberg-products-block' ),
+				'<a href="https://woocommerce.com/" target="_blank" rel="noreferrer nofollow">WooCommerce</a>'
+			);
+			?>
+		</em></p>
 		<!-- /wp:paragraph -->
 	</div>
 	<!-- /wp:group -->

--- a/patterns/footer-with-3-menus.php
+++ b/patterns/footer-with-3-menus.php
@@ -57,12 +57,13 @@
 					<p class="has-text-align-right">
 						<?php
 						echo sprintf(
-							esc_html(
 							/* translators: Footer powered by text. %1$s being WordPress, %2$s being WooCommerce */
-								__( 'Powered by %1$s with %2$s', 'woo-gutenberg-products-block' )
+							esc_html__(
+								'Powered by %1$s with %2$s',
+								'woo-gutenberg-products-block'
 							),
-							'<a href="https://wordpress.org">WordPress</a>',
-							'<a href="https://woocommerce.com">WooCommerce</a>'
+							'<a href="https://wordpress.org" target="_blank" rel="noreferrer nofollow">WordPress</a>',
+							'<a href="https://woocommerce.com" target="_blank" rel="noreferrer nofollow">WooCommerce</a>'
 						);
 						?>
 					</p>


### PR DESCRIPTION
This PR unifies the way we link to WordPress and WooCommerce websites in patterns following these rules:

1.  Add `target="_blank"` and `rel="noreferrer nofollow"` to all links (I used a similar PR in Storefront for inspiration: https://github.com/woocommerce/storefront/pull/2096).
2. Converge to `esc_html()`.
3. Make strings translatable.
4. Move `WordPress` and `WooCommerce` to the untranslatable part of the string. I don't have a strong preference on this, but wanted to unify to one approach and [used this](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/patterns/footer-simple-menu-and-cart.php#L45) as a reference. This also gives us the benefit to be able to use `esc_html()` instead of `wp_kses()`.

### Testing

#### User Facing Testing

1. Create a new page and add the following patterns: Large Footer, Large Footer Dark, Simple Footer, Simple Footer Dark, Footer with Simple Menu and Cart, Footer with 2 Menus, Footer with 2 Menus Dark and Footer with 3 Menus.
2. Publish the page and visit it from the frontend.
4. Click on the links to the WordPress and/or WooCommerce templates which appear at the bottom of the patterns and verify all of them look ok and open in a new tab.

* [ ] Do not include in the Testing Notes

### WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Unify 'Powered by' and 'Built with' texts in all patterns.
