### PR TITLE
Product Gallery: Fix zoom animation on large Image

### DIFF
--- a/assets/js/blocks/product-gallery/style.scss
+++ b/assets/js/blocks/product-gallery/style.scss
@@ -28,6 +28,13 @@ $outside-image-max-width: calc(100% - (2 * $outside-image-offset));
 	position: relative;
 	overflow: hidden;
 
+	// Restrict the width of the Large Image when the Next/Previous buttons are outside the image.
+	#{$gallery-next-previous-outside-image} & .wc-block-woocommerce-product-gallery-large-image__container {
+		overflow: hidden;
+		max-width: $outside-image-max-width;
+		margin: 0 auto;
+	}
+
 	img {
 		display: block;
 		margin: 0 auto;
@@ -39,11 +46,6 @@ $outside-image-max-width: calc(100% - (2 * $outside-image-offset));
 
 		&[hidden] {
 			display: none;
-		}
-
-		// Restrict the width of the Large Image when the Next/Previous buttons are outside the image.
-		#{$gallery-next-previous-outside-image} & {
-			max-width: $outside-image-max-width;
 		}
 	}
 

--- a/src/Utils/ProductGalleryUtils.php
+++ b/src/Utils/ProductGalleryUtils.php
@@ -35,6 +35,7 @@ class ProductGalleryUtils {
 						$attributes
 					);
 
+					$product_image_html           = '<div class="wc-block-woocommerce-product-gallery-large-image__container">' . $product_image_html . '</div>';
 					$product_image_html_processor = new \WP_HTML_Tag_Processor( $product_image_html );
 					$product_image_html_processor->next_tag();
 					$product_image_html_processor->set_attribute(

--- a/src/Utils/ProductGalleryUtils.php
+++ b/src/Utils/ProductGalleryUtils.php
@@ -37,7 +37,7 @@ class ProductGalleryUtils {
 
 					$product_image_html           = '<div class="wc-block-woocommerce-product-gallery-large-image__container">' . $product_image_html . '</div>';
 					$product_image_html_processor = new \WP_HTML_Tag_Processor( $product_image_html );
-					$product_image_html_processor->next_tag();
+					$product_image_html_processor->next_tag( 'img' );
 					$product_image_html_processor->set_attribute(
 						'data-wc-context',
 						wp_json_encode(


### PR DESCRIPTION
This PR fixes the `Zoom effect` for the Product Gallery Large Image (with `outside` Next/Previous arrows) by adding an additional wrapper to the `img` element.

## What

Fixes #11011

## Why

The #10867 broke the Zoom animation when the Next/Previous buttons block is in the `Outside` mode.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. With a block theme, open `Appearance > Editor`.
2. Open `Templates > Single Product`.
3. Select `Convert to Blocks` if you are using the Classic Templates.
4. Add the `Product Gallery` block.
5. Ensure the `Next/Previous Buttons` are set to display **outside** of the image.
6. Ensure the `Zoom while hovering` setting is enabled.
7. Open a product page on the frontend **with multiple product images** and test the Zoom animation. Make sure the image doesn't bleed over to the `Next/Previous` arrows.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|![0LLCGda3fp](https://github.com/woocommerce/woocommerce-blocks/assets/905781/8f0d89bb-a87b-4184-877f-11e689718ed5)|![BND1unFXoM](https://github.com/woocommerce/woocommerce-blocks/assets/905781/f02e8d16-37ba-463e-a44e-ef43285a0b57)|

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Product Gallery: Fix zoom animation on large Image
