### PR TITLE
Add universal border radius for form elements and components

### DIFF
--- a/assets/css/abstracts/_variables.scss
+++ b/assets/css/abstracts/_variables.scss
@@ -8,3 +8,6 @@ $gap:          2 * $grid-unit;		// 16px
 $gap-small:    1.5 * $grid-unit;	// 12px
 $gap-smaller:  1 * $grid-unit;		// 8px
 $gap-smallest: 0.5 * $grid-unit;	// 4px
+
+// Standard border radius for forms.
+$universal-border-radius: 4px;

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -146,7 +146,7 @@
 	display: inline-block;
 	width: auto;
 	border: 1px solid #43454b;
-	border-radius: 3px;
+	border-radius: $universal-border-radius;
 	color: #43454b;
 	background: #fff;
 	text-align: center;

--- a/assets/js/atomic/blocks/product-elements/add-to-cart/style.scss
+++ b/assets/js/atomic/blocks/product-elements/add-to-cart/style.scss
@@ -25,7 +25,7 @@
 		padding: 0.618em;
 		background: $white;
 		border: 1px solid #ccc;
-		border-radius: 2px;
+		border-radius: $universal-border-radius;
 		color: #43454b;
 		box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.125);
 		text-align: center;

--- a/assets/js/atomic/blocks/product-elements/product-details/style.scss
+++ b/assets/js/atomic/blocks/product-elements/product-details/style.scss
@@ -12,7 +12,7 @@
 			display: inline-block;
 			position: relative;
 			z-index: 0;
-			border-radius: 4px 4px 0 0;
+			border-radius: $universal-border-radius $universal-border-radius 0 0;
 			margin: 0;
 			padding: 0.5em 1em;
 

--- a/assets/js/atomic/blocks/product-elements/sale-badge/style.scss
+++ b/assets/js/atomic/blocks/product-elements/sale-badge/style.scss
@@ -9,7 +9,7 @@
 	display: inline-block;
 	width: fit-content;
 	border: 1px solid #43454b;
-	border-radius: 3px;
+	border-radius: $universal-border-radius;
 	box-sizing: border-box;
 	color: #43454b;
 	background: #fff;

--- a/assets/js/base/components/cart-checkout/product-badge/style.scss
+++ b/assets/js/base/components/cart-checkout/product-badge/style.scss
@@ -1,6 +1,6 @@
 .wc-block-components-product-badge {
 	@include font-size(smaller);
-	border-radius: 2px;
+	border-radius: $universal-border-radius;
 	border: 1px solid;
 	display: inline-block;
 	font-weight: 600;

--- a/assets/js/base/components/combobox/style.scss
+++ b/assets/js/base/components/combobox/style.scss
@@ -34,7 +34,7 @@
 			white-space: nowrap;
 			width: 100%;
 			opacity: initial;
-			border-radius: 4px;
+			border-radius: $universal-border-radius;
 
 			&[aria-expanded="true"],
 			&:focus {

--- a/assets/js/base/components/combobox/style.scss
+++ b/assets/js/base/components/combobox/style.scss
@@ -73,6 +73,8 @@
 			min-width: 100%;
 			overflow: auto;
 			color: $input-text-active;
+			border-bottom-left-radius: $universal-border-radius;
+			border-bottom-right-radius: $universal-border-radius;
 
 			.has-dark-controls & {
 				background-color: $select-dropdown-dark;

--- a/assets/js/base/components/notice-banner/style.scss
+++ b/assets/js/base/components/notice-banner/style.scss
@@ -6,7 +6,7 @@
 	padding: $gap !important;
 	gap: $gap-small;
 	margin: $gap 0;
-	border-radius: 4px;
+	border-radius: $universal-border-radius;
 	border-color: $gray-800;
 	font-weight: 400;
 	line-height: 1.5;

--- a/assets/js/base/components/quantity-selector/style.scss
+++ b/assets/js/base/components/quantity-selector/style.scss
@@ -12,7 +12,7 @@
 }
 
 .wc-block-components-quantity-selector {
-	border-radius: 4px;
+	border-radius: $universal-border-radius;
 	// needed so that buttons fill the container.
 	box-sizing: content-box;
 	display: flex;
@@ -21,7 +21,7 @@
 	width: 107px;
 
 	&::after {
-		border-radius: 4px;
+		border-radius: $universal-border-radius;
 		border: 1px solid currentColor;
 		bottom: 0;
 		content: "";
@@ -89,12 +89,12 @@
 	}
 
 	> .wc-block-components-quantity-selector__button--minus {
-		border-radius: 4px 0 0 4px;
+		border-radius: $universal-border-radius 0 0 $universal-border-radius;
 		order: 1;
 	}
 
 	> .wc-block-components-quantity-selector__button--plus {
-		border-radius: 0 4px 4px 0;
+		border-radius: 0 $universal-border-radius $universal-border-radius 0;
 		order: 3;
 	}
 }

--- a/assets/js/base/components/skeleton/style.scss
+++ b/assets/js/base/components/skeleton/style.scss
@@ -11,7 +11,7 @@
 	width: 100%;
 	position: relative;
 	background: $universal-border-light;
-	border-radius: 2px;
+	border-radius: $universal-border-radius;
 
 	&:last-child {
 		width: 80%;

--- a/assets/js/base/components/textarea/style.scss
+++ b/assets/js/base/components/textarea/style.scss
@@ -2,7 +2,7 @@
 	@include font-size(regular);
 	background-color: #fff;
 	border: 1px solid $input-border-gray;
-	border-radius: 4px;
+	border-radius: $universal-border-radius;
 	color: $input-text-active;
 	font-family: inherit;
 	line-height: 1.375; // =22px when font-size is 16px.

--- a/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment/style.scss
+++ b/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment/style.scss
@@ -1,5 +1,4 @@
 $border-width: 1px;
-$border-radius: 5px;
 
 .wc-block-components-express-payment {
 	margin: auto;
@@ -26,7 +25,7 @@ $border-radius: 5px;
 
 .wc-block-components-express-payment--checkout {
 	/* stylelint-disable-next-line function-calc-no-unspaced-operator */
-	margin-top: calc($border-radius * 3);
+	margin-top: calc($universal-border-radius * 3);
 
 	.wc-block-components-express-payment__event-buttons {
 		list-style: none;
@@ -45,17 +44,17 @@ $border-radius: 5px;
 		left: 0;
 		position: absolute;
 		right: 0;
-		top: -$border-radius;
+		top: -$universal-border-radius;
 		vertical-align: middle;
 
 		// Pseudo-elements used to show the border before and after the title.
 		&::before {
 			border-left: $border-width solid currentColor;
 			border-top: $border-width solid currentColor;
-			border-radius: $border-radius 0 0 0;
+			border-radius: $universal-border-radius 0 0 0;
 			content: "";
 			display: block;
-			height: $border-radius - $border-width;
+			height: $universal-border-radius - $border-width;
 			margin-right: $gap-small;
 			opacity: 0.3;
 			pointer-events: none;
@@ -65,10 +64,10 @@ $border-radius: 5px;
 		&::after {
 			border-right: $border-width solid currentColor;
 			border-top: $border-width solid currentColor;
-			border-radius: 0 $border-radius 0 0;
+			border-radius: 0 $universal-border-radius 0 0;
 			content: "";
 			display: block;
-			height: $border-radius - $border-width;
+			height: $universal-border-radius - $border-width;
 			margin-left: $gap-small;
 			opacity: 0.3;
 			pointer-events: none;
@@ -83,10 +82,10 @@ $border-radius: 5px;
 
 	.wc-block-components-express-payment__content {
 		@include with-translucent-border(0 $border-width $border-width);
-		padding: #{$gap-large - $border-radius} $gap-large $gap-large;
+		padding: #{$gap-large - $universal-border-radius} $gap-large $gap-large;
 
 		&::after {
-			border-radius: 0 0 $border-radius $border-radius;
+			border-radius: 0 0 $universal-border-radius $universal-border-radius;
 		}
 
 		> p {

--- a/assets/js/blocks/cart-checkout-shared/payment-methods/style.scss
+++ b/assets/js/blocks/cart-checkout-shared/payment-methods/style.scss
@@ -39,7 +39,7 @@
 		line-height: 1.375; // =22px when font-size is 16px.
 		background-color: #fff;
 		padding: em($gap-small) 0 em($gap-small) $gap;
-		border-radius: 4px;
+		border-radius: $universal-border-radius;
 		border: 1px solid $input-border-gray;
 		width: 100%;
 		font-family: inherit;
@@ -199,6 +199,16 @@
 	.wc-block-components-radio-control-accordion-option,
 	.wc-block-components-radio-control__option {
 		@include with-translucent-border(1px 1px 0 1px);
+	}
+
+	.wc-block-components-radio-control-accordion-option:first-child::after {
+		border-top-left-radius: $universal-border-radius;
+		border-top-right-radius: $universal-border-radius;
+	}
+
+	.wc-block-components-radio-control-accordion-option:last-child::after {
+		border-bottom-left-radius: $universal-border-radius;
+		border-bottom-right-radius: $universal-border-radius;
 	}
 
 	.wc-block-components-radio-control__option:last-child::after,

--- a/assets/js/blocks/checkout/address-card/style.scss
+++ b/assets/js/blocks/checkout/address-card/style.scss
@@ -3,7 +3,7 @@
 	@include font-size(regular);
 	padding: $gap;
 	margin: 0;
-	border-radius: 4px;
+	border-radius: $universal-border-radius;
 	display: flex;
 	justify-content: flex-start;
 	align-items: flex-start;

--- a/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/style.scss
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-pickup-options-block/style.scss
@@ -42,7 +42,7 @@
 		width: 100%;
 		box-sizing: border-box;
 		background-color: $gray-100;
-		border-radius: 4px;
+		border-radius: $universal-border-radius;
 		padding: 1px em($gap-small);
 		margin-top: em($gap-smaller);
 		@include font-size(regular);

--- a/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/style.scss
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-shipping-method-block/style.scss
@@ -22,7 +22,7 @@
 	border: none;
 	box-shadow: none !important;
 	outline: 1px solid currentColor;
-	border-radius: 0 !important;
+	border-radius: $universal-border-radius;
 	&.components-button:hover:not(:disabled),
 	&.components-button:focus:not(:disabled),
 	&:focus,

--- a/assets/js/blocks/classic-shortcode/editor.scss
+++ b/assets/js/blocks/classic-shortcode/editor.scss
@@ -21,7 +21,7 @@
 	border: 1px solid $gray-900;
 	background-color: #fff;
 	padding: $gap-large $gap-larger;
-	border-radius: 3px;
+	border-radius: $universal-border-radius;
 	display: flex;
 	flex-direction: column;
 	max-width: 900px;

--- a/assets/js/blocks/classic-template/editor.scss
+++ b/assets/js/blocks/classic-template/editor.scss
@@ -21,7 +21,7 @@
 	border: 1px solid $gray-900;
 	background-color: #fff;
 	padding: $gap-large $gap-larger;
-	border-radius: 3px;
+	border-radius: $universal-border-radius;
 	display: flex;
 	flex-direction: column;
 	max-width: 900px;

--- a/assets/js/blocks/order-confirmation/additional-information/style.scss
+++ b/assets/js/blocks/order-confirmation/additional-information/style.scss
@@ -2,5 +2,5 @@
 .wc-block-order-confirmation-additional-information {
 	margin-top: $gap-largest;
 	margin-bottom: $gap-largest;
-	border-radius: 2px;
+	border-radius: $universal-border-radius;
 }

--- a/assets/js/blocks/order-confirmation/billing-address/style.scss
+++ b/assets/js/blocks/order-confirmation/billing-address/style.scss
@@ -16,7 +16,7 @@
 }
 .wc-block-order-confirmation-billing-address {
 	border: 1px solid $universal-border-light;
-	border-radius: 2px;
+	border-radius: $universal-border-radius;
 	padding: $gap;
 
 	address,

--- a/assets/js/blocks/order-confirmation/downloads/style.scss
+++ b/assets/js/blocks/order-confirmation/downloads/style.scss
@@ -7,7 +7,7 @@
 		width: 100%;
 		border: 1px solid $universal-border-light;
 		border-spacing: 0;
-		border-radius: 2px;
+		border-radius: $universal-border-radius;
 		th,
 		td {
 			border: 1px solid $universal-border-light;

--- a/assets/js/blocks/order-confirmation/shipping-address/style.scss
+++ b/assets/js/blocks/order-confirmation/shipping-address/style.scss
@@ -16,7 +16,7 @@
 }
 .wc-block-order-confirmation-shipping-address {
 	border: 1px solid $universal-border-light;
-	border-radius: 2px;
+	border-radius: $universal-border-radius;
 	padding: $gap;
 
 	address,

--- a/assets/js/blocks/order-confirmation/summary/style.scss
+++ b/assets/js/blocks/order-confirmation/summary/style.scss
@@ -2,7 +2,7 @@
 .wc-block-order-confirmation-summary {
 	margin-top: $gap-largest;
 	margin-bottom: $gap-largest;
-	border-radius: 2px;
+	border-radius: $universal-border-radius;
 }
 .wc-block-order-confirmation-summary {
 	ul {

--- a/assets/js/blocks/order-confirmation/totals/style.scss
+++ b/assets/js/blocks/order-confirmation/totals/style.scss
@@ -7,7 +7,7 @@
 		width: 100%;
 		border: 1px solid $universal-border-light;
 		border-spacing: 0;
-		border-radius: 2px;
+		border-radius: $universal-border-radius;
 		border-collapse: collapse;
 		th,
 		td {

--- a/assets/js/blocks/price-filter/style.scss
+++ b/assets/js/blocks/price-filter/style.scss
@@ -1,6 +1,6 @@
 .wp-block-woocommerce-price-filter {
 	border-color: $gray-700;
-	border-radius: 4px;
+	border-radius: $universal-border-radius;
 	border-style: none !important;
 
 	h1,

--- a/packages/checkout/components/checkbox-control/style.scss
+++ b/packages/checkout/components/checkbox-control/style.scss
@@ -19,7 +19,7 @@
 		font-size: 1em;
 		appearance: none;
 		border: 2px solid $input-border-gray;
-		border-radius: 2px;
+		border-radius: $universal-border-radius;
 		box-sizing: border-box;
 		height: em(24px);
 		width: em(24px);

--- a/packages/checkout/components/text-input/style.scss
+++ b/packages/checkout/components/text-input/style.scss
@@ -47,7 +47,7 @@
 		background-color: #fff;
 		padding: em($gap-small) 0;
 		text-indent: $gap;
-		border-radius: 4px;
+		border-radius: $universal-border-radius;
 		border: 1px solid $input-border-gray;
 		width: 100%;
 		line-height: 1.375; // =22px when font-size is 16px.


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Adds a variable for a shared border radius property to make components more consistent across blocks. This is also now applied to the payment and shipping selector areas. I've replaced all radii of around 4px with this variable.

Fixes #11147

## Why

Prevents the need to manual set border radius when working on new components and creates consistency.

## Testing Instructions

Since this is visual I don't think it needs to be tested by global step.

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Add and item to cart and go to checkout
2. Confirm the form input, shipping selector, and payment areas all use the same border radius.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [x] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

![Screenshot 2023-10-10 at 11 21 02](https://github.com/woocommerce/woocommerce-blocks/assets/90977/e855b5b9-b2f7-4caa-b148-dd4aeef7566f)

![Screenshot 2023-10-10 at 11 21 06](https://github.com/woocommerce/woocommerce-blocks/assets/90977/c43f1998-b230-49f7-ab7e-5c68fbac1ff1)

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog

> Make border radius consistent across checkout components.
