### PR TITLE
BlockTemplatesController: Check that $attributes['theme'] value isset before operating on it

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -158,7 +158,7 @@ class BlockTemplatesController {
 	 * @return string The render.
 	 */
 	public function render_woocommerce_template_part( $attributes ) {
-		if ( 'woocommerce/woocommerce' === $attributes['theme'] ) {
+		if ( isset( $attributes['theme'] ) && 'woocommerce/woocommerce' === $attributes['theme'] ) {
 			$template_part = BlockTemplateUtils::get_block_template( $attributes['theme'] . '//' . $attributes['slug'], 'wp_template_part' );
 
 			if ( $template_part && ! empty( $template_part->content ) ) {


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Check that `$attributes['theme']` has a set value before operating on it for a comparison.

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/10872

## Why

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

An error was reporting in the associated issue linked above. Additionally the code was previously assuming that there was always a value here and it appears in some cases there may not be one. Resulting in a PHP error.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Load WooCommerce template parts in the Site Editor and check they are all there and load as expected.
2. Customize the template parts (e.g. Checkout Header) and check this is reflect on the frontend.
3. Clear the customizations, revisit the frontend and check they are expected.

I would additionally do some regression testing around the block templates by loading and customising some of these.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> BlockTemplatesController: Check that $attributes['theme'] value isset before operating on it
