### PR TITLE
Best selling products block: show only products with sales and most sold first

### DIFF
--- a/src/BlockTypes/ProductBestSellers.php
+++ b/src/BlockTypes/ProductBestSellers.php
@@ -19,6 +19,14 @@ class ProductBestSellers extends AbstractProductGrid {
 	 * @param array $query_args Query args.
 	 */
 	protected function set_block_query_args( &$query_args ) {
-		$query_args['orderby'] = 'popularity';
+		$query_args['meta_key'] = 'total_sales'; // phpcs:ignore WordPress.DB.SlowDBQuery
+		$query_args['orderby']  = 'meta_value_num';
+		$query_args['order']    = 'DESC';
+
+		$this->meta_query[] = array(
+			'key'     => 'total_sales',
+			'value'   => 0,
+			'compare' => '>',
+		);
 	}
 }


### PR DESCRIPTION
This PR updates the query in the `Best Selling Product` blocks to show only products with sales and show the most sold before.

Fixes https://github.com/woocommerce/woocommerce/issues/42596

### Screenshots

| Before | After |
| ------ | ----- |
| ![CleanShot 2023-08-02 at 14 39 01@2x](https://github.com/woocommerce/woocommerce-blocks/assets/186112/2ffa60e7-317b-4f4b-96ce-a1d1892b955f)|<img alt="Screenshot 2023-08-02 at 14 38 03" src="https://github.com/woocommerce/woocommerce-blocks/assets/186112/d1465196-b1ad-49a8-8769-8f3f5eda1bf0">|

### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Create a new page or post.
2. Insert the `Best Selling Product` block.
3. Make sure only products that were sold at least once appear on the block and order by number of sales.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Best Selling Products: show only products with sales, ordered by number of sales.
