### PR TITLE
Interactivity API: Add support to view.ts files in Webpack

### DIFF
--- a/bin/webpack-entries.js
+++ b/bin/webpack-entries.js
@@ -198,6 +198,9 @@ const entries = {
 		'wc-blocks-classic-template-revert-button':
 			'./assets/js/templates/revert-button/index.tsx',
 	},
+	interactivityBlocks: {
+		...getBlockEntries( 'view.{t,j}s' ),
+	},
 };
 
 const getEntryConfig = ( type = 'main', exclude = [] ) => {

--- a/docs/contributors/javascript-build-system.md
+++ b/docs/contributors/javascript-build-system.md
@@ -16,6 +16,7 @@ WooCommerce Blocks uses Webpack to build the files that will be consumed by brow
 -   `FrontendConfig`: config that builds the JS files used by blocks in the store frontend.
 -   `PaymentsConfig`: config that builds the JS files used by payment methods in the Cart and Checkout blocks.
 -   `ExtensionsConfig`: config that builds extension integrations.
+-   `InteractivityBlocksConfig`: config that builds the JS files used by blocks that utilize the Interactivity API.
 -   `StylingConfig`: config that builds CSS files. You can read more about it in the page [CSS build system](css-build-system.md).
 
 Details on each config can be found in [`webpack-configs.js`](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/bin/webpack-configs.js). Entry points are declared in [`webpack-entries.js`](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/bin/webpack-entries.js).

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,6 +11,7 @@ const {
 	getSiteEditorConfig,
 	getStylingConfig,
 	getInteractivityAPIConfig,
+	getInteractivityBlocksConfig,
 } = require( './bin/webpack-configs.js' );
 
 // Only options shared between all configs should be defined here.
@@ -92,6 +93,14 @@ const InteractivityConfig = {
 };
 
 /**
+ * Config to generate the Interactivity Blocks runtime.
+ */
+const InteractivityBlocksConfig = {
+	...sharedConfig,
+	...getInteractivityBlocksConfig( { alias: getAlias() } ),
+};
+
+/**
  * Config to generate the site editor scripts.
  */
 const SiteEditorConfig = {
@@ -108,5 +117,6 @@ module.exports = [
 	SiteEditorConfig,
 	StylingConfig,
 	InteractivityConfig,
+	InteractivityBlocksConfig,
 	StylingClassicThemeConfig,
 ];


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What
According to the InteractivityAPI's [documentation](https://github.com/WordPress/gutenberg/blob/trunk/packages/interactivity/docs/2-api-reference.md#the-store) the "store is usually created in the view.js file of each block, although it can be initialized from the render.php of the block". Currently, if we want to initialize the store using Typescript, we have to rely on the frontend.tsx file that has historically been used with "static" blocks.

Fixes woocommerce/woocommerce#42242

## Why
This will enable us to stay in sync with the approach suggested by the InteractivityAPI team and mantain a clear separation between "static" blocks and blocks that utilize the InteractivityAPI.

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Create a view.ts file inside a block folder (for example: `assets/js/blocks/product-gallery`) and add any content to it;
2. Build the application with `npm start` or `npm run build`
3. Check the folder `/build` and make sure there is a file named as `[block-name]-interactivity-view.js` (for example: `product-gallery-interactivity-view.js`

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [x] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [x] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.
