### PR TITLE
Product Button: use setTimeout when requestIdleCallback isn't available

### DIFF
--- a/assets/js/atomic/blocks/product-elements/button/frontend.tsx
+++ b/assets/js/atomic/blocks/product-elements/button/frontend.tsx
@@ -64,6 +64,10 @@ const injectNotice = ( domNode: Element, errorMessage: string ) => {
 	} );
 };
 
+// RequestIdleCallback is not available in Safari, so we use setTimeout as an alternative.
+const callIdleCallback =
+	window.requestIdleCallback || ( ( cb ) => setTimeout( cb, 100 ) );
+
 const getProductById = ( cartState: Cart | undefined, productId: number ) => {
 	return cartState?.items.find( ( item ) => item.id === productId );
 };
@@ -286,7 +290,7 @@ interactivityStore(
 
 			// This selector triggers a fetch of the Cart data. It is done in a
 			// `requestIdleCallback` to avoid potential performance issues.
-			requestIdleCallback( () => {
+			callIdleCallback( () => {
 				if ( ! selectors.woocommerce.hasCartLoaded( store ) ) {
 					select( storeKey ).getCartData();
 				}


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Fixes #

## Why

@luisherranz reported that `requestIdleCallback` isn't available on Safari (https://caniuse.com/?search=requestIdleCallback). Currently, any user doesn't have any issues because the function is poly-filled by a dependency of our dependencies. (https://github.com/woocommerce/woocommerce-blocks/blob/948b0fa10ec66da4c5ffa7584dacd2353f143781/package-lock.json/#L26956-L26966)

Given that we don't have control over this and an update can remove the dependency, it is better to provide an alternative.

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Use Safari (or a browser that doesn't support `requestIdleCallback`.
2. Install a cache plugin and enable the cache (like WP-Optimize - Clean, Compress, Cache).
3. Ensure that you are using the blockified Product Catalog template.
4. Open an incognito session (and ensure you are not logged in) and visit the /shop page.
5. Open the console.
6. Ensure that no error related to the `requestIdleCallback` is visible.
7. Add a product in the cart.
8. Refresh the page.
9. Ensure that the animation works correctly.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Add suggested changelog entry here.
