### PR TITLE
$post validation on Cart and Checkout template

### DIFF
--- a/src/Templates/CartTemplate.php
+++ b/src/Templates/CartTemplate.php
@@ -33,7 +33,7 @@ class CartTemplate extends AbstractPageTemplate {
 	 */
 	protected function is_active_template() {
 		global $post;
-		return get_option( 'woocommerce_cart_page_endpoint' ) === $post->post_name;
+		return $post instanceof \WP_Post && get_option( 'woocommerce_cart_page_endpoint' ) === $post->post_name;
 	}
 
 	/**

--- a/src/Templates/CheckoutTemplate.php
+++ b/src/Templates/CheckoutTemplate.php
@@ -42,6 +42,6 @@ class CheckoutTemplate extends AbstractPageTemplate {
 	 */
 	public function is_active_template() {
 		global $post;
-		return get_option( 'woocommerce_checkout_page_endpoint' ) === $post->post_name;
+		return $post instanceof \WP_Post && get_option( 'woocommerce_checkout_page_endpoint' ) === $post->post_name;
 	}
 }


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

We need to check `$post` before accessing `post_name` property.


#### Dev testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Access a 404 page
2. No warnings should appear on logs regarding CartTemplate.php or CheckoutTemplate.php

### Changelog

> n/a
