### PR TITLE
Returning $pre_render_block in the pre_render_block filter

### DIFF
--- a/src/BlockTypes/ProductCollection.php
+++ b/src/BlockTypes/ProductCollection.php
@@ -235,17 +235,18 @@ class ProductCollection extends AbstractBlock {
 		$is_product_collection_block = $parsed_block['attrs']['query']['isProductCollectionBlock'] ?? false;
 
 		if ( ! $is_product_collection_block ) {
-			return;
+			return $pre_render;
 		}
 
 		$this->parsed_block = $parsed_block;
-
 		$this->asset_data_registry->add( 'hasFilterableProducts', true, true );
 		/**
 		 * It enables the page to refresh when a filter is applied, ensuring that the product collection block,
 		 * which is a server-side rendered (SSR) block, retrieves the products that match the filters.
 		 */
 		$this->asset_data_registry->add( 'isRenderingPhpTemplate', true, true );
+
+		return $pre_render;
 	}
 
 	/**

--- a/src/BlockTypes/ProductQuery.php
+++ b/src/BlockTypes/ProductQuery.php
@@ -170,7 +170,7 @@ class ProductQuery extends AbstractBlock {
 	 */
 	public function update_query( $pre_render, $parsed_block ) {
 		if ( 'core/query' !== $parsed_block['blockName'] ) {
-			return;
+			return $pre_render;
 		}
 
 		$this->parsed_block = $parsed_block;
@@ -186,6 +186,8 @@ class ProductQuery extends AbstractBlock {
 				1
 			);
 		}
+
+		return $pre_render;
 	}
 
 	/**

--- a/src/BlockTypes/RelatedProducts.php
+++ b/src/BlockTypes/RelatedProducts.php
@@ -68,7 +68,7 @@ class RelatedProducts extends AbstractBlock {
 	 */
 	public function update_query( $pre_render, $parsed_block ) {
 		if ( 'core/query' !== $parsed_block['blockName'] ) {
-			return;
+			return $pre_render;
 		}
 
 		$this->parsed_block = $parsed_block;
@@ -82,6 +82,8 @@ class RelatedProducts extends AbstractBlock {
 				1
 			);
 		}
+
+		return $pre_render;
 	}
 
 	/**


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What
Fixes #11077 (partially) - Currently, we use a filter for doing side-effects, and we don't return any value.

## Why

This PR fixes this wrong behavior, returning a value. It is worth mentioning that even with PR #11077, it will not be fixed entirely because, in WordPress Core, the filter is used without returning any value (https://github.com/WordPress/wordpress-develop/blob/d8206d2167f2c082258f31db163289bae3682e06/src/wp-includes/block-supports/elements.php/#L135-L225).

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Smoke test: Products Beta, Product Collection, and Related Products blocks.


* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [ ] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Add suggested changelog entry here.
