### PR TITLE
Recognise template parts after theme switch

### DIFF
--- a/templates/templates/blockified/order-confirmation.html
+++ b/templates/templates/blockified/order-confirmation.html
@@ -1,7 +1,9 @@
-<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
 <!-- wp:group {"tagName": "main", "layout":{"inherit":true,"type":"constrained"}} -->
 <main class="wp-block-group">
 	<!-- wp:woocommerce/legacy-template {"template":"order-confirmation"} /-->
 </main>
 <!-- /wp:group -->
-<!-- wp:template-part {"slug":"footer"} /-->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/templates/templates/order-confirmation.html
+++ b/templates/templates/order-confirmation.html
@@ -1,7 +1,9 @@
-<!-- wp:template-part {"slug":"header"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header"} /-->
+
 <!-- wp:group {"tagName": "main", "layout":{"inherit":true,"type":"constrained"}} -->
 <main class="wp-block-group">
 	<!-- wp:woocommerce/legacy-template {"template":"order-confirmation"} /-->
 </main>
 <!-- /wp:group -->
-<!-- wp:template-part {"slug":"footer"} /-->
+
+<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->


### PR DESCRIPTION
## What

Ensure consistent recognition of header and footer template parts in the Order Confirmation template when switching themes.

Fixes #11106 

## Why

In the current setup, blockifying the Order Confirmation template locks in the name of the active theme, e.g. `twentytwentyfour`, for its header and footer template parts. Upon switching themes, these template parts fail to load as they search for the initially set theme's header and footer, causing a mismatch.

## Testing Instructions

1. Install [WordPress 6.4 Beta 1](https://wordpress.org/news/2023/09/wordpress-6-4-beta-1/).
2. Ensure that the Twenty Twenty-Four theme is active.
3. Go to `WP Admin » Appearance » Editor » Templates » Order Confirmation`.
4. Open the template, click on it, press the button `Transform into blocks` and save the template.
5. Switch to the Twenty Twenty-Three theme. 
6. Verify that both the header and the footer templates are loading.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<table>
<tr>
<td>Before:
<br><br>
<img width="1441" alt="Screenshot 2023-10-10 at 13 25 05" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/bfacbee0-de94-4061-adf6-f0f041673d0b">
</td>
<td>After:
<br><br>
<img width="1441" alt="Screenshot 2023-10-10 at 13 26 19" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/fbe33646-d545-41e1-b73e-7e8fd881c1ae">
</td>
</tr>
</table>

## WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog

> Fixed loader issue for header and footer template parts in Order Confirmation template after theme switch.