### PR TITLE
Check endpoint was preloaded before returning it to prevent PHP notice

### DIFF
--- a/src/Domain/Services/Hydration.php
+++ b/src/Domain/Services/Hydration.php
@@ -47,8 +47,8 @@ class Hydration {
 		$this->restore_cached_store_notices();
 		$this->restore_nonce_check();
 
-		// Returns just the single preloaded request.
-		return $preloaded_requests[ $path ];
+		// Returns just the single preloaded request, or an empty array if it doesn't exist.
+		return $preloaded_requests[ $path ] ?? [];
 	}
 
 	/**


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Fixes a PHP notice when a property does not exist due to the preload failing.

## Why

Notice was visible with debugging on when looking at certain endpoints.

## Testing Instructions

Unit tests should suffice. This fixes a PHP warning so should be merged as soon as tests are green.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [x] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog

> Fixed PHP notice that would appear if an API endpoint failed to load.
