### PR TITLE
Ensure validation of fields occurs when collapsing fields

### DIFF
--- a/assets/js/blocks/checkout/address-wrapper/index.tsx
+++ b/assets/js/blocks/checkout/address-wrapper/index.tsx
@@ -1,12 +1,17 @@
 /**
  * External dependencies
  */
-import { CSSTransition, TransitionGroup } from 'react-transition-group';
+import classnames from 'classnames';
+
 /**
  * Internal dependencies
  */
 import './style.scss';
 
+/**
+ * Wrapper for address fields which handles the edit/preview transition. Form fields are always rendered so that
+ * validation can occur.
+ */
 export const AddressWrapper = ( {
 	isEditing = false,
 	addressCard,
@@ -16,25 +21,22 @@ export const AddressWrapper = ( {
 	addressCard: () => JSX.Element;
 	addressForm: () => JSX.Element;
 } ): JSX.Element | null => {
+	const wrapperClasses = classnames(
+		'wc-block-components-address-address-wrapper',
+		{
+			'is-editing': isEditing,
+		}
+	);
+
 	return (
-		<TransitionGroup className="address-fade-transition-wrapper">
-			{ ! isEditing && (
-				<CSSTransition
-					timeout={ 300 }
-					classNames="address-fade-transition"
-				>
-					{ addressCard() }
-				</CSSTransition>
-			) }
-			{ isEditing && (
-				<CSSTransition
-					timeout={ 300 }
-					classNames="address-fade-transition"
-				>
-					{ addressForm() }
-				</CSSTransition>
-			) }
-		</TransitionGroup>
+		<div className={ wrapperClasses }>
+			<div className="wc-block-components-address-card-wrapper">
+				{ addressCard() }
+			</div>
+			<div className="wc-block-components-address-form-wrapper">
+				{ addressForm() }
+			</div>
+		</div>
 	);
 };
 

--- a/assets/js/blocks/checkout/address-wrapper/style.scss
+++ b/assets/js/blocks/checkout/address-wrapper/style.scss
@@ -1,25 +1,30 @@
-.address-fade-transition-wrapper {
+.wc-block-components-address-address-wrapper {
 	position: relative;
-}
-.address-fade-transition-enter {
-	opacity: 0;
-}
-.address-fade-transition-enter-active {
-	opacity: 1;
-	transition: opacity 300ms ease-in;
-}
-.address-fade-transition-enter-done {
-	opacity: 1;
-}
-.address-fade-transition-exit {
-	opacity: 1;
-	position: absolute;
-	top: 0;
-}
-.address-fade-transition-exit-active {
-	opacity: 0;
-	transition: opacity 300ms ease-out;
-}
-.address-fade-transition-done {
-	opacity: 0;
+
+	.wc-block-components-address-card-wrapper,
+	.wc-block-components-address-form-wrapper {
+		transition: opacity 300ms ease-in-out, height 300ms ease-in-out;
+		width: 100%;
+	}
+
+	&.is-editing {
+		.wc-block-components-address-form-wrapper {
+			opacity: 1;
+		}
+		.wc-block-components-address-card-wrapper {
+			opacity: 0;
+			position: absolute;
+			top: 0;
+		}
+	}
+
+	&:not(.is-editing) {
+		.wc-block-components-address-form-wrapper {
+			opacity: 0;
+			height: 0;
+		}
+		.wc-block-components-address-card-wrapper {
+			opacity: 1;
+		}
+	}
 }

--- a/assets/js/blocks/checkout/address-wrapper/style.scss
+++ b/assets/js/blocks/checkout/address-wrapper/style.scss
@@ -22,6 +22,7 @@
 		.wc-block-components-address-form-wrapper {
 			opacity: 0;
 			height: 0;
+			pointer-events: none;
 		}
 		.wc-block-components-address-card-wrapper {
 			opacity: 1;

--- a/assets/js/blocks/checkout/address-wrapper/style.scss
+++ b/assets/js/blocks/checkout/address-wrapper/style.scss
@@ -3,7 +3,7 @@
 
 	.wc-block-components-address-card-wrapper,
 	.wc-block-components-address-form-wrapper {
-		transition: opacity 300ms ease-in-out, height 300ms ease-in-out;
+		transition: all 300ms ease-in-out;
 		width: 100%;
 	}
 
@@ -13,6 +13,7 @@
 		}
 		.wc-block-components-address-card-wrapper {
 			opacity: 0;
+			visibility: hidden;
 			position: absolute;
 			top: 0;
 		}
@@ -21,8 +22,8 @@
 	&:not(.is-editing) {
 		.wc-block-components-address-form-wrapper {
 			opacity: 0;
+			visibility: hidden;
 			height: 0;
-			pointer-events: none;
 		}
 		.wc-block-components-address-card-wrapper {
 			opacity: 1;

--- a/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/block.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/block.tsx
@@ -80,10 +80,6 @@ const Block = ( {
 	const noticeContext = useBillingAsShipping
 		? [ noticeContexts.BILLING_ADDRESS, noticeContexts.SHIPPING_ADDRESS ]
 		: [ noticeContexts.BILLING_ADDRESS ];
-	const hasAddress = !! (
-		billingAddress.address_1 &&
-		( billingAddress.first_name || billingAddress.last_name )
-	);
 
 	return (
 		<>
@@ -93,7 +89,6 @@ const Block = ( {
 					addressFieldsConfig={ addressFieldsConfig }
 					showPhoneField={ showPhoneField }
 					requirePhoneField={ requirePhoneField }
-					hasAddress={ hasAddress }
 					forceEditing={ forceEditing }
 				/>
 			</WrapperComponent>

--- a/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/block.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/block.tsx
@@ -104,7 +104,6 @@ const Block = ( {
 					addressFieldsConfig={ addressFieldsConfig }
 					showPhoneField={ showPhoneField }
 					requirePhoneField={ requirePhoneField }
-					hasAddress={ hasAddress }
 				/>
 			</WrapperComponent>
 			{ hasAddress && (

--- a/tests/e2e/tests/checkout/checkout.page.ts
+++ b/tests/e2e/tests/checkout/checkout.page.ts
@@ -126,34 +126,22 @@ export class CheckoutPage {
 	}
 
 	async editBillingDetails() {
-		const editButton = await this.page
-			.locator(
-				'.wc-block-checkout__billing-fields .wc-block-components-address-card__edit'
-			)
-			.isVisible();
+		const editButton = this.page.locator(
+			'.wc-block-checkout__billing-fields .wc-block-components-address-card__edit'
+		);
 
-		if ( editButton ) {
-			await this.page
-				.locator(
-					'.wc-block-checkout__billing-fields .wc-block-components-address-card__edit'
-				)
-				.click();
+		if ( await editButton.isVisible() ) {
+			await editButton.click();
 		}
 	}
 
 	async editShippingDetails() {
-		const editButton = await this.page
-			.locator(
-				'.wc-block-checkout__shipping-fields .wc-block-components-address-card__edit'
-			)
-			.isVisible();
+		const editButton = this.page.locator(
+			'.wc-block-checkout__shipping-fields .wc-block-components-address-card__edit'
+		);
 
-		if ( editButton ) {
-			await this.page
-				.locator(
-					'.wc-block-checkout__shipping-fields .wc-block-components-address-card__edit'
-				)
-				.click();
+		if ( await editButton.isVisible() ) {
+			await editButton.click();
 		}
 	}
 


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Fixes an issue with collapsed address whereby it would collapse an incomplete address and prevent validation occurring. This was fixed by rendering fields hidden, and then toggling edit mode if a validation error is found.

Since we're rendering both card and form at all times, we don't need to use CSSTransition any more. We can do the transition with pure CSS.

## Why

Fields need to be rendered to validate. By rendering the fields (hidden) we can still validate values.

## Testing Instructions

To replicate the bug, before checking out this PR:

1.  Go to checkout as a logged out guest user
2. Enter a first name, last name, and address 1 field. Leave the other fields blank
3. Refresh the page. The address will be collapsed but is incomplete. Placing order fails without error notices.

Then checkout this PR.

1. Go to checkout as a logged out guest user
2. Enter a first name, last name, and address 1 field. Leave the other fields blank
3. Refresh the page. The address form should still be visible.
4. Complete your address fields.
5. Refresh the page. The address will be collapsed.
6. Place order successfully.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
 
N/A
