### PR TITLE
Add style controls for order shipping and billing address blocks

### DIFF
--- a/assets/js/blocks/order-confirmation/billing-address/block.json
+++ b/assets/js/blocks/order-confirmation/billing-address/block.json
@@ -40,6 +40,14 @@
 				"width": true,
 				"color": true
 			}
+		},
+		"spacing": {
+			"padding": true,
+			"margin": true,
+			"__experimentalDefaultControls": {
+				"margin": false,
+				"padding": false
+			}
 		}
 	},
 	"attributes": {

--- a/assets/js/blocks/order-confirmation/billing-address/block.json
+++ b/assets/js/blocks/order-confirmation/billing-address/block.json
@@ -9,7 +9,38 @@
 		"multiple": false,
 		"align": [ "wide", "full" ],
 		"inserter": false,
-		"html": false
+		"html": false,
+		"color": {
+			"text": true,
+			"background": true,
+			"__experimentalDefaultControls": {
+				"background": true,
+				"text": true
+			}
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
+		},
+		"__experimentalBorder": {
+			"color": true,
+			"radius": true,
+			"width": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"width": true,
+				"color": true
+			}
+		}
 	},
 	"attributes": {
 		"align": {

--- a/assets/js/blocks/order-confirmation/billing-address/style.scss
+++ b/assets/js/blocks/order-confirmation/billing-address/style.scss
@@ -1,7 +1,9 @@
 .wc-block-order-confirmation-billing-address {
+	border: 1px solid currentColor;
+	padding: $gap-large;
+
 	address {
 		width: 100% !important;
-		padding: $gap-large;
 		display: block;
 		box-sizing: border-box;
 	}

--- a/assets/js/blocks/order-confirmation/billing-address/style.scss
+++ b/assets/js/blocks/order-confirmation/billing-address/style.scss
@@ -4,6 +4,5 @@
 		padding: $gap-large;
 		display: block;
 		box-sizing: border-box;
-		border: 1px solid currentColor;
 	}
 }

--- a/assets/js/blocks/order-confirmation/shipping-address/block.json
+++ b/assets/js/blocks/order-confirmation/shipping-address/block.json
@@ -40,6 +40,14 @@
 				"width": true,
 				"color": true
 			}
+		},
+		"spacing": {
+			"padding": true,
+			"margin": true,
+			"__experimentalDefaultControls": {
+				"margin": false,
+				"padding": false
+			}
 		}
 	},
 	"attributes": {

--- a/assets/js/blocks/order-confirmation/shipping-address/block.json
+++ b/assets/js/blocks/order-confirmation/shipping-address/block.json
@@ -9,7 +9,38 @@
 		"multiple": false,
 		"align": [ "wide", "full" ],
 		"inserter": false,
-		"html": false
+		"html": false,
+		"color": {
+			"text": true,
+			"background": true,
+			"__experimentalDefaultControls": {
+				"background": true,
+				"text": true
+			}
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
+		},
+		"__experimentalBorder": {
+			"color": true,
+			"radius": true,
+			"width": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"width": true,
+				"color": true
+			}
+		}
 	},
 	"attributes": {
 		"align": {

--- a/assets/js/blocks/order-confirmation/shipping-address/style.scss
+++ b/assets/js/blocks/order-confirmation/shipping-address/style.scss
@@ -4,6 +4,5 @@
 		padding: $gap-large;
 		display: block;
 		box-sizing: border-box;
-		border: 1px solid currentColor;
 	}
 }

--- a/assets/js/blocks/order-confirmation/shipping-address/style.scss
+++ b/assets/js/blocks/order-confirmation/shipping-address/style.scss
@@ -1,7 +1,9 @@
 .wc-block-order-confirmation-shipping-address {
+	border: 1px solid currentColor;
+	padding: $gap-large;
+
 	address {
 		width: 100% !important;
-		padding: $gap-large;
 		display: block;
 		box-sizing: border-box;
 	}


### PR DESCRIPTION
<!-- Start by describing the changes made in this Pull Request, and the reason for such changes. -->
In this PR, we added style controls (i.e., Typography, colors, border styles) on the settings sidebar of the `Shipping Address` and `Billing Address` blocks.

<img width="272" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/14235870/a1ce8e83-ea9b-4723-bfa2-624fa0423ab9">
<!-- Reference any related issues or PRs here -->

Fixes #10120

<!-- Don't forget to update the title with something descriptive. -->
<!-- If you can, add the appropriate labels -->

#### Other Checks

- [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
- [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] This PR adds/removes an experimental interfaces and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
- [ ] I tagged two reviewers because this PR makes queries to the database or I think it might have some security impact.

### Testing

#### User Facing Testing

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. Go to the Order Confirmation on the editor side
2. Open the `Settings` sidebar
3. Select the `Billing Address` or `Shipping Address` inner block
4. Ensure the `Color`, `Typography`, and `Border` style controls are available
5. Change the style of the Block, and save.
6. Reload the page. Ensure the changes are still applied
7. Place an order on the client side. Ensure we have the same style on the Order Confirmation page.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental

### Performance Impact

<!-- Please document any known performance impact (positive or negative) here. If negative, provide some rationale for why this is an okay tradeoff or how this will be addressed. -->

