### PR TITLE
Fix bug with wpautop for the empty cart

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -116,7 +116,7 @@ class BlockTemplatesController {
 						$settings['original_render_callback'] = $settings['render_callback'];
 						$settings['render_callback']          = function( $attributes, $content ) use ( $settings ) {
 							// The shortcode has already been rendered, so look for the cart/checkout HTML.
-							if ( strstr( $content, 'woocommerce-cart-form' ) || strstr( $content, 'woocommerce-checkout-form' ) ) {
+							if ( strstr( $content, 'woocommerce-cart-form' ) || strstr( $content, 'wc-empty-cart-message' ) || strstr( $content, 'woocommerce-checkout-form' ) ) {
 								// Return early before wpautop runs again.
 								return $content;
 							}


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->
## What
When parsing shortcodes in the BlockTemplatesController, we need to avoid parsing the content through `wpautop` to stop it from breaking the formatting. This works for the Cart and Checkout, but the empty cart view was missing. This PRs stops running `wpautop` for the empty cart view to fix a styling issues.

Fixes #10767 

## Why
There is a [known bug](https://core.trac.wordpress.org/ticket/58366) where templates that include shortcodes sometimes break the formatting, because the content of the shortcode is passed through the `wpautop` function, which converts `/n` characters to `<br />` and `/n/n` to `<p>` (roughly speaking). For the cart and checkout templates, we check if the templates include the shortcode, and skip passing the content to the `wpautop` function. This should also be the case for the empty cart form.


<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Install WooCommerce WC 8.0.x and a block theme (such as Twenty Twenty Three)
2. Go to Appearance > Editor > Templates > Cart
3. If this has the Cart Block, delete it and Include the `[woocommerce_cart]` shortcode.
4. Save and visit this page with an empty cart
5. The `Return to Shop` button should have equal padding top and bottom

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before                                                                                                                                                                	| After                                                                                                                                                                 	|
|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------	|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------	|
| <img width="721" alt="Screenshot 2023-08-29 at 15 05 47" src="https://github.com/woocommerce/woocommerce-blocks/assets/3966773/35fbce4d-09da-4c4d-b535-0f76aa786e85"> 	| <img width="709" alt="Screenshot 2023-08-29 at 15 05 21" src="https://github.com/woocommerce/woocommerce-blocks/assets/3966773/cdb19385-3a7d-49cf-b620-4d5cd5254f55"> 	|

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Fix a styling bug with the Return to Shop button on the empty cart shortcode, when used as the cart template
