### PR TITLE
Product Gallery > Pager block: Fix classname to adhere to the Coding Guidelines

### DIFF
--- a/assets/js/blocks/product-gallery/style.scss
+++ b/assets/js/blocks/product-gallery/style.scss
@@ -156,9 +156,6 @@ $outside-image-max-width: calc(100% - (2 * $outside-image-offset));
 	cursor: pointer;
 }
 
-// Despite the guideline suggests that the state class should be named like "...--is-active"
-// this is not possible due to limitations in the Interactivity API that does not allow
-// to use the "--" (double dash) in the class name.
 .wc-block-woocommerce-product-gallery__pager-item--is-active {
 	font-weight: bold;
 	color: $black;

--- a/assets/js/blocks/product-gallery/style.scss
+++ b/assets/js/blocks/product-gallery/style.scss
@@ -159,7 +159,7 @@ $outside-image-max-width: calc(100% - (2 * $outside-image-offset));
 // Despite the guideline suggests that the state class should be named like "...--is-active"
 // this is not possible due to limitations in the Interactivity API that does not allow
 // to use the "--" (double dash) in the class name.
-.wc-block-woocommerce-product-gallery-pager-item-is-active {
+.wc-block-woocommerce-product-gallery__pager-item--is-active {
 	font-weight: bold;
 	color: $black;
 }

--- a/assets/js/interactivity/vdom.js
+++ b/assets/js/interactivity/vdom.js
@@ -15,7 +15,7 @@ const directiveParser = new RegExp(
 		// (Optional) Match '--' followed by any alphanumeric charachters. It
 		// excludes underscore intentionally to prevent confusion, but it can
 		// contain multiple hyphens. E.g., "--custom-prefix--with-more-info".
-		'(?:--([a-z0-9][a-z0-9-]+))?$',
+		'(?:--([a-z0-9_-]+))?$',
 	'i' // Case insensitive.
 );
 

--- a/src/BlockTypes/ProductGalleryPager.php
+++ b/src/BlockTypes/ProductGalleryPager.php
@@ -108,7 +108,7 @@ class ProductGalleryPager extends AbstractBlock {
 			$pager_item          = sprintf(
 				'<li class="wc-block-product-gallery-pager__item %2$s">%1$s</li>',
 				'dots' === $pager_display_mode ? $this->get_dot_icon( $is_first_pager_item ) : $key + 1,
-				$is_first_pager_item ? 'wc-block-woocommerce-product-gallery-pager-item-is-active' : ''
+				$is_first_pager_item ? 'wc-block-woocommerce-product-gallery__pager-item--is-active' : ''
 			);
 			$p                   = new \WP_HTML_Tag_Processor( $pager_item );
 
@@ -126,7 +126,7 @@ class ProductGalleryPager extends AbstractBlock {
 					'actions.woocommerce.handleSelectImage'
 				);
 				$p->set_attribute(
-					'data-wc-class--wc-block-woocommerce-product-gallery-pager-item-is-active',
+					'data-wc-class--wc-block-woocommerce-product-gallery__pager-item--is-active',
 					'selectors.woocommerce.isSelected'
 				);
 				$html .= $p->get_updated_html();


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What
During the implementation of #10630, we made the decision to remove the extra underscores and leading dashes because the Interactivity API lacked support for them. In https://github.com/woocommerce/woocommerce-blocks/pull/11034, support for these features was added. Now, I'm addressing the classname inconsistency with our code guidelines.

Fixes #10630 

## Why

To make sure that we are following the [Coding Guidelines](https://github.com/woocommerce/woocommerce-blocks/blob/73151afd5929b747fb8bd98c37337e22a830ee2e/docs/contributors/coding-guidelines.md/#L15-L18).

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. From your WordPress dashboard, go to Appearance > Themes. Make sure you have a block-based theme installed and activated. If not, you can install one from the Add New option. Block-based themes include "Twenty-twenty Two," "Twenty-twenty Three," etc.
2. On the left-hand side menu, click on Appearance > Editor
3. On the left-hand side menu, click on Templates. 
4. Find and select the 'Single Product' template from the list.
5. When the Classic Product Template renders, click on Transform into Blocks. This will transform the Classic template in a block template if you haven't done it before.
6. Click on the plus icon (+) at the top left corner or within the editor to add a new block. In the search bar that appears, type Product Gallery and click on it to add the block to the template.
7. On the top-right side, click on the Save button.
8. Visit a product and make sure the Pager block is working correctly, and the active style for the selected page is correctly being applied when inspecting the block.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [x] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
| ![CleanShot 2023-09-22 at 18 22 06](https://github.com/woocommerce/woocommerce-blocks/assets/20469356/a6d2a43f-d4d4-46c7-9538-4b9197844b69) | ![CleanShot 2023-09-22 at 18 20 38](https://github.com/woocommerce/woocommerce-blocks/assets/20469356/3796139a-dffc-48f8-afa1-b96cffe545f0) |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental
* [ ] N/A