### PR TITLE
Add template placeholder notices

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -5,6 +5,8 @@ import { getCategories, setCategories } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 import { woo } from '@woocommerce/icons';
 import { Icon } from '@wordpress/icons';
+import { dispatch } from '@wordpress/data';
+import { getSetting } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
@@ -39,3 +41,16 @@ setCategories( [
 		),
 	},
 ] );
+
+// Gets editor notices injected into the client and dispatches them to the store.
+const editorNotices = getSetting( 'editorNotices' );
+
+if ( editorNotices ) {
+	editorNotices.forEach( ( notice ) => {
+		dispatch( 'core/notices' ).createNotice( notice.type, notice.content, {
+			id: notice.id || null,
+			isDismissible: notice.dismissible || false,
+			actions: notice.actions || null,
+		} );
+	} );
+}

--- a/src/Assets/AssetDataRegistry.php
+++ b/src/Assets/AssetDataRegistry.php
@@ -105,6 +105,8 @@ class AssetDataRegistry {
 	 * Inject notices into the client to be rendered in the editor.
 	 */
 	protected function get_editor_notices() {
+		global $post;
+
 		$notices = [];
 
 		if ( ! is_admin() ) {
@@ -114,52 +116,62 @@ class AssetDataRegistry {
 		$screen          = get_current_screen();
 		$is_block_editor = $screen && $screen->is_block_editor();
 
-		if ( wc_current_theme_is_fse_theme() && $is_block_editor ) {
-			global $post;
-
+		if ( wc_current_theme_is_fse_theme() && $is_block_editor && $post && $post->ID > 0 ) {
 			$cart_page     = wc_get_page_id( 'cart' );
 			$checkout_page = wc_get_page_id( 'checkout' );
+			$shop_page     = wc_get_page_id( 'shop' );
 
-			if ( $post && $post->ID === $cart_page ) {
-				$notices[] = [
-					'id'          => 'cart-page-notice',
-					'type'        => 'warning',
-					'dismissible' => false,
-					'content'     => __(
-						'Your store is currently using a block theme and the Cart template. Any changes made to the content of this page will not be reflected in your store. If you need to edit your cart, please use the Site Editor.',
-						'woo-gutenberg-products-block'
-					),
-					'actions'     => [
-						[
-							'url'   => admin_url( 'site-editor.php?postType=wp_template&postId=woocommerce%2Fwoocommerce%2F%2Fcart' ),
-							'label' => __(
-								'Edit the Cart Template',
+			$page_notices = [
+				'cart'     => [
+					'page_id'       => $cart_page,
+					'page_name'     => _x( 'cart', 'page name', 'woo-gutenberg-products-block' ),
+					'template_name' => _x( 'Cart Template', 'template name', 'woo-gutenberg-products-block' ),
+					'edit_link'     => admin_url( 'site-editor.php?postType=wp_template&postId=woocommerce%2Fwoocommerce%2F%2Fcart' ),
+				],
+				'checkout' => [
+					'page_id'       => $checkout_page,
+					'page_name'     => _x( 'checkout', 'page name', 'woo-gutenberg-products-block' ),
+					'template_name' => _x( 'Checkout Template', 'template name', 'woo-gutenberg-products-block' ),
+					'edit_link'     => admin_url( 'site-editor.php?postType=wp_template&postId=woocommerce%2Fwoocommerce%2F%2Fcheckout' ),
+				],
+				'shop'     => [
+					'page_id'       => $shop_page,
+					'page_name'     => _x( 'shop', 'page name', 'woo-gutenberg-products-block' ),
+					'template_name' => _x( 'Shop Template', 'template name', 'woo-gutenberg-products-block' ),
+					'edit_link'     => admin_url( 'site-editor.php?postType=wp_template&postId=woocommerce%2Fwoocommerce%2F%2Farchive-product' ),
+				],
+			];
+
+			foreach ( $page_notices as $page_key => $page_notice ) {
+				if ( $post->ID === $page_notice['page_id'] ) {
+					$notices[] = [
+						'id'          => $page_key . '-page-notice',
+						'type'        => 'warning',
+						'dismissible' => false,
+						'content'     => sprintf(
+							/* translators: %1$s: template name, %2$s: page name */
+							__(
+								'Your store is currently using a block theme and the %1$s. Any changes made to the content of this page will not be reflected in your store. If you need to edit your %2$s, please use the Site Editor.',
 								'woo-gutenberg-products-block'
 							),
+							esc_html( $page_notice['template_name'] ),
+							esc_html( $page_notice['page_name'] )
+						),
+						'actions'     => [
+							[
+								'url'   => $page_notice['edit_link'],
+								'label' => sprintf(
+									// translators: %s: template name.
+									__(
+										'Edit the %s',
+										'woo-gutenberg-products-block'
+									),
+									esc_html( $page_notice['template_name'] )
+								),
+							],
 						],
-					],
-				];
-			}
-
-			if ( $post && $post->ID === $checkout_page ) {
-				$notices[] = [
-					'id'          => 'checkout-page-notice',
-					'type'        => 'warning',
-					'dismissible' => false,
-					'content'     => __(
-						'Your store is currently using a block theme and the Checkout template. Any changes made to the content of this page will not be reflected in your store. If you need to edit your checkout, please use the Site Editor.',
-						'woo-gutenberg-products-block'
-					),
-					'actions'     => [
-						[
-							'url'   => admin_url( 'site-editor.php?postType=wp_template&postId=woocommerce%2Fwoocommerce%2F%2Fcheckout' ),
-							'label' => __(
-								'Edit the Checkout Template',
-								'woo-gutenberg-products-block'
-							),
-						],
-					],
-				];
+					];
+				}
 			}
 		}
 

--- a/src/Assets/AssetDataRegistry.php
+++ b/src/Assets/AssetDataRegistry.php
@@ -147,7 +147,7 @@ class AssetDataRegistry {
 					'type'        => 'warning',
 					'dismissible' => false,
 					'content'     => __(
-						'Your store is currently using a block theme and the Checkout template. Any changes made to the content of this page will not be reflected in your store. If you need to modify edit your checkout page, please use the Site Editor.',
+						'Your store is currently using a block theme and the Checkout template. Any changes made to the content of this page will not be reflected in your store. If you need to edit your checkout, please use the Site Editor.',
 						'woo-gutenberg-products-block'
 					),
 					'actions'     => [

--- a/src/Assets/AssetDataRegistry.php
+++ b/src/Assets/AssetDataRegistry.php
@@ -126,7 +126,7 @@ class AssetDataRegistry {
 					'type'        => 'warning',
 					'dismissible' => false,
 					'content'     => __(
-						'Your store is currently using a block theme and the Cart template. Any changes made to the content of this page will not be reflected in your store. If you need to modify edit your cart page, please use the Site Editor.',
+						'Your store is currently using a block theme and the Cart template. Any changes made to the content of this page will not be reflected in your store. If you need to edit your cart, please use the Site Editor.',
 						'woo-gutenberg-products-block'
 					),
 					'actions'     => [

--- a/src/Assets/AssetDataRegistry.php
+++ b/src/Assets/AssetDataRegistry.php
@@ -97,7 +97,73 @@ class AssetDataRegistry {
 			'wcVersion'          => defined( 'WC_VERSION' ) ? WC_VERSION : '',
 			'wpLoginUrl'         => wp_login_url(),
 			'wpVersion'          => get_bloginfo( 'version' ),
+			'editorNotices'      => $this->get_editor_notices(),
 		];
+	}
+
+	/**
+	 * Inject notices into the client to be rendered in the editor.
+	 */
+	protected function get_editor_notices() {
+		$notices = [];
+
+		if ( ! is_admin() ) {
+			return $notices;
+		}
+
+		$screen          = get_current_screen();
+		$is_block_editor = $screen && $screen->is_block_editor();
+
+		if ( wc_current_theme_is_fse_theme() && $is_block_editor ) {
+			global $post;
+
+			$cart_page     = wc_get_page_id( 'cart' );
+			$checkout_page = wc_get_page_id( 'checkout' );
+
+			if ( $post && $post->ID === $cart_page ) {
+				$notices[] = [
+					'id'          => 'cart-page-notice',
+					'type'        => 'warning',
+					'dismissible' => false,
+					'content'     => __(
+						'Your store is currently using a block theme and the Cart template. Any changes made to the content of this page will not be reflected in your store. If you need to modify edit your cart page, please use the Site Editor.',
+						'woo-gutenberg-products-block'
+					),
+					'actions'     => [
+						[
+							'url'   => admin_url( 'site-editor.php?postType=wp_template&postId=woocommerce%2Fwoocommerce%2F%2Fcart' ),
+							'label' => __(
+								'Edit the Cart Template',
+								'woo-gutenberg-products-block'
+							),
+						],
+					],
+				];
+			}
+
+			if ( $post && $post->ID === $checkout_page ) {
+				$notices[] = [
+					'id'          => 'checkout-page-notice',
+					'type'        => 'warning',
+					'dismissible' => false,
+					'content'     => __(
+						'Your store is currently using a block theme and the Checkout template. Any changes made to the content of this page will not be reflected in your store. If you need to modify edit your checkout page, please use the Site Editor.',
+						'woo-gutenberg-products-block'
+					),
+					'actions'     => [
+						[
+							'url'   => admin_url( 'site-editor.php?postType=wp_template&postId=woocommerce%2Fwoocommerce%2F%2Fcheckout' ),
+							'label' => __(
+								'Edit the Checkout Template',
+								'woo-gutenberg-products-block'
+							),
+						],
+					],
+				];
+			}
+		}
+
+		return $notices;
 	}
 
 	/**

--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -900,6 +900,7 @@ class BlockTemplatesController {
 					'desc_tip' => __( 'This is the URL to the checkout page.', 'woo-gutenberg-products-block' ),
 					'id'       => 'woocommerce_checkout_page_endpoint',
 					'type'     => 'permalink',
+					'value'    => $checkout_page ? $checkout_page->post_name : get_option( 'woocommerce_checkout_page_endpoint' ),
 					'default'  => $checkout_page ? $checkout_page->post_name : CheckoutTemplate::get_slug(),
 					'autoload' => false,
 				];
@@ -917,6 +918,7 @@ class BlockTemplatesController {
 					'desc_tip' => __( 'This is the URL to the cart page.', 'woo-gutenberg-products-block' ),
 					'id'       => 'woocommerce_cart_page_endpoint',
 					'type'     => 'permalink',
+					'value'    => $cart_page ? $cart_page->post_name : get_option( 'woocommerce_cart_page_endpoint' ),
 					'default'  => $cart_page ? $cart_page->post_name : CartTemplate::get_slug(),
 					'autoload' => false,
 				];

--- a/src/Templates/AbstractPageTemplate.php
+++ b/src/Templates/AbstractPageTemplate.php
@@ -23,7 +23,6 @@ abstract class AbstractPageTemplate {
 	 */
 	protected function init() {
 		add_filter( 'page_template_hierarchy', array( $this, 'page_template_hierarchy' ), 1 );
-		add_action( 'current_screen', array( $this, 'page_template_editor_redirect' ) );
 		add_filter( 'pre_get_document_title', array( $this, 'page_template_title' ) );
 	}
 
@@ -78,21 +77,6 @@ abstract class AbstractPageTemplate {
 			array_unshift( $templates, $this->get_slug() );
 		}
 		return $templates;
-	}
-
-	/**
-	 * Redirect the edit page screen to the template editor.
-	 *
-	 * @param \WP_Screen $current_screen Current screen information.
-	 */
-	public function page_template_editor_redirect( \WP_Screen $current_screen ) {
-		$page         = $this->get_placeholder_page();
-		$edit_page_id = 'page' === $current_screen->id && ! empty( $_GET['post'] ) ? absint( $_GET['post'] ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-
-		if ( $page && $edit_page_id === $page->ID ) {
-			wp_safe_redirect( $this->get_edit_template_url() );
-			exit;
-		}
 	}
 
 	/**


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Removes the redirect from page->site editor for cart and checkout pages and instead renders a notice. The notices are injected into the client via wcSettings and rendered in the main entry point.

Only affects FSE themes.

## Why

Users were confused when they were unable to access pages. Some users resorted to trashing pages which caused 404s.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. With a block theme active, edit the main Cart page on your store.
2. Confirm you see a notice above the post content stating this is a placeholder.
3. Repeat for checkout page. There should be a notice.
4. Repeat for any other page. There should be no notices.
5. Switch to a non-block theme. Repeat the above tests. There should be no notices displayed at all.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

![Screenshot 2023-08-17 at 15 37 04](https://github.com/woocommerce/woocommerce-blocks/assets/90977/2e729e60-7ff0-4cc6-a78b-62d4dc3737a6)

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Added a notice to cart/checkout pages when they are acting as placeholders for a block template.
