### PR TITLE
Fix the `on sale` badge for product blocks

### DIFF
--- a/assets/css/editor.scss
+++ b/assets/css/editor.scss
@@ -8,6 +8,10 @@
 
 			.wc-block-grid__product {
 				margin: 0 0 $gap-large 0;
+
+				.wc-block-grid__product-onsale {
+					position: absolute;
+				}
 			}
 		}
 

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -139,7 +139,7 @@
 		}
 	}
 }
-.wc-block-grid__product-onsale {
+.wc-block-grid .wc-block-grid__product-onsale {
 	@include font-size(small);
 	padding: em($gap-smallest) em($gap-small);
 	display: inline-block;


### PR DESCRIPTION
This PR increases the CSS selector specificity of the sale badge to fix its position.

<img width="850" alt="Screenshot 2023-08-11 at 15 39 12" src="https://github.com/woocommerce/woocommerce-blocks/assets/186112/c0cc17b1-817e-43a6-bea3-5a5e6add325e">

### Testing

1. Enable the `Storefront` theme.
2. Create a new page or post.
3. Add the `Products by Attribute`, `Products by Tag`, `Products by Category`, `Handpicked products` and `All products` blocks.
4. Check the `Sale` back shows on the top-right corner of the image on all of them, in the editor and in the frontend.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> Fix the "On Sale" badge position.
