### PR TITLE
[Store Customization MVP] Fix conflict with other plugins

### DIFF
--- a/src/StoreApi/Routes/V1/Patterns.php
+++ b/src/StoreApi/Routes/V1/Patterns.php
@@ -116,7 +116,7 @@ class Patterns extends AbstractRoute {
 
 		if ( ! isset( $response ) ) {
 			$response = $this->prepare_item_for_response(
-				(object) [
+				[
 					'ai_content_generated' => true,
 				],
 				$request

--- a/src/StoreApi/Schemas/V1/PatternsSchema.php
+++ b/src/StoreApi/Schemas/V1/PatternsSchema.php
@@ -31,12 +31,12 @@ class PatternsSchema extends AbstractSchema {
 	/**
 	 * Get the Patterns response.
 	 *
-	 * @param object $item Item to get response for.
+	 * @param array $item Item to get response for.
 	 *
-	 * @return object
+	 * @return array
 	 */
 	public function get_item_response( $item ) {
-		return (object) [
+		return [
 			'ai_content_generated' => true,
 		];
 	}


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Fixes a PHP error that was occurring when the `WooCommerce Product Add-ons` or the `WooCommerce Product Bundles` plugins were enabled.

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/11040

## Why

Both plugins are using the `rest_request_after_callbacks` filter and accessing the response data as an array but we were returning and object.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Create a new [JN install](https://jurassic.ninja/) with both Jetpack and Woocommerce installed and activated.
2. Install and activate WooCommerce Blocks from this zip file: [woocommerce-gutenberg-products-block.zip]
(https://wcblocks.wpcomstaging.com/wp-content/uploads/woocommerce-gutenberg-products-block-11082.zip), also install and enable the `WooCommerce Product Add-ons` or the `WooCommerce Product Bundles`.
3. In your wp-admin, set up the JetPack connection, make sure it's successful.
4. From your admin screen, click on Tools > Plugin editor:

    Select the WooCommerce Blocks plugin and add the following within your woocommerce-blocks/woocommerce-gutenberg-products-block.php file and save:

```php
function connect_to_endpoint() {
	update_option( 'woocommerce_blocks_allow_ai_connection', true );

	$request = new WP_REST_Request( 'POST', '/wc/store/patterns' );

	$request->set_param( 'business_description', 'A store that sells organic food' );

	$response = rest_do_request( $request )->get_data();

	error_log( print_r( $response, true ) );
}

add_action( 'admin_init', 'connect_to_endpoint' );
```

5. Create a new post.
6. Insert the Featured Category Triple pattern (or any other you want with at least one image).
7. Make sure the images on the pattern match the business description you provided: 'A store that sells organic food' and no PHP error occurred.
8. Go back to the plugin editor and update the business description over there to something else (e.g. books, clothes, sports gear etc.) and saveç
9. Return to your post editor, save it, and refresh the page.
10. Insert the same Featured Category Triple pattern again.
11. Notice how all images were updated to now match what you selected as the new description for your store.


* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [x] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast


## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
- Fix a PHP error that was occurring when the WooCommerce Product Add-ons or the WooCommerce Product Bundles plugins were enabled.