### PR TITLE
Fix badge wrong spacing on the newest arrivals pattern

### DIFF
--- a/patterns/product-collections-newest-arrivals.php
+++ b/patterns/product-collections-newest-arrivals.php
@@ -43,7 +43,7 @@
 		<!-- wp:query {"query":{"perPage":"4","pages":0,"offset":0,"postType":"product","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"__woocommerceAttributes":[],"__woocommerceStockStatus":["instock","onbackorder"]},"displayLayout":{"type":"flex","columns":4},"namespace":"woocommerce/product-query"} -->
 		<div class="wp-block-query">
 			<!-- wp:post-template {"className":"products-block-post-template","__woocommerceNamespace":"woocommerce/product-query/product-template"} -->
-			<!-- wp:woocommerce/product-image {"imageSizing":"thumbnail","isDescendentOfQueryLoop":true,"style":{"spacing":{"padding":{"top":"var:preset|spacing|20","right":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20"}}}} /-->
+			<!-- wp:woocommerce/product-image {"imageSizing":"thumbnail","isDescendentOfQueryLoop":true} /-->
 			<!-- wp:post-title {"textAlign":"center","level":3,"isLink":true,"style":{"spacing":{"margin":{"bottom":"0.75rem","top":"0"}}},"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-query/product-title"} /-->
 			<!-- /wp:post-template -->
 		</div>


### PR DESCRIPTION
This PR fixes a problem with the `Sale` badge in the editor in the `Product Collections Newest Arrivals` pattern.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
| <img width="1220" alt="Screenshot 2023-08-02 at 10 39 43" src="https://github.com/woocommerce/woocommerce-blocks/assets/186112/93d0755d-922c-4821-b4d0-0d3e698dd553"> | <img width="1211" alt="Screenshot 2023-08-02 at 10 39 48" src="https://github.com/woocommerce/woocommerce-blocks/assets/186112/efeb63a8-8ef5-4619-adf7-16905a830657">|

### Testing
#### User Facing Testing

1. Create a new page or post.
2. Insert the `Product Collections Newest Arrivals`.
3. In the editor check the `Sale` badge looks as the `after` screenshot above.
4. Save and check it looks the same on the frontend.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
