### PR TITLE
Add additional information block

### DIFF
--- a/assets/js/base/components/skeleton/index.tsx
+++ b/assets/js/base/components/skeleton/index.tsx
@@ -5,10 +5,14 @@ import './style.scss';
 
 export interface SkeletonProps {
 	numberOfLines?: number;
+	tag?: keyof JSX.IntrinsicElements;
+	maxWidth?: string;
 }
 
 export const Skeleton = ( {
 	numberOfLines = 1,
+	tag: Tag = 'div',
+	maxWidth = '100%',
 }: SkeletonProps ): JSX.Element => {
 	const skeletonLines = Array.from(
 		{ length: numberOfLines },
@@ -21,6 +25,13 @@ export const Skeleton = ( {
 		)
 	);
 	return (
-		<div className="wc-block-components-skeleton">{ skeletonLines }</div>
+		<Tag
+			className="wc-block-components-skeleton"
+			style={ {
+				maxWidth,
+			} }
+		>
+			{ skeletonLines }
+		</Tag>
 	);
 };

--- a/assets/js/base/components/skeleton/style.scss
+++ b/assets/js/base/components/skeleton/style.scss
@@ -7,11 +7,11 @@
 }
 
 .wc-block-components-skeleton-text-line {
-	height: 0.8em;
+	height: 0.85em;
 	width: 100%;
 	position: relative;
-	background: $gray-200;
-	border-radius: 2em;
+	background: $universal-border-light;
+	border-radius: 2px;
 
 	&:last-child {
 		width: 80%;

--- a/assets/js/blocks/classic-template/order-confirmation.tsx
+++ b/assets/js/blocks/classic-template/order-confirmation.tsx
@@ -55,6 +55,10 @@ const getBlockifiedTemplate = ( inheritedAttributes: InheritedAttributes ) =>
 				] ),
 			]
 		),
+		createBlock(
+			'woocommerce/order-confirmation-additional-information',
+			inheritedAttributes
+		),
 	].filter( Boolean ) as BlockInstance[];
 
 const onClickCallback = ( {

--- a/assets/js/blocks/order-confirmation/additional-information/block.json
+++ b/assets/js/blocks/order-confirmation/additional-information/block.json
@@ -8,7 +8,25 @@
 	"supports": {
 		"multiple": false,
 		"align": [ "wide", "full" ],
-		"html": false
+		"html": false,
+		"__experimentalBorder": {
+			"color": true,
+			"radius": true,
+			"width": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"width": true,
+				"color": true
+			}
+		},
+		"spacing": {
+			"padding": true,
+			"margin": true,
+			"__experimentalDefaultControls": {
+				"margin": false,
+				"padding": false
+			}
+		}
 	},
 	"attributes": {
 		"align": {

--- a/assets/js/blocks/order-confirmation/additional-information/block.json
+++ b/assets/js/blocks/order-confirmation/additional-information/block.json
@@ -1,0 +1,26 @@
+{
+	"name": "woocommerce/order-confirmation-additional-information",
+	"version": "1.0.0",
+	"title": "Additional Information",
+	"description": "Displays additional information provided by third-party extensions for the current order.",
+	"category": "woocommerce",
+	"keywords": [ "WooCommerce" ],
+	"supports": {
+		"multiple": false,
+		"align": [ "wide", "full" ],
+		"html": false
+	},
+	"attributes": {
+		"align": {
+			"type": "string",
+			"default": "wide"
+		},
+		"className": {
+			"type": "string",
+			"default": ""
+		}
+	},
+	"textdomain": "woo-gutenberg-products-block",
+	"apiVersion": 2,
+	"$schema": "https://schemas.wp.org/trunk/block.json"
+}

--- a/assets/js/blocks/order-confirmation/additional-information/edit.tsx
+++ b/assets/js/blocks/order-confirmation/additional-information/edit.tsx
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import { useBlockProps } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+import { Placeholder } from '@wordpress/components';
+import { Icon, info } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+const Edit = (): JSX.Element => {
+	const blockProps = useBlockProps( {
+		className: 'wc-block-order-confirmation-additional-information',
+	} );
+
+	return (
+		<div { ...blockProps }>
+			<Placeholder
+				icon={ <Icon icon={ info } /> }
+				label={ __(
+					'Additional Information',
+					'woo-gutenberg-products-block'
+				) }
+				instructions={ __(
+					'Displays additional information provided by third-party extensions for the current order. This block will be hidden if no extensions provide additional information.',
+					'woo-gutenberg-products-block'
+				) }
+				withIllustration={ true }
+			/>
+		</div>
+	);
+};
+
+export default Edit;

--- a/assets/js/blocks/order-confirmation/additional-information/edit.tsx
+++ b/assets/js/blocks/order-confirmation/additional-information/edit.tsx
@@ -2,9 +2,7 @@
  * External dependencies
  */
 import { useBlockProps } from '@wordpress/block-editor';
-import { __ } from '@wordpress/i18n';
-import { Placeholder } from '@wordpress/components';
-import { Icon, info } from '@wordpress/icons';
+import { Skeleton } from '@woocommerce/base-components/skeleton';
 
 /**
  * Internal dependencies
@@ -18,18 +16,8 @@ const Edit = (): JSX.Element => {
 
 	return (
 		<div { ...blockProps }>
-			<Placeholder
-				icon={ <Icon icon={ info } /> }
-				label={ __(
-					'Additional Information',
-					'woo-gutenberg-products-block'
-				) }
-				instructions={ __(
-					'Displays additional information provided by third-party extensions for the current order. This block will be hidden if no extensions provide additional information.',
-					'woo-gutenberg-products-block'
-				) }
-				withIllustration={ true }
-			/>
+			<Skeleton tag="h3" numberOfLines={ 1 } maxWidth="25%" />
+			<Skeleton numberOfLines={ 3 } />
 		</div>
 	);
 };

--- a/assets/js/blocks/order-confirmation/additional-information/index.tsx
+++ b/assets/js/blocks/order-confirmation/additional-information/index.tsx
@@ -1,0 +1,29 @@
+/**
+ * External dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+import { Icon, info } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import edit from './edit';
+
+registerBlockType( metadata, {
+	icon: {
+		src: (
+			<Icon
+				icon={ info }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
+	},
+	attributes: {
+		...metadata.attributes,
+	},
+	edit,
+	save() {
+		return null;
+	},
+} );

--- a/assets/js/blocks/order-confirmation/additional-information/style.scss
+++ b/assets/js/blocks/order-confirmation/additional-information/style.scss
@@ -1,0 +1,6 @@
+.editor-styles-wrapper .wc-block-order-confirmation-additional-information,
+.wc-block-order-confirmation-additional-information {
+	margin-top: $gap-largest;
+	margin-bottom: $gap-largest;
+	border-radius: 2px;
+}

--- a/bin/webpack-entries.js
+++ b/bin/webpack-entries.js
@@ -120,6 +120,9 @@ const blocks = {
 	'order-confirmation-status': {
 		customDir: 'order-confirmation/status',
 	},
+	'order-confirmation-additional-information': {
+		customDir: 'order-confirmation/additional-information',
+	},
 };
 
 // Returns the entries for each block given a relative path (ie: `index.js`,

--- a/src/BlockTypes/OrderConfirmation/AdditionalInformation.php
+++ b/src/BlockTypes/OrderConfirmation/AdditionalInformation.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Automattic\WooCommerce\Blocks\BlockTypes\OrderConfirmation;
+
+/**
+ * AdditionalInformation class.
+ */
+class AdditionalInformation extends AbstractOrderConfirmationBlock {
+
+	/**
+	 * Block name.
+	 *
+	 * @var string
+	 */
+	protected $block_name = 'order-confirmation-additional-information';
+
+	/**
+	 * This renders the content of the block within the wrapper.
+	 *
+	 * @param \WC_Order $order Order object.
+	 * @param string    $permission Permission level for viewing order details.
+	 * @param array     $attributes Block attributes.
+	 * @param string    $content Original block content.
+	 * @return string
+	 */
+	protected function render_content( $order, $permission = false, $attributes = [], $content = '' ) {
+		if ( ! $permission ) {
+			return $content;
+		}
+
+		$this->remove_core_hooks();
+		$content .= $this->get_hook_content( 'woocommerce_thankyou_' . $order->get_payment_method(), [ $order->get_id() ] );
+		$content .= $this->get_hook_content( 'woocommerce_thankyou', [ $order->get_id() ] );
+		$this->restore_core_hooks();
+
+		return $content;
+	}
+
+	/**
+	 * Remove core hooks from the thankyou page.
+	 */
+	protected function remove_core_hooks() {
+		remove_action( 'woocommerce_thankyou', 'woocommerce_order_details_table', 10 );
+	}
+
+	/**
+	 * Restore core hooks from the thankyou page.
+	 */
+	protected function restore_core_hooks() {
+		add_action( 'woocommerce_thankyou', 'woocommerce_order_details_table', 10 );
+	}
+}

--- a/src/BlockTypes/OrderConfirmation/Summary.php
+++ b/src/BlockTypes/OrderConfirmation/Summary.php
@@ -38,11 +38,6 @@ class Summary extends AbstractOrderConfirmationBlock {
 		}
 		$content .= '</ul>';
 
-		$this->remove_core_hooks();
-		$content .= $this->get_hook_content( 'woocommerce_thankyou_' . $order->get_payment_method(), [ $order->get_id() ] );
-		$content .= $this->get_hook_content( 'woocommerce_thankyou', [ $order->get_id() ] );
-		$this->restore_core_hooks();
-
 		return $content;
 	}
 

--- a/src/BlockTypes/OrderConfirmation/Summary.php
+++ b/src/BlockTypes/OrderConfirmation/Summary.php
@@ -51,18 +51,4 @@ class Summary extends AbstractOrderConfirmationBlock {
 	protected function render_summary_row( $name, $value ) {
 		return $value ? '<li class="wc-block-order-confirmation-summary-list-item"><span class="wc-block-order-confirmation-summary-list-item__key">' . esc_html( $name ) . '</span> <span class="wc-block-order-confirmation-summary-list-item__value">' . wp_kses_post( $value ) . '</span></li>' : '';
 	}
-
-	/**
-	 * Remove core hooks from the thankyou page.
-	 */
-	protected function remove_core_hooks() {
-		remove_action( 'woocommerce_thankyou', 'woocommerce_order_details_table', 10 );
-	}
-
-	/**
-	 * Restore core hooks from the thankyou page.
-	 */
-	protected function restore_core_hooks() {
-		add_action( 'woocommerce_thankyou', 'woocommerce_order_details_table', 10 );
-	}
 }

--- a/src/BlockTypesController.php
+++ b/src/BlockTypesController.php
@@ -244,6 +244,7 @@ final class BlockTypesController {
 			$block_types[] = 'OrderConfirmation\ShippingAddress';
 			$block_types[] = 'OrderConfirmation\BillingWrapper';
 			$block_types[] = 'OrderConfirmation\ShippingWrapper';
+			$block_types[] = 'OrderConfirmation\AdditionalInformation';
 		}
 
 		/**


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Adds an "additional information" block which renders content provided by the legacy hooks. 

Fixes #10050

## Why

This allows us to render the hooks underneath all other content, and allows it to be moved by the merchant. 

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Go to Appearance > Edit > Templates > Order Confirmation and reset any customisations
2. Edit the default page, select the confirmation placeholder, convert to blocks
3. See the "additional information" block at the bottom of the page
4. Install an extension which uses the hooks. I tested with "Share Your Purchase for WooCommerce" from woo.com.
5. Place an order and confirm 3rd party content is rendered on the page.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

![Screenshot 2023-09-05 at 17 09 56](https://github.com/woocommerce/woocommerce-blocks/assets/90977/cb482e14-cfe0-4ad9-a611-4de6b5b162ab)

![Screenshot 2023-09-05 at 17 10 06](https://github.com/woocommerce/woocommerce-blocks/assets/90977/eabd362b-1541-492a-87eb-599a32f224ec)

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
 
N/A