### PR TITLE
Revert "Fix: use correct bump strategy for Assign Milestone workflow (#10805)

### DIFF
--- a/.github/workflows/approved-with-labels.yml
+++ b/.github/workflows/approved-with-labels.yml
@@ -22,4 +22,4 @@ jobs:
               with:
                   github_token: ${{ secrets.GITHUB_TOKEN }}
                   automations: assign-milestone
-                  milestone_bump_strategy: minor
+                  milestone_bump_strategy: none


### PR DESCRIPTION
This reverts commit 97fa0bfe99d595279a6cfce17ab5f6d77a9d4df5.

<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

In #10805, we changed the bump stategy to minor to fix the workflow doesn't assign milestone to approved PR. But our usage is more complex, we need to better determine the version. I'm reverting the #10805 because using `none` as the bumping strategy works betters for more cases. We should use `none` while working on the better mechanism.

Fixes #10805

## Why

We determine the current version using the `version` filed in the `package.json` file. That version is the next version with `-dev` suffix. For example, our next version is `11.2.0` then the version in `package.json` is `11.2.0-dev`.

Using `none` as the bump strategy, the milestone to be use will be `11.2.0`, and this is the case most of the time. But it can fail if we close the milestone but haven't bump the version yet, this usually happens when a release takes longer than expected.

Also PR merged during the release process can also get unexpected milestone. If the `11.2.0` is being released, PR merged during that period should be assigned to next milestone `11.3.0`, but in fact, they will be assign to `11.2.0` milestone as the current behavior.

So, we should work on a better way to correctly apply the milestone to PR.

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Approve this PR.
2. See the milestone is set to `11.2.0`

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [x] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Add suggested changelog entry here.
