### PR TITLE
Icon should use current color on checkout error

### DIFF
--- a/assets/js/blocks/checkout/checkout-order-error/style.scss
+++ b/assets/js/blocks/checkout/checkout-order-error/style.scss
@@ -8,6 +8,7 @@
 		margin: 0 auto 1em;
 		display: block;
 		color: inherit;
+		fill: currentColor;
 	}
 	.wc-block-checkout-error__title {
 		display: block;


### PR DESCRIPTION
## What

Makes the icon shown on checkout error use the current text color.

Fixes #9266

## Why

Improved appearance.

## Testing Instructions

1. With TT3 go to Appearance > Editor, edit one template and open the styles sidebar. Select a dark style variation, like Pilgrimage.
2. In the frontend, add a product to your cart and go to the Checkout page with the Checkout block.
3. In the admin, mark that product as out of stock.
4. Reload the Checkout page.
5. Icon color should match text.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|  ![Screenshot 2023-10-04 at 12 31 18](https://github.com/woocommerce/woocommerce-blocks/assets/90977/63fd3b2d-31c3-4666-aa2b-c5620204ca6f) |  ![Screenshot 2023-10-04 at 12 36 12](https://github.com/woocommerce/woocommerce-blocks/assets/90977/874a66cc-4ab7-4434-8884-b96ea041784d) |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog

> Made error icon on checkout match text color.
