### PR TITLE
Pattern: fetch product id on the JS side

### DIFF
--- a/assets/js/blocks/single-product/edit/index.tsx
+++ b/assets/js/blocks/single-product/edit/index.tsx
@@ -2,18 +2,19 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { Placeholder, Button, PanelBody } from '@wordpress/components';
 import { withProduct } from '@woocommerce/block-hocs';
 import BlockErrorBoundary from '@woocommerce/base-components/block-error-boundary';
 import EditProductLink from '@woocommerce/editor-components/edit-product-link';
-import { singleProductBlockPreview } from '@woocommerce/resource-previews';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { ProductResponseItem } from '@woocommerce/types';
 import ErrorPlaceholder, {
 	ErrorObject,
 } from '@woocommerce/editor-components/error-placeholder';
 
+import { PRODUCTS_STORE_NAME } from '@woocommerce/data';
+import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
@@ -52,9 +53,29 @@ const Editor = ( {
 	const [ isEditing, setIsEditing ] = useState( ! productId );
 	const blockProps = useBlockProps();
 
-	if ( isPreview ) {
-		return singleProductBlockPreview;
-	}
+	const productPreview = useSelect( ( select ) => {
+		if ( ! isPreview ) {
+			return null;
+		}
+		return select( PRODUCTS_STORE_NAME ).getProducts( {
+			per_page: 1,
+		} );
+	} );
+
+	useEffect( () => {
+		const productPreviewId = productPreview
+			? productPreview[ 0 ]?.id
+			: null;
+		if ( ! productPreviewId ) {
+			return;
+		}
+
+		setAttributes( {
+			...attributes,
+			productId: productPreviewId,
+		} );
+		setIsEditing( false );
+	}, [ attributes, productPreview, setAttributes ] );
 
 	if ( error ) {
 		return (

--- a/assets/js/blocks/single-product/edit/index.tsx
+++ b/assets/js/blocks/single-product/edit/index.tsx
@@ -13,7 +13,7 @@ import ErrorPlaceholder, {
 	ErrorObject,
 } from '@woocommerce/editor-components/error-placeholder';
 
-import { PRODUCTS_STORE_NAME } from '@woocommerce/data';
+import { PRODUCTS_STORE_NAME, Product } from '@woocommerce/data';
 import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
@@ -57,7 +57,7 @@ const Editor = ( {
 		if ( ! isPreview ) {
 			return null;
 		}
-		return select( PRODUCTS_STORE_NAME ).getProducts( {
+		return select( PRODUCTS_STORE_NAME ).getProducts< Array< Product > >( {
 			per_page: 1,
 		} );
 	} );

--- a/patterns/product-details-listing.php
+++ b/patterns/product-details-listing.php
@@ -4,20 +4,9 @@
  * Slug: woocommerce-blocks/product-details-listing
  * Categories: WooCommerce
  */
-
-$query = new \WC_Product_Query(
-	array(
-		'limit'  => 1,
-		'return' => 'ids',
-		'status' => array( 'publish' ),
-	)
-);
-
-$products   = $query->get_products();
-$product_id = $products ? $products[0] : null;
 ?>
 
-<!-- wp:woocommerce/single-product {"productId":<?php echo esc_attr( $product_id ); ?>} -->
+<!-- wp:woocommerce/single-product {"isPreview": true} -->
 <div class="wp-block-woocommerce-single-product">
 	<!-- wp:columns -->
 	<div class="wp-block-columns">

--- a/patterns/product-hero.php
+++ b/patterns/product-hero.php
@@ -5,19 +5,9 @@
  * Categories: WooCommerce
  */
 
-$query = new \WC_Product_Query(
-	array(
-		'limit'  => 1,
-		'return' => 'ids',
-		'status' => array( 'publish' ),
-	)
-);
-
-$products   = $query->get_products();
-$product_id = $products ? $products[0] : null;
 ?>
 
-<!-- wp:woocommerce/single-product {"productId":<?php echo esc_attr( $product_id ); ?>,"align":"wide"} -->
+<!-- wp:woocommerce/single-product {"isPreview":true, "align":"wide"} -->
 <div class="wp-block-woocommerce-single-product alignwide">
 	<!-- wp:columns -->
 	<div class="wp-block-columns">


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Fixes #11103. Fix unnecessary queries on the front end side.

## Why

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

The patterns are currently registered during the init action, which implies that these patterns are registered on the frontend. However, there is a problem with the current setup: two patterns perform a custom query each time a page is rendered on the frontend.

This pull request addresses this issue by transferring the logic responsible for fetching the product ID from PHP to JavaScript.


## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Open the post editor.
2. Add the `Product hero` and `Product details listing` patterns.
3. Ensure that a product is visible.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [ ] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Pattern: Fetch product ID with JS to prevent unnecesary queries on every page load.
