### PR TITLE
Featured Items: Add selection button when id not found

### DIFF
--- a/assets/js/blocks/featured-items/featured-category/block.tsx
+++ b/assets/js/blocks/featured-items/featured-category/block.tsx
@@ -36,6 +36,10 @@ const CONTENT_CONFIG = {
 		'No product category is selected.',
 		'woo-gutenberg-products-block'
 	),
+	noSelectionButtonLabel: __(
+		'Select a category',
+		'woo-gutenberg-products-block'
+	),
 };
 
 const EDIT_MODE_CONFIG = {

--- a/assets/js/blocks/featured-items/featured-product/block.tsx
+++ b/assets/js/blocks/featured-items/featured-product/block.tsx
@@ -36,6 +36,10 @@ const CONTENT_CONFIG = {
 		'No product is selected.',
 		'woo-gutenberg-products-block'
 	),
+	noSelectionButtonLabel: __(
+		'Select a product',
+		'woo-gutenberg-products-block'
+	),
 };
 
 const EDIT_MODE_CONFIG = {

--- a/assets/js/blocks/featured-items/with-featured-item.tsx
+++ b/assets/js/blocks/featured-items/with-featured-item.tsx
@@ -27,6 +27,7 @@ import {
 
 interface WithFeaturedItemConfig extends GenericBlockUIConfig {
 	emptyMessage: string;
+	noSelectionButtonLabel: string;
 }
 
 export interface FeaturedItemRequiredAttributes {
@@ -44,6 +45,7 @@ export interface FeaturedItemRequiredAttributes {
 	overlayGradient: string;
 	showDesc: boolean;
 	showPrice: boolean;
+	editMode: boolean;
 }
 
 interface FeaturedCategoryRequiredAttributes
@@ -92,7 +94,12 @@ type FeaturedItemProps< T extends EditorBlock< T > > =
 	| ( T & FeaturedProductProps< T > );
 
 export const withFeaturedItem =
-	( { emptyMessage, icon, label }: WithFeaturedItemConfig ) =>
+	( {
+		emptyMessage,
+		icon,
+		label,
+		noSelectionButtonLabel,
+	}: WithFeaturedItemConfig ) =>
 	< T extends EditorBlock< T > >( Component: ComponentType< T > ) =>
 	( props: FeaturedItemProps< T > ) => {
 		const [ isEditingImage ] = props.useEditingImage;
@@ -140,13 +147,29 @@ export const withFeaturedItem =
 			);
 		};
 
+		const renderNoItemButton = () => {
+			return (
+				<>
+					<p>{ emptyMessage }</p>
+					<div style={ { flexBasis: '100%', height: '0' } }></div>
+					<button
+						type="button"
+						className="components-button is-secondary"
+						onClick={ () => setAttributes( { editMode: true } ) }
+					>
+						{ noSelectionButtonLabel }
+					</button>
+				</>
+			);
+		};
+
 		const renderNoItem = () => (
 			<Placeholder
 				className={ className }
 				icon={ <Icon icon={ icon } /> }
 				label={ label }
 			>
-				{ isLoading ? <Spinner /> : emptyMessage }
+				{ isLoading ? <Spinner /> : renderNoItemButton() }
 			</Placeholder>
 		);
 


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/10257

This PR adds a `call to action` button to allow user to re-select a featured item when the original saved ID is not found. Otherwise there is no way for the user to select an ID in a user friendly way.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|![file.png](https://github.com/woocommerce/woocommerce-blocks/assets/2132595/43775953-41be-4641-baae-79d0f48b8600)        |![file.png](https://github.com/woocommerce/woocommerce-blocks/assets/2132595/8082adf2-f715-4369-ae09-1a75a0f811a4)       |

### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Add the `Featured Category` block to a page.
2. Select an existing ID and click `Done`.
3. Go into `Code editor` mode and replace the `categoryId` to some random number that does not exists.
4. Click on `Exit code editor`.
5. You should now see an error `Sorry, an error occurred`.
6. Ensure you see the `Select a category` button and click it.
7. Ensure now you can select an existing category.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Add selection button to featured items block when id not found