### PR TITLE
Hide unexpected bullet point in Product Collection on Storefront

### DIFF
--- a/assets/js/blocks/product-template/style.scss
+++ b/assets/js/blocks/product-template/style.scss
@@ -27,6 +27,8 @@ $break-small: 600px;
 		> li {
 			margin: 0;
 			width: 100%;
+			// Below style is required to override high-specificity Storefront styles
+			list-style: none;
 		}
 
 		@include break-small {


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Add bullet points before each product in Product Collection on Storefront.

Fixes: https://github.com/woocommerce/woocommerce-blocks/issues/10948

## Why

High specificity styles from theme override out styles to hide the bullet points so they started to appear in Editor. Found during WC Core testing.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Use Storefront theme
2. Create new post
3. Add Product Collection block
4. Make sure there are no bullet points before the products
5. Publish the post and go to frontend
6. Make sure there are no bullet points before the products


* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|    <img width="954" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/20098064/b7cb7ac7-5f7d-4db0-b5bf-ccd1949eb767">    |    
<img width="895" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/20098064/5d3a07a7-3403-47dc-ae5d-a39243c9777b">   |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Product Collection: Hide unexpected bullet point in Product Collection on Storefront
