### PR TITLE
Fix fatal JS error in checkout when customer has saved payment methods

### DIFF
--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -422,11 +422,13 @@ class Checkout extends AbstractBlock {
 
 		// Filter out payment methods that are not enabled.
 		foreach ( $payment_methods as $payment_method_group => $saved_payment_methods ) {
-			$payment_methods[ $payment_method_group ] = array_filter(
-				$saved_payment_methods,
-				function( $saved_payment_method ) use ( $payment_gateways ) {
-					return in_array( $saved_payment_method['method']['gateway'], array_keys( $payment_gateways ), true );
-				}
+			$payment_methods[ $payment_method_group ] = array_values(
+				array_filter(
+					$saved_payment_methods,
+					function( $saved_payment_method ) use ( $payment_gateways ) {
+						return in_array( $saved_payment_method['method']['gateway'], array_keys( $payment_gateways ), true );
+					}
+				)
 			);
 		}
 


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Fixes a fatal JS error in checkout which happens when the following conditions are met:
* Customer has multiple saved payment methods of the same type (for example, Credit Card), from multiple different gateways
* At least 1 of the payment gateways for which a saved payment method exists, is disabled

## Why

This error happens because customer payment methods are filtered in `Automattic\WooCommerce\Blocks\BlockTypes\Checkout::hydrate_customer_payment_methods()` to leave out any payment methods where the gateway is not active. `array_filter` does _not_ re-index the array, meaning that the resulting array may have non-sequential (associative) keys. When converting such an array to JSON, the result is not an array, but rather a JSON object:

```php
wp_json_encode( [ 3 => 'foo', 4 => 'bar' ] ); // results in "{"3":"foo","4":"bar"}"
```

However, if the PHP array is sequentially indexed (starting from `0`), the result is an array:
```php
wp_json_encode( [ 0 => 'foo', 1 => 'bar' ] ); // results in "["foo","bar"]"
wp_json_encode( [ 'foo', 'bar' ] ); // same as above
```

The fix is simple: **pass the filtered array through `array_values`**, which will re-index the array and ensure a JSON array is output, fixing the JS TypeError.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. As a customer, add a saved payment method (Credit Card) with 2 different gateways
2. As a merchant, disable one of the gateways
3. As a customer, add product to cart and go to block-based checkout
4. Without this fix, you should see the same JS error in console as shown in the screenshot above
5.  With this fix, the checkout should load fine with no errors

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
| ![CleanShot 2023-09-29 at 14 49 02@2x](https://github.com/woocommerce/woocommerce-blocks/assets/593267/0438268e-3e90-4cea-9cb7-b89cb00d5f97)       |  ![CleanShot 2023-09-29 at 15 02 02@2x](https://github.com/woocommerce/woocommerce-blocks/assets/593267/d79a543d-1798-4538-a94d-0e1c9b6546fa)|

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [ ] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Address a JS error in checkout when customer has saved payment methods from multiple gateways and one of them is inactive
