### PR TITLE
added the cart_item_data request field to the CartAddItem.php

### DIFF
--- a/src/StoreApi/Routes/V1/CartAddItem.php
+++ b/src/StoreApi/Routes/V1/CartAddItem.php
@@ -112,7 +112,7 @@ class CartAddItem extends AbstractCartRoute {
 				'id'             => $request['id'],
 				'quantity'       => $request['quantity'],
 				'variation'      => $request['variation'],
-				'cart_item_data' => [],
+				'cart_item_data' => $request['cart_item_data'] ?? [],
 			),
 			$request
 		);


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Updated: Enhanced woocommerce_store_api_add_to_cart_data filter

## Why

Currently it has not been possible to send new cart items with cart_item_data to the StoreAPI. The cart_item_data can be used in many ways, for example if you want to give a custom_note to the item to be added:

data: {
		"id": postId,
		"quantity": 1,
		"cart_item_data": {
			"custom_note": "This is a custom note"
		}
},

## Changelog

> Modified the structure of the woocommerce_store_api_add_to_cart_data filter to accommodate cart_item_data from the request if available. If cart_item_data isn't available in the request, it defaults to an empty array. 