### PR TITLE
Make patterns full width and fix margin

### DIFF
--- a/patterns/featured-category-cover-image.php
+++ b/patterns/featured-category-cover-image.php
@@ -11,8 +11,8 @@ $images  = PatternsHelper::get_pattern_images( 'woocommerce-blocks/featured-cate
 
 $image1 = PatternsHelper::get_image_url( $images, 0, 'images/pattern-placeholders/shop-jeans.png' );
 ?>
-<!-- wp:cover {"url":"<?php echo esc_url( $image1 ); ?>","dimRatio":50,"align":"wide","style":{"spacing":{"padding":{"top":"3%","right":"0%","bottom":"10%","left":"5%"},"margin":{"top":"0","bottom":"0"},"blockGap":"1%"}},"layout":{"type":"default"}} -->
-<div class="wp-block-cover alignwide" style="margin-top:0;margin-bottom:0;padding-top:3%;padding-right:0%;padding-bottom:10%;padding-left:5%">
+<!-- wp:cover {"url":"<?php echo esc_url( $image1 ); ?>","dimRatio":50,"align":"full","style":{"spacing":{"padding":{"top":"3%","right":"0%","bottom":"10%","left":"5%"},"margin":{"top":"0","bottom":"0"},"blockGap":"1%"}},"layout":{"type":"default"}} -->
+<div class="wp-block-cover alignfull" style="margin-top:0;margin-bottom:0;padding-top:3%;padding-right:0%;padding-bottom:10%;padding-left:5%">
 	<span aria-hidden="true" class="wp-block-cover__background has-background-dim"></span>
 	<img class="wp-block-cover__image-background" alt="" src="<?php echo esc_url( $image1 ); ?>" data-object-fit="cover"/>
 	<div class="wp-block-cover__inner-container">

--- a/patterns/hero-product-3-split.php
+++ b/patterns/hero-product-3-split.php
@@ -47,8 +47,8 @@ $images  = PatternsHelper::get_pattern_images( 'woocommerce-blocks/hero-product-
 	</div>
 	<!-- /wp:column -->
 
-	<!-- wp:column {"verticalAlignment":"center","width":"33.33%"} -->
-	<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:33.33%">
+	<!-- wp:column {"verticalAlignment":"center","width":"30%","style":{"spacing":{"padding":{"right":"var:preset|spacing|30","left":"var:preset|spacing|30"}}}} -->
+	<div class="wp-block-column is-vertically-aligned-center" style="padding-right:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30);flex-basis:30%">
 		<!-- wp:paragraph -->
 		<p><strong><?php echo esc_html( $content['titles'][1]['default'] ); ?></strong></p>
 		<!-- /wp:paragraph -->

--- a/patterns/hero-product-3-split.php
+++ b/patterns/hero-product-3-split.php
@@ -10,8 +10,8 @@ $content = PatternsHelper::get_pattern_content( 'woocommerce-blocks/hero-product
 $images  = PatternsHelper::get_pattern_images( 'woocommerce-blocks/hero-product-3-split' );
 ?>
 
-<!-- wp:columns {"align":"wide","style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"}}}} -->
-<div class="wp-block-columns alignwide" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">
+<!-- wp:columns {"align":"full","style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"}}}} -->
+<div class="wp-block-columns alignfull" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">
 	<!-- wp:column {"width":"66.66%"} -->
 	<div class="wp-block-column" style="flex-basis:66.66%">
 		<!-- wp:media-text {"mediaPosition":"right","mediaId":1,"mediaLink":"<?php echo esc_url( plugins_url( 'images/pattern-placeholders/hand-guitar-finger-tshirt-clothing-rack.png', dirname( __FILE__ ) ) ); ?>","mediaType":"image"} -->

--- a/patterns/hero-product-chessboard.php
+++ b/patterns/hero-product-chessboard.php
@@ -15,8 +15,8 @@ $image2 = PatternsHelper::get_image_url( $images, 1, 'images/pattern-placeholder
 
 <!-- wp:group {"align":"full","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull">
-	<!-- wp:columns {"align":"wide","style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"},"blockGap":{"top":"0","left":"0"}}}} -->
-	<div class="wp-block-columns alignwide" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">
+	<!-- wp:columns {"align":"full","style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"},"blockGap":{"top":"0","left":"0"}}}} -->
+	<div class="wp-block-columns alignfull" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">
 		<!-- wp:column -->
 		<div class="wp-block-column">
 			<!-- wp:cover {"url":"<?php echo esc_url( $image1 ); ?>","dimRatio":0,"focalPoint":{"x":0.54,"y":0.52},"isDark":false,"style":{"color":{}}} -->
@@ -57,8 +57,8 @@ $image2 = PatternsHelper::get_image_url( $images, 1, 'images/pattern-placeholder
 	</div>
 	<!-- /wp:columns -->
 
-	<!-- wp:columns {"verticalAlignment":"center","align":"wide","style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"},"blockGap":{"top":"0","left":"0"},"margin":{"top":"0","bottom":"0"}}}} -->
-	<div class="wp-block-columns alignwide are-vertically-aligned-center" style="margin-top:0;margin-bottom:0;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">
+	<!-- wp:columns {"verticalAlignment":"center","align":"full","style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"},"blockGap":{"top":"0","left":"0"},"margin":{"top":"0","bottom":"0"}}}} -->
+	<div class="wp-block-columns alignfull are-vertically-aligned-center" style="margin-top:0;margin-bottom:0;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">
 		<!-- wp:column {"verticalAlignment":"center","style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"}}}} -->
 		<div class="wp-block-column is-vertically-aligned-center" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">
 			<!-- wp:group {"style":{"spacing":{"padding":{"top":"50px","right":"50px","bottom":"50px","left":"50px"}}},"layout":{"type":"flex","orientation":"vertical"}} -->

--- a/patterns/just-arrived-full-hero.php
+++ b/patterns/just-arrived-full-hero.php
@@ -14,8 +14,9 @@ $pattern_description = $content['descriptions'][0]['default'] ?? '';
 $pattern_button      = $content['buttons'][0]['default'] ?? '';
 $pattern_image       = PatternsHelper::get_image_url( $images, 0, 'images/pattern-placeholders/plant-in-vase.jpg' );
 ?>
-<!-- wp:cover {"url":"<?php echo esc_url( $pattern_image ); ?>","dimRatio":30,"minHeight":739,"contentPosition":"center right","align":"wide","style":{"spacing":{"padding":{"right":"4em"}}}} -->
-<div class="wp-block-cover alignwide has-custom-content-position is-position-center-right" style="padding-right:4em;min-height:739px">
+
+<!-- wp:cover {"url":"<?php echo esc_url( $pattern_image ); ?>","dimRatio":30,"minHeight":739,"contentPosition":"center right","align":"full","style":{"spacing":{"padding":{"right":"4em"}}}} -->
+<div class="wp-block-cover alignfull has-custom-content-position is-position-center-right" style="padding-right:4em;min-height:739px">
 	<span aria-hidden="true" class="wp-block-cover__background has-background-dim-30 has-background-dim"></span>
 	<img class="wp-block-cover__image-background" alt="" src="<?php echo esc_url( $pattern_image ); ?>" data-object-fit="cover"/>
 	<div class="wp-block-cover__inner-container">


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

1. Makes the following patterns `Full width`:
- `woocommerce-blocks/just-arrived-full-hero`
- `woocommerce-blocks/hero-product-3-split`
- `woocommerce-blocks/hero-product-chessboard`
- `woocommerce-blocks/featured-category-cover-image`
2. Add padding to the `woocommerce-blocks/hero-product-3-split` to make it work better on mobile.

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/11202

## Why

To adapt to the designs.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

**Test the individual patterns**
1. Create a new page or post.
2. Insert the blocks mentioned on the PR description.
3. Make sure they are `Full width` and look good on the editor and the front end.

**Test the homepage templates**
Compare the 3 templates show below to the designs: Mrk6SERPZ4KrFHSjM0a8TK-fi-5716_46688

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

| Homepage 1 | Homepage 2 | Homepage 3 |
|--------|--------|--------|
| ![homepage1](https://github.com/woocommerce/woocommerce-blocks/assets/186112/a0f6f306-1891-48ff-a219-44c55873cfc9)| ![homepage2](https://github.com/woocommerce/woocommerce-blocks/assets/186112/1221406c-95b6-4c8b-8f34-c2efc1d829f9)|![homepage3](https://github.com/woocommerce/woocommerce-blocks/assets/186112/6778ba76-1b20-4a84-a74f-c5ff0741f0bb)|


<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Make the "Just Arrived Full Hero", "Featured Category Cover Image", "Hero Product 3 Split", and "Hero Product Chessboard" pattern full width.