### PR TITLE
Tests for order confirmation conditional blocks

### DIFF
--- a/tests/e2e/tests/checkout/checkout.page.ts
+++ b/tests/e2e/tests/checkout/checkout.page.ts
@@ -6,7 +6,7 @@ import { expect } from '@woocommerce/e2e-playwright-utils';
 
 export class CheckoutPage {
 	private BLOCK_NAME = 'woocommerce/checkout';
-	private page: Page;
+	public page: Page;
 	private testData = {
 		...{
 			firstname: 'John',
@@ -73,6 +73,7 @@ export class CheckoutPage {
 		await this.page.getByText( 'Place Order', { exact: true } ).click();
 		await this.page.waitForURL( /order-received/ );
 	}
+
 	async verifyAddressDetails(
 		shippingOrBilling: 'shipping' | 'billing',
 		overrideAddressDetails = {}

--- a/tests/e2e/tests/checkout/order-confirmation.block_theme.spec.ts
+++ b/tests/e2e/tests/checkout/order-confirmation.block_theme.spec.ts
@@ -46,7 +46,11 @@ test.describe( 'Shopper → Order Confirmation', () => {
 } );
 
 test.describe( 'Shopper → Order Confirmation → Local Pickup', () => {
-	test.beforeAll( async ( { admin } ) => {
+	test( 'Confirm shipping address section is hidden, but billing is visible', async ( {
+		pageObject,
+		frontendUtils,
+		admin,
+	} ) => {
 		await admin.visitAdminPage(
 			'admin.php?page=wc-settings&tab=shipping&section=pickup_location'
 		);
@@ -69,12 +73,6 @@ test.describe( 'Shopper → Order Confirmation → Local Pickup', () => {
 		await admin.page
 			.getByRole( 'button', { name: 'Dismiss this notice' } )
 			.click();
-	} );
-
-	test( 'Confirm shipping address section is hidden, but billing is visible', async ( {
-		pageObject,
-		frontendUtils,
-	} ) => {
 		await frontendUtils.emptyCart();
 		await frontendUtils.goToShop();
 		await frontendUtils.addToCart( SIMPLE_PHYSICAL_PRODUCT_NAME );
@@ -96,7 +94,7 @@ test.describe( 'Shopper → Order Confirmation → Local Pickup', () => {
 test.describe( 'Shopper → Order Confirmation → Downloadable Products', () => {
 	let confirmationPageUrl: string;
 
-	test.beforeAll( async ( { frontendUtils, pageObject } ) => {
+	test.beforeEach( async ( { frontendUtils, pageObject } ) => {
 		await frontendUtils.emptyCart();
 		await frontendUtils.goToShop();
 		await frontendUtils.addToCart( SIMPLE_VIRTUAL_PRODUCT_NAME );

--- a/tests/e2e/tests/checkout/order-confirmation.block_theme.spec.ts
+++ b/tests/e2e/tests/checkout/order-confirmation.block_theme.spec.ts
@@ -10,6 +10,7 @@ import {
 	FREE_SHIPPING_NAME,
 	FREE_SHIPPING_PRICE,
 	SIMPLE_PHYSICAL_PRODUCT_NAME,
+	SIMPLE_VIRTUAL_PRODUCT_NAME,
 } from './constants';
 import { CheckoutPage } from './checkout.page';
 
@@ -40,5 +41,108 @@ test.describe( 'Shopper → Order Confirmation', () => {
 		).toBe( true );
 		await pageObject.fillInCheckoutWithTestData();
 		await pageObject.placeOrder();
+		await pageObject.verifyOrderDetailsOnConfirmationPage();
+	} );
+} );
+
+test.describe( 'Shopper → Order Confirmation → Local Pickup', () => {
+	test.beforeAll( async ( { admin } ) => {
+		await admin.visitAdminPage(
+			'admin.php?page=wc-settings&tab=shipping&section=pickup_location'
+		);
+		await admin.page.getByLabel( 'Enable local pickup' ).uncheck();
+		await admin.page.getByLabel( 'Enable local pickup' ).check();
+		await admin.page
+			.getByRole( 'button', { name: 'Add pickup location' } )
+			.click();
+		await admin.page.getByLabel( 'Location name' ).fill( 'Testing' );
+		await admin.page.getByPlaceholder( 'Address' ).fill( 'Test Address' );
+		await admin.page.getByPlaceholder( 'City' ).fill( 'Test City' );
+		await admin.page.getByPlaceholder( 'Postcode / ZIP' ).fill( '90210' );
+		await admin.page
+			.getByLabel( 'Pickup details' )
+			.fill( 'Pickup method.' );
+		await admin.page.getByRole( 'button', { name: 'Done' } ).click();
+		await admin.page
+			.getByRole( 'button', { name: 'Save changes' } )
+			.click();
+		await admin.page
+			.getByRole( 'button', { name: 'Dismiss this notice' } )
+			.click();
+	} );
+
+	test( 'Confirm shipping address section is hidden, but billing is visible', async ( {
+		pageObject,
+		frontendUtils,
+	} ) => {
+		await frontendUtils.emptyCart();
+		await frontendUtils.goToShop();
+		await frontendUtils.addToCart( SIMPLE_PHYSICAL_PRODUCT_NAME );
+		await frontendUtils.goToCheckout();
+		await pageObject.page
+			.getByRole( 'radio', { name: 'Local Pickup free' } )
+			.click();
+		await pageObject.fillInCheckoutWithTestData();
+		await pageObject.placeOrder();
+		await expect(
+			pageObject.page.getByRole( 'heading', { name: 'Shipping address' } )
+		).toBeHidden();
+		await expect(
+			pageObject.page.getByRole( 'heading', { name: 'Billing address' } )
+		).toBeVisible();
+	} );
+} );
+
+test.describe( 'Shopper → Order Confirmation → Downloadable Products', () => {
+	let confirmationPageUrl: string;
+
+	test.beforeAll( async ( { frontendUtils, pageObject } ) => {
+		await frontendUtils.emptyCart();
+		await frontendUtils.goToShop();
+		await frontendUtils.addToCart( SIMPLE_VIRTUAL_PRODUCT_NAME );
+		await frontendUtils.goToCheckout();
+		await pageObject.fillInCheckoutWithTestData();
+		await pageObject.placeOrder();
+		confirmationPageUrl = pageObject.page.url();
+	} );
+
+	test( 'Confirm shipping address section is hidden, but billing is visible', async ( {
+		pageObject,
+	} ) => {
+		await expect(
+			pageObject.page.getByRole( 'heading', { name: 'Shipping address' } )
+		).toBeHidden();
+		await expect(
+			pageObject.page.getByRole( 'heading', { name: 'Billing address' } )
+		).toBeVisible();
+	} );
+
+	test( 'Confirm order downloads are visible', async ( {
+		pageObject,
+		admin,
+	} ) => {
+		// While order is pending the downloads are hidden.
+		await expect(
+			pageObject.page.getByRole( 'heading', { name: 'Downloads' } )
+		).toBeHidden();
+
+		// Update last order status to completed.
+		await admin.visitAdminPage( 'edit.php?post_type=shop_order' );
+		await admin.page.waitForSelector( '.wp-list-table' );
+		await admin.page.click(
+			'.wp-list-table tbody tr:first-child a.order-view'
+		);
+		await admin.page.getByRole( 'textbox', { name: 'On hold' } ).click();
+		await admin.page.getByRole( 'option', { name: 'Completed' } ).click();
+		await admin.page
+			.getByRole( 'button', { name: 'Update' } )
+			.first()
+			.click();
+
+		// Go back to page.
+		await pageObject.page.goto( confirmationPageUrl );
+		await expect(
+			pageObject.page.getByRole( 'heading', { name: 'Downloads' } )
+		).toBeVisible();
 	} );
 } );


### PR DESCRIPTION
Adds e2e test for conditional blocks on the order confirmation page. Part of #10762

## Testing Instructions

Just confirm the new tests pass. Other tests relating to templates may be flakey but are out of scope for this PR.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [x] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental
* [ ] N/A
