### PR TITLE
Ensure WooCommerce Core scripts are dequeued correctly

### DIFF
--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -160,7 +160,7 @@ class Cart extends AbstractBlock {
 	 */
 	protected function render( $attributes, $content, $block ) {
 		// Dequeue the core scripts when rendering this block.
-		add_action( 'wp_enqueue_scripts', array( $this, 'dequeue_woocommerce_core_scripts' ) );
+		add_action( 'wp_enqueue_scripts', array( $this, 'dequeue_woocommerce_core_scripts' ), 20 );
 
 		/**
 		 * We need to check if $content has any templates from prior iterations of the block, in order to update to the latest iteration.

--- a/src/BlockTypes/Cart.php
+++ b/src/BlockTypes/Cart.php
@@ -35,6 +35,18 @@ class Cart extends AbstractBlock {
 	}
 
 	/**
+	 * Dequeues the scripts added by WC Core to the Cart page.
+	 *
+	 * @return void
+	 */
+	public function dequeue_woocommerce_core_scripts() {
+		wp_dequeue_script( 'wc-cart' );
+		wp_dequeue_script( 'wc-password-strength-meter' );
+		wp_dequeue_script( 'selectWoo' );
+		wp_dequeue_style( 'select2' );
+	}
+
+	/**
 	 * Register block pattern for Empty Cart Message to make it translatable.
 	 */
 	public function register_patterns() {
@@ -147,11 +159,8 @@ class Cart extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		// Deregister core cart scripts and styles.
-		wp_dequeue_script( 'wc-cart' );
-		wp_dequeue_script( 'wc-password-strength-meter' );
-		wp_dequeue_script( 'selectWoo' );
-		wp_dequeue_style( 'select2' );
+		// Dequeue the core scripts when rendering this block.
+		add_action( 'wp_enqueue_scripts', array( $this, 'dequeue_woocommerce_core_scripts' ) );
 
 		/**
 		 * We need to check if $content has any templates from prior iterations of the block, in order to update to the latest iteration.

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -140,7 +140,7 @@ class Checkout extends AbstractBlock {
 		}
 
 		// Dequeue the core scripts when rendering this block.
-		add_action( 'wp_enqueue_scripts', array( $this, 'dequeue_woocommerce_core_scripts' ) );
+		add_action( 'wp_enqueue_scripts', array( $this, 'dequeue_woocommerce_core_scripts' ), 20 );
 
 		/**
 		 * We need to check if $content has any templates from prior iterations of the block, in order to update to the latest iteration.

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -33,6 +33,19 @@ class Checkout extends AbstractBlock {
 	protected function initialize() {
 		parent::initialize();
 		add_action( 'wp_loaded', array( $this, 'register_patterns' ) );
+
+	}
+
+	/**
+	 * Dequeues the scripts added by WC Core to the Checkout page.
+	 *
+	 * @return void
+	 */
+	public function dequeue_woocommerce_core_scripts() {
+		wp_dequeue_script( 'wc-checkout' );
+		wp_dequeue_script( 'wc-password-strength-meter' );
+		wp_dequeue_script( 'selectWoo' );
+		wp_dequeue_style( 'select2' );
 	}
 
 	/**
@@ -119,17 +132,15 @@ class Checkout extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
+
+		// Dequeue the core scripts when rendering this block.
+		add_action( 'wp_enqueue_scripts', array( $this, 'dequeue_woocommerce_core_scripts' ) );
+
 		if ( $this->is_checkout_endpoint() ) {
 			// Note: Currently the block only takes care of the main checkout form -- if an endpoint is set, refer to the
 			// legacy shortcode instead and do not render block.
 			return wc_current_theme_is_fse_theme() ? do_shortcode( '[woocommerce_checkout]' ) : '[woocommerce_checkout]';
 		}
-
-		// Deregister core checkout scripts and styles.
-		wp_dequeue_script( 'wc-checkout' );
-		wp_dequeue_script( 'wc-password-strength-meter' );
-		wp_dequeue_script( 'selectWoo' );
-		wp_dequeue_style( 'select2' );
 
 		/**
 		 * We need to check if $content has any templates from prior iterations of the block, in order to update to the latest iteration.

--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -133,14 +133,14 @@ class Checkout extends AbstractBlock {
 	 */
 	protected function render( $attributes, $content, $block ) {
 
-		// Dequeue the core scripts when rendering this block.
-		add_action( 'wp_enqueue_scripts', array( $this, 'dequeue_woocommerce_core_scripts' ) );
-
 		if ( $this->is_checkout_endpoint() ) {
 			// Note: Currently the block only takes care of the main checkout form -- if an endpoint is set, refer to the
 			// legacy shortcode instead and do not render block.
 			return wc_current_theme_is_fse_theme() ? do_shortcode( '[woocommerce_checkout]' ) : '[woocommerce_checkout]';
 		}
+
+		// Dequeue the core scripts when rendering this block.
+		add_action( 'wp_enqueue_scripts', array( $this, 'dequeue_woocommerce_core_scripts' ) );
 
 		/**
 		 * We need to check if $content has any templates from prior iterations of the block, in order to update to the latest iteration.


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
When rendering the Cart/Checkout blocks, we should dequeue the equivalent WC Core scripts. Previously we dequeued them directly during the `render` function of each block, however they are registered by WC Core _after_ we dequeue them (so our dequeue has no effect). I believe this is because of recent changes to the Cart/Checkout templates however I'm not certain about that.

When combined with #10619 this can close #9864

#### Other Checks

- [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. Add an item to your cart and go to the Cart block. Ensure it renders correctly.
2. Remove the item from your cart and ensure you see the Empty Cart block.
3. From the Empty Cart block, add an item to your cart. 
4. Notice the cart loads and shows the new item.
5. Ensure the page does not reload during this process.
6. Create a page and add Products (Beta) to it. Save the page.
7. Visit the page and add items to your cart. Ensure they work and you can go to Cart -> Checkout successfully and place the order.
8. Repeat step 6 and 7 with the Products by Attribute block, and Product Collection block.

#### Developer testing

1. Install [Query Monitor](https://wordpress.org/plugins/query-monitor/) and load the Cart page on the front end.
2. Open Query Monitor and click "Scripts"
3. Ensure `wc-cart` is not loaded.
4. You can also view source and verify it's not on the page.
5. Repeat for the Checkout block, ensure `wc-checkout` is not loaded.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental


### Changelog

> Prevent the Cart block reloading when adding an item to it from the Empty Cart block
