### PR TITLE
Fix JS Lint issues

### DIFF
--- a/assets/js/base/context/hooks/cart/test/use-store-cart.js
+++ b/assets/js/base/context/hooks/cart/test/use-store-cart.js
@@ -147,9 +147,9 @@ describe( 'useStoreCart', () => {
 			useStoreCart( options );
 		return (
 			<div
-				results={ results }
-				receiveCart={ receiveCart }
-				receiveCartContents={ receiveCartContents }
+				data-results={ results }
+				data-receiveCart={ receiveCart }
+				data-receiveCartContents={ receiveCartContents }
 			/>
 		);
 	};
@@ -200,8 +200,11 @@ describe( 'useStoreCart', () => {
 				);
 			} );
 
-			const { results, receiveCart, receiveCartContents } =
-				renderer.root.findByType( 'div' ).props; //eslint-disable-line testing-library/await-async-query
+			const props = renderer.root.findByType( 'div' ).props; //eslint-disable-line testing-library/await-async-query
+			const results = props[ 'data-results' ];
+			const receiveCart = props[ 'data-receiveCart' ];
+			const receiveCartContents = props[ 'data-receiveCartContents' ];
+
 			const {
 				receiveCart: defaultReceiveCart,
 				receiveCartContents: defaultReceiveCartContents,
@@ -223,8 +226,10 @@ describe( 'useStoreCart', () => {
 				);
 			} );
 
-			const { results, receiveCart, receiveCartContents } =
-				renderer.root.findByType( 'div' ).props; //eslint-disable-line testing-library/await-async-query
+			const props = renderer.root.findByType( 'div' ).props; //eslint-disable-line testing-library/await-async-query
+			const results = props[ 'data-results' ];
+			const receiveCart = props[ 'data-receiveCart' ];
+			const receiveCartContents = props[ 'data-receiveCartContents' ];
 
 			expect( results ).toEqual( mockStoreCartData );
 			expect( receiveCart ).toBeUndefined();
@@ -255,8 +260,10 @@ describe( 'useStoreCart', () => {
 				);
 			} );
 
-			const { results, receiveCart, receiveCartContents } =
-				renderer.root.findByType( 'div' ).props; //eslint-disable-line testing-library/await-async-query
+			const props = renderer.root.findByType( 'div' ).props; //eslint-disable-line testing-library/await-async-query
+			const results = props[ 'data-results' ];
+			const receiveCart = props[ 'data-receiveCart' ];
+			const receiveCartContents = props[ 'data-receiveCartContents' ];
 
 			expect( results ).toEqual( previewCartData );
 			expect( receiveCart ).toEqual( receiveCartMock );

--- a/assets/js/base/context/hooks/collections/test/use-collection.js
+++ b/assets/js/base/context/hooks/collections/test/use-collection.js
@@ -28,7 +28,7 @@ class TestErrorBoundary extends ReactComponent {
 
 	render() {
 		if ( this.state.hasError ) {
-			return <div error={ this.state.error } />;
+			return <div data-error={ this.state.error } />;
 		}
 
 		return this.props.children;
@@ -100,7 +100,7 @@ describe( 'useCollection', () => {
 			} );
 			//eslint-disable-next-line testing-library/await-async-query
 			const props = renderer.root.findByType( 'div' ).props;
-			expect( props.error.message ).toMatch( /options object/ );
+			expect( props[ 'data-error' ].message ).toMatch( /options object/ );
 			expect( console ).toHaveErrored( /your React components:/ );
 			renderer.unmount();
 		}
@@ -122,7 +122,7 @@ describe( 'useCollection', () => {
 			} );
 			//eslint-disable-next-line testing-library/await-async-query
 			const props = renderer.root.findByType( 'div' ).props;
-			expect( props.error.message ).toMatch( /options object/ );
+			expect( props[ 'data-error' ].message ).toMatch( /options object/ );
 			expect( console ).toHaveErrored( /your React components:/ );
 			renderer.unmount();
 		}

--- a/assets/js/base/context/hooks/test/use-query-state.js
+++ b/assets/js/base/context/hooks/test/use-query-state.js
@@ -38,7 +38,7 @@ describe( 'Testing Query State Hooks', () => {
 	const getProps = ( testRenderer ) => {
 		//eslint-disable-next-line testing-library/await-async-query
 		const props = testRenderer.root.findByType( 'div' ).props;
-		return [ props.queryState, props.setQueryState ];
+		return [ props[ 'data-queryState' ], props[ 'data-setQueryState' ] ];
 	};
 
 	/**
@@ -75,7 +75,10 @@ describe( 'Testing Query State Hooks', () => {
 		const args = propKeysForArgs.map( ( key ) => props[ key ] );
 		const [ queryValue, setQueryValue ] = hookTested( ...args );
 		return (
-			<div queryState={ queryValue } setQueryState={ setQueryValue } />
+			<div
+				data-queryState={ queryValue }
+				data-setQueryState={ setQueryValue }
+			/>
 		);
 	};
 

--- a/assets/js/base/hocs/test/with-reviews.js
+++ b/assets/js/base/hocs/test/with-reviews.js
@@ -40,13 +40,13 @@ const defaultArgs = {
 const TestComponent = withReviews( ( props ) => {
 	return (
 		<div
-			error={ props.error }
-			getReviews={ props.getReviews }
-			appendReviews={ props.appendReviews }
-			onChangeArgs={ props.onChangeArgs }
-			isLoading={ props.isLoading }
-			reviews={ props.reviews }
-			totalReviews={ props.totalReviews }
+			data-error={ props.error }
+			data-getReviews={ props.getReviews }
+			data-appendReviews={ props.appendReviews }
+			data-onChangeArgs={ props.onChangeArgs }
+			data-isLoading={ props.isLoading }
+			data-reviews={ props.reviews }
+			data-totalReviews={ props.totalReviews }
 		/>
 	);
 } );
@@ -127,10 +127,14 @@ describe( 'withReviews Component', () => {
 		it( 'sets reviews based on API response', () => {
 			const props = renderer.root.findByType( 'div' ).props;
 
-			expect( props.error ).toBeNull();
-			expect( props.isLoading ).toBe( false );
-			expect( props.reviews ).toEqual( mockReviews.slice( 0, 2 ) );
-			expect( props.totalReviews ).toEqual( mockReviews.length );
+			expect( props[ 'data-error' ] ).toBeNull();
+			expect( props[ 'data-isLoading' ] ).toBe( false );
+			expect( props[ 'data-reviews' ] ).toEqual(
+				mockReviews.slice( 0, 2 )
+			);
+			expect( props[ 'data-totalReviews' ] ).toEqual(
+				mockReviews.length
+			);
 		} );
 	} );
 
@@ -155,9 +159,9 @@ describe( 'withReviews Component', () => {
 
 			expect( formatError ).toHaveBeenCalledWith( error );
 			expect( formatError ).toHaveBeenCalledTimes( 1 );
-			expect( props.error ).toEqual( formattedError );
-			expect( props.isLoading ).toBe( false );
-			expect( props.reviews ).toEqual( [] );
+			expect( props[ 'data-error' ] ).toEqual( formattedError );
+			expect( props[ 'data-isLoading' ] ).toBe( false );
+			expect( props[ 'data-reviews' ] ).toEqual( [] );
 		} );
 	} );
 } );

--- a/assets/js/base/hooks/test/use-previous.js
+++ b/assets/js/base/hooks/test/use-previous.js
@@ -14,7 +14,12 @@ import { usePrevious } from '../use-previous';
 describe( 'usePrevious', () => {
 	const TestComponent = ( { testValue, validation } ) => {
 		const previousValue = usePrevious( testValue, validation );
-		return <div testValue={ testValue } previousValue={ previousValue } />;
+		return (
+			<div
+				data-testValue={ testValue }
+				data-previousValue={ previousValue }
+			/>
+		);
 	};
 
 	let renderer;
@@ -24,9 +29,10 @@ describe( 'usePrevious', () => {
 		act( () => {
 			renderer = TestRenderer.create( <TestComponent testValue={ 1 } /> );
 		} );
-		const testValue = renderer.root.findByType( 'div' ).props.testValue;
+		const testValue =
+			renderer.root.findByType( 'div' ).props[ 'data-testValue' ];
 		const testPreviousValue =
-			renderer.root.findByType( 'div' ).props.previousValue;
+			renderer.root.findByType( 'div' ).props[ 'data-previousValue' ];
 
 		expect( testValue ).toBe( 1 );
 		expect( testPreviousValue ).toBe( undefined );
@@ -42,18 +48,18 @@ describe( 'usePrevious', () => {
 		act( () => {
 			renderer.update( <TestComponent testValue={ 2 } /> );
 		} );
-		testValue = renderer.root.findByType( 'div' ).props.testValue;
+		testValue = renderer.root.findByType( 'div' ).props[ 'data-testValue' ];
 		testPreviousValue =
-			renderer.root.findByType( 'div' ).props.previousValue;
+			renderer.root.findByType( 'div' ).props[ 'data-previousValue' ];
 		expect( testValue ).toBe( 2 );
 		expect( testPreviousValue ).toBe( 1 );
 
 		act( () => {
 			renderer.update( <TestComponent testValue={ 3 } /> );
 		} );
-		testValue = renderer.root.findByType( 'div' ).props.testValue;
+		testValue = renderer.root.findByType( 'div' ).props[ 'data-testValue' ];
 		testPreviousValue =
-			renderer.root.findByType( 'div' ).props.previousValue;
+			renderer.root.findByType( 'div' ).props[ 'data-previousValue' ];
 		expect( testValue ).toBe( 3 );
 		expect( testPreviousValue ).toBe( 2 );
 	} );
@@ -72,9 +78,9 @@ describe( 'usePrevious', () => {
 				<TestComponent testValue="abc" validation={ Number.isFinite } />
 			);
 		} );
-		testValue = renderer.root.findByType( 'div' ).props.testValue;
+		testValue = renderer.root.findByType( 'div' ).props[ 'data-testValue' ];
 		testPreviousValue =
-			renderer.root.findByType( 'div' ).props.previousValue;
+			renderer.root.findByType( 'div' ).props[ 'data-previousValue' ];
 		expect( testValue ).toBe( 'abc' );
 		expect( testPreviousValue ).toBe( 1 );
 
@@ -83,9 +89,9 @@ describe( 'usePrevious', () => {
 				<TestComponent testValue={ 3 } validation={ Number.isFinite } />
 			);
 		} );
-		testValue = renderer.root.findByType( 'div' ).props.testValue;
+		testValue = renderer.root.findByType( 'div' ).props[ 'data-testValue' ];
 		testPreviousValue =
-			renderer.root.findByType( 'div' ).props.previousValue;
+			renderer.root.findByType( 'div' ).props[ 'data-previousValue' ];
 		expect( testValue ).toBe( 3 );
 		expect( testPreviousValue ).toBe( 1 );
 	} );

--- a/assets/js/base/hooks/test/use-shallow-equal.js
+++ b/assets/js/base/hooks/test/use-shallow-equal.js
@@ -14,7 +14,7 @@ import { useShallowEqual } from '../use-shallow-equal';
 describe( 'useShallowEqual', () => {
 	const TestComponent = ( { testValue } ) => {
 		const newValue = useShallowEqual( testValue );
-		return <div newValue={ newValue } />;
+		return <div data-newValue={ newValue } />;
 	};
 	let renderer;
 	beforeEach( () => ( renderer = null ) );
@@ -34,13 +34,15 @@ describe( 'useShallowEqual', () => {
 					<TestComponent testValue={ testValueA } />
 				);
 			} );
-			testPropValue = renderer.root.findByType( 'div' ).props.newValue;
+			testPropValue =
+				renderer.root.findByType( 'div' ).props[ 'data-newValue' ];
 			expect( testPropValue ).toBe( testValueA );
 			// do update
 			act( () => {
 				renderer.update( <TestComponent testValue={ testValueB } /> );
 			} );
-			testPropValue = renderer.root.findByType( 'div' ).props.newValue;
+			testPropValue =
+				renderer.root.findByType( 'div' ).props[ 'data-newValue' ];
 			expect( testPropValue ).toBe( testValueA );
 		}
 	);
@@ -62,13 +64,15 @@ describe( 'useShallowEqual', () => {
 					<TestComponent testValue={ testValueA } />
 				);
 			} );
-			testPropValue = renderer.root.findByType( 'div' ).props.newValue;
+			testPropValue =
+				renderer.root.findByType( 'div' ).props[ 'data-newValue' ];
 			expect( testPropValue ).toBe( testValueA );
 			// do update
 			act( () => {
 				renderer.update( <TestComponent testValue={ testValueB } /> );
 			} );
-			testPropValue = renderer.root.findByType( 'div' ).props.newValue;
+			testPropValue =
+				renderer.root.findByType( 'div' ).props[ 'data-newValue' ];
 			expect( testPropValue ).toBe( testValueB );
 		}
 	);

--- a/assets/js/blocks/price-filter/test/use-price-constraints.js
+++ b/assets/js/blocks/price-filter/test/use-price-constraints.js
@@ -18,8 +18,8 @@ describe( 'usePriceConstraints', () => {
 		const minPriceConstraint = usePriceConstraint( price, 2, ROUND_DOWN );
 		return (
 			<div
-				minPriceConstraint={ minPriceConstraint }
-				maxPriceConstraint={ maxPriceConstraint }
+				data-minPriceConstraint={ minPriceConstraint }
+				data-maxPriceConstraint={ maxPriceConstraint }
 			/>
 		);
 	};
@@ -30,11 +30,11 @@ describe( 'usePriceConstraints', () => {
 		);
 		const container = renderer.root.findByType( 'div' );
 
-		expect( container.props.maxPriceConstraint ).toBe( 1000 );
+		expect( container.props[ 'data-maxPriceConstraint' ] ).toBe( 1000 );
 
 		renderer.update( <TestComponent price={ 2000 } /> );
 
-		expect( container.props.maxPriceConstraint ).toBe( 2000 );
+		expect( container.props[ 'data-maxPriceConstraint' ] ).toBe( 2000 );
 	} );
 
 	it( 'min price constraint should be updated when new price is set', () => {
@@ -43,11 +43,11 @@ describe( 'usePriceConstraints', () => {
 		);
 		const container = renderer.root.findByType( 'div' );
 
-		expect( container.props.minPriceConstraint ).toBe( 1000 );
+		expect( container.props[ 'data-minPriceConstraint' ] ).toBe( 1000 );
 
 		renderer.update( <TestComponent price={ 2000 } /> );
 
-		expect( container.props.minPriceConstraint ).toBe( 2000 );
+		expect( container.props[ 'data-minPriceConstraint' ] ).toBe( 2000 );
 	} );
 
 	it( 'previous price constraint should be preserved when new price is not a infinite number', () => {
@@ -56,11 +56,11 @@ describe( 'usePriceConstraints', () => {
 		);
 		const container = renderer.root.findByType( 'div' );
 
-		expect( container.props.maxPriceConstraint ).toBe( 1000 );
+		expect( container.props[ 'data-maxPriceConstraint' ] ).toBe( 1000 );
 
 		renderer.update( <TestComponent price={ Infinity } /> );
 
-		expect( container.props.maxPriceConstraint ).toBe( 1000 );
+		expect( container.props[ 'data-maxPriceConstraint' ] ).toBe( 1000 );
 	} );
 
 	it( 'max price constraint should be higher if the price is decimal', () => {
@@ -69,21 +69,21 @@ describe( 'usePriceConstraints', () => {
 		);
 		const container = renderer.root.findByType( 'div' );
 
-		expect( container.props.maxPriceConstraint ).toBe( 2000 );
+		expect( container.props[ 'data-maxPriceConstraint' ] ).toBe( 2000 );
 
 		renderer.update( <TestComponent price={ 1999 } /> );
 
-		expect( container.props.maxPriceConstraint ).toBe( 2000 );
+		expect( container.props[ 'data-maxPriceConstraint' ] ).toBe( 2000 );
 	} );
 
 	it( 'min price constraint should be lower if the price is decimal', () => {
 		const renderer = TestRenderer.create( <TestComponent price={ 999 } /> );
 		const container = renderer.root.findByType( 'div' );
 
-		expect( container.props.minPriceConstraint ).toBe( 0 );
+		expect( container.props[ 'data-minPriceConstraint' ] ).toBe( 0 );
 
 		renderer.update( <TestComponent price={ 1999 } /> );
 
-		expect( container.props.minPriceConstraint ).toBe( 1000 );
+		expect( container.props[ 'data-minPriceConstraint' ] ).toBe( 1000 );
 	} );
 } );

--- a/assets/js/hocs/test/with-categories.js
+++ b/assets/js/hocs/test/with-categories.js
@@ -1,6 +1,7 @@
 // We need to disable the following eslint check as it's only applicable
 // to testing-library/react not `react-test-renderer` used here
 /* eslint-disable testing-library/await-async-query */
+
 /**
  * External dependencies
  */
@@ -28,9 +29,9 @@ const mockCategories = [
 const TestComponent = withCategories( ( props ) => {
 	return (
 		<div
-			error={ props.error }
-			isLoading={ props.isLoading }
-			categories={ props.categories }
+			data-error={ props.error }
+			data-isLoading={ props.isLoading }
+			data-categories={ props.categories }
 		/>
 	);
 } );
@@ -69,9 +70,9 @@ describe( 'withCategories Component', () => {
 		it( 'sets the categories props', () => {
 			const props = renderer.root.findByType( 'div' ).props;
 
-			expect( props.error ).toBeNull();
-			expect( props.isLoading ).toBe( false );
-			expect( props.categories ).toEqual( mockCategories );
+			expect( props[ 'data-error' ] ).toBeNull();
+			expect( props[ 'data-isLoading' ] ).toBe( false );
+			expect( props[ 'data-categories' ] ).toEqual( mockCategories );
 		} );
 	} );
 
@@ -98,9 +99,9 @@ describe( 'withCategories Component', () => {
 
 			expect( formatError ).toHaveBeenCalledWith( error );
 			expect( formatError ).toHaveBeenCalledTimes( 1 );
-			expect( props.error ).toEqual( formattedError );
-			expect( props.isLoading ).toBe( false );
-			expect( props.categories ).toEqual( [] );
+			expect( props[ 'data-error' ] ).toEqual( formattedError );
+			expect( props[ 'data-isLoading' ] ).toBe( false );
+			expect( props[ 'data-categories' ] ).toEqual( [] );
 		} );
 	} );
 } );

--- a/assets/js/hocs/test/with-category.js
+++ b/assets/js/hocs/test/with-category.js
@@ -26,10 +26,10 @@ const attributes = { categoryId: 1 };
 const TestComponent = withCategory( ( props ) => {
 	return (
 		<div
-			error={ props.error }
-			getCategory={ props.getCategory }
-			isLoading={ props.isLoading }
-			category={ props.category }
+			data-error={ props.error }
+			data-getCategory={ props.getCategory }
+			data-isLoading={ props.isLoading }
+			data-category={ props.category }
 		/>
 	);
 } );
@@ -72,7 +72,7 @@ describe( 'withCategory Component', () => {
 			const { getCategory } = mockUtils;
 			const props = renderer.root.findByType( 'div' ).props;
 
-			props.getCategory();
+			props[ 'data-getCategory' ]();
 
 			expect( getCategory ).toHaveBeenCalledTimes( 2 );
 		} );
@@ -89,10 +89,10 @@ describe( 'withCategory Component', () => {
 		it( 'sets the category props', () => {
 			const props = renderer.root.findByType( 'div' ).props;
 
-			expect( props.error ).toBeNull();
-			expect( typeof props.getCategory ).toBe( 'function' );
-			expect( props.isLoading ).toBe( false );
-			expect( props.category ).toEqual( {
+			expect( props[ 'data-error' ] ).toBeNull();
+			expect( typeof props[ 'data-getCategory' ] ).toBe( 'function' );
+			expect( props[ 'data-isLoading' ] ).toBe( false );
+			expect( props[ 'data-category' ] ).toEqual( {
 				...mockCategory,
 				id: attributes.categoryId,
 			} );
@@ -122,10 +122,10 @@ describe( 'withCategory Component', () => {
 
 			expect( formatError ).toHaveBeenCalledWith( error );
 			expect( formatError ).toHaveBeenCalledTimes( 1 );
-			expect( props.error ).toEqual( formattedError );
-			expect( typeof props.getCategory ).toBe( 'function' );
-			expect( props.isLoading ).toBe( false );
-			expect( props.category ).toBeNull();
+			expect( props[ 'data-error' ] ).toEqual( formattedError );
+			expect( typeof props[ 'data-getCategory' ] ).toBe( 'function' );
+			expect( props[ 'data-isLoading' ] ).toBe( false );
+			expect( props[ 'data-category' ] ).toBeNull();
 		} );
 	} );
 } );

--- a/assets/js/hocs/test/with-product-variations.js
+++ b/assets/js/hocs/test/with-product-variations.js
@@ -32,11 +32,11 @@ const mockVariations = [
 const TestComponent = withProductVariations( ( props ) => {
 	return (
 		<div
-			error={ props.error }
-			expandedProduct={ props.expandedProduct }
-			isLoading={ props.isLoading }
-			variations={ props.variations }
-			variationsLoading={ props.variationsLoading }
+			data-error={ props.error }
+			data-expandedProduct={ props.expandedProduct }
+			data-isLoading={ props.isLoading }
+			data-variations={ props.variations }
+			data-variationsLoading={ props.variationsLoading }
 		/>
 	);
 } );
@@ -148,9 +148,9 @@ describe( 'withProductVariations Component', () => {
 				],
 			};
 
-			expect( props.error ).toBeNull();
-			expect( props.isLoading ).toBe( false );
-			expect( props.variations ).toEqual( expectedVariations );
+			expect( props[ 'data-error' ] ).toBeNull();
+			expect( props[ 'data-isLoading' ] ).toBe( false );
+			expect( props[ 'data-variations' ] ).toEqual( expectedVariations );
 		} );
 	} );
 
@@ -177,9 +177,9 @@ describe( 'withProductVariations Component', () => {
 
 			expect( formatError ).toHaveBeenCalledWith( error );
 			expect( formatError ).toHaveBeenCalledTimes( 1 );
-			expect( props.error ).toEqual( formattedError );
-			expect( props.isLoading ).toBe( false );
-			expect( props.variations ).toEqual( { 1: null } );
+			expect( props[ 'data-error' ] ).toEqual( formattedError );
+			expect( props[ 'data-isLoading' ] ).toBe( false );
+			expect( props[ 'data-variations' ] ).toEqual( { 1: null } );
 		} );
 	} );
 } );

--- a/assets/js/hocs/test/with-product.js
+++ b/assets/js/hocs/test/with-product.js
@@ -26,10 +26,10 @@ const attributes = { productId: 1 };
 const TestComponent = withProduct( ( props ) => {
 	return (
 		<div
-			error={ props.error }
-			getProduct={ props.getProduct }
-			isLoading={ props.isLoading }
-			product={ props.product }
+			data-error={ props.error }
+			data-getProduct={ props.getProduct }
+			data-isLoading={ props.isLoading }
+			data-product={ props.product }
 		/>
 	);
 } );
@@ -72,7 +72,7 @@ describe( 'withProduct Component', () => {
 			const { getProduct } = mockUtils;
 			const props = renderer.root.findByType( 'div' ).props;
 
-			props.getProduct();
+			props[ 'data-getProduct' ]();
 
 			expect( getProduct ).toHaveBeenCalledTimes( 2 );
 		} );
@@ -89,10 +89,10 @@ describe( 'withProduct Component', () => {
 		it( 'sets the product props', () => {
 			const props = renderer.root.findByType( 'div' ).props;
 
-			expect( props.error ).toBeNull();
-			expect( typeof props.getProduct ).toBe( 'function' );
-			expect( props.isLoading ).toBe( false );
-			expect( props.product ).toEqual( {
+			expect( props[ 'data-error' ] ).toBeNull();
+			expect( typeof props[ 'data-getProduct' ] ).toBe( 'function' );
+			expect( props[ 'data-isLoading' ] ).toBe( false );
+			expect( props[ 'data-product' ] ).toEqual( {
 				...mockProduct,
 				id: attributes.productId,
 			} );
@@ -120,10 +120,10 @@ describe( 'withProduct Component', () => {
 
 			expect( formatError ).toHaveBeenCalledWith( error );
 			expect( formatError ).toHaveBeenCalledTimes( 1 );
-			expect( props.error ).toEqual( formattedError );
-			expect( typeof props.getProduct ).toBe( 'function' );
-			expect( props.isLoading ).toBe( false );
-			expect( props.product ).toBeNull();
+			expect( props[ 'data-error' ] ).toEqual( formattedError );
+			expect( typeof props[ 'data-getProduct' ] ).toBe( 'function' );
+			expect( props[ 'data-isLoading' ] ).toBe( false );
+			expect( props[ 'data-product' ] ).toBeNull();
 		} );
 	} );
 } );

--- a/assets/js/hocs/test/with-searched-products.js
+++ b/assets/js/hocs/test/with-searched-products.js
@@ -49,10 +49,10 @@ describe( 'withSearchedProducts Component', () => {
 		( { selected, products, isLoading, onSearch } ) => {
 			return (
 				<div
-					products={ products }
-					selected={ selected }
-					isLoading={ isLoading }
-					onSearch={ onSearch }
+					data-products={ products }
+					data-selected={ selected }
+					data-isLoading={ isLoading }
+					data-onSearch={ onSearch }
 				/>
 			);
 		}
@@ -69,8 +69,8 @@ describe( 'withSearchedProducts Component', () => {
 
 		it( 'has expected values for props', () => {
 			props = renderer.root.findByType( 'div' ).props;
-			expect( props.selected ).toEqual( selected );
-			expect( props.products ).toEqual( [
+			expect( props[ 'data-selected' ] ).toEqual( selected );
+			expect( props[ 'data-products' ] ).toEqual( [
 				{ id: 10, name: 'foo', parent: 0 },
 				{ id: 20, name: 'bar', parent: 0 },
 			] );
@@ -80,7 +80,7 @@ describe( 'withSearchedProducts Component', () => {
 			props = renderer.root.findByType( 'div' ).props;
 
 			act( () => {
-				props.onSearch();
+				props[ 'data-onSearch' ]();
 			} );
 
 			expect( useDebouncedCallback ).toHaveBeenCalled();


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Fix JS Lint issues occurring on `trunk` since 2 days.

## Why

Apparently, the lining lib was updated and JS Lint job started to fail. I couldn't reproduce the issue locally until I updated the dependencies. After updating I could recognise the errors related to this rule: [react/no-unknown-property](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unknown-property.md).

So this PR fix the errors.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Unit tests should pass
2. JS Lint job should pass

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

