### PR TITLE
Fix: Made migration migrate block templates in the current theme

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -767,65 +767,11 @@ class BlockTemplatesController {
 	 * Migrates page content to templates if needed.
 	 */
 	public function maybe_migrate_content() {
-		if ( ! $this->has_migrated_page( 'cart' ) ) {
-			$this->migrate_page( 'cart', CartTemplate::get_placeholder_page() );
+		if ( ! BlockTemplateMigrationUtils::has_migrated_page( 'cart' ) ) {
+			BlockTemplateMigrationUtils::migrate_page( 'cart', CartTemplate::get_placeholder_page() );
 		}
-		if ( ! $this->has_migrated_page( 'checkout' ) ) {
-			$this->migrate_page( 'checkout', CheckoutTemplate::get_placeholder_page() );
-		}
-	}
-
-	/**
-	 * Check if a page has been migrated to a template.
-	 *
-	 * @param string $page_id Page ID.
-	 * @return boolean
-	 */
-	protected function has_migrated_page( $page_id ) {
-		return (bool) get_option( 'has_migrated_' . $page_id, false );
-	}
-
-	/**
-	 * Stores an option to indicate that a template has been migrated.
-	 *
-	 * @param string $page_id Page ID.
-	 */
-	public function set_has_migrated_page( $page_id ) {
-		update_option( 'has_migrated_' . $page_id, 1 );
-	}
-
-	/**
-	 * Migrates a page to a template if needed.
-	 *
-	 * @param string   $template_slug Template slug.
-	 * @param \WP_Post $page Page object.
-	 */
-	protected function migrate_page( $template_slug, $page ) {
-		// Get the block template for this page. If it exists, we won't migrate because the user already has custom content.
-		$block_template = BlockTemplateUtils::get_block_template( 'woocommerce/woocommerce//' . $template_slug, 'wp_template' );
-
-		// If we were unable to get the block template, bail. Try again later.
-		if ( ! $block_template ) {
-			return;
-		}
-
-		// If a custom template is present already, no need to migrate.
-		if ( $block_template->wp_id ) {
-			return $this->set_has_migrated_page( $template_slug );
-		}
-
-		// Use the page template if it exists, which we'll use over our default template if found.
-		$page_template    = BlockTemplateMigrationUtils::get_page_template( $page );
-		$default_template = BlockTemplateMigrationUtils::get_default_template( $page );
-		$template_content = $page_template ?: $default_template;
-
-		// If at this point we have no content to migrate, bail.
-		if ( ! $template_content ) {
-			return $this->set_has_migrated_page( $template_slug );
-		}
-
-		if ( BlockTemplateMigrationUtils::create_custom_template( $block_template, $template_content ) ) {
-			return $this->set_has_migrated_page( $template_slug );
+		if ( ! BlockTemplateMigrationUtils::has_migrated_page( 'checkout' ) ) {
+			BlockTemplateMigrationUtils::migrate_page( 'checkout', CheckoutTemplate::get_placeholder_page() );
 		}
 	}
 

--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -817,7 +817,7 @@ class BlockTemplatesController {
 		// Use the page template if it exists, which we'll use over our default template if found.
 		$page_template    = BlockTemplateMigrationUtils::get_page_template( $page );
 		$default_template = BlockTemplateMigrationUtils::get_default_template( $page );
-		$template_content = $page_template ? $page_template : $default_template;
+		$template_content = $page_template ?: $default_template;
 
 		// If at this point we have no content to migrate, bail.
 		if ( ! $template_content ) {

--- a/src/Utils/BlockTemplateMigrationUtils.php
+++ b/src/Utils/BlockTemplateMigrationUtils.php
@@ -1,0 +1,112 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\Utils;
+
+/**
+ * Utility methods used for migrating pages to block templates.
+ * {@internal This class and its methods should only be used within the BlockTemplateController.php and is not intended for public use.}
+ */
+class BlockTemplateMigrationUtils {
+
+	/**
+	 * Get template for a page following the page hierarchy.
+	 *
+	 * @param \WP_Post|null $page Page object.
+	 * @return string
+	 */
+	public static function get_page_template( $page ) {
+		$templates = array();
+
+		if ( $page && $page->ID ) {
+			$template = get_page_template_slug( $page->ID );
+
+			if ( $template && 0 === validate_file( $template ) ) {
+				$templates[] = $template;
+			}
+
+			$pagename = $page->post_name;
+
+			if ( $pagename ) {
+				$pagename_decoded = urldecode( $pagename );
+				if ( $pagename_decoded !== $pagename ) {
+					$templates[] = "page-{$pagename_decoded}";
+				}
+				$templates[] = "page-{$pagename}";
+			}
+		}
+
+		$block_template = false;
+
+		foreach ( $templates as $template ) {
+			$block_template = BlockTemplateUtils::get_block_template( get_stylesheet() . '//' . $template, 'wp_template' );
+
+			if ( $block_template && ! empty( $block_template->content ) ) {
+				break;
+			}
+		}
+
+		return $block_template ? $block_template->content : '';
+	}
+
+	/**
+	 * Prepare default page template.
+	 *
+	 * @param \WP_Post $page Page object.
+	 * @return string
+	 */
+	public static function get_default_template( $page ) {
+		if ( ! $page || empty( $page->post_content ) ) {
+			return '';
+		}
+		$default_template_content = '
+			<!-- wp:group {"layout":{"inherit":true}} -->
+			<div class="wp-block-group">
+				<!-- wp:heading {"level":1} -->
+				<h1 class="wp-block-heading">' . wp_kses_post( $page->post_title ) . '</h1>
+				<!-- /wp:heading -->
+				' . wp_kses_post( $page->post_content ) . '
+			</div>
+			<!-- /wp:group -->
+		';
+		return self::get_block_template_part( 'header' ) . $default_template_content . self::get_block_template_part( 'footer' );
+	}
+
+	/**
+	 * Create a custom template with given content.
+	 *
+	 * @param \WP_Block_Template|null $template Template object.
+	 * @param string                  $content Template content.
+	 * @return boolean Success.
+	 */
+	public static function create_custom_template( $template, $content ) {
+		$template_id = wp_insert_post(
+			[
+				'post_name'    => $template->slug,
+				'post_type'    => 'wp_template',
+				'post_status'  => 'publish',
+				'tax_input'    => array(
+					'wp_theme' => $template->theme,
+				),
+				'meta_input'   => array(
+					'origin' => $template->source,
+				),
+				'post_content' => $content,
+			],
+			true
+		);
+		return $template_id && ! is_wp_error( $template_id );
+	}
+
+	/**
+	 * Returns the requested template part.
+	 *
+	 * @param string $part The part to return.
+	 * @return string
+	 */
+	protected static function get_block_template_part( $part ) {
+		$template_part = BlockTemplateUtils::get_block_template( get_stylesheet() . '//' . $part, 'wp_template_part' );
+		if ( ! $template_part || empty( $template_part->content ) ) {
+			return '';
+		}
+		return $template_part->content;
+	}
+}


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

This is related to #10595. Updates the page migration logic to respect the contents of block templates. 

Rather than just move the contents of the _page_ to the checkout template, this will look for a block template that is assigned to the page, or a template named `page-checkout` and use that for the contents of the new custom block template for the cart/checkout pages.

## Why

The previous behaviour led to a mismatch between the old and new cart/checkout pages after migration.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Install a theme that uses block templates. In my case I used FotaWP.
2. Go to Appearance > Edit > Templates and reset the cart/checkout templates to default.
3. Delete has_migrated_cart and has_migrated_checkout options from your options database.
4. View a page on the store.
5. Confirm by viewing the cart and checkout pages that they inherited the block template from the theme. In this case for instance, instead of the default distraction free template we had, you'll see something like this:

![Screenshot 2023-08-17 at 12 55 00](https://github.com/woocommerce/woocommerce-blocks/assets/90977/bf55ff6c-e8f7-440e-99ed-ec1e676a988b)

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [x] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

N/A

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Fixed checkout and cart page migration routine for users of block themes so that block templates are also migrated.
