### PR TITLE
Featured Products 5-Item Grid pattern: fix compatibility with WordPress 6.2

### DIFF
--- a/patterns/featured-products-5-cols.php
+++ b/patterns/featured-products-5-cols.php
@@ -12,9 +12,9 @@
 </h3>
 <!-- /wp:heading -->
 
-<!-- wp:query {"queryId":3,"query":{"perPage":"5","pages":0,"offset":"5","postType":"product","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":false,"__woocommerceAttributes":[],"__woocommerceStockStatus":["instock","outofstock","onbackorder"]},"namespace":"woocommerce/product-query","align":"wide","layout":{"type":"constrained"}} -->
+<!-- wp:query {"queryId":3,"query":{"perPage":"5","pages":0,"offset":"5","postType":"product","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":false,"__woocommerceAttributes":[],"__woocommerceStockStatus":["instock","outofstock","onbackorder"]}, "displayLayout":{"type":"flex","columns":5}, "namespace":"woocommerce/product-query","align":"wide","layout":{"type":"constrained"}} -->
 <div class="wp-block-query alignwide">
-	<!-- wp:post-template {"align":"wide","className":"products-block-post-template","layout":{"type":"grid","columnCount":5},"__woocommerceNamespace":"woocommerce/product-query/product-template"} -->
+	<!-- wp:post-template {"align":"wide","className":"products-block-post-template","__woocommerceNamespace":"woocommerce/product-query/product-template"} -->
 	<!-- wp:woocommerce/product-image {"imageSizing":"thumbnail","isDescendentOfQueryLoop":true} /-->
 
 	<!-- wp:post-title {"textAlign":"left","level":3,"isLink":true,"style":{"spacing":{"margin":{"bottom":"0.75rem","top":"0"}}},"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-query/product-title"} /-->


### PR DESCRIPTION
This PR fixes the compatibility of the `Featured Products 5-Item Grid` pattern with WordPress 6.2. 
The fix I did here is the same that was used in #9916 to fix other patterns.

### Screenshots


#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->
1. Ensure that you have WordPress 6.2.
2. Add the `Featured Products 5-item grid` pattern in a post/page.
3. Ensure that the Products Block defaults to the grid layout.
4. Save it.
5. Visit the page.
6. Ensure that the Products Block defaults to the grid layout.
7. Enable Gutenberg or upgrade to WordPress 6.3.
8. Edit the page created earlier.
9. Ensure that the Products Block defaults to the grid layout.
10. Visit the page.


* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->


