### PR TITLE
Fix: Store Notices block breaks page editors

### DIFF
--- a/src/BlockTypes/StoreNotices.php
+++ b/src/BlockTypes/StoreNotices.php
@@ -26,6 +26,17 @@ class StoreNotices extends AbstractBlock {
 	 * @return string | void Rendered block output.
 	 */
 	protected function render( $attributes, $content, $block ) {
+		/**
+		 * This block should be rendered only on the frontend. Woo loads notice
+		 * functions on the front end requests only. So it's safe and handy to
+		 * check for the print notice function existence to short circuit the
+		 * render process on the admin side.
+		 * See WooCommerce::is_request() for the frontend request definition.
+		 */
+		if ( ! function_exists( 'wc_print_notices' ) ) {
+			return $content;
+		}
+
 		ob_start();
 		woocommerce_output_all_notices();
 		$notices = ob_get_clean();


### PR DESCRIPTION

<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

This PR fixes the issue when Store Notices block is added outside the WooCommerce pages.

Fixes #11163 

## Why

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

The WC notice functions are only loaded for frontend requests. That makes the Editor broken when the Store Notices block is added to the page editor. This PR fixes that issue by checking for the existence of the notice function before using it.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Edit a page.
2. Add the Store Notices Block.
3. Try Saving the page.
4. See no error. The page is saved successfully.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|    <img width="957" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/5423135/c2a23518-5ccc-4aee-969c-311c58aa2eaf">    |   <img width="953" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/5423135/7c380762-7ca1-466d-a03a-8e6c2a3682f1">    |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Fix: Store Notices block breaks page editors