### PR TITLE
WooExpress: Fix Checkout and Cart Blocks Editor Crash

### DIFF
--- a/assets/js/blocks/cart-checkout-shared/use-forced-layout/index.ts
+++ b/assets/js/blocks/cart-checkout-shared/use-forced-layout/index.ts
@@ -46,6 +46,15 @@ export const useForcedLayout = ( {
 		const { replaceInnerBlocks } = dispatch( 'core/block-editor' );
 
 		return registry.subscribe( () => {
+			const currentBlock = registry
+				.select( 'core/block-editor' )
+				.getBlock( clientId );
+
+			// If the block is removed we shouldn't reinsert its inner blocks.
+			if ( ! currentBlock ) {
+				return;
+			}
+
 			const innerBlocks = registry
 				.select( 'core/block-editor' )
 				.getBlocks( clientId );


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

This PR resolves the editor crash issue on WooExpress sites when trying to delete the Cart or Checkout templates.

Fixes #10885

## Why

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

If a block is removed, we shouldn't reinsert its inner blocks.

Jetpack performs a verification to ascertain if specific blocks are children of a premium-content parent block. The critical function can be [seen here](https://github.com/Automattic/jetpack/blob/trunk/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/premium.js#L13-L17):

```JS
export const blockHasParentPremiumBlock = block => {
	const { getBlocksByClientId, getBlockParents } = select( 'core/block-editor' );
	const parents = getBlocksByClientId( getBlockParents( block.clientId ) );
	return !! parents.find( parent => parent.name.indexOf( 'premium-content/' ) === 0 );
};
```

When deleting the Checkout (or Cart) Block, our block-locking feature attempts to reinsert an Inner Block (like `Gift Card Form`). However, its parent block (`checkout-order-summary-block`) has already been removed from the DOM. Consequently, the `parents` variable yields `[ null ]`. This leads to the `TypeError: Cannot read properties of null (reading 'name')` error when executing the line `return !! parents.find( parent => parent.name.indexOf( 'premium-content/' ) === 0 );`. This error subsequently causes the Editor to crash.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

You'll need a WooExpress site. You can create one for free from [here](https://woocommerce.com/express/).
To upload and install this PR's Woo Blocks ZIP file, you can either upgrade your WooExpress site or use the CLI as described here: p1693928195787919/1693489673.470409-slack-C7U3Y3VMY

### Ensure the block-locking feature is still working

1. Go to `Appearance -> Editor -> Templates -> Checkout` (or Cart)
2. Clear customizations of the Checkout (or Cart) template if necessary and reload the page

<img width="355" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/14235870/9d66bbd7-d62e-418e-87bd-93cec9141ff9">

3. Click on `Edit` to access the template editor

<img width="355" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/14235870/fe676b09-c7fb-495b-8297-05d6f231e87d">

4. Within the Checkout (or Cart) template editor, open the `List View` and try to delete the `Gift Card Form` or the `Gift Card Totals` Blocks. Untick `Prevent removal` under the `Unlock` option:

<img width="500" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/14235870/fa30d66d-007f-4900-8057-46ee338535e8">

<img width="500" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/14235870/94c45576-e74d-4cdf-a623-0a91a85b2462">

5. Ensure the `Gift Card Form` (or `Gift Card Totals`) Block isn't deleted (It's actually being reinserted each time we click on `Delete)`)

### Test removing the Checkout (or Cart) Blocks in the Editor

1. Try to delete the Checkout (or Cart) Block

<img width="563" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/14235870/4a403b80-f314-4df0-8c13-7d33907f3be0">

2. Ensure the Checkout (or Cart) Block is successfully deleted

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [x] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

N/A

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> WooExpress: Fix Checkout and Cart Blocks Editor Crash