### PR TITLE
Fix for storybook to ensure all components render

### DIFF
--- a/assets/js/settings/blocks/constants.ts
+++ b/assets/js/settings/blocks/constants.ts
@@ -34,15 +34,15 @@ export const WC_BLOCKS_IMAGE_URL = blocksConfig.pluginUrl + 'images/';
 export const WC_BLOCKS_BUILD_URL = blocksConfig.pluginUrl + 'build/';
 export const WC_BLOCKS_PHASE = blocksConfig.buildPhase;
 export const SHOP_URL = STORE_PAGES.shop?.permalink;
-export const CHECKOUT_PAGE_ID = STORE_PAGES.checkout.id;
-export const CHECKOUT_URL = STORE_PAGES.checkout.permalink;
-export const PRIVACY_URL = STORE_PAGES.privacy.permalink;
-export const PRIVACY_PAGE_NAME = STORE_PAGES.privacy.title;
-export const TERMS_URL = STORE_PAGES.terms.permalink;
-export const TERMS_PAGE_NAME = STORE_PAGES.terms.title;
-export const CART_PAGE_ID = STORE_PAGES.cart.id;
-export const CART_URL = STORE_PAGES.cart.permalink;
-export const LOGIN_URL = STORE_PAGES.myaccount.permalink
+export const CHECKOUT_PAGE_ID = STORE_PAGES.checkout?.id;
+export const CHECKOUT_URL = STORE_PAGES.checkout?.permalink;
+export const PRIVACY_URL = STORE_PAGES.privacy?.permalink;
+export const PRIVACY_PAGE_NAME = STORE_PAGES.privacy?.title;
+export const TERMS_URL = STORE_PAGES.terms?.permalink;
+export const TERMS_PAGE_NAME = STORE_PAGES.terms?.title;
+export const CART_PAGE_ID = STORE_PAGES.cart?.id;
+export const CART_URL = STORE_PAGES.cart?.permalink;
+export const LOGIN_URL = STORE_PAGES.myaccount?.permalink
 	? STORE_PAGES.myaccount.permalink
 	: getSetting( 'wpLoginUrl', '/wp-login.php' );
 export const LOCAL_PICKUP_ENABLED = getSetting< boolean >(

--- a/storybook/webpack.config.js
+++ b/storybook/webpack.config.js
@@ -63,5 +63,14 @@ module.exports = ( { config: storybookConfig } ) => {
 		} )
 	);
 
+	storybookConfig.module.rules = storybookConfig.module.rules.filter(
+		( rule ) =>
+			! (
+				rule.use &&
+				typeof rule.use.loader === 'string' &&
+				rule.use.loader.indexOf( 'babel-loader' ) >= 0
+			)
+	);
+
 	return storybookConfig;
 };


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Fixes Storybook as not all components are rendering there despite the fix added in #11456.

It removes the `babel-loader` webpack loader that is included in storybook by default, for some reason this isn't parsing our files correctly. I followed the comment here: https://github.com/storybookjs/storybook/issues/3346#issuecomment-425516669

## Why

After upgrading to webpack 5 storybook stopped working and in #11456 I added a fix, however some components still didn't show after this. It is due to the `STORE_PAGES` item in the `allSettings` object not being defined in the storybook context.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Run `npm run storybook`
2. Go to `localhost:6006` and check all components load.
3. Open the console, there is a warning but check that there are no errors.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [x] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Skipping
