### PR TITLE
Update wording on checkout error message to try to prevent retries

### DIFF
--- a/assets/js/base/context/providers/cart-checkout/checkout-processor.ts
+++ b/assets/js/base/context/providers/cart-checkout/checkout-processor.ts
@@ -296,7 +296,7 @@ const CheckoutProcessor = () => {
 					processErrorResponse( {
 						code: 'unknown_error',
 						message: __(
-							'Something went wrong. Please try placing your order again.',
+							'Something went wrong, but your order may still have been placed. Please check your email or your order history in the "My Account" area before retrying.',
 							'woo-gutenberg-products-block'
 						),
 						data: null,

--- a/assets/js/base/context/providers/cart-checkout/checkout-processor.ts
+++ b/assets/js/base/context/providers/cart-checkout/checkout-processor.ts
@@ -296,13 +296,13 @@ const CheckoutProcessor = () => {
 						} );
 				} catch {
 					let errorMessage = __(
-						'Something went wrong, but your order may still have been placed. Please check your email inbox before retrying.',
+						'Something went wrong when placing the order. Check your email for order updates before retrying.',
 						'woo-gutenberg-products-block'
 					);
 
 					if ( customerId !== 0 ) {
 						errorMessage = __(
-							'Something went wrong, but your order may still have been placed. Please check your email inbox or your order history in the "My Account" area before retrying.',
+							"Something went wrong when placing the order. Check your account's order history or your email for order updates before retrying.",
 							'woo-gutenberg-products-block'
 						);
 					}

--- a/assets/js/base/context/providers/cart-checkout/checkout-processor.ts
+++ b/assets/js/base/context/providers/cart-checkout/checkout-processor.ts
@@ -58,6 +58,7 @@ const CheckoutProcessor = () => {
 		orderNotes,
 		shouldCreateAccount,
 		extensionData,
+		customerId,
 	} = useSelect( ( select ) => {
 		const store = select( CHECKOUT_STORE_KEY );
 		return {
@@ -69,6 +70,7 @@ const CheckoutProcessor = () => {
 			orderNotes: store.getOrderNotes(),
 			shouldCreateAccount: store.getShouldCreateAccount(),
 			extensionData: store.getExtensionData(),
+			customerId: store.getCustomerId(),
 		};
 	} );
 
@@ -293,12 +295,20 @@ const CheckoutProcessor = () => {
 							__internalProcessCheckoutResponse( response );
 						} );
 				} catch {
+					let errorMessage = __(
+						'Something went wrong, but your order may still have been placed. Please check your email inbox before retrying.',
+						'woo-gutenberg-products-block'
+					);
+
+					if ( customerId !== 0 ) {
+						errorMessage = __(
+							'Something went wrong, but your order may still have been placed. Please check your email inbox or your order history in the "My Account" area before retrying.',
+							'woo-gutenberg-products-block'
+						);
+					}
 					processErrorResponse( {
 						code: 'unknown_error',
-						message: __(
-							'Something went wrong, but your order may still have been placed. Please check your email or your order history in the "My Account" area before retrying.',
-							'woo-gutenberg-products-block'
-						),
+						message: errorMessage,
 						data: null,
 					} );
 				}


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

This PR updates the error message on the Checkout block that's displayed if an error is encountered during processing. It recommends the user checks their email or My Account area before retrying to prevent duplicate orders.

Partially solves woocommerce/woocommerce#42223, however we will keep that open until a more robust solution is in place.

## Why

Some shoppers would continually retry their order when seeing this error as it's unclear that the order was placed.

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Add a new snippet to your site:
```php
add_filter( 'wp_mail', function( $args ) {
  exit;
} );
```
2. Add an item to your cart and go to the Checkout block.
3. Place your order and verify the error shows with the correct wording.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [x] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="774" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/5656702/3912039c-7453-4308-8cce-065db02c8b09"> | <img width="756" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/5656702/f4ebf72b-eb0e-47f7-9b36-c3706099ab73"> |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Improve error message to prevent duplicate orders when the Checkout process encounters an error and cannot proceed to the confirmation page. 
