### PR TITLE
LocalPickup: fix learn more documentation link

### DIFF
--- a/assets/js/extensions/shipping-methods/pickup-location/location-settings.tsx
+++ b/assets/js/extensions/shipping-methods/pickup-location/location-settings.tsx
@@ -30,7 +30,7 @@ const LocationSettingsDescription = () => (
 				'woo-gutenberg-products-block'
 			) }
 		</p>
-		<ExternalLink href="https://woocommerce.com/document/local-pickup/">
+		<ExternalLink href="https://woocommerce.com/document/woocommerce-blocks-local-pickup/">
 			{ __( 'Learn more', 'woo-gutenberg-products-block' ) }
 		</ExternalLink>
 	</>


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Fixes #11231

## Why

The "Learn more" option in the Local Pickup tab links currently to the wrong document @pmcpinto reported

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Go to Settings > Shipping > Local Pickup
2. Click on "Learn more" under Pickup locations
3. Confirm that you're redirected to this page: https://woocommerce.com/document/woocommerce-blocks-local-pickup/

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [ ] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Add suggested changelog entry here.
