### PR TITLE
Store Customization > Remove placeholder text from the image on the Hero Product Chessboard pattern

### DIFF
--- a/patterns/hero-product-chessboard.php
+++ b/patterns/hero-product-chessboard.php
@@ -35,6 +35,9 @@ $fifth_description  = $content['descriptions'][4]['default'] ?? '';
 			<div class="wp-block-cover is-light">
 				<img class="wp-block-cover__image-background" alt="<?php esc_attr_e( 'Placeholder image used to represent a product being showcased in a hero section. 1 out of 2.', 'woo-gutenberg-products-block' ); ?>" src="<?php echo esc_url( $image1 ); ?>" style="object-position:54% 52%" data-object-fit="cover" data-object-position="54% 52%"/>
 				<div class="wp-block-cover__inner-container">
+					<!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
+						<p class="has-text-align-center has-large-font-size"> </p>
+					<!-- /wp:paragraph -->
 				</div>
 			</div>
 			<!-- /wp:cover -->
@@ -141,6 +144,9 @@ $fifth_description  = $content['descriptions'][4]['default'] ?? '';
 			<div class="wp-block-cover">
 				<img class="wp-block-cover__image-background" alt="<?php esc_attr_e( 'Placeholder image used to represent a product being showcased in a hero section. 2 out of 2.', 'woo-gutenberg-products-block' ); ?>" src="<?php echo esc_url( $image2 ); ?>" style="object-position:33% 6%" data-object-fit="cover" data-object-position="33% 6%"/>
 				<div class="wp-block-cover__inner-container">
+					<!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
+						<p class="has-text-align-center has-large-font-size"> </p>
+					<!-- /wp:paragraph -->
 				</div>
 			</div>
 			<!-- /wp:cover -->


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Adds an empty paragraph tag to the Cover block.

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/11181

## Why

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

This is necessary to avoid the "Write title..." placeholder text appearing which needs removing to ensure it is like the designs.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Create post
2. Add pattern `woocommerce-blocks/hero-product-chessboard`
3. Ensure no "Write title..." placeholders appear over the images as shown in the linked issue.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
| ![Screenshot 2023-10-14 at 10 42 02](https://github.com/woocommerce/woocommerce-blocks/assets/8639742/1f2737fa-cd51-4e8a-8bb0-e769e1c8b8d2) | ![Screenshot 2023-10-14 at 10 41 23](https://github.com/woocommerce/woocommerce-blocks/assets/8639742/7d05d52f-6d50-496a-9394-22d2eb073922) |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Remove placeholder text from the image on the Hero Product Chessboard pattern
