### PR TITLE
Unauthenticated views for Order Confirmation template

### DIFF
--- a/assets/js/blocks/classic-template/order-confirmation.tsx
+++ b/assets/js/blocks/classic-template/order-confirmation.tsx
@@ -18,10 +18,10 @@ const getButtonLabel = () =>
 
 const getBlockifiedTemplate = ( inheritedAttributes: InheritedAttributes ) =>
 	[
-		createBlock(
-			'woocommerce/order-confirmation-status',
-			inheritedAttributes
-		),
+		createBlock( 'woocommerce/order-confirmation-status', {
+			...inheritedAttributes,
+			fontSize: 'large',
+		} ),
 		createBlock(
 			'woocommerce/order-confirmation-summary',
 			inheritedAttributes

--- a/assets/js/blocks/order-confirmation/summary/style.scss
+++ b/assets/js/blocks/order-confirmation/summary/style.scss
@@ -12,10 +12,10 @@
 		li {
 			flex: 1 1 auto;
 
-			> span {
-				@include font-size(small);
+			> .wc-block-order-confirmation-summary-list-item__key {
+				font-weight: bold;
 			}
-			> strong {
+			> .wc-block-order-confirmation-summary-list-item__value {
 				font-weight: inherit;
 				display: block;
 			}

--- a/src/BlockTypes/OrderConfirmation/AbstractOrderConfirmationBlock.php
+++ b/src/BlockTypes/OrderConfirmation/AbstractOrderConfirmationBlock.php
@@ -3,6 +3,7 @@
 namespace Automattic\WooCommerce\Blocks\BlockTypes\OrderConfirmation;
 
 use Automattic\WooCommerce\Blocks\BlockTypes\AbstractBlock;
+use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
 
 /**
  * AbstractOrderConfirmationBlock class.
@@ -23,15 +24,55 @@ abstract class AbstractOrderConfirmationBlock extends AbstractBlock {
 	}
 
 	/**
-	 * This renders the content of the block within the wrapper.
+	 * Render the block.
 	 *
-	 * @param \WC_Order $order Order object.
-	 * @return string
+	 * @param array    $attributes Block attributes.
+	 * @param string   $content Block content.
+	 * @param WP_Block $block Block instance.
+	 *
+	 * @return string | void Rendered block output.
 	 */
-	abstract protected function render_content( $order );
+	protected function render( $attributes, $content, $block ) {
+		if ( ! empty( $attributes['isPreview'] ) ) {
+			$order      = $this->get_preview_order();
+			$permission = 'full';
+		} else {
+			$order      = $this->get_order();
+			$permission = $this->get_view_order_permissions( $order );
+		}
+
+		$block_content      = $order ? $this->render_content( $order, $permission, $attributes ) : $this->render_content_fallback();
+		$classname          = $attributes['className'] ?? '';
+		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes );
+
+		if ( isset( $attributes['align'] ) ) {
+			$classname .= " align{$attributes['align']}";
+		}
+
+		return sprintf(
+			'<div class="wc-block-%5$s %1$s %2$s" style="%3$s">%4$s</div>',
+			esc_attr( $classes_and_styles['classes'] ),
+			esc_attr( $classname ),
+			esc_attr( $classes_and_styles['styles'] ),
+			$block_content,
+			esc_attr( $this->block_name )
+		);
+	}
 
 	/**
-	 * This is what gets rendered when the order does not exist.
+	 * This renders the content of the block within the wrapper. The permission determines what data can be shown under
+	 * the given context.
+	 *
+	 * @param \WC_Order $order Order object.
+	 * @param string    $permission Permission level for viewing order details.
+	 * @param array     $attributes Block attributes.
+	 * @return string
+	 */
+	abstract protected function render_content( $order, $permission = false, $attributes = [] );
+
+	/**
+	 * This is what gets rendered when the order does not exist. Renders nothing by default, but can be overridden by
+	 * child classes.
 	 *
 	 * @return string
 	 */
@@ -57,26 +98,72 @@ abstract class AbstractOrderConfirmationBlock extends AbstractBlock {
 	}
 
 	/**
-	 * See if the current user has access to sensitive order details.
+	 * View mode for order details based on the order, current user, and settings.
+	 *
+	 * Possible values are:
+	 * - "full" user can view all order details.
+	 * - "limited" user can view some order details, but no PII. This may happen for example, if the user checked out as a guest.
+	 * - false user cannot view order details.
 	 *
 	 * @param \WC_Order|null $order Order object.
-	 * @return boolean
+	 * @return "full"|"limited"|false
 	 */
-	protected function is_current_customer_order( $order ) {
+	protected function get_view_order_permissions( $order ) {
 		if ( ! $order ) {
 			return false;
 		}
 
-		if ( ! is_user_logged_in() || $order->get_user_id() !== get_current_user_id() ) {
-			return false;
+		if ( is_user_logged_in() ) {
+			// If logged in, check the user owns the order.
+			return $this->is_current_customer_order( $order ) ? 'full' : false;
 		}
 
+		// If the user is logged out, check the order key for validity.
+		if ( $this->allow_guest_checkout() && $this->has_valid_order_key( $order ) ) {
+			return $this->order_matches_session( $order ) ? 'full' : 'limited';
+		}
+
+		return false;
+	}
+
+	/**
+	 * See if guest checkout is enabled.
+	 *
+	 * @return boolean
+	 */
+	protected function allow_guest_checkout() {
+		return 'yes' === get_option( 'woocommerce_enable_guest_checkout' );
+	}
+
+	/**
+	 * See if the order key is valid.
+	 *
+	 * @param \WC_Order $order Order object.
+	 * @return boolean
+	 */
+	protected function has_valid_order_key( $order ) {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		if ( empty( $_GET['key'] ) || ! $order->key_is_valid( wc_clean( wp_unslash( $_GET['key'] ) ) ) ) {
-			return false;
-		}
+		return ! empty( $_GET['key'] ) && $order->key_is_valid( wc_clean( wp_unslash( $_GET['key'] ) ) );
+	}
 
-		return true;
+	/**
+	 * See if the current user has access to sensitive order details.
+	 *
+	 * @param \WC_Order $order Order object.
+	 * @return boolean
+	 */
+	protected function is_current_customer_order( $order ) {
+		return get_current_user_id() > 0 && $order->get_user_id() === get_current_user_id();
+	}
+
+	/**
+	 * See if the order matches the current session.
+	 *
+	 * @param \WC_Order $order Order object.
+	 * @return boolean
+	 */
+	protected function order_matches_session( $order ) {
+		return $order->get_id() === wc()->session->get( 'store_api_draft_order' );
 	}
 
 	/**

--- a/src/BlockTypes/OrderConfirmation/AbstractOrderConfirmationBlock.php
+++ b/src/BlockTypes/OrderConfirmation/AbstractOrderConfirmationBlock.php
@@ -119,7 +119,7 @@ abstract class AbstractOrderConfirmationBlock extends AbstractBlock {
 		}
 
 		// If the user is logged out, check the order key for validity.
-		if ( $this->allow_guest_checkout() && $this->has_valid_order_key( $order ) ) {
+		if ( $this->allow_guest_checkout() && $this->is_current_customer_order( $order ) && $this->has_valid_order_key( $order ) ) {
 			return $this->order_matches_session( $order ) ? 'full' : 'limited';
 		}
 
@@ -147,13 +147,13 @@ abstract class AbstractOrderConfirmationBlock extends AbstractBlock {
 	}
 
 	/**
-	 * See if the current user has access to sensitive order details.
+	 * See if the current user ID matches the given order customer ID.
 	 *
 	 * @param \WC_Order $order Order object.
 	 * @return boolean
 	 */
 	protected function is_current_customer_order( $order ) {
-		return get_current_user_id() > 0 && $order->get_user_id() === get_current_user_id();
+		return $order->get_user_id() === get_current_user_id();
 	}
 
 	/**

--- a/src/BlockTypes/OrderConfirmation/BillingAddress.php
+++ b/src/BlockTypes/OrderConfirmation/BillingAddress.php
@@ -17,58 +17,20 @@ class BillingAddress extends AbstractOrderConfirmationBlock {
 	protected $block_name = 'order-confirmation-billing-address';
 
 	/**
-	 * Render the block.
-	 *
-	 * @param array    $attributes Block attributes.
-	 * @param string   $content Block content.
-	 * @param WP_Block $block Block instance.
-	 *
-	 * @return string | void Rendered block output.
-	 */
-	protected function render( $attributes, $content, $block ) {
-		$order              = $this->get_order();
-		$content            = $order && $this->is_current_customer_order( $order ) ? $this->render_content( $order ) : $this->render_content_fallback();
-		$classname          = $attributes['className'] ?? '';
-		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes );
-
-		if ( isset( $attributes['align'] ) ) {
-			$classname .= " align{$attributes['align']}";
-		}
-
-		return sprintf(
-			'<div class="wc-block-%4$s %1$s %2$s">%3$s</div>',
-			esc_attr( $classes_and_styles['classes'] ),
-			esc_attr( $classname ),
-			$content,
-			esc_attr( $this->block_name )
-		);
-	}
-
-	/**
 	 * This renders the content of the block within the wrapper.
 	 *
 	 * @param \WC_Order $order Order object.
+	 * @param string    $permission Permission level for viewing order details.
+	 * @param array     $attributes Block attributes.
 	 * @return string
 	 */
-	protected function render_content( $order ) {
-		$fallback = esc_html__( 'This order has no billing address.', 'woo-gutenberg-products-block' );
-		$address  = $order->get_formatted_billing_address( $fallback );
-		$address  = $address . ( $order->get_billing_phone() ? '<p class="woocommerce-customer-details--phone">' . esc_html( $order->get_billing_phone() ) . '</p>' : '' );
-		$address  = $address . ( $order->get_billing_email() ? '<p class="woocommerce-customer-details--email">' . esc_html( $order->get_billing_email() ) . '</p>' : '' );
+	protected function render_content( $order, $permission = false, $attributes = [] ) {
+		if ( 'full' !== $permission ) {
+			return '';
+		}
+		$address = $order->get_formatted_billing_address( esc_html__( 'This order has no billing address.', 'woo-gutenberg-products-block' ) );
+		$address = $address . ( $order->get_billing_phone() ? '<br><span class="woocommerce-customer-details--phone">' . esc_html( $order->get_billing_phone() ) . '</span>' : '' );
 
-		return '
-			<address>
-				' . wp_kses_post( $address ) . '
-			</address>
-		';
-	}
-
-	/**
-	 * This is what gets rendered when the order does not exist.
-	 *
-	 * @return string
-	 */
-	protected function render_content_fallback() {
-		return '-';
+		return '<address>' . wp_kses_post( $address ) . '</address>';
 	}
 }

--- a/src/BlockTypes/OrderConfirmation/Downloads.php
+++ b/src/BlockTypes/OrderConfirmation/Downloads.php
@@ -17,17 +17,15 @@ class Downloads extends AbstractOrderConfirmationBlock {
 	protected $block_name = 'order-confirmation-downloads';
 
 	/**
-	 * Render the block.
+	 * This renders the content of the block within the wrapper.
 	 *
-	 * @param array    $attributes Block attributes.
-	 * @param string   $content Block content.
-	 * @param WP_Block $block Block instance.
-	 *
-	 * @return string | void Rendered block output.
+	 * @param \WC_Order $order Order object.
+	 * @param string    $permission Permission level for viewing order details.
+	 * @param array     $attributes Block attributes.
+	 * @return string
 	 */
-	protected function render( $attributes, $content, $block ) {
+	protected function render_content( $order, $permission = false, $attributes = [] ) {
 		if ( ! empty( $attributes['isPreview'] ) ) {
-			$order          = $this->get_preview_order();
 			$show_downloads = true;
 			$downloads      = [
 				[
@@ -38,41 +36,14 @@ class Downloads extends AbstractOrderConfirmationBlock {
 				],
 			];
 		} else {
-			$order = $this->get_order();
-
-			if ( ! $this->is_current_customer_order( $order ) ) {
-				$order = null;
-			}
-
 			$show_downloads = $order && $order->has_downloadable_item() && $order->is_download_permitted();
 			$downloads      = $order ? $order->get_downloadable_items() : [];
 		}
 
-		$content            = $order && $show_downloads ? $this->render_content( $order, $downloads ) : $this->render_content_fallback();
-		$classname          = $attributes['className'] ?? '';
-		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes );
-
-		if ( isset( $attributes['align'] ) ) {
-			$classname .= " align{$attributes['align']}";
+		if ( 'full' !== $permission || ! $show_downloads ) {
+			return $this->render_content_fallback();
 		}
 
-		return $content ? sprintf(
-			'<div class="wc-block-%4$s %1$s %2$s">%3$s</div>',
-			esc_attr( $classes_and_styles['classes'] ),
-			esc_attr( $classname ),
-			$content,
-			esc_attr( $this->block_name )
-		) : '';
-	}
-
-	/**
-	 * This renders the content of the block within the wrapper.
-	 *
-	 * @param \WC_Order $order Order object.
-	 * @param array     $downloads Array of downloads.
-	 * @return string
-	 */
-	protected function render_content( $order, $downloads = [] ) {
 		return '
 			<section class="woocommerce-order-downloads">
 				<table class="woocommerce-table woocommerce-table--order-downloads shop_table shop_table_responsive order_details" cellspacing="0">


### PR DESCRIPTION
This PR implements multiple views of the order confirmation blocks depending on the user accessing the page.

Access is determined by:

- The order ID in the URL
- The order KEY in the URL
- Current user ID
- The order's user ID
- The current draft order ID in session

Using this data we can lock down certain blocks or hide personal information. This can be **full** (all details shown), **limited** (no PII), **false** (no details). There is also a state where no order was found at all. This table summarises the different views and what they would render.

| Logged in | User ID = order user ID | Has session | Valid Key | Result
| ------ | ----- | ----- | ----- | ----- |
| ✅ | ✅ | n/a | n/a | Full |
| ✅ | no | n/a | n/a | False |
| no | ✅ | ✅ | ✅ | Full |
| no | ✅ | no | ✅ | Limited |

All other cases result in `false` permissions. Screenshots can be found below showing the various states.

Fixes #10408

### Screenshots

Note the billing and shipping visibility is waiting on https://github.com/woocommerce/woocommerce-blocks/pull/10286 

#### Full

![Screenshot 2023-07-31 at 14 49 11](https://github.com/woocommerce/woocommerce-blocks/assets/90977/fffb1ec1-455f-4858-a15c-d49c71bcda2d)

#### Limited

![Screenshot 2023-07-31 at 14 49 24](https://github.com/woocommerce/woocommerce-blocks/assets/90977/d1fd9025-bf1c-45c5-a841-f05400c79063)

#### False (no access)

![Screenshot 2023-07-31 at 14 49 32](https://github.com/woocommerce/woocommerce-blocks/assets/90977/fa320813-f129-4ba2-ad10-3ccac8c35d85)

#### No order

![Screenshot 2023-07-31 at 14 49 39](https://github.com/woocommerce/woocommerce-blocks/assets/90977/b22c01f1-f301-40c7-8ce8-0410f801ade8)

### Testing

1. Place an order as a guest. 
2. Confirm that the confirmation shows full details after checkout.
3. Take the URL and open a new incognito window. Confirm confirmation shows limited details.
4. Remove the order key from the URL. Confirm confirmation shows no details.
5. Place an order as a logged in user.
6. Confirm that the confirmation shows full details after checkout.
7. Copy the URL, Log out, and access the url again. Confirm confirmation shows no details.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental