### PR TITLE
Order confirmation block styling

### DIFF
--- a/assets/css/abstracts/_colors.scss
+++ b/assets/css/abstracts/_colors.scss
@@ -15,3 +15,6 @@ $select-dropdown-dark: #1e1e1e;
 $select-dropdown-light: #fff;
 $select-item-dark: rgba(0, 0, 0, 0.4);
 $image-placeholder-border-color: #f2f2f2;
+
+// Universal colors for use on the frontend, currently being applied to checkout blocks.
+$universal-border-light: rgba(17, 17, 17, 0.115); // e7e7e7 on white

--- a/assets/css/abstracts/_variables.scss
+++ b/assets/css/abstracts/_variables.scss
@@ -1,9 +1,10 @@
 @import "node_modules/@wordpress/base-styles/variables";
 
-$gap-largest: $grid-unit-50;
-$gap-larger: 4.5 * $grid-unit;
-$gap-large: $grid-unit-30;
-$gap: $grid-unit-20;
-$gap-small: $grid-unit-15;
-$gap-smaller: $grid-unit-10;
-$gap-smallest: $grid-unit-05;
+// grid-unit from base-styles is 8px.
+$gap-largest:  6 * $grid-unit;		// 48px
+$gap-larger:   4.5 * $grid-unit;	// 36px
+$gap-large:    3 * $grid-unit;		// 24px
+$gap:          2 * $grid-unit;		// 16px
+$gap-small:    1.5 * $grid-unit;	// 12px
+$gap-smaller:  1 * $grid-unit;		// 8px
+$gap-smallest: 0.5 * $grid-unit;	// 4px

--- a/assets/js/blocks/classic-template/order-confirmation.tsx
+++ b/assets/js/blocks/classic-template/order-confirmation.tsx
@@ -36,6 +36,10 @@ const getBlockifiedTemplate = ( inheritedAttributes: InheritedAttributes ) =>
 			'woocommerce/order-confirmation-totals',
 			inheritedAttributes
 		),
+		createBlock(
+			'woocommerce/order-confirmation-downloads-wrapper',
+			inheritedAttributes
+		),
 		createBlock( 'core/columns', inheritedAttributes, [
 			createBlock( 'core/column', inheritedAttributes, [
 				createBlock(

--- a/assets/js/blocks/classic-template/order-confirmation.tsx
+++ b/assets/js/blocks/classic-template/order-confirmation.tsx
@@ -26,6 +26,11 @@ const getBlockifiedTemplate = ( inheritedAttributes: InheritedAttributes ) =>
 			'woocommerce/order-confirmation-summary',
 			inheritedAttributes
 		),
+		createBlock( 'core/heading', {
+			...inheritedAttributes,
+			content: __( 'Order details', 'woo-gutenberg-products-block' ),
+			level: 3,
+		} ),
 		createBlock(
 			'woocommerce/order-confirmation-totals',
 			inheritedAttributes

--- a/assets/js/blocks/classic-template/order-confirmation.tsx
+++ b/assets/js/blocks/classic-template/order-confirmation.tsx
@@ -30,6 +30,7 @@ const getBlockifiedTemplate = ( inheritedAttributes: InheritedAttributes ) =>
 			...inheritedAttributes,
 			content: __( 'Order details', 'woo-gutenberg-products-block' ),
 			level: 3,
+			style: { typography: { fontSize: '24px' } },
 		} ),
 		createBlock(
 			'woocommerce/order-confirmation-totals',

--- a/assets/js/blocks/classic-template/order-confirmation.tsx
+++ b/assets/js/blocks/classic-template/order-confirmation.tsx
@@ -26,14 +26,8 @@ const getBlockifiedTemplate = ( inheritedAttributes: InheritedAttributes ) =>
 			'woocommerce/order-confirmation-summary',
 			inheritedAttributes
 		),
-		createBlock( 'core/heading', {
-			...inheritedAttributes,
-			content: __( 'Order details', 'woo-gutenberg-products-block' ),
-			level: 3,
-			style: { typography: { fontSize: '24px' } },
-		} ),
 		createBlock(
-			'woocommerce/order-confirmation-totals',
+			'woocommerce/order-confirmation-totals-wrapper',
 			inheritedAttributes
 		),
 		createBlock(

--- a/assets/js/blocks/order-confirmation/billing-address/style.scss
+++ b/assets/js/blocks/order-confirmation/billing-address/style.scss
@@ -1,3 +1,11 @@
+.wp-block-woocommerce-order-confirmation-billing-wrapper > *:first-child {
+	margin-top: 0;
+}
+.wp-block-woocommerce-order-confirmation-billing-wrapper {
+	.block-editor-block-list__layout > *:first-child {
+		margin-top: 0 !important;
+	}
+}
 .wc-block-order-confirmation-billing-address {
 	border: 1px solid $universal-border-light;
 	border-radius: 2px;

--- a/assets/js/blocks/order-confirmation/billing-address/style.scss
+++ b/assets/js/blocks/order-confirmation/billing-address/style.scss
@@ -1,10 +1,17 @@
 .wc-block-order-confirmation-billing-address {
-	border: 1px solid currentColor;
-	padding: $gap-large;
+	border: 1px solid $universal-border-light;
+	border-radius: 2px;
+	padding: $gap;
 
-	address {
+	address,
+	p {
 		width: 100% !important;
 		display: block;
 		box-sizing: border-box;
+		margin: 0 0 $gap;
+
+		&:last-child {
+			margin-bottom: 0;
+		}
 	}
 }

--- a/assets/js/blocks/order-confirmation/billing-wrapper/block.json
+++ b/assets/js/blocks/order-confirmation/billing-wrapper/block.json
@@ -1,7 +1,7 @@
 {
 	"name": "woocommerce/order-confirmation-billing-wrapper",
 	"version": "1.0.0",
-	"title": "Order Confirmation Billing",
+	"title": "Billing Address Section",
 	"description": "Display the order confirmation billing section.",
 	"category": "woocommerce",
 	"keywords": [ "WooCommerce" ],

--- a/assets/js/blocks/order-confirmation/billing-wrapper/edit.tsx
+++ b/assets/js/blocks/order-confirmation/billing-wrapper/edit.tsx
@@ -23,6 +23,7 @@ const Edit = ( {
 						'core/heading',
 						{
 							level: 3,
+							style: { typography: { fontSize: '24px' } },
 							content: attributes.heading || '',
 							onChangeContent: ( value: string ) =>
 								setAttributes( { heading: value } ),

--- a/assets/js/blocks/order-confirmation/downloads-wrapper/attributes.tsx
+++ b/assets/js/blocks/order-confirmation/downloads-wrapper/attributes.tsx
@@ -1,0 +1,11 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export default {
+	heading: {
+		type: 'string',
+		default: __( 'Downloads', 'woo-gutenberg-products-block' ),
+	},
+};

--- a/assets/js/blocks/order-confirmation/downloads-wrapper/block.json
+++ b/assets/js/blocks/order-confirmation/downloads-wrapper/block.json
@@ -2,7 +2,7 @@
 	"name": "woocommerce/order-confirmation-downloads-wrapper",
 	"version": "1.0.0",
 	"title": "Order Confirmation Downloads",
-	"description": "Display the downloadale products section.",
+	"description": "Display the downloadable products section.",
 	"category": "woocommerce",
 	"keywords": [ "WooCommerce" ],
 	"attributes": {

--- a/assets/js/blocks/order-confirmation/downloads-wrapper/block.json
+++ b/assets/js/blocks/order-confirmation/downloads-wrapper/block.json
@@ -1,0 +1,21 @@
+{
+	"name": "woocommerce/order-confirmation-downloads-wrapper",
+	"version": "1.0.0",
+	"title": "Order Confirmation Downloads",
+	"description": "Display the downloadale products section.",
+	"category": "woocommerce",
+	"keywords": [ "WooCommerce" ],
+	"attributes": {
+		"heading": {
+			"type": "string"
+		}
+	},
+	"supports": {
+		"multiple": false,
+		"align": [ "wide", "full" ],
+		"html": false
+	},
+	"textdomain": "woo-gutenberg-products-block",
+	"apiVersion": 2,
+	"$schema": "https://schemas.wp.org/trunk/block.json"
+}

--- a/assets/js/blocks/order-confirmation/downloads-wrapper/edit.tsx
+++ b/assets/js/blocks/order-confirmation/downloads-wrapper/edit.tsx
@@ -1,0 +1,53 @@
+/**
+ * External dependencies
+ */
+import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
+import { getSetting } from '@woocommerce/settings';
+
+const Edit = ( {
+	attributes,
+	setAttributes,
+}: {
+	attributes: {
+		heading: string;
+	};
+	setAttributes: ( attributes: Record< string, unknown > ) => void;
+} ) => {
+	const blockProps = useBlockProps();
+	const hasDownloadableProducts = getSetting(
+		'storeHasDownloadableProducts'
+	);
+
+	if ( ! hasDownloadableProducts ) {
+		return null;
+	}
+
+	return (
+		<div { ...blockProps }>
+			<InnerBlocks
+				allowedBlocks={ [ 'core/heading' ] }
+				template={ [
+					[
+						'core/heading',
+						{
+							level: 3,
+							content: attributes.heading || '',
+							onChangeContent: ( value: string ) =>
+								setAttributes( { heading: value } ),
+						},
+					],
+					[
+						'woocommerce/order-confirmation-downloads',
+						{
+							lock: {
+								remove: true,
+							},
+						},
+					],
+				] }
+			/>
+		</div>
+	);
+};
+
+export default Edit;

--- a/assets/js/blocks/order-confirmation/downloads-wrapper/index.tsx
+++ b/assets/js/blocks/order-confirmation/downloads-wrapper/index.tsx
@@ -3,7 +3,7 @@
  */
 import { registerBlockType, type BlockConfiguration } from '@wordpress/blocks';
 import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
-import { Icon, mapMarker } from '@wordpress/icons';
+import { Icon, download } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -18,7 +18,7 @@ registerBlockType(
 		icon: {
 			src: (
 				<Icon
-					icon={ mapMarker }
+					icon={ download }
 					className="wc-block-editor-components-block-icon"
 				/>
 			),

--- a/assets/js/blocks/order-confirmation/downloads-wrapper/index.tsx
+++ b/assets/js/blocks/order-confirmation/downloads-wrapper/index.tsx
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import { registerBlockType, type BlockConfiguration } from '@wordpress/blocks';
+import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
+import { Icon, mapMarker } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
+import metadata from './block.json';
+import attributes from './attributes';
+
+registerBlockType(
+	metadata as BlockConfiguration,
+	{
+		icon: {
+			src: (
+				<Icon
+					icon={ mapMarker }
+					className="wc-block-editor-components-block-icon"
+				/>
+			),
+		},
+		edit,
+		save() {
+			return (
+				<div { ...useBlockProps.save() }>
+					<InnerBlocks.Content />
+				</div>
+			);
+		},
+		attributes,
+	} as unknown as Partial< BlockConfiguration >
+);

--- a/assets/js/blocks/order-confirmation/downloads/block.json
+++ b/assets/js/blocks/order-confirmation/downloads/block.json
@@ -30,8 +30,7 @@
 			"__experimentalDefaultControls": {
 				"background": true,
 				"text": true
-			},
-			"__experimentalSkipSerialization": true
+			}
 		},
 		"spacing": {
 			"padding": true,
@@ -49,8 +48,7 @@
 				"color": true,
 				"style": true,
 				"width": true
-			},
-			"__experimentalSkipSerialization": true
+			}
 		},
 		"__experimentalSelector": ".wp-block-woocommerce-order-confirmation-totals table"
 	},
@@ -62,10 +60,6 @@
 		"className": {
 			"type": "string",
 			"default": ""
-		},
-		"isPreview": {
-			"type": "boolean",
-			"default": false
 		}
 	},
 	"textdomain": "woo-gutenberg-products-block",

--- a/assets/js/blocks/order-confirmation/downloads/block.json
+++ b/assets/js/blocks/order-confirmation/downloads/block.json
@@ -7,7 +7,52 @@
 	"keywords": [ "WooCommerce" ],
 	"supports": {
 		"multiple": false,
-		"align": [ "wide", "full" ]
+		"align": [ "wide", "full" ],
+		"html": false,
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalFontStyle": true,
+			"__experimentalFontWeight": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalTextTransform": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
+		},
+		"color": {
+			"background": true,
+			"text": true,
+			"link": true,
+			"gradients": true,
+			"__experimentalDefaultControls": {
+				"background": true,
+				"text": true
+			},
+			"__experimentalSkipSerialization": true
+		},
+		"spacing": {
+			"padding": true,
+			"margin": true,
+			"__experimentalDefaultControls": {
+				"margin": false,
+				"padding": false
+			}
+		},
+		"__experimentalBorder": {
+			"color": true,
+			"style": true,
+			"width": true,
+			"__experimentalDefaultControls": {
+				"color": true,
+				"style": true,
+				"width": true
+			},
+			"__experimentalSkipSerialization": true
+		},
+		"__experimentalSelector": ".wp-block-woocommerce-order-confirmation-totals table"
 	},
 	"attributes": {
 		"align": {

--- a/assets/js/blocks/order-confirmation/downloads/edit.tsx
+++ b/assets/js/blocks/order-confirmation/downloads/edit.tsx
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import ServerSideRender from '@wordpress/server-side-render';
 import { useBlockProps } from '@wordpress/block-editor';
 import { Disabled } from '@wordpress/components';
 
@@ -10,31 +9,82 @@ import { Disabled } from '@wordpress/components';
  */
 import './style.scss';
 
-interface Props {
-	attributes: {
-		align: string;
-		className: string;
-		isPreview: boolean;
-	};
-	name: string;
-}
-
-const Edit = ( props: Props ): JSX.Element => {
-	const { attributes, name } = props;
+const Edit = (): JSX.Element => {
 	const blockProps = useBlockProps( {
 		className: 'wc-block-order-confirmation-downloads',
 	} );
 
+	const borderStyles = ( ( {
+		borderBottomColor,
+		borderLeftColor,
+		borderRightColor,
+		borderTopColor,
+		borderWidth,
+	} ) => ( {
+		borderBottomColor,
+		borderLeftColor,
+		borderRightColor,
+		borderTopColor,
+		borderWidth,
+	} ) )( blockProps.style );
+
 	return (
 		<div { ...blockProps }>
 			<Disabled>
-				<ServerSideRender
-					block={ name }
-					attributes={ {
-						...attributes,
-						isPreview: true,
-					} }
-				/>
+				<table
+					style={ borderStyles }
+					cellSpacing="0"
+					className="wc-block-order-confirmation-downloads__table"
+				>
+					<thead>
+						<tr>
+							<th className="download-product">
+								<span className="nobr">Product</span>
+							</th>
+							<th className="download-remaining">
+								<span className="nobr">
+									Downloads remaining
+								</span>
+							</th>
+							<th className="download-expires">
+								<span className="nobr">Expires</span>
+							</th>
+							<th className="download-file">
+								<span className="nobr">Download</span>
+							</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td
+								className="download-product"
+								data-title="Product"
+							>
+								<a href="https://example.com">Test Product</a>
+							</td>
+							<td
+								className="download-remaining"
+								data-title="Downloads remaining"
+							>
+								∞
+							</td>
+							<td
+								className="download-expires"
+								data-title="Expires"
+							>
+								Never
+							</td>
+							<td className="download-file" data-title="Download">
+								<a
+									href="https://example.com"
+									className="woocommerce-MyAccount-downloads-file button alt"
+								>
+									Test Download
+								</a>
+							</td>
+						</tr>
+					</tbody>
+				</table>
 			</Disabled>
 		</div>
 	);

--- a/assets/js/blocks/order-confirmation/downloads/edit.tsx
+++ b/assets/js/blocks/order-confirmation/downloads/edit.tsx
@@ -3,6 +3,7 @@
  */
 import { useBlockProps } from '@wordpress/block-editor';
 import { Disabled } from '@wordpress/components';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -39,18 +40,36 @@ const Edit = (): JSX.Element => {
 					<thead>
 						<tr>
 							<th className="download-product">
-								<span className="nobr">Product</span>
+								<span className="nobr">
+									{ __(
+										'Product',
+										'woo-gutenberg-products-block'
+									) }
+								</span>
 							</th>
 							<th className="download-remaining">
 								<span className="nobr">
-									Downloads remaining
+									{ __(
+										'Downloads remaining',
+										'woo-gutenberg-products-block'
+									) }
 								</span>
 							</th>
 							<th className="download-expires">
-								<span className="nobr">Expires</span>
+								<span className="nobr">
+									{ __(
+										'Expires',
+										'woo-gutenberg-products-block'
+									) }
+								</span>
 							</th>
 							<th className="download-file">
-								<span className="nobr">Download</span>
+								<span className="nobr">
+									{ __(
+										'Download',
+										'woo-gutenberg-products-block'
+									) }
+								</span>
 							</th>
 						</tr>
 					</thead>
@@ -60,26 +79,44 @@ const Edit = (): JSX.Element => {
 								className="download-product"
 								data-title="Product"
 							>
-								<a href="https://example.com">Test Product</a>
+								<a href="https://example.com">
+									{ _x(
+										'Test Product',
+										'sample product name',
+										'woo-gutenberg-products-block'
+									) }
+								</a>
 							</td>
 							<td
 								className="download-remaining"
 								data-title="Downloads remaining"
 							>
-								∞
+								{ _x(
+									'∞',
+									'infinite downloads remaining',
+									'woo-gutenberg-products-block'
+								) }
 							</td>
 							<td
 								className="download-expires"
 								data-title="Expires"
 							>
-								Never
+								{ _x(
+									'Never',
+									'download expires',
+									'woo-gutenberg-products-block'
+								) }
 							</td>
 							<td className="download-file" data-title="Download">
 								<a
 									href="https://example.com"
 									className="woocommerce-MyAccount-downloads-file button alt"
 								>
-									Test Download
+									{ _x(
+										'Test Download',
+										'sample download name',
+										'woo-gutenberg-products-block'
+									) }
 								</a>
 							</td>
 						</tr>

--- a/assets/js/blocks/order-confirmation/downloads/index.tsx
+++ b/assets/js/blocks/order-confirmation/downloads/index.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { registerBlockType } from '@wordpress/blocks';
+import { registerBlockType, type BlockConfiguration } from '@wordpress/blocks';
 import { Icon, download } from '@wordpress/icons';
 
 /**
@@ -11,7 +11,7 @@ import metadata from './block.json';
 import edit from './edit';
 import './style.scss';
 
-registerBlockType( metadata, {
+registerBlockType( metadata as BlockConfiguration, {
 	icon: {
 		src: (
 			<Icon

--- a/assets/js/blocks/order-confirmation/downloads/style.scss
+++ b/assets/js/blocks/order-confirmation/downloads/style.scss
@@ -1,7 +1,9 @@
 .wc-block-order-confirmation-downloads {
+	border: none !important;
+
 	table {
-		width: 100%;
 		border: 1px solid currentColor;
+		width: 100%;
 		border-collapse: collapse;
 		th,
 		td {

--- a/assets/js/blocks/order-confirmation/downloads/style.scss
+++ b/assets/js/blocks/order-confirmation/downloads/style.scss
@@ -1,26 +1,32 @@
 .wc-block-order-confirmation-downloads {
-	.woocommerce-order-downloads table,
-	.woocommerce-order-downloads table.shop_table {
+	table {
 		width: 100%;
 		border: 1px solid currentColor;
-		border-bottom: 0;
-
-		thead {
-			text-transform: uppercase;
-		}
-
-		th {
-			font-weight: bold;
-		}
-
+		border-collapse: collapse;
 		th,
 		td {
-			border-style: solid;
-			border-color: currentColor;
-			border-width: 0 0 1px 0;
-			padding: $gap-small;
+			border: 1px solid currentColor;
+			border-right-width: 0;
+			border-left-width: 0;
+			padding: $gap;
 			margin: 0;
 			text-align: left;
+			font-weight: inherit;
+		}
+		thead {
+			font-weight: bold;
+		}
+	}
+	table[style*="border-width"] {
+		> *,
+		tr,
+		th,
+		td {
+			border-style: inherit;
+			border-width: inherit;
+			border-color: inherit;
+			border-right-width: 0;
+			border-left-width: 0;
 		}
 	}
 }

--- a/assets/js/blocks/order-confirmation/downloads/style.scss
+++ b/assets/js/blocks/order-confirmation/downloads/style.scss
@@ -1,25 +1,46 @@
 .wc-block-order-confirmation-downloads {
-	border: none !important;
+	margin-top: $gap-large;
+	margin-bottom: $gap-large * 2;
+	border: 0 !important; // We want styles to appear on table, not on block.
 
 	table {
-		border: 1px solid currentColor;
 		width: 100%;
-		border-collapse: collapse;
+		border: 1px solid $universal-border-light;
+		border-spacing: 0;
+		border-radius: 2px;
 		th,
 		td {
-			border: 1px solid currentColor;
+			border: 1px solid $universal-border-light;
 			border-right-width: 0;
 			border-left-width: 0;
+			border-top-width: 0;
 			padding: $gap;
 			margin: 0;
-			text-align: left;
+			text-align: center;
 			font-weight: inherit;
+		}
+		tr {
+			> th:first-child,
+			> td:first-child {
+				text-align: left;
+			}
+			> th:last-child,
+			> td:last-child {
+				text-align: right;
+			}
 		}
 		thead {
 			font-weight: bold;
 		}
+		tbody tr:last-child {
+			td,
+			th {
+				border-bottom-width: 0;
+			}
+		}
 	}
-	table[style*="border-width"] {
+	table[style*="border-width"],
+	table[style*="border-color"] {
 		> *,
 		tr,
 		th,
@@ -29,6 +50,7 @@
 			border-color: inherit;
 			border-right-width: 0;
 			border-left-width: 0;
+			border-top-width: 0;
 		}
 	}
 }

--- a/assets/js/blocks/order-confirmation/shipping-address/style.scss
+++ b/assets/js/blocks/order-confirmation/shipping-address/style.scss
@@ -1,10 +1,17 @@
 .wc-block-order-confirmation-shipping-address {
-	border: 1px solid currentColor;
-	padding: $gap-large;
+	border: 1px solid $universal-border-light;
+	border-radius: 2px;
+	padding: $gap;
 
-	address {
+	address,
+	p {
 		width: 100% !important;
 		display: block;
 		box-sizing: border-box;
+		margin: 0 0 $gap;
+
+		&:last-child {
+			margin-bottom: 0;
+		}
 	}
 }

--- a/assets/js/blocks/order-confirmation/shipping-address/style.scss
+++ b/assets/js/blocks/order-confirmation/shipping-address/style.scss
@@ -1,3 +1,11 @@
+.wp-block-woocommerce-order-confirmation-shipping-wrapper > *:first-child {
+	margin-top: 0;
+}
+.wp-block-woocommerce-order-confirmation-shipping-wrapper {
+	.block-editor-block-list__layout > *:first-child {
+		margin-top: 0 !important;
+	}
+}
 .wc-block-order-confirmation-shipping-address {
 	border: 1px solid $universal-border-light;
 	border-radius: 2px;

--- a/assets/js/blocks/order-confirmation/shipping-wrapper/block.json
+++ b/assets/js/blocks/order-confirmation/shipping-wrapper/block.json
@@ -1,7 +1,7 @@
 {
 	"name": "woocommerce/order-confirmation-shipping-wrapper",
 	"version": "1.0.0",
-	"title": "Order Confirmation Shipping",
+	"title": "Shipping Address Section",
 	"description": "Display the order confirmation shipping section.",
 	"category": "woocommerce",
 	"keywords": [ "WooCommerce" ],

--- a/assets/js/blocks/order-confirmation/shipping-wrapper/edit.tsx
+++ b/assets/js/blocks/order-confirmation/shipping-wrapper/edit.tsx
@@ -23,6 +23,7 @@ const Edit = ( {
 						'core/heading',
 						{
 							level: 3,
+							style: { typography: { fontSize: '24px' } },
 							content: attributes.heading || '',
 							onChangeContent: ( value: string ) =>
 								setAttributes( { heading: value } ),

--- a/assets/js/blocks/order-confirmation/status/block.json
+++ b/assets/js/blocks/order-confirmation/status/block.json
@@ -48,10 +48,6 @@
 		"className": {
 			"type": "string",
 			"default": ""
-		},
-		"isPreview": {
-			"type": "boolean",
-			"default": false
 		}
 	},
 	"textdomain": "woo-gutenberg-products-block",

--- a/assets/js/blocks/order-confirmation/summary/block.json
+++ b/assets/js/blocks/order-confirmation/summary/block.json
@@ -31,6 +31,15 @@
 				"text": true
 			}
 		},
+		"__experimentalBorder": {
+			"color": true,
+			"radius": true,
+			"width": true,
+			"__experimentalDefaultControls": {
+				"width": true,
+				"color": true
+			}
+		},
 		"spacing": {
 			"padding": true,
 			"margin": true,
@@ -48,10 +57,6 @@
 		"className": {
 			"type": "string",
 			"default": ""
-		},
-		"isPreview": {
-			"type": "boolean",
-			"default": false
 		}
 	},
 	"textdomain": "woo-gutenberg-products-block",

--- a/assets/js/blocks/order-confirmation/summary/edit.tsx
+++ b/assets/js/blocks/order-confirmation/summary/edit.tsx
@@ -1,37 +1,82 @@
 /**
  * External dependencies
  */
-import ServerSideRender from '@wordpress/server-side-render';
 import { useBlockProps } from '@wordpress/block-editor';
+import { Disabled } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { formatPrice } from '@woocommerce/price-format';
+import { date } from '@wordpress/date';
+import { getSetting } from '@woocommerce/settings';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
 
-interface Props {
-	attributes: {
-		align: string;
-		className: string;
-		isPreview: boolean;
-	};
-	name: string;
-}
-
-const Edit = ( props: Props ): JSX.Element => {
-	const { attributes, name } = props;
-	// Remove style because its handled by the server-side render.
-	const { style, ...blockProps } = useBlockProps();
+const Edit = (): JSX.Element => {
+	const blockProps = useBlockProps( {
+		className: 'wc-block-order-confirmation-summary',
+	} );
 
 	return (
 		<div { ...blockProps }>
-			<ServerSideRender
-				block={ name }
-				attributes={ {
-					...attributes,
-					isPreview: true,
-				} }
-			/>
+			<Disabled>
+				<ul className="wc-block-order-confirmation-summary-list">
+					<li className="wc-block-order-confirmation-summary-list-item">
+						<span className="wc-block-order-confirmation-summary-list-item__key">
+							{ __(
+								'Order number:',
+								'woo-gutenberg-products-block'
+							) }
+						</span>{ ' ' }
+						<span className="wc-block-order-confirmation-summary-list-item__value">
+							123
+						</span>
+					</li>
+					<li className="wc-block-order-confirmation-summary-list-item">
+						<span className="wc-block-order-confirmation-summary-list-item__key">
+							{ __( 'Date:', 'woo-gutenberg-products-block' ) }
+						</span>{ ' ' }
+						<span className="wc-block-order-confirmation-summary-list-item__value">
+							{ date(
+								getSetting( 'dateFormat' ),
+								new Date(),
+								undefined
+							) }
+						</span>
+					</li>
+					<li className="wc-block-order-confirmation-summary-list-item">
+						<span className="wc-block-order-confirmation-summary-list-item__key">
+							{ __( 'Total:', 'woo-gutenberg-products-block' ) }
+						</span>{ ' ' }
+						<span className="wc-block-order-confirmation-summary-list-item__value">
+							{ formatPrice( 4000 ) }
+						</span>
+					</li>
+					<li className="wc-block-order-confirmation-summary-list-item">
+						<span className="wc-block-order-confirmation-summary-list-item__key">
+							{ __( 'Email:', 'woo-gutenberg-products-block' ) }
+						</span>{ ' ' }
+						<span className="wc-block-order-confirmation-summary-list-item__value">
+							test@test.com
+						</span>
+					</li>
+					<li className="wc-block-order-confirmation-summary-list-item">
+						<span className="wc-block-order-confirmation-summary-list-item__key">
+							{ __(
+								'Payment method:',
+								'woo-gutenberg-products-block'
+							) }
+						</span>{ ' ' }
+						<span className="wc-block-order-confirmation-summary-list-item__value">
+							{ __(
+								'Credit Card',
+								'woo-gutenberg-products-block'
+							) }
+						</span>
+					</li>
+				</ul>
+			</Disabled>
 		</div>
 	);
 };

--- a/assets/js/blocks/order-confirmation/summary/edit.tsx
+++ b/assets/js/blocks/order-confirmation/summary/edit.tsx
@@ -21,9 +21,7 @@ interface Props {
 const Edit = ( props: Props ): JSX.Element => {
 	const { attributes, name } = props;
 	// Remove style because its handled by the server-side render.
-	const { style, ...blockProps } = useBlockProps( {
-		className: 'wc-block-order-confirmation-summary',
-	} );
+	const { style, ...blockProps } = useBlockProps();
 
 	return (
 		<div { ...blockProps }>

--- a/assets/js/blocks/order-confirmation/summary/style.scss
+++ b/assets/js/blocks/order-confirmation/summary/style.scss
@@ -1,5 +1,6 @@
 .wc-block-order-confirmation-summary {
-	margin: $gap-large 0;
+	margin-top: $gap-largest;
+	margin-bottom: $gap-largest;
 	ul {
 		list-style: none outside;
 		display: flex;

--- a/assets/js/blocks/order-confirmation/summary/style.scss
+++ b/assets/js/blocks/order-confirmation/summary/style.scss
@@ -1,6 +1,7 @@
 .wc-block-order-confirmation-summary {
 	margin-top: $gap-largest;
 	margin-bottom: $gap-largest;
+	border-radius: 2px;
 	ul {
 		list-style: none outside;
 		display: flex;
@@ -19,6 +20,10 @@
 				font-weight: inherit;
 				display: block;
 			}
+		}
+
+		@media only screen and (max-width: 480px) {
+			flex-direction: column;
 		}
 	}
 	.woocommerce-verify-email {

--- a/assets/js/blocks/order-confirmation/summary/style.scss
+++ b/assets/js/blocks/order-confirmation/summary/style.scss
@@ -1,7 +1,10 @@
+.editor-styles-wrapper .wc-block-order-confirmation-summary,
 .wc-block-order-confirmation-summary {
 	margin-top: $gap-largest;
 	margin-bottom: $gap-largest;
 	border-radius: 2px;
+}
+.wc-block-order-confirmation-summary {
 	ul {
 		list-style: none outside;
 		display: flex;
@@ -33,8 +36,7 @@
 		}
 	}
 
-	&.has-background,
-	&.has-border {
+	&.has-background {
 		padding: $gap;
 	}
 }

--- a/assets/js/blocks/order-confirmation/summary/style.scss
+++ b/assets/js/blocks/order-confirmation/summary/style.scss
@@ -7,12 +7,11 @@
 		flex-direction: row;
 		margin: 0;
 		padding: 0;
-		gap: 1em;
+		gap: $gap;
 		flex-wrap: wrap;
+		justify-content: space-between;
 
 		li {
-			flex: 1 1 auto;
-
 			> .wc-block-order-confirmation-summary-list-item__key {
 				font-weight: bold;
 			}
@@ -27,5 +26,10 @@
 		#verify-email {
 			width: 50%;
 		}
+	}
+
+	&.has-background,
+	&.has-border {
+		padding: $gap;
 	}
 }

--- a/assets/js/blocks/order-confirmation/totals-wrapper/attributes.tsx
+++ b/assets/js/blocks/order-confirmation/totals-wrapper/attributes.tsx
@@ -1,0 +1,11 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+export default {
+	heading: {
+		type: 'string',
+		default: __( 'Order details', 'woo-gutenberg-products-block' ),
+	},
+};

--- a/assets/js/blocks/order-confirmation/totals-wrapper/block.json
+++ b/assets/js/blocks/order-confirmation/totals-wrapper/block.json
@@ -1,8 +1,8 @@
 {
-	"name": "woocommerce/order-confirmation-downloads-wrapper",
+	"name": "woocommerce/order-confirmation-totals-wrapper",
 	"version": "1.0.0",
-	"title": "Downloads Section",
-	"description": "Display the downloadable products section.",
+	"title": "Order Totals Section",
+	"description": "Display the order details section.",
 	"category": "woocommerce",
 	"keywords": [ "WooCommerce" ],
 	"attributes": {

--- a/assets/js/blocks/order-confirmation/totals-wrapper/edit.tsx
+++ b/assets/js/blocks/order-confirmation/totals-wrapper/edit.tsx
@@ -38,7 +38,7 @@ const Edit = ( {
 						},
 					],
 					[
-						'woocommerce/order-confirmation-downloads',
+						'woocommerce/order-confirmation-totals',
 						{
 							lock: {
 								remove: true,

--- a/assets/js/blocks/order-confirmation/totals-wrapper/index.tsx
+++ b/assets/js/blocks/order-confirmation/totals-wrapper/index.tsx
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import { registerBlockType, type BlockConfiguration } from '@wordpress/blocks';
+import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
+import { Icon } from '@wordpress/icons';
+import { totals } from '@woocommerce/icons';
+
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
+import metadata from './block.json';
+import attributes from './attributes';
+
+registerBlockType(
+	metadata as BlockConfiguration,
+	{
+		icon: {
+			src: (
+				<Icon
+					icon={ totals }
+					className="wc-block-editor-components-block-icon"
+				/>
+			),
+		},
+		edit,
+		save() {
+			return (
+				<div { ...useBlockProps.save() }>
+					<InnerBlocks.Content />
+				</div>
+			);
+		},
+		attributes,
+	} as unknown as Partial< BlockConfiguration >
+);

--- a/assets/js/blocks/order-confirmation/totals/block.json
+++ b/assets/js/blocks/order-confirmation/totals/block.json
@@ -30,8 +30,7 @@
 			"__experimentalDefaultControls": {
 				"background": true,
 				"text": true
-			},
-			"__experimentalSkipSerialization": true
+			}
 		},
 		"spacing": {
 			"padding": true,
@@ -49,8 +48,7 @@
 				"color": true,
 				"style": true,
 				"width": true
-			},
-			"__experimentalSkipSerialization": true
+			}
 		},
 		"__experimentalSelector": ".wp-block-woocommerce-order-confirmation-totals table"
 	},
@@ -62,10 +60,6 @@
 		"className": {
 			"type": "string",
 			"default": ""
-		},
-		"isPreview": {
-			"type": "boolean",
-			"default": false
 		}
 	},
 	"textdomain": "woo-gutenberg-products-block",

--- a/assets/js/blocks/order-confirmation/totals/edit.tsx
+++ b/assets/js/blocks/order-confirmation/totals/edit.tsx
@@ -1,38 +1,117 @@
 /**
  * External dependencies
  */
-import ServerSideRender from '@wordpress/server-side-render';
 import { useBlockProps } from '@wordpress/block-editor';
+import { Disabled } from '@wordpress/components';
+import { __, _x } from '@wordpress/i18n';
+import { formatPrice } from '@woocommerce/price-format';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
 
-interface Props {
-	attributes: {
-		align: string;
-		className: string;
-		isPreview: boolean;
-	};
-	name: string;
-}
-
-const Edit = ( props: Props ): JSX.Element => {
-	const { attributes, name } = props;
+const Edit = (): JSX.Element => {
 	const blockProps = useBlockProps( {
 		className: 'wc-block-order-confirmation-totals',
 	} );
 
+	const borderStyles = ( ( {
+		borderBottomColor,
+		borderLeftColor,
+		borderRightColor,
+		borderTopColor,
+		borderWidth,
+	} ) => ( {
+		borderBottomColor,
+		borderLeftColor,
+		borderRightColor,
+		borderTopColor,
+		borderWidth,
+	} ) )( blockProps.style );
+
 	return (
 		<div { ...blockProps }>
-			<ServerSideRender
-				block={ name }
-				attributes={ {
-					...attributes,
-					isPreview: true,
-				} }
-			/>
+			<Disabled>
+				<table
+					style={ borderStyles }
+					cellSpacing="0"
+					className="wc-block-order-confirmation-totals__table"
+				>
+					<thead>
+						<tr>
+							<th className="wc-block-order-confirmation-totals__product">
+								{ __(
+									'Product',
+									'woo-gutenberg-products-block'
+								) }
+							</th>
+							<th className="wc-block-order-confirmation-totals__total">
+								{ __(
+									'Total',
+									'woo-gutenberg-products-block'
+								) }
+							</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr className="woocommerce-table__line-item order_item">
+							<th
+								scope="row"
+								className="wc-block-order-confirmation-totals__product"
+							>
+								{ _x(
+									'Test Product',
+									'sample product name',
+									'woo-gutenberg-products-block'
+								) }
+								&nbsp;
+								<strong className="product-quantity">
+									&times;&nbsp;2
+								</strong>
+							</th>
+							<td className="wc-block-order-confirmation-totals__total">
+								{ formatPrice( 2000 ) }
+							</td>
+						</tr>
+						<tr className="woocommerce-table__line-item order_item">
+							<th
+								scope="row"
+								className="wc-block-order-confirmation-totals__product"
+							>
+								{ _x(
+									'Test Product',
+									'sample product name',
+									'woo-gutenberg-products-block'
+								) }
+								&nbsp;
+								<strong className="product-quantity">
+									&times;&nbsp;2
+								</strong>
+							</th>
+							<td className="wc-block-order-confirmation-totals__total">
+								{ formatPrice( 2000 ) }
+							</td>
+						</tr>
+					</tbody>
+					<tfoot>
+						<tr>
+							<th
+								className="wc-block-order-confirmation-totals__label"
+								scope="row"
+							>
+								{ __(
+									'Total',
+									'woo-gutenberg-products-block'
+								) }
+							</th>
+							<td className="wc-block-order-confirmation-totals__total">
+								{ formatPrice( 4000 ) }
+							</td>
+						</tr>
+					</tfoot>
+				</table>
+			</Disabled>
 		</div>
 	);
 };

--- a/assets/js/blocks/order-confirmation/totals/style.scss
+++ b/assets/js/blocks/order-confirmation/totals/style.scss
@@ -1,17 +1,18 @@
 .wc-block-order-confirmation-totals {
 	margin-top: $gap-large;
 	margin-bottom: $gap-large;
-	border: 0;
+	border: 0 !important; // We want styles to appear on table, not on block.
 	table {
 		width: 100%;
-		border: 1px solid currentColor;
+		border: 1px solid $universal-border-light;
 		border-spacing: 0;
 		border-radius: 2px;
 		th,
 		td {
-			border-bottom: 1px solid currentColor;
+			border: 1px solid $universal-border-light;
 			border-right-width: 0;
 			border-left-width: 0;
+			border-top-width: 0;
 			padding: $gap;
 			margin: 0;
 			text-align: left;
@@ -20,16 +21,19 @@
 		thead {
 			font-weight: bold;
 		}
-		tfoot tr:last-child td,
-		tfoot tr:last-child th {
-			border-bottom-width: 0;
+		tfoot tr:last-child {
+			td,
+			th {
+				border-bottom-width: 0;
+			}
 		}
 		.wc-block-order-confirmation-totals__total {
 			font-variant-numeric: tabular-nums;
 			text-align: right;
 		}
 	}
-	table[style*="border-width"] {
+	table[style*="border-width"],
+	table[style*="border-color"] {
 		> *,
 		tr,
 		th,
@@ -39,7 +43,7 @@
 			border-color: inherit;
 			border-right-width: 0;
 			border-left-width: 0;
+			border-top-width: 0;
 		}
 	}
 }
-

--- a/assets/js/blocks/order-confirmation/totals/style.scss
+++ b/assets/js/blocks/order-confirmation/totals/style.scss
@@ -1,11 +1,15 @@
 .wc-block-order-confirmation-totals {
+	margin-top: $gap-large;
+	margin-bottom: $gap-large;
+	border: 0;
 	table {
 		width: 100%;
 		border: 1px solid currentColor;
-		border-collapse: collapse;
+		border-spacing: 0;
+		border-radius: 2px;
 		th,
 		td {
-			border: 1px solid currentColor;
+			border-bottom: 1px solid currentColor;
 			border-right-width: 0;
 			border-left-width: 0;
 			padding: $gap;
@@ -15,6 +19,10 @@
 		}
 		thead {
 			font-weight: bold;
+		}
+		tfoot tr:last-child td,
+		tfoot tr:last-child th {
+			border-bottom-width: 0;
 		}
 		.wc-block-order-confirmation-totals__total {
 			font-variant-numeric: tabular-nums;

--- a/assets/js/blocks/order-confirmation/totals/style.scss
+++ b/assets/js/blocks/order-confirmation/totals/style.scss
@@ -1,7 +1,8 @@
 .wc-block-order-confirmation-totals {
 	margin-top: $gap-large;
-	margin-bottom: $gap-large;
+	margin-bottom: $gap-large * 2;
 	border: 0 !important; // We want styles to appear on table, not on block.
+
 	table {
 		width: 100%;
 		border: 1px solid $universal-border-light;
@@ -18,7 +19,8 @@
 			text-align: left;
 			font-weight: inherit;
 		}
-		thead {
+		thead,
+		tfoot th {
 			font-weight: bold;
 		}
 		tfoot tr:last-child {

--- a/assets/js/blocks/order-confirmation/totals/style.scss
+++ b/assets/js/blocks/order-confirmation/totals/style.scss
@@ -27,7 +27,8 @@
 				border-bottom-width: 0;
 			}
 		}
-		.wc-block-order-confirmation-totals__total {
+		.wc-block-order-confirmation-totals__total,
+		.wc-block-order-confirmation-totals__note {
 			font-variant-numeric: tabular-nums;
 			text-align: right;
 		}

--- a/bin/webpack-entries.js
+++ b/bin/webpack-entries.js
@@ -96,6 +96,9 @@ const blocks = {
 	'order-confirmation-totals': {
 		customDir: 'order-confirmation/totals',
 	},
+	'order-confirmation-downloads-wrapper': {
+		customDir: 'order-confirmation/downloads-wrapper',
+	},
 	'order-confirmation-downloads': {
 		customDir: 'order-confirmation/downloads',
 	},

--- a/bin/webpack-entries.js
+++ b/bin/webpack-entries.js
@@ -93,6 +93,9 @@ const blocks = {
 	'order-confirmation-summary': {
 		customDir: 'order-confirmation/summary',
 	},
+	'order-confirmation-totals-wrapper': {
+		customDir: 'order-confirmation/totals-wrapper',
+	},
 	'order-confirmation-totals': {
 		customDir: 'order-confirmation/totals',
 	},

--- a/package-lock.json
+++ b/package-lock.json
@@ -15395,6 +15395,7 @@
 			"version": "0.6.0",
 			"resolved": "https://github.com/woocommerce/woocommerce-blocks/files/12309320/wordpress-e2e-test-utils-playwright-0.6.0.tgz",
 			"integrity": "sha512-5lo8iRuRfUOAPMRsQteSkKyMoP1IHHu6GKye8Df+YEPz1LWXcS6YRFGI3HrONBpcaHLrJC7LVav4UdB/sBPqUw==",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "file:../api-fetch",
@@ -65931,6 +65932,7 @@
 			"version": "0.6.0",
 			"resolved": "https://github.com/woocommerce/woocommerce-blocks/files/12309320/wordpress-e2e-test-utils-playwright-0.6.0.tgz",
 			"integrity": "sha512-5lo8iRuRfUOAPMRsQteSkKyMoP1IHHu6GKye8Df+YEPz1LWXcS6YRFGI3HrONBpcaHLrJC7LVav4UdB/sBPqUw==",
+			"dev": true,
 			"requires": {
 				"@wordpress/api-fetch": "file:../api-fetch",
 				"@wordpress/keycodes": "file:../keycodes",

--- a/src/Assets/AssetDataRegistry.php
+++ b/src/Assets/AssetDataRegistry.php
@@ -85,6 +85,7 @@ class AssetDataRegistry {
 			'currency'           => $this->get_currency_data(),
 			'currentUserId'      => get_current_user_id(),
 			'currentUserIsAdmin' => current_user_can( 'manage_woocommerce' ),
+			'dateFormat'         => wc_date_format(),
 			'homeUrl'            => esc_url( home_url( '/' ) ),
 			'locale'             => $this->get_locale_data(),
 			'dashboardUrl'       => wc_get_account_endpoint_url( 'dashboard' ),

--- a/src/BlockTypes/OrderConfirmation/AbstractOrderConfirmationBlock.php
+++ b/src/BlockTypes/OrderConfirmation/AbstractOrderConfirmationBlock.php
@@ -33,14 +33,8 @@ abstract class AbstractOrderConfirmationBlock extends AbstractBlock {
 	 * @return string | void Rendered block output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		if ( ! empty( $attributes['isPreview'] ) ) {
-			$order      = $this->get_preview_order();
-			$permission = 'full';
-		} else {
-			$order      = $this->get_order();
-			$permission = $this->get_view_order_permissions( $order );
-		}
-
+		$order              = $this->get_order();
+		$permission         = $this->get_view_order_permissions( $order );
 		$block_content      = $order ? $this->render_content( $order, $permission, $attributes, $content ) : $this->render_content_fallback();
 		$classname          = $attributes['className'] ?? '';
 		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes );
@@ -251,35 +245,5 @@ abstract class AbstractOrderConfirmationBlock extends AbstractBlock {
 	 */
 	protected function get_block_type_script( $key = null ) {
 		return null;
-	}
-
-	/**
-	 * Get a fake order for previews.
-	 *
-	 * @return \WC_Order Fake order.
-	 */
-	protected function get_preview_order() {
-		$product = new \WC_Product();
-		$product->set_name( 'Test Product' );
-		$product->set_price( '10' );
-
-		$order = new \WC_Order();
-		$order->set_id( 123 );
-		$order->set_billing_email( 'test@test.com' );
-		$order->set_date_created( 'now' );
-		$order->set_payment_method_title( 'Credit Card' );
-		$order->set_total( 40 );
-
-		$item_1 = new \WC_Order_Item_Product();
-		$item_1->set_props(
-			array(
-				'product'  => $product,
-				'quantity' => 4,
-				'total'    => 40,
-			)
-		);
-		$order->add_item( $item_1 );
-
-		return $order;
 	}
 }

--- a/src/BlockTypes/OrderConfirmation/BillingAddress.php
+++ b/src/BlockTypes/OrderConfirmation/BillingAddress.php
@@ -24,12 +24,13 @@ class BillingAddress extends AbstractOrderConfirmationBlock {
 	 * @return string
 	 */
 	protected function render_content( $order, $permission = false, $attributes = [], $content = '' ) {
-		if ( 'full' !== $permission ) {
+		if ( 'full' !== $permission || ! $order->has_billing_address() ) {
 			return '';
 		}
-		$address = $order->get_formatted_billing_address( esc_html__( 'This order has no billing address.', 'woo-gutenberg-products-block' ) );
-		$address = $address . ( $order->get_billing_phone() ? '<br><span class="woocommerce-customer-details--phone">' . esc_html( $order->get_billing_phone() ) . '</span>' : '' );
 
-		return '<address>' . wp_kses_post( $address ) . '</address>';
+		$address = '<address>' . wp_kses_post( $order->get_formatted_billing_address() ) . '</address>';
+		$phone   = $order->get_billing_phone() ? '<p class="woocommerce-customer-details--phone">' . esc_html( $order->get_billing_phone() ) . '</p>' : '';
+
+		return $address . $phone;
 	}
 }

--- a/src/BlockTypes/OrderConfirmation/Downloads.php
+++ b/src/BlockTypes/OrderConfirmation/Downloads.php
@@ -17,6 +17,55 @@ class Downloads extends AbstractOrderConfirmationBlock {
 	protected $block_name = 'order-confirmation-downloads';
 
 	/**
+	 * Render the block.
+	 *
+	 * @param array    $attributes Block attributes.
+	 * @param string   $content Block content.
+	 * @param WP_Block $block Block instance.
+	 * @return string | void Rendered block output.
+	 */
+	protected function render( $attributes, $content, $block ) {
+		$render = parent::render( $attributes, $content, $block );
+
+		// Appends inline styles in the editor.
+		if ( ! empty( $attributes['isPreview'] ) ) {
+			$styles  = $this->get_link_styles( $attributes );
+			$render .= '<style>' . esc_html( $styles ) . '</style>';
+		}
+
+		return $render;
+	}
+
+	/**
+	 * Enqueue frontend assets for this block, just in time for rendering.
+	 *
+	 * @param array $attributes  Any attributes that currently are available from the block.
+	 * @return string
+	 */
+	protected function get_link_styles( array $attributes ) {
+		$link_classes_and_styles       = StyleAttributesUtils::get_link_color_class_and_style( $attributes );
+		$link_hover_classes_and_styles = StyleAttributesUtils::get_link_hover_color_class_and_style( $attributes );
+
+		return '
+			.wc-block-order-confirmation-downloads__table a {' . $link_classes_and_styles['style'] . '}
+			.wc-block-order-confirmation-downloads__table a:hover, .wc-block-order-confirmation-downloads__table a:focus {' . $link_hover_classes_and_styles['style'] . '}
+		';
+	}
+
+	/**
+	 * Enqueue frontend assets for this block, just in time for rendering.
+	 *
+	 * @param array $attributes  Any attributes that currently are available from the block.
+	 */
+	protected function enqueue_assets( array $attributes ) {
+		parent::enqueue_assets( $attributes );
+
+		$styles = $this->get_link_styles( $attributes );
+
+		wp_add_inline_style( 'wc-blocks-style', $styles );
+	}
+
+	/**
 	 * This renders the content of the block within the wrapper.
 	 *
 	 * @param \WC_Order $order Order object.
@@ -45,19 +94,19 @@ class Downloads extends AbstractOrderConfirmationBlock {
 			return $this->render_content_fallback();
 		}
 
+		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, [ 'border_color', 'border_radius', 'border_width', 'background_color', 'text_color' ] );
+
 		return '
-			<section class="woocommerce-order-downloads">
-				<table class="woocommerce-table woocommerce-table--order-downloads shop_table shop_table_responsive order_details" cellspacing="0">
-					<thead>
-						<tr>
-							' . $this->render_order_downloads_column_headers( $order ) . '
-						</td>
-					</thead>
-					<tbody>
-						' . $this->render_order_downloads( $order, $downloads ) . '
-					</tbody>
-				</table>
-			</section>
+			<table cellspacing="0" class="wc-block-order-confirmation-downloads__table ' . esc_attr( $classes_and_styles['classes'] ) . '" style="' . esc_attr( $classes_and_styles['styles'] ) . '">
+				<thead>
+					<tr>
+						' . $this->render_order_downloads_column_headers( $order ) . '
+					</td>
+				</thead>
+				<tbody>
+					' . $this->render_order_downloads( $order, $downloads ) . '
+				</tbody>
+			</table>
 		';
 	}
 

--- a/src/BlockTypes/OrderConfirmation/Downloads.php
+++ b/src/BlockTypes/OrderConfirmation/Downloads.php
@@ -36,7 +36,7 @@ class Downloads extends AbstractOrderConfirmationBlock {
 		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, [ 'border_color', 'border_radius', 'border_width', 'background_color', 'text_color' ] );
 
 		return '
-			<table cellspacing="0" class="wc-block-order-confirmation-downloads__table">
+			<table cellspacing="0" class="wc-block-order-confirmation-downloads__table ' . esc_attr( $classes_and_styles['classes'] ) . '" style="' . esc_attr( $classes_and_styles['styles'] ) . '">
 				<thead>
 					<tr>
 						' . $this->render_order_downloads_column_headers( $order ) . '

--- a/src/BlockTypes/OrderConfirmation/Downloads.php
+++ b/src/BlockTypes/OrderConfirmation/Downloads.php
@@ -17,55 +17,6 @@ class Downloads extends AbstractOrderConfirmationBlock {
 	protected $block_name = 'order-confirmation-downloads';
 
 	/**
-	 * Render the block.
-	 *
-	 * @param array    $attributes Block attributes.
-	 * @param string   $content Block content.
-	 * @param WP_Block $block Block instance.
-	 * @return string | void Rendered block output.
-	 */
-	protected function render( $attributes, $content, $block ) {
-		$render = parent::render( $attributes, $content, $block );
-
-		// Appends inline styles in the editor.
-		if ( ! empty( $attributes['isPreview'] ) ) {
-			$styles  = $this->get_link_styles( $attributes );
-			$render .= '<style>' . esc_html( $styles ) . '</style>';
-		}
-
-		return $render;
-	}
-
-	/**
-	 * Enqueue frontend assets for this block, just in time for rendering.
-	 *
-	 * @param array $attributes  Any attributes that currently are available from the block.
-	 * @return string
-	 */
-	protected function get_link_styles( array $attributes ) {
-		$link_classes_and_styles       = StyleAttributesUtils::get_link_color_class_and_style( $attributes );
-		$link_hover_classes_and_styles = StyleAttributesUtils::get_link_hover_color_class_and_style( $attributes );
-
-		return '
-			.wc-block-order-confirmation-downloads__table a {' . $link_classes_and_styles['style'] . '}
-			.wc-block-order-confirmation-downloads__table a:hover, .wc-block-order-confirmation-downloads__table a:focus {' . $link_hover_classes_and_styles['style'] . '}
-		';
-	}
-
-	/**
-	 * Enqueue frontend assets for this block, just in time for rendering.
-	 *
-	 * @param array $attributes  Any attributes that currently are available from the block.
-	 */
-	protected function enqueue_assets( array $attributes ) {
-		parent::enqueue_assets( $attributes );
-
-		$styles = $this->get_link_styles( $attributes );
-
-		wp_add_inline_style( 'wc-blocks-style', $styles );
-	}
-
-	/**
 	 * This renders the content of the block within the wrapper.
 	 *
 	 * @param \WC_Order $order Order object.
@@ -75,20 +26,8 @@ class Downloads extends AbstractOrderConfirmationBlock {
 	 * @return string
 	 */
 	protected function render_content( $order, $permission = false, $attributes = [], $content = '' ) {
-		if ( ! empty( $attributes['isPreview'] ) ) {
-			$show_downloads = true;
-			$downloads      = [
-				[
-					'product_name'  => 'Test Product',
-					'product_url'   => 'https://example.com',
-					'download_name' => 'Test Download',
-					'download_url'  => 'https://example.com',
-				],
-			];
-		} else {
-			$show_downloads = $order && $order->has_downloadable_item() && $order->is_download_permitted();
-			$downloads      = $order ? $order->get_downloadable_items() : [];
-		}
+		$show_downloads = $order && $order->has_downloadable_item() && $order->is_download_permitted();
+		$downloads      = $order ? $order->get_downloadable_items() : [];
 
 		if ( ! $permission || ! $show_downloads ) {
 			return $this->render_content_fallback();
@@ -97,7 +36,7 @@ class Downloads extends AbstractOrderConfirmationBlock {
 		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, [ 'border_color', 'border_radius', 'border_width', 'background_color', 'text_color' ] );
 
 		return '
-			<table cellspacing="0" class="wc-block-order-confirmation-downloads__table ' . esc_attr( $classes_and_styles['classes'] ) . '" style="' . esc_attr( $classes_and_styles['styles'] ) . '">
+			<table cellspacing="0" class="wc-block-order-confirmation-downloads__table">
 				<thead>
 					<tr>
 						' . $this->render_order_downloads_column_headers( $order ) . '

--- a/src/BlockTypes/OrderConfirmation/Downloads.php
+++ b/src/BlockTypes/OrderConfirmation/Downloads.php
@@ -41,7 +41,7 @@ class Downloads extends AbstractOrderConfirmationBlock {
 			$downloads      = $order ? $order->get_downloadable_items() : [];
 		}
 
-		if ( 'full' !== $permission || ! $show_downloads ) {
+		if ( ! $permission || ! $show_downloads ) {
 			return $this->render_content_fallback();
 		}
 

--- a/src/BlockTypes/OrderConfirmation/Downloads.php
+++ b/src/BlockTypes/OrderConfirmation/Downloads.php
@@ -33,7 +33,7 @@ class Downloads extends AbstractOrderConfirmationBlock {
 			return $this->render_content_fallback();
 		}
 
-		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, [ 'border_color', 'border_radius', 'border_width', 'background_color', 'text_color' ] );
+		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, [ 'border_color', 'border_radius', 'border_width', 'border_style', 'background_color', 'text_color' ] );
 
 		return '
 			<table cellspacing="0" class="wc-block-order-confirmation-downloads__table ' . esc_attr( $classes_and_styles['classes'] ) . '" style="' . esc_attr( $classes_and_styles['styles'] ) . '">
@@ -47,6 +47,38 @@ class Downloads extends AbstractOrderConfirmationBlock {
 				</tbody>
 			</table>
 		';
+	}
+
+	/**
+	 * Enqueue frontend assets for this block, just in time for rendering.
+	 *
+	 * @param array $attributes  Any attributes that currently are available from the block.
+	 * @return string
+	 */
+	protected function get_inline_styles( array $attributes ) {
+		$link_classes_and_styles       = StyleAttributesUtils::get_link_color_class_and_style( $attributes );
+		$link_hover_classes_and_styles = StyleAttributesUtils::get_link_hover_color_class_and_style( $attributes );
+		$border_classes_and_styles     = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, [ 'border_color', 'border_radius', 'border_width', 'border_style' ] );
+
+		return '
+			.wc-block-order-confirmation-downloads__table a {' . $link_classes_and_styles['style'] . '}
+			.wc-block-order-confirmation-downloads__table a:hover, .wc-block-order-confirmation-downloads__table a:focus {' . $link_hover_classes_and_styles['style'] . '}
+			.wc-block-order-confirmation-downloads__table {' . $border_classes_and_styles['styles'] . '}
+			.wc-block-order-confirmation-downloads__table th, .wc-block-order-confirmation-downloads__table td {' . $border_classes_and_styles['styles'] . '}
+		';
+	}
+
+	/**
+	 * Enqueue frontend assets for this block, just in time for rendering.
+	 *
+	 * @param array $attributes  Any attributes that currently are available from the block.
+	 */
+	protected function enqueue_assets( array $attributes ) {
+		parent::enqueue_assets( $attributes );
+
+		$styles = $this->get_inline_styles( $attributes );
+
+		wp_add_inline_style( 'wc-blocks-style', $styles );
 	}
 
 	/**

--- a/src/BlockTypes/OrderConfirmation/DownloadsWrapper.php
+++ b/src/BlockTypes/OrderConfirmation/DownloadsWrapper.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Automattic\WooCommerce\Blocks\BlockTypes\OrderConfirmation;
+
+/**
+ * DownloadsWrapper class.
+ */
+class DownloadsWrapper extends AbstractOrderConfirmationBlock {
+
+	/**
+	 * Block name.
+	 *
+	 * @var string
+	 */
+	protected $block_name = 'order-confirmation-downloads-wrapper';
+
+	/**
+	 * See if the store has a downloadable product. This controls if we bother to show a preview in the editor.
+	 *
+	 * @return boolean
+	 */
+	protected function store_has_downloadable_products() {
+		$has_downloadable_product = get_transient( 'wc_blocks_has_downloadable_product', false );
+
+		if ( false === $has_downloadable_product ) {
+			$product_ids              = get_posts(
+				array(
+					'post_type'   => 'product',
+					'numberposts' => 1,
+					'post_status' => 'publish',
+					'fields'      => 'ids',
+					// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+					'meta_query'  => array(
+						array(
+							'key'     => '_downloadable',
+							'value'   => 'yes',
+							'compare' => '=',
+						),
+					),
+				)
+			);
+			$has_downloadable_product = ! empty( $product_ids );
+			set_transient( 'wc_blocks_has_downloadable_product', $has_downloadable_product ? '1' : '0', MONTH_IN_SECONDS );
+		}
+
+		return (bool) $has_downloadable_product;
+	}
+
+	/**
+	 * Extra data passed through from server to client for block.
+	 *
+	 * @param array $attributes  Any attributes that currently are available from the block.
+	 *                           Note, this will be empty in the editor context when the block is
+	 *                           not in the post content on editor load.
+	 */
+	protected function enqueue_data( array $attributes = [] ) {
+		parent::enqueue_data( $attributes );
+
+		$this->asset_data_registry->add( 'storeHasDownloadableProducts', $this->store_has_downloadable_products() );
+	}
+
+	/**
+	 * This renders the content of the downloads wrapper.
+	 *
+	 * @param \WC_Order $order Order object.
+	 * @param string    $permission Permission level for viewing order details.
+	 * @param array     $attributes Block attributes.
+	 * @param string    $content Original block content.
+	 */
+	protected function render_content( $order, $permission = false, $attributes = [], $content = '' ) {
+		$show_downloads = $order && $order->has_downloadable_item() && $order->is_download_permitted();
+
+		if ( ! $show_downloads || ! $permission ) {
+			return '';
+		}
+
+		return $content;
+	}
+}

--- a/src/BlockTypes/OrderConfirmation/ShippingAddress.php
+++ b/src/BlockTypes/OrderConfirmation/ShippingAddress.php
@@ -24,37 +24,35 @@ class ShippingAddress extends AbstractOrderConfirmationBlock {
 	 * @return string
 	 */
 	protected function render_content( $order, $permission = false, $attributes = [], $content = '' ) {
-		if ( ! $permission ) {
+		if ( ! $permission || ! $order->needs_shipping_address() || ! $order->has_shipping_address() ) {
 			return $this->render_content_fallback();
 		}
 
-		if ( $order->needs_shipping_address() ) {
-			if ( 'full' === $permission ) {
-				$address = $order->get_formatted_shipping_address( esc_html__( 'This order has no shipping address.', 'woo-gutenberg-products-block' ) );
-				$address = $address . ( $order->get_shipping_phone() ? '<br><span class="woocommerce-customer-details--phone">' . esc_html( $order->get_shipping_phone() ) . '</span>' : '' );
-			} else {
-				$states  = wc()->countries->get_states( $order->get_shipping_country() );
-				$address = esc_html(
-					sprintf(
-					/* translators: %s location. */
-						__( 'Shipping to %s', 'woo-gutenberg-products-block' ),
-						implode(
-							', ',
-							array_filter(
-								[
-									$order->get_shipping_postcode(),
-									$order->get_shipping_city(),
-									$states[ $order->get_shipping_state() ] ?? $order->get_shipping_state(),
-									wc()->countries->countries[ $order->get_shipping_country() ] ?? $order->get_shipping_country(),
-								]
-							)
-						)
-					)
-				);
-			}
-		} else {
-			$address = esc_html__( 'This order does not require shipping.', 'woo-gutenberg-products-block' );
+		if ( 'full' === $permission ) {
+			$address = '<address>' . wp_kses_post( $order->get_formatted_shipping_address() ) . '</address>';
+			$phone   = $order->get_shipping_phone() ? '<p class="woocommerce-customer-details--phone">' . esc_html( $order->get_shipping_phone() ) . '</p>' : '';
+
+			return $address . $phone;
 		}
+
+		$states  = wc()->countries->get_states( $order->get_shipping_country() );
+		$address = esc_html(
+			sprintf(
+			/* translators: %s location. */
+				__( 'Shipping to %s', 'woo-gutenberg-products-block' ),
+				implode(
+					', ',
+					array_filter(
+						[
+							$order->get_shipping_postcode(),
+							$order->get_shipping_city(),
+							$states[ $order->get_shipping_state() ] ?? $order->get_shipping_state(),
+							wc()->countries->countries[ $order->get_shipping_country() ] ?? $order->get_shipping_country(),
+						]
+					)
+				)
+			)
+		);
 
 		return '<address>' . wp_kses_post( $address ) . '</address>';
 	}

--- a/src/BlockTypes/OrderConfirmation/Summary.php
+++ b/src/BlockTypes/OrderConfirmation/Summary.php
@@ -2,8 +2,6 @@
 
 namespace Automattic\WooCommerce\Blocks\BlockTypes\OrderConfirmation;
 
-use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
-
 /**
  * Summary class.
  */

--- a/src/BlockTypes/OrderConfirmation/Totals.php
+++ b/src/BlockTypes/OrderConfirmation/Totals.php
@@ -29,7 +29,7 @@ class Totals extends AbstractOrderConfirmationBlock {
 
 		// Appends inline styles in the editor.
 		if ( ! empty( $attributes['isPreview'] ) ) {
-			$styles  = $this->get_link_styles( $attributes );
+			$styles  = $this->get_inline_styles( $attributes );
 			$render .= '<style>' . esc_html( $styles ) . '</style>';
 		}
 
@@ -49,7 +49,7 @@ class Totals extends AbstractOrderConfirmationBlock {
 		if ( ! $permission ) {
 			return $this->render_content_fallback();
 		}
-		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, [ 'border_color', 'border_radius', 'border_width', 'background_color', 'text_color' ] );
+		$classes_and_styles = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, [ 'border_color', 'border_radius', 'border_width', 'border_style', 'background_color', 'text_color' ] );
 
 		return $this->get_hook_content( 'woocommerce_order_details_before_order_table', [ $order ] ) . '
 			<table cellspacing="0" class="wc-block-order-confirmation-totals__table ' . esc_attr( $classes_and_styles['classes'] ) . '" style="' . esc_attr( $classes_and_styles['styles'] ) . '">
@@ -80,13 +80,16 @@ class Totals extends AbstractOrderConfirmationBlock {
 	 * @param array $attributes  Any attributes that currently are available from the block.
 	 * @return string
 	 */
-	protected function get_link_styles( array $attributes ) {
+	protected function get_inline_styles( array $attributes ) {
 		$link_classes_and_styles       = StyleAttributesUtils::get_link_color_class_and_style( $attributes );
 		$link_hover_classes_and_styles = StyleAttributesUtils::get_link_hover_color_class_and_style( $attributes );
+		$border_classes_and_styles     = StyleAttributesUtils::get_classes_and_styles_by_attributes( $attributes, [ 'border_color', 'border_radius', 'border_width', 'border_style' ] );
 
 		return '
 			.wc-block-order-confirmation-totals__table a {' . $link_classes_and_styles['style'] . '}
 			.wc-block-order-confirmation-totals__table a:hover, .wc-block-order-confirmation-totals__table a:focus {' . $link_hover_classes_and_styles['style'] . '}
+			.wc-block-order-confirmation-totals__table {' . $border_classes_and_styles['styles'] . '}
+			.wc-block-order-confirmation-totals__table th, .wc-block-order-confirmation-totals__table td {' . $border_classes_and_styles['styles'] . '}
 		';
 	}
 
@@ -98,7 +101,7 @@ class Totals extends AbstractOrderConfirmationBlock {
 	protected function enqueue_assets( array $attributes ) {
 		parent::enqueue_assets( $attributes );
 
-		$styles = $this->get_link_styles( $attributes );
+		$styles = $this->get_inline_styles( $attributes );
 
 		wp_add_inline_style( 'wc-blocks-style', $styles );
 	}

--- a/src/BlockTypes/OrderConfirmation/Totals.php
+++ b/src/BlockTypes/OrderConfirmation/Totals.php
@@ -17,26 +17,6 @@ class Totals extends AbstractOrderConfirmationBlock {
 	protected $block_name = 'order-confirmation-totals';
 
 	/**
-	 * Render the block.
-	 *
-	 * @param array    $attributes Block attributes.
-	 * @param string   $content Block content.
-	 * @param WP_Block $block Block instance.
-	 * @return string | void Rendered block output.
-	 */
-	protected function render( $attributes, $content, $block ) {
-		$render = parent::render( $attributes, $content, $block );
-
-		// Appends inline styles in the editor.
-		if ( ! empty( $attributes['isPreview'] ) ) {
-			$styles  = $this->get_inline_styles( $attributes );
-			$render .= '<style>' . esc_html( $styles ) . '</style>';
-		}
-
-		return $render;
-	}
-
-	/**
 	 * This renders the content of the block within the wrapper.
 	 *
 	 * @param \WC_Order $order Order object.
@@ -61,7 +41,7 @@ class Totals extends AbstractOrderConfirmationBlock {
 				</thead>
 				<tbody>
 					' . $this->get_hook_content( 'woocommerce_order_details_before_order_table_items', [ $order ] ) . '
-					' . $this->render_order_details_table_items( $order, $attributes ) . '
+					' . $this->render_order_details_table_items( $order ) . '
 					' . $this->get_hook_content( 'woocommerce_order_details_after_order_table_items', [ $order ] ) . '
 				</tbody>
 				<tfoot>
@@ -112,10 +92,9 @@ class Totals extends AbstractOrderConfirmationBlock {
 	 * Loosely based on the templates order-details.php and order-details-item.php from core.
 	 *
 	 * @param \WC_Order $order Order object.
-	 * @param array     $attributes Block attributes.
 	 * @return string
 	 */
-	protected function render_order_details_table_items( $order, $attributes ) {
+	protected function render_order_details_table_items( $order ) {
 		$return      = '';
 		$order_items = array_filter(
 			// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
@@ -128,7 +107,7 @@ class Totals extends AbstractOrderConfirmationBlock {
 
 		foreach ( $order_items as $item_id => $item ) {
 			$product = $item->get_product();
-			$return .= $this->render_order_details_table_item( $order, $item_id, $item, $product, $attributes );
+			$return .= $this->render_order_details_table_item( $order, $item_id, $item, $product );
 		}
 
 		return $return;
@@ -141,20 +120,14 @@ class Totals extends AbstractOrderConfirmationBlock {
 	 * @param integer           $item_id Item ID.
 	 * @param \WC_Order_Item    $item Item object.
 	 * @param \WC_Product|false $product Product object if it exists.
-	 * @param array             $attributes Block attributes.
 	 * @return string
 	 */
-	protected function render_order_details_table_item( $order, $item_id, $item, $product, $attributes ) {
+	protected function render_order_details_table_item( $order, $item_id, $item, $product ) {
 		$is_visible = $product && $product->is_visible();
 		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		$row_class = apply_filters( 'woocommerce_order_item_class', 'woocommerce-table__line-item order_item', $item, $order );
 		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		$product_permalink = apply_filters( 'woocommerce_order_item_permalink', $is_visible ? $product->get_permalink( $item ) : '', $item, $order );
-
-		// Previews enable links.
-		if ( ! empty( $attributes['isPreview'] ) ) {
-			$product_permalink = '#';
-		}
 
 		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 		$item_name    = apply_filters(
@@ -182,7 +155,7 @@ class Totals extends AbstractOrderConfirmationBlock {
 					' . wc_display_item_meta( $item, [ 'echo' => false ] ) . '
 					' . $this->get_hook_content( 'woocommerce_order_item_meta_end', [ $item_id, $item, $order, false ] ) . '
 					' . $this->render_order_details_table_item_purchase_note( $order, $product ) . '
-				</td>
+				</th>
 				<td class="wc-block-order-confirmation-totals__total">
 					' . wp_kses_post( $order->get_formatted_line_subtotal( $item ) ) . '
 				</td>

--- a/src/BlockTypes/OrderConfirmation/TotalsWrapper.php
+++ b/src/BlockTypes/OrderConfirmation/TotalsWrapper.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Automattic\WooCommerce\Blocks\BlockTypes\OrderConfirmation;
+
+/**
+ * TotalsWrapper class.
+ */
+class TotalsWrapper extends AbstractOrderConfirmationBlock {
+
+	/**
+	 * Block name.
+	 *
+	 * @var string
+	 */
+	protected $block_name = 'order-confirmation-totals-wrapper';
+
+	/**
+	 * This renders the content of the totals wrapper.
+	 *
+	 * @param \WC_Order $order Order object.
+	 * @param string    $permission Permission level for viewing order details.
+	 * @param array     $attributes Block attributes.
+	 * @param string    $content Original block content.
+	 */
+	protected function render_content( $order, $permission = false, $attributes = [], $content = '' ) {
+		if ( ! $permission ) {
+			return '';
+		}
+		return $content;
+	}
+}

--- a/src/BlockTypesController.php
+++ b/src/BlockTypesController.php
@@ -236,6 +236,7 @@ final class BlockTypesController {
 			$block_types[] = 'OrderConfirmation\Status';
 			$block_types[] = 'OrderConfirmation\Summary';
 			$block_types[] = 'OrderConfirmation\Totals';
+			$block_types[] = 'OrderConfirmation\TotalsWrapper';
 			$block_types[] = 'OrderConfirmation\Downloads';
 			$block_types[] = 'OrderConfirmation\DownloadsWrapper';
 			$block_types[] = 'OrderConfirmation\BillingAddress';

--- a/src/BlockTypesController.php
+++ b/src/BlockTypesController.php
@@ -237,6 +237,7 @@ final class BlockTypesController {
 			$block_types[] = 'OrderConfirmation\Summary';
 			$block_types[] = 'OrderConfirmation\Totals';
 			$block_types[] = 'OrderConfirmation\Downloads';
+			$block_types[] = 'OrderConfirmation\DownloadsWrapper';
 			$block_types[] = 'OrderConfirmation\BillingAddress';
 			$block_types[] = 'OrderConfirmation\ShippingAddress';
 			$block_types[] = 'OrderConfirmation\BillingWrapper';

--- a/src/Utils/StyleAttributesUtils.php
+++ b/src/Utils/StyleAttributesUtils.php
@@ -172,38 +172,40 @@ class StyleAttributesUtils {
 	 * @return array
 	 */
 	public static function get_border_color_class_and_style( $attributes ) {
-
 		$border_color_linked_preset = $attributes['borderColor'] ?? '';
 		$border_color_linked_custom = $attributes['style']['border']['color'] ?? '';
 		$custom_border              = $attributes['style']['border'] ?? '';
 
-		$border_color_class = '';
-		$border_color_css   = '';
+		$class = '';
+		$style = '';
+		$value = '';
 
 		if ( $border_color_linked_preset ) {
 			// Linked preset color.
-			$border_color_class = sprintf( 'has-border-color has-%s-border-color', $border_color_linked_preset );
+			$class = sprintf( 'has-border-color has-%s-border-color', $border_color_linked_preset );
+			$value = self::get_preset_value( $border_color_linked_preset );
+			$style = 'border-color:' . $value . ';';
 		} elseif ( $border_color_linked_custom ) {
 			// Linked custom color.
-			$border_color_css .= 'border-color:' . $border_color_linked_custom . ';';
-		} else {
+			$style .= 'border-color:' . $border_color_linked_custom . ';';
+			$value  = $border_color_linked_custom;
+		} elseif ( is_array( $custom_border ) ) {
 			// Unlinked.
-			if ( is_array( $custom_border ) ) {
-				foreach ( $custom_border as $border_color_key => $border_color_value ) {
-					if ( is_array( $border_color_value ) && array_key_exists( 'color', ( $border_color_value ) ) ) {
-						$border_color_css .= 'border-' . $border_color_key . '-color:' . self::get_color_value( $border_color_value['color'] ) . ';';
-					}
+			foreach ( $custom_border as $border_color_key => $border_color_value ) {
+				if ( is_array( $border_color_value ) && array_key_exists( 'color', ( $border_color_value ) ) ) {
+					$style .= 'border-' . $border_color_key . '-color:' . self::get_color_value( $border_color_value['color'] ) . ';';
 				}
 			}
 		}
 
-		if ( ! $border_color_class && ! $border_color_css ) {
+		if ( ! $class && ! $style ) {
 			return self::EMPTY_STYLE;
 		}
 
 		return array(
-			'class' => $border_color_class,
-			'style' => $border_color_css,
+			'class' => $class,
+			'style' => $style,
+			'value' => $value,
 		);
 	}
 
@@ -214,18 +216,17 @@ class StyleAttributesUtils {
 	 * @return array
 	 */
 	public static function get_border_radius_class_and_style( $attributes ) {
-
 		$custom_border_radius = $attributes['style']['border']['radius'] ?? '';
 
 		if ( '' === $custom_border_radius ) {
 			return self::EMPTY_STYLE;
 		}
 
-		$border_radius_css = '';
+		$style = '';
 
 		if ( is_string( $custom_border_radius ) ) {
 			// Linked sides.
-			$border_radius_css = 'border-radius:' . $custom_border_radius . ';';
+			$style = 'border-radius:' . $custom_border_radius . ';';
 		} else {
 			// Unlinked sides.
 			$border_radius = array();
@@ -237,14 +238,14 @@ class StyleAttributesUtils {
 
 			foreach ( $border_radius as $border_radius_side => $border_radius_value ) {
 				if ( '' !== $border_radius_value ) {
-					$border_radius_css .= $border_radius_side . ':' . $border_radius_value . ';';
+					$style .= $border_radius_side . ':' . $border_radius_value . ';';
 				}
 			}
 		}
 
 		return array(
 			'class' => null,
-			'style' => $border_radius_css,
+			'style' => $style,
 		);
 	}
 
@@ -255,30 +256,60 @@ class StyleAttributesUtils {
 	 * @return array
 	 */
 	public static function get_border_width_class_and_style( $attributes ) {
-
 		$custom_border = $attributes['style']['border'] ?? '';
 
 		if ( '' === $custom_border ) {
 			return self::EMPTY_STYLE;
 		}
 
-		$border_width_css = '';
+		$style = '';
 
 		if ( array_key_exists( 'width', ( $custom_border ) ) && ! empty( $custom_border['width'] ) ) {
 			// Linked sides.
-			$border_width_css = 'border-width:' . $custom_border['width'] . ';';
+			$style = 'border-width:' . $custom_border['width'] . ';';
 		} else {
 			// Unlinked sides.
 			foreach ( $custom_border as $border_width_side => $border_width_value ) {
 				if ( isset( $border_width_value['width'] ) ) {
-					$border_width_css .= 'border-' . $border_width_side . '-width:' . $border_width_value['width'] . ';';
+					$style .= 'border-' . $border_width_side . '-width:' . $border_width_value['width'] . ';';
 				}
 			}
 		}
 
 		return array(
 			'class' => null,
-			'style' => $border_width_css,
+			'style' => $style,
+		);
+	}
+
+	/**
+	 * Get class and style for border width from attributes.
+	 *
+	 * @param array $attributes Block attributes.
+	 * @return array
+	 */
+	public static function get_border_style_class_and_style( $attributes ) {
+		$custom_border = $attributes['style']['border'] ?? '';
+
+		if ( '' === $custom_border ) {
+			return self::EMPTY_STYLE;
+		}
+
+		$style = '';
+
+		if ( array_key_exists( 'style', ( $custom_border ) ) && ! empty( $custom_border['style'] ) ) {
+			$style = 'border-style:' . $custom_border['style'] . ';';
+		} else {
+			foreach ( $custom_border as $side => $value ) {
+				if ( isset( $value['style'] ) ) {
+					$style .= 'border-' . $side . '-style:' . $value['style'] . ';';
+				}
+			}
+		}
+
+		return array(
+			'class' => null,
+			'style' => $style,
 		);
 	}
 
@@ -671,6 +702,7 @@ class StyleAttributesUtils {
 			'border_color'     => self::get_border_color_class_and_style( $attributes ),
 			'border_radius'    => self::get_border_radius_class_and_style( $attributes ),
 			'border_width'     => self::get_border_width_class_and_style( $attributes ),
+			'border_style'     => self::get_border_style_class_and_style( $attributes ),
 			'font_family'      => self::get_font_family_class_and_style( $attributes ),
 			'font_size'        => self::get_font_size_class_and_style( $attributes ),
 			'font_style'       => self::get_font_style_class_and_style( $attributes ),

--- a/src/Utils/StyleAttributesUtils.php
+++ b/src/Utils/StyleAttributesUtils.php
@@ -690,6 +690,8 @@ class StyleAttributesUtils {
 	/**
 	 * Get classes and styles from attributes.
 	 *
+	 * Excludes link_color and link_hover_color since those should not apply to the container.
+	 *
 	 * @param array $attributes Block attributes.
 	 * @param array $properties Properties to get classes/styles from.
 	 * @param array $exclude Properties to exclude.
@@ -709,8 +711,6 @@ class StyleAttributesUtils {
 			'font_weight'      => self::get_font_weight_class_and_style( $attributes ),
 			'letter_spacing'   => self::get_letter_spacing_class_and_style( $attributes ),
 			'line_height'      => self::get_line_height_class_and_style( $attributes ),
-			'link_color'       => self::get_link_color_class_and_style( $attributes ),
-			'link_hover_color' => self::get_link_hover_color_class_and_style( $attributes ),
 			'margin'           => self::get_margin_class_and_style( $attributes ),
 			'padding'          => self::get_padding_class_and_style( $attributes ),
 			'text_align'       => self::get_text_align_class_and_style( $attributes ),


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

This PR restores https://github.com/woocommerce/woocommerce-blocks/pull/10606 and applies styles (padding, alignment, colors) to finalise the order confirmation page.

Fixes #10763

## Why

n/a

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Go to Appearance > Editor > Templates, select Order Confirmation
2. If you've made edits, click the three dots and "reset customisations"
3. Hover over the order confirmation placeholder and "convert to blocks"
4. You should see the correct layout now including summary, status, details, downloads, address sections
5. Confirm the design matches the screenshot below
6. Try applying some changes such as background and color changes. One to test is the summary block; give it a background color and confirm it gets automatic padding of 16px once it refreshes
7. Save changes
8. Place an order and confirm the frontend matches the preview state

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

![screenshot_2023-08-30_at_16 16 24_720](https://github.com/woocommerce/woocommerce-blocks/assets/90977/be6e49a8-d0cf-40a4-abe3-681320dcf85f)

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [ ] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
 
n/a