### PR TITLE
Add feature gate for the block templates controller refactor

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -42,8 +42,11 @@ class BlockTemplatesController {
 	public function __construct( Package $package ) {
 		$this->package = $package;
 
+		$feature_gating                                 = $package->feature();
+		$is_block_templates_controller_refactor_enabled = $feature_gating->is_block_templates_controller_refactor_enabled();
+
 		// This feature is gated for WooCommerce versions 6.0.0 and above.
-		if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '6.0.0', '>=' ) ) {
+		if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '6.0.0', '>=' ) && ! $is_block_templates_controller_refactor_enabled ) {
 			$this->init();
 		}
 	}

--- a/src/Domain/Services/FeatureGating.php
+++ b/src/Domain/Services/FeatureGating.php
@@ -172,7 +172,7 @@ class FeatureGating {
 	 */
 	public function is_block_templates_controller_refactor_enabled() {
 		$conf = parse_ini_file( __DIR__ . '/../../../blocks.ini' );
-		return $this->is_development_environment() && true === (bool) $conf['use_block_templates_controller_refactor'];
+		return $this->is_development_environment() && isset( $conf['use_block_templates_controller_refactor'] ) && true === (bool) $conf['use_block_templates_controller_refactor'];
 	}
 
 }

--- a/src/Domain/Services/FeatureGating.php
+++ b/src/Domain/Services/FeatureGating.php
@@ -164,4 +164,15 @@ class FeatureGating {
 		return self::EXPERIMENTAL_FLAG;
 	}
 
+
+	/**
+	 * Check if the block templates controller refactor should be used to display blocks.
+	 *
+	 * @return boolean
+	 */
+	public function is_block_templates_controller_refactor_enabled() {
+		$conf = parse_ini_file( __DIR__ . '/../../../blocks.ini' );
+		return $this->is_development_environment() && true === (bool) $conf['use_block_templates_controller_refactor'];
+	}
+
 }


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

We will work on block templates controller refactor (#10605 ). We are mindful not to disrupt the ongoing workflow for team members who need to work on the existing template while the refactor is in progress. As a result, the new block templates controller will be activated under the following conditions:

- is a development build.
- the blocks.ini file has the `use_block_templates_controller_refactor` flag set to true.

The code that this PR introduced will be removed when the refactor of the block templates controller is terminated (#11180).


## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Ensure that you are using a development build.
2. Introduce some changes to the Single Product template (e.g: adding a paragraph block).
3. Edit the block.ini file, adding the current line: `use_block_templates_controller_refactor = true`.
4. Visit a single product page and ensure that the paragraph block isn't visible. This means that the current BlockTemplatesController isn't loaded.
5. Generate a production build (`npm run build:deploy`).
6. Visit a single product page and ensure that the paragraph block is visible. This means that the current BlockTemplatesController is loaded.


* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Add suggested changelog entry here.
