### PR TITLE
Fix: Mini-Cart block shows wrong total if theres multiple installs on the same domain

### DIFF
--- a/assets/js/blocks/mini-cart/utils/data.ts
+++ b/assets/js/blocks/mini-cart/utils/data.ts
@@ -13,6 +13,7 @@ import {
 } from '@woocommerce/types';
 import { getSettingWithCoercion } from '@woocommerce/settings';
 import type { ColorPaletteOption } from '@woocommerce/editor-components/color-panel/types';
+import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
@@ -128,15 +129,9 @@ export const getMiniCartTotalsFromLocalStorage = ():
 export const getMiniCartTotalsFromServer = async (): Promise<
 	[ CartResponseTotals, number ] | undefined
 > => {
-	return fetch( '/wp-json/wc/store/v1/cart/' )
-		.then( ( response ) => {
-			// Check if the response was successful.
-			if ( ! response.ok ) {
-				throw new Error();
-			}
-
-			return response.json();
-		} )
+	return apiFetch< CartResponse >( {
+		path: '/wc/store/v1/cart',
+	} )
 		.then( ( data: CartResponse ) => {
 			// Save server data to local storage, so we can re-fetch it faster
 			// on the next page load.

--- a/assets/js/blocks/mini-cart/utils/test/data.ts
+++ b/assets/js/blocks/mini-cart/utils/test/data.ts
@@ -4,6 +4,7 @@
  */
 import { getByTestId, waitFor } from '@testing-library/dom';
 import { getSettingWithCoercion } from '@woocommerce/settings';
+import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
@@ -17,23 +18,20 @@ import {
 
 // This is a simplified version of the response of the Cart API endpoint.
 const responseMock = {
-	ok: true,
-	json: async () => ( {
-		totals: {
-			total_price: '1800',
-			total_items: '1400',
-			total_items_tax: '200',
-			currency_code: 'USD',
-			currency_symbol: '$',
-			currency_minor_unit: 2,
-			currency_decimal_separator: '.',
-			currency_thousand_separator: ',',
-			currency_prefix: '$',
-			currency_suffix: '',
-		},
-		items_count: 2,
-	} ),
-} as Response;
+	totals: {
+		total_price: '1800',
+		total_items: '1400',
+		total_items_tax: '200',
+		currency_code: 'USD',
+		currency_symbol: '$',
+		currency_minor_unit: 2,
+		currency_decimal_separator: '.',
+		currency_thousand_separator: ',',
+		currency_prefix: '$',
+		currency_suffix: '',
+	},
+	items_count: 2,
+};
 const localStorageMock = {
 	totals: {
 		total_price: '1800',
@@ -80,6 +78,8 @@ jest.mock( '@woocommerce/settings', () => {
 	};
 } );
 
+jest.mock( '@wordpress/api-fetch' );
+
 describe( 'Mini-Cart frontend script when "the display prices during cart and checkout" option is set to "Including Tax"', () => {
 	beforeAll( () => {
 		( getSettingWithCoercion as jest.Mock ).mockReturnValue( true );
@@ -110,7 +110,7 @@ describe( 'Mini-Cart frontend script when "the display prices during cart and ch
 	} );
 
 	it( 'updates the cart contents based on the API response', async () => {
-		jest.spyOn( window, 'fetch' ).mockResolvedValue( responseMock );
+		apiFetch.mockResolvedValue( responseMock );
 		const container = getMiniCartDOM();
 		document.body.appendChild( container );
 
@@ -118,9 +118,9 @@ describe( 'Mini-Cart frontend script when "the display prices during cart and ch
 
 		// Assert we called the correct endpoint.
 		await waitFor( () =>
-			expect( window.fetch ).toHaveBeenCalledWith(
-				'/wp-json/wc/store/v1/cart/'
-			)
+			expect( apiFetch ).toHaveBeenCalledWith( {
+				path: '/wc/store/v1/cart',
+			} )
 		);
 
 		// Assert we saved the values returned to the localStorage.
@@ -172,7 +172,7 @@ describe( 'Mini-Cart frontend script when "the display prices during cart and ch
 	} );
 
 	it( 'updates the cart contents based on the API response', async () => {
-		jest.spyOn( window, 'fetch' ).mockResolvedValue( responseMock );
+		apiFetch.mockResolvedValue( responseMock );
 		const container = getMiniCartDOM();
 		document.body.appendChild( container );
 
@@ -180,9 +180,9 @@ describe( 'Mini-Cart frontend script when "the display prices during cart and ch
 
 		// Assert we called the correct endpoint.
 		await waitFor( () =>
-			expect( window.fetch ).toHaveBeenCalledWith(
-				'/wp-json/wc/store/v1/cart/'
-			)
+			expect( apiFetch ).toHaveBeenCalledWith( {
+				path: '/wc/store/v1/cart',
+			} )
 		);
 
 		// Assert we saved the values returned to the localStorage.


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

This PR fixes the issue when Mini Cart block, when is used in a sub directory, failed to fetch the cart or fetch the cart of the Woo store under the root domain.

Fixes #11168

## Why

The `getMiniCartTotalsFromServer()` was using a hard-coded URL to fetch the cart data, it works when the Woo store URL is the root domain but when the store uses sub directory, it doesn't. This PR fixes that issue by using `@wordpress/api-fetch` instead of browser's `fetch`.

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Setup _Site B_ on domain.com/test and use USD as the currency
5. See the Site B Mini Cart works as expected.
1. Setup _Site A_ on domain.com, lets use EUR as the currency
3. Add something to the cart on _Site A_
4. Go to _Site B_ and **don't see** its mini-cart affected by site A.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Fix the Mini Cart button shows incorrect data for stores under sub-directories.
