### PR TITLE
Order confirmation: Add wrapper for the order downloads block

### DIFF
--- a/assets/js/blocks/classic-template/order-confirmation.tsx
+++ b/assets/js/blocks/classic-template/order-confirmation.tsx
@@ -30,6 +30,10 @@ const getBlockifiedTemplate = ( inheritedAttributes: InheritedAttributes ) =>
 			'woocommerce/order-confirmation-totals',
 			inheritedAttributes
 		),
+		createBlock(
+			'woocommerce/order-confirmation-downloads-wrapper',
+			inheritedAttributes
+		),
 		createBlock( 'core/columns', inheritedAttributes, [
 			createBlock( 'core/column', inheritedAttributes, [
 				createBlock(

--- a/assets/js/blocks/order-confirmation/downloads-wrapper/attributes.tsx
+++ b/assets/js/blocks/order-confirmation/downloads-wrapper/attributes.tsx
@@ -1,0 +1,11 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export default {
+	heading: {
+		type: 'string',
+		default: __( 'Downloads', 'woo-gutenberg-products-block' ),
+	},
+};

--- a/assets/js/blocks/order-confirmation/downloads-wrapper/block.json
+++ b/assets/js/blocks/order-confirmation/downloads-wrapper/block.json
@@ -2,7 +2,7 @@
 	"name": "woocommerce/order-confirmation-downloads-wrapper",
 	"version": "1.0.0",
 	"title": "Order Confirmation Downloads",
-	"description": "Display the downloadale products section.",
+	"description": "Display the downloadable products section.",
 	"category": "woocommerce",
 	"keywords": [ "WooCommerce" ],
 	"attributes": {

--- a/assets/js/blocks/order-confirmation/downloads-wrapper/block.json
+++ b/assets/js/blocks/order-confirmation/downloads-wrapper/block.json
@@ -1,0 +1,21 @@
+{
+	"name": "woocommerce/order-confirmation-downloads-wrapper",
+	"version": "1.0.0",
+	"title": "Order Confirmation Downloads",
+	"description": "Display the downloadale products section.",
+	"category": "woocommerce",
+	"keywords": [ "WooCommerce" ],
+	"attributes": {
+		"heading": {
+			"type": "string"
+		}
+	},
+	"supports": {
+		"multiple": false,
+		"align": [ "wide", "full" ],
+		"html": false
+	},
+	"textdomain": "woo-gutenberg-products-block",
+	"apiVersion": 2,
+	"$schema": "https://schemas.wp.org/trunk/block.json"
+}

--- a/assets/js/blocks/order-confirmation/downloads-wrapper/edit.tsx
+++ b/assets/js/blocks/order-confirmation/downloads-wrapper/edit.tsx
@@ -1,0 +1,53 @@
+/**
+ * External dependencies
+ */
+import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
+import { getSetting } from '@woocommerce/settings';
+
+const Edit = ( {
+	attributes,
+	setAttributes,
+}: {
+	attributes: {
+		heading: string;
+	};
+	setAttributes: ( attributes: Record< string, unknown > ) => void;
+} ) => {
+	const blockProps = useBlockProps();
+	const hasDownloadableProducts = getSetting(
+		'storeHasDownloadableProducts'
+	);
+
+	if ( ! hasDownloadableProducts ) {
+		return null;
+	}
+
+	return (
+		<div { ...blockProps }>
+			<InnerBlocks
+				allowedBlocks={ [ 'core/heading' ] }
+				template={ [
+					[
+						'core/heading',
+						{
+							level: 3,
+							content: attributes.heading || '',
+							onChangeContent: ( value: string ) =>
+								setAttributes( { heading: value } ),
+						},
+					],
+					[
+						'woocommerce/order-confirmation-downloads',
+						{
+							lock: {
+								remove: true,
+							},
+						},
+					],
+				] }
+			/>
+		</div>
+	);
+};
+
+export default Edit;

--- a/assets/js/blocks/order-confirmation/downloads-wrapper/index.tsx
+++ b/assets/js/blocks/order-confirmation/downloads-wrapper/index.tsx
@@ -3,7 +3,7 @@
  */
 import { registerBlockType, type BlockConfiguration } from '@wordpress/blocks';
 import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
-import { Icon, mapMarker } from '@wordpress/icons';
+import { Icon, download } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -18,7 +18,7 @@ registerBlockType(
 		icon: {
 			src: (
 				<Icon
-					icon={ mapMarker }
+					icon={ download }
 					className="wc-block-editor-components-block-icon"
 				/>
 			),

--- a/assets/js/blocks/order-confirmation/downloads-wrapper/index.tsx
+++ b/assets/js/blocks/order-confirmation/downloads-wrapper/index.tsx
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import { registerBlockType, type BlockConfiguration } from '@wordpress/blocks';
+import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
+import { Icon, mapMarker } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
+import metadata from './block.json';
+import attributes from './attributes';
+
+registerBlockType(
+	metadata as BlockConfiguration,
+	{
+		icon: {
+			src: (
+				<Icon
+					icon={ mapMarker }
+					className="wc-block-editor-components-block-icon"
+				/>
+			),
+		},
+		edit,
+		save() {
+			return (
+				<div { ...useBlockProps.save() }>
+					<InnerBlocks.Content />
+				</div>
+			);
+		},
+		attributes,
+	} as unknown as Partial< BlockConfiguration >
+);

--- a/assets/js/blocks/order-confirmation/downloads/block.json
+++ b/assets/js/blocks/order-confirmation/downloads/block.json
@@ -30,8 +30,7 @@
 			"__experimentalDefaultControls": {
 				"background": true,
 				"text": true
-			},
-			"__experimentalSkipSerialization": true
+			}
 		},
 		"spacing": {
 			"padding": true,
@@ -49,8 +48,7 @@
 				"color": true,
 				"style": true,
 				"width": true
-			},
-			"__experimentalSkipSerialization": true
+			}
 		},
 		"__experimentalSelector": ".wp-block-woocommerce-order-confirmation-totals table"
 	},
@@ -62,10 +60,6 @@
 		"className": {
 			"type": "string",
 			"default": ""
-		},
-		"isPreview": {
-			"type": "boolean",
-			"default": false
 		}
 	},
 	"textdomain": "woo-gutenberg-products-block",

--- a/assets/js/blocks/order-confirmation/downloads/block.json
+++ b/assets/js/blocks/order-confirmation/downloads/block.json
@@ -7,7 +7,52 @@
 	"keywords": [ "WooCommerce" ],
 	"supports": {
 		"multiple": false,
-		"align": [ "wide", "full" ]
+		"align": [ "wide", "full" ],
+		"html": false,
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalFontStyle": true,
+			"__experimentalFontWeight": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalTextTransform": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
+		},
+		"color": {
+			"background": true,
+			"text": true,
+			"link": true,
+			"gradients": true,
+			"__experimentalDefaultControls": {
+				"background": true,
+				"text": true
+			},
+			"__experimentalSkipSerialization": true
+		},
+		"spacing": {
+			"padding": true,
+			"margin": true,
+			"__experimentalDefaultControls": {
+				"margin": false,
+				"padding": false
+			}
+		},
+		"__experimentalBorder": {
+			"color": true,
+			"style": true,
+			"width": true,
+			"__experimentalDefaultControls": {
+				"color": true,
+				"style": true,
+				"width": true
+			},
+			"__experimentalSkipSerialization": true
+		},
+		"__experimentalSelector": ".wp-block-woocommerce-order-confirmation-totals table"
 	},
 	"attributes": {
 		"align": {

--- a/assets/js/blocks/order-confirmation/downloads/edit.tsx
+++ b/assets/js/blocks/order-confirmation/downloads/edit.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import ServerSideRender from '@wordpress/server-side-render';
 import { useBlockProps } from '@wordpress/block-editor';
 import { Disabled } from '@wordpress/components';
 
@@ -10,31 +9,82 @@ import { Disabled } from '@wordpress/components';
  */
 import './style.scss';
 
-interface Props {
-	attributes: {
-		align: string;
-		className: string;
-		isPreview: boolean;
-	};
-	name: string;
-}
-
-const Edit = ( props: Props ): JSX.Element => {
-	const { attributes, name } = props;
+const Edit = (): JSX.Element => {
 	const blockProps = useBlockProps( {
 		className: 'wc-block-order-confirmation-downloads',
 	} );
 
+	const borderStyles = ( ( {
+		borderBottomColor,
+		borderLeftColor,
+		borderRightColor,
+		borderTopColor,
+		borderWidth,
+	} ) => ( {
+		borderBottomColor,
+		borderLeftColor,
+		borderRightColor,
+		borderTopColor,
+		borderWidth,
+	} ) )( blockProps.style );
+
 	return (
 		<div { ...blockProps }>
 			<Disabled>
-				<ServerSideRender
-					block={ name }
-					attributes={ {
-						...attributes,
-						isPreview: true,
-					} }
-				/>
+				<table
+					style={ borderStyles }
+					cellSpacing="0"
+					className="wc-block-order-confirmation-downloads__table"
+				>
+					<thead>
+						<tr>
+							<th className="download-product">
+								<span className="nobr">Product</span>
+							</th>
+							<th className="download-remaining">
+								<span className="nobr">
+									Downloads remaining
+								</span>
+							</th>
+							<th className="download-expires">
+								<span className="nobr">Expires</span>
+							</th>
+							<th className="download-file">
+								<span className="nobr">Download</span>
+							</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td
+								className="download-product"
+								data-title="Product"
+							>
+								<a href="https://example.com">Test Product</a>
+							</td>
+							<td
+								className="download-remaining"
+								data-title="Downloads remaining"
+							>
+								∞
+							</td>
+							<td
+								className="download-expires"
+								data-title="Expires"
+							>
+								Never
+							</td>
+							<td className="download-file" data-title="Download">
+								<a
+									href="https://example.com"
+									className="woocommerce-MyAccount-downloads-file button alt"
+								>
+									Test Download
+								</a>
+							</td>
+						</tr>
+					</tbody>
+				</table>
 			</Disabled>
 		</div>
 	);

--- a/assets/js/blocks/order-confirmation/downloads/index.tsx
+++ b/assets/js/blocks/order-confirmation/downloads/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { registerBlockType } from '@wordpress/blocks';
+import { registerBlockType, type BlockConfiguration } from '@wordpress/blocks';
 import { Icon, download } from '@wordpress/icons';
 
 /**
@@ -11,7 +11,7 @@ import metadata from './block.json';
 import edit from './edit';
 import './style.scss';
 
-registerBlockType( metadata, {
+registerBlockType( metadata as BlockConfiguration, {
 	icon: {
 		src: (
 			<Icon

--- a/assets/js/blocks/order-confirmation/downloads/style.scss
+++ b/assets/js/blocks/order-confirmation/downloads/style.scss
@@ -1,7 +1,9 @@
 .wc-block-order-confirmation-downloads {
+	border: none !important;
+
 	table {
-		width: 100%;
 		border: 1px solid currentColor;
+		width: 100%;
 		border-collapse: collapse;
 		th,
 		td {

--- a/assets/js/blocks/order-confirmation/downloads/style.scss
+++ b/assets/js/blocks/order-confirmation/downloads/style.scss
@@ -1,26 +1,32 @@
 .wc-block-order-confirmation-downloads {
-	.woocommerce-order-downloads table,
-	.woocommerce-order-downloads table.shop_table {
+	table {
 		width: 100%;
 		border: 1px solid currentColor;
-		border-bottom: 0;
-
-		thead {
-			text-transform: uppercase;
-		}
-
-		th {
-			font-weight: bold;
-		}
-
+		border-collapse: collapse;
 		th,
 		td {
-			border-style: solid;
-			border-color: currentColor;
-			border-width: 0 0 1px 0;
-			padding: $gap-small;
+			border: 1px solid currentColor;
+			border-right-width: 0;
+			border-left-width: 0;
+			padding: $gap;
 			margin: 0;
 			text-align: left;
+			font-weight: inherit;
+		}
+		thead {
+			font-weight: bold;
+		}
+	}
+	table[style*="border-width"] {
+		> *,
+		tr,
+		th,
+		td {
+			border-style: inherit;
+			border-width: inherit;
+			border-color: inherit;
+			border-right-width: 0;
+			border-left-width: 0;
 		}
 	}
 }

--- a/bin/webpack-entries.js
+++ b/bin/webpack-entries.js
@@ -92,6 +92,9 @@ const blocks = {
 	'order-confirmation-totals': {
 		customDir: 'order-confirmation/totals',
 	},
+	'order-confirmation-downloads-wrapper': {
+		customDir: 'order-confirmation/downloads-wrapper',
+	},
 	'order-confirmation-downloads': {
 		customDir: 'order-confirmation/downloads',
 	},

--- a/src/BlockTypes/OrderConfirmation/Downloads.php
+++ b/src/BlockTypes/OrderConfirmation/Downloads.php
@@ -17,6 +17,55 @@ class Downloads extends AbstractOrderConfirmationBlock {
 	protected $block_name = 'order-confirmation-downloads';
 
 	/**
+	 * Render the block.
+	 *
+	 * @param array    $attributes Block attributes.
+	 * @param string   $content Block content.
+	 * @param WP_Block $block Block instance.
+	 * @return string | void Rendered block output.
+	 */
+	protected function render( $attributes, $content, $block ) {
+		$render = parent::render( $attributes, $content, $block );
+
+		// Appends inline styles in the editor.
+		if ( ! empty( $attributes['isPreview'] ) ) {
+			$styles  = $this->get_link_styles( $attributes );
+			$render .= '<style>' . esc_html( $styles ) . '</style>';
+		}
+
+		return $render;
+	}
+
+	/**
+	 * Enqueue frontend assets for this block, just in time for rendering.
+	 *
+	 * @param array $attributes  Any attributes that currently are available from the block.
+	 * @return string
+	 */
+	protected function get_link_styles( array $attributes ) {
+		$link_classes_and_styles       = StyleAttributesUtils::get_link_color_class_and_style( $attributes );
+		$link_hover_classes_and_styles = StyleAttributesUtils::get_link_hover_color_class_and_style( $attributes );
+
+		return '
+			.wc-block-order-confirmation-downloads__table a {' . $link_classes_and_styles['style'] . '}
+			.wc-block-order-confirmation-downloads__table a:hover, .wc-block-order-confirmation-downloads__table a:focus {' . $link_hover_classes_and_styles['style'] . '}
+		';
+	}
+
+	/**
+	 * Enqueue frontend assets for this block, just in time for rendering.
+	 *
+	 * @param array $attributes  Any attributes that currently are available from the block.
+	 */
+	protected function enqueue_assets( array $attributes ) {
+		parent::enqueue_assets( $attributes );
+
+		$styles = $this->get_link_styles( $attributes );
+
+		wp_add_inline_style( 'wc-blocks-style', $styles );
+	}
+
+	/**
 	 * This renders the content of the block within the wrapper.
 	 *
 	 * @param \WC_Order $order Order object.
@@ -45,19 +94,19 @@ class Downloads extends AbstractOrderConfirmationBlock {
 			return $this->render_content_fallback();
 		}
 
+		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, [ 'border_color', 'border_radius', 'border_width', 'background_color', 'text_color' ] );
+
 		return '
-			<section class="woocommerce-order-downloads">
-				<table class="woocommerce-table woocommerce-table--order-downloads shop_table shop_table_responsive order_details" cellspacing="0">
-					<thead>
-						<tr>
-							' . $this->render_order_downloads_column_headers( $order ) . '
-						</td>
-					</thead>
-					<tbody>
-						' . $this->render_order_downloads( $order, $downloads ) . '
-					</tbody>
-				</table>
-			</section>
+			<table cellspacing="0" class="wc-block-order-confirmation-downloads__table ' . esc_attr( $classes_and_styles['classes'] ) . '" style="' . esc_attr( $classes_and_styles['styles'] ) . '">
+				<thead>
+					<tr>
+						' . $this->render_order_downloads_column_headers( $order ) . '
+					</td>
+				</thead>
+				<tbody>
+					' . $this->render_order_downloads( $order, $downloads ) . '
+				</tbody>
+			</table>
 		';
 	}
 

--- a/src/BlockTypes/OrderConfirmation/Downloads.php
+++ b/src/BlockTypes/OrderConfirmation/Downloads.php
@@ -36,7 +36,7 @@ class Downloads extends AbstractOrderConfirmationBlock {
 		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, [ 'border_color', 'border_radius', 'border_width', 'background_color', 'text_color' ] );
 
 		return '
-			<table cellspacing="0" class="wc-block-order-confirmation-downloads__table">
+			<table cellspacing="0" class="wc-block-order-confirmation-downloads__table ' . esc_attr( $classes_and_styles['classes'] ) . '" style="' . esc_attr( $classes_and_styles['styles'] ) . '">
 				<thead>
 					<tr>
 						' . $this->render_order_downloads_column_headers( $order ) . '

--- a/src/BlockTypes/OrderConfirmation/Downloads.php
+++ b/src/BlockTypes/OrderConfirmation/Downloads.php
@@ -17,55 +17,6 @@ class Downloads extends AbstractOrderConfirmationBlock {
 	protected $block_name = 'order-confirmation-downloads';
 
 	/**
-	 * Render the block.
-	 *
-	 * @param array    $attributes Block attributes.
-	 * @param string   $content Block content.
-	 * @param WP_Block $block Block instance.
-	 * @return string | void Rendered block output.
-	 */
-	protected function render( $attributes, $content, $block ) {
-		$render = parent::render( $attributes, $content, $block );
-
-		// Appends inline styles in the editor.
-		if ( ! empty( $attributes['isPreview'] ) ) {
-			$styles  = $this->get_link_styles( $attributes );
-			$render .= '<style>' . esc_html( $styles ) . '</style>';
-		}
-
-		return $render;
-	}
-
-	/**
-	 * Enqueue frontend assets for this block, just in time for rendering.
-	 *
-	 * @param array $attributes  Any attributes that currently are available from the block.
-	 * @return string
-	 */
-	protected function get_link_styles( array $attributes ) {
-		$link_classes_and_styles       = StyleAttributesUtils::get_link_color_class_and_style( $attributes );
-		$link_hover_classes_and_styles = StyleAttributesUtils::get_link_hover_color_class_and_style( $attributes );
-
-		return '
-			.wc-block-order-confirmation-downloads__table a {' . $link_classes_and_styles['style'] . '}
-			.wc-block-order-confirmation-downloads__table a:hover, .wc-block-order-confirmation-downloads__table a:focus {' . $link_hover_classes_and_styles['style'] . '}
-		';
-	}
-
-	/**
-	 * Enqueue frontend assets for this block, just in time for rendering.
-	 *
-	 * @param array $attributes  Any attributes that currently are available from the block.
-	 */
-	protected function enqueue_assets( array $attributes ) {
-		parent::enqueue_assets( $attributes );
-
-		$styles = $this->get_link_styles( $attributes );
-
-		wp_add_inline_style( 'wc-blocks-style', $styles );
-	}
-
-	/**
 	 * This renders the content of the block within the wrapper.
 	 *
 	 * @param \WC_Order $order Order object.
@@ -75,20 +26,8 @@ class Downloads extends AbstractOrderConfirmationBlock {
 	 * @return string
 	 */
 	protected function render_content( $order, $permission = false, $attributes = [], $content = '' ) {
-		if ( ! empty( $attributes['isPreview'] ) ) {
-			$show_downloads = true;
-			$downloads      = [
-				[
-					'product_name'  => 'Test Product',
-					'product_url'   => 'https://example.com',
-					'download_name' => 'Test Download',
-					'download_url'  => 'https://example.com',
-				],
-			];
-		} else {
-			$show_downloads = $order && $order->has_downloadable_item() && $order->is_download_permitted();
-			$downloads      = $order ? $order->get_downloadable_items() : [];
-		}
+		$show_downloads = $order && $order->has_downloadable_item() && $order->is_download_permitted();
+		$downloads      = $order ? $order->get_downloadable_items() : [];
 
 		if ( ! $permission || ! $show_downloads ) {
 			return $this->render_content_fallback();
@@ -97,7 +36,7 @@ class Downloads extends AbstractOrderConfirmationBlock {
 		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, [ 'border_color', 'border_radius', 'border_width', 'background_color', 'text_color' ] );
 
 		return '
-			<table cellspacing="0" class="wc-block-order-confirmation-downloads__table ' . esc_attr( $classes_and_styles['classes'] ) . '" style="' . esc_attr( $classes_and_styles['styles'] ) . '">
+			<table cellspacing="0" class="wc-block-order-confirmation-downloads__table">
 				<thead>
 					<tr>
 						' . $this->render_order_downloads_column_headers( $order ) . '

--- a/src/BlockTypes/OrderConfirmation/Downloads.php
+++ b/src/BlockTypes/OrderConfirmation/Downloads.php
@@ -41,7 +41,7 @@ class Downloads extends AbstractOrderConfirmationBlock {
 			$downloads      = $order ? $order->get_downloadable_items() : [];
 		}
 
-		if ( 'full' !== $permission || ! $show_downloads ) {
+		if ( ! $permission || ! $show_downloads ) {
 			return $this->render_content_fallback();
 		}
 

--- a/src/BlockTypes/OrderConfirmation/DownloadsWrapper.php
+++ b/src/BlockTypes/OrderConfirmation/DownloadsWrapper.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Automattic\WooCommerce\Blocks\BlockTypes\OrderConfirmation;
+
+/**
+ * DownloadsWrapper class.
+ */
+class DownloadsWrapper extends AbstractOrderConfirmationBlock {
+
+	/**
+	 * Block name.
+	 *
+	 * @var string
+	 */
+	protected $block_name = 'order-confirmation-downloads-wrapper';
+
+	/**
+	 * See if the store has a downloadable product. This controls if we bother to show a preview in the editor.
+	 *
+	 * @return boolean
+	 */
+	protected function store_has_downloadable_products() {
+		$has_downloadable_product = get_transient( 'wc_blocks_has_downloadable_product', false );
+
+		if ( false === $has_downloadable_product ) {
+			$product_ids              = get_posts(
+				array(
+					'post_type'   => 'product',
+					'numberposts' => 1,
+					'post_status' => 'publish',
+					'fields'      => 'ids',
+					// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+					'meta_query'  => array(
+						array(
+							'key'     => '_downloadable',
+							'value'   => 'yes',
+							'compare' => '=',
+						),
+					),
+				)
+			);
+			$has_downloadable_product = ! empty( $product_ids );
+			set_transient( 'wc_blocks_has_downloadable_product', $has_downloadable_product ? '1' : '0', MONTH_IN_SECONDS );
+		}
+
+		return (bool) $has_downloadable_product;
+	}
+
+	/**
+	 * Extra data passed through from server to client for block.
+	 *
+	 * @param array $attributes  Any attributes that currently are available from the block.
+	 *                           Note, this will be empty in the editor context when the block is
+	 *                           not in the post content on editor load.
+	 */
+	protected function enqueue_data( array $attributes = [] ) {
+		parent::enqueue_data( $attributes );
+
+		$this->asset_data_registry->add( 'storeHasDownloadableProducts', $this->store_has_downloadable_products() );
+	}
+
+	/**
+	 * This renders the content of the downloads wrapper.
+	 *
+	 * @param \WC_Order $order Order object.
+	 * @param string    $permission Permission level for viewing order details.
+	 * @param array     $attributes Block attributes.
+	 * @param string    $content Original block content.
+	 */
+	protected function render_content( $order, $permission = false, $attributes = [], $content = '' ) {
+		$show_downloads = $order && $order->has_downloadable_item() && $order->is_download_permitted();
+
+		if ( ! $show_downloads || ! $permission ) {
+			return '';
+		}
+
+		return $content;
+	}
+}

--- a/src/BlockTypesController.php
+++ b/src/BlockTypesController.php
@@ -236,6 +236,7 @@ final class BlockTypesController {
 			$block_types[] = 'OrderConfirmation\Summary';
 			$block_types[] = 'OrderConfirmation\Totals';
 			$block_types[] = 'OrderConfirmation\Downloads';
+			$block_types[] = 'OrderConfirmation\DownloadsWrapper';
 			$block_types[] = 'OrderConfirmation\BillingAddress';
 			$block_types[] = 'OrderConfirmation\ShippingAddress';
 			$block_types[] = 'OrderConfirmation\BillingWrapper';

--- a/src/Utils/StyleAttributesUtils.php
+++ b/src/Utils/StyleAttributesUtils.php
@@ -659,6 +659,8 @@ class StyleAttributesUtils {
 	/**
 	 * Get classes and styles from attributes.
 	 *
+	 * Excludes link_color and link_hover_color since those should not apply to the container.
+	 *
 	 * @param array $attributes Block attributes.
 	 * @param array $properties Properties to get classes/styles from.
 	 * @param array $exclude Properties to exclude.
@@ -677,8 +679,6 @@ class StyleAttributesUtils {
 			'font_weight'      => self::get_font_weight_class_and_style( $attributes ),
 			'letter_spacing'   => self::get_letter_spacing_class_and_style( $attributes ),
 			'line_height'      => self::get_line_height_class_and_style( $attributes ),
-			'link_color'       => self::get_link_color_class_and_style( $attributes ),
-			'link_hover_color' => self::get_link_hover_color_class_and_style( $attributes ),
 			'margin'           => self::get_margin_class_and_style( $attributes ),
 			'padding'          => self::get_padding_class_and_style( $attributes ),
 			'text_align'       => self::get_text_align_class_and_style( $attributes ),


### PR DESCRIPTION
Adds a wrapper for the order downloads block so the heading is only visible when downloads are present in the order. Also introduces styling controls for the downloads block itself.

Fixes #10599

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

### Screenshots

![Screenshot 2023-08-15 at 15 31 06](https://github.com/woocommerce/woocommerce-blocks/assets/90977/9720461c-029c-4303-8975-3b53e732d5ea)

![Screenshot 2023-08-15 at 15 29 17](https://github.com/woocommerce/woocommerce-blocks/assets/90977/278a6cfc-4862-4d4f-bede-9381523101d3)

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. Ensure you have a legacy order confirmation page before testing. You should reset the template.
2. Also delete/trash any downloadable products in your store.
3. Convert the template to blocks. There should be no downloads section right now, but save the template anyway.
4. Untrash the downloadable products in your store, or create some new ones.
5. Go back to the template editor. The downloads section is now visible.
6. Change styles/controls etc and check that styles appear. Save changes.
7. Go to the frontend and purchase some downloadable products.
8. The confirmation page will show but downloads may not be present yet. Leave the page open.
9. Go into admin and mark the order complete or processing.
10. Refresh the confirmation page.
11. See the downloads block is now visible.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [x] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental
