### PR TITLE
Make default heading level for cart and checkout templates a h1

### DIFF
--- a/templates/templates/blockified/page-cart.html
+++ b/templates/templates/blockified/page-cart.html
@@ -3,7 +3,7 @@
 <!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group">
 	<!-- wp:woocommerce/page-content-wrapper {"page":"cart"} -->
-	<!-- wp:post-title {"align":"wide"} /-->
+	<!-- wp:post-title {"align":"wide", "level":1} /-->
 
 	<!-- wp:post-content {"align":"wide"} /-->
 	<!-- /wp:woocommerce/page-content-wrapper -->

--- a/templates/templates/blockified/page-checkout.html
+++ b/templates/templates/blockified/page-checkout.html
@@ -3,7 +3,7 @@
 <!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group">
 	<!-- wp:woocommerce/page-content-wrapper {"page":"checkout"} -->
-	<!-- wp:post-title {"align":"wide"} /-->
+	<!-- wp:post-title {"align":"wide", "level":1} /-->
 
 	<!-- wp:post-content {"align":"wide"} /-->
 	<!-- /wp:woocommerce/page-content-wrapper -->

--- a/templates/templates/page-cart.html
+++ b/templates/templates/page-cart.html
@@ -3,7 +3,7 @@
 <!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group">
 	<!-- wp:woocommerce/page-content-wrapper {"page":"cart"} -->
-	<!-- wp:post-title {"align":"wide"} /-->
+	<!-- wp:post-title {"align":"wide", "level":1} /-->
 
 	<!-- wp:post-content {"align":"wide"} /-->
 	<!-- /wp:woocommerce/page-content-wrapper -->

--- a/templates/templates/page-checkout.html
+++ b/templates/templates/page-checkout.html
@@ -3,7 +3,7 @@
 <!-- wp:group {"layout":{"inherit":true}} -->
 <div class="wp-block-group">
 	<!-- wp:woocommerce/page-content-wrapper {"page":"checkout"} -->
-	<!-- wp:post-title {"align":"wide"} /-->
+	<!-- wp:post-title {"align":"wide", "level":1} /-->
 
 	<!-- wp:post-content {"align":"wide"} /-->
 	<!-- /wp:woocommerce/page-content-wrapper -->


### PR DESCRIPTION
Updates the default cart and checkout template to use a `h1` for the page title instead of a `h2`. This was a regression caught by extension test suites after the changes in https://github.com/woocommerce/woocommerce-blocks/pull/10773

## Testing Instructions

1. Use a block theme (Twenty Twenty Three)
2. Make sure templates are not custom by going to Appearance > Editor > Template > Page: Cart / Page: Checkout, clicking the icon with three dots and clearing customisations (if its there)
3. Go to frontend cart/checkout. 
4. Confirm the main page heading is a h1 element.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [ ] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [x] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.
