### PR TITLE
Product Gallery: Fix justification not saving correctly

### DIFF
--- a/assets/js/blocks/product-gallery/utils.tsx
+++ b/assets/js/blocks/product-gallery/utils.tsx
@@ -170,6 +170,10 @@ export const moveInnerBlocksToPosition = (
 	const productGalleryBlock = getBlock( clientId );
 
 	if ( productGalleryBlock ) {
+		const previousLayout = productGalleryBlock.innerBlocks.length
+			? productGalleryBlock.innerBlocks[ 0 ].attributes.layout
+			: null;
+
 		const thumbnailsBlock = findBlock( {
 			blocks: [ productGalleryBlock ],
 			findCondition( block ) {
@@ -211,6 +215,22 @@ export const moveInnerBlocksToPosition = (
 				thumbnailsPosition,
 				clientId
 			);
+
+			setGroupBlockLayoutByThumbnailsPosition(
+				thumbnailsPosition,
+				productGalleryBlock.innerBlocks[ 0 ].clientId
+			);
+
+			if ( previousLayout ) {
+				const orientation =
+					getGroupLayoutAttributes( thumbnailsPosition ).orientation;
+				updateBlockAttributes(
+					{
+						layout: { ...previousLayout, orientation },
+					},
+					productGalleryBlock.innerBlocks[ 0 ]
+				);
+			}
 
 			if (
 				( ( thumbnailsPosition === 'bottom' ||


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/11104

This was a tricky one as I went down a rabbit hole :)

NOTE: While playing around with this, I realize the Orientation setting for the first inner block Row is not useful at all because that setting is dictated by the position of the thumbnails. So even if you explicitly set it to say "Vertical", after you change the thumbnails position, the Orientation can change. If we agree, I can open a separate issue to remove that setting from users (if possible).

## Why

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

This PR fixes the issue where when you use the first `core/group` row/stack's justification settings, the settings does not persist after refreshing in the editor.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Go to themes->editor->single product template
2. Add the Product Gallery block under the Store notices block (this way you can use full width to replicate better)
3. Set the Product Gallery block (root) to use Full Width
4. Select the first innerblock row and set the justification to right
5. Save and refresh the page
6. Ensure your saved settings appears as what you expect
7. Try setting the thumbnails layout position to something different (try right)
8. Ensure the editor is showing what you would expect
9. Test all other possible justification and thumbnails layout positions
10. Now test the same for the frontend and make sure it appears as what is saved in the settings

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Product Gallery: Fix justification not saving correctly