### PR TITLE
Replace propTypes with TypeScript definitions on `price-filter/block.tsx`

### DIFF
--- a/assets/js/blocks/price-filter/block.tsx
+++ b/assets/js/blocks/price-filter/block.tsx
@@ -11,7 +11,6 @@ import { useCallback, useState, useEffect } from '@wordpress/element';
 import PriceSlider from '@woocommerce/base-components/price-slider';
 import FilterTitlePlaceholder from '@woocommerce/base-components/filter-placeholder';
 import { useDebouncedCallback } from 'use-debounce';
-import PropTypes from 'prop-types';
 import { getCurrencyFromPriceResponse } from '@woocommerce/price-format';
 import { getSettingWithCoercion } from '@woocommerce/settings';
 import { addQueryArgs, removeQueryArgs } from '@wordpress/url';
@@ -72,6 +71,17 @@ function formatPrice( value: unknown, minorUnit: number ) {
 	return Number( value ) * 10 ** minorUnit;
 }
 
+interface PriceFilterBlockProps {
+	/**
+	 * The attributes for this block.
+	 */
+	attributes: Attributes;
+	/**
+	 * Whether it's in the editor or frontend display.
+	 */
+	isEditor: boolean;
+}
+
 /**
  * Component displaying a price filter.
  *
@@ -82,10 +92,7 @@ function formatPrice( value: unknown, minorUnit: number ) {
 const PriceFilterBlock = ( {
 	attributes,
 	isEditor = false,
-}: {
-	attributes: Attributes;
-	isEditor: boolean;
-} ) => {
+}: PriceFilterBlockProps ) => {
 	const setWrapperVisibility = useSetWraperVisibility();
 	const hasFilterableProducts = getSettingWithCoercion(
 		'has_filterable_products',
@@ -353,17 +360,6 @@ const PriceFilterBlock = ( {
 			</div>
 		</>
 	);
-};
-
-PriceFilterBlock.propTypes = {
-	/**
-	 * The attributes for this block.
-	 */
-	attributes: PropTypes.object.isRequired,
-	/**
-	 * Whether it's in the editor or frontend display.
-	 */
-	isEditor: PropTypes.bool,
 };
 
 export default PriceFilterBlock;


### PR DESCRIPTION
This PR replaces the `propTypes` for the `Price filter`.

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/9545

### Testing

#### User Facing Testing

1. Create a post/page and insert the `Price filter` block.
2. Smoke-test the block and make sure it works as expected.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
