### PR TITLE
Run `phpcs` on all files

### DIFF
--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -64,4 +64,4 @@ jobs:
               run: |
                 git fetch origin trunk
                 changes=$(git diff --name-only origin/trunk..HEAD | tr '\n' ' ')
-                phpcs ${changes} -q --report=checkstyle | cs2pr
+                [ -z "$changes" ] || phpcs ${changes} -q --report=checkstyle | cs2pr

--- a/.github/workflows/php-coding-standards.yml
+++ b/.github/workflows/php-coding-standards.yml
@@ -62,6 +62,4 @@ jobs:
 
             - name: Run PHPCS on all changed files
               run: |
-                git fetch origin trunk
-                changes=$(git diff --name-only origin/trunk..HEAD | tr '\n' ' ')
-                [ -z "$changes" ] || phpcs ${changes} -q --report=checkstyle | cs2pr
+                phpcs ./src -q --report=checkstyle | cs2pr

--- a/src/BlockTypes/HandpickedProducts.php
+++ b/src/BlockTypes/HandpickedProducts.php
@@ -21,7 +21,7 @@ class HandpickedProducts extends AbstractProductGrid {
 		$ids = array_map( 'absint', $this->attributes['products'] );
 
 		$query_args['post__in']       = $ids;
-		$query_args['posts_per_page'] = count( $ids );
+		$query_args['posts_per_page'] = count( $ids ); // phpcs:ignore WordPress.WP.PostsPerPage.posts_per_page_posts_per_page
 	}
 
 	/**


### PR DESCRIPTION
This goes back to running the PHP lint in all files, since it was failing when merging to trunk.

### Testing
Introduce a lint error or warning on a PHP file and check the CI fails.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
