### PR TITLE
Revert dequeue add-to-cart-variation script 

### DIFF
--- a/src/BlockTypes/ProductButton.php
+++ b/src/BlockTypes/ProductButton.php
@@ -61,7 +61,6 @@ class ProductButton extends AbstractBlock {
 	 */
 	public function dequeue_add_to_cart_scripts() {
 		wp_dequeue_script( 'wc-add-to-cart' );
-		wp_dequeue_script( 'wc-add-to-cart-variation' );
 	}
 
 	/**


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

In this PR I revert dequeing `add-to-cart-variation` script which handles logic of variable products.

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/10702

## Why

It was dequeued in[ the PR ](https://github.com/woocommerce/woocommerce-blocks/pull/10006)related to adding Interactivity API to Product Button, but it's actually required to properly display variations and allow adding variable products to Cart.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Make sure you're using blockified Single Product template
2. Go to frontend
3. Go to product page for variable product (e.g. Hoodie when using sample products)
4. Choose Color and With Logo
5. Make sure Price appears when you chose the options
6. Add the product to Cart
7. Make sure product is added to cart correctly and there's no error

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|    https://github.com/woocommerce/woocommerce-blocks/assets/20098064/bc4937dd-9f95-4700-9c48-76f5c1cde7ad    |   https://github.com/woocommerce/woocommerce-blocks/assets/20098064/2bd66403-45de-4a73-8d27-4bb38dfd8fc1  |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Add to Cart: fix the problem that variable products couldn't be added to cart
