### PR TITLE
Add data-price button attribute containing product price

### DIFF
--- a/src/BlockTypes/AbstractProductGrid.php
+++ b/src/BlockTypes/AbstractProductGrid.php
@@ -649,6 +649,7 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 			'data-quantity'    => '1',
 			'data-product_id'  => $product->get_id(),
 			'data-product_sku' => $product->get_sku(),
+			'data-price'       => wc_get_price_to_display($product),
 			'rel'              => 'nofollow',
 			'class'            => 'wp-block-button__link ' . ( function_exists( 'wc_wp_theme_get_element_class_name' ) ? wc_wp_theme_get_element_class_name( 'button' ) : '' ) . ' add_to_cart_button',
 		);

--- a/src/BlockTypes/AbstractProductGrid.php
+++ b/src/BlockTypes/AbstractProductGrid.php
@@ -649,7 +649,7 @@ abstract class AbstractProductGrid extends AbstractDynamicBlock {
 			'data-quantity'    => '1',
 			'data-product_id'  => $product->get_id(),
 			'data-product_sku' => $product->get_sku(),
-			'data-price'       => wc_get_price_to_display($product),
+			'data-price'       => wc_get_price_to_display( $product ),
 			'rel'              => 'nofollow',
 			'class'            => 'wp-block-button__link ' . ( function_exists( 'wc_wp_theme_get_element_class_name' ) ? wc_wp_theme_get_element_class_name( 'button' ) : '' ) . ' add_to_cart_button',
 		);


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Fixes #11116 

## Why

Add to cart button `data-price` attribute is used by trackers e.g. Pinterest Tag tracker to report store visitor's events.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Add a page with a Products (Beta), Product by Category or Products by Attribute block on it.
2. Install Pinterest Tag Helper extension into your browser (I use Chrome for that matter).
3. Navigate to the page with the added block and click Add to Cart button.
4. See an AddToCart event inside Pinterest Tag Helper has no value attribute value (it has it set to null, instead of a product price).

![240404349-7dbb2c93-2fd4-4820-ac59-87e3cee11075](https://github.com/woocommerce/woocommerce-blocks/assets/9010963/f42032c7-a971-4f52-a6ff-d3336e9e1182)

Expected value is not `null`

<img width="1335" alt="All_Products_–_WordPress_Pinterest" src="https://github.com/woocommerce/woocommerce-blocks/assets/9010963/1d023231-3807-4bdc-b641-9d51ae4830cd">

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Add Add to Cart button's product price data attribute
