### PR TITLE
Fix wcSettings inconsistent property naming style

### DIFF
--- a/assets/js/atomic/blocks/product-elements/image/edit.tsx
+++ b/assets/js/atomic/blocks/product-elements/image/edit.tsx
@@ -54,7 +54,7 @@ const Edit = ( {
 	const blockProps = useBlockProps( { style: { width, height } } );
 	const isDescendentOfQueryLoop = Number.isFinite( context.queryId );
 	const isBlockThemeEnabled = getSettingWithCoercion(
-		'is_block_theme_enabled',
+		'isBlockThemeEnabled',
 		false,
 		isBoolean
 	);

--- a/assets/js/blocks/active-filters/active-attribute-filters.tsx
+++ b/assets/js/blocks/active-filters/active-attribute-filters.tsx
@@ -73,7 +73,7 @@ const ActiveAttributeFilters = ( {
 	const attributeLabel = attributeObject.label;
 
 	const filteringForPhpTemplate = getSettingWithCoercion(
-		'is_rendering_php_template',
+		'isRenderingPhpTemplate',
 		false,
 		isBoolean
 	);

--- a/assets/js/blocks/active-filters/block.tsx
+++ b/assets/js/blocks/active-filters/block.tsx
@@ -59,7 +59,7 @@ const ActiveFiltersBlock = ( {
 	const isMounted = useIsMounted();
 	const componentHasMounted = isMounted();
 	const filteringForPhpTemplate = getSettingWithCoercion(
-		'is_rendering_php_template',
+		'isRenderingPhpTemplate',
 		false,
 		isBoolean
 	);
@@ -323,7 +323,7 @@ const ActiveFiltersBlock = ( {
 	);
 
 	const hasFilterableProducts = getSettingWithCoercion(
-		'has_filterable_products',
+		'hasFilterableProducts',
 		false,
 		isBoolean
 	);

--- a/assets/js/blocks/attribute-filter/block.tsx
+++ b/assets/js/blocks/attribute-filter/block.tsx
@@ -72,19 +72,19 @@ const AttributeFilterBlock = ( {
 	getNotice?: GetNotice;
 } ) => {
 	const hasFilterableProducts = getSettingWithCoercion(
-		'has_filterable_products',
+		'hasFilterableProducts',
 		false,
 		isBoolean
 	);
 
 	const filteringForPhpTemplate = getSettingWithCoercion(
-		'is_rendering_php_template',
+		'isRenderingPhpTemplate',
 		false,
 		isBoolean
 	);
 
 	const pageUrl = getSettingWithCoercion(
-		'page_url',
+		'pageUrl',
 		window.location.href,
 		isString
 	);

--- a/assets/js/blocks/cart/inner-blocks/cart-cross-sells-products/edit.tsx
+++ b/assets/js/blocks/cart/inner-blocks/cart-cross-sells-products/edit.tsx
@@ -42,8 +42,8 @@ export const Edit = ( { attributes, setAttributes }: Props ): JSX.Element => {
 						onChange={ ( value ) =>
 							setAttributes( { columns: value } )
 						}
-						min={ getSetting( 'min_columns', 1 ) }
-						max={ getSetting( 'max_columns', 6 ) }
+						min={ getSetting( 'minColumns', 1 ) }
+						max={ getSetting( 'maxColumns', 6 ) }
 					/>
 				</PanelBody>
 			</InspectorControls>

--- a/assets/js/blocks/featured-items/register.tsx
+++ b/assets/js/blocks/featured-items/register.tsx
@@ -64,7 +64,7 @@ export function register(
 			 */
 			minHeight: {
 				type: 'number',
-				default: getSetting( 'default_height', 500 ),
+				default: getSetting( 'defaultHeight', 500 ),
 			},
 		},
 		supports: {
@@ -100,7 +100,7 @@ export function register(
 			editMode: false,
 			hasParallax: false,
 			isRepeated: false,
-			height: getSetting( 'default_height', 500 ),
+			height: getSetting( 'defaultHeight', 500 ),
 			mediaSrc: '',
 			overlayColor: '#000000',
 			showDesc: true,

--- a/assets/js/blocks/handpicked-products/index.tsx
+++ b/assets/js/blocks/handpicked-products/index.tsx
@@ -25,7 +25,7 @@ registerBlockType( metadata, {
 		...metadata.attributes,
 		columns: {
 			type: 'number',
-			default: getSetting( 'default_columns', 3 ),
+			default: getSetting( 'defaultColumns', 3 ),
 		},
 	},
 

--- a/assets/js/blocks/handpicked-products/inspector-controls.tsx
+++ b/assets/js/blocks/handpicked-products/inspector-controls.tsx
@@ -32,8 +32,8 @@ export const HandpickedProductsInspectorControls = (
 					onChange={ ( value ) =>
 						setAttributes( { columns: value } )
 					}
-					min={ getSetting( 'min_columns', 1 ) }
-					max={ getSetting( 'max_columns', 6 ) }
+					min={ getSetting( 'minColumns', 1 ) }
+					max={ getSetting( 'maxColumns', 6 ) }
 				/>
 				<ToggleControl
 					label={ __(

--- a/assets/js/blocks/price-filter/block.tsx
+++ b/assets/js/blocks/price-filter/block.tsx
@@ -88,13 +88,13 @@ const PriceFilterBlock = ( {
 } ) => {
 	const setWrapperVisibility = useSetWraperVisibility();
 	const hasFilterableProducts = getSettingWithCoercion(
-		'has_filterable_products',
+		'hasFilterableProducts',
 		false,
 		isBoolean
 	);
 
 	const filteringForPhpTemplate = getSettingWithCoercion(
-		'is_rendering_php_template',
+		'isRenderingPhpTemplate',
 		false,
 		isBoolean
 	);

--- a/assets/js/blocks/product-best-sellers/inspector-controls.tsx
+++ b/assets/js/blocks/product-best-sellers/inspector-controls.tsx
@@ -38,10 +38,10 @@ export const ProductBestSellersInspectorControls = (
 					rows={ rows }
 					alignButtons={ alignButtons }
 					setAttributes={ setAttributes }
-					minColumns={ getSetting( 'min_columns', 1 ) }
-					maxColumns={ getSetting( 'max_columns', 6 ) }
-					minRows={ getSetting( 'min_rows', 1 ) }
-					maxRows={ getSetting( 'max_rows', 6 ) }
+					minColumns={ getSetting( 'minColumns', 1 ) }
+					maxColumns={ getSetting( 'maxColumns', 6 ) }
+					minRows={ getSetting( 'minRows', 1 ) }
+					maxRows={ getSetting( 'maxRows', 6 ) }
 				/>
 			</PanelBody>
 			<PanelBody

--- a/assets/js/blocks/product-category/inspector-controls.tsx
+++ b/assets/js/blocks/product-category/inspector-controls.tsx
@@ -73,10 +73,10 @@ export const ProductsByCategoryInspectorControls = (
 					rows={ rows }
 					alignButtons={ alignButtons }
 					setAttributes={ setAttributes }
-					minColumns={ getSetting( 'min_columns', 1 ) }
-					maxColumns={ getSetting( 'max_columns', 6 ) }
-					minRows={ getSetting( 'min_rows', 1 ) }
-					maxRows={ getSetting( 'max_rows', 6 ) }
+					minColumns={ getSetting( 'minColumns', 1 ) }
+					maxColumns={ getSetting( 'maxColumns', 6 ) }
+					minRows={ getSetting( 'minRows', 1 ) }
+					maxRows={ getSetting( 'maxRows', 6 ) }
 				/>
 			</PanelBody>
 			<PanelBody

--- a/assets/js/blocks/product-new/block.tsx
+++ b/assets/js/blocks/product-new/block.tsx
@@ -46,10 +46,10 @@ export const ProductNewestBlock = ( {
 						rows={ rows }
 						alignButtons={ alignButtons }
 						setAttributes={ setAttributes }
-						minColumns={ getSetting( 'min_columns', 1 ) }
-						maxColumns={ getSetting( 'max_columns', 6 ) }
-						minRows={ getSetting( 'min_rows', 1 ) }
-						maxRows={ getSetting( 'max_rows', 6 ) }
+						minColumns={ getSetting( 'minColumns', 1 ) }
+						maxColumns={ getSetting( 'maxColumns', 6 ) }
+						minRows={ getSetting( 'minRows', 1 ) }
+						maxRows={ getSetting( 'maxRows', 6 ) }
 					/>
 				</PanelBody>
 				<PanelBody

--- a/assets/js/blocks/product-on-sale/inspector-controls.tsx
+++ b/assets/js/blocks/product-on-sale/inspector-controls.tsx
@@ -47,10 +47,10 @@ export const ProductOnSaleInspectorControls = (
 					rows={ rows }
 					alignButtons={ alignButtons }
 					setAttributes={ setAttributes }
-					minColumns={ getSetting< number >( 'min_columns', 1 ) }
-					maxColumns={ getSetting< number >( 'max_columns', 6 ) }
-					minRows={ getSetting< number >( 'min_rows', 1 ) }
-					maxRows={ getSetting< number >( 'max_rows', 6 ) }
+					minColumns={ getSetting< number >( 'minColumns', 1 ) }
+					maxColumns={ getSetting< number >( 'maxColumns', 6 ) }
+					minRows={ getSetting< number >( 'minRows', 1 ) }
+					maxRows={ getSetting< number >( 'maxRows', 6 ) }
 				/>
 			</PanelBody>
 			<PanelBody

--- a/assets/js/blocks/product-query/constants.ts
+++ b/assets/js/blocks/product-query/constants.ts
@@ -76,7 +76,7 @@ export const QUERY_DEFAULT_ATTRIBUTES: QueryBlockAttributes = {
 
 // This is necessary to fix https://github.com/woocommerce/woocommerce-blocks/issues/9884.
 const postTemplateHasSupportForGridView = getSettingWithCoercion(
-	'post_template_has_support_for_grid_view',
+	'postTemplateHasSupportForGridView',
 	false,
 	isBoolean
 );

--- a/assets/js/blocks/product-query/inspector-controls.tsx
+++ b/assets/js/blocks/product-query/inspector-controls.tsx
@@ -132,7 +132,7 @@ export const WooInheritToggleControl = (
 
 				if ( inherit ) {
 					inheritQuery.perPage = getSettingWithCoercion(
-						'loop_shop_per_page',
+						'loopShopPerPage',
 						12,
 						isNumber
 					);

--- a/assets/js/blocks/product-query/variations/product-query.tsx
+++ b/assets/js/blocks/product-query/variations/product-query.tsx
@@ -87,7 +87,7 @@ if ( isWpVersion( '6.1', '>=' ) ) {
 
 			if ( inherit ) {
 				inheritQuery.perPage = getSettingWithCoercion(
-					'loop_shop_per_page',
+					'loopShopPerPage',
 					12,
 					isNumber
 				);

--- a/assets/js/blocks/product-query/variations/related-products.tsx
+++ b/assets/js/blocks/product-query/variations/related-products.tsx
@@ -46,7 +46,7 @@ export const BLOCK_ATTRIBUTES = {
 };
 
 const postTemplateHasSupportForGridView = getSettingWithCoercion(
-	'post_template_has_support_for_grid_view',
+	'postTemplateHasSupportForGridView',
 	false,
 	isBoolean
 );

--- a/assets/js/blocks/product-tag/block.tsx
+++ b/assets/js/blocks/product-tag/block.tsx
@@ -109,22 +109,22 @@ const ProductsByTagBlock = ( {
 						alignButtons={ alignButtons }
 						setAttributes={ setAttributes }
 						minColumns={ getSettingWithCoercion(
-							'min_columns',
+							'minColumns',
 							1,
 							isNumber
 						) }
 						maxColumns={ getSettingWithCoercion(
-							'max_columns',
+							'maxColumns',
 							6,
 							isNumber
 						) }
 						minRows={ getSettingWithCoercion(
-							'min_rows',
+							'minRows',
 							6,
 							isNumber
 						) }
 						maxRows={ getSettingWithCoercion(
-							'max_rows',
+							'maxRows',
 							6,
 							isNumber
 						) }

--- a/assets/js/blocks/product-tag/index.tsx
+++ b/assets/js/blocks/product-tag/index.tsx
@@ -28,11 +28,11 @@ registerBlockType( metadata, {
 		...metadata.attributes,
 		columns: {
 			type: 'number',
-			default: getSetting( 'default_columns', 3 ),
+			default: getSetting( 'defaultColumns', 3 ),
 		},
 		rows: {
 			type: 'number',
-			default: getSetting( 'default_rows', 3 ),
+			default: getSetting( 'defaultRows', 3 ),
 		},
 		tags: {
 			type: 'array',

--- a/assets/js/blocks/product-template/edit.tsx
+++ b/assets/js/blocks/product-template/edit.tsx
@@ -105,7 +105,7 @@ const ProductTemplateEdit = ( {
 	const [ activeBlockContextId, setActiveBlockContextId ] = useState();
 	const postType = 'product';
 	const loopShopPerPage = getSettingWithCoercion(
-		'loop_shop_per_page',
+		'loopShopPerPage',
 		12,
 		isNumber
 	);

--- a/assets/js/blocks/product-top-rated/block.tsx
+++ b/assets/js/blocks/product-top-rated/block.tsx
@@ -47,10 +47,10 @@ export const ProductTopRatedBlock = ( {
 						rows={ rows }
 						alignButtons={ alignButtons }
 						setAttributes={ setAttributes }
-						minColumns={ getSetting( 'min_columns', 1 ) }
-						maxColumns={ getSetting( 'max_columns', 6 ) }
-						minRows={ getSetting( 'min_rows', 1 ) }
-						maxRows={ getSetting( 'max_rows', 6 ) }
+						minColumns={ getSetting( 'minColumns', 1 ) }
+						maxColumns={ getSetting( 'maxColumns', 6 ) }
+						minRows={ getSetting( 'minRows', 1 ) }
+						maxRows={ getSetting( 'maxRows', 6 ) }
 					/>
 				</PanelBody>
 				<PanelBody

--- a/assets/js/blocks/products-by-attribute/index.tsx
+++ b/assets/js/blocks/products-by-attribute/index.tsx
@@ -25,11 +25,11 @@ registerBlockType( metadata, {
 		...metadata.attributes,
 		columns: {
 			type: 'number',
-			default: getSetting( 'default_columns', 3 ),
+			default: getSetting( 'defaultColumns', 3 ),
 		},
 		rows: {
 			type: 'number',
-			default: getSetting( 'default_rows', 3 ),
+			default: getSetting( 'defaultRows', 3 ),
 		},
 		stockStatus: {
 			type: 'array',

--- a/assets/js/blocks/products-by-attribute/inspector-controls.tsx
+++ b/assets/js/blocks/products-by-attribute/inspector-controls.tsx
@@ -42,10 +42,10 @@ export const ProductsByAttributeInspectorControls = (
 					rows={ rows }
 					alignButtons={ alignButtons }
 					setAttributes={ setAttributes }
-					minColumns={ getSetting( 'min_columns', 1 ) }
-					maxColumns={ getSetting( 'max_columns', 6 ) }
-					minRows={ getSetting( 'min_rows', 1 ) }
-					maxRows={ getSetting( 'max_rows', 6 ) }
+					minColumns={ getSetting( 'minColumns', 1 ) }
+					maxColumns={ getSetting( 'maxColumns', 6 ) }
+					minRows={ getSetting( 'minRows', 1 ) }
+					maxRows={ getSetting( 'maxRows', 6 ) }
 				/>
 			</PanelBody>
 			<PanelBody

--- a/assets/js/blocks/products/all-products/defaults.js
+++ b/assets/js/blocks/products/all-products/defaults.js
@@ -9,8 +9,8 @@ import { getSetting } from '@woocommerce/settings';
 import { DEFAULT_PRODUCT_LIST_LAYOUT } from '../base-utils';
 
 export default {
-	columns: getSetting( 'default_columns', 3 ),
-	rows: getSetting( 'default_rows', 3 ),
+	columns: getSetting( 'defaultColumns', 3 ),
+	rows: getSetting( 'defaultRows', 3 ),
 	alignButtons: false,
 	contentVisibility: {
 		orderBy: true,

--- a/assets/js/blocks/products/all-products/edit.js
+++ b/assets/js/blocks/products/all-products/edit.js
@@ -120,10 +120,10 @@ class Editor extends Component {
 						rows={ rows }
 						alignButtons={ alignButtons }
 						setAttributes={ setAttributes }
-						minColumns={ getSetting( 'min_columns', 1 ) }
-						maxColumns={ getSetting( 'max_columns', 6 ) }
-						minRows={ getSetting( 'min_rows', 1 ) }
-						maxRows={ getSetting( 'max_rows', 6 ) }
+						minColumns={ getSetting( 'minColumns', 1 ) }
+						maxColumns={ getSetting( 'maxColumns', 6 ) }
+						minRows={ getSetting( 'minRows', 1 ) }
+						maxRows={ getSetting( 'maxRows', 6 ) }
 					/>
 				</PanelBody>
 				<PanelBody

--- a/assets/js/blocks/rating-filter/block.tsx
+++ b/assets/js/blocks/rating-filter/block.tsx
@@ -73,7 +73,7 @@ const RatingFilterBlock = ( {
 	const setWrapperVisibility = useSetWraperVisibility();
 
 	const filteringForPhpTemplate = getSettingWithCoercion(
-		'is_rendering_php_template',
+		'isRenderingPhpTemplate',
 		false,
 		isBoolean
 	);
@@ -312,7 +312,7 @@ const RatingFilterBlock = ( {
 	}
 
 	const hasFilterableProducts = getSettingWithCoercion(
-		'has_filterable_products',
+		'hasFilterableProducts',
 		false,
 		isBoolean
 	);

--- a/assets/js/blocks/shared/scripts/migration-utils.tsx
+++ b/assets/js/blocks/shared/scripts/migration-utils.tsx
@@ -73,7 +73,7 @@ const checkIfBlockCanBeInserted = (
 };
 
 const postTemplateHasSupportForGridView = getSettingWithCoercion(
-	'post_template_has_support_for_grid_view',
+	'postTemplateHasSupportForGridView',
 	false,
 	isBoolean
 );

--- a/assets/js/blocks/stock-filter/block.tsx
+++ b/assets/js/blocks/stock-filter/block.tsx
@@ -63,7 +63,7 @@ const StockStatusFilterBlock = ( {
 	const setWrapperVisibility = useSetWraperVisibility();
 
 	const filteringForPhpTemplate = getSettingWithCoercion(
-		'is_rendering_php_template',
+		'isRenderingPhpTemplate',
 		false,
 		isBoolean
 	);
@@ -412,7 +412,7 @@ const StockStatusFilterBlock = ( {
 	const isDisabled = ! blockAttributes.isPreview && filteredCountsLoading;
 
 	const hasFilterableProducts = getSettingWithCoercion(
-		'has_filterable_products',
+		'hasFilterableProducts',
 		false,
 		isBoolean
 	);

--- a/assets/js/blocks/stock-filter/test/block.tsx
+++ b/assets/js/blocks/stock-filter/test/block.tsx
@@ -43,7 +43,7 @@ jest.mock( '@woocommerce/settings', () => {
 		getSettingWithCoercion: jest
 			.fn()
 			.mockImplementation( ( key, defaultValue ) => {
-				if ( key === 'has_filterable_products' ) {
+				if ( key === 'hasFilterableProducts' ) {
 					return true;
 				}
 				return defaultValue;

--- a/assets/js/data/payment/utils/check-payment-methods.ts
+++ b/assets/js/data/payment/utils/check-payment-methods.ts
@@ -175,7 +175,7 @@ export const checkPaymentMethodsCanPay = async ( express = false ) => {
 		? Object.keys( paymentMethods )
 		: Array.from(
 				new Set( [
-					...( getSetting( 'paymentGatewaySortOrder', [] ) as [] ),
+					...( getSetting( 'paymentMethodSortOrder', [] ) as [] ),
 					...Object.keys( paymentMethods ),
 				] )
 		  );

--- a/assets/js/extensions/payment-methods/bacs/index.js
+++ b/assets/js/extensions/payment-methods/bacs/index.js
@@ -3,7 +3,7 @@
  */
 import { registerPaymentMethod } from '@woocommerce/blocks-registry';
 import { __ } from '@wordpress/i18n';
-import { getSetting } from '@woocommerce/settings';
+import { getPaymentMethodData } from '@woocommerce/settings';
 import { decodeEntities } from '@wordpress/html-entities';
 
 /**
@@ -11,12 +11,12 @@ import { decodeEntities } from '@wordpress/html-entities';
  */
 import { PAYMENT_METHOD_NAME } from './constants';
 
-const settings = getSetting( 'bacs_data', {} );
+const settings = getPaymentMethodData( 'bacs', {} );
 const defaultLabel = __(
 	'Direct bank transfer',
 	'woo-gutenberg-products-block'
 );
-const label = decodeEntities( settings.title ) || defaultLabel;
+const label = decodeEntities( settings?.title || '' ) || defaultLabel;
 
 /**
  * Content component

--- a/assets/js/extensions/payment-methods/cheque/index.js
+++ b/assets/js/extensions/payment-methods/cheque/index.js
@@ -3,7 +3,7 @@
  */
 import { registerPaymentMethod } from '@woocommerce/blocks-registry';
 import { __ } from '@wordpress/i18n';
-import { getSetting } from '@woocommerce/settings';
+import { getPaymentMethodData } from '@woocommerce/settings';
 import { decodeEntities } from '@wordpress/html-entities';
 
 /**
@@ -11,9 +11,9 @@ import { decodeEntities } from '@wordpress/html-entities';
  */
 import { PAYMENT_METHOD_NAME } from './constants';
 
-const settings = getSetting( 'cheque_data', {} );
+const settings = getPaymentMethodData( 'cheque', {} );
 const defaultLabel = __( 'Check payment', 'woo-gutenberg-products-block' );
-const label = decodeEntities( settings.title ) || defaultLabel;
+const label = decodeEntities( settings?.title || '' ) || defaultLabel;
 
 /**
  * Content component

--- a/assets/js/extensions/payment-methods/cod/index.js
+++ b/assets/js/extensions/payment-methods/cod/index.js
@@ -3,7 +3,7 @@
  */
 import { registerPaymentMethod } from '@woocommerce/blocks-registry';
 import { __ } from '@wordpress/i18n';
-import { getSetting } from '@woocommerce/settings';
+import { getPaymentMethodData } from '@woocommerce/settings';
 import { decodeEntities } from '@wordpress/html-entities';
 
 /**
@@ -11,9 +11,9 @@ import { decodeEntities } from '@wordpress/html-entities';
  */
 import { PAYMENT_METHOD_NAME } from './constants';
 
-const settings = getSetting( 'cod_data', {} );
+const settings = getPaymentMethodData( 'cod', {} );
 const defaultLabel = __( 'Cash on delivery', 'woo-gutenberg-products-block' );
-const label = decodeEntities( settings.title ) || defaultLabel;
+const label = decodeEntities( settings?.title || '' ) || defaultLabel;
 
 /**
  * Content component

--- a/assets/js/extensions/payment-methods/paypal/index.js
+++ b/assets/js/extensions/payment-methods/paypal/index.js
@@ -3,7 +3,7 @@
  */
 import { registerPaymentMethod } from '@woocommerce/blocks-registry';
 import { __ } from '@wordpress/i18n';
-import { getSetting, WC_ASSET_URL } from '@woocommerce/settings';
+import { getPaymentMethodData, WC_ASSET_URL } from '@woocommerce/settings';
 import { decodeEntities } from '@wordpress/html-entities';
 
 /**
@@ -11,7 +11,7 @@ import { decodeEntities } from '@wordpress/html-entities';
  */
 import { PAYMENT_METHOD_NAME } from './constants';
 
-const settings = getSetting( 'paypal_data', {} );
+const settings = getPaymentMethodData( 'paypal', {} );
 
 /**
  * Content component
@@ -38,7 +38,7 @@ const paypalPaymentMethod = {
 	edit: <Content />,
 	canMakePayment: () => true,
 	ariaLabel: decodeEntities(
-		settings.title ||
+		settings?.title ||
 			__( 'Payment via PayPal', 'woo-gutenberg-products-block' )
 	),
 	supports: {

--- a/assets/js/utils/filters.ts
+++ b/assets/js/utils/filters.ts
@@ -6,7 +6,7 @@ import { getSettingWithCoercion } from '@woocommerce/settings';
 import { isBoolean } from '@woocommerce/types';
 
 const filteringForPhpTemplate = getSettingWithCoercion(
-	'is_rendering_php_template',
+	'isRenderingPhpTemplate',
 	false,
 	isBoolean
 );

--- a/assets/js/utils/shared-attributes.js
+++ b/assets/js/utils/shared-attributes.js
@@ -17,7 +17,7 @@ export default {
 	 */
 	columns: {
 		type: 'number',
-		default: getSetting( 'default_columns', 3 ),
+		default: getSetting( 'defaultColumns', 3 ),
 	},
 
 	/**
@@ -25,7 +25,7 @@ export default {
 	 */
 	rows: {
 		type: 'number',
-		default: getSetting( 'default_rows', 3 ),
+		default: getSetting( 'defaultRows', 3 ),
 	},
 
 	/**

--- a/src/Assets/AssetDataRegistry.php
+++ b/src/Assets/AssetDataRegistry.php
@@ -293,9 +293,9 @@ class AssetDataRegistry {
 	 * You can only register data that is not already in the registry identified by the given key. If there is a
 	 * duplicate found, unless $ignore_duplicates is true, an exception will be thrown.
 	 *
-	 * @param string  $key               The key used to reference the data being registered.
-	 * @param mixed   $data              If not a function, registered to the registry as is. If a function, then the
-	 *                                   callback is invoked right before output to the screen.
+	 * @param string  $key              The key used to reference the data being registered. This should use camelCase.
+	 * @param mixed   $data             If not a function, registered to the registry as is. If a function, then the
+	 *                                  callback is invoked right before output to the screen.
 	 * @param boolean $check_key_exists If set to true, duplicate data will be ignored if the key exists.
 	 *                                  If false, duplicate data will cause an exception.
 	 *

--- a/src/BlockTypes/AbstractProductGrid.php
+++ b/src/BlockTypes/AbstractProductGrid.php
@@ -678,13 +678,12 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 	 */
 	protected function enqueue_data( array $attributes = [] ) {
 		parent::enqueue_data( $attributes );
-		$this->asset_data_registry->add( 'min_columns', wc_get_theme_support( 'product_blocks::min_columns', 1 ), true );
-		$this->asset_data_registry->add( 'max_columns', wc_get_theme_support( 'product_blocks::max_columns', 6 ), true );
-		$this->asset_data_registry->add( 'default_columns', wc_get_theme_support( 'product_blocks::default_columns', 3 ), true );
-		$this->asset_data_registry->add( 'min_rows', wc_get_theme_support( 'product_blocks::min_rows', 1 ), true );
-		$this->asset_data_registry->add( 'max_rows', wc_get_theme_support( 'product_blocks::max_rows', 6 ), true );
-		$this->asset_data_registry->add( 'default_rows', wc_get_theme_support( 'product_blocks::default_rows', 3 ), true );
-		$this->asset_data_registry->add( 'stock_status_options', wc_get_product_stock_status_options(), true );
+		$this->asset_data_registry->add( 'minColumns', wc_get_theme_support( 'product_blocks::min_columns', 1 ), true );
+		$this->asset_data_registry->add( 'maxColumns', wc_get_theme_support( 'product_blocks::max_columns', 6 ), true );
+		$this->asset_data_registry->add( 'defaultColumns', wc_get_theme_support( 'product_blocks::default_columns', 3 ), true );
+		$this->asset_data_registry->add( 'minRows', wc_get_theme_support( 'product_blocks::min_rows', 1 ), true );
+		$this->asset_data_registry->add( 'maxRows', wc_get_theme_support( 'product_blocks::max_rows', 6 ), true );
+		$this->asset_data_registry->add( 'defaultRows', wc_get_theme_support( 'product_blocks::default_rows', 3 ), true );
 	}
 
 	/**

--- a/src/BlockTypes/AllProducts.php
+++ b/src/BlockTypes/AllProducts.php
@@ -22,14 +22,13 @@ class AllProducts extends AbstractBlock {
 	protected function enqueue_data( array $attributes = [] ) {
 		parent::enqueue_data( $attributes );
 		// Set this so filter blocks being used as widgets know when to render.
-		$this->asset_data_registry->add( 'has_filterable_products', true, true );
-
-		$this->asset_data_registry->add( 'min_columns', wc_get_theme_support( 'product_blocks::min_columns', 1 ), true );
-		$this->asset_data_registry->add( 'max_columns', wc_get_theme_support( 'product_blocks::max_columns', 6 ), true );
-		$this->asset_data_registry->add( 'default_columns', wc_get_theme_support( 'product_blocks::default_columns', 3 ), true );
-		$this->asset_data_registry->add( 'min_rows', wc_get_theme_support( 'product_blocks::min_rows', 1 ), true );
-		$this->asset_data_registry->add( 'max_rows', wc_get_theme_support( 'product_blocks::max_rows', 6 ), true );
-		$this->asset_data_registry->add( 'default_rows', wc_get_theme_support( 'product_blocks::default_rows', 3 ), true );
+		$this->asset_data_registry->add( 'hasFilterableProducts', true, true );
+		$this->asset_data_registry->add( 'minColumns', wc_get_theme_support( 'product_blocks::min_columns', 1 ), true );
+		$this->asset_data_registry->add( 'maxColumns', wc_get_theme_support( 'product_blocks::max_columns', 6 ), true );
+		$this->asset_data_registry->add( 'defaultColumns', wc_get_theme_support( 'product_blocks::default_columns', 3 ), true );
+		$this->asset_data_registry->add( 'minRows', wc_get_theme_support( 'product_blocks::min_rows', 1 ), true );
+		$this->asset_data_registry->add( 'maxRows', wc_get_theme_support( 'product_blocks::max_rows', 6 ), true );
+		$this->asset_data_registry->add( 'defaultRows', wc_get_theme_support( 'product_blocks::default_rows', 3 ), true );
 
 		// Hydrate the All Product block with data from the API. This is for the add to cart buttons which show current quantity in cart, and events.
 		if ( ! is_admin() && ! WC()->is_rest_api_request() ) {

--- a/src/BlockTypes/ClassicTemplate.php
+++ b/src/BlockTypes/ClassicTemplate.php
@@ -105,13 +105,13 @@ class ClassicTemplate extends AbstractDynamicBlock {
 
 		if ( in_array( $attributes['template'], $archive_templates, true ) ) {
 			// Set this so that our product filters can detect if it's a PHP template.
-			$this->asset_data_registry->add( 'is_rendering_php_template', true, true );
+			$this->asset_data_registry->add( 'isRenderingPhpTemplate', true, true );
 
 			// Set this so filter blocks being used as widgets know when to render.
-			$this->asset_data_registry->add( 'has_filterable_products', true, true );
+			$this->asset_data_registry->add( 'hasFilterableProducts', true, true );
 
 			$this->asset_data_registry->add(
-				'page_url',
+				'pageUrl',
 				html_entity_decode( get_pagenum_link() ),
 				''
 			);

--- a/src/BlockTypes/FeaturedItem.php
+++ b/src/BlockTypes/FeaturedItem.php
@@ -321,7 +321,6 @@ abstract class FeaturedItem extends AbstractDynamicBlock {
 	 */
 	protected function enqueue_data( array $attributes = [] ) {
 		parent::enqueue_data( $attributes );
-		$this->asset_data_registry->add( 'min_height', wc_get_theme_support( 'featured_block::min_height', 500 ), true );
-		$this->asset_data_registry->add( 'default_height', wc_get_theme_support( 'featured_block::default_height', 500 ), true );
+		$this->asset_data_registry->add( 'defaultHeight', wc_get_theme_support( 'featured_block::default_height', 500 ), true );
 	}
 }

--- a/src/BlockTypes/ProductCollection.php
+++ b/src/BlockTypes/ProductCollection.php
@@ -98,7 +98,7 @@ class ProductCollection extends AbstractBlock {
 
 		// The `loop_shop_per_page` filter can be found in WC_Query::product_query().
 		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
-		$this->asset_data_registry->add( 'loop_shop_per_page', apply_filters( 'loop_shop_per_page', wc_get_default_products_per_row() * wc_get_default_product_rows_per_page() ), true );
+		$this->asset_data_registry->add( 'loopShopPerPage', apply_filters( 'loop_shop_per_page', wc_get_default_products_per_row() * wc_get_default_product_rows_per_page() ), true );
 	}
 
 	/**
@@ -150,12 +150,12 @@ class ProductCollection extends AbstractBlock {
 			return;
 		}
 
-		$this->asset_data_registry->add( 'has_filterable_products', true, true );
+		$this->asset_data_registry->add( 'hasFilterableProducts', true, true );
 		/**
 		 * It enables the page to refresh when a filter is applied, ensuring that the product collection block,
 		 * which is a server-side rendered (SSR) block, retrieves the products that match the filters.
 		 */
-		$this->asset_data_registry->add( 'is_rendering_php_template', true, true );
+		$this->asset_data_registry->add( 'isRenderingPhpTemplate', true, true );
 	}
 
 	/**

--- a/src/BlockTypes/ProductImage.php
+++ b/src/BlockTypes/ProductImage.php
@@ -190,7 +190,7 @@ class ProductImage extends AbstractBlock {
 	 *                           not in the post content on editor load.
 	 */
 	protected function enqueue_data( array $attributes = [] ) {
-		$this->asset_data_registry->add( 'is_block_theme_enabled', wc_current_theme_is_fse_theme(), false );
+		$this->asset_data_registry->add( 'isBlockThemeEnabled', wc_current_theme_is_fse_theme(), false );
 	}
 
 

--- a/src/BlockTypes/ProductQuery.php
+++ b/src/BlockTypes/ProductQuery.php
@@ -126,13 +126,13 @@ class ProductQuery extends AbstractBlock {
 		$post_template_has_support_for_grid_view = $this->check_if_post_template_has_support_for_grid_view();
 
 		$this->asset_data_registry->add(
-			'post_template_has_support_for_grid_view',
+			'postTemplateHasSupportForGridView',
 			$post_template_has_support_for_grid_view
 		);
 
 		// The `loop_shop_per_page` filter can be found in WC_Query::product_query().
 		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
-		$this->asset_data_registry->add( 'loop_shop_per_page', apply_filters( 'loop_shop_per_page', wc_get_default_products_per_row() * wc_get_default_product_rows_per_page() ), true );
+		$this->asset_data_registry->add( 'loopShopPerPage', apply_filters( 'loop_shop_per_page', wc_get_default_products_per_row() * wc_get_default_product_rows_per_page() ), true );
 	}
 
 	/**
@@ -177,8 +177,8 @@ class ProductQuery extends AbstractBlock {
 
 		if ( self::is_woocommerce_variation( $parsed_block ) ) {
 			// Set this so that our product filters can detect if it's a PHP template.
-			$this->asset_data_registry->add( 'has_filterable_products', true, true );
-			$this->asset_data_registry->add( 'is_rendering_php_template', true, true );
+			$this->asset_data_registry->add( 'hasFilterableProducts', true, true );
+			$this->asset_data_registry->add( 'isRenderingPhpTemplate', true, true );
 			add_filter(
 				'query_loop_block_query_vars',
 				array( $this, 'build_query' ),

--- a/src/Payments/Api.php
+++ b/src/Payments/Api.php
@@ -80,13 +80,13 @@ class Api {
 	 * Add payment method data to Asset Registry.
 	 */
 	public function add_payment_method_script_data() {
-		// Enqueue the order of enabled gateways as `paymentGatewaySortOrder`.
-		if ( ! $this->asset_registry->exists( 'paymentGatewaySortOrder' ) ) {
+		// Enqueue the order of enabled gateways.
+		if ( ! $this->asset_registry->exists( 'paymentMethodSortOrder' ) ) {
 			// We use payment_gateways() here to get the sort order of all enabled gateways. Some may be
 			// programmatically disabled later on, but we still need to know where the enabled ones are in the list.
 			$payment_gateways = WC()->payment_gateways->payment_gateways();
 			$enabled_gateways = array_filter( $payment_gateways, array( $this, 'is_payment_gateway_enabled' ) );
-			$this->asset_registry->add( 'paymentGatewaySortOrder', array_keys( $enabled_gateways ) );
+			$this->asset_registry->add( 'paymentMethodSortOrder', array_keys( $enabled_gateways ) );
 		}
 
 		// Enqueue all registered gateway data (settings/config etc).

--- a/src/Payments/PaymentMethodRegistry.php
+++ b/src/Payments/PaymentMethodRegistry.php
@@ -59,9 +59,9 @@ final class PaymentMethodRegistry extends IntegrationRegistry {
 		$payment_methods = $this->get_all_active_registered();
 
 		foreach ( $payment_methods as $payment_method ) {
-			$script_data[ $payment_method->get_name() . '_data' ] = $payment_method->get_payment_method_data();
+			$script_data[ $payment_method->get_name() ] = $payment_method->get_payment_method_data();
 		}
 
-		return array_filter( $script_data );
+		return array( 'paymentMethodData' => array_filter( $script_data ) );
 	}
 }

--- a/src/Templates/ClassicTemplatesCompatibility.php
+++ b/src/Templates/ClassicTemplatesCompatibility.php
@@ -60,7 +60,7 @@ class ClassicTemplatesCompatibility {
 		global $pagenow;
 
 		if ( is_shop() || is_product_taxonomy() || 'widgets.php' === $pagenow ) {
-			$this->asset_data_registry->add( 'has_filterable_products', true, true );
+			$this->asset_data_registry->add( 'hasFilterableProducts', true, true );
 		}
 	}
 
@@ -75,7 +75,7 @@ class ClassicTemplatesCompatibility {
 	 */
 	public function set_php_template_data() {
 		if ( is_shop() || is_product_taxonomy() ) {
-			$this->asset_data_registry->add( 'is_rendering_php_template', true, true );
+			$this->asset_data_registry->add( 'isRenderingPhpTemplate', true, true );
 		}
 	}
 }

--- a/tests/js/setup-globals.js
+++ b/tests/js/setup-globals.js
@@ -14,7 +14,7 @@ global.wcSettings = {
 	date: {
 		dow: 0,
 	},
-	has_filterable_products: true,
+	hasFilterableProducts: true,
 	orderStatuses: {
 		pending: 'Pending payment',
 		processing: 'Processing',


### PR DESCRIPTION
This PR renames all snake_case properties with camelCase properties. For payment gateways, this changes how settings are structured and adds a compatibility layer for extensions making use of `_data` properties.

Fixes #7754

### Testing

- Requires a smoke test
- Confirm you can checkout
- Confirm a payment gateway extension (Stripe) works with these changes

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fixed wcSettings inconsistent property naming style by converting all properties to camelCase
