### PR TITLE
Create wc-all-block-styles chunk with all blocks stylesheet for classic themes

### DIFF
--- a/bin/webpack-configs.js
+++ b/bin/webpack-configs.js
@@ -733,7 +733,7 @@ const getSiteEditorConfig = ( options = {} ) => {
  * @param {Object} options Build options.
  */
 const getStylingConfig = ( options = {} ) => {
-	let { fileSuffix } = options;
+	let { fileSuffix, isClassicThemeConfig } = options;
 	const { alias, resolvePlugins = [] } = options;
 	fileSuffix = fileSuffix ? `-${ fileSuffix }` : '';
 	const resolve = alias
@@ -775,11 +775,58 @@ const getStylingConfig = ( options = {} ) => {
 						chunks: 'all',
 						priority: 10,
 					},
+					...( isClassicThemeConfig && {
+						vendorsStyle: {
+							test: /[\/\\]node_modules[\/\\].*?style\.s?css$/,
+							name: 'wc-blocks-vendors-style',
+							chunks: 'all',
+							priority: 7,
+						},
+						blocksStyle: {
+							// Capture all stylesheets with name `style` or name that starts with underscore (abstracts).
+							test: /(style|_.*)\.scss$/,
+							name: 'wc-all-blocks-style',
+							chunks: 'all',
+							priority: 5,
+						},
+					} ),
 				},
 			},
 		},
 		module: {
 			rules: [
+				{
+					test: /[\/\\]node_modules[\/\\].*?style\.s?css$/,
+					use: [
+						MiniCssExtractPlugin.loader,
+						{ loader: 'css-loader', options: { importLoaders: 1 } },
+						'postcss-loader',
+						{
+							loader: 'sass-loader',
+							options: {
+								sassOptions: {
+									includePaths: [ 'node_modules' ],
+								},
+								additionalData: ( content ) => {
+									const styleImports = [
+										'colors',
+										'breakpoints',
+										'variables',
+										'mixins',
+										'animations',
+										'z-index',
+									]
+										.map(
+											( imported ) =>
+												`@import "~@wordpress/base-styles/${ imported }";`
+										)
+										.join( ' ' );
+									return styleImports + content;
+								},
+							},
+						},
+					],
+				},
 				{
 					test: /\.(j|t)sx?$/,
 					use: {
@@ -800,6 +847,7 @@ const getStylingConfig = ( options = {} ) => {
 				},
 				{
 					test: /\.s?css$/,
+					exclude: /node_modules/,
 					use: [
 						MiniCssExtractPlugin.loader,
 						'css-loader',

--- a/bin/webpack-entries.js
+++ b/bin/webpack-entries.js
@@ -118,6 +118,16 @@ const getBlockEntries = ( relativePath ) => {
 
 const entries = {
 	styling: {
+		// @wordpress/components styles
+		'custom-select-control-style':
+			'./node_modules/wordpress-components/src/custom-select-control/style.scss',
+		'snackbar-notice-style':
+			'./node_modules/wordpress-components/src/snackbar/style.scss',
+		'combobox-control-style':
+			'./node_modules/wordpress-components/src/combobox-control/style.scss',
+		'form-token-field-style':
+			'./node_modules/wordpress-components/src/form-token-field/style.scss',
+
 		// Packages styles
 		'packages-style': glob.sync( './packages/**/index.js' ),
 

--- a/src/AssetsController.php
+++ b/src/AssetsController.php
@@ -46,9 +46,16 @@ final class AssetsController {
 	 * Register block scripts & styles.
 	 */
 	public function register_assets() {
-		$this->register_style( 'wc-blocks-packages-style', plugins_url( $this->api->get_block_asset_build_path( 'packages-style', 'css' ), __DIR__ ), [], 'all', true );
-		$this->register_style( 'wc-blocks-style', plugins_url( $this->api->get_block_asset_build_path( 'wc-blocks', 'css' ), __DIR__ ), [], 'all', true );
 		$this->register_style( 'wc-blocks-editor-style', plugins_url( $this->api->get_block_asset_build_path( 'wc-blocks-editor-style', 'css' ), __DIR__ ), [ 'wp-edit-blocks' ], 'all', true );
+
+		if ( wc_current_theme_is_fse_theme() ) {
+			$this->register_style( 'wc-blocks-packages-style', plugins_url( $this->api->get_block_asset_build_path( 'packages-style', 'css' ), __DIR__ ), [], 'all', true );
+			$this->register_style( 'wc-blocks-style', plugins_url( $this->api->get_block_asset_build_path( 'wc-blocks', 'css' ), __DIR__ ), [], 'all', true );
+		} else {
+
+			$this->register_style( 'wc-blocks-vendors-style', plugins_url( $this->api->get_block_asset_build_path( 'wc-blocks-vendors-style', 'css' ), __DIR__ ) );
+			$this->register_style( 'wc-all-blocks-style', plugins_url( $this->api->get_block_asset_build_path( 'wc-all-blocks-style', 'css' ), __DIR__ ), [ 'wc-blocks-vendors-style' ], 'all', true );
+		}
 
 		$this->api->register_script( 'wc-blocks-middleware', 'build/wc-blocks-middleware.js', [], false );
 		$this->api->register_script( 'wc-blocks-data-store', 'build/wc-blocks-data.js', [ 'wc-blocks-middleware' ] );

--- a/src/BlockTypes/AbstractBlock.php
+++ b/src/BlockTypes/AbstractBlock.php
@@ -303,9 +303,12 @@ abstract class AbstractBlock {
 	 * @return string[]|null
 	 */
 	protected function get_block_type_style() {
-		$this->asset_api->register_style( 'wc-blocks-style-' . $this->block_name, $this->asset_api->get_block_asset_build_path( $this->block_name, 'css' ), [], 'all', true );
+		if ( wc_current_theme_is_fse_theme() ) {
+			$this->asset_api->register_style( 'wc-blocks-style-' . $this->block_name, $this->asset_api->get_block_asset_build_path( $this->block_name, 'css' ), [], 'all', true );
+			return [ 'wc-blocks-style', 'wc-blocks-style-' . $this->block_name ];
+		}
 
-		return [ 'wc-blocks-style', 'wc-blocks-style-' . $this->block_name ];
+		return [ 'wc-all-blocks-style' ];
 	}
 
 	/**

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -75,7 +75,12 @@ const PaymentsConfig = {
  */
 const StylingConfig = {
 	...sharedConfig,
-	...getStylingConfig( { alias: getAlias() } ),
+	...getStylingConfig( { alias: getAlias(), isClassicThemeConfig: false } ),
+};
+
+const StylingClassicThemeConfig = {
+	...sharedConfig,
+	...getStylingConfig( { alias: getAlias(), isClassicThemeConfig: true } ),
 };
 
 /**
@@ -103,4 +108,5 @@ module.exports = [
 	SiteEditorConfig,
 	StylingConfig,
 	InteractivityConfig,
+	StylingClassicThemeConfig,
 ];


### PR DESCRIPTION
This PR fixes https://github.com/woocommerce/woocommerce/issues/39658. @Aljullu with #9831 introduces an optimization  focuses on enhancing WordPress performance by selectively loading only the necessary block stylesheets that correspond to the blocks present on a given page. While this mechanism has been successfully implemented for block themes, it doesn't work on classic themes. This happens for the block themes, but not for the classic themes. Referencing the post titled [Block-styles loading enhancements in WordPress 5.8](https://make.wordpress.org/core/2021/07/01/block-styles-loading-enhancements-in-wordpress-5-8/):

> In a classic, php-based theme, when a page starts to render, WordPress is not aware which blocks exist on a page and which don’t. Blocks gets parsed on render, and what that means is that block-styles don’t get added in the <head> of the page. Instead, they are added to the footer, when [print_late_styles()](https://developer.wordpress.org/reference/functions/print_late_styles/) runs.

Classic themes currently suffer from a deficiency in identifying the specific blocks within a page, resulting in the loading of the complete stylesheet for every block. To mitigate this, a temporary solution has been adopted, reinstating the previous behavior for classic themes. However, we acknowledge that this is not a permanent fix. Over the upcoming weeks, our efforts will be directed towards devising an appropriate optimization strategy for classic themes.

In technical terms, a Webpack chunk has been crafted with all necessary stylesheets. This specialized chunk will be enqueued and exclusively loaded with classic themes.



<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

<!-- Reference any related issues or PRs here -->

Fixes https://github.com/woocommerce/woocommerce/issues/39658.

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Accessibility

<!-- If you've changed or added any interactions, check off the appropriate items below. You can delete any that don't apply. Use this space to elaborate on anything if needed. -->

- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)

#### Other Checks

- [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|        |       |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

⚠️: Following these testing instruction for a classic theme (Storefront) and a block theme (TT3)

##### For classic theme ensure that is loaded only `wc-all-blocks-style.css` and `wc-blocks-vendors-style.css` stylesheets.

##### For block theme sure that is loaded only the stylesheets of blocks visible in the page.

1. Create a post or page and add the All Products block. Verify styles are loaded correctly.
2. Visit the page in the frontend and verify styles are loaded correctly in the frontend as well.
3. Repeat steps 1 and 2 with all blocks listed on [this page](https://wordpress.org/plugins/woo-gutenberg-products-block/). Make sure to test each block individually. So, when possible, try with only one block on the page (in some cases, that's not possible, ie: filter blocks, in that case, try with as few blocks as possible on the page). The reason is that we want to make sure each block includes the style dependencies that it needs, so they need to be tested in isolation, otherwise styles from other blocks might leak into other blocks and "help fix issues".

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

### Changelog

> Create wc-all-block-styles chunk with all blocks stylesheet for classic themes
