### PR TITLE
Interactivity API: Add `data-wc-init` directive

### DIFF
--- a/assets/js/interactivity/directives.js
+++ b/assets/js/interactivity/directives.js
@@ -74,6 +74,16 @@ export default () => {
 		}
 	);
 
+	// data-wc-init--[name]
+	directive( 'init', ( { directives: { init }, context, evaluate } ) => {
+		const contextValue = useContext( context );
+		Object.values( init ).forEach( ( path ) => {
+			useEffect( () => {
+				return evaluate( path, { context: contextValue } );
+			}, [] );
+		} );
+	} );
+
 	// data-wc-on--[event]
 	directive( 'on', ( { directives: { on }, element, evaluate, context } ) => {
 		const contextValue = useContext( context );


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

This PR adds the `data-wc-init` directive to Interactivity API

Fixes #11457 

## Why

During the Product Gallery block work, I've noticed that we would benefit from using this to handle cases, for example, where we want to include listeners in the DOM.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. From your WordPress dashboard, go to Appearance > Themes. Make sure you have a block-based theme installed and activated. If not, you can install one from the Add New option. Block-based themes include "Twenty-twenty Three," "Twenty-twenty Four," etc.
2. On the left-hand side menu, click on Appearance > Editor > Templates
3. Find and select the 'Single Product' template from the list.
4. When the Classic Product Template renders, click on Transform into Blocks. This will transform the Classic template in a block template if you haven't done it before.
5. Inside the Page editor, click on the '+' button, usually found at the top left of the editing space or within the content area itself, to add a new block.
6. In the block library that pops up, search for the 'Product Gallery' block. Click on it to add the block to the template.
7. Click on Save;
8. Visit the file `assets/js/blocks/product-gallery/frontend.tsx` and add the `logTimeInit` effect inside the Interactivity API store:
```
interactivityApiStore( {
	state: {},
	effects: {
		woocommerce: {
			logTimeInit: () => console.log( `Init at ` + new Date() ),
			...
	         },
	 ...
	 },
	 ...
});
```
9. Visit the file `src/BlockTypes/ProductGallery.php` and add the following attribute to the HTML Tag Processor:
```
if ( $p->next_tag() ) {
	...
	$p->set_attribute( 'data-wc-init', 'effects.woocommerce.logTimeInit' );
	...
}
```
10. Visit a product page with the browser console open and check that there is a console message like `Init at {{ date }}` where date is the current timestamp.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [x] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast
![CleanShot 2023-10-25 at 16 06 01](https://github.com/woocommerce/woocommerce-blocks/assets/20469356/8c3f0b68-59c3-4a32-ae8d-806dd5446aec)

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental
* [ ] N/A
