### PR TITLE
Fix: disable product query title and summary variations from inserter in favour of Product Collection ones

### DIFF
--- a/assets/js/blocks/product-query/variations/elements/product-summary.tsx
+++ b/assets/js/blocks/product-query/variations/elements/product-summary.tsx
@@ -21,4 +21,5 @@ registerElementVariation( CORE_NAME, {
 	blockIcon: <Icon icon={ page } />,
 	blockTitle: BLOCK_TITLE,
 	variationName: VARIATION_NAME,
+	scope: [ 'block' ],
 } );

--- a/assets/js/blocks/product-query/variations/elements/product-template.tsx
+++ b/assets/js/blocks/product-query/variations/elements/product-template.tsx
@@ -21,4 +21,5 @@ registerElementVariation( CORE_NAME, {
 	blockIcon: <Icon icon={ layout } />,
 	blockTitle: __( 'Product template', 'woo-gutenberg-products-block' ),
 	variationName: VARIATION_NAME,
+	scope: [ 'block', 'inserter' ],
 } );

--- a/assets/js/blocks/product-query/variations/elements/product-title.tsx
+++ b/assets/js/blocks/product-query/variations/elements/product-title.tsx
@@ -21,4 +21,5 @@ registerElementVariation( CORE_NAME, {
 	blockIcon: <Icon icon={ heading } />,
 	blockTitle: BLOCK_TITLE,
 	variationName: VARIATION_NAME,
+	scope: [ 'block' ],
 } );

--- a/assets/js/blocks/product-query/variations/elements/utils.tsx
+++ b/assets/js/blocks/product-query/variations/elements/utils.tsx
@@ -1,13 +1,17 @@
 /**
  * External dependencies
  */
-import { registerBlockVariation } from '@wordpress/blocks';
+import {
+	registerBlockVariation,
+	type BlockVariationScope,
+} from '@wordpress/blocks';
 
 interface VariationDetails {
 	blockDescription: string;
 	blockIcon: JSX.Element;
 	blockTitle: string;
 	variationName: string;
+	scope: BlockVariationScope[];
 }
 
 export function registerElementVariation(
@@ -26,6 +30,6 @@ export function registerElementVariation(
 		attributes: {
 			__woocommerceNamespace: variationName,
 		},
-		scope: [ 'block', 'inserter' ],
+		scope,
 	} );
 }

--- a/assets/js/blocks/product-query/variations/elements/utils.tsx
+++ b/assets/js/blocks/product-query/variations/elements/utils.tsx
@@ -16,7 +16,13 @@ interface VariationDetails {
 
 export function registerElementVariation(
 	coreName: string,
-	{ blockDescription, blockIcon, blockTitle, variationName }: VariationDetails
+	{
+		blockDescription,
+		blockIcon,
+		blockTitle,
+		variationName,
+		scope,
+	}: VariationDetails
 ) {
 	registerBlockVariation( coreName, {
 		description: blockDescription,


### PR DESCRIPTION
Product Collection provides its own variation of blocks:

- Product Title (core/post-title)
- Product Summary (core/post-excerpt)

This is the same approach as Products (Beta) block does.
Unfortunately, that results in the block being duplicated in the inserter.

In this PR the variations from Products (Beta) block have limited scope, so from now on only Product Collection ones will be used in both cases. This will ONLY work if Product Collection (and its variations) are core features, hence this PR is not to `trunk` but to `enable/product-collection` branch which removes experimental flag from Product Collection block.

⚠️ It's not confirmed we'll go with this approach! We're still exploring other possibilities with @imanish003.

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/10525

#### Other Checks

- [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Screenshots

<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

| Before | After |
| ------ | ----- |
|     <img width="327" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/20098064/abddbf67-811e-4fc2-8852-085257bfb182">   |   <img width="341" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/20098064/5e3b063e-81e0-4801-a9a8-8df771029c15">    |
| <img width="357" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/20098064/37b20fd4-539b-4ffb-8053-0a3865643d4b"> | <img width="358" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/20098064/eb01adf6-6a35-46a3-98da-60bb33984808"> |

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

##### Include in general testing notes

1. Go to Editor
2. Add Products (Beta) block and Product Collection block
3. Try to add "Product Title" and "Product Summary" blocks within both
4. **Expected**: There should be just one block to choose from
5. Save and go to frontend
6. **Expected**: Blocks should render properly

##### Testing only for developers

1. Be on `trunk`
2. Go to Editor
3. Add Products (Beta) block and Product Collection blocks
5. Save the page/template
6. Switch to this branch (`fix/10525-disable-product-query-title-and-summary-variations-from-inserter`)
7. Go to the same Editor page
8. Make sure the previously added Product Title displays correctly and the same on the frontend
9. Repeat steps 3 - 6 from previous section

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [x] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
