### PR TITLE
Prevent hooks from being attached to empty content

### DIFF
--- a/src/Templates/ArchiveProductTemplatesCompatibility.php
+++ b/src/Templates/ArchiveProductTemplatesCompatibility.php
@@ -144,6 +144,10 @@ class ArchiveProductTemplatesCompatibility extends AbstractTemplateCompatibility
 			return $content;
 		}
 
+		if ( empty( $block_content ) ) {
+			return $block_content;
+		}
+
 		return sprintf(
 			'%1$s%2$s%3$s',
 			$this->get_hooks_buffer( $block_hooks, 'before' ),


### PR DESCRIPTION
Hooks were attached also to the blocks that has empty content which is unexpected. As an example the `woocommerce_before_shop_loop_item` and `woocommerce_after_shop_loop_item` where rendered "around" the empty Products (Beta) block. This issue fixes the problem.

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/10452

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|   <img width="1465" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/20098064/9a74e1f7-3a5b-432e-b6ce-3928fb05f456">     |   <img width="1465" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/20098064/b2087fc9-d028-4caf-880c-6d19ec83fcf1">    |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

Issue found during writing E2E test for Compatibility Layer so it will be covered.

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Add the following code to your site using the [Code Snippets](https://wordpress.org/plugins/code-snippets/) plugin:
```
add_action( 'woocommerce_before_shop_loop', function () {
	echo 'Hook: woocommerce_before_shop_loop';
});

add_action( 'woocommerce_after_shop_loop', function () {
	echo 'Hook: woocommerce_after_shop_loop';
});

add_action( 'woocommerce_no_products_found', function () {
	echo 'Hook: woocommerce_no_products_found';
});
```

2. Go to Editor and edit Product Search Result template
3. Add Group block and inside add Products (Beta) block
4. Add Product Search to the Header
5. Save and go to frontend
6. In the search, type phrase that won't give you any products (e.g. "asdfasdf")

Expected: Only `woocommerce_no_products_found` should be fired
* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Products (Beta): hooks are no longer fired around the empty content
