### PR TITLE
Add local pickup tracking

### DIFF
--- a/src/Domain/Bootstrap.php
+++ b/src/Domain/Bootstrap.php
@@ -130,6 +130,7 @@ class Bootstrap {
 		$this->container->get( DraftOrders::class )->init();
 		$this->container->get( CreateAccount::class )->init();
 		$this->container->get( ShippingController::class )->init();
+		$this->container->get( JetpackWooCommerceAnalytics::class )->init();
 
 		// Load assets in admin and on the frontend.
 		if ( ! $is_rest ) {
@@ -138,7 +139,6 @@ class Bootstrap {
 			$this->container->get( AssetsController::class );
 			$this->container->get( Installer::class )->init();
 			$this->container->get( GoogleAnalytics::class )->init();
-			$this->container->get( JetpackWooCommerceAnalytics::class )->init();
 		}
 
 		// Load assets unless this is a request specifically for the store API.

--- a/src/Domain/Services/JetpackWooCommerceAnalytics.php
+++ b/src/Domain/Services/JetpackWooCommerceAnalytics.php
@@ -362,7 +362,7 @@ class JetpackWooCommerceAnalytics {
 			return $served;
 		}
 
-		$event_name = 'wcadmin_local_pickup_save_changes';
+		$event_name = 'local_pickup_save_changes';
 
 		$settings  = $request->get_param( 'pickup_location_settings' );
 		$locations = $request->get_param( 'pickup_locations' );

--- a/src/Domain/Services/JetpackWooCommerceAnalytics.php
+++ b/src/Domain/Services/JetpackWooCommerceAnalytics.php
@@ -337,8 +337,16 @@ class JetpackWooCommerceAnalytics {
 		return $additional_blocks;
 	}
 
-	public function track_local_pickup( $served, $result, $request, $server ) {
-		if ( $request->get_route() !== '/wp/v2/settings' ) {
+	/**
+	 * Track local pickup settings changes via Store API
+	 *
+	 * @param bool              $served
+	 * @param \WP_REST_Response $result
+	 * @param \WP_REST_Request  $request
+	 * @return bool
+	 */
+	public function track_local_pickup( $served, $result, $request ) {
+		if ( '/wp/v2/settings' !== $request->get_route() ) {
 			return $served;
 		}
 		// Param name here comes from the show_in_rest['name'] value when registering the setting.
@@ -356,17 +364,17 @@ class JetpackWooCommerceAnalytics {
 		$locations = $request->get_param( 'pickup_locations' );
 
 		$data = array(
-			'local_pickup_enabled'     => $settings['enabled'] === 'yes' ? true : false,
+			'local_pickup_enabled'     => 'yes' === $settings['enabled'] ? true : false,
 			'title'                    => $settings['title'],
-			'price'                    => $settings['cost'] === '',
-			'cost'                     => $settings['cost'] === '' ? 0 : $settings['cost'],
+			'price'                    => '' === $settings['cost'],
+			'cost'                     => '' === $settings['cost'] ? 0 : $settings['cost'],
 			'taxes'                    => $settings['tax_status'],
 			'total_pickup_locations'   => count( $locations ),
 			'pickup_locations_enabled' => count(
 				array_filter(
 					$locations,
 					function( $location ) {
-						return $location['enabled'] === 'yes'; }
+						return 'yes' === $location['enabled']; }
 				)
 			),
 		);


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->
This adds PHP side tracking to Local Pickup save action, it will push the whole object everytime being saved.
## What

Closes https://github.com/woocommerce/woocommerce/issues/37699
Closes https://github.com/woocommerce/woocommerce-blocks/issues/9731

### Testing

1. Enable trackings
2. Save settings
3. See if the action shows up in the tracks.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [x] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->


