### PR TITLE
Product Collection - shrink columns to fit

### DIFF
--- a/assets/js/blocks/product-collection/constants.ts
+++ b/assets/js/blocks/product-collection/constants.ts
@@ -58,6 +58,7 @@ export const DEFAULT_ATTRIBUTES: Partial< ProductCollectionAttributes > = {
 	displayLayout: {
 		type: LayoutOptions.GRID,
 		columns: 3,
+		shrinkColumns: false,
 	},
 };
 

--- a/assets/js/blocks/product-collection/inspector-controls/columns-control.tsx
+++ b/assets/js/blocks/product-collection/inspector-controls/columns-control.tsx
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import {
 	RangeControl,
+	ToggleControl,
 	// @ts-expect-error Using experimental features
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalToolsPanelItem as ToolsPanelItem,
@@ -12,44 +13,86 @@ import {
 /**
  * Internal dependencies
  */
-import { DisplayLayoutControlProps } from '../types';
+import { DisplayLayoutToolbarProps } from '../types';
 import { getDefaultDisplayLayout } from '../constants';
 
-const ColumnsControl = ( props: DisplayLayoutControlProps ) => {
-	const { type, columns } = props.displayLayout;
+const toggleLabel = __(
+	'Shrink columns to fit',
+	'woo-gutenberg-products-block'
+);
+
+const toggleHelp = __(
+	'Reduce the number of columns to better fit smaller screens and spaces.',
+	'woo-gutenberg-products-block'
+);
+
+const getColumnsLabel = ( shrinkColumns: boolean ) =>
+	shrinkColumns
+		? __( 'Max Columns', 'woo-gutenberg-products-block' )
+		: __( 'Columns', 'woo-gutenberg-products-block' );
+
+const ColumnsControl = ( props: DisplayLayoutToolbarProps ) => {
+	const { type, columns, shrinkColumns } = props.displayLayout;
 	const showColumnsControl = type === 'flex';
 
 	const defaultLayout = getDefaultDisplayLayout();
 
+	const onToggleChange = ( value: boolean ) => {
+		props.setAttributes( {
+			displayLayout: {
+				...props.displayLayout,
+				shrinkColumns: value,
+			},
+		} );
+	};
+
+	const onPanelDeselect = () => {
+		props.setAttributes( {
+			displayLayout: defaultLayout,
+		} );
+	};
+
+	const onColumnsChange = ( value: number ) =>
+		props.setAttributes( {
+			displayLayout: {
+				...props.displayLayout,
+				columns: value,
+			},
+		} );
+
 	return showColumnsControl ? (
-		<ToolsPanelItem
-			label={ __( 'Columns', 'woo-gutenberg-products-block' ) }
-			hasValue={ () =>
-				defaultLayout?.columns !== columns ||
-				defaultLayout?.type !== type
-			}
-			isShownByDefault
-			onDeselect={ () => {
-				props.setAttributes( {
-					displayLayout: defaultLayout,
-				} );
-			} }
-		>
-			<RangeControl
-				label={ __( 'Columns', 'woo-gutenberg-products-block' ) }
-				value={ columns }
-				onChange={ ( value: number ) =>
-					props.setAttributes( {
-						displayLayout: {
-							...props.displayLayout,
-							columns: value,
-						},
-					} )
+		<>
+			<ToolsPanelItem
+				hasValue={ () =>
+					defaultLayout?.shrinkColumns !== shrinkColumns
 				}
-				min={ 2 }
-				max={ Math.max( 6, columns ) }
-			/>
-		</ToolsPanelItem>
+				isShownByDefault
+				onDeselect={ onPanelDeselect }
+			>
+				<ToggleControl
+					checked={ shrinkColumns }
+					label={ toggleLabel }
+					help={ toggleHelp }
+					onChange={ onToggleChange }
+				/>
+			</ToolsPanelItem>
+			<ToolsPanelItem
+				hasValue={ () =>
+					defaultLayout?.columns !== columns ||
+					defaultLayout?.type !== type
+				}
+				isShownByDefault
+				onDeselect={ onPanelDeselect }
+			>
+				<RangeControl
+					label={ getColumnsLabel( !! shrinkColumns ) }
+					onChange={ onColumnsChange }
+					value={ columns }
+					min={ 2 }
+					max={ Math.max( 6, columns ) }
+				/>
+			</ToolsPanelItem>
+		</>
 	) : null;
 };
 

--- a/assets/js/blocks/product-collection/inspector-controls/columns-control.tsx
+++ b/assets/js/blocks/product-collection/inspector-controls/columns-control.tsx
@@ -37,7 +37,7 @@ const ColumnsControl = ( props: DisplayLayoutToolbarProps ) => {
 
 	const defaultLayout = getDefaultDisplayLayout();
 
-	const onToggleChange = ( value: boolean ) => {
+	const onShrinkColumnsToggleChange = ( value: boolean ) => {
 		props.setAttributes( {
 			displayLayout: {
 				...props.displayLayout,
@@ -73,7 +73,7 @@ const ColumnsControl = ( props: DisplayLayoutToolbarProps ) => {
 					checked={ !! shrinkColumns }
 					label={ toggleLabel }
 					help={ toggleHelp }
-					onChange={ onToggleChange }
+					onChange={ onShrinkColumnsToggleChange }
 				/>
 			</ToolsPanelItem>
 			<ToolsPanelItem

--- a/assets/js/blocks/product-collection/inspector-controls/columns-control.tsx
+++ b/assets/js/blocks/product-collection/inspector-controls/columns-control.tsx
@@ -70,7 +70,7 @@ const ColumnsControl = ( props: DisplayLayoutToolbarProps ) => {
 				onDeselect={ onPanelDeselect }
 			>
 				<ToggleControl
-					checked={ shrinkColumns }
+					checked={ !! shrinkColumns }
 					label={ toggleLabel }
 					help={ toggleHelp }
 					onChange={ onToggleChange }

--- a/assets/js/blocks/product-collection/types.ts
+++ b/assets/js/blocks/product-collection/types.ts
@@ -25,6 +25,7 @@ export enum LayoutOptions {
 export interface ProductCollectionDisplayLayout {
 	type: LayoutOptions;
 	columns: number;
+	shrinkColumns?: boolean;
 }
 
 export interface ProductCollectionQuery {

--- a/assets/js/blocks/product-template/edit.tsx
+++ b/assets/js/blocks/product-template/edit.tsx
@@ -87,9 +87,10 @@ const ProductTemplateEdit = ( {
 		},
 		queryContext = [ { page: 1 } ],
 		templateSlug,
-		displayLayout: { type: layoutType, columns } = {
+		displayLayout: { type: layoutType, columns, shrinkColumns } = {
 			type: 'flex',
 			columns: 3,
+			shrinkColumns: false,
 		},
 	},
 	__unstableLayoutClassNames,
@@ -203,15 +204,21 @@ const ProductTemplateEdit = ( {
 			} ) ),
 		[ products ]
 	);
+
 	const hasLayoutFlex = layoutType === 'flex' && columns > 1;
+	let customClassName = '';
+	if ( hasLayoutFlex ) {
+		const dynamicGrid = `wc-block-product-template__responsive columns-${ columns }`;
+		const staticGrid = `is-flex-container columns-${ columns }`;
+
+		customClassName = shrinkColumns ? dynamicGrid : staticGrid;
+	}
+
 	const blockProps = useBlockProps( {
 		className: classnames(
 			__unstableLayoutClassNames,
 			'wc-block-product-template',
-			{
-				'is-flex-container': hasLayoutFlex,
-				[ `columns-${ columns }` ]: hasLayoutFlex,
-			}
+			customClassName
 		),
 	} );
 

--- a/assets/js/blocks/product-template/style.scss
+++ b/assets/js/blocks/product-template/style.scss
@@ -1,5 +1,8 @@
 $break-small: 600px;
 
+$grid-gap: 1.25em;
+$min-product-width: 150px;
+
 @mixin break-small() {
 	@media (min-width: #{ ($break-small) }) {
 		@content;
@@ -37,6 +40,25 @@ $break-small: 600px;
 					width: calc((100% / #{ $i }) - 1.25em + (1.25em / #{ $i }));
 				}
 			}
+		}
+	}
+
+	&__responsive {
+		display: grid;
+		grid-gap: $grid-gap;
+
+		@for $i from 2 through 6 {
+			$gap-count: calc(#{ $i } - 1);
+			$total-gap-width: calc(#{ $gap-count } * #{ $grid-gap });
+			$grid-item--max-width: calc((100% - #{ $total-gap-width }) / #{ $i });
+
+			&.columns-#{ $i } {
+				grid-template-columns: repeat(auto-fill, minmax(max(#{ $min-product-width }, #{ $grid-item--max-width }), 1fr));
+			}
+		}
+
+		> li {
+			margin-block-start: 0;
 		}
 	}
 }

--- a/assets/js/blocks/product-template/style.scss
+++ b/assets/js/blocks/product-template/style.scss
@@ -50,10 +50,10 @@ $min-product-width: 150px;
 		@for $i from 2 through 6 {
 			$gap-count: calc(#{ $i } - 1);
 			$total-gap-width: calc(#{ $gap-count } * #{ $grid-gap });
-			$grid-item--max-width: calc((100% - #{ $total-gap-width }) / #{ $i });
+			$max-product-width: calc((100% - #{ $total-gap-width }) / #{ $i });
 
 			&.columns-#{ $i } {
-				grid-template-columns: repeat(auto-fill, minmax(max(#{ $min-product-width }, #{ $grid-item--max-width }), 1fr));
+				grid-template-columns: repeat(auto-fill, minmax(max(#{ $min-product-width }, #{ $max-product-width }), 1fr));
 			}
 		}
 

--- a/src/BlockTypes/ProductTemplate.php
+++ b/src/BlockTypes/ProductTemplate.php
@@ -61,7 +61,11 @@ class ProductTemplate extends AbstractBlock {
 		$classnames = '';
 		if ( isset( $block->context['displayLayout'] ) && isset( $block->context['query'] ) ) {
 			if ( isset( $block->context['displayLayout']['type'] ) && 'flex' === $block->context['displayLayout']['type'] ) {
-				$classnames = "is-flex-container columns-{$block->context['displayLayout']['columns']}";
+				if ( $block->context['displayLayout']['shrinkColumns'] ) {
+					$classnames = "wc-block-product-template__responsive columns-{$block->context['displayLayout']['columns']}";
+				} else {
+					$classnames = "is-flex-container columns-{$block->context['displayLayout']['columns']}";
+				}
 			}
 		}
 		if ( isset( $attributes['style']['elements']['link']['color']['text'] ) ) {


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Add an option to "Shrink columns to fit" in Product Collection so the blocks is responsive.

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/10827

## Why

Product Collection has the option to set a number of columns but it's a fixed number which looks weird on smaller screens. That number of columns collapses to a single one on mobile devices ( check https://github.com/woocommerce/woocommerce-blocks/issues/9971).

This option allows to set a MAX number of columns but as the screen gets narrower, the number of columns decreases.

The minimal width of a product was chosen arbitrarily to `150px` and is a subject to change (I'm open to suggestion in this area).

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Go to Editor
2. Add Product Collection block
3. "Shrink columns to fit" is disabled by default. Enable it
4. Label of columns control should change from "Columns" to "Max Columns"
5. Play with the "Max Columns" control and make sure it's respected in the Editor
6. Narrow down the screen width and make sure the number of columns decreases as the screen gets narrower
7. Save the Editor with couple of different "Max Columns" settings and go to frontend
8. Narrow down the screen width and make sure the number of columns decreases as the screen gets narrower
9. Verify frontend on major browsers

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|      https://github.com/woocommerce/woocommerce-blocks/assets/20098064/ae3e12e0-b894-46b8-9027-614da9a5fb51  |     https://github.com/woocommerce/woocommerce-blocks/assets/20098064/ecc7e75c-c787-486c-a000-8f951c52416e |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Product Collection: add "Shrink columns to fit" option so the columns are responsive and adjust to the screen width.
