### PR TITLE
Fix downloads block visibility

### DIFF
--- a/assets/js/blocks/order-confirmation/downloads-wrapper/edit.tsx
+++ b/assets/js/blocks/order-confirmation/downloads-wrapper/edit.tsx
@@ -3,6 +3,12 @@
  */
 import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
 import { getSetting } from '@woocommerce/settings';
+import classnames from 'classnames';
+
+/**
+ * Internal dependencies
+ */
+import './editor.scss';
 
 const Edit = ( {
 	attributes,
@@ -18,12 +24,13 @@ const Edit = ( {
 		'storeHasDownloadableProducts'
 	);
 
-	if ( ! hasDownloadableProducts ) {
-		return null;
-	}
-
 	return (
-		<div { ...blockProps }>
+		<div
+			{ ...blockProps }
+			className={ classnames( blockProps.className, {
+				'store-has-downloads': hasDownloadableProducts,
+			} ) }
+		>
 			<InnerBlocks
 				allowedBlocks={ [ 'core/heading' ] }
 				template={ [

--- a/assets/js/blocks/order-confirmation/downloads-wrapper/editor.scss
+++ b/assets/js/blocks/order-confirmation/downloads-wrapper/editor.scss
@@ -1,0 +1,3 @@
+.wp-block-woocommerce-order-confirmation-downloads-wrapper:not(.store-has-downloads):not(.is-selected):not(.has-child-selected) {
+	display: none;
+}

--- a/assets/js/blocks/order-confirmation/totals-wrapper/edit.tsx
+++ b/assets/js/blocks/order-confirmation/totals-wrapper/edit.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';
-import { getSetting } from '@woocommerce/settings';
 
 const Edit = ( {
 	attributes,
@@ -14,13 +13,6 @@ const Edit = ( {
 	setAttributes: ( attributes: Record< string, unknown > ) => void;
 } ) => {
 	const blockProps = useBlockProps();
-	const hasDownloadableProducts = getSetting(
-		'storeHasDownloadableProducts'
-	);
-
-	if ( ! hasDownloadableProducts ) {
-		return null;
-	}
 
 	return (
 		<div { ...blockProps }>

--- a/src/BlockTypesController.php
+++ b/src/BlockTypesController.php
@@ -51,6 +51,7 @@ final class BlockTypesController {
 		add_filter( 'render_block', array( $this, 'add_data_attributes' ), 10, 2 );
 		add_action( 'woocommerce_login_form_end', array( $this, 'redirect_to_field' ) );
 		add_filter( 'widget_types_to_hide_from_legacy_widget_block', array( $this, 'hide_legacy_widgets_with_block_equivalent' ) );
+		add_action( 'woocommerce_delete_product_transients', array( $this, 'delete_product_transients' ) );
 	}
 
 	/**
@@ -157,6 +158,13 @@ final class BlockTypesController {
 		);
 
 		return $widget_types;
+	}
+
+	/**
+	 * Delete product transients when a product is deleted.
+	 */
+	public function delete_product_transients() {
+		delete_transient( 'wc_blocks_has_downloadable_product' );
 	}
 
 	/**


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Ensures that the totals and downloads blocks are visible on the order confirmation page.

## Why

The transient used here was cached for too long and never cleared. Also, totals does not need to use this transient.

## Testing Instructions

1. On a fresh install with a block theme and no products, go to Templates > Editor > Templates > Order Confirmation
2. Transform the confirmation to blocks
3. Confirm the totals block is visible
4. Add a downloadable product with files
5. Place an order for the downloadable product
6. Leave the confirmation page open
7. In another tab, change the order status to completed
8. Refresh the confirmation page
9. downloads should be visible

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.