### PR TITLE
Fix/Template endpoint update for subpages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15395,6 +15395,7 @@
 			"version": "0.6.0",
 			"resolved": "https://github.com/woocommerce/woocommerce-blocks/files/12309320/wordpress-e2e-test-utils-playwright-0.6.0.tgz",
 			"integrity": "sha512-5lo8iRuRfUOAPMRsQteSkKyMoP1IHHu6GKye8Df+YEPz1LWXcS6YRFGI3HrONBpcaHLrJC7LVav4UdB/sBPqUw==",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "file:../api-fetch",
@@ -65931,6 +65932,7 @@
 			"version": "0.6.0",
 			"resolved": "https://github.com/woocommerce/woocommerce-blocks/files/12309320/wordpress-e2e-test-utils-playwright-0.6.0.tgz",
 			"integrity": "sha512-5lo8iRuRfUOAPMRsQteSkKyMoP1IHHu6GKye8Df+YEPz1LWXcS6YRFGI3HrONBpcaHLrJC7LVav4UdB/sBPqUw==",
+			"dev": true,
 			"requires": {
 				"@wordpress/api-fetch": "file:../api-fetch",
 				"@wordpress/keycodes": "file:../keycodes",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15395,7 +15395,6 @@
 			"version": "0.6.0",
 			"resolved": "https://github.com/woocommerce/woocommerce-blocks/files/12309320/wordpress-e2e-test-utils-playwright-0.6.0.tgz",
 			"integrity": "sha512-5lo8iRuRfUOAPMRsQteSkKyMoP1IHHu6GKye8Df+YEPz1LWXcS6YRFGI3HrONBpcaHLrJC7LVav4UdB/sBPqUw==",
-			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "file:../api-fetch",

--- a/package-lock.json
+++ b/package-lock.json
@@ -65931,7 +65931,6 @@
 			"version": "0.6.0",
 			"resolved": "https://github.com/woocommerce/woocommerce-blocks/files/12309320/wordpress-e2e-test-utils-playwright-0.6.0.tgz",
 			"integrity": "sha512-5lo8iRuRfUOAPMRsQteSkKyMoP1IHHu6GKye8Df+YEPz1LWXcS6YRFGI3HrONBpcaHLrJC7LVav4UdB/sBPqUw==",
-			"dev": true,
 			"requires": {
 				"@wordpress/api-fetch": "file:../api-fetch",
 				"@wordpress/keycodes": "file:../keycodes",

--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -869,7 +869,7 @@ class BlockTemplatesController {
 		 *                                for a 404 request. Default true.
 		 */
 		if ( ! $matching_page instanceof WP_Post && apply_filters( 'do_redirect_guess_404_permalink', true ) ) {
-			// If it is a subpage and url guessing is on, then we will need to get it via postname as path will not match.
+			// If it is a subpage and url guessing is on, then we will need to get it via post_name as path will not match.
 			$query = new \WP_Query(
 				[
 					'post_type' => 'page',

--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -855,12 +855,36 @@ class BlockTemplatesController {
 	 * @return string THe actual permalink assigned to the page. May differ from $permalink if it was already taken.
 	 */
 	protected function sync_endpoint_with_page( $page, $page_slug, $permalink ) {
-		$matching_page = get_page_by_path( $permalink );
+		$matching_page = get_page_by_path( $permalink, OBJECT, 'page' );
+
+		/**
+		 * Filters whether to attempt to guess a redirect URL for a 404 request.
+		 *
+		 * Returning a false value from the filter will disable the URL guessing
+		 * and return early without performing a redirect.
+		 *
+		 * @since 5.5.0
+		 *
+		 * @param bool $do_redirect_guess Whether to attempt to guess a redirect URL
+		 *                                for a 404 request. Default true.
+		 */
+		if ( ! $matching_page instanceof WP_Post && apply_filters( 'do_redirect_guess_404_permalink', true ) ) {
+			// If it is a subpage and url guessing is on, then we will need to get it via postname as path will not match.
+			$query = new \WP_Query(
+				[
+					'post_type' => 'page',
+					'name'      => $permalink,
+				]
+			);
+
+			$matching_page = $query->have_posts() ? $query->posts[0] : null;
+		}
 
 		if ( $matching_page && 'publish' === $matching_page->post_status ) {
 			// Existing page matches given permalink; use its ID.
 			update_option( 'woocommerce_' . $page_slug . '_page_id', $matching_page->ID );
-			return $permalink;
+
+			return get_page_uri( $matching_page );
 		}
 
 		// No matching page; either update current page (by ID stored in option table) or create a new page.
@@ -884,8 +908,9 @@ class BlockTemplatesController {
 
 		// Get post again in case slug was updated with a suffix.
 		if ( $updated_page_id && ! is_wp_error( $updated_page_id ) ) {
-			return get_post( $updated_page_id )->post_name;
+			return get_page_uri( get_post( $updated_page_id ) );
 		}
+
 		return $permalink;
 	}
 }

--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -863,7 +863,7 @@ class BlockTemplatesController {
 		 * Returning a false value from the filter will disable the URL guessing
 		 * and return early without performing a redirect.
 		 *
-		 * @since 5.5.0
+		 * @since 11.0.0
 		 *
 		 * @param bool $do_redirect_guess Whether to attempt to guess a redirect URL
 		 *                                for a 404 request. Default true.


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

This PR complements #10640 and adds support to URL guessing by WordPress when updating Cart/Checkout template endpoints.

## Why

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Enable a blocks theme (eg TT3)
2. Create a page, and a subpage
3. On the frontend check for redirection from `/subpage` to `/page/subpage` (it's on by default)
4. Go to WooCommerce > Settings > Advanced and change the Cart and Checkout endpoints to match the created pages slug, and also the full path (eg `page/subpage`)
5. Verify on the page list, the correct page is marked as Cart/Checkout
6. Check that changing the endpoint to `subpage` correctly saves it as `page/subpage`

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Fixed template endpoint editing to support WP redirection