### PR TITLE
Interactivity API: Add support for underscores and leading dashes in the suffix part of the directive

### DIFF
--- a/assets/js/interactivity/vdom.js
+++ b/assets/js/interactivity/vdom.js
@@ -15,7 +15,7 @@ const directiveParser = new RegExp(
 		// (Optional) Match '--' followed by any alphanumeric charachters. It
 		// excludes underscore intentionally to prevent confusion, but it can
 		// contain multiple hyphens. E.g., "--custom-prefix--with-more-info".
-		'(?:--([a-z0-9][a-z0-9-]+))?$',
+		'(?:--([a-z0-9_-]+))?$',
 	'i' // Case insensitive.
 );
 


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What
Allow data-wp-class directive to contain classes with underscores.

Fixes #11033 

## Why

As suggested by @luisherranz (https://github.com/woocommerce/woocommerce-blocks/pull/10736#discussion_r1334556140), this is a feature already implemented on WC Core, so it would be great to have this in WC Blocks as well.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. From your WordPress dashboard, go to Appearance > Themes. Make sure you have a block-based theme installed and activated. If not, you can install one from the Add New option. Block-based themes include "Twenty-twenty Two," "Twenty-twenty Three," etc.
2. On the left-hand side menu, click on Appearance > Editor > Templates
3. Find and select the 'Single Product' template from the list.
4. When the Classic Product Template renders, click on Transform into Blocks. This will transform the Classic template in a block template if you haven't done it before.
5. In the block library, search for the 'Product Gallery' block. Click on it to add the block to the template.
6. Click on save and visit a product page that contains multiple gallery images, make sure the block is correctly being displayed, that everything is working as expected and no error is shown in the console.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [x] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A