### PR TITLE
Make View Cart link displayed below the Add to Cart button

### DIFF
--- a/assets/js/atomic/blocks/product-elements/button/style.scss
+++ b/assets/js/atomic/blocks/product-elements/button/style.scss
@@ -3,6 +3,7 @@
 	white-space: normal;
 	display: flex;
 	justify-content: center;
+	flex-direction: column;
 	align-items: center;
 	gap: $gap-small;
 


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Fix the layout of Add to Cart button vs View Cart link that appears after adding product to cart.

## Why

After introducing Interactivity API to Product Button, the View Cart link was wrapped with additional `span` element and the layout is broken (as there were some styles attached to the Vie Cart link directly).

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Edit Product Catalog template
2. Add Products (Beta) block if it's not there already
3. Save and go to frontend
4. Add a simple product to cart
5. Expected: "View Cart" link appears BELOW the Add to Cart button

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|    <img width="955" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/20098064/6debf2e7-b529-4c45-828b-9705686f08a3">    |   <img width="956" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/20098064/a1b7cb06-0ac0-40d8-b865-5c87977016a8">    |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Add to Cart button: fix the layout of View Cart link showing after adding product to cart
