### PR TITLE
Next Previous Buttons: hide buttons when the product has only one image

### DIFF
--- a/assets/js/blocks/product-gallery/edit.tsx
+++ b/assets/js/blocks/product-gallery/edit.tsx
@@ -22,6 +22,7 @@ import { ProductGalleryThumbnailsBlockSettings } from './inner-blocks/product-ga
 import { ProductGalleryPagerBlockSettings } from './inner-blocks/product-gallery-pager/settings';
 import { ProductGalleryBlockSettings } from './block-settings/index';
 import type { ProductGalleryAttributes } from './types';
+import { ProductGalleryNextPreviousBlockSettings } from './inner-blocks/product-gallery-large-image-next-previous/settings';
 
 const TEMPLATE: InnerBlockTemplate[] = [
 	[

--- a/assets/js/blocks/product-gallery/inner-blocks/product-gallery-large-image-next-previous/block.json
+++ b/assets/js/blocks/product-gallery/inner-blocks/product-gallery-large-image-next-previous/block.json
@@ -7,7 +7,7 @@
     "description": "Dispaly next and previous buttons.",
     "category": "woocommerce",
     "keywords": [ "WooCommerce" ],
-	"usesContext": [ "nextPreviousButtonsPosition", "productGalleryClientId" ],
+	"usesContext": [ "nextPreviousButtonsPosition", "productGalleryClientId", "postId"],
     "textdomain": "woo-gutenberg-products-block",
 	"ancestor": [ "woocommerce/product-gallery-large-image" ]
 }

--- a/assets/js/blocks/product-gallery/inner-blocks/product-gallery-large-image-next-previous/edit.tsx
+++ b/assets/js/blocks/product-gallery/inner-blocks/product-gallery-large-image-next-previous/edit.tsx
@@ -10,9 +10,13 @@ import { useMemo } from '@wordpress/element';
 import { NextButton, PrevButton } from './icons';
 import './editor.scss';
 import { ProductGalleryNextPreviousBlockSettings } from './settings';
-import { Context } from '../../types';
+import { ProductGalleryContext } from '../../types';
 
-export const Edit = ( { context }: { context: Context } ): JSX.Element => {
+export const Edit = ( {
+	context,
+}: {
+	context: ProductGalleryContext;
+} ): JSX.Element => {
 	const blockProps = useBlockProps();
 
 	const suffixClass = useMemo( () => {

--- a/assets/js/blocks/product-gallery/types.ts
+++ b/assets/js/blocks/product-gallery/types.ts
@@ -42,12 +42,12 @@ export interface ProductGalleryThumbnailsSettingsProps {
 	context: ProductGalleryThumbnailsBlockAttributes;
 }
 
-export interface ProductGalleryContext {
+export type ProductGalleryContext = {
 	thumbnailsPosition: ThumbnailsPosition;
 	thumbnailsNumberOfThumbnails: number;
 	productGalleryClientId: string;
 	pagerDisplayMode: PagerDisplayModes;
-}
+} & ProductGalleryNextPreviousBlockAttributes;
 
 export type ProductGalleryPagerContext = Pick<
 	ProductGalleryContext,

--- a/src/BlockTypes/ProductGalleryLargeImageNextPrevious.php
+++ b/src/BlockTypes/ProductGalleryLargeImageNextPrevious.php
@@ -55,6 +55,19 @@ class ProductGalleryLargeImageNextPrevious extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
+		$post_id = $block->context['postId'];
+		if ( ! isset( $post_id ) ) {
+			return '';
+		}
+
+		$product = wc_get_product( $post_id );
+
+		$product_gallery = $product->get_gallery_image_ids();
+
+		if ( empty( $product_gallery ) ) {
+			return null;
+		}
+
 		$context     = $block->context;
 		$prev_button = sprintf(
 			'

--- a/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-large-image-next-previous/product-gallery-large-image-next-previous.block_theme.spec.ts
+++ b/tests/e2e/tests/product-gallery/inner-blocks/product-gallery-large-image-next-previous/product-gallery-large-image-next-previous.block_theme.spec.ts
@@ -36,7 +36,7 @@ const blockData = {
 		},
 	},
 	slug: 'single-product',
-	productPage: '/product/album/',
+	productPage: '/product/logo-collection/',
 };
 
 const getBoundingClientRect = async ( {


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

This PR hides Next/Previous buttons when the product has only one image.

## Why

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Open the Single Product Template.
2. Add the Product Gallery Image.
3. Save the Template
4. Visit a product that has multiple images (e.g: Logo Collection)
5. Ensure that the Next and Previous buttons are visible.
6. Visit a product that has only one image (e.g: Album).
7. Ensure that the Next and Previous buttons aren't visible.
* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental
* [ ] N/A

## Checklist

Required:
* [ ] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Add suggested changelog entry here.
