### PR TITLE
Open links from the Editor in the top frame, not editor iframe

### DIFF
--- a/assets/js/blocks/attribute-filter/edit.tsx
+++ b/assets/js/blocks/attribute-filter/edit.tsx
@@ -405,8 +405,7 @@ const Edit = ( {
 		);
 	};
 
-	// return Object.keys( ATTRIBUTES ).length === 0 ? (
-	return true ? (
+	return Object.keys( ATTRIBUTES ).length === 0 ? (
 		noAttributesPlaceholder()
 	) : (
 		<div { ...blockProps }>

--- a/assets/js/blocks/attribute-filter/edit.tsx
+++ b/assets/js/blocks/attribute-filter/edit.tsx
@@ -362,7 +362,7 @@ const Edit = ( {
 				className="wc-block-attribute-filter__read_more_button"
 				isTertiary
 				href="https://docs.woocommerce.com/document/managing-product-taxonomies/"
-				target="_top"
+				target="_blank"
 			>
 				{ __( 'Learn more', 'woo-gutenberg-products-block' ) }
 			</Button>

--- a/assets/js/blocks/attribute-filter/edit.tsx
+++ b/assets/js/blocks/attribute-filter/edit.tsx
@@ -352,6 +352,7 @@ const Edit = ( {
 				href={ getAdminLink(
 					'edit.php?post_type=product&page=product_attributes'
 				) }
+				target="_top"
 			>
 				{ __( 'Add new attribute', 'woo-gutenberg-products-block' ) +
 					' ' }
@@ -361,6 +362,7 @@ const Edit = ( {
 				className="wc-block-attribute-filter__read_more_button"
 				isTertiary
 				href="https://docs.woocommerce.com/document/managing-product-taxonomies/"
+				target="_top"
 			>
 				{ __( 'Learn more', 'woo-gutenberg-products-block' ) }
 			</Button>
@@ -403,7 +405,8 @@ const Edit = ( {
 		);
 	};
 
-	return Object.keys( ATTRIBUTES ).length === 0 ? (
+	// return Object.keys( ATTRIBUTES ).length === 0 ? (
+	return true ? (
 		noAttributesPlaceholder()
 	) : (
 		<div { ...blockProps }>

--- a/assets/js/blocks/price-filter/edit.tsx
+++ b/assets/js/blocks/price-filter/edit.tsx
@@ -136,6 +136,7 @@ export default function ( {
 				className="wc-block-price-slider__add-product-button"
 				isSecondary
 				href={ getAdminLink( 'post-new.php?post_type=product' ) }
+				target="_top"
 			>
 				{ __( 'Add new product', 'woo-gutenberg-products-block' ) +
 					' ' }
@@ -145,6 +146,7 @@ export default function ( {
 				className="wc-block-price-slider__read_more_button"
 				isTertiary
 				href="https://docs.woocommerce.com/document/managing-products/"
+				target="_top"
 			>
 				{ __( 'Learn more', 'woo-gutenberg-products-block' ) }
 			</Button>

--- a/assets/js/blocks/price-filter/edit.tsx
+++ b/assets/js/blocks/price-filter/edit.tsx
@@ -146,7 +146,7 @@ export default function ( {
 				className="wc-block-price-slider__read_more_button"
 				isTertiary
 				href="https://docs.woocommerce.com/document/managing-products/"
-				target="_top"
+				target="_blank"
 			>
 				{ __( 'Learn more', 'woo-gutenberg-products-block' ) }
 			</Button>

--- a/assets/js/blocks/products/edit-utils.js
+++ b/assets/js/blocks/products/edit-utils.js
@@ -31,7 +31,7 @@ export const renderNoProductsPlaceholder = ( blockTitle, blockIcon ) => (
 			className="wc-block-products__read_more_button"
 			isTertiary
 			href="https://docs.woocommerce.com/document/managing-products/"
-			target="_top"
+			target="_blank"
 		>
 			{ __( 'Learn more', 'woo-gutenberg-products-block' ) }
 		</Button>

--- a/assets/js/blocks/products/edit-utils.js
+++ b/assets/js/blocks/products/edit-utils.js
@@ -22,6 +22,7 @@ export const renderNoProductsPlaceholder = ( blockTitle, blockIcon ) => (
 			className="wc-block-products__add-product-button"
 			isSecondary
 			href={ ADMIN_URL + 'post-new.php?post_type=product' }
+			target="_top"
 		>
 			{ __( 'Add new product', 'woo-gutenberg-products-block' ) + ' ' }
 			<Icon icon={ external } />
@@ -30,6 +31,7 @@ export const renderNoProductsPlaceholder = ( blockTitle, blockIcon ) => (
 			className="wc-block-products__read_more_button"
 			isTertiary
 			href="https://docs.woocommerce.com/document/managing-products/"
+			target="_top"
 		>
 			{ __( 'Learn more', 'woo-gutenberg-products-block' ) }
 		</Button>


### PR DESCRIPTION
Editor is in a separate iframe and while we add some links within the blocks, they affect the iframe and not main frame.

This PR fixes this issue by targeting mentioned links to "_top".

Question: Maybe these links should be opened in "_blank"?

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|     https://github.com/woocommerce/woocommerce-blocks/assets/20098064/d49c3ad4-8e59-4a0f-a94b-cb0a79fdf49c   |     https://github.com/woocommerce/woocommerce-blocks/assets/20098064/94ba7e73-ae03-481b-9f43-ad576c45cc0b |


### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Make sure you have no products and attributes in the store (consider creating a fresh page)
2. Go to Editor
3. Add: Filter by Attribute, Filter by Price and All Products
4. Click the links that appear in placeholders:
<img width="664" alt="Screen Shot 2023-08-09 at 11 46 47 AM" src="https://github.com/woocommerce/woocommerce-blocks/assets/20098064/4393505b-61c0-44ef-b042-dc97c55d03df">

5. "Add new product/attribute" should redirect the whole page
6. "Learn more" should open a new tab

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Links from blocks in Editor open in the main frame instead of Editor's iframe.
