### PR TITLE
Revalidate inputs when the value in the store changes on checkout

### DIFF
--- a/packages/checkout/components/text-input/validated-text-input.tsx
+++ b/packages/checkout/components/text-input/validated-text-input.tsx
@@ -166,6 +166,8 @@ const ValidatedTextInput = forwardRef<
 
 				if ( formattedValue !== value ) {
 					onChange( formattedValue );
+				} else {
+					validateInput( true );
 				}
 			}
 		}, [ validateInput, customFormatter, value, previousValue, onChange ] );


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

When data changes via the data store, validated text inputs watch for changes via `useEffect` and then trigger a change event if the data changes format. What it lacks however is a call to revalidate. 

This PR introduces revalidation when the store changes.

Fixes #10748

## Why

This clears any error messages regarding validation so checkout may proceed.

## Testing Instructions

The instructions in https://github.com/woocommerce/woocommerce-blocks/issues/10748 work but need testing by devs.

1. Go to checkout as a logged out guest. Fields should be empty.
2. Use the following in browser console.

```
wp.data.dispatch('wc/store/cart').setShippingAddress({
    country: "US",
    state: "CA",
    city: "SF",
    postcode: "94110",
    first_name: "fist",
    last_name: "last",
    address_1: "address",
    phone: "0612985430"
    
});

wp.data.dispatch('wc/store/cart').setBillingAddress({
    country: "US",
    state: "CA",
    city: "SF",
    postcode: "94110",
    first_name: "fist",
    last_name: "last",
    address_1: "address",
    phone: "0612985430",
    email: "test@example.com"
    
})
```

3. Place order. There should be no blocking validation errors on address fields. 

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [x] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

