### PR TITLE
Product Collection: Featured Products 5 Columns - Remove no results block.

### DIFF
--- a/patterns/product-collection-featured-products-5-columns.php
+++ b/patterns/product-collection-featured-products-5-columns.php
@@ -18,22 +18,17 @@ $content = PatternsHelper::get_pattern_content( 'woocommerce-blocks/product-coll
 	</h3>
 	<!-- /wp:heading -->
 
-<!-- wp:woocommerce/product-collection {"query":{"perPage":5,"pages":0,"offset":0,"postType":"product","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":{},"parents":[],"isProductCollectionBlock":true,"woocommerceOnSale":false,"woocommerceStockStatus":["instock","outofstock","onbackorder"],"woocommerceAttributes":[],"woocommerceHandPickedProducts":[]},"tagName":"div","displayLayout":{"type":"flex","columns":5},"align":"wide"} -->
-<div class="wp-block-woocommerce-product-collection alignwide">
-	<!-- wp:woocommerce/product-template -->
-	<!-- wp:woocommerce/product-image {"imageSizing":"thumbnail","isDescendentOfQueryLoop":true} /-->
+	<!-- wp:woocommerce/product-collection {"query":{"perPage":5,"pages":0,"offset":0,"postType":"product","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":{},"parents":[],"isProductCollectionBlock":true,"woocommerceOnSale":false,"woocommerceStockStatus":["instock","outofstock","onbackorder"],"woocommerceAttributes":[],"woocommerceHandPickedProducts":[]},"tagName":"div","displayLayout":{"type":"flex","columns":5},"align":"wide"} -->
+		<div class="wp-block-woocommerce-product-collection alignwide">
+			<!-- wp:woocommerce/product-template -->
+			<!-- wp:woocommerce/product-image {"imageSizing":"thumbnail","isDescendentOfQueryLoop":true} /-->
 
-	<!-- wp:post-title {"textAlign":"left","level":3,"isLink":true,"style":{"spacing":{"margin":{"bottom":"0.75rem","top":"0"}}},"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
+			<!-- wp:post-title {"textAlign":"left","level":3,"isLink":true,"style":{"spacing":{"margin":{"bottom":"0.75rem","top":"0"}}},"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
 
-	<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"left","fontSize":"small"} /-->
-	<!-- /wp:woocommerce/product-template -->
-
-	<!-- wp:query-no-results -->
-	<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
-	<p></p>
-	<!-- /wp:paragraph -->
-	<!-- /wp:query-no-results --></div>
-<!-- /wp:woocommerce/product-collection -->
+			<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"left","fontSize":"small"} /-->
+			<!-- /wp:woocommerce/product-template -->
+		</div>
+	<!-- /wp:woocommerce/product-collection -->
 
 	<!-- wp:buttons {"align":"wide","layout":{"type":"flex","verticalAlignment":"center","justifyContent":"center"}} -->
 	<div class="wp-block-buttons alignwide">


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Removes the "No results" text from the Product Collection: Featured Products 5 Columns pattern.

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/11187

## Why

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

This text isn't necessary for this pattern and convolutes the editor since it won't represent what is being rendered on the frontend during the CYS step.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Create new page or post
2. add Product Collection: Featured Products 5 Columns pattern
3. Ensure the `wp:query-no-results` block isn't rendered and that the text `Add text or blocks that will display when a query returns no results.` isn't present.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
| ![Screenshot 2023-10-10 at 14 11 47](https://github.com/woocommerce/woocommerce-blocks/assets/8639742/fdd7f061-7411-4158-af11-6a226215ea45) | ![Screenshot 2023-10-10 at 14 09 50](https://github.com/woocommerce/woocommerce-blocks/assets/8639742/776f45a2-1cfc-431f-9df8-8b66175ca804) |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Remove the No Results block and text from the Product Collection: Featured Products 5 Columns pattern