### PR TITLE
Change default number of columns in Related Products

### DIFF
--- a/assets/js/blocks/product-query/variations/related-products.tsx
+++ b/assets/js/blocks/product-query/variations/related-products.tsx
@@ -64,7 +64,7 @@ export const INNER_BLOCKS_TEMPLATE: InnerBlockTemplate[] = [
 		{
 			__woocommerceNamespace: PRODUCT_TEMPLATE_ID,
 			...( postTemplateHasSupportForGridView && {
-				layout: { type: 'grid', columnCount: 3 },
+				layout: { type: 'grid', columnCount: 5 },
 			} ),
 		},
 		[

--- a/templates/templates/blockified/single-product.html
+++ b/templates/templates/blockified/single-product.html
@@ -53,7 +53,7 @@
 			<h2 class="wp-block-heading">Related products</h2>
 			<!-- /wp:heading -->
 
-			<!-- wp:post-template {"className":"products-block-post-template","layout":{"type":"grid","columnCount":5},"__woocommerceNamespace":"woocommerce/product-query/product-template"} -->
+			<!-- wp:post-template {"className":"products-block-post-template","__woocommerceNamespace":"woocommerce/product-query/product-template"} -->
 			<!-- wp:woocommerce/product-image {"isDescendentOfQueryLoop":true} /-->
 
 			<!-- wp:post-title {"textAlign":"center","level":3,"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-query/product-title"} /-->

--- a/templates/templates/blockified/single-product.html
+++ b/templates/templates/blockified/single-product.html
@@ -53,7 +53,7 @@
 			<h2 class="wp-block-heading">Related products</h2>
 			<!-- /wp:heading -->
 
-			<!-- wp:post-template {"className":"products-block-post-template","__woocommerceNamespace":"woocommerce/product-query/product-template"} -->
+			<!-- wp:post-template {"className":"products-block-post-template","layout":{"type":"grid","columnCount":5},"__woocommerceNamespace":"woocommerce/product-query/product-template"} -->
 			<!-- wp:woocommerce/product-image {"isDescendentOfQueryLoop":true} /-->
 
 			<!-- wp:post-title {"textAlign":"center","level":3,"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-query/product-title"} /-->


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Change default number of columns in Related Products in Single Product template when migrating from Classic Template.

## Why

The block is configured to display 5 products by default and the expected number of columns is 5, but probably by accident, it was set to 3.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Go to Single Product template
2. Remove the content and add "WooCommerce Single Product Block"
3. Transform it to blockified template by clicking a blue button in the center of the block
4. Related Products blocks has 5 columns and grid layout

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|   <img width="1004" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/20098064/858ac043-5979-47e0-a682-d992876d574b">     |    <img width="1285" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/20098064/8f88a269-39b5-4b0b-8513-e90e2c3558e4">   |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Single Product Template: Related Products is displaying 5 columns instead of 3 when transforming from Classic Template
