### PR TITLE
Revert #10032 so All Products renders in the frontend

### DIFF
--- a/assets/js/blocks/products/all-products/deprecated.js
+++ b/assets/js/blocks/products/all-products/deprecated.js
@@ -33,32 +33,4 @@ const v1 = {
 	},
 };
 
-const v2 = {
-	attributes: Object.assign( {}, attributeDefinitions, {
-		rows: { type: 'number', default: 1 },
-	} ),
-	save( { attributes } ) {
-		const dataAttributes = {};
-		Object.keys( attributes )
-			.sort()
-			.forEach( ( key ) => {
-				dataAttributes[ key ] = attributes[ key ];
-			} );
-		const data = {
-			'data-attributes': JSON.stringify( dataAttributes ),
-		};
-		return (
-			<div
-				className={ getBlockClassName(
-					'wc-block-all-products',
-					attributes
-				) }
-				{ ...data }
-			>
-				<InnerBlocks.Content />
-			</div>
-		);
-	},
-};
-
-export default [ v2, v1 ];
+export default [ v1 ];

--- a/assets/js/blocks/products/all-products/save.js
+++ b/assets/js/blocks/products/all-products/save.js
@@ -9,12 +9,22 @@ import { InnerBlocks } from '@wordpress/block-editor';
 import { getBlockClassName } from '../utils.js';
 
 export default function save( { attributes } ) {
+	const dataAttributes = {};
+	Object.keys( attributes )
+		.sort()
+		.forEach( ( key ) => {
+			dataAttributes[ key ] = attributes[ key ];
+		} );
+	const data = {
+		'data-attributes': JSON.stringify( dataAttributes ),
+	};
 	return (
 		<div
 			className={ getBlockClassName(
 				'wc-block-all-products',
 				attributes
 			) }
+			{ ...data }
 		>
 			<InnerBlocks.Content />
 		</div>

--- a/tests/e2e/tests/price-filter/price-filter.block_theme.side_effects.spec.ts
+++ b/tests/e2e/tests/price-filter/price-filter.block_theme.side_effects.spec.ts
@@ -42,8 +42,7 @@ test.describe( `${ blockData.name } Block - with All products Block`, () => {
 		await page.goto( `/?p=${ postId }`, { waitUntil: 'commit' } );
 	} );
 
-	// eslint-disable-next-line playwright/no-skipped-test
-	test.skip( 'should show all products', async ( { frontendUtils } ) => {
+	test( 'should show all products', async ( { frontendUtils } ) => {
 		const allProductsBlock = await frontendUtils.getBlockByName(
 			'woocommerce/all-products'
 		);
@@ -60,8 +59,7 @@ test.describe( `${ blockData.name } Block - with All products Block`, () => {
 		expect( products ).toHaveLength( 9 );
 	} );
 
-	// eslint-disable-next-line playwright/no-skipped-test
-	test.skip( 'should show only products that match the filter', async ( {
+	test( 'should show only products that match the filter', async ( {
 		page,
 		frontendUtils,
 	} ) => {


### PR DESCRIPTION
Revert https://github.com/woocommerce/woocommerce-blocks/pull/10032 so All Products block renders properly in the frontend.
Revert part of https://github.com/woocommerce/woocommerce-blocks/pull/11055.

## What

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/11261 and https://github.com/woocommerce/woocommerce-blocks/issues/11215

## Why

The newly added All Products block doesn't render on the frontend.

This is due to https://github.com/woocommerce/woocommerce-blocks/pull/10032 in which the `data-attributes` HTML attribute was removed from the block's save function which is a must for a correct block render.

Additionally, this PR un-skips two tests that were skipped in the scope of https://github.com/woocommerce/woocommerce-blocks/pull/10032. These tests correctly found the problem of All Products block not being rendered.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Go to Editor
2. Add All Products block
3. Save and go to frontend
4. All Products block is correctly rendered and there's no console errors related to this block

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> All Products: fix error during rendering on the frontend
