### PR TITLE
Archive Templates - Compatibility Layer: fix E2E tests

### DIFF
--- a/tests/e2e/tests/product-collection/compatibility-layer.block_theme.side_effects.spec.ts
+++ b/tests/e2e/tests/product-collection/compatibility-layer.block_theme.side_effects.spec.ts
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import { test as base, expect } from '@woocommerce/e2e-playwright-utils';
-import { deleteAllTemplates } from '@wordpress/e2e-test-utils';
 import {
 	installPluginFromPHPFile,
 	uninstallPluginFromPHPFile,
@@ -51,7 +50,7 @@ const multipleOccurranceScenarios: Scenario[] = [
 	{
 		title: 'Before Shop Loop Item Title',
 		dataTestId: 'woocommerce_before_shop_loop_item_title',
-		content: 'Hook: woocommerce_before_shop_loop_item_title',
+		content: ' Hook: woocommerce_before_shop_loop_item_title',
 		amount: 16,
 	},
 	{
@@ -115,39 +114,44 @@ test.describe( 'Compatibility Layer with Product Collection block', () => {
 				await pageObject.goToProductCatalogFrontend();
 			} );
 
-			// eslint-disable-next-line playwright/no-skipped-test
-			test.skip( 'Hooks are attached to the page', async ( {
-				pageObject,
-			} ) => {
-				singleOccurranceScenarios.forEach(
-					async ( { title, dataTestId, content, amount } ) => {
-						await test.step( title, async () => {
-							const hooks =
-								pageObject.locateByTestId( dataTestId );
-							await expect( hooks ).toHaveCount( amount );
-							await expect( hooks ).toHaveText( content );
-						} );
-					}
-				);
+			for ( const scenario of singleOccurranceScenarios ) {
+				test( `${ scenario.title } is attached to the page`, async ( {
+					pageObject,
+				} ) => {
+					await test.step( scenario.title, async () => {
+						const hooks = pageObject.locateByTestId(
+							scenario.dataTestId
+						);
 
-				multipleOccurranceScenarios.forEach(
-					async ( { title, dataTestId, content, amount } ) => {
-						await test.step( title, async () => {
-							const hooks =
-								pageObject.locateByTestId( dataTestId );
-							await expect( hooks ).toHaveCount( amount );
-							await expect( hooks.first() ).toHaveText( content );
-						} );
-					}
-				);
-			} );
+						await expect( hooks ).toHaveCount( scenario.amount );
+						await expect( hooks ).toHaveText( scenario.content );
+					} );
+				} );
+			}
+
+			for ( const scenario of multipleOccurranceScenarios ) {
+				test( `${ scenario.title } is attached to the page`, async ( {
+					pageObject,
+				} ) => {
+					await test.step( scenario.title, async () => {
+						const hooks = pageObject.locateByTestId(
+							scenario.dataTestId
+						);
+
+						await expect( hooks ).toHaveCount( scenario.amount );
+						await expect( hooks.first() ).toHaveText(
+							scenario.content
+						);
+					} );
+				} );
+			}
 		}
 	);
 
-	test.afterAll( async () => {
+	test.afterAll( async ( { requestUtils } ) => {
 		await uninstallPluginFromPHPFile(
 			`${ __dirname }/${ compatiblityPluginFileName }`
 		);
-		await deleteAllTemplates( 'wp_template' );
+		await requestUtils.deleteAllTemplates( 'wp_template' );
 	} );
 } );

--- a/tests/e2e/tests/product-collection/compatibility-layer.block_theme.side_effects.spec.ts
+++ b/tests/e2e/tests/product-collection/compatibility-layer.block_theme.side_effects.spec.ts
@@ -50,7 +50,7 @@ const multipleOccurranceScenarios: Scenario[] = [
 	{
 		title: 'Before Shop Loop Item Title',
 		dataTestId: 'woocommerce_before_shop_loop_item_title',
-		content: ' Hook: woocommerce_before_shop_loop_item_title',
+		content: 'Hook: woocommerce_before_shop_loop_item_title',
 		amount: 16,
 	},
 	{
@@ -118,14 +118,12 @@ test.describe( 'Compatibility Layer with Product Collection block', () => {
 				test( `${ scenario.title } is attached to the page`, async ( {
 					pageObject,
 				} ) => {
-					await test.step( scenario.title, async () => {
-						const hooks = pageObject.locateByTestId(
-							scenario.dataTestId
-						);
+					const hooks = pageObject.locateByTestId(
+						scenario.dataTestId
+					);
 
-						await expect( hooks ).toHaveCount( scenario.amount );
-						await expect( hooks ).toHaveText( scenario.content );
-					} );
+					await expect( hooks ).toHaveCount( scenario.amount );
+					await expect( hooks ).toHaveText( scenario.content );
 				} );
 			}
 
@@ -133,16 +131,14 @@ test.describe( 'Compatibility Layer with Product Collection block', () => {
 				test( `${ scenario.title } is attached to the page`, async ( {
 					pageObject,
 				} ) => {
-					await test.step( scenario.title, async () => {
-						const hooks = pageObject.locateByTestId(
-							scenario.dataTestId
-						);
+					const hooks = pageObject.locateByTestId(
+						scenario.dataTestId
+					);
 
-						await expect( hooks ).toHaveCount( scenario.amount );
-						await expect( hooks.first() ).toHaveText(
-							scenario.content
-						);
-					} );
+					await expect( hooks ).toHaveCount( scenario.amount );
+					await expect( hooks.first() ).toHaveText(
+						scenario.content
+					);
 				} );
 			}
 		}


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Partial fixes for #11270
## Why

This PR enabled the E2E tests for the compatibility layer that they were disabled with https://github.com/woocommerce/woocommerce-blocks/pull/11055.

These E2E tests started to fail after the PW update. PW documentation suggested a [different approach for parameterized tests](https://playwright.dev/docs/test-parameterize).

Applying the changes following the documentation, tests don't fail anymore.

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Ensure that E2E tests don't fail.


* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Add suggested changelog entry here.
