### PR TITLE
Interactivity API: Disable scroll for Pagination block links inside Product Query

### DIFF
--- a/src/BlockTypes/ProductQuery.php
+++ b/src/BlockTypes/ProductQuery.php
@@ -138,7 +138,7 @@ class ProductQuery extends AbstractBlock {
 
 				$navigation_link_payload = array(
 					'prefetch' => $is_previous_or_next,
-					'scroll'   => true,
+					'scroll'   => false,
 				);
 
 				$p->set_attribute(


### PR DESCRIPTION
Follow-up of https://github.com/woocommerce/woocommerce-blocks/pull/10200/

Make links inside a Pagination block not to scroll to the top of the page, as requested in https://github.com/woocommerce/woocommerce-blocks/pull/10200#issuecomment-1662563431.

### Testing

#### User Facing Testing

1. Follow user-facing testing steps defined in https://github.com/woocommerce/woocommerce-blocks/pull/10200
2. Ensure the scroll doesn't go up when you click on any link inside the Pagination block.
