### PR TITLE
Respect the item data keys of the item data on CartItemSchema

### DIFF
--- a/src/StoreApi/Schemas/V1/CartItemSchema.php
+++ b/src/StoreApi/Schemas/V1/CartItemSchema.php
@@ -100,7 +100,7 @@ class CartItemSchema extends ItemSchema {
 		 */
 		$item_data       = apply_filters( 'woocommerce_get_item_data', array(), $cart_item );
 		$clean_item_data = [];
-		foreach ( $item_data as $data ) {
+		foreach ( $item_data as $key => $data ) {
 			// We will check each piece of data in the item data element to ensure it is scalar. Extensions could add arrays
 			// to this, which would cause a fatal in wp_strip_all_tags. If it is not scalar, we will return an empty array,
 			// which will be filtered out in get_item_data (after this function has run).
@@ -109,7 +109,7 @@ class CartItemSchema extends ItemSchema {
 					continue 2;
 				}
 			}
-			$clean_item_data[] = $this->format_item_data_element( $data );
+			$clean_item_data[$key] = $this->format_item_data_element( $data );
 		}
 		return $clean_item_data;
 	}


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What
Respect the item_data keys provided by the use of `woocommerce_get_item_data` filter.

Fixes #

## Why
On previous updates to the CartItemSchema.php file, new logic added to filter the item data, and the new data does not include the provided data keys, which led to the item data json to be an array of objects, hard to access by key.

ex: I have this filter in my application, I include the menu_item_data on the item_data to be able to use on front-end
and I was able to access the menu_item_data by `item.item_data.menu_item_data`
But with the last update to the schema, I am not able to access it, because the item data does not have the keys I added.
```
add_filter( 'woocommerce_get_item_data', 'custom_rest_woocommerce_get_item_data' ], 10, 2 );

function custom_rest_woocommerce_get_item_data( $data, $cart_item ) {
	$data['menu_item_data'] = $cart_item['menu_item_data'];
	return $data;
}
```


<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1.
2.
3.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [ ] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Add suggested changelog entry here.
