### PR TITLE
Add a generic arg to useCollection to improve typing of results.

### DIFF
--- a/assets/js/base/context/hooks/collections/use-collection.ts
+++ b/assets/js/base/context/hooks/collections/use-collection.ts
@@ -49,10 +49,10 @@ export interface useCollectionOptions {
 	isEditor?: boolean;
 }
 
-export const useCollection = (
+export const useCollection = < T >(
 	options: useCollectionOptions
 ): {
-	results: unknown;
+	results: T[];
 	isLoading: boolean;
 } => {
 	const {
@@ -68,7 +68,7 @@ export const useCollection = (
 				'the resource properties.'
 		);
 	}
-	const currentResults = useRef< { results: unknown; isLoading: boolean } >( {
+	const currentResults = useRef< { results: T[]; isLoading: boolean } >( {
 		results: [],
 		isLoading: true,
 	} );
@@ -102,7 +102,7 @@ export const useCollection = (
 			}
 
 			return {
-				results: store.getCollection< T >( ...args ),
+				results: store.getCollection< T[] >( ...args ),
 				isLoading: ! store.hasFinishedResolution(
 					'getCollection',
 					args

--- a/assets/js/base/context/hooks/use-store-products.ts
+++ b/assets/js/base/context/hooks/use-store-products.ts
@@ -35,16 +35,17 @@ export const useStoreProducts = (
 		namespace: '/wc/store/v1',
 		resourceName: 'products',
 	};
-	const { results: products, isLoading: productsLoading } = useCollection( {
-		...collectionOptions,
-		query,
-	} );
+	const { results: products, isLoading: productsLoading } =
+		useCollection< ProductResponseItem >( {
+			...collectionOptions,
+			query,
+		} );
 	const { value: totalProducts } = useCollectionHeader( 'x-wp-total', {
 		...collectionOptions,
 		query,
 	} );
 	return {
-		products: products as ProductResponseItem[], // TODO: Remove this once getCollection selector and resolver is converted to TS.
+		products,
 		totalProducts: parseInt( totalProducts as string, 10 ),
 		productsLoading,
 	};

--- a/assets/js/blocks/active-filters/active-attribute-filters.tsx
+++ b/assets/js/blocks/active-filters/active-attribute-filters.tsx
@@ -11,6 +11,7 @@ import { __ } from '@wordpress/i18n';
 import { getSettingWithCoercion } from '@woocommerce/settings';
 import {
 	AttributeObject,
+	AttributeTerm,
 	isAttributeQueryCollection,
 	isAttributeTermCollection,
 	isBoolean,
@@ -47,7 +48,7 @@ const ActiveAttributeFilters = ( {
 	displayStyle,
 	isLoadingCallback,
 }: ActiveAttributeFiltersProps ) => {
-	const { results, isLoading } = useCollection( {
+	const { results, isLoading } = useCollection< AttributeTerm >( {
 		namespace: '/wc/store/v1',
 		resourceName: 'products/attributes/terms',
 		resourceValues: [ attributeObject.id ],

--- a/assets/js/blocks/attribute-filter/block.tsx
+++ b/assets/js/blocks/attribute-filter/block.tsx
@@ -19,6 +19,7 @@ import { getSettingWithCoercion } from '@woocommerce/settings';
 import { getQueryArgs, removeQueryArgs } from '@wordpress/url';
 import {
 	AttributeQuery,
+	AttributeTerm,
 	isAttributeQueryCollection,
 	isBoolean,
 	isString,
@@ -124,7 +125,7 @@ const AttributeFilterBlock = ( {
 		useQueryStateByKey( 'attributes', [] );
 
 	const { results: attributeTerms, isLoading: attributeTermsLoading } =
-		useCollection( {
+		useCollection< AttributeTerm >( {
 			namespace: '/wc/store/v1',
 			resourceName: 'products/attributes/terms',
 			resourceValues: [ attributeObject?.id || 0 ],


### PR DESCRIPTION
Closes #5726

## What

Add a generic arg to useCollection. I've also passed the arg where relevant so we can remove a cast which was the original problem mentioned in the issue.

## Why

Typing the returned result set based on the generic allows the removal of code that casts on the result. Cast should typically be avoided since you're forcing the types to match your expectation even when they are not. Of course a generic is not perfect, but with polymorphic data retrieved from an API it's difficult to perfectly solve that problem. At least with a generic arg it keeps consistency with the type of the returned result.

## Testing Instructions

There is no runtime change here so just checking that the TS code compiles should be sufficient.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

n/a

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [x] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Add suggested changelog entry here.
