### PR TITLE
Assign milestone only after merging a PR

### DIFF
--- a/.github/workflows/approved-with-labels.yml
+++ b/.github/workflows/approved-with-labels.yml
@@ -12,14 +12,3 @@ jobs:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   ADD_LABEL: 'status: ready to merge'
                   REMOVE_LABEL: 'status:%20needs%20review'
-    milestoneWhenApproved:
-        name: Add Milestone
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v3
-            - name: Latest milestone
-              uses: woocommerce/automations@v1
-              with:
-                  github_token: ${{ secrets.GITHUB_TOKEN }}
-                  automations: assign-milestone
-                  milestone_bump_strategy: none

--- a/.github/workflows/merged-with-labels.yml
+++ b/.github/workflows/merged-with-labels.yml
@@ -14,3 +14,16 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           labels: |
             status: ready to merge
+
+  milestoneWhenMerged:
+    if: github.event.pull_request.merged
+    name: Add Milestone
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Latest milestone
+        uses: woocommerce/automations@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          automations: assign-milestone
+          milestone_bump_strategy: none


### PR DESCRIPTION
The goal of this PR is to assign the milestone to a PR once it is merged. 

The main reason is that PRs might be approved, but they might not be ready for release yet (ie: there are conflicts, the PR needs to be released with a pairing PR, the PR was pre-approved but there are still changes needed, etc.).

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/6516

### Testing
I've tested with a test repo on my account https://github.com/albarin/test-action and the action was skipped when the PR was closed https://github.com/albarin/test-action/actions/runs/5750564158 and it run after the PR was merged https://github.com/albarin/test-action/actions/runs/5750595094. So the condition seems to be working, but until we merge I think we cannot be completely sure 🤔 

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->
