### PR TITLE
Ensure input is validated when autofilled in Firefox

### DIFF
--- a/packages/checkout/components/text-input/validated-text-input.tsx
+++ b/packages/checkout/components/text-input/validated-text-input.tsx
@@ -160,6 +160,8 @@ const ValidatedTextInput = forwardRef<
 				inputRef.current?.ownerDocument?.activeElement !==
 					inputRef.current
 			) {
+				validateInput( true );
+
 				const formattedValue = customFormatter(
 					inputRef.current.value
 				);


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Ensures the `validateInput` function is fired when a `ValidatedTextInput` gets its value autofilled in Firefox.

## Why

For some reason there seems to be a race condition where inputs get validated _before_ the `useEffect` that handles autofill/direct changes to the data store in Chrome. This PR causes validation to run when the input is updated via data store or autofill.

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

**Perform these steps both in Firefox and Chrome/Brave/Edge**
1. As a guest user (open the site in an incognito/private window), add an item to your cart and go to the Checkout block.
2. Enter your details and check out successfully.
3. Repeat again without closing the window, when you load the Checkout block the second time, expand the saved address card.
4. The address details should be auto filled based on your last order.
5. Ensure you can check out without editing the fields.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

n/a

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Ensure some checkout fields are not incorrectly marked as invalid when using browser autofill.
