### PR TITLE
Add custom regex for validating Nicaraguan postal codes

### DIFF
--- a/packages/checkout/utils/validation/is-postcode.ts
+++ b/packages/checkout/utils/validation/is-postcode.ts
@@ -12,6 +12,7 @@ const CUSTOM_REGEXES = new Map< string, RegExp >( [
 	[ 'IN', /^[1-9]{1}[0-9]{2}\s{0,1}[0-9]{3}$/ ],
 	[ 'JP', /^([0-9]{3})([-]?)([0-9]{4})$/ ],
 	[ 'LI', /^(94[8-9][0-9])$/ ],
+	[ 'NI', /^[1-9]{1}[0-9]{4}$/ ], // Nicaragua (5-digit postal code)
 	[ 'NL', /^([1-9][0-9]{3})(\s?)(?!SA|SD|SS)[A-Z]{2}$/i ],
 	[ 'SI', /^([1-9][0-9]{3})$/ ],
 	[ 'KH', /^[0-9]{6}$/ ], // Cambodia (6-digit postal code)

--- a/packages/checkout/utils/validation/test/is-postcode.ts
+++ b/packages/checkout/utils/validation/test/is-postcode.ts
@@ -119,6 +119,12 @@ describe( 'isPostcode', () => {
 		[ false, '9385', 'LI' ],
 		[ false, '9475', 'LI' ],
 
+		// Nicaraguan postcodes
+		[ true, '12345', 'NI' ],
+		[ false, '01234', 'NI' ],
+		[ false, '1234', 'NI' ],
+		[ false, '123456', 'NI' ],
+
 		// Dutch postcodes
 		[ true, '3852GC', 'NL' ],
 		[ true, '3852 GC', 'NL' ],


### PR DESCRIPTION
## What

This PR adds a custom regex to validate Nicaraguan postal codes, which have 5 digits.

Fixes #10854

## Why

We recently discovered that the validation of Nicaraguan postal codes doesn't work as expected. According to [codigo-postal.org](https://codigo-postal.org/en-us/nicaragua/zip/13024/) and [en.youbianku.com](https://en.youbianku.com/Nicaragua), Nicaraguan postal codes have 5 digits, but they do not start with a 0.

## Testing Instructions

1. Add the Cart block to a test page.
2. Enable the `Shipping calculator` in the Shipping inner block.
3. Add the Checkout block to another test page.
4. Add a test product to the cart via the frontend.
5. Navigate to the test page with the Cart block and click `Change address` in the Shipping section.
6. Select `Nicaragua` as the country and enter a 5-digit postal code (e.g., `13024`).
7. See that that validation passes.
8. Navigate to the test page with the Checkout block.
9. Repeat steps 6-7.
10. Change the postal code to `01234`, and see that the validation fails.
11. Change the postal code to anything other than 5 digits, and see that the validation also fails.

Apart from the manual testing instructions, I also added unit tests. You can execute these by running the following command:

```sh
npm t -- packages/checkout/utils/validation/test/is-postcode.ts
```

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog

> Fix Nicaraguan postal code validation