### PR TITLE
Force 100% width for combobox in checkout block

### DIFF
--- a/assets/js/base/components/country-input/style.scss
+++ b/assets/js/base/components/country-input/style.scss
@@ -4,4 +4,9 @@
 
 .wc-block-components-country-input {
 	margin-top: em($gap-large);
+
+	// Fixes width in the editor.
+	.components-flex {
+		width: 100%;
+	}
 }

--- a/assets/js/base/components/state-input/style.scss
+++ b/assets/js/base/components/state-input/style.scss
@@ -1,3 +1,8 @@
 .wc-block-components-state-input {
 	margin-top: em($gap-large);
+
+	// Fixes width in the editor.
+	.components-flex {
+		width: 100%;
+	}
 }


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Forces 100% width for the combobox in the editor.

Fixes #9155

## Why

Inputs were smaller only in editor view. Frontend was unaffected. 

## Testing Instructions

1. Install and activate the Twenty Twenty-Three theme.
2. Install and activate the Gutenberg plugin.
3. Create a test page and add the Checkout block.
4. Edit the page and verify that the Country/Region and State fields are full width.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

![Screenshot 2023-10-04 at 15 14 24](https://github.com/woocommerce/woocommerce-blocks/assets/90977/f42f91c8-d235-40ba-8571-1d0714958ae4)

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Fix checkout state/country field width in the site editor.
