### PR TITLE
Update check for active cart template and migration routine

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -80,6 +80,7 @@ class BlockTemplatesController {
 
 		if ( wc_current_theme_is_fse_theme() ) {
 			add_action( 'init', array( $this, 'maybe_migrate_content' ) );
+			add_action( 'init', array( $this, 'maybe_update_endpoint_option' ) );
 			add_filter( 'woocommerce_settings_pages', array( $this, 'template_permalink_settings' ) );
 			add_filter( 'pre_update_option', array( $this, 'update_template_permalink' ), 10, 2 );
 			add_action( 'woocommerce_admin_field_permalink', array( SettingsUtils::class, 'permalink_input_field' ) );
@@ -129,6 +130,25 @@ class BlockTemplatesController {
 				10,
 				2
 			);
+		}
+	}
+
+	/**
+	 * Upates the options to reflect correct cart and checkout endpoints.
+	 *
+	 * @return void
+	 */
+	public function maybe_update_endpoint_option() {
+		$cart_page      = CartTemplate::get_placeholder_page();
+		$checkout_page  = CheckoutTemplate::get_placeholder_page();
+		$cart_value     = $cart_page ? $cart_page->post_name : CartTemplate::get_slug();
+		$checkout_value = $checkout_page ? $checkout_page->post_name : CheckoutTemplate::get_slug();
+
+		if ( get_option( 'woocommerce_cart_page_endpoint' ) !== $cart_value ) {
+			update_option( 'woocommerce_cart_page_endpoint', $cart_value );
+		}
+		if ( get_option( 'woocommerce_checkout_page_endpoint' ) !== $checkout_value ) {
+			update_option( 'woocommerce_checkout_page_endpoint', $checkout_value );
 		}
 	}
 

--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -822,7 +822,7 @@ class BlockTemplatesController {
 		// Use the page template if it exists, which we'll use over our default template if found.
 		$existing_page_template = BlockTemplateUtils::get_block_template( get_stylesheet() . '//page', 'wp_template' );
 
-		if ( $existing_page_template && ! empty( $existing_page_template->content ) ) {
+		if ( $existing_page_template && ! empty( $existing_page_template->content ) && strstr( $existing_page_template->content, 'wp:post-content' ) ) {
 			// Massage the original content into something we can use. Replace post content with a group block.
 			$pattern          = '/(<!--\s*)wp:post-content(.*?)(\/-->)/';
 			$replacement      = '

--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -80,7 +80,6 @@ class BlockTemplatesController {
 
 		if ( wc_current_theme_is_fse_theme() ) {
 			add_action( 'init', array( $this, 'maybe_migrate_content' ) );
-			add_action( 'init', array( $this, 'maybe_update_endpoint_option' ) );
 			add_filter( 'woocommerce_settings_pages', array( $this, 'template_permalink_settings' ) );
 			add_filter( 'pre_update_option', array( $this, 'update_template_permalink' ), 10, 2 );
 			add_action( 'woocommerce_admin_field_permalink', array( SettingsUtils::class, 'permalink_input_field' ) );
@@ -130,25 +129,6 @@ class BlockTemplatesController {
 				10,
 				2
 			);
-		}
-	}
-
-	/**
-	 * Upates the options to reflect correct cart and checkout endpoints.
-	 *
-	 * @return void
-	 */
-	public function maybe_update_endpoint_option() {
-		$cart_page      = CartTemplate::get_placeholder_page();
-		$checkout_page  = CheckoutTemplate::get_placeholder_page();
-		$cart_value     = $cart_page ? $cart_page->post_name : CartTemplate::get_slug();
-		$checkout_value = $checkout_page ? $checkout_page->post_name : CheckoutTemplate::get_slug();
-
-		if ( get_option( 'woocommerce_cart_page_endpoint' ) !== $cart_value ) {
-			update_option( 'woocommerce_cart_page_endpoint', $cart_value );
-		}
-		if ( get_option( 'woocommerce_checkout_page_endpoint' ) !== $checkout_value ) {
-			update_option( 'woocommerce_checkout_page_endpoint', $checkout_value );
 		}
 	}
 

--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -835,15 +835,33 @@ class BlockTemplatesController {
 			$template_content = $this->get_default_migrate_page_template( $page );
 		}
 
-		$request = new \WP_REST_Request( 'POST', '/wp/v2/templates/woocommerce/woocommerce//' . $page_id );
-		$request->set_body_params(
+		$new_page_template = BlockTemplateUtils::get_block_template( 'woocommerce/woocommerce//' . $page_id, 'wp_template' );
+
+		// Check template validity--template must exist, and custom template must not be present already.
+		if ( ! $new_page_template || $new_page_template->wp_id ) {
+			update_option( 'has_migrated_' . $page_id, '1' );
+			return;
+		}
+
+		$new_page_template_id = wp_insert_post(
 			[
-				'id'      => 'woocommerce/woocommerce//' . $page_id,
-				'content' => $template_content,
-			]
+				'post_name'    => $new_page_template->slug,
+				'post_type'    => 'wp_template',
+				'post_status'  => 'publish',
+				'tax_input'    => array(
+					'wp_theme' => $new_page_template->theme,
+				),
+				'meta_input'   => array(
+					'origin' => $new_page_template->source,
+				),
+				'post_content' => $template_content,
+			],
+			true
 		);
-		rest_get_server()->dispatch( $request );
-		update_option( 'has_migrated_' . $page_id, '1' );
+
+		if ( ! is_wp_error( $new_page_template_id ) ) {
+			update_option( 'has_migrated_' . $page_id, '1' );
+		}
 	}
 
 	/**

--- a/src/Templates/CartTemplate.php
+++ b/src/Templates/CartTemplate.php
@@ -33,7 +33,8 @@ class CartTemplate extends AbstractPageTemplate {
 	 */
 	protected function is_active_template() {
 		global $post;
-		return $post instanceof \WP_Post && get_option( 'woocommerce_cart_page_endpoint' ) === $post->post_name;
+		$placeholder = $this->get_placeholder_page();
+		return null !== $placeholder && $post instanceof \WP_Post && $placeholder->post_name === $post->post_name;
 	}
 
 	/**

--- a/src/Templates/CheckoutTemplate.php
+++ b/src/Templates/CheckoutTemplate.php
@@ -42,6 +42,7 @@ class CheckoutTemplate extends AbstractPageTemplate {
 	 */
 	public function is_active_template() {
 		global $post;
-		return $post instanceof \WP_Post && get_option( 'woocommerce_checkout_page_endpoint' ) === $post->post_name;
+		$placeholder = $this->get_placeholder_page();
+		return null !== $placeholder && $post instanceof \WP_Post && $placeholder->post_name === $post->post_name;
 	}
 }


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
This PR updates the logic used to decide whether a template is active by checking the current post slug vs. the post slug for the Cart/Checkout page that is set in WooCommerce.

Previously the `woocommerce_cart_page_endpoint` option was used, however this is not set in some scenarios, and only seems to be set when manually updating the slug in WooCommerce > Settings > Advanced

_Mike edit:_
As well as fixing the detection, this fixes the migration if the migration is triggered by a non-logged in user, by switching from a REST endpoint, to raw PHP.

<!-- Reference any related issues or PRs here -->

Fixes the failing e2e tests for Cart template.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Other Checks

- [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [x] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Go to Pages > Cart and edit the page. It will load the site editor. Add some text below the header, for example. Feel free to add anything for testing purposes. Save the template.
2. Add an item to your cart and then load the Cart page on the front end. Ensure your changes from step 1 are visible.
3. Go to the WP Dasboard, then WooCommerce > Settings > Advanced and change the cart page slug to something different. Repeat step 2 and ensure it still works with your change visible. Ensure the path to the Cart page shown in your browser is the one you updated it to.

##### Dev testing

Ensure the playwright tests have passed! 

1. Create a fresh website, install WC Core only, add products set up the store etc. Go to the Cart page and ensure the Cart block is added.
2. Install the zip from this PR (check [this comment for the zip](https://github.com/woocommerce/woocommerce-blocks/pull/10462#issuecomment-1663979563))
3. Ensure you have a blocks theme enabled (eg. TT3)
4. Go to Pages > Cart and edit the page. It will load the site editor. Add some text below the header, for example. Feel free to add anything for testing purposes. Save the template.
5. Add an item to your cart and then load the Cart page on the front end. Ensure your changes from step 3 are visible.
6. Go to the WP Dasboard, then WooCommerce > Settings > Advanced and change the cart page slug to something different. Repeat step 4 and ensure it still works with your change visible. Ensure the path to the Cart page shown in your browser is the one you updated it to.
7. Delete `has_migrated_cart` and `has_migrated_checkout` entries from from` wp_options`
8. Without refreshing the currently opened store tab, visit the store in incognito mode
9. Return to the logged in tab, navigate to `Appearance > Editor > Templates > Manage all templates` and verify content from cart and checkout pages have been correctly migrated.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Fixed an issue where modifications to the Cart/Checkout templates made in the site editor would not be visible on the front end.
