### PR TITLE
Checkout templates: Fix endpoint and page sync logic

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -952,6 +952,15 @@ class BlockTemplatesController {
 	 * @return string THe actual permalink assigned to the page. May differ from $permalink if it was already taken.
 	 */
 	protected function sync_endpoint_with_page( $page, $page_slug, $permalink ) {
+		$matching_page = get_page_by_path( $permalink );
+
+		if ( $matching_page && 'publish' === $matching_page->post_status ) {
+			// Existing page matches given permalink; use its ID.
+			update_option( 'woocommerce_' . $page_slug . '_page_id', $matching_page->ID );
+			return $permalink;
+		}
+
+		// No matching page; either update current page (by ID stored in option table) or create a new page.
 		if ( ! $page ) {
 			$updated_page_id = wc_create_page(
 				esc_sql( $permalink ),


### PR DESCRIPTION
This fixes an issue with the settings page which won't allow you to select an existing page endpoint. Instead it currently creates a new page with a `-2` or similar suffix appended.

### Testing

#### Automated Tests
* [ ] Changes in this PR are covered by Automated Tests.
  * [ ] Unit tests
  * [ ] E2E tests

#### User Facing Testing

1. With a Block theme activated, go to WooCommerce > Settings > Advanced.
2. Edit the checkout permalink and choose a slug that matches an existing page which is not a subpage of another page.
3. Save the changes.
4. Go to Admin > Pages and find the page you chose in the list. It should be marked as being the WooCommerce Checkout Page.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

### WooCommerce Visibility

<!-- Check this [this doc](../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WC core or not (part of the feature plugin or experimental)-->

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental

### Changelog

> In Checkout settings, an existing page can now be selected as the main checkout page by entering its permalink. This prevents the creation of new pages on save.
