### PR TITLE
Product Gallery: Fix the Product Gallery Thumbnails on click

### DIFF
--- a/src/BlockTypes/ProductGalleryLargeImage.php
+++ b/src/BlockTypes/ProductGalleryLargeImage.php
@@ -132,7 +132,8 @@ class ProductGalleryLargeImage extends AbstractBlock {
 		$main_images = ProductGalleryUtils::get_product_gallery_images(
 			$product_id,
 			'full',
-			$attributes
+			$attributes,
+			'wc-block-woocommerce-product-gallery-large-image__container'
 		);
 
 		$visible_main_image           = array_shift( $main_images );

--- a/src/BlockTypes/ProductGalleryThumbnails.php
+++ b/src/BlockTypes/ProductGalleryThumbnails.php
@@ -63,7 +63,7 @@ class ProductGalleryThumbnails extends AbstractBlock {
 
 			if ( $product ) {
 				$post_thumbnail_id      = $product->get_image_id();
-				$product_gallery_images = ProductGalleryUtils::get_product_gallery_images( $post_id, 'thumbnail', array() );
+				$product_gallery_images = ProductGalleryUtils::get_product_gallery_images( $post_id, 'thumbnail', array(), 'wc-block-product-gallery-thumbnails__thumbnail' );
 				if ( $product_gallery_images && $post_thumbnail_id ) {
 					$html                 = '';
 					$number_of_thumbnails = isset( $block->context['thumbnailsNumberOfThumbnails'] ) ? $block->context['thumbnailsNumberOfThumbnails'] : 3;
@@ -74,11 +74,9 @@ class ProductGalleryThumbnails extends AbstractBlock {
 							break;
 						}
 
-						$html .= '<div class="wc-block-product-gallery-thumbnails__thumbnail">';
-
 						$processor = new \WP_HTML_Tag_Processor( $product_gallery_image_html );
 
-						if ( $processor->next_tag() ) {
+						if ( $processor->next_tag( 'img' ) ) {
 							$processor->set_attribute(
 								'data-wc-on--click',
 								'actions.woocommerce.thumbnails.handleClick'
@@ -86,8 +84,6 @@ class ProductGalleryThumbnails extends AbstractBlock {
 
 							$html .= $processor->get_updated_html();
 						}
-
-						$html .= '</div>';
 
 						$thumbnails_count++;
 					}

--- a/src/Utils/ProductGalleryUtils.php
+++ b/src/Utils/ProductGalleryUtils.php
@@ -17,9 +17,10 @@ class ProductGalleryUtils {
 	 * @param int    $post_id Post ID.
 	 * @param string $size Image size.
 	 * @param array  $attributes Attributes.
+	 * @param string $wrapper_class Wrapper class.
 	 * @return array
 	 */
-	public static function get_product_gallery_images( $post_id, $size = 'full', $attributes = array() ) {
+	public static function get_product_gallery_images( $post_id, $size = 'full', $attributes = array(), $wrapper_class = '' ) {
 		$product_gallery_images = array();
 		$product                = wc_get_product( $post_id );
 
@@ -35,7 +36,10 @@ class ProductGalleryUtils {
 						$attributes
 					);
 
-					$product_image_html           = '<div class="wc-block-woocommerce-product-gallery-large-image__container">' . $product_image_html . '</div>';
+					if ( $wrapper_class ) {
+						$product_image_html = '<div class="' . $wrapper_class . '">' . $product_image_html . '</div>';
+					}
+
 					$product_image_html_processor = new \WP_HTML_Tag_Processor( $product_image_html );
 					$product_image_html_processor->next_tag( 'img' );
 					$product_image_html_processor->set_attribute(


### PR DESCRIPTION
This PR fixes the broken Product Gallery Thumbnails on click.

<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Fixes #11030

## Why

https://github.com/woocommerce/woocommerce-blocks/pull/11023 added an additional wrapper for the Large Image `img` tag, which was erroneously being added to the Thumbnails images.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. With a block theme, open `Appearance > Editor`.
2. Open `Templates > Single Product`.
3. Select `Convert to Blocks` if you are using the Classic Templates.
4. Add the `Product Gallery` block.
5. Open a product page on the frontend **with multiple product images** and try selecting individual thumbnails. Confirm that the Large Image gets updated correctly.


* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|![xRJVRRPmhk](https://github.com/woocommerce/woocommerce-blocks/assets/905781/d4354887-76bd-4f84-8013-fc63c0b4ab2e)|![lznwzpHTys](https://github.com/woocommerce/woocommerce-blocks/assets/905781/0a771ab3-3d4f-4e60-9c42-660174978d74)|

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Product Gallery: Fix the on-click thumbnail behavior.