### PR TITLE
Register Legacy block for all taxonomy-product_ template

### DIFF
--- a/assets/js/blocks/classic-template/constants.ts
+++ b/assets/js/blocks/classic-template/constants.ts
@@ -67,7 +67,7 @@ export const TEMPLATES: TemplateDetails = {
 		),
 		placeholder: PLACEHOLDERS.archiveProduct,
 	},
-	'taxonomy-product_': {
+	'taxonomy-product': {
 		type: TYPES.productTaxonomy,
 		title: __(
 			"WooCommerce Product's Custom Taxonomy Block",

--- a/assets/js/blocks/classic-template/constants.ts
+++ b/assets/js/blocks/classic-template/constants.ts
@@ -67,6 +67,14 @@ export const TEMPLATES: TemplateDetails = {
 		),
 		placeholder: PLACEHOLDERS.archiveProduct,
 	},
+	'taxonomy-product_': {
+		type: TYPES.productTaxonomy,
+		title: __(
+			"WooCommerce Product's Custom Taxonomy Block",
+			'woo-gutenberg-products-block'
+		),
+		placeholder: PLACEHOLDERS.archiveProduct,
+	},
 	'product-search-results': {
 		type: TYPES.productSearchResults,
 		title: __(

--- a/assets/js/blocks/classic-template/constants.ts
+++ b/assets/js/blocks/classic-template/constants.ts
@@ -67,6 +67,7 @@ export const TEMPLATES: TemplateDetails = {
 		),
 		placeholder: PLACEHOLDERS.archiveProduct,
 	},
+	// Since that it is a fallback value, it has to be the last one.
 	'taxonomy-product': {
 		type: TYPES.productTaxonomy,
 		title: __(

--- a/assets/js/blocks/classic-template/test/utils.ts
+++ b/assets/js/blocks/classic-template/test/utils.ts
@@ -25,6 +25,15 @@ describe( 'getTemplateDetailsBySlug', function () {
 
 	it( 'should return taxonomy-product object when given a partial match', () => {
 		expect(
+			getTemplateDetailsBySlug( 'taxonomy-product_tag', TEMPLATES )
+		).toBeTruthy();
+		expect(
+			getTemplateDetailsBySlug( 'taxonomy-product_tag', TEMPLATES )
+		).toStrictEqual( TEMPLATES[ 'taxonomy-product_tag' ] );
+	} );
+
+	it( 'should return taxonomy-product object when given an exact match', () => {
+		expect(
 			getTemplateDetailsBySlug( 'taxonomy-product_brands', TEMPLATES )
 		).toBeTruthy();
 		expect(

--- a/assets/js/blocks/classic-template/test/utils.ts
+++ b/assets/js/blocks/classic-template/test/utils.ts
@@ -1,26 +1,8 @@
 /**
  * Internal dependencies
  */
+import { TEMPLATES } from '../constants';
 import { getTemplateDetailsBySlug } from '../utils';
-
-const TEMPLATES = {
-	'single-product': {
-		title: 'Single Product Title',
-		placeholder: 'Single Product Placeholder',
-	},
-	'archive-product': {
-		title: 'Product Archive Title',
-		placeholder: 'Product Archive Placeholder',
-	},
-	'taxonomy-product_cat': {
-		title: 'Product Taxonomy Title',
-		placeholder: 'Product Taxonomy Placeholder',
-	},
-	'taxonomy-product_attribute': {
-		title: 'Product Attribute Title',
-		placeholder: 'Product Attribute Placeholder',
-	},
-};
 
 describe( 'getTemplateDetailsBySlug', function () {
 	it( 'should return single-product object when given an exact match', () => {
@@ -39,6 +21,15 @@ describe( 'getTemplateDetailsBySlug', function () {
 		expect(
 			getTemplateDetailsBySlug( 'single-product-hoodie', TEMPLATES )
 		).toStrictEqual( TEMPLATES[ 'single-product' ] );
+	} );
+
+	it( 'should return taxonomy-product object when given a partial match', () => {
+		expect(
+			getTemplateDetailsBySlug( 'taxonomy-product_brands', TEMPLATES )
+		).toBeTruthy();
+		expect(
+			getTemplateDetailsBySlug( 'taxonomy-product_brands', TEMPLATES )
+		).toStrictEqual( TEMPLATES[ 'taxonomy-product' ] );
 	} );
 
 	it( 'should return null object when given an incorrect match', () => {

--- a/assets/js/blocks/classic-template/utils.ts
+++ b/assets/js/blocks/classic-template/utils.ts
@@ -31,6 +31,10 @@ export function getTemplateDetailsBySlug(
 		}
 	}
 
+	if ( parsedTemplate.includes( 'taxonomy-product_' ) ) {
+		templateDetails = templates[ 'taxonomy-product_' ];
+	}
+
 	return templateDetails;
 }
 

--- a/assets/js/blocks/classic-template/utils.ts
+++ b/assets/js/blocks/classic-template/utils.ts
@@ -31,10 +31,6 @@ export function getTemplateDetailsBySlug(
 		}
 	}
 
-	if ( parsedTemplate.includes( 'taxonomy-product_' ) ) {
-		templateDetails = templates[ 'taxonomy-product_' ];
-	}
-
 	return templateDetails;
 }
 


### PR DESCRIPTION
This PR introduces a change to finds the closest matching template for the taxonomy-product_* templates. For example, `taxonomy-product_brands` will match the template details for `taxonomy-product`. (similar tohttps://github.com/woocommerce/woocommerce-blocks/pull/7033)


### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Ensure that you have the legacy block enabled for the templates by default (if not, open the database, in the table wp_option set key `wc_blocks_use_blockified_product_grid_block_as_template` to `"no"`.
2. Install WooCommerce Brands.
3. Open the template `Taxonomy Product Brand` and ensure that the legacy template is displayed correctly.

* [x] Do not include in the Testing Notes


### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental


