### PR TITLE
Import RouteException in CheckoutTrait

### DIFF
--- a/src/StoreApi/Utilities/CheckoutTrait.php
+++ b/src/StoreApi/Utilities/CheckoutTrait.php
@@ -1,6 +1,7 @@
 <?php
 namespace Automattic\WooCommerce\StoreApi\Utilities;
 
+use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
 use Automattic\WooCommerce\StoreApi\Payments\PaymentContext;
 use Automattic\WooCommerce\StoreApi\Payments\PaymentResult;
 

--- a/src/StoreApi/Utilities/OrderAuthorizationTrait.php
+++ b/src/StoreApi/Utilities/OrderAuthorizationTrait.php
@@ -1,7 +1,6 @@
 <?php
 namespace Automattic\WooCommerce\StoreApi\Utilities;
 
-use Automattic\WooCommerce\StoreApi\Utilities\OrderController;
 use Automattic\WooCommerce\StoreApi\Exceptions\RouteException;
 
 /**


### PR DESCRIPTION
CheckoutTrait was missing `RouteException`, which means errors were not reported correctly.