### PR TITLE
Remove info-verbosity from `npm start` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
 		"reformat-files": "prettier --ignore-path .eslintignore --write \"**/*.{js,jsx,json,ts,tsx}\"",
 		"release": "sh ./bin/wordpress-deploy.sh",
 		"rimraf": "./node_modules/rimraf/bin.js",
-		"start": "rimraf build/* && cross-env BABEL_ENV=default CHECK_CIRCULAR_DEPS=true webpack --watch --info-verbosity none",
+		"start": "rimraf build/* && cross-env BABEL_ENV=default CHECK_CIRCULAR_DEPS=true webpack --watch",
 		"storybook": "start-storybook  -c ./storybook -p 6006 --ci",
 		"storybook:build": "BABEL_ENV=development build-storybook  -c ./storybook -o ./storybook/dist",
 		"storybook:deploy": "rimraf ./storybook/dist/* && npm run storybook:build && gh-pages -d ./storybook/dist",


### PR DESCRIPTION
Earlier we updated the `webpack-cli` dependency:

https://github.com/woocommerce/woocommerce-blocks/commit/4dcbe986647e19be2df27683d5ad9a167409d7a4

`--info-verbosity` is no longer supported, so this PR removes it. It doesn't appear to be needed.

### Testing

Successfully run:

`nvm use && npm install && npm start`

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->
