### PR TITLE
Checkout Block: Prevent changes in the selected shipping method when new rates are added or removed

### DIFF
--- a/src/Shipping/ShippingController.php
+++ b/src/Shipping/ShippingController.php
@@ -77,12 +77,7 @@ class ShippingController {
 		add_filter( 'wc_shipping_enabled', array( $this, 'force_shipping_enabled' ), 100, 1 );
 		add_filter( 'woocommerce_order_shipping_to_display', array( $this, 'show_local_pickup_details' ), 10, 2 );
 
-		add_filter(
-			'woocommerce_shipping_chosen_method',
-			array( $this, 'prevent_shipping_method_selection_changes' ),
-			20,
-			3
-		);
+		add_filter( 'woocommerce_shipping_chosen_method', array( $this, 'prevent_shipping_method_selection_changes' ), 20, 3 );
 
 		// This is required to short circuit `show_shipping` from class-wc-cart.php - without it, that function
 		// returns based on the option's value in the DB and we can't override it any other way.

--- a/src/Shipping/ShippingController.php
+++ b/src/Shipping/ShippingController.php
@@ -76,7 +76,6 @@ class ShippingController {
 		add_filter( 'woocommerce_shipping_settings', array( $this, 'remove_shipping_settings' ) );
 		add_filter( 'wc_shipping_enabled', array( $this, 'force_shipping_enabled' ), 100, 1 );
 		add_filter( 'woocommerce_order_shipping_to_display', array( $this, 'show_local_pickup_details' ), 10, 2 );
-
 		add_filter( 'woocommerce_shipping_chosen_method', array( $this, 'prevent_shipping_method_selection_changes' ), 20, 3 );
 
 		// This is required to short circuit `show_shipping` from class-wc-cart.php - without it, that function

--- a/src/Shipping/ShippingController.php
+++ b/src/Shipping/ShippingController.php
@@ -77,9 +77,39 @@ class ShippingController {
 		add_filter( 'wc_shipping_enabled', array( $this, 'force_shipping_enabled' ), 100, 1 );
 		add_filter( 'woocommerce_order_shipping_to_display', array( $this, 'show_local_pickup_details' ), 10, 2 );
 
+		add_filter(
+			'woocommerce_shipping_chosen_method',
+			array( $this, 'prevent_shipping_method_selection_changes' ),
+			20,
+			3
+		);
+
 		// This is required to short circuit `show_shipping` from class-wc-cart.php - without it, that function
 		// returns based on the option's value in the DB and we can't override it any other way.
 		add_filter( 'option_woocommerce_shipping_cost_requires_address', array( $this, 'override_cost_requires_address_option' ) );
+	}
+
+	/**
+	 * Prevent changes in the selected shipping method when new rates are added or removed.
+	 *
+	 * If the chosen method exists within package rates, it is returned to maintain the selection.
+	 * Otherwise, the default rate is returned.
+	 *
+	 * @param string $default        Default shipping method.
+	 * @param array  $package_rates  Associative array of available package rates.
+	 * @param string $chosen_method  Previously chosen shipping method.
+	 *
+	 * @return string                Chosen shipping method or default.
+	 */
+	public function prevent_shipping_method_selection_changes( $default, $package_rates, $chosen_method ) {
+
+		// If the chosen method exists in the package rates, return it.
+		if ( $chosen_method && isset( $package_rates[ $chosen_method ] ) ) {
+			return $chosen_method;
+		}
+
+		// Otherwise, return the default method.
+		return $default;
 	}
 
 	/**


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->
Fixes #9790

If local pickup is enabled and there are no available shipping methods for a particular address, we have observed that the shipping method will automatically switch to the default option once the shipping address is modified and the shipping method is available for the new address.

With this PR, we're preventing the switch to the default shipping method address from being changed. 


### Changes in the PR
- Implement `woocommerce_shipping_chosen_method` filter to prevent changes in the selected shipping method.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Enable local pickup.
2. Go to the Checkout block page, and add an address for which you don't have a shipping zone defined without changing the selected shipping method. 
3. Confirm local pickup is selected as a shipping method for the address, and shipping is not available for the given address. 
 
<img width="543" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/11503784/f807a8b7-f89c-401b-9aa0-7f696c0fa183">

4. In another tab, open shipping zones and add a new rate to your current zone.
5. Refresh checkout. 
6. Confirm local pickup is selected as a shipping method for the address, and shipping is also available for the given address. 

<img width="541" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/11503784/82ca5ebc-27a7-4b5b-92a1-0b30478bd5ef">


* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental


<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Checkout Block: Prevent changes in the selected shipping method when new rates are added or removed
