### PR TITLE
Improve 'hero product 3 split' pattern

### DIFF
--- a/patterns/hero-product-3-split.php
+++ b/patterns/hero-product-3-split.php
@@ -22,89 +22,101 @@ $fourth_description = $content['descriptions'][3]['default'] ?? '';
 $fifth_description  = $content['descriptions'][4]['default'] ?? '';
 ?>
 
-<!-- wp:columns {"align":"full","style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"},"margin":{"top":"0px","bottom":"80px"}}}} -->
-<div class="wp-block-columns alignfull" style="margin-top:0px;margin-bottom:80px;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">
-	<!-- wp:column {"width":"66.66%"} -->
-	<div class="wp-block-column" style="flex-basis:66.66%">
-		<!-- wp:media-text {"mediaPosition":"right","mediaId":1,"mediaLink":"<?php echo esc_url( plugins_url( 'images/pattern-placeholders/hand-guitar-finger-tshirt-clothing-rack.png', dirname( __FILE__ ) ) ); ?>","mediaType":"image"} -->
-		<div class="wp-block-media-text alignwide has-media-on-the-right is-stacked-on-mobile">
-			<div class="wp-block-media-text__content">
-				<!-- wp:group {"style":{"spacing":{"margin":{"top":"20px","bottom":"20px"}}},"layout":{"type":"flex","orientation":"vertical"}} -->
-				<div class="wp-block-group" style="margin-top:20px;margin-bottom:20px;">
-					<!-- wp:heading -->
-					<h2 class="wp-block-heading"><?php echo esc_html( $first_title ); ?></h2>
-					<!-- /wp:heading -->
-
-					<!-- wp:paragraph -->
-					<p><?php echo esc_html( $first_description ); ?></p>
-					<!-- /wp:paragraph -->
-
-					<!-- wp:buttons -->
-					<div class="wp-block-buttons">
-						<!-- wp:button {"textAlign":"left"} -->
-						<div class="wp-block-button has-custom-font-size">
-							<a class="wp-block-button__link has-text-align-left wp-element-button" href="<?php echo esc_url( get_permalink( wc_get_page_id( 'shop' ) ) ); ?>"><?php esc_attr_e( 'Shop now', 'woo-gutenberg-products-block' ); ?></a>
-						</div>
-						<!-- /wp:button -->
-					</div>
-					<!-- /wp:buttons -->
-				</div>
-				<!-- /wp:group -->
+<!-- wp:columns {"align":"full","style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"},"margin":{"top":"0px","bottom":"80px"},"blockGap":{"left":"0"}}}} -->
+<div class="wp-block-columns alignfull" style="margin-top: 0px; margin-bottom: 80px; padding-top: 0; padding-right: 0; padding-bottom: 0; padding-left: 0;">
+	<!-- wp:column {"verticalAlignment":"center","width":"","style":{"spacing":{"padding":{"left":"60px"}}}} -->
+	<div class="wp-block-column is-vertically-aligned-center" style="padding-left: 60px;">
+		<!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"left"}} -->
+		<div class="wp-block-group">
+			<!-- wp:heading {"className":"wp-block-heading"} -->
+			<h2 class="wp-block-heading"><?php echo esc_html( $first_title ); ?></h2>
+			<!-- /wp:heading -->
+			<!-- wp:paragraph -->
+			<p><?php echo esc_html( $first_description ); ?></p>
+			<!-- /wp:paragraph -->
+		<!-- wp:buttons -->
+		<div class="wp-block-buttons">
+			<!-- wp:button -->
+			<div class="wp-block-button">
+				<a href="<?php echo esc_url( wc_get_page_permalink( 'shop' ) ); ?>" class="wp-block-button__link wp-element-button">
+				<?php esc_attr_e( 'Shop now', 'woo-gutenberg-products-block' ); ?>
+				</a>
 			</div>
-			<figure class="wp-block-media-text__media">
-				<img src="<?php echo esc_url( PatternsHelper::get_image_url( $images, 0, 'images/pattern-placeholders/hand-guitar-finger-tshirt-clothing-rack.png' ) ); ?>" alt="<?php esc_attr_e( 'Placeholder image used to represent a product being showcased in a hero section.', 'woo-gutenberg-products-block' ); ?>" class="wp-image-1 size-full" />
-			</figure>
+			<!-- /wp:button -->
 		</div>
-		<!-- /wp:media-text -->
+		<!-- /wp:buttons -->
+		</div>
+			<!-- /wp:group  -->
 	</div>
-	<!-- /wp:column -->
+		<!-- /wp:column -->
+		<!-- wp:column {"layout":{"type":"default"}} -->
+		<div class="wp-block-column">
+			<!-- wp:image {"aspectRatio":"9/16","scale":"cover"} -->
+			<figure class="wp-block-image">
+				<img
+					src="<?php echo esc_url( PatternsHelper::get_image_url( $images, 0, 'images/pattern-placeholders/hand-guitar-finger-tshirt-clothing-rack.png' ) ); ?>"
+					alt="<?php esc_attr_e( 'Placeholder image used to represent a product being showcased in a hero section.', 'woo-gutenberg-products-block' ); ?>"
+					style="aspect-ratio: 9/16; object-fit: cover;"
+				/>
+			</figure>
+			<!-- /wp:image -->
+		</div>
+		<!-- /wp:column -->
 
-	<!-- wp:column {"verticalAlignment":"center","width":"30%","style":{"spacing":{"padding":{"right":"var:preset|spacing|30","left":"var:preset|spacing|30"}}}} -->
-	<div class="wp-block-column is-vertically-aligned-center" style="padding-right:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30);flex-basis:30%">
-		<!-- wp:paragraph -->
-		<p><strong><?php echo esc_html( $second_title ); ?></strong></p>
-		<!-- /wp:paragraph -->
+		<!-- wp:column {"verticalAlignment":"center","style":{"spacing":{"padding":{"right":"75px","left":"75px"}}}} -->
+		<div class="wp-block-column is-vertically-aligned-center" style="padding-right: 75px; padding-left: 75px;">
+			<!-- wp:paragraph -->
+			<p>
+				<strong><?php echo esc_html( $second_title ); ?></strong>
+			</p>
+			<!-- /wp:paragraph -->
 
-		<!-- wp:paragraph -->
-		<p><?php echo esc_html( $second_description ); ?></p>
-		<!-- /wp:paragraph -->
+			<!-- wp:paragraph -->
+			<p><?php echo esc_html( $second_description ); ?></p>
+			<!-- /wp:paragraph -->
 
-		<!-- wp:separator {"className":"is-style-wide"} -->
-		<hr class="wp-block-separator has-alpha-channel-opacity is-style-wide" />
-		<!-- /wp:separator -->
+			<!-- wp:separator {"className":"is-style-wide"} -->
+			<hr class="wp-block-separator has-alpha-channel-opacity is-style-wide" />
+			<!-- /wp:separator -->
 
-		<!-- wp:paragraph -->
-		<p><strong><?php echo esc_html( $third_title ); ?></strong></p>
-		<!-- /wp:paragraph -->
+			<!-- wp:paragraph -->
+			<p>
+				<strong><?php echo esc_html( $third_title ); ?></strong>
+			</p>
+			<!-- /wp:paragraph -->
 
-		<!-- wp:paragraph -->
-		<p><?php echo esc_html( $third_description ); ?></p>
-		<!-- /wp:paragraph -->
+			<!-- wp:paragraph -->
+			<p><?php echo esc_html( $third_description ); ?></p>
+			<!-- /wp:paragraph -->
 
-		<!-- wp:separator {"className":"is-style-wide"} -->
-		<hr class="wp-block-separator has-alpha-channel-opacity is-style-wide" />
-		<!-- /wp:separator -->
+			<!-- wp:separator {"className":"is-style-wide"} -->
+			<hr class="wp-block-separator has-alpha-channel-opacity is-style-wide" />
+			<!-- /wp:separator -->
 
-		<!-- wp:paragraph -->
-		<p><strong><?php echo esc_html( $fourth_title ); ?></strong></p>
-		<!-- /wp:paragraph -->
+			<!-- wp:paragraph -->
+			<p>
+				<strong><?php echo esc_html( $fourth_title ); ?></strong>
+			</p>
+			<!-- /wp:paragraph -->
 
-		<!-- wp:paragraph -->
-		<p><?php echo esc_html( $fourth_description ); ?></p>
-		<!-- /wp:paragraph -->
+			<!-- wp:paragraph -->
+			<p><?php echo esc_html( $fourth_description ); ?></p>
+			<!-- /wp:paragraph -->
 
-		<!-- wp:separator {"className":"is-style-wide"} -->
-		<hr class="wp-block-separator has-alpha-channel-opacity is-style-wide" />
-		<!-- /wp:separator -->
+			<!-- wp:separator {"className":"is-style-wide"} -->
+			<hr class="wp-block-separator has-alpha-channel-opacity is-style-wide" />
+			<!-- /wp:separator -->
 
-		<!-- wp:paragraph -->
-		<p><strong><?php echo esc_html( $fifth_title ); ?></strong></p>
-		<!-- /wp:paragraph -->
+			<!-- wp:paragraph -->
+			<p>
+				<strong><?php echo esc_html( $fifth_title ); ?></strong>
+			</p>
+			<!-- /wp:paragraph -->
 
-		<!-- wp:paragraph -->
-		<p><?php echo esc_html( $fifth_description ); ?></p>
-		<!-- /wp:paragraph -->
+			<!-- wp:paragraph -->
+			<p><?php echo esc_html( $fifth_description ); ?></p>
+			<!-- /wp:paragraph -->
+		</div>
+		<!-- /wp:column -->
 	</div>
-	<!-- /wp:column -->
-</div>
-<!-- /wp:columns -->
+	<!-- /wp:columns -->


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Fixes #11398.

This PR improves:
- spacing
- mobile view

## Why

For fixing the mobile view (put the text on top and after the image), it has been necessary not to use the Media & Text block.

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Add a new post.
2. Add the `Hero Product 3 split` pattern.
3. Save
4. Visit the post.
5. Ensure that the pattern (desktop and mobile view) matches the mockup.


> [!WARNING]
> I noticed that in the "tablet view" the current pattern doesn't look great. Should we address this in the current iteration? The screenshot below was taken with the Pixel 5 viewport in horizontal mode.

![locale local_606-2_(Pixel 5) png``` -  ```Locale Pixel 5](https://github.com/woocommerce/woocommerce-blocks/assets/4463174/e4ec46d3-6ba7-46d4-9f14-8cb51b2bb4f6)







* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

### Mockup

| Desktop | Mobile |
| ------ | ----- |
|![image](https://github.com/woocommerce/woocommerce-blocks/assets/4463174/6f790530-a539-44b9-bcc1-fb159d33e369)|![image](https://github.com/woocommerce/woocommerce-blocks/assets/4463174/79e30897-ad6f-4c83-9740-c652752a0355)|

### Implementation

| Desktop | Mobile |
| ------ | ----- |
|![image](https://github.com/woocommerce/woocommerce-blocks/assets/4463174/9e6b8fff-6e81-464c-aa29-4a3cbf1701c0)|![image](https://github.com/woocommerce/woocommerce-blocks/assets/4463174/7671e45e-4518-4eb4-a59f-66e3fe94be4c)|

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Add suggested changelog entry here.
