### PR TITLE
Revert "Top Rated Products: show only products with rating"

### DIFF
--- a/src/BlockTypes/ProductTopRated.php
+++ b/src/BlockTypes/ProductTopRated.php
@@ -14,17 +14,11 @@ class ProductTopRated extends AbstractProductGrid {
 	protected $block_name = 'product-top-rated';
 
 	/**
-	 * Show only products with ratings and order by rating.
+	 * Force orderby to rating.
 	 *
 	 * @param array $query_args Query args.
 	 */
 	protected function set_block_query_args( &$query_args ) {
 		$query_args['orderby'] = 'rating';
-
-		$this->meta_query[] = array(
-			'key'     => '_wc_average_rating',
-			'value'   => 0,
-			'compare' => '>',
-		);
 	}
 }


### PR DESCRIPTION
Reverts woocommerce/woocommerce-blocks#10434

Fixes https://github.com/woocommerce/woocommerce/issues/42593
### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|<img  alt="Screenshot 2023-08-01 at 15 09 32" src="https://github.com/woocommerce/woocommerce-blocks/assets/186112/cecd9eab-04c5-4eec-a4d9-ae5bbb8f3d81">| ![CleanShot 2023-08-01 at 15 10 02@2x](https://github.com/woocommerce/woocommerce-blocks/assets/186112/3f19b38e-1ef5-4180-9141-fd646b22ca21)|

### Testing
#### User Facing Testing

1. Create a new page or post.
2. Insert the `Top rated product` block.
3. Make sure the block shows **at least one rating** on top, but it's filled also with products without rating.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested by users (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

