### PR TITLE
Add: `menu-order` orderby option for Product Attribute Terms route

### DIFF
--- a/assets/js/blocks/attribute-filter/block.tsx
+++ b/assets/js/blocks/attribute-filter/block.tsx
@@ -130,6 +130,7 @@ const AttributeFilterBlock = ( {
 			resourceName: 'products/attributes/terms',
 			resourceValues: [ attributeObject?.id || 0 ],
 			shouldSelect: blockAttributes.attributeId > 0,
+			query: { orderby: 'menu_order' },
 		} );
 
 	const { results: filteredCounts, isLoading: filteredCountsLoading } =

--- a/src/StoreApi/Routes/V1/ProductAttributeTerms.php
+++ b/src/StoreApi/Routes/V1/ProductAttributeTerms.php
@@ -47,6 +47,17 @@ class ProductAttributeTerms extends AbstractTermsRoute {
 	}
 
 	/**
+	 * Get the query params for collections of attributes.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		$params                      = parent::get_collection_params();
+		$params['orderby']['enum'][] = 'menu_order';
+		return $params;
+	}
+
+	/**
 	 * Get a collection of attribute terms.
 	 *
 	 * @throws RouteException On error.

--- a/src/StoreApi/docs/product-attribute-terms.md
+++ b/src/StoreApi/docs/product-attribute-terms.md
@@ -2,7 +2,7 @@
 
 ```http
 GET /products/attributes/:id/terms
-GET /products/attributes/:id/terms&orderby=slug
+GET /products/attributes/:id/terms?orderby=slug
 ```
 
 | Attribute | Type    | Required | Description                                                                                 |

--- a/src/StoreApi/docs/product-attribute-terms.md
+++ b/src/StoreApi/docs/product-attribute-terms.md
@@ -5,11 +5,11 @@ GET /products/attributes/:id/terms
 GET /products/attributes/:id/terms&orderby=slug
 ```
 
-| Attribute | Type    | Required | Description                                                                   |
-| :-------- | :------ | :------: | :---------------------------------------------------------------------------- |
-| `id`      | integer |   Yes    | The ID of the attribute to retrieve terms for.                                |
-| `order`   | string  |    no    | Order ascending or descending. Allowed values: `asc`, `desc`                  |
-| `orderby` | string  |    no    | Sort collection by object attribute. Allowed values: `name`, `slug`, `count`. |
+| Attribute | Type    | Required | Description                                                                                 |
+| :-------- | :------ | :------: | :------------------------------------------------------------------------------------------ |
+| `id`      | integer |   Yes    | The ID of the attribute to retrieve terms for.                                              |
+| `order`   | string  |    no    | Order ascending or descending. Allowed values: `asc`, `desc`                                |
+| `orderby` | string  |    no    | Sort collection by object attribute. Allowed values: `name`, `slug`, `count`, `menu_order`. |
 
 ```sh
 curl "https://example-store.com/wp-json/wc/store/v1/products/attributes/1/terms"
@@ -43,4 +43,3 @@ curl "https://example-store.com/wp-json/wc/store/v1/products/attributes/1/terms"
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-blocks/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./src/StoreApi/docs/product-attribute-terms.md)
 
 <!-- /FEEDBACK -->
-


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What
This PR adds a new `orderby` option call `menu_order` to Product Attribute Terms route to allow attribute terms can be sorted by custom ordering. WooCommerce sort the attribute terms by custom ordering by default but the API sorts terms by name by default. This API won't change that behavior.

This PR also update the Attribute Filter block to get query attribute terms sorted by custom ordering.

Fixes #11219

## Why

See #11219.

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Edit or create a new page contain Attribute Filter block.
2. See the attribute terms list sorted by custom order in the Editor.
3. Check the page on the front end, confirm the terms are also sorted by custom ordering.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Add new `orderby` option (`menu_order`) to `product/attributes/terms/` route.