### PR TITLE
Remove opinionated styles from the Hero Product 3 Split pattern

### DIFF
--- a/patterns/hero-product-3-split.php
+++ b/patterns/hero-product-3-split.php
@@ -15,7 +15,7 @@ $images  = PatternsHelper::get_pattern_images( 'woocommerce-blocks/hero-product-
 	<!-- wp:column {"width":"66.66%"} -->
 	<div class="wp-block-column" style="flex-basis:66.66%">
 		<!-- wp:media-text {"mediaPosition":"right","mediaId":1,"mediaLink":"<?php echo esc_url( plugins_url( 'images/pattern-placeholders/hand-guitar-finger-tshirt-clothing-rack.png', dirname( __FILE__ ) ) ); ?>","mediaType":"image"} -->
-		<div class="wp-block-media-text alignwide has-media-on-the-right is-stacked-on-mobile has-base-2-background-color has-background">
+		<div class="wp-block-media-text alignwide has-media-on-the-right is-stacked-on-mobile">
 			<div class="wp-block-media-text__content">
 				<!-- wp:group {"style":{"spacing":{"margin":{"top":"20px","bottom":"20px"}}},"layout":{"type":"flex","orientation":"vertical"}} -->
 				<div class="wp-block-group" style="margin-top:20px;margin-bottom:20px;">

--- a/patterns/hero-product-3-split.php
+++ b/patterns/hero-product-3-split.php
@@ -14,8 +14,8 @@ $images  = PatternsHelper::get_pattern_images( 'woocommerce-blocks/hero-product-
 <div class="wp-block-columns alignwide" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">
 	<!-- wp:column {"width":"66.66%"} -->
 	<div class="wp-block-column" style="flex-basis:66.66%">
-		<!-- wp:media-text {"mediaPosition":"right","mediaId":1,"mediaLink":"<?php echo esc_url( plugins_url( 'images/pattern-placeholders/hand-guitar-finger-tshirt-clothing-rack.png', dirname( __FILE__ ) ) ); ?>","mediaType":"image","style":{"color":{"background":"#000000","text":"#ffffff"}}} -->
-		<div class="wp-block-media-text alignwide has-media-on-the-right is-stacked-on-mobile has-text-color has-background" style="color:#ffffff;background-color:#000000">
+		<!-- wp:media-text {"mediaPosition":"right","mediaId":1,"mediaLink":"<?php echo esc_url( plugins_url( 'images/pattern-placeholders/hand-guitar-finger-tshirt-clothing-rack.png', dirname( __FILE__ ) ) ); ?>","mediaType":"image"} -->
+		<div class="wp-block-media-text alignwide has-media-on-the-right is-stacked-on-mobile has-base-2-background-color has-background">
 			<div class="wp-block-media-text__content">
 				<!-- wp:group {"style":{"spacing":{"margin":{"top":"20px","bottom":"20px"}}},"layout":{"type":"flex","orientation":"vertical"}} -->
 				<div class="wp-block-group" style="margin-top:20px;margin-bottom:20px;">
@@ -29,9 +29,9 @@ $images  = PatternsHelper::get_pattern_images( 'woocommerce-blocks/hero-product-
 
 					<!-- wp:buttons -->
 					<div class="wp-block-buttons">
-						<!-- wp:button {"textAlign":"left","style":{"color":{"background":"#ffffff","text":"#000000"}}} -->
+						<!-- wp:button {"textAlign":"left"} -->
 						<div class="wp-block-button has-custom-font-size">
-							<a class="wp-block-button__link has-text-color has-background has-text-align-left wp-element-button" href="<?php echo esc_url( get_permalink( wc_get_page_id( 'shop' ) ) ); ?>" style="color:#000000;background-color:#ffffff"><?php esc_attr_e( 'Shop now', 'woo-gutenberg-products-block' ); ?></a>
+							<a class="wp-block-button__link has-text-align-left wp-element-button" href="<?php echo esc_url( get_permalink( wc_get_page_id( 'shop' ) ) ); ?>"><?php esc_attr_e( 'Shop now', 'woo-gutenberg-products-block' ); ?></a>
 						</div>
 						<!-- /wp:button -->
 					</div>


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Removes the opinionated styles for the Hero Product 3 Split pattern.

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/11092

## Why

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

When color palettes are selected globally for a theme, this patterns inherits the colors from the selected palette or global styles so that it doesn't contrast, or look out of place on the page.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Insert the `Hero Product 3 Split` pattern into your page.
2. Go to Site Editor > Styles and select various color palettes.
3. Ensure the patterns style changes color based on the selected preferences.
4. Test in various block themes to ensure it works as expected.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="1199" alt="Screenshot 2023-10-03 at 15 29 20" src="https://github.com/woocommerce/woocommerce-blocks/assets/8639742/7e0596c6-9873-4ac5-af98-14e014722008"> | <img width="1217" alt="Screenshot 2023-10-03 at 15 27 59" src="https://github.com/woocommerce/woocommerce-blocks/assets/8639742/960ac65f-468f-42f3-99be-1da28b9a20a5"> |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Remove opinionated styles from the Hero Product 3 Split pattern.