### PR TITLE
Improve Just Arrived Full Hero pattern

### DIFF
--- a/patterns/just-arrived-full-hero.php
+++ b/patterns/just-arrived-full-hero.php
@@ -16,12 +16,12 @@ $pattern_button      = $content['buttons'][0]['default'] ?? '';
 $pattern_image       = PatternsHelper::get_image_url( $images, 0, 'images/pattern-placeholders/plant-in-vase.jpg' );
 ?>
 
-<!-- wp:cover {"url":"<?php echo esc_url( $pattern_image ); ?>","dimRatio":30,"minHeight":739,"contentPosition":"center right","align":"full","style":{"spacing":{"margin":{"bottom":"80px"}}}} -->
-<div class="wp-block-cover alignfull has-custom-content-position is-position-center-right" style="margin-bottom:80px;min-height:739px">
+<!-- wp:cover {"url":"<?php echo esc_url( $pattern_image ); ?>","dimRatio":30,"minHeight":739,"contentPosition":"center right","align":"full","style":{"spacing":{"margin":{"bottom":"80px"},"padding":{"left":"0","right":"25%"}}}}  -->
+<div class="wp-block-cover alignfull has-custom-content-position is-position-center-right" style="margin-bottom:80px;padding-right:25%;padding-left:0;min-height:739px">
 	<span aria-hidden="true" class="wp-block-cover__background has-background-dim-30 has-background-dim"></span>
 	<img class="wp-block-cover__image-background" alt="" src="<?php echo esc_url( $pattern_image ); ?>" data-object-fit="cover" />
 	<div class="wp-block-cover__inner-container">
-		<!-- wp:group {"layout":{"type":"constrained"}} -->
+		<!-- wp:group {"style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"right":"var:preset|spacing|80","left":"var:preset|spacing|80"},"blockGap":"16px"}}} {"layout":{"type":"constrained"}} -->
 		<div class="wp-block-group">
 			<!-- wp:heading {"anchor":"just-arrived"} -->
 			<h2 class="wp-block-heading" id="just-arrived"><?php echo esc_html( $pattern_title ); ?></h2>


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

This Improves the spacing between the title and the button. Also it improves the padding to center more the text.

Fixes #11359 and #11396

## Why

The pattern has to match with:

![image](https://github.com/woocommerce/woocommerce-blocks/assets/4463174/3bcb393b-8c01-4083-bc3b-3ac74c3d48f0)


<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Add a new post.
2. Add the `Just Arrived Full Hero` pattern.
3. Save the post. 
4. Ensure that the looks like the screenshots below

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

### Design

![image](https://github.com/woocommerce/woocommerce-blocks/assets/4463174/3bcb393b-8c01-4083-bc3b-3ac74c3d48f0)

| Editor | Frontend |
| ------ | ----- |
|![image](https://github.com/woocommerce/woocommerce-blocks/assets/4463174/52b90181-26a8-4cee-91ab-3277cfd14947)|![image](https://github.com/woocommerce/woocommerce-blocks/assets/4463174/d6c3a84c-cd5e-4257-bd3e-bcf1b4a601e3)|

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [ ] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Add suggested changelog entry here.
