### PR TITLE
Load Interactivity API in `bootstrap.php`

### DIFF
--- a/src/Domain/Bootstrap.php
+++ b/src/Domain/Bootstrap.php
@@ -252,7 +252,7 @@ class Bootstrap {
 	 * @param bool $enabled Current filter value.
 	 * @return bool True if _also_ the `WP_HTML_Tag_Processor` class was found.
 	 */
-	protected function has_wp_html_tag_processor( $enabled ) {
+	public function has_wp_html_tag_processor( $enabled ) {
 		return $enabled && class_exists( 'WP_HTML_Tag_Processor' );
 
 	}

--- a/src/Domain/Bootstrap.php
+++ b/src/Domain/Bootstrap.php
@@ -100,6 +100,12 @@ class Bootstrap {
 	protected function init() {
 		$this->register_dependencies();
 		$this->register_payment_methods();
+		add_filter(
+			'woocommerce_blocks_enable_interactivity_api',
+			array( $this, 'has_wp_html_tag_processor' ),
+			999
+		);
+		$this->load_interactivity_api();
 
 		// This is just a temporary solution to make sure the migrations are run. We have to refactor this. More details: https://github.com/woocommerce/woocommerce-blocks/issues/10196.
 		if ( $this->package->get_version() !== $this->package->get_version_stored_on_db() ) {
@@ -224,6 +230,33 @@ class Bootstrap {
 			}
 		);
 	}
+
+	/**
+	 * Load and set up the Interactivity API if enabled.
+	 */
+	protected function load_interactivity_api() {
+	// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+		$is_enabled = apply_filters(
+			'woocommerce_blocks_enable_interactivity_api',
+			true
+		);
+
+		if ( $is_enabled ) {
+			require_once __DIR__ . '/../Interactivity/load.php';
+		}
+	}
+	/**
+	 * Disable the Interactivity API if the required `WP_HTML_Tag_Processor` class
+	 * doesn't exist, regardless of whether it was enabled manually.
+	 *
+	 * @param bool $enabled Current filter value.
+	 * @return bool True if _also_ the `WP_HTML_Tag_Processor` class was found.
+	 */
+	protected function has_wp_html_tag_processor( $enabled ) {
+		return $enabled && class_exists( 'WP_HTML_Tag_Processor' );
+
+	}
+
 
 	/**
 	 * Register core dependencies with the container.

--- a/src/Domain/Bootstrap.php
+++ b/src/Domain/Bootstrap.php
@@ -235,7 +235,7 @@ class Bootstrap {
 	 * Load and set up the Interactivity API if enabled.
 	 */
 	protected function load_interactivity_api() {
-	// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		$is_enabled = apply_filters(
 			'woocommerce_blocks_enable_interactivity_api',
 			true

--- a/src/Domain/Bootstrap.php
+++ b/src/Domain/Bootstrap.php
@@ -100,11 +100,6 @@ class Bootstrap {
 	protected function init() {
 		$this->register_dependencies();
 		$this->register_payment_methods();
-		add_filter(
-			'woocommerce_blocks_enable_interactivity_api',
-			array( $this, 'has_wp_html_tag_processor' ),
-			999
-		);
 		$this->load_interactivity_api();
 
 		// This is just a temporary solution to make sure the migrations are run. We have to refactor this. More details: https://github.com/woocommerce/woocommerce-blocks/issues/10196.
@@ -235,26 +230,7 @@ class Bootstrap {
 	 * Load and set up the Interactivity API if enabled.
 	 */
 	protected function load_interactivity_api() {
-		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
-		$is_enabled = apply_filters(
-			'woocommerce_blocks_enable_interactivity_api',
-			true
-		);
-
-		if ( $is_enabled ) {
 			require_once __DIR__ . '/../Interactivity/load.php';
-		}
-	}
-	/**
-	 * Disable the Interactivity API if the required `WP_HTML_Tag_Processor` class
-	 * doesn't exist, regardless of whether it was enabled manually.
-	 *
-	 * @param bool $enabled Current filter value.
-	 * @return bool True if _also_ the `WP_HTML_Tag_Processor` class was found.
-	 */
-	public function has_wp_html_tag_processor( $enabled ) {
-		return $enabled && class_exists( 'WP_HTML_Tag_Processor' );
-
 	}
 
 	/**

--- a/src/Domain/Bootstrap.php
+++ b/src/Domain/Bootstrap.php
@@ -257,7 +257,6 @@ class Bootstrap {
 
 	}
 
-
 	/**
 	 * Register core dependencies with the container.
 	 */

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -293,27 +293,3 @@ add_action( 'admin_notices', 'woocommerce_blocks_plugin_outdated_notice' );
  * @param bool $enabled Current filter value.
  * @return bool True if _also_ the `WP_HTML_Tag_Processor` class was found.
  */
-function woocommerce_blocks_has_wp_html_tag_processor( $enabled ) {
-	return $enabled && class_exists( 'WP_HTML_Tag_Processor' );
-}
-add_filter(
-	'woocommerce_blocks_enable_interactivity_api',
-	'woocommerce_blocks_has_wp_html_tag_processor',
-	999
-);
-
-/**
- * Load and set up the Interactivity API if enabled.
- */
-function woocommerce_blocks_interactivity_setup() {
-	// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
-	$is_enabled = apply_filters(
-		'woocommerce_blocks_enable_interactivity_api',
-		true
-	);
-
-	if ( $is_enabled ) {
-		require_once __DIR__ . '/src/Interactivity/load.php';
-	}
-}
-add_action( 'plugins_loaded', 'woocommerce_blocks_interactivity_setup' );

--- a/woocommerce-gutenberg-products-block.php
+++ b/woocommerce-gutenberg-products-block.php
@@ -285,11 +285,3 @@ function woocommerce_blocks_plugin_outdated_notice() {
 }
 
 add_action( 'admin_notices', 'woocommerce_blocks_plugin_outdated_notice' );
-
-/**
- * Disable the Interactivity API if the required `WP_HTML_Tag_Processor` class
- * doesn't exist, regardless of whether it was enabled manually.
- *
- * @param bool $enabled Current filter value.
- * @return bool True if _also_ the `WP_HTML_Tag_Processor` class was found.
- */


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/10661 https://github.com/woocommerce/woocommerce-blocks/issues/10662

## Why

`woocommerce-gutenberg-products-block.php` is loaded only when WooCommerce Blocks is loaded as feature plugin.

This means when the WooCommerce Blocks is included into WooCommerce Core, the Interactivity API aren't loaded. This causes a runtime error:

![image](https://github.com/woocommerce/woocommerce-blocks/assets/4463174/88b04328-8c12-4096-9307-8e6f594e3533).

This PR refactors how the Interactivity API are loaded.

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Install this custom build of WooCommerce that includes this patch: [woocommerce.zip](https://github.com/woocommerce/woocommerce-blocks/files/12378677/woocommerce.zip).
2. Open the Site Editor and ensure that you are using the blockified template on the Product Catalog template.
3. Visit the `/shop` page and ensure that the Product Button works as expected.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Improved how Interactivity API are loaded.
