### PR TITLE
WIP: Fix broken e2e tests

### DIFF
--- a/tests/e2e/tests/checkout/order-confirmation.block_theme.side_effects.spec.ts
+++ b/tests/e2e/tests/checkout/order-confirmation.block_theme.side_effects.spec.ts
@@ -44,6 +44,7 @@ test.describe( 'Shopper → Order Confirmation', () => {
 		} );
 		await editorUtils.enterEditMode();
 		await editorUtils.closeWelcomeGuideModal();
+		await editorUtils.closePageEditingModal();
 		await editorUtils.transformIntoBlocks();
 	} );
 

--- a/tests/e2e/tests/templates/cart-template.block_theme.spec.ts
+++ b/tests/e2e/tests/templates/cart-template.block_theme.spec.ts
@@ -21,7 +21,7 @@ test.describe( 'Test the cart template', async () => {
 		await expect(
 			page
 				.frameLocator( 'iframe[title="Editor canvas"i]' )
-				.locator( 'h2:has-text("Cart")' )
+				.locator( 'h1:has-text("Cart")' )
 				.first()
 		).toBeVisible();
 	} );
@@ -38,12 +38,12 @@ test.describe( 'Test the cart template', async () => {
 		await editor.page.getByRole( 'button', { name: /Cart/i } ).click();
 		await editorUtils.enterEditMode();
 		await expect(
-			editor.canvas.locator( 'h2:has-text("Cart")' ).first()
+			editor.canvas.locator( 'h1:has-text("Cart")' ).first()
 		).toBeVisible();
 		await editor.openDocumentSettingsSidebar();
 		await page.getByRole( 'button', { name: 'Edit template' } ).click();
 		await expect(
-			editor.canvas.locator( 'h2:has-text("Cart")' ).first()
+			editor.canvas.locator( 'h1:has-text("Cart")' ).first()
 		).toBeVisible();
 	} );
 
@@ -53,7 +53,7 @@ test.describe( 'Test the cart template', async () => {
 		await expect(
 			admin.page
 				.frameLocator( 'iframe[title="Editor canvas"i]' )
-				.locator( 'h2:has-text("Cart")' )
+				.locator( 'h1:has-text("Cart")' )
 				.first()
 		).toBeVisible();
 	} );

--- a/tests/e2e/tests/templates/cart-template.block_theme.spec.ts
+++ b/tests/e2e/tests/templates/cart-template.block_theme.spec.ts
@@ -21,7 +21,7 @@ test.describe( 'Test the cart template', async () => {
 		await expect(
 			page
 				.frameLocator( 'iframe[title="Editor canvas"i]' )
-				.locator( 'h1:has-text("Cart")' )
+				.locator( 'h1:has-text("Cart block")' )
 				.first()
 		).toBeVisible();
 	} );
@@ -38,12 +38,12 @@ test.describe( 'Test the cart template', async () => {
 		await editor.page.getByRole( 'button', { name: /Cart/i } ).click();
 		await editorUtils.enterEditMode();
 		await expect(
-			editor.canvas.locator( 'h1:has-text("Cart")' ).first()
+			editor.canvas.locator( 'h1:has-text("Cart block")' ).first()
 		).toBeVisible();
 		await editor.openDocumentSettingsSidebar();
 		await page.getByRole( 'button', { name: 'Edit template' } ).click();
 		await expect(
-			editor.canvas.locator( 'h1:has-text("Cart")' ).first()
+			editor.canvas.locator( 'h1:has-text("Cart block")' ).first()
 		).toBeVisible();
 	} );
 
@@ -53,7 +53,7 @@ test.describe( 'Test the cart template', async () => {
 		await expect(
 			admin.page
 				.frameLocator( 'iframe[title="Editor canvas"i]' )
-				.locator( 'h1:has-text("Cart")' )
+				.locator( 'h1:has-text("Cart block")' )
 				.first()
 		).toBeVisible();
 	} );

--- a/tests/e2e/tests/templates/cart-template.block_theme.spec.ts
+++ b/tests/e2e/tests/templates/cart-template.block_theme.spec.ts
@@ -8,25 +8,7 @@ const templatePath = 'woocommerce/woocommerce//page-cart';
 const templateType = 'wp_template';
 
 test.describe( 'Test the cart template', async () => {
-	test( 'Template can be opened in the site editor', async ( {
-		admin,
-		page,
-		editorUtils,
-	} ) => {
-		await admin.visitAdminPage( 'site-editor.php' );
-		await editorUtils.waitForSiteEditorFinishLoading();
-		await page.getByRole( 'button', { name: /Templates/i } ).click();
-		await page.getByRole( 'button', { name: /Page: Cart/i } ).click();
-		await editorUtils.enterEditMode();
-		await expect(
-			page
-				.frameLocator( 'iframe[title="Editor canvas"i]' )
-				.locator( 'h1:has-text("Cart block")' )
-				.first()
-		).toBeVisible();
-	} );
-
-	test( 'Template can be accessed from the page editor', async ( {
+	test( 'Page can be accessed from the site editor', async ( {
 		admin,
 		editor,
 		page,
@@ -37,6 +19,8 @@ test.describe( 'Test the cart template', async () => {
 		await editor.page.getByRole( 'button', { name: /Pages/i } ).click();
 		await editor.page.getByRole( 'button', { name: /Cart/i } ).click();
 		await editorUtils.enterEditMode();
+		await editorUtils.closeWelcomeGuideModal();
+		await editorUtils.closePageEditingModal();
 		await expect(
 			editor.canvas.locator( 'h1:has-text("Cart block")' ).first()
 		).toBeVisible();
@@ -44,6 +28,26 @@ test.describe( 'Test the cart template', async () => {
 		await page.getByRole( 'button', { name: 'Edit template' } ).click();
 		await expect(
 			editor.canvas.locator( 'h1:has-text("Cart block")' ).first()
+		).toBeVisible();
+	} );
+
+	test( 'Template can be opened in the site editor', async ( {
+		admin,
+		page,
+		editorUtils,
+	} ) => {
+		await admin.visitAdminPage( 'site-editor.php' );
+		await editorUtils.waitForSiteEditorFinishLoading();
+		await page.getByRole( 'button', { name: /Templates/i } ).click();
+		await page.getByRole( 'button', { name: /Page: Cart/i } ).click();
+		await editorUtils.enterEditMode();
+		await editorUtils.closeWelcomeGuideModal();
+		await editorUtils.closePageEditingModal();
+		await expect(
+			page
+				.frameLocator( 'iframe[title="Editor canvas"i]' )
+				.locator( 'h1:has-text("Cart block")' )
+				.first()
 		).toBeVisible();
 	} );
 
@@ -74,8 +78,10 @@ test.describe( 'Test editing the cart template', async () => {
 		await admin.visitAdminPage( 'site-editor.php' );
 		await editorUtils.waitForSiteEditorFinishLoading();
 		await page.getByRole( 'button', { name: /Templates/i } ).click();
-		await page.getByRole( 'button', { name: /Page: Checkout/i } ).click();
+		await page.getByRole( 'button', { name: /Page: Cart/i } ).click();
 		await editorUtils.enterEditMode();
+		await editorUtils.closeWelcomeGuideModal();
+		await editorUtils.closePageEditingModal();
 		await editor.setContent(
 			'<!-- wp:woocommerce/classic-shortcode {"shortcode":"cart"} /-->'
 		);

--- a/tests/e2e/tests/templates/checkout-template.block_theme.spec.ts
+++ b/tests/e2e/tests/templates/checkout-template.block_theme.spec.ts
@@ -21,7 +21,7 @@ test.describe( 'Test the checkout template', async () => {
 		await expect(
 			page
 				.frameLocator( 'iframe[title="Editor canvas"i]' )
-				.locator( 'h2:has-text("Checkout")' )
+				.locator( 'h1:has-text("Checkout")' )
 				.first()
 		).toBeVisible();
 	} );
@@ -38,12 +38,12 @@ test.describe( 'Test the checkout template', async () => {
 		await editor.page.getByRole( 'button', { name: /Checkout/i } ).click();
 		await editorUtils.enterEditMode();
 		await expect(
-			editor.canvas.locator( 'h2:has-text("Checkout")' ).first()
+			editor.canvas.locator( 'h1:has-text("Checkout")' ).first()
 		).toBeVisible();
 		await editor.openDocumentSettingsSidebar();
 		await page.getByRole( 'button', { name: 'Edit template' } ).click();
 		await expect(
-			editor.canvas.locator( 'h2:has-text("Checkout")' ).first()
+			editor.canvas.locator( 'h1:has-text("Checkout")' ).first()
 		).toBeVisible();
 	} );
 
@@ -53,7 +53,7 @@ test.describe( 'Test the checkout template', async () => {
 		await expect(
 			admin.page
 				.frameLocator( 'iframe[title="Editor canvas"i]' )
-				.locator( 'h2:has-text("Checkout")' )
+				.locator( 'h1:has-text("Checkout")' )
 				.first()
 		).toBeVisible();
 	} );

--- a/tests/e2e/tests/templates/checkout-template.block_theme.spec.ts
+++ b/tests/e2e/tests/templates/checkout-template.block_theme.spec.ts
@@ -8,25 +8,7 @@ const templatePath = 'woocommerce/woocommerce//page-checkout';
 const templateType = 'wp_template';
 
 test.describe( 'Test the checkout template', async () => {
-	test( 'Template can be opened in the site editor', async ( {
-		admin,
-		page,
-		editorUtils,
-	} ) => {
-		await admin.visitAdminPage( 'site-editor.php' );
-		await editorUtils.waitForSiteEditorFinishLoading();
-		await page.getByRole( 'button', { name: /Templates/i } ).click();
-		await page.getByRole( 'button', { name: /Page: Checkout/i } ).click();
-		await editorUtils.enterEditMode();
-		await expect(
-			page
-				.frameLocator( 'iframe[title="Editor canvas"i]' )
-				.locator( 'h1:has-text("Checkout block")' )
-				.first()
-		).toBeVisible();
-	} );
-
-	test( 'Template can be accessed from the page editor', async ( {
+	test( 'Page can be accessed from the site editor', async ( {
 		admin,
 		editor,
 		page,
@@ -37,6 +19,8 @@ test.describe( 'Test the checkout template', async () => {
 		await editor.page.getByRole( 'button', { name: /Pages/i } ).click();
 		await editor.page.getByRole( 'button', { name: /Checkout/i } ).click();
 		await editorUtils.enterEditMode();
+		await editorUtils.closeWelcomeGuideModal();
+		await editorUtils.closePageEditingModal();
 		await expect(
 			editor.canvas.locator( 'h1:has-text("Checkout block")' ).first()
 		).toBeVisible();
@@ -44,6 +28,26 @@ test.describe( 'Test the checkout template', async () => {
 		await page.getByRole( 'button', { name: 'Edit template' } ).click();
 		await expect(
 			editor.canvas.locator( 'h1:has-text("Checkout block")' ).first()
+		).toBeVisible();
+	} );
+
+	test( 'Template can be opened in the site editor', async ( {
+		admin,
+		page,
+		editorUtils,
+	} ) => {
+		await admin.visitAdminPage( 'site-editor.php' );
+		await editorUtils.waitForSiteEditorFinishLoading();
+		await page.getByRole( 'button', { name: /Templates/i } ).click();
+		await page.getByRole( 'button', { name: /Page: Checkout/i } ).click();
+		await editorUtils.enterEditMode();
+		await editorUtils.closeWelcomeGuideModal();
+		await editorUtils.closePageEditingModal();
+		await expect(
+			page
+				.frameLocator( 'iframe[title="Editor canvas"i]' )
+				.locator( 'h1:has-text("Checkout block")' )
+				.first()
 		).toBeVisible();
 	} );
 
@@ -76,6 +80,8 @@ test.describe( 'Test editing the checkout template', async () => {
 		await page.getByRole( 'button', { name: /Templates/i } ).click();
 		await page.getByRole( 'button', { name: /Page: Checkout/i } ).click();
 		await editorUtils.enterEditMode();
+		await editorUtils.closeWelcomeGuideModal();
+		await editorUtils.closePageEditingModal();
 		await editor.setContent(
 			'<!-- wp:woocommerce/classic-shortcode {"shortcode":"checkout"} /-->'
 		);

--- a/tests/e2e/tests/templates/checkout-template.block_theme.spec.ts
+++ b/tests/e2e/tests/templates/checkout-template.block_theme.spec.ts
@@ -21,7 +21,7 @@ test.describe( 'Test the checkout template', async () => {
 		await expect(
 			page
 				.frameLocator( 'iframe[title="Editor canvas"i]' )
-				.locator( 'h1:has-text("Checkout")' )
+				.locator( 'h1:has-text("Checkout block")' )
 				.first()
 		).toBeVisible();
 	} );
@@ -38,12 +38,12 @@ test.describe( 'Test the checkout template', async () => {
 		await editor.page.getByRole( 'button', { name: /Checkout/i } ).click();
 		await editorUtils.enterEditMode();
 		await expect(
-			editor.canvas.locator( 'h1:has-text("Checkout")' ).first()
+			editor.canvas.locator( 'h1:has-text("Checkout block")' ).first()
 		).toBeVisible();
 		await editor.openDocumentSettingsSidebar();
 		await page.getByRole( 'button', { name: 'Edit template' } ).click();
 		await expect(
-			editor.canvas.locator( 'h1:has-text("Checkout")' ).first()
+			editor.canvas.locator( 'h1:has-text("Checkout block")' ).first()
 		).toBeVisible();
 	} );
 
@@ -53,7 +53,7 @@ test.describe( 'Test the checkout template', async () => {
 		await expect(
 			admin.page
 				.frameLocator( 'iframe[title="Editor canvas"i]' )
-				.locator( 'h1:has-text("Checkout")' )
+				.locator( 'h1:has-text("Checkout block")' )
 				.first()
 		).toBeVisible();
 	} );

--- a/tests/e2e/tests/templates/order-confirmation.block_theme.spec.ts
+++ b/tests/e2e/tests/templates/order-confirmation.block_theme.spec.ts
@@ -37,6 +37,7 @@ test.describe( 'Test the order confirmation template', async () => {
 		} );
 		await editorUtils.enterEditMode();
 		await editorUtils.closeWelcomeGuideModal();
+		await editorUtils.closePageEditingModal();
 		await editorUtils.transformIntoBlocks();
 		await editorUtils.waitForSiteEditorFinishLoading();
 		await expect(

--- a/tests/e2e/utils/editor/editor-utils.page.ts
+++ b/tests/e2e/utils/editor/editor-utils.page.ts
@@ -266,8 +266,7 @@ export class EditorUtils {
 			.getByRole( 'dialog', { name: 'Welcome to the site editor' } )
 			.locator( 'div' )
 			.filter( {
-				hasText:
-					'Edit your siteDesign everything on your site — from the header right down to the',
+				hasText: 'Edit your site',
 			} )
 			.nth( 2 )
 			.isVisible();
@@ -277,6 +276,22 @@ export class EditorUtils {
 			await this.page
 				.getByRole( 'button', { name: 'Get started' } )
 				.click();
+		}
+	}
+
+	async closePageEditingModal() {
+		const isModalOpen = await this.page
+			.getByRole( 'dialog', { name: 'Editing a page' } )
+			.locator( 'div' )
+			.filter( {
+				hasText: 'Editing a page',
+			} )
+			.nth( 2 )
+			.isVisible();
+
+		// eslint-disable-next-line playwright/no-conditional-in-test
+		if ( isModalOpen ) {
+			await this.page.getByRole( 'button', { name: 'Continue' } ).click();
 		}
 	}
 


### PR DESCRIPTION
Fixes #11042

## What

Fixing various broken Playwright e2e tests.

## Why

To detect problems early, it’s crucial to maintain reliable end-to-end (e2e) tests. When such tests fail, and we merge Pull Requests (PRs) dismissing those failures as simply due to flaky tests, it undermines trust in our testing process. This could lead us to overlook real issues in the codebase, continuing to merge PRs despite legitimate failures in e2e tests. To maintain confidence in our testing suite and avoid overlooking potential issues, we must ensure that our tests consistently pass, addressing failures promptly and thoroughly.

## Testing Instructions

Ensure that the Playwright e2e tests pass.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.