### PR TITLE
Update `postcode-validator` to 3.8.15 to validate "new" Taiwanese postcodes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
 				"fast-deep-equal": "^3.1.3",
 				"fast-sort": "^3.4.0",
 				"html-react-parser": "3.0.4",
-				"postcode-validator": "3.7.0",
+				"postcode-validator": "3.8.15",
 				"preact": "^10.11.3",
 				"react-number-format": "4.9.3",
 				"react-transition-group": "^4.4.5",
@@ -44336,8 +44336,9 @@
 			}
 		},
 		"node_modules/postcode-validator": {
-			"version": "3.7.0",
-			"license": "MIT"
+			"version": "3.8.15",
+			"resolved": "https://registry.npmjs.org/postcode-validator/-/postcode-validator-3.8.15.tgz",
+			"integrity": "sha512-B2oeZ4E9D7JBHk0GEo0lv9aqHGd6vv+VsWoTG6Jt0tMtc5RUzSXOSQixBZgAAn4A/Dbajp8GbwzMtUkkyYw2Ig=="
 		},
 		"node_modules/postcss": {
 			"version": "8.4.14",

--- a/package.json
+++ b/package.json
@@ -279,7 +279,7 @@
 		"fast-deep-equal": "^3.1.3",
 		"fast-sort": "^3.4.0",
 		"html-react-parser": "3.0.4",
-		"postcode-validator": "3.7.0",
+		"postcode-validator": "3.8.15",
 		"preact": "^10.11.3",
 		"react-number-format": "4.9.3",
 		"react-transition-group": "^4.4.5",

--- a/packages/checkout/utils/validation/is-postcode.ts
+++ b/packages/checkout/utils/validation/is-postcode.ts
@@ -11,11 +11,11 @@ const CUSTOM_REGEXES = new Map< string, RegExp >( [
 	],
 	[ 'IN', /^[1-9]{1}[0-9]{2}\s{0,1}[0-9]{3}$/ ],
 	[ 'JP', /^([0-9]{3})([-]?)([0-9]{4})$/ ],
+	[ 'KH', /^[0-9]{6}$/ ], // Cambodia (6-digit postal code).
 	[ 'LI', /^(94[8-9][0-9])$/ ],
 	[ 'NL', /^([1-9][0-9]{3})(\s?)(?!SA|SD|SS)[A-Z]{2}$/i ],
 	[ 'SI', /^([1-9][0-9]{3})$/ ],
 	[ 'TW', /^\d{3}(\d{2,3})?$/ ], // Taiwanese postcodes can be a 5 digit or 6-digit number. (3+3 or 3+2).
-	[ 'KH', /^[0-9]{6}$/ ], // Cambodia (6-digit postal code)
 ] );
 
 const DEFAULT_REGEXES = new Map< string, RegExp >( [

--- a/packages/checkout/utils/validation/is-postcode.ts
+++ b/packages/checkout/utils/validation/is-postcode.ts
@@ -14,6 +14,7 @@ const CUSTOM_REGEXES = new Map< string, RegExp >( [
 	[ 'LI', /^(94[8-9][0-9])$/ ],
 	[ 'NL', /^([1-9][0-9]{3})(\s?)(?!SA|SD|SS)[A-Z]{2}$/i ],
 	[ 'SI', /^([1-9][0-9]{3})$/ ],
+	[ 'TW', /^\d{3}(\d{2,3})?$/ ], // Taiwanese postcodes can be a 5 digit or 6-digit number. (3+3 or 3+2).
 	[ 'KH', /^[0-9]{6}$/ ], // Cambodia (6-digit postal code)
 ] );
 

--- a/packages/checkout/utils/validation/is-postcode.ts
+++ b/packages/checkout/utils/validation/is-postcode.ts
@@ -15,7 +15,7 @@ const CUSTOM_REGEXES = new Map< string, RegExp >( [
 	[ 'LI', /^(94[8-9][0-9])$/ ],
 	[ 'NL', /^([1-9][0-9]{3})(\s?)(?!SA|SD|SS)[A-Z]{2}$/i ],
 	[ 'SI', /^([1-9][0-9]{3})$/ ],
-	[ 'TW', /^\d{3}(\d{2,3})?$/ ], // Taiwanese postcodes can be a 5 digit or 6-digit number. (3+3 or 3+2).
+	[ 'TW', /^\d{3}(\d{2,3})?$/ ], // Taiwanese postcodes can be a 5 digit or 6-digit number. (3+2 or 3+3).
 ] );
 
 const DEFAULT_REGEXES = new Map< string, RegExp >( [

--- a/packages/checkout/utils/validation/is-postcode.ts
+++ b/packages/checkout/utils/validation/is-postcode.ts
@@ -15,7 +15,6 @@ const CUSTOM_REGEXES = new Map< string, RegExp >( [
 	[ 'LI', /^(94[8-9][0-9])$/ ],
 	[ 'NL', /^([1-9][0-9]{3})(\s?)(?!SA|SD|SS)[A-Z]{2}$/i ],
 	[ 'SI', /^([1-9][0-9]{3})$/ ],
-	[ 'TW', /^\d{3}(\d{2,3})?$/ ], // Taiwanese postcodes can be a 5 digit or 6-digit number. (3+2 or 3+3).
 ] );
 
 const DEFAULT_REGEXES = new Map< string, RegExp >( [

--- a/packages/checkout/utils/validation/test/is-postcode.ts
+++ b/packages/checkout/utils/validation/test/is-postcode.ts
@@ -172,6 +172,17 @@ describe( 'isPostcode', () => {
 		[ false, '12345', 'KH' ],
 		[ false, '1234', 'KH' ],
 		[ true, '123456', 'KH' ],
+
+		// Taiwanese postcodes
+		[ false, '12', 'TW' ],
+		[ false, '2', 'TW' ],
+		[ false, '1234567', 'TW' ],
+		[ false, '1234', 'TW' ],
+		[ false, 'ABC34', 'TW' ],
+		[ false, '', 'TW' ],
+		[ true, '123456', 'TW' ],
+		[ true, '12345', 'TW' ],
+		[ true, '123', 'TW' ],
 	];
 
 	test.each( cases )( '%s: %s for %s', ( result, postcode, country ) =>


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

This PR updates `postcode-validator` to include a recent change which validates newer Taiwanese postcodes.

Fixes #10921

## Why

As @devinmaeztri pointed out, Taiwanese postcodes contain a group of three mandatory digits followed by either two, or three optional digits. The change that allowed three digits came into effect in 2020. https://en.wikipedia.org/wiki/Postal_codes_in_Taiwan#Change_from_3+2_to_3+3_postal_codes

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Add an item to your cart.
2. Go to the Checkout block.
3. Enter your address and choose Taiwan as the country. Enter a postcode with 5 digits. (`12345`) verify there is no validation error.
4. Enter a postcode with 6 digits (`123456`), verify there is no validation error.
5. Check out successfully using a Taiwanese postcode.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

N/A

| Before | After |
| ------ | ----- |
|        |       |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Ensure 6-digit Taiwanese postcodes can be used.
