### PR TITLE
Store Customization > Homepage Template 2: Review layout and spacing in between patterns

### DIFF
--- a/patterns/product-collection-4-columns.php
+++ b/patterns/product-collection-4-columns.php
@@ -4,31 +4,43 @@
  * Slug: woocommerce-blocks/product-collection-4-columns
  * Categories: WooCommerce
  */
+use Automattic\WooCommerce\Blocks\Patterns\PatternsHelper;
+
+$content = PatternsHelper::get_pattern_content( 'woocommerce-blocks/product-collection-4-columns' );
 ?>
-<!-- wp:woocommerce/product-collection {"query":{"perPage":4,"pages":0,"offset":0,"postType":"product","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":{},"parents":[],"isProductCollectionBlock":true,"woocommerceOnSale":false,"woocommerceStockStatus":["instock","outofstock","onbackorder"],"woocommerceAttributes":[],"woocommerceHandPickedProducts":[]},"tagName":"div","displayLayout":{"type":"flex","columns":4},"align":"wide"} -->
-<div class="wp-block-woocommerce-product-collection alignwide">
-	<!-- wp:woocommerce/product-template -->
-	<!-- wp:woocommerce/product-image {"imageSizing":"thumbnail","isDescendentOfQueryLoop":true} /-->
 
-	<!-- wp:post-title {"textAlign":"center","level":3,"isLink":true,"style":{"spacing":{"margin":{"bottom":"0.75rem","top":"0"}}},"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
+<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)">
+	<!-- wp:heading {"level":3,"align":"wide"} -->
+	<h3 class="wp-block-heading alignwide"><?php echo esc_html( $content['titles'][0]['default'] ); ?></h3>
+	<!-- /wp:heading -->
 
-	<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"center","fontSize":"small"} /-->
+	<!-- wp:woocommerce/product-collection {"query":{"perPage":4,"pages":0,"offset":0,"postType":"product","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":{},"parents":[],"isProductCollectionBlock":true,"woocommerceOnSale":false,"woocommerceStockStatus":["instock","outofstock","onbackorder"],"woocommerceAttributes":[],"woocommerceHandPickedProducts":[]},"tagName":"div","displayLayout":{"type":"flex","columns":4},"align":"wide"} -->
+	<div class="wp-block-woocommerce-product-collection alignwide">
+		<!-- wp:woocommerce/product-template -->
+		<!-- wp:woocommerce/product-image {"imageSizing":"thumbnail","isDescendentOfQueryLoop":true} /-->
 
-	<!-- wp:woocommerce/product-button {"textAlign":"center","isDescendentOfQueryLoop":true,"fontSize":"small"} /-->
-	<!-- /wp:woocommerce/product-template -->
+		<!-- wp:post-title {"textAlign":"center","level":3,"isLink":true,"style":{"spacing":{"margin":{"bottom":"0.75rem","top":"0"}}},"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
 
-	<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
-	<!-- wp:query-pagination-previous /-->
+		<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"center","fontSize":"small"} /-->
 
-	<!-- wp:query-pagination-numbers /-->
+		<!-- wp:woocommerce/product-button {"textAlign":"center","isDescendentOfQueryLoop":true,"fontSize":"small"} /-->
+		<!-- /wp:woocommerce/product-template -->
 
-	<!-- wp:query-pagination-next /-->
-	<!-- /wp:query-pagination -->
+		<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
+		<!-- wp:query-pagination-previous /-->
 
-	<!-- wp:query-no-results -->
-	<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
-	<p></p>
-	<!-- /wp:paragraph -->
-	<!-- /wp:query-no-results -->
+		<!-- wp:query-pagination-numbers /-->
+
+		<!-- wp:query-pagination-next /-->
+		<!-- /wp:query-pagination -->
+
+		<!-- wp:query-no-results -->
+		<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
+		<p></p>
+		<!-- /wp:paragraph -->
+		<!-- /wp:query-no-results -->
+	</div>
+	<!-- /wp:woocommerce/product-collection -->
 </div>
-<!-- /wp:woocommerce/product-collection -->
+<!-- /wp:group -->

--- a/patterns/product-collection-5-columns.php
+++ b/patterns/product-collection-5-columns.php
@@ -4,41 +4,53 @@
  * Slug: woocommerce-blocks/product-collection-5-columns
  * Categories: WooCommerce
  */
+use Automattic\WooCommerce\Blocks\Patterns\PatternsHelper;
+
+$content = PatternsHelper::get_pattern_content( 'woocommerce-blocks/product-collection-5-columns' );
 ?>
-<!-- wp:woocommerce/product-collection {"query":{"perPage":5,"pages":0,"offset":0,"postType":"product","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":{},"parents":[],"isProductCollectionBlock":true,"woocommerceOnSale":false,"woocommerceStockStatus":["instock","outofstock","onbackorder"],"woocommerceAttributes":[],"woocommerceHandPickedProducts":[]},"tagName":"div","displayLayout":{"type":"flex","columns":5},"align":"wide"} -->
-<div class="wp-block-woocommerce-product-collection alignwide">
-	<!-- wp:woocommerce/product-template -->
-	<!-- wp:woocommerce/product-image {"imageSizing":"thumbnail","isDescendentOfQueryLoop":true} /-->
 
-	<!-- wp:columns -->
-	<div class="wp-block-columns">
-		<!-- wp:column -->
-		<div class="wp-block-column">
-			<!-- wp:post-title {"textAlign":"left","level":3,"isLink":true,"style":{"spacing":{"margin":{"bottom":"0.75rem","top":"0"}}},"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
-		</div>
-		<!-- /wp:column -->
+<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)">
+	<!-- wp:heading {"level":3,"align":"wide"} -->
+	<h3 class="wp-block-heading alignwide"><?php echo esc_html( $content['titles'][0]['default'] ); ?></h3>
+	<!-- /wp:heading -->
 
-		<!-- wp:column -->
-		<div class="wp-block-column">
-			<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"right","fontSize":"small"} /-->
+	<!-- wp:woocommerce/product-collection {"query":{"perPage":5,"pages":0,"offset":0,"postType":"product","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":{},"parents":[],"isProductCollectionBlock":true,"woocommerceOnSale":false,"woocommerceStockStatus":["instock","outofstock","onbackorder"],"woocommerceAttributes":[],"woocommerceHandPickedProducts":[]},"tagName":"div","displayLayout":{"type":"flex","columns":5},"align":"wide"} -->
+	<div class="wp-block-woocommerce-product-collection alignwide">
+		<!-- wp:woocommerce/product-template -->
+		<!-- wp:woocommerce/product-image {"imageSizing":"thumbnail","isDescendentOfQueryLoop":true} /-->
+
+		<!-- wp:columns -->
+		<div class="wp-block-columns">
+			<!-- wp:column -->
+			<div class="wp-block-column">
+				<!-- wp:post-title {"textAlign":"left","level":3,"isLink":true,"style":{"spacing":{"margin":{"bottom":"0.75rem","top":"0"}}},"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
+			</div>
+			<!-- /wp:column -->
+
+			<!-- wp:column -->
+			<div class="wp-block-column">
+				<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"right","fontSize":"small"} /-->
+			</div>
+			<!-- /wp:column -->
 		</div>
-		<!-- /wp:column -->
+		<!-- /wp:columns -->
+		<!-- /wp:woocommerce/product-template -->
+
+		<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
+		<!-- wp:query-pagination-previous /-->
+
+		<!-- wp:query-pagination-numbers /-->
+
+		<!-- wp:query-pagination-next /-->
+		<!-- /wp:query-pagination -->
+
+		<!-- wp:query-no-results -->
+		<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
+		<p></p>
+		<!-- /wp:paragraph -->
+		<!-- /wp:query-no-results -->
 	</div>
-	<!-- /wp:columns -->
-	<!-- /wp:woocommerce/product-template -->
-
-	<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"center"}} -->
-	<!-- wp:query-pagination-previous /-->
-
-	<!-- wp:query-pagination-numbers /-->
-
-	<!-- wp:query-pagination-next /-->
-	<!-- /wp:query-pagination -->
-
-	<!-- wp:query-no-results -->
-	<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
-	<p></p>
-	<!-- /wp:paragraph -->
-	<!-- /wp:query-no-results -->
+	<!-- /wp:woocommerce/product-collection -->
 </div>
-<!-- /wp:woocommerce/product-collection -->
+<!-- /wp:group -->

--- a/patterns/testimonials-3-columns.php
+++ b/patterns/testimonials-3-columns.php
@@ -9,8 +9,8 @@ use Automattic\WooCommerce\Blocks\Patterns\PatternsHelper;
 $content = PatternsHelper::get_pattern_content( 'woocommerce-blocks/testimonials-3-columns' );
 ?>
 
-<!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignwide">
+<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30","right":"var:preset|spacing|30"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignwide" style="padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)">
 	<!-- wp:heading {"level":3,"align":"wide"} -->
 	<h3 class="wp-block-heading alignwide"><?php echo esc_html( $content['titles'][3]['default'] ); ?></h3>
 	<!-- /wp:heading -->

--- a/patterns/testimonials-3-columns.php
+++ b/patterns/testimonials-3-columns.php
@@ -9,55 +9,63 @@ use Automattic\WooCommerce\Blocks\Patterns\PatternsHelper;
 $content = PatternsHelper::get_pattern_content( 'woocommerce-blocks/testimonials-3-columns' );
 ?>
 
-<!-- wp:columns {"align":"full"} -->
-<div class="wp-block-columns alignfull">
-	<!-- wp:column -->
-	<div class="wp-block-column">
-		<!-- wp:paragraph -->
-		<p><strong><?php echo esc_html( $content['titles'][0]['default'] ); ?></strong></p>
-		<!-- /wp:paragraph -->
+<!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignwide">
+	<!-- wp:heading {"level":3,"align":"wide"} -->
+	<h3 class="wp-block-heading alignwide"><?php echo esc_html( $content['titles'][3]['default'] ); ?></h3>
+	<!-- /wp:heading -->
 
-		<!-- wp:paragraph -->
-		<p><?php echo esc_html( $content['descriptions'][0]['default'] ); ?></p>
-		<!-- /wp:paragraph -->
+	<!-- wp:columns {"align":"full"} -->
+	<div class="wp-block-columns alignfull">
+		<!-- wp:column -->
+		<div class="wp-block-column">
+			<!-- wp:paragraph -->
+			<p><strong><?php echo esc_html( $content['titles'][0]['default'] ); ?></strong></p>
+			<!-- /wp:paragraph -->
 
-		<!-- wp:paragraph -->
-		<p>~ Tanner P.</p>
-		<!-- /wp:paragraph -->
+			<!-- wp:paragraph -->
+			<p><?php echo esc_html( $content['descriptions'][0]['default'] ); ?></p>
+			<!-- /wp:paragraph -->
+
+			<!-- wp:paragraph -->
+			<p>~ Tanner P.</p>
+			<!-- /wp:paragraph -->
+		</div>
+		<!-- /wp:column -->
+
+		<!-- wp:column -->
+		<div class="wp-block-column">
+			<!-- wp:paragraph -->
+
+			<p><strong><?php echo esc_html( $content['titles'][1]['default'] ); ?></strong></p>
+			<!-- /wp:paragraph -->
+
+			<!-- wp:paragraph -->
+			<p><?php echo esc_html( $content['descriptions'][1]['default'] ); ?></p>
+			<!-- /wp:paragraph -->
+
+			<!-- wp:paragraph -->
+			<p>~ Abigail N.</p>
+			<!-- /wp:paragraph -->
+		</div>
+		<!-- /wp:column -->
+
+		<!-- wp:column -->
+		<div class="wp-block-column">
+			<!-- wp:paragraph -->
+			<p><strong><?php echo esc_html( $content['titles'][2]['default'] ); ?></strong></p>
+			<!-- /wp:paragraph -->
+
+			<!-- wp:paragraph -->
+			<p><?php echo esc_html( $content['descriptions'][2]['default'] ); ?></p>
+			<!-- /wp:paragraph -->
+
+			<!-- wp:paragraph -->
+			<p>~ Albert L.</p>
+			<!-- /wp:paragraph -->
+		</div>
+		<!-- /wp:column -->
 	</div>
-	<!-- /wp:column -->
-
-	<!-- wp:column -->
-	<div class="wp-block-column">
-		<!-- wp:paragraph -->
-
-		<p><strong><?php echo esc_html( $content['titles'][1]['default'] ); ?></strong></p>
-		<!-- /wp:paragraph -->
-
-		<!-- wp:paragraph -->
-		<p><?php echo esc_html( $content['descriptions'][1]['default'] ); ?></p>
-		<!-- /wp:paragraph -->
-
-		<!-- wp:paragraph -->
-		<p>~ Abigail N.</p>
-		<!-- /wp:paragraph -->
-	</div>
-	<!-- /wp:column -->
-
-	<!-- wp:column -->
-	<div class="wp-block-column">
-		<!-- wp:paragraph -->
-		<p><strong><?php echo esc_html( $content['titles'][2]['default'] ); ?></strong></p>
-		<!-- /wp:paragraph -->
-
-		<!-- wp:paragraph -->
-		<p><?php echo esc_html( $content['descriptions'][2]['default'] ); ?></p>
-		<!-- /wp:paragraph -->
-
-		<!-- wp:paragraph -->
-		<p>~ Albert L.</p>
-		<!-- /wp:paragraph -->
-	</div>
-	<!-- /wp:column -->
+	<!-- /wp:columns -->
 </div>
-<!-- /wp:columns -->
+<!-- /wp:group -->

--- a/src/Patterns/dictionary.json
+++ b/src/Patterns/dictionary.json
@@ -368,7 +368,7 @@
 		}
 	},
 	{
-		"name": "Minimal 5-Column Product Row",
+		"name": "Product Collection 5 Columns",
 		"slug": "woocommerce-blocks/product-collection-5-columns",
 		"content": {
 			"titles": [

--- a/src/Patterns/dictionary.json
+++ b/src/Patterns/dictionary.json
@@ -356,6 +356,30 @@
 		}
 	},
 	{
+		"name": "1:1 Image 4-Column Product Row",
+		"slug": "woocommerce-blocks/product-query-1-1-image-4-column-products-row",
+		"content": {
+			"titles": [
+				{
+					"default": "Our newest arrivals",
+					"ai_prompt": "An impact phrase that advertises the displayed product collection"
+				}
+			]
+		}
+	},
+	{
+		"name": "Minimal 5-Column Product Row",
+		"slug": "woocommerce-blocks/product-query-minimal-5-column-products-row",
+		"content": {
+			"titles": [
+				{
+					"default": "Our newest arrivals",
+					"ai_prompt": "An impact phrase that advertises the displayed product collection"
+				}
+			]
+		}
+	},
+	{
 		"name": "Featured Products 2 Columns",
 		"slug": "woocommerce-blocks/featured-products-2-columns",
 		"content": {
@@ -547,6 +571,10 @@
 				{
 					"default": "Awesome couch and great buying experience",
 					"ai_prompt": "A title that advertises the third testimonial"
+				},
+				{
+					"default": "What our customers say",
+					"ai_prompt": "A title that advertises the set of testimonials"
 				}
 			],
 			"descriptions": [

--- a/src/Patterns/dictionary.json
+++ b/src/Patterns/dictionary.json
@@ -356,8 +356,8 @@
 		}
 	},
 	{
-		"name": "1:1 Image 4-Column Product Row",
-		"slug": "woocommerce-blocks/product-query-1-1-image-4-column-products-row",
+		"name": "Product Collection 4 Columns",
+		"slug": "woocommerce-blocks/product-collection-4-columns",
 		"content": {
 			"titles": [
 				{
@@ -369,7 +369,7 @@
 	},
 	{
 		"name": "Minimal 5-Column Product Row",
-		"slug": "woocommerce-blocks/product-query-minimal-5-column-products-row",
+		"slug": "woocommerce-blocks/product-collection-5-columns",
 		"content": {
 			"titles": [
 				{


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

This PR:
- Adds titles to the `Product Collection 4 Columns`, `Product Collection 5 Columns`, and `Testimonials 3 Columns` patterns.
- Adds padding to the same patterns.

Fixes #11089

## Why

To adapt to the designs shown on #11089.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Create a new page or post and insert all the patterns shown in the screenshot below 👇 
- `1:1 image 4-column products row` corresponds to `Product Collection 4 Columns`.
- `Minimal 5-column products row` corresponds to `Product Collection 5 Columns`.
2. Make sure the design is the same and the spacing between patterns matches.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<img width="449" alt="Screenshot 2023-10-02 at 17 36 50" src="https://github.com/woocommerce/woocommerce-blocks/assets/15730971/56232ac8-8917-4a7f-96f0-058d88aa11e5">

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Add titles and padding to the `Product Collection 4 Columns`, `Product Collection 5 Columns`, and `Testimonials 3 Columns` patterns.
