### PR TITLE
Increase number of visible products when cart is empty

### DIFF
--- a/assets/js/blocks/cart/inner-blocks/empty-cart-block/edit.tsx
+++ b/assets/js/blocks/cart/inner-blocks/empty-cart-block/edit.tsx
@@ -65,7 +65,7 @@ const defaultTemplate = [
 	[
 		'woocommerce/product-new',
 		{
-			columns: 3,
+			columns: 4,
 			rows: 1,
 		},
 	],


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Increase the number of visible products when the cart is empty.

Fixes #11058

## Why

While the Twenty Twenty-Three theme sets `.alignwide` to `1200px`, which renders the product images in a width of `450px`, the Twenty Twenty-Four theme sets `.alignwide` to `1280px` rendering the product images in a width of `300px`. This leads to gaps between the product images and causes the sales badge to be visible next to the product image instead of within it. 

In p1696841688418399-slack-C02UBB1EPEF, @gigitux and @kmanijak suggested using the Product Collection block instead of the Newest Products block, which is showing the issue. Apart from addressing the initial issue, and alternative approach would be to increase the number of visible products, when the cart is empty, from three to four. This reduces the gap between the product images, resulting in the sales badge showing as expected. As the Product Collection block is still in beta, and we would rather not relocate resources to the Newest Products block, given that this block might be deprecated in the future. In pca54o-6sH-p2#comment-5830, @pmcpinto and I agreed on increasing the number of visible products. This change will only affect new installations, but not existing stores.

## Testing Instructions

1. Create a testing site using [WordPress 6.4 Beta 2](https://wordpress.org/news/2023/10/wordpress-6-4-beta-2/).
2. Ensure that you are using the Twenty Twenty-Four theme.
3. Ensure that you have at least four products of which at least one of the most recent ones has a discounted price.
4. Create a test page and add the Cart block to it.
5. Switch the view from `Filled Cart` to `Empty Cart`.
6. Verify that four products are visible and that the sales badge is shown within the product image.
7. Go to the frontend.
8. Do not add a product to the cart and go directly to the test page with the cart block.
9. Verify that four products are visible and that the sales badge is shown within the product image.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<table>
<tr>
<td>Before:
<br><br>

<img width="1279" alt="Screenshot 2023-10-09 at 20 05 46" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/1c633575-b2ea-4389-9e87-fc98b014407a">

</td>
<td>After:
<br><br>

<img width="1280" alt="Screenshot 2023-10-09 at 20 00 50" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/58178674-6cfa-49e3-8172-95566bb192cc">

</td>
</tr>
</table>

> **Note**
> Depending on the screen size, the sales badge might overlap or be visible next to the product image.

## WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog

> Ensure that the sales badge is rendered within the product image when using the Twenty Twenty-Four theme and the cart is empty.