### PR TITLE
Single Product block: Redirect to the cart page after successful addition setting isn't respected

### DIFF
--- a/src/BlockTypes/AddToCartForm.php
+++ b/src/BlockTypes/AddToCartForm.php
@@ -162,6 +162,11 @@ class AddToCartForm extends AbstractBlock {
 	public function add_to_cart_redirect_filter( $url ) {
 		// phpcs:ignore
 		if ( isset( $_POST['is-descendent-of-single-product-block'] ) && 'true' == $_POST['is-descendent-of-single-product-block'] ) {
+
+			if ( 'yes' === get_option( 'woocommerce_cart_redirect_after_add' ) ) {
+				return wc_get_cart_url();
+			}
+
 			return wp_validate_redirect( wp_get_referer(), $url );
 		}
 


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What
The Single Product block does not respect the setting under WooCommerce > Settings > Products > General > Add to cart behaviour > Check - Redirect to the cart page after successful addition.

Fixes #10775 

## Why
This PR solves that by checking if the "Redirect to the cart page after successful addition" option was set in the WooCommerce Settings. If that is the case, then we allow the user to be redirected to the cart page after adding the product to the cart.

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

#### Test 1: Redirect shopper to the cart page after successful addition when setting is enabled
1. Enable redirects to the cart page with the setting under WooCommerce > Settings > Products > General > Add to cart behaviour > Check - Redirect to the cart page after successful addition
2. Create a product and a page with an FSE theme.
3. Add the product to the page with the Single Product block.
4. View the page and click "Add to cart". Make sure the shopper is redirected to the Cart page and the product was correctly added to the cart

#### Test 2: Keep shopper at the same page when setting is disabled
1. Enable redirects to the cart page with the setting under WooCommerce > Settings > Products > General > Add to cart behaviour > Check - Redirect to the cart page after successful addition
2. Create a product and a page with an FSE theme.
3. Add the product to the page with the Single Product block.
4. View the page and click "Add to cart". Make sure the shopper is NOT redirected to the Cart page;
5. Visit the Cart page and make sure the product was correctly added to the cart.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Resolved an issue where the Single Product block did not respect the WooCommerce setting for redirecting to the cart page after successful addition. 
