### PR TITLE
Product Gallery block: Add support for variation image updates

### DIFF
--- a/assets/js/blocks/product-gallery/frontend.tsx
+++ b/assets/js/blocks/product-gallery/frontend.tsx
@@ -63,6 +63,41 @@ interactivityApiStore( {
 	state: {},
 	effects: {
 		woocommerce: {
+			watchForChangesOnAddToCartForm: ( store: Store ) => {
+				const variableProductCartForm = document.querySelector(
+					'[data-product_id="16"]'
+				);
+
+				if ( ! variableProductCartForm ) {
+					return;
+				}
+
+				const observer = new MutationObserver( function ( mutations ) {
+					for ( const mutation of mutations ) {
+						const mutationTarget = mutation.target as HTMLElement;
+						const currentImageAttribute =
+							mutationTarget.getAttribute( 'current-image' );
+						if (
+							mutation.type === 'attributes' &&
+							currentImageAttribute &&
+							store.context.woocommerce.visibleImagesIds.includes(
+								currentImageAttribute
+							)
+						) {
+							store.context.woocommerce.selectedImage =
+								currentImageAttribute;
+						}
+					}
+				} );
+
+				observer.observe( variableProductCartForm, {
+					attributes: true,
+				} );
+
+				return () => {
+					observer.disconnect();
+				};
+			},
 			keyboardAccess: ( store: Store ) => {
 				const { context, actions } = store;
 				let allowNavigation = true;

--- a/assets/js/blocks/product-gallery/frontend.tsx
+++ b/assets/js/blocks/product-gallery/frontend.tsx
@@ -13,6 +13,7 @@ interface Context {
 		imageId: string;
 		visibleImagesIds: string[];
 		isDialogOpen: boolean;
+		productId: string;
 	};
 }
 
@@ -65,7 +66,7 @@ interactivityApiStore( {
 		woocommerce: {
 			watchForChangesOnAddToCartForm: ( store: Store ) => {
 				const variableProductCartForm = document.querySelector(
-					'[data-product_id="16"]'
+					`form[data-product_id="${ store.context.woocommerce.productId }"]`
 				);
 
 				if ( ! variableProductCartForm ) {

--- a/assets/js/interactivity/directives.js
+++ b/assets/js/interactivity/directives.js
@@ -74,6 +74,16 @@ export default () => {
 		}
 	);
 
+	// data-wc-init--[name]
+	directive( 'init', ( { directives: { init }, context, evaluate } ) => {
+		const contextValue = useContext( context );
+		Object.values( init ).forEach( ( path ) => {
+			useEffect( () => {
+				return evaluate( path, { context: contextValue } );
+			}, [] );
+		} );
+	} );
+
 	// data-wc-on--[event]
 	directive( 'on', ( { directives: { on }, element, evaluate, context } ) => {
 		const contextValue = useContext( context );

--- a/src/BlockTypes/ProductGallery.php
+++ b/src/BlockTypes/ProductGallery.php
@@ -132,6 +132,7 @@ class ProductGallery extends AbstractBlock {
 
 		if ( $p->next_tag() ) {
 			$p->set_attribute( 'data-wc-interactive', true );
+			$p->set_attribute( 'data-wc-init--watch-changes-on-add-to-cart-form', 'effects.woocommerce.watchForChangesOnAddToCartForm' );
 			$p->set_attribute(
 				'data-wc-context',
 				wp_json_encode(

--- a/src/BlockTypes/ProductGallery.php
+++ b/src/BlockTypes/ProductGallery.php
@@ -126,6 +126,7 @@ class ProductGallery extends AbstractBlock {
 		$dialog               = ( true === $attributes['fullScreenOnClick'] && isset( $attributes['mode'] ) && 'full' !== $attributes['mode'] ) ? $this->render_dialog() : '';
 		$post_id              = $block->context['postId'] ?? '';
 		$product              = wc_get_product( $post_id );
+		$productId            = strval( $product->get_id() );
 
 		$html = $this->inject_dialog( $content, $dialog );
 		$p    = new \WP_HTML_Tag_Processor( $html );
@@ -141,6 +142,7 @@ class ProductGallery extends AbstractBlock {
 							'selectedImage'    => $product->get_image_id(),
 							'visibleImagesIds' => ProductGalleryUtils::get_product_gallery_image_ids( $product, $number_of_thumbnails, true ),
 							'isDialogOpen'     => false,
+							'productId'        => $productId,
 						),
 					)
 				)

--- a/src/BlockTypes/ProductGallery.php
+++ b/src/BlockTypes/ProductGallery.php
@@ -126,7 +126,7 @@ class ProductGallery extends AbstractBlock {
 		$dialog               = ( true === $attributes['fullScreenOnClick'] && isset( $attributes['mode'] ) && 'full' !== $attributes['mode'] ) ? $this->render_dialog() : '';
 		$post_id              = $block->context['postId'] ?? '';
 		$product              = wc_get_product( $post_id );
-		$product_id            = strval( $product->get_id() );
+		$product_id           = strval( $product->get_id() );
 
 		$html = $this->inject_dialog( $content, $dialog );
 		$p    = new \WP_HTML_Tag_Processor( $html );

--- a/src/BlockTypes/ProductGallery.php
+++ b/src/BlockTypes/ProductGallery.php
@@ -133,7 +133,6 @@ class ProductGallery extends AbstractBlock {
 
 		if ( $p->next_tag() ) {
 			$p->set_attribute( 'data-wc-interactive', true );
-			$p->set_attribute( 'data-wc-init--watch-changes-on-add-to-cart-form', 'effects.woocommerce.watchForChangesOnAddToCartForm' );
 			$p->set_attribute(
 				'data-wc-context',
 				wp_json_encode(
@@ -147,6 +146,11 @@ class ProductGallery extends AbstractBlock {
 					)
 				)
 			);
+
+			if ( $product->is_type( 'variable' ) ) {
+				$p->set_attribute( 'data-wc-init--watch-changes-on-add-to-cart-form', 'effects.woocommerce.watchForChangesOnAddToCartForm' );
+			}
+
 			$p->add_class( $classname );
 			$p->add_class( $classname_single_image );
 			$html = $p->get_updated_html();

--- a/src/BlockTypes/ProductGallery.php
+++ b/src/BlockTypes/ProductGallery.php
@@ -126,7 +126,7 @@ class ProductGallery extends AbstractBlock {
 		$dialog               = ( true === $attributes['fullScreenOnClick'] && isset( $attributes['mode'] ) && 'full' !== $attributes['mode'] ) ? $this->render_dialog() : '';
 		$post_id              = $block->context['postId'] ?? '';
 		$product              = wc_get_product( $post_id );
-		$productId            = strval( $product->get_id() );
+		$product_id            = strval( $product->get_id() );
 
 		$html = $this->inject_dialog( $content, $dialog );
 		$p    = new \WP_HTML_Tag_Processor( $html );
@@ -142,7 +142,7 @@ class ProductGallery extends AbstractBlock {
 							'selectedImage'    => $product->get_image_id(),
 							'visibleImagesIds' => ProductGalleryUtils::get_product_gallery_image_ids( $product, $number_of_thumbnails, true ),
 							'isDialogOpen'     => false,
-							'productId'        => $productId,
+							'productId'        => $product_id,
 						),
 					)
 				)


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

> [!IMPORTANT]  
> **_This issue is blocked by_** #11458


## What
The current implementation for the Product Gallery does not offer support for variation image updates. This PR adds the following functionalities:

- When the shopper selects a product variation, the Large Image block updates with the image of the selected variation.
- If the selected variation does not contain a corresponding visible thumbnail, nothing will happen. The Large Image block will only display the image for visible variation thumbnails.

Fixes #10880 

## Why
When the shopper selects a product variation, the Large Image block should replace its displayed image with the one from the selected product variation.
<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. From your WordPress dashboard, go to Appearance > Themes. Make sure you have a block-based theme installed and activated. If not, you can install one from the Add New option. Block-based themes include "Twenty-twenty Three," "Twenty-twenty Four," etc.
2. On the left-hand side menu, click on Appearance > Editor > Templates
3. Find and select the 'Single Product' template from the list.
4. When the Classic Product Template renders, click on Transform into Blocks. This will transform the Classic template in a block template if you haven't done it before.
5. Inside the Page editor, click on the '+' button, usually found at the top left of the editing space or within the content area itself, to add a new block.
6. In the block library that pops up, search for the 'Product Gallery' block. Click on it to add the block to the template.
7. Click on Save;
8. Visit a product page of a Variable Product;
9. On the Add to Cart with Options block, select different combinations of the variable product and make sure the Large Image block updates the image with the selected variation (when the variation has a corresponding visible thumbnail image).

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|  ![CleanShot 2023-10-26 at 15 12 57](https://github.com/woocommerce/woocommerce-blocks/assets/20469356/187d5a86-f073-4600-b25d-072cbbfe7312) | ![CleanShot 2023-10-26 at 15 10 51](https://github.com/woocommerce/woocommerce-blocks/assets/20469356/481f1cf6-a360-4c71-9800-f439f9eefbb1) |



## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental
* [ ] N/A