### PR TITLE
Classic block registration: add defensive type handling

### DIFF
--- a/assets/js/atomic/utils/register-block-single-product-template.ts
+++ b/assets/js/atomic/utils/register-block-single-product-template.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { isNumber } from '@woocommerce/types';
 import {
 	BlockAttributes,
 	BlockConfiguration,
@@ -16,8 +17,10 @@ import { subscribe, select } from '@wordpress/data';
 // Creating a local cache to prevent multiple registration tries.
 const blocksRegistered = new Set();
 
-function parseTemplateId( templateId: string | undefined ) {
-	return templateId?.split( '//' )[ 1 ];
+function parseTemplateId( templateId: string | number | undefined ) {
+	// With GB 16.3.0 the return type can be a number: https://github.com/WordPress/gutenberg/issues/53230
+	const parsedTemplateId = isNumber( templateId ) ? undefined : templateId;
+	return parsedTemplateId?.split( '//' )[ 1 ];
 }
 
 export const registerBlockSingleProductTemplate = ( {
@@ -40,7 +43,11 @@ export const registerBlockSingleProductTemplate = ( {
 	subscribe( () => {
 		const previousTemplateId = currentTemplateId;
 		const store = select( 'core/edit-site' );
-		currentTemplateId = parseTemplateId( store?.getEditedPostId() );
+
+		// With GB 16.3.0 the return type can be a number: https://github.com/WordPress/gutenberg/issues/53230
+		currentTemplateId = parseTemplateId(
+			store?.getEditedPostId() as string | number | undefined
+		);
 		const hasChangedTemplate = previousTemplateId !== currentTemplateId;
 		const hasTemplateId = Boolean( currentTemplateId );
 

--- a/assets/js/blocks/classic-template/index.tsx
+++ b/assets/js/blocks/classic-template/index.tsx
@@ -31,6 +31,7 @@ import { store as noticesStore } from '@wordpress/notices';
 import { useEntityRecord } from '@wordpress/core-data';
 import { debounce } from '@woocommerce/base-utils';
 import { woo } from '@woocommerce/icons';
+import { isNumber } from '@woocommerce/types';
 
 /**
  * Internal dependencies
@@ -417,7 +418,14 @@ let currentTemplateId: string | undefined;
 subscribe( () => {
 	const previousTemplateId = currentTemplateId;
 	const store = select( 'core/edit-site' );
-	currentTemplateId = store?.getEditedPostId() as string | undefined;
+	// With GB 16.3.0 the return type can be a number: https://github.com/WordPress/gutenberg/issues/53230
+	const editedPostId = store?.getEditedPostId() as
+		| string
+		| number
+		| undefined;
+
+	currentTemplateId = isNumber( editedPostId ) ? undefined : editedPostId;
+
 	const parsedTemplate = currentTemplateId?.split( '//' )[ 1 ];
 
 	if ( parsedTemplate === null || parsedTemplate === undefined ) {


### PR DESCRIPTION
https://github.com/WordPress/gutenberg/pull/52338 introduces a change in the return type of the function `getEditedPostType`. In some cases the return type could be a `number`.  A dedicated issue is opened on Gutenberg repo: https://github.com/WordPress/gutenberg/issues/53230.

In meantime, this PRs add a defensive type handling to avoid any crash at runtime. 



<!-- Reference any related issues or PRs here -->

Fixes #10467

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Ensure that you have installed Gutenberg 16.3.0.
2. Open the Site Editor.
3. Click on the navigation.
4. Click on the pencil (to edit button).
5. Ensure that the Site Editor doesn't crash 




| Before | After |
|--------|--------|
| <video src=https://github.com/woocommerce/woocommerce-blocks/assets/4463174/86ce276e-e372-40e1-8142-cfde84e32bd6 /> | <video src=https://github.com/woocommerce/woocommerce-blocks/assets/4463174/e655eab3-6339-47c9-8447-d9b06c55b795/>  | 

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Classic Template block registration: add defensive type handling.
