### PR TITLE
Product Gallery block: Add `woocommerce` namespace to Interactivity API store

### DIFF
--- a/assets/js/blocks/product-gallery/frontend.tsx
+++ b/assets/js/blocks/product-gallery/frontend.tsx
@@ -8,12 +8,16 @@ interface State {
 }
 
 interface Context {
-	productGallery: { numberOfThumbnails: number };
+	woocommerce: {
+		productGallery: { numberOfThumbnails: number };
+	};
 }
 
 interface Selectors {
-	productGallery: {
-		getNumberOfPages: ( store: unknown ) => number;
+	woocommerce: {
+		productGallery: {
+			numberOfPages: ( store: unknown ) => number;
+		};
 	};
 }
 
@@ -28,11 +32,14 @@ type SelectorsStore = Pick< Store, 'context' | 'selectors' >;
 
 interactivityApiStore( {
 	selectors: {
-		productGallery: {
-			getNumberOfPages: ( store: SelectorsStore ) => {
-				const { context } = store;
+		woocommerce: {
+			productGallery: {
+				numberOfPages: ( store: SelectorsStore ) => {
+					const { context } = store;
 
-				return context.productGallery.numberOfThumbnails;
+					return context.woocommerce.productGallery
+						.numberOfThumbnails;
+				},
 			},
 		},
 	},

--- a/src/BlockTypes/ProductGallery.php
+++ b/src/BlockTypes/ProductGallery.php
@@ -45,7 +45,7 @@ class ProductGallery extends AbstractBlock {
 			$p->set_attribute( 'data-wc-interactive', true );
 			$p->set_attribute(
 				'data-wc-context',
-				wp_json_encode( array( 'productGallery' => array( 'numberOfThumbnails' => 0 ) ) )
+				wp_json_encode( array( 'woocommerce' => array( 'productGallery' => array( 'numberOfThumbnails' => 0 ) ) ) )
 			);
 			$html = $p->get_updated_html();
 		}
@@ -69,8 +69,8 @@ class ProductGallery extends AbstractBlock {
 	 */
 	protected function get_block_type_script( $key = null ) {
 		$script = [
-			'handle'       => 'wc-' . $this->block_name . '-interactivity-frontend',
-			'path'         => $this->asset_api->get_block_asset_build_path( $this->block_name . '-interactivity-frontend' ),
+			'handle'       => 'wc-' . $this->block_name . '-frontend',
+			'path'         => $this->asset_api->get_block_asset_build_path( $this->block_name . '-frontend' ),
 			'dependencies' => [ 'wc-interactivity' ],
 		];
 


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What
In https://github.com/woocommerce/woocommerce-blocks/pull/10716, I worked to add Interactivity API support to the Product Gallery block; however, after the PR was already merged, Luigi pointed out that we should include the `woocommerce` namespace when instantiating the store.

Fixes #10715 

## Why

This way we can follow the guidelines for the [new Interactivity API proposal](https://github.com/WordPress/gutenberg/discussions/53586)

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. From your WordPress dashboard, go to Appearance > Themes. Make sure you have a block-based theme installed and activated. If not, you can install one from the Add New option. Block-based themes include "Twenty-twenty Two," "Twenty-twenty Three," etc.
2. On the left-hand side menu, click on Appearance > Editor
3. On the left-hand side menu, click on Templates. 
4. Find and select the 'Single Product' template from the list.
5. When the Classic Product Template renders, click on Transform into Blocks. This will transform the Classic template in a block template if you haven't done it before.
6. Click on the plus icon (+) at the top left corner or within the editor to add a new block. In the search bar that appears, type Product Gallery and click on it to add the block to the template.
7. On the top-right side, click on the Save button.
8. Visit a product and inspect the Product Gallery block. Make sure you see the Interactivity API directives added to the block
9. Check for the `woocommerce` namespace in the directive value: `data-wc-context='{"woocommerce":{"productGallery":{"numberOfThumbnails":0}}}'`

![CleanShot 2023-08-23 at 21 34 14@2x](https://github.com/woocommerce/woocommerce-blocks/assets/20469356/46c84354-2f7b-429d-8289-01543640df74)

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [x] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.
