### PR TITLE
Always show the `Enable the shipping calculator on the cart page` option in WC Admin

### DIFF
--- a/src/Shipping/ShippingController.php
+++ b/src/Shipping/ShippingController.php
@@ -171,10 +171,10 @@ class ShippingController {
 	}
 
 	/**
-	 * If the Checkout block Remove shipping settings from WC Core's admin panels that are now block settings.
+	 * When using the cart and checkout blocks this method is used to adjust core shipping settings via a filter hook.
 	 *
 	 * @param array $settings The default WC shipping settings.
-	 * @return array|mixed The filtered settings with relevant items removed.
+	 * @return array|mixed The filtered settings.
 	 */
 	public function remove_shipping_settings( $settings ) {
 		if ( CartCheckoutUtils::is_checkout_block_default() && $this->local_pickup_enabled ) {

--- a/src/Shipping/ShippingController.php
+++ b/src/Shipping/ShippingController.php
@@ -177,46 +177,6 @@ class ShippingController {
 	 * @return array|mixed The filtered settings with relevant items removed.
 	 */
 	public function remove_shipping_settings( $settings ) {
-
-		// Do not add the shipping calculator setting if the Cart block is not used on the WC cart page.
-		if ( CartCheckoutUtils::is_cart_block_default() ) {
-
-			// Ensure the 'Calculations' title is added to the `woocommerce_shipping_cost_requires_address` options
-			// group, since it is attached to the `woocommerce_enable_shipping_calc` option that gets removed if the
-			// Cart block is in use.
-			$calculations_title = '';
-
-			// Get Calculations title so we can add it to 'Hide shipping costs until an address is entered' option.
-			foreach ( $settings as $setting ) {
-				if ( 'woocommerce_enable_shipping_calc' === $setting['id'] ) {
-					$calculations_title = $setting['title'];
-					break;
-				}
-			}
-
-			// Add Calculations title to 'Hide shipping costs until an address is entered' option.
-			foreach ( $settings as $index => $setting ) {
-				if ( 'woocommerce_shipping_cost_requires_address' === $setting['id'] ) {
-					$settings[ $index ]['title']         = $calculations_title;
-					$settings[ $index ]['checkboxgroup'] = 'start';
-					break;
-				}
-			}
-
-			$settings = array_filter(
-				$settings,
-				function( $setting ) {
-					return ! in_array(
-						$setting['id'],
-						array(
-							'woocommerce_enable_shipping_calc',
-						),
-						true
-					);
-				}
-			);
-		}
-
 		if ( CartCheckoutUtils::is_checkout_block_default() && $this->local_pickup_enabled ) {
 			foreach ( $settings as $index => $setting ) {
 				if ( 'woocommerce_shipping_cost_requires_address' === $setting['id'] ) {


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

In #11184 we removed the shipping calculator settings from the Block Settings bar to enable merchants to set up the shipping calculator in the WC Admin only.

In this PR, we always show the `Enable the shipping calculator on the cart page` option in WC Admin. We don't hide it anymore when the Cart Block is on the Cart page.

Fixes #11415

## Why

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

We reverted the change in #8679, which hides the `Enable the shipping calculator on the cart page` option when the Cart Block is on the Cart page. 

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Go to `WooCommerce -> Settings -> Advanced` - set the Cart page to one containing the Cart Block. Save.
2. Go to `WooCommerce -> Settings -> Shipping -> Shipping Options` - confirm the `Enable the shipping calculator on the cart page` option is displayed.
3. Check the `Enable the shipping calculator on the cart page` option and save.
4. Add a product to the cart and go to the Cart page. Confirm the shipping calculator is displayed
5. Go to `WooCommerce -> Settings -> Shipping -> Shipping Options` - Uncheck the `Enable the shipping calculator on the cart page` option and save.
6. Go to the Cart page on the front-end. Confirm the shipping calculator is hidden.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|     <img width="839" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/14235870/678f8311-d242-4b7c-a140-370db44a24a0">   |    <img width="686" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/14235870/b05b6ccc-6fc1-4909-8229-b777f289e2f9">   |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [ ] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Always show the `Enable the shipping calculator on the cart page` option
