### PR TITLE
Condensed Address Form Implementation

### DIFF
--- a/assets/css/abstracts/_colors.scss
+++ b/assets/css/abstracts/_colors.scss
@@ -17,4 +17,5 @@ $select-item-dark: rgba(0, 0, 0, 0.4);
 $image-placeholder-border-color: #f2f2f2;
 
 // Universal colors for use on the frontend, currently being applied to checkout blocks.
-$universal-border-light: rgba(17, 17, 17, 0.115); // e7e7e7 on white
+$universal-border: rgba(17, 17, 17, 0.3); // Used for form step borders.
+$universal-border-light: rgba(17, 17, 17, 0.115); // e7e7e7 on white.

--- a/assets/js/base/components/cart-checkout/form-step/style.scss
+++ b/assets/js/base/components/cart-checkout/form-step/style.scss
@@ -96,8 +96,7 @@
 	.wc-block-components-checkout-step__container::after {
 		content: "";
 		height: 100%;
-		border-left: 1px solid;
-		opacity: 0.3;
+		border-left: 1px solid $universal-border;
 		position: absolute;
 		left: -$gap-large;
 		top: 0;

--- a/assets/js/blocks/checkout/address-card/index.tsx
+++ b/assets/js/blocks/checkout/address-card/index.tsx
@@ -1,0 +1,83 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Icon } from '@wordpress/icons';
+import { ALLOWED_COUNTRIES } from '@woocommerce/block-settings';
+import type {
+	CartShippingAddress,
+	CartBillingAddress,
+} from '@woocommerce/types';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+const AddressCard = ( {
+	address,
+	onEdit,
+	target,
+	icon: IconComponent,
+}: {
+	address: CartShippingAddress | CartBillingAddress;
+	onEdit: () => void;
+	target: string;
+	icon: JSX.Element;
+} ): JSX.Element | null => {
+	return (
+		<div className="wc-block-components-address-card">
+			<Icon
+				icon={ IconComponent }
+				className="wc-block-components-address-card__icon"
+			/>
+			<address>
+				<span className="wc-block-components-address-card__address-section">
+					{ address.first_name + ' ' + address.last_name }
+				</span>
+				<div className="wc-block-components-address-card__address-section">
+					{ [
+						address.address_1,
+						address.address_2,
+						address.city,
+						address.state,
+						address.postcode,
+						ALLOWED_COUNTRIES[ address.country ]
+							? ALLOWED_COUNTRIES[ address.country ]
+							: address.country,
+					]
+						.filter( ( field ) => !! field )
+						.map( ( field, index ) => (
+							<span key={ `address-` + index }>{ field }</span>
+						) ) }
+				</div>
+				{ address.phone ? (
+					<div
+						key={ `address-phone` }
+						className="wc-block-components-address-card__address-section"
+					>
+						{ address.phone }
+					</div>
+				) : (
+					''
+				) }
+			</address>
+			{ onEdit && (
+				<a
+					role="button"
+					href={ '#' + target }
+					className="wc-block-components-address-card__edit"
+					aria-label={ __(
+						'Change address',
+						'woo-gutenberg-products-block'
+					) }
+					onClick={ onEdit }
+				>
+					{ __( 'Change', 'woo-gutenberg-products-block' ) }
+				</a>
+			) }
+		</div>
+	);
+};
+
+export default AddressCard;

--- a/assets/js/blocks/checkout/address-card/index.tsx
+++ b/assets/js/blocks/checkout/address-card/index.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Icon } from '@wordpress/icons';
 import { ALLOWED_COUNTRIES } from '@woocommerce/block-settings';
 import type {
 	CartShippingAddress,
@@ -18,19 +17,13 @@ const AddressCard = ( {
 	address,
 	onEdit,
 	target,
-	icon: IconComponent,
 }: {
 	address: CartShippingAddress | CartBillingAddress;
 	onEdit: () => void;
 	target: string;
-	icon: JSX.Element;
 } ): JSX.Element | null => {
 	return (
 		<div className="wc-block-components-address-card">
-			<Icon
-				icon={ IconComponent }
-				className="wc-block-components-address-card__icon"
-			/>
 			<address>
 				<span className="wc-block-components-address-card__address-section">
 					{ address.first_name + ' ' + address.last_name }
@@ -68,12 +61,15 @@ const AddressCard = ( {
 					href={ '#' + target }
 					className="wc-block-components-address-card__edit"
 					aria-label={ __(
-						'Change address',
+						'Edit address',
 						'woo-gutenberg-products-block'
 					) }
-					onClick={ onEdit }
+					onClick={ ( e ) => {
+						onEdit();
+						e.preventDefault();
+					} }
 				>
-					{ __( 'Change', 'woo-gutenberg-products-block' ) }
+					{ __( 'Edit', 'woo-gutenberg-products-block' ) }
 				</a>
 			) }
 		</div>

--- a/assets/js/blocks/checkout/address-card/style.scss
+++ b/assets/js/blocks/checkout/address-card/style.scss
@@ -1,0 +1,48 @@
+.wc-block-components-address-card {
+	border: 1px solid $form-step-border;
+	font-size: 0.875em;
+	padding: em($gap-small);
+	margin: 0;
+	border-radius: 4px;
+	display: flex;
+	justify-content: flex-start;
+	align-items: flex-start;
+
+	.has-dark-controls & {
+		border-color: $form-step-border-dark;
+	}
+
+	address {
+		margin: 0;
+		font-style: normal;
+		color: $gray-700;
+
+		.wc-block-components-address-card__address-section {
+			display: block;
+			margin: 0 0 2px 0;
+			span {
+				display: inline-block;
+				padding: 0 4px 0 0;
+				&::after {
+					content: ", ";
+				}
+				&:last-child::after {
+					content: "";
+				}
+			}
+			&:last-child {
+				margin-bottom: 0;
+			}
+		}
+	}
+}
+.wc-block-components-address-card__icon {
+	width: 1em;
+	font-size: 2em;
+	margin: 0 0.15em 0 -0.1em;
+	position: relative;
+	vertical-align: top;
+}
+.wc-block-components-address-card__edit {
+	margin: 0 0 0 auto;
+}

--- a/assets/js/blocks/checkout/address-card/style.scss
+++ b/assets/js/blocks/checkout/address-card/style.scss
@@ -1,7 +1,7 @@
 .wc-block-components-address-card {
-	border: 1px solid $universal-border-light;
-	font-size: 0.875em;
-	padding: em($gap-small);
+	border: 1px solid $universal-border;
+	@include font-size(regular);
+	padding: $gap;
 	margin: 0;
 	border-radius: 4px;
 	display: flex;
@@ -11,7 +11,6 @@
 	address {
 		margin: 0;
 		font-style: normal;
-		color: $gray-700;
 
 		.wc-block-components-address-card__address-section {
 			display: block;
@@ -29,16 +28,14 @@
 			&:last-child {
 				margin-bottom: 0;
 			}
+			&:first-child {
+				font-weight: bold;
+			}
 		}
 	}
 }
-.wc-block-components-address-card__icon {
-	width: 1em;
-	font-size: 2em;
-	margin: 0 0.15em 0 -0.1em;
-	position: relative;
-	vertical-align: top;
-}
 .wc-block-components-address-card__edit {
 	margin: 0 0 0 auto;
+	text-decoration: none;
+	@include font-size(small);
 }

--- a/assets/js/blocks/checkout/address-card/style.scss
+++ b/assets/js/blocks/checkout/address-card/style.scss
@@ -1,5 +1,5 @@
 .wc-block-components-address-card {
-	border: 1px solid $form-step-border;
+	border: 1px solid $universal-border-light;
 	font-size: 0.875em;
 	padding: em($gap-small);
 	margin: 0;
@@ -7,10 +7,6 @@
 	display: flex;
 	justify-content: flex-start;
 	align-items: flex-start;
-
-	.has-dark-controls & {
-		border-color: $form-step-border-dark;
-	}
 
 	address {
 		margin: 0;

--- a/assets/js/blocks/checkout/address-wrapper/index.tsx
+++ b/assets/js/blocks/checkout/address-wrapper/index.tsx
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import { CSSTransition, TransitionGroup } from 'react-transition-group';
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+export const AddressWrapper = ( {
+	isEditing = false,
+	addressCard,
+	addressForm,
+}: {
+	isEditing: boolean;
+	addressCard: () => JSX.Element;
+	addressForm: () => JSX.Element;
+} ): JSX.Element | null => {
+	return (
+		<TransitionGroup className="address-fade-transition-wrapper">
+			{ ! isEditing && (
+				<CSSTransition
+					timeout={ 300 }
+					classNames="address-fade-transition"
+				>
+					{ addressCard() }
+				</CSSTransition>
+			) }
+			{ isEditing && (
+				<CSSTransition
+					timeout={ 300 }
+					classNames="address-fade-transition"
+				>
+					{ addressForm() }
+				</CSSTransition>
+			) }
+		</TransitionGroup>
+	);
+};
+
+export default AddressWrapper;

--- a/assets/js/blocks/checkout/address-wrapper/style.scss
+++ b/assets/js/blocks/checkout/address-wrapper/style.scss
@@ -1,0 +1,25 @@
+.address-fade-transition-wrapper {
+	position: relative;
+}
+.address-fade-transition-enter {
+	opacity: 0;
+}
+.address-fade-transition-enter-active {
+	opacity: 1;
+	transition: opacity 300ms ease-in;
+}
+.address-fade-transition-enter-done {
+	opacity: 1;
+}
+.address-fade-transition-exit {
+	opacity: 1;
+	position: absolute;
+	top: 0;
+}
+.address-fade-transition-exit-active {
+	opacity: 0;
+	transition: opacity 300ms ease-out;
+}
+.address-fade-transition-done {
+	opacity: 0;
+}

--- a/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/customer-address.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/customer-address.tsx
@@ -1,0 +1,114 @@
+/**
+ * External dependencies
+ */
+import { useState, useCallback } from '@wordpress/element';
+import { AddressForm } from '@woocommerce/base-components/cart-checkout';
+import { useCheckoutAddress, useStoreEvents } from '@woocommerce/base-context';
+import { receipt } from '@wordpress/icons';
+import type {
+	BillingAddress,
+	AddressField,
+	AddressFields,
+} from '@woocommerce/settings';
+
+/**
+ * Internal dependencies
+ */
+import PhoneNumber from '../../phone-number';
+import AddressCard from '../../address-card';
+
+const CustomerAddress = ( {
+	addressFieldsConfig,
+	showPhoneField,
+	requirePhoneField,
+	hasAddress,
+	forceEditing = false,
+}: {
+	addressFieldsConfig: Record< keyof AddressFields, Partial< AddressField > >;
+	showPhoneField: boolean;
+	requirePhoneField: boolean;
+	hasAddress: boolean;
+	forceEditing?: boolean;
+} ) => {
+	const {
+		defaultAddressFields,
+		billingAddress,
+		setShippingAddress,
+		setBillingAddress,
+		setBillingPhone,
+		setShippingPhone,
+		useBillingAsShipping,
+	} = useCheckoutAddress();
+	const { dispatchCheckoutEvent } = useStoreEvents();
+
+	const [ editing, setEditing ] = useState( ! hasAddress || forceEditing );
+	const addressFieldKeys = Object.keys(
+		defaultAddressFields
+	) as ( keyof AddressFields )[];
+
+	const onChangeAddress = useCallback(
+		( values: Partial< BillingAddress > ) => {
+			setBillingAddress( values );
+			if ( useBillingAsShipping ) {
+				setShippingAddress( values );
+				dispatchCheckoutEvent( 'set-shipping-address' );
+			}
+			dispatchCheckoutEvent( 'set-billing-address' );
+		},
+		[
+			dispatchCheckoutEvent,
+			setBillingAddress,
+			setShippingAddress,
+			useBillingAsShipping,
+		]
+	);
+
+	return (
+		<>
+			{ hasAddress && ! editing && (
+				<AddressCard
+					address={ billingAddress }
+					target="billing"
+					onEdit={ () => {
+						setEditing( true );
+					} }
+					icon={ receipt }
+				/>
+			) }
+			{ ( editing || ! hasAddress ) && (
+				<>
+					<AddressForm
+						id="billing"
+						type="billing"
+						onChange={ onChangeAddress }
+						values={ billingAddress }
+						fields={ addressFieldKeys }
+						fieldConfig={ addressFieldsConfig }
+					/>
+					{ showPhoneField && (
+						<PhoneNumber
+							id="billing-phone"
+							errorId={ 'billing_phone' }
+							isRequired={ requirePhoneField }
+							value={ billingAddress.phone }
+							onChange={ ( value ) => {
+								setBillingPhone( value );
+								dispatchCheckoutEvent( 'set-phone-number', {
+									step: 'shipping',
+								} );
+								if ( useBillingAsShipping ) {
+									setShippingPhone( value );
+									dispatchCheckoutEvent( 'set-phone-number', {
+										step: 'shipping',
+									} );
+								}
+							} }
+						/>
+					) }
+				</>
+			) }
+		</>
+	);
+};
+
+export default CustomerAddress;

--- a/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/frontend.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/frontend.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { useRef } from '@wordpress/element';
+import { useRef, useEffect } from '@wordpress/element';
 import { withFilteredAttributes } from '@woocommerce/shared-hocs';
 import { FormStep } from '@woocommerce/base-components/cart-checkout';
 import { useCheckoutAddress } from '@woocommerce/base-context/hooks';
@@ -51,7 +51,13 @@ const FrontendBlock = ( {
 	} = useCheckoutAddress();
 
 	// If initial state was true, force editing to true so address fields are visible if the useShippingAsBilling option is unchecked.
-	const initialUseShippingAsBilling = useRef( useShippingAsBilling );
+	const toggledUseShippingAsBilling = useRef( useShippingAsBilling );
+
+	useEffect( () => {
+		if ( useShippingAsBilling ) {
+			toggledUseShippingAsBilling.current = true;
+		}
+	}, [ useShippingAsBilling ] );
 
 	if ( ! showBillingFields && ! useBillingAsShipping ) {
 		return null;
@@ -80,7 +86,7 @@ const FrontendBlock = ( {
 				showCompanyField={ showCompanyField }
 				showPhoneField={ showPhoneField }
 				requirePhoneField={ requirePhoneField }
-				forceEditing={ initialUseShippingAsBilling.current }
+				forceEditing={ toggledUseShippingAsBilling.current }
 			/>
 			{ children }
 		</FormStep>

--- a/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/frontend.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/frontend.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import { useRef } from '@wordpress/element';
 import { withFilteredAttributes } from '@woocommerce/shared-hocs';
 import { FormStep } from '@woocommerce/base-components/cart-checkout';
 import { useCheckoutAddress } from '@woocommerce/base-context/hooks';
@@ -42,12 +43,20 @@ const FrontendBlock = ( {
 		showCompanyField,
 		showPhoneField,
 	} = useCheckoutBlockContext();
-	const { showBillingFields, forcedBillingAddress, useBillingAsShipping } =
-		useCheckoutAddress();
+	const {
+		showBillingFields,
+		forcedBillingAddress,
+		useBillingAsShipping,
+		useShippingAsBilling,
+	} = useCheckoutAddress();
+
+	// If initial state was true, force editing to true so address fields are visible if the useShippingAsBilling option is unchecked.
+	const initialUseShippingAsBilling = useRef( useShippingAsBilling );
 
 	if ( ! showBillingFields && ! useBillingAsShipping ) {
 		return null;
 	}
+
 	title = getBillingAddresssBlockTitle( title, forcedBillingAddress );
 	description = getBillingAddresssBlockDescription(
 		description,
@@ -71,6 +80,7 @@ const FrontendBlock = ( {
 				showCompanyField={ showCompanyField }
 				showPhoneField={ showPhoneField }
 				requirePhoneField={ requirePhoneField }
+				forceEditing={ initialUseShippingAsBilling.current }
 			/>
 			{ children }
 		</FormStep>

--- a/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/block.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/block.tsx
@@ -2,17 +2,10 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import {
-	useMemo,
-	useEffect,
-	Fragment,
-	useState,
-	useCallback,
-} from '@wordpress/element';
-import { AddressForm } from '@woocommerce/base-components/cart-checkout';
+import { useMemo, Fragment } from '@wordpress/element';
+import { useEffectOnce } from 'usehooks-ts';
 import {
 	useCheckoutAddress,
-	useStoreEvents,
 	useEditorContext,
 	noticeContexts,
 } from '@woocommerce/base-context';
@@ -23,7 +16,6 @@ import {
 import Noninteractive from '@woocommerce/base-components/noninteractive';
 import type {
 	BillingAddress,
-	ShippingAddress,
 	AddressField,
 	AddressFields,
 } from '@woocommerce/settings';
@@ -31,7 +23,7 @@ import type {
 /**
  * Internal dependencies
  */
-import PhoneNumber from '../../phone-number';
+import CustomerAddress from './customer-address';
 
 const Block = ( {
 	showCompanyField = false,
@@ -47,52 +39,33 @@ const Block = ( {
 	requirePhoneField: boolean;
 } ): JSX.Element => {
 	const {
-		defaultAddressFields,
-		setShippingAddress,
 		setBillingAddress,
 		shippingAddress,
 		billingAddress,
-		setShippingPhone,
 		useShippingAsBilling,
 		setUseShippingAsBilling,
 	} = useCheckoutAddress();
-	const { dispatchCheckoutEvent } = useStoreEvents();
 	const { isEditor } = useEditorContext();
 
-	const { email } = billingAddress;
-	// This is used to track whether the "Use shipping as billing" checkbox was checked on first load and if we synced
-	// the shipping address to the billing address if it was. This is not used on further toggles of the checkbox.
-	const [ addressesSynced, setAddressesSynced ] = useState( false );
+	// Syncs the billing address with the shipping address.
+	const syncBillingWithShipping = () => {
+		setBillingAddress( {
+			...shippingAddress,
+			email: billingAddress.email,
+			phone: showPhoneField
+				? shippingAddress.phone
+				: billingAddress.phone,
+		} as BillingAddress );
+	};
 
-	// Clears data if fields are hidden.
-	useEffect( () => {
-		if ( ! showPhoneField ) {
-			setShippingPhone( '' );
+	// Run this on first render to ensure addresses sync if needed (this is not re-ran when toggling the checkbox).
+	useEffectOnce( () => {
+		if ( useShippingAsBilling ) {
+			syncBillingWithShipping();
 		}
-	}, [ showPhoneField, setShippingPhone ] );
+	} );
 
-	// Run this on first render to ensure addresses sync if needed, there is no need to re-run this when toggling the
-	// checkbox.
-	useEffect(
-		() => {
-			if ( addressesSynced ) {
-				return;
-			}
-			if ( useShippingAsBilling ) {
-				setBillingAddress( { ...shippingAddress, email } );
-			}
-			setAddressesSynced( true );
-		},
-		// Skip the `email` dependency since we don't want to re-run if that changes, but we do want to sync it on first render.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-		[
-			addressesSynced,
-			setBillingAddress,
-			shippingAddress,
-			useShippingAsBilling,
-		]
-	);
-
+	// Create address fields config from block attributes.
 	const addressFieldsConfig = useMemo( () => {
 		return {
 			company: {
@@ -109,74 +82,42 @@ const Block = ( {
 		showApartmentField,
 	] ) as Record< keyof AddressFields, Partial< AddressField > >;
 
-	const onChangeAddress = useCallback(
-		( values: Partial< ShippingAddress > ) => {
-			setShippingAddress( values );
-			if ( useShippingAsBilling ) {
-				setBillingAddress( { ...values, email } );
-				dispatchCheckoutEvent( 'set-billing-address' );
-			}
-			dispatchCheckoutEvent( 'set-shipping-address' );
-		},
-		[
-			dispatchCheckoutEvent,
-			email,
-			setBillingAddress,
-			setShippingAddress,
-			useShippingAsBilling,
-		]
-	);
-
-	const AddressFormWrapperComponent = isEditor ? Noninteractive : Fragment;
+	const WrapperComponent = isEditor ? Noninteractive : Fragment;
 	const noticeContext = useShippingAsBilling
 		? [ noticeContexts.SHIPPING_ADDRESS, noticeContexts.BILLING_ADDRESS ]
 		: [ noticeContexts.SHIPPING_ADDRESS ];
+	const hasAddress = !! (
+		shippingAddress.address_1 &&
+		( shippingAddress.first_name || shippingAddress.last_name )
+	);
 
 	return (
 		<>
-			<AddressFormWrapperComponent>
-				<StoreNoticesContainer context={ noticeContext } />
-				<AddressForm
-					id="shipping"
-					type="shipping"
-					onChange={ onChangeAddress }
-					values={ shippingAddress }
-					fields={
-						Object.keys(
-							defaultAddressFields
-						) as ( keyof AddressFields )[]
-					}
-					fieldConfig={ addressFieldsConfig }
+			<StoreNoticesContainer context={ noticeContext } />
+			<WrapperComponent>
+				<CustomerAddress
+					addressFieldsConfig={ addressFieldsConfig }
+					showPhoneField={ showPhoneField }
+					requirePhoneField={ requirePhoneField }
+					hasAddress={ hasAddress }
 				/>
-				{ showPhoneField && (
-					<PhoneNumber
-						id="shipping-phone"
-						errorId={ 'shipping_phone' }
-						isRequired={ requirePhoneField }
-						value={ shippingAddress.phone }
-						onChange={ ( value ) => {
-							setShippingPhone( value );
-							dispatchCheckoutEvent( 'set-phone-number', {
-								step: 'shipping',
-							} );
-						} }
-					/>
-				) }
-			</AddressFormWrapperComponent>
-			<CheckboxControl
-				className="wc-block-checkout__use-address-for-billing"
-				label={ __(
-					'Use same address for billing',
-					'woo-gutenberg-products-block'
-				) }
-				checked={ useShippingAsBilling }
-				onChange={ ( checked: boolean ) => {
-					setUseShippingAsBilling( checked );
-					if ( checked ) {
-						setBillingAddress( shippingAddress as BillingAddress );
-					}
-				} }
-			/>
+			</WrapperComponent>
+			{ hasAddress && (
+				<CheckboxControl
+					className="wc-block-checkout__use-address-for-billing"
+					label={ __(
+						'Use same address for billing',
+						'woo-gutenberg-products-block'
+					) }
+					checked={ useShippingAsBilling }
+					onChange={ ( checked: boolean ) => {
+						setUseShippingAsBilling( checked );
+						if ( checked ) {
+							syncBillingWithShipping();
+						}
+					} }
+				/>
+			) }
 		</>
 	);
 };

--- a/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/block.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/block.tsx
@@ -41,7 +41,6 @@ const Block = ( {
 	const {
 		setBillingAddress,
 		shippingAddress,
-		billingAddress,
 		useShippingAsBilling,
 		setUseShippingAsBilling,
 	} = useCheckoutAddress();
@@ -49,13 +48,19 @@ const Block = ( {
 
 	// Syncs the billing address with the shipping address.
 	const syncBillingWithShipping = () => {
-		setBillingAddress( {
+		const syncValues: Partial< BillingAddress > = {
 			...shippingAddress,
-			email: billingAddress.email,
-			phone: showPhoneField
-				? shippingAddress.phone
-				: billingAddress.phone,
-		} as BillingAddress );
+		};
+
+		if ( ! showPhoneField ) {
+			delete syncValues.phone;
+		}
+
+		if ( showCompanyField ) {
+			delete syncValues.company;
+		}
+
+		setBillingAddress( syncValues );
 	};
 
 	// Run this on first render to ensure addresses sync if needed (this is not re-ran when toggling the checkbox).

--- a/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/customer-address.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/customer-address.tsx
@@ -1,0 +1,113 @@
+/**
+ * External dependencies
+ */
+import { useState, useCallback } from '@wordpress/element';
+import { AddressForm } from '@woocommerce/base-components/cart-checkout';
+import { useCheckoutAddress, useStoreEvents } from '@woocommerce/base-context';
+import { home } from '@wordpress/icons';
+import type {
+	ShippingAddress,
+	AddressField,
+	AddressFields,
+} from '@woocommerce/settings';
+
+/**
+ * Internal dependencies
+ */
+import PhoneNumber from '../../phone-number';
+import AddressCard from '../../address-card';
+
+const CustomerAddress = ( {
+	addressFieldsConfig,
+	showPhoneField,
+	requirePhoneField,
+	hasAddress,
+}: {
+	addressFieldsConfig: Record< keyof AddressFields, Partial< AddressField > >;
+	showPhoneField: boolean;
+	requirePhoneField: boolean;
+	hasAddress: boolean;
+} ) => {
+	const {
+		defaultAddressFields,
+		shippingAddress,
+		setShippingAddress,
+		setBillingAddress,
+		setShippingPhone,
+		useShippingAsBilling,
+	} = useCheckoutAddress();
+	const { dispatchCheckoutEvent } = useStoreEvents();
+
+	const [ editing, setEditing ] = useState( ! hasAddress );
+	const addressFieldKeys = Object.keys(
+		defaultAddressFields
+	) as ( keyof AddressFields )[];
+
+	const onChangeAddress = useCallback(
+		( values: Partial< ShippingAddress > ) => {
+			setShippingAddress( values );
+			if ( useShippingAsBilling ) {
+				// Sync billing with shipping. Ensure unwanted properties are omitted.
+				const { ...syncBilling } = values;
+
+				if ( ! showPhoneField ) {
+					delete syncBilling.phone;
+				}
+
+				setBillingAddress( syncBilling );
+				dispatchCheckoutEvent( 'set-billing-address' );
+			}
+			dispatchCheckoutEvent( 'set-shipping-address' );
+		},
+		[
+			dispatchCheckoutEvent,
+			setBillingAddress,
+			setShippingAddress,
+			useShippingAsBilling,
+			showPhoneField,
+		]
+	);
+
+	return (
+		<>
+			{ hasAddress && ! editing && (
+				<AddressCard
+					address={ shippingAddress }
+					target="shipping"
+					onEdit={ () => {
+						setEditing( true );
+					} }
+					icon={ home }
+				/>
+			) }
+			{ ( editing || ! hasAddress ) && (
+				<>
+					<AddressForm
+						id="shipping"
+						type="shipping"
+						onChange={ onChangeAddress }
+						values={ shippingAddress }
+						fields={ addressFieldKeys }
+						fieldConfig={ addressFieldsConfig }
+					/>
+					{ showPhoneField && (
+						<PhoneNumber
+							id="shipping-phone"
+							errorId={ 'shipping_phone' }
+							isRequired={ requirePhoneField }
+							value={ shippingAddress.phone }
+							onChange={ ( value ) => {
+								setShippingPhone( value );
+								dispatchCheckoutEvent( 'set-phone-number', {
+									step: 'shipping',
+								} );
+							} }
+						/>
+					) }
+				</>
+			) }
+		</>
+	);
+};
+
+export default CustomerAddress;

--- a/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/customer-address.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/customer-address.tsx
@@ -4,7 +4,6 @@
 import { useState, useCallback } from '@wordpress/element';
 import { AddressForm } from '@woocommerce/base-components/cart-checkout';
 import { useCheckoutAddress, useStoreEvents } from '@woocommerce/base-context';
-import { home } from '@wordpress/icons';
 import type {
 	ShippingAddress,
 	AddressField,
@@ -14,6 +13,7 @@ import type {
 /**
  * Internal dependencies
  */
+import AddressWrapper from '../../address-wrapper';
 import PhoneNumber from '../../phone-number';
 import AddressCard from '../../address-card';
 
@@ -68,45 +68,64 @@ const CustomerAddress = ( {
 		]
 	);
 
-	return (
-		<>
-			{ hasAddress && ! editing && (
-				<AddressCard
-					address={ shippingAddress }
-					target="shipping"
-					onEdit={ () => {
-						setEditing( true );
-					} }
-					icon={ home }
+	const renderAddressCardComponent = useCallback(
+		() => (
+			<AddressCard
+				address={ shippingAddress }
+				target="shipping"
+				onEdit={ () => {
+					setEditing( true );
+				} }
+			/>
+		),
+		[ shippingAddress ]
+	);
+
+	const renderAddressFormComponent = useCallback(
+		() => (
+			<>
+				<AddressForm
+					id="shipping"
+					type="shipping"
+					onChange={ onChangeAddress }
+					values={ shippingAddress }
+					fields={ addressFieldKeys }
+					fieldConfig={ addressFieldsConfig }
 				/>
-			) }
-			{ ( editing || ! hasAddress ) && (
-				<>
-					<AddressForm
-						id="shipping"
-						type="shipping"
-						onChange={ onChangeAddress }
-						values={ shippingAddress }
-						fields={ addressFieldKeys }
-						fieldConfig={ addressFieldsConfig }
+				{ showPhoneField && (
+					<PhoneNumber
+						id="shipping-phone"
+						errorId={ 'shipping_phone' }
+						isRequired={ requirePhoneField }
+						value={ shippingAddress.phone }
+						onChange={ ( value ) => {
+							setShippingPhone( value );
+							dispatchCheckoutEvent( 'set-phone-number', {
+								step: 'shipping',
+							} );
+						} }
 					/>
-					{ showPhoneField && (
-						<PhoneNumber
-							id="shipping-phone"
-							errorId={ 'shipping_phone' }
-							isRequired={ requirePhoneField }
-							value={ shippingAddress.phone }
-							onChange={ ( value ) => {
-								setShippingPhone( value );
-								dispatchCheckoutEvent( 'set-phone-number', {
-									step: 'shipping',
-								} );
-							} }
-						/>
-					) }
-				</>
-			) }
-		</>
+				) }
+			</>
+		),
+		[
+			addressFieldKeys,
+			addressFieldsConfig,
+			dispatchCheckoutEvent,
+			onChangeAddress,
+			requirePhoneField,
+			setShippingPhone,
+			shippingAddress,
+			showPhoneField,
+		]
+	);
+
+	return (
+		<AddressWrapper
+			isEditing={ editing }
+			addressCard={ renderAddressCardComponent }
+			addressForm={ renderAddressFormComponent }
+		/>
 	);
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
 				"request": "2.88.2",
 				"trim-html": "0.1.9",
 				"use-debounce": "9.0.4",
+				"usehooks-ts": "^2.9.1",
 				"wordpress-components": "npm:@wordpress/components@14.2.0"
 			},
 			"devDependencies": {
@@ -57730,6 +57731,19 @@
 				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
 			}
 		},
+		"node_modules/usehooks-ts": {
+			"version": "2.9.1",
+			"resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-2.9.1.tgz",
+			"integrity": "sha512-2FAuSIGHlY+apM9FVlj8/oNhd+1y+Uwv5QNkMQz1oSfdHk4PXo1qoCw9I5M7j0vpH8CSWFJwXbVPeYDjLCx9PA==",
+			"engines": {
+				"node": ">=16.15.0",
+				"npm": ">=8"
+			},
+			"peerDependencies": {
+				"react": "^16.8.0  || ^17.0.0 || ^18.0.0",
+				"react-dom": "^16.8.0  || ^17.0.0 || ^18.0.0"
+			}
+		},
 		"node_modules/util": {
 			"version": "0.10.4",
 			"dev": true,
@@ -99532,6 +99546,12 @@
 		"use-sync-external-store": {
 			"version": "1.2.0",
 			"dev": true,
+			"requires": {}
+		},
+		"usehooks-ts": {
+			"version": "2.9.1",
+			"resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-2.9.1.tgz",
+			"integrity": "sha512-2FAuSIGHlY+apM9FVlj8/oNhd+1y+Uwv5QNkMQz1oSfdHk4PXo1qoCw9I5M7j0vpH8CSWFJwXbVPeYDjLCx9PA==",
 			"requires": {}
 		},
 		"util": {

--- a/package.json
+++ b/package.json
@@ -291,6 +291,7 @@
 		"request": "2.88.2",
 		"trim-html": "0.1.9",
 		"use-debounce": "9.0.4",
+		"usehooks-ts": "^2.9.1",
 		"wordpress-components": "npm:@wordpress/components@14.2.0"
 	},
 	"peerDependencies": {

--- a/tests/e2e/tests/checkout/checkout.page.ts
+++ b/tests/e2e/tests/checkout/checkout.page.ts
@@ -125,7 +125,40 @@ export class CheckoutPage {
 		}
 	}
 
+	async editBillingDetails() {
+		const editButton = await this.page
+			.locator(
+				'.wc-block-checkout__billing-fields .wc-block-components-address-card__edit'
+			)
+			.isVisible();
+
+		if ( editButton ) {
+			await this.page
+				.locator(
+					'.wc-block-checkout__billing-fields .wc-block-components-address-card__edit'
+				)
+				.click();
+		}
+	}
+
+	async editShippingDetails() {
+		const editButton = await this.page
+			.locator(
+				'.wc-block-checkout__shipping-fields .wc-block-components-address-card__edit'
+			)
+			.isVisible();
+
+		if ( editButton ) {
+			await this.page
+				.locator(
+					'.wc-block-checkout__shipping-fields .wc-block-components-address-card__edit'
+				)
+				.click();
+		}
+	}
+
 	async fillBillingDetails( customerBillingDetails ) {
+		await this.editBillingDetails();
 		const billingForm = this.page.getByRole( 'group', {
 			name: 'Billing address',
 		} );
@@ -168,6 +201,7 @@ export class CheckoutPage {
 	}
 
 	async fillShippingDetails( customerShippingDetails ) {
+		await this.editShippingDetails();
 		const shippingForm = this.page.getByRole( 'group', {
 			name: 'Shipping address',
 		} );


### PR DESCRIPTION
## What

Introduces condensed address components on the checkout for returning shoppers.

Fixes #9787

## Why

Removes long forms when address data already exists, whilst allowing easy editing during checkout. Tests have been updated to click the "edit" button.

Justification and designs can be found in https://github.com/woocommerce/woocommerce-blocks/issues/9787#issue-1752445790

## Testing Instructions

As a logged out guest customer

1. Add something to cart and then go to checkout
2. Notice the address form is shown
3. Fill out address. Wait for totals to update.
4. Refresh the page. Condensed address component should be visible.

As a logged in user who has checked out before (has an address)

1. Repeat above tests. Condensed address component should be visible upon entry to checkout.
2. Click "edit" on the condensed shipping address. Form should be shown instead.
3. Uncheck "use shipping for billing". Billing address form should be shown.
4. Change some item of billing address data.
5. Refresh the page.
6. Condensed billing address should be shown.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

![Screenshot 2023-10-06 at 17 15 21](https://github.com/woocommerce/woocommerce-blocks/assets/90977/06621207-9ab6-4e75-8b04-e2c8e532971e)

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog

> Introduced condensed address components on checkout for customers with an existing address
