### PR TITLE
Add new GH Action for ensuring the correct labels are added to PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,6 +18,7 @@ Fixes #
 
 #### Other Checks
 
+- [ ] This PR has either a `[type]` label or a `[skip-changelog]` label.
 - [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
 - [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
 - [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

--- a/.github/workflows/pr-label-validation.yml
+++ b/.github/workflows/pr-label-validation.yml
@@ -20,5 +20,5 @@ jobs:
     name: Check [Type] Label
     runs-on: ubuntu-latest
     steps:
-      - if: contains( env.LABELS, '[Type]' ) === false && contains( env.LABELS, 'skip-changelog' ) === false
+      - if: contains( env.LABELS, '[type]' ) == false && contains( env.LABELS, 'skip-changelog' ) == false
         run: exit 1

--- a/.github/workflows/pr-label-validation.yml
+++ b/.github/workflows/pr-label-validation.yml
@@ -1,0 +1,24 @@
+name: Pull Request Label Validation
+
+on:
+  pull_request:
+    branches:
+      - trunk
+    types:
+      - labeled
+      - unlabeled
+      - opened
+      - reopened
+      - synchronize
+      - edited
+
+env:
+  LABELS: ${{ join( github.event.pull_request.labels.*.name, ' ' ) }}
+
+jobs:
+  check-type-label:
+    name: Check [Type] Label
+    runs-on: ubuntu-latest
+    steps:
+      - if: contains( env.LABELS, '[Type]' ) === false && contains( env.LABELS, 'skip-changelog' ) === false
+        run: exit 1

--- a/.github/workflows/pr-label-validation.yml
+++ b/.github/workflows/pr-label-validation.yml
@@ -20,5 +20,5 @@ jobs:
     name: Check [Type] Label
     runs-on: ubuntu-latest
     steps:
-      - if: contains( env.LABELS, '[type]' ) == false && contains( env.LABELS, 'skip-changelog' ) == false
+      - if: contains( env.LABELS, 'type' ) == false && contains( env.LABELS, 'skip-changelog' ) == false
         run: exit 1


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

Introduce a new action to ensure every pull request has either one of the `[type] abc` labels or the `[skip-changelog]` label, which is used to group pull requests in the changelog. By making this a requirement that has to be met before a pull request can be merged, we are streamlining the process & reducing the overhead for the release manager.

### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Make sure all checks on this PR are successful - Including the new one introduced here called `Pull Request Label Validation`

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->