### PR TITLE
Fix border color class names not being applied correctly

### DIFF
--- a/assets/js/base/utils/get-inline-styles.ts
+++ b/assets/js/base/utils/get-inline-styles.ts
@@ -50,8 +50,8 @@ function getBorderClassName( attributes: {
 		: '';
 
 	return classnames( {
-		'has-border-color': borderColor || style?.border?.color,
-		borderColorClass,
+		'has-border-color': !! borderColor || !! style?.border?.color,
+		[ borderColorClass ]: !! borderColorClass,
 	} );
 }
 


### PR DESCRIPTION
Border colors class names where not applied correctly to blocks using style props. Custom border colors were working correctly, but theme colors were not being applied. While this PR references #10389 which mentions the Featured Category block, this was in fact a problem with all blocks supporting border colors.

Fixes #10389

#### Other Checks

- [x] This PR has either a `[type]` label or a `[skip-changelog]` label.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. Add a “Featured Category” block to your page.
2. Open the Inspector Controls → Styles tab → Add a border.
3. Select a custom width and select a color from the theme colors.
4. Ensure this color is shown correctly in the editor.
5. [Regression test] Ensure custom colors are shown correctly in the editor.
6. [Regression test] Ensure both are shown in the front-end.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Fixed a bug which caused theme border colors to not correctly show on the blocks on the editor side.
