### PR TITLE
Copy shipping phone to billing phone if sync is checked

### DIFF
--- a/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/customer-address.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/customer-address.tsx
@@ -34,6 +34,7 @@ const CustomerAddress = ( {
 		setShippingAddress,
 		setBillingAddress,
 		setShippingPhone,
+		setBillingPhone,
 		useShippingAsBilling,
 	} = useCheckoutAddress();
 	const { dispatchCheckoutEvent } = useStoreEvents();
@@ -129,6 +130,12 @@ const CustomerAddress = ( {
 							dispatchCheckoutEvent( 'set-phone-number', {
 								step: 'shipping',
 							} );
+							if ( useShippingAsBilling ) {
+								setBillingPhone( value );
+								dispatchCheckoutEvent( 'set-phone-number', {
+									step: 'billing',
+								} );
+							}
 						} }
 					/>
 				) }

--- a/tests/e2e/tests/checkout/checkout-block-shipping.block_theme.side_effects.spec.ts
+++ b/tests/e2e/tests/checkout/checkout-block-shipping.block_theme.side_effects.spec.ts
@@ -57,7 +57,23 @@ test.describe( 'Shopper → Checkout block → Shipping', () => {
 				FLAT_RATE_SHIPPING_PRICE
 			)
 		).toBe( true );
-		await page.getByLabel( 'Use same address for billing' ).uncheck();
+
+		await pageObject.syncBillingWithShipping();
+		await pageObject.fillInCheckoutWithTestData( {
+			phone: '0987654322',
+		} );
+		await pageObject.unsyncBillingWithShipping();
+		const shippingForm = page.getByRole( 'group', {
+			name: 'Shipping address',
+		} );
+		const billingForm = page.getByRole( 'group', {
+			name: 'Billing address',
+		} );
+
+		await expect( shippingForm.getByLabel( 'Phone' ).inputValue ).toEqual(
+			billingForm.getByLabel( 'Phone' ).inputValue
+		);
+
 		await pageObject.fillInCheckoutWithTestData();
 		const overrideBillingDetails = {
 			firstname: 'Juan',

--- a/tests/e2e/tests/checkout/checkout.page.ts
+++ b/tests/e2e/tests/checkout/checkout.page.ts
@@ -332,6 +332,14 @@ export class CheckoutPage {
 		}
 	}
 
+	async syncBillingWithShipping() {
+		await this.page.getByLabel( 'Use same address for billing' ).check();
+	}
+
+	async unsyncBillingWithShipping() {
+		await this.page.getByLabel( 'Use same address for billing' ).uncheck();
+	}
+
 	getOrderId() {
 		// Get the current URL
 		const url = this.page.url();


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->

This PR syncs up billing phone with shipping phone if the sync checkbox is checked.
<!-- Reference any related issues or PRs here -->

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/10602

### Testing

1. In Checkout, make sure the "use shipping as billing" is filled.
2. Fill out the phone number.
3. Uncheck the checkbox, the value should be copied.
4. Update shipping, it shouldn't keep syncing.

### Changelog

> Fix a bug in which shipping phone field was not being synced to the billing field.
