### PR TITLE
Add fee ID/key to parent cart and checkout block

### DIFF
--- a/packages/checkout/components/totals/fees/index.tsx
+++ b/packages/checkout/components/totals/fees/index.tsx
@@ -37,7 +37,7 @@ const TotalsFees = ( {
 }: TotalsFeesProps ): ReactElement | null => {
 	return (
 		<>
-			{ cartFees.map( ( { id, name, totals }, index ) => {
+			{ cartFees.map( ( { id, key, name, totals }, index ) => {
 				const feesValue = parseInt( totals.total, 10 );
 
 				if ( ! feesValue ) {
@@ -51,6 +51,7 @@ const TotalsFees = ( {
 						key={ id || `${ index }-${ name }` }
 						className={ classnames(
 							'wc-block-components-totals-fees',
+							'wc-block-components-totals-fees__' + key,
 							className
 						) }
 						currency={ currency }


### PR DESCRIPTION
## What

Add the ID of a fee to the parent DIV in cart and checkout block.
So
`<div class="wc-block-components-totals-item wc-block-components-totals-fees">`
becomes
`<div class="wc-block-components-totals-item wc-block-components-totals-fees wc-block-components-totals-fees__fee-1">`

see discussion:
https://github.com/woocommerce/woocommerce-blocks/discussions/11041#discussioncomment-7103099
closes https://github.com/woocommerce/woocommerce-blocks/issues/11053

## Why

To add styles to a specific fee or other data with css (content-attribute).

## Testing Instructions

- add a fee to you cart, for example by using this code in your functions.php
```
add_action( 'woocommerce_cart_calculate_fees', function( $cart ) {
	$cart->add_fee( 'Fee 0', 5, true );
	$cart->add_fee( 'Fee 2', 10, true );
	$cart->add_fee( 'Fee 3', 50, true );
});

```
- go to your cart or checkout block
- check the CSS classes of the fee elements with your browser developer tool

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast
![screen](https://github.com/woocommerce/woocommerce-blocks/assets/2648926/e89c27de-6306-4dcf-84cc-ab0a7a297988)

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Add fee ID to parent cart and checkout block.
