### PR TITLE
Store Breadcrumbs block: Fix icon color when block is selected in List View

### DIFF
--- a/assets/js/blocks/breadcrumbs/icon.tsx
+++ b/assets/js/blocks/breadcrumbs/icon.tsx
@@ -1,0 +1,33 @@
+/**
+ * External dependencies
+ */
+import { SVG, Rect } from '@wordpress/primitives';
+
+export const queryPaginationIcon = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Rect
+			x="4"
+			y="10.5"
+			width="6"
+			height="3"
+			rx="1.5"
+			fill="currentColor"
+		/>
+		<Rect
+			x="12"
+			y="10.5"
+			width="3"
+			height="3"
+			rx="1.5"
+			fill="currentColor"
+		/>
+		<Rect
+			x="17"
+			y="10.5"
+			width="3"
+			height="3"
+			rx="1.5"
+			fill="currentColor"
+		/>
+	</SVG>
+);

--- a/assets/js/blocks/breadcrumbs/index.tsx
+++ b/assets/js/blocks/breadcrumbs/index.tsx
@@ -3,13 +3,14 @@
  */
 import { registerBlockType } from '@wordpress/blocks';
 import { isFeaturePluginBuild } from '@woocommerce/block-settings';
-import { Icon, queryPagination } from '@wordpress/icons';
+import { Icon } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import metadata from './block.json';
 import edit from './edit';
+import { queryPaginationIcon } from './icon';
 import './style.scss';
 
 const featurePluginSupport = {
@@ -32,7 +33,7 @@ registerBlockType( metadata, {
 	icon: {
 		src: (
 			<Icon
-				icon={ queryPagination }
+				icon={ queryPaginationIcon }
 				className="wc-block-editor-components-block-icon"
 			/>
 		),


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Currently, when selecting the Store Breadcrumbs block, the icon color remains the same as when the block is not selected. The expected behavior is that when the block is selected, the icon color should reflect the selected state (shown in white color).

Fixes #10651 

## Why

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->
To keep consistency throughout the application. The expected behavior is that all icons reflect the current component/block state.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

1. From your WordPress dashboard, go to Appearance > Themes. Make sure you have a block-based theme installed and activated. If not, you can install one from the Add New option. Block-based themes include "Twenty-twenty Two," "Twenty-twenty Three," etc.
2. On the left-hand side menu, click on Appearance > Editor > Templates
3. Find and select the 'Single Product' template from the list.
4. When the Classic Product Template renders, click on Transform into Blocks. This will transform the Classic template in a block template if you haven't done it before.
5. On the top-right side, click on the Save button.
6. On the left side, check the List View and select the 'Store Breadcrumbs' block. Make sure the icon changes it's color from a dark color to a white color when the block is selected on the list

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="352" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/20469356/731f900f-247a-4d48-b399-4bf503a986a2"> | <img width="354" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/20469356/3c7c4c05-fb38-49f2-9710-a278ab3776d1"> | 

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Store Breadcrumbs: Fix the icon color when the block is selected in the List View.
