### PR TITLE
Product Collection 5 Columns pattern - Update title and price to be rows instead of columns

### DIFF
--- a/patterns/product-collection-5-columns.php
+++ b/patterns/product-collection-5-columns.php
@@ -19,22 +19,8 @@ $content = PatternsHelper::get_pattern_content( 'woocommerce-blocks/product-coll
 	<div class="wp-block-woocommerce-product-collection alignwide">
 		<!-- wp:woocommerce/product-template -->
 		<!-- wp:woocommerce/product-image {"aspectRatio":"3/5","imageSizing":"thumbnail","isDescendentOfQueryLoop":true} /-->
-
-		<!-- wp:columns -->
-		<div class="wp-block-columns">
-			<!-- wp:column -->
-			<div class="wp-block-column">
-				<!-- wp:post-title {"textAlign":"left","level":3,"isLink":true,"style":{"spacing":{"margin":{"bottom":"0.75rem","top":"0"}}},"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
-			</div>
-			<!-- /wp:column -->
-
-			<!-- wp:column -->
-			<div class="wp-block-column">
-				<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"right","fontSize":"small"} /-->
-			</div>
-			<!-- /wp:column -->
-		</div>
-		<!-- /wp:columns -->
+		<!-- wp:post-title {"textAlign":"left","level":3,"isLink":true,"style":{"spacing":{"margin":{"bottom":"0.75rem","top":"0"}}},"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-collection/product-title"} /-->
+		<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"left","fontSize":"small"} /-->
 		<!-- /wp:woocommerce/product-template -->
 	</div>
 	<!-- /wp:woocommerce/product-collection -->


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Update the Product Collection 5 Columns pattern so that the product title and price are stacked in rows rather than side-by-side in columns.

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/11186

## Why

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

Having columns leaves limited space for longer product titles and can lead to text wrapping on multi-lines and looking disjointed.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Create post or page.
2. Insert the `Product Collection 5 Columns` pattern and check that the title and price are stacked rather than side-by-side.
3. Ensure the spacing between the title and price is consistent with other Product Collection patterns. You can check by searching `Product Collection` under the patterns tab to find others.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
| ![Screenshot 2023-10-11 at 11 24 44](https://github.com/woocommerce/woocommerce-blocks/assets/8639742/704652b0-7fe4-4d0a-95a8-e06156444eb0) | ![Screenshot 2023-10-11 at 11 24 07](https://github.com/woocommerce/woocommerce-blocks/assets/8639742/a30a275b-ee03-4e72-9e97-d2164101de90) |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Product Collection 5 Columns pattern - Update title and price to be rows instead of columns
