### PR TITLE
Fix inconsistent border focus styles

### DIFF
--- a/assets/js/base/components/radio-control/style.scss
+++ b/assets/js/base/components/radio-control/style.scss
@@ -73,6 +73,11 @@
 		margin: inherit;
 		cursor: pointer;
 
+		&:focus {
+			outline: 2px solid $input-border-gray;
+			outline-offset: 2px;
+		}
+
 		&:checked::before {
 			background: #000;
 			border-radius: 50%;

--- a/assets/js/blocks/checkout/inner-blocks/checkout-order-note-block/style.scss
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-order-note-block/style.scss
@@ -15,6 +15,13 @@
 
 .wc-block-checkout__add-note .wc-block-components-textarea {
 	margin-top: $gap;
+
+	&:focus {
+		background-color: #fff;
+		color: $input-text-active;
+		outline: 0;
+		box-shadow: 0 0 0 1px $input-border-gray;
+	}
 }
 
 .wc-block-components-form .wc-block-checkout__order-notes.wc-block-components-checkout-step {


### PR DESCRIPTION
## What

This PR standardizes border focus styles across the Checkout block.

Fixes #8227

## Why

Previously, border focus styles varied among the text input, textarea, radio button, and checkbox fields.

## Testing Instructions

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Create a test page and add the Checkout block to it.
2. Go to the frontend and add a product to the cart.
3. Go to the checkout and select these fields: `Text input`, `Textarea`, `Radio input`, and `Checkbox input`.
4. Verify that the border focus styles of the `Text input` and `Textarea` are identical.
5. Verify that the border focus styles of the `Radio input` and `Checkbox input` are identical.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

> **Important**  
> Only the border focus styles of the `Radio input` and `Textarea` were adjusted in this PR, as the `Text input` and `Checkbox input` focus styles were already correct.

### `Radio input`

<table>
<tr>
<td>Before:
<br><br>
<img width="808" alt="Screenshot 2023-10-11 at 15 58 06" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/11cdc9bc-e0b0-4934-ac3a-f52ee914ca8b">
</td>
<td>After:
<br><br>
<img width="823" alt="Screenshot 2023-10-11 at 15 54 25" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/536876ad-265e-40a4-bd29-301f3ece2936">
</td>
</tr>
</table>

### `Textarea`

<table>
<tr>
<td>Before:
<br><br>
<img width="822" alt="Screenshot 2023-10-11 at 15 58 19" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/adf47ee7-1bc7-4516-8f05-e6034c327c6d">
</td>
<td>After:
<br><br>
<img width="826" alt="Screenshot 2023-10-11 at 15 54 43" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/08cf8a34-95fb-4235-8a29-27b74655164f">
</td>
</tr>
</table>

## WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog

> Fix inconsistent border focus styles