### PR TITLE
Refactor block variation registration in product-collection

### DIFF
--- a/assets/js/blocks/product-collection/index.tsx
+++ b/assets/js/blocks/product-collection/index.tsx
@@ -10,10 +10,13 @@ import metadata from './block.json';
 import edit from './edit';
 import save from './save';
 import icon from './icon';
-import './variations';
+import registerProductSummaryVariation from './variations/elements/product-summary';
+import registerProductTitleVariation from './variations/elements/product-title';
 
 registerBlockType( metadata, {
 	icon,
 	edit,
 	save,
 } );
+registerProductSummaryVariation();
+registerProductTitleVariation();

--- a/assets/js/blocks/product-collection/variations/elements/product-summary.tsx
+++ b/assets/js/blocks/product-collection/variations/elements/product-summary.tsx
@@ -16,9 +16,13 @@ import {
 export const CORE_NAME = 'core/post-excerpt';
 export const VARIATION_NAME = 'woocommerce/product-collection/product-summary';
 
-registerElementVariation( CORE_NAME, {
-	blockDescription: BLOCK_DESCRIPTION,
-	blockIcon: <Icon icon={ page } />,
-	blockTitle: BLOCK_TITLE,
-	variationName: VARIATION_NAME,
-} );
+const registerProductSummary = () => {
+	registerElementVariation( CORE_NAME, {
+		blockDescription: BLOCK_DESCRIPTION,
+		blockIcon: <Icon icon={ page } />,
+		blockTitle: BLOCK_TITLE,
+		variationName: VARIATION_NAME,
+	} );
+};
+
+export default registerProductSummary;

--- a/assets/js/blocks/product-collection/variations/elements/product-title.tsx
+++ b/assets/js/blocks/product-collection/variations/elements/product-title.tsx
@@ -16,9 +16,13 @@ import {
 export const CORE_NAME = 'core/post-title';
 export const VARIATION_NAME = 'woocommerce/product-collection/product-title';
 
-registerElementVariation( CORE_NAME, {
-	blockDescription: BLOCK_DESCRIPTION,
-	blockIcon: <Icon icon={ heading } />,
-	blockTitle: BLOCK_TITLE,
-	variationName: VARIATION_NAME,
-} );
+const registerProductTitle = () => {
+	registerElementVariation( CORE_NAME, {
+		blockDescription: BLOCK_DESCRIPTION,
+		blockIcon: <Icon icon={ heading } />,
+		blockTitle: BLOCK_TITLE,
+		variationName: VARIATION_NAME,
+	} );
+};
+
+export default registerProductTitle;


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

This PR refactors the product-collection block's variation registration.

Changes:
- The `product-summary` and `product-title` variations have been encapsulated within their own respective functions: `registerProductSummaryVariation` and `registerProductTitleVariation`.
- Imported and invoked these new functions in the main `index.tsx` of the product-collection block, ensuring the variations are registered.

Fixes #10718

## Why

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

We are enabling Product Collection block as a core feature in #10524. @nefeline reported that `Product Summary` variation is not available in inserter, therefore I created this PR to fix it. 

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Since the issue was reproducible in Production build, so run `npm run build:deploy` to create a production build
2. Create a new post.
3. Insert a 'Product Collection' block.
4. Ensure you can include a 'Product Summary' block within it using the block inserter.
5. Upon adding the 'Product Summary' block, publish the post and check that the 'Product Collection' block is displayed accurately on the frontend.

Here is a quick demo:

https://github.com/woocommerce/woocommerce-blocks/assets/16707866/70e570e6-4c02-4bb5-b400-0ae11d155249


* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [X] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [X] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [X] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Fix: Product Summary isn't available in inserter
