### PR TITLE
Add rounded borders to product images on TT4

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -12,6 +12,7 @@
 	}
 
 	img {
+		border-radius: inherit;
 		height: auto;
 		width: auto;
 		max-width: 100%;
@@ -23,6 +24,11 @@
 		&[alt=""] {
 			border: 1px solid $image-placeholder-border-color;
 		}
+	}
+
+	// Theme-specific CSS
+	.theme-twentytwentyfour & {
+		border-radius: var(--wp--preset--spacing--20);
 	}
 }
 .edit-post-visual-editor .editor-block-list__block .wc-block-grid__product-title,

--- a/assets/js/atomic/blocks/product-elements/image/style.scss
+++ b/assets/js/atomic/blocks/product-elements/image/style.scss
@@ -51,6 +51,11 @@
 			margin: 0;
 		}
 	}
+
+	// Theme-specific CSS
+	.theme-twentytwentyfour & {
+		border-radius: var(--wp--preset--spacing--20);
+	}
 }
 
 .is-loading .wc-block-components-product-image {

--- a/assets/js/blocks/featured-items/style.scss
+++ b/assets/js/blocks/featured-items/style.scss
@@ -180,4 +180,9 @@
 	.wp-block-button.aligncenter {
 		text-align: center;
 	}
+
+	// Theme-specific CSS
+	.theme-twentytwentyfour & {
+		border-radius: var(--wp--preset--spacing--20);
+	}
 }


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

This PR adds rounded borders as default to product images in the context of the TT4 theme.

Fixes woocommerce/woocommerce#42173

## Why

We want to ship with the best possible TT4 default experience: TT4 uses a rounded-borders aesthetic throughout. In order to better fit into the default experience of the theme, we include this aesthetic as a default on our images.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Activate the TT4 theme.
2. Add “Single Product”, “Featured Product”, “Featured Category”, “Product Collection” and other blocks containing product images to a page.
3. Ensure that the images show a default border radius which is in line with TT4 images.
4. Ensure that it can be overridden by the user via the inspector controls.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="639" alt="Screenshot 2023-10-26 at 00 07 29" src="https://github.com/woocommerce/woocommerce-blocks/assets/1847066/54681f95-9492-496e-a115-4ff3f2dd434d"> | <img width="644" alt="Screenshot 2023-10-26 at 00 06 36" src="https://github.com/woocommerce/woocommerce-blocks/assets/1847066/25ade0bb-51d3-46d0-8164-7b170b0d34d9"> |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> TT4: Add theme default border radii to product images.
