### PR TITLE
Comboboxes should match against values before looking at labels

### DIFF
--- a/assets/js/base/components/combobox/index.tsx
+++ b/assets/js/base/components/combobox/index.tsx
@@ -121,14 +121,26 @@ const Combobox = ( {
 						// Try to match.
 						const normalizedFilterValue =
 							filterValue.toLocaleUpperCase();
-						const foundOption = options.find(
+
+						// Try to find an exact match first using values.
+						const foundValue = options.find(
 							( option ) =>
-								option.label
-									.toLocaleUpperCase()
-									.startsWith( normalizedFilterValue ) ||
 								option.value.toLocaleUpperCase() ===
-									normalizedFilterValue
+								normalizedFilterValue
 						);
+
+						if ( foundValue ) {
+							onChange( foundValue.value );
+							return;
+						}
+
+						// Fallback to a label match.
+						const foundOption = options.find( ( option ) =>
+							option.label
+								.toLocaleUpperCase()
+								.startsWith( normalizedFilterValue )
+						);
+
 						if ( foundOption ) {
 							onChange( foundOption.value );
 						}


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

The combobox component tries to find a match `onFilterValueChange` against values and labels, however, since it matches labels at the same time as values, sometimes incorrect matches are returned. This PR splits the logic.

Fixes #11322

## Why

The example given in #11322 was a state value of MA which should match against massachusetts, but matches against Maine first (because of the label). This PR fixes the matcher.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. In chrome, add a new address for autocompletion. Use a US address with MA as the state.
2. As a guest user, go to checkout. Autocomplete the shipping address section.
3. Ensure that the state field selects massachusetts.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [ ] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog

> Fixed state and country matching when used with browser autocomplete.
