### PR TITLE
"Product Collection X Columns" patterns: align "no reviews" text with the star

### DIFF
--- a/assets/js/base/components/product-rating/style.scss
+++ b/assets/js/base/components/product-rating/style.scss
@@ -2,6 +2,10 @@
 	display: block;
 	line-height: 1;
 
+	span {
+		line-height: 1.618;
+	}
+
 	&__stars {
 		display: inline-block;
 		overflow: hidden;

--- a/assets/js/base/components/product-rating/style.scss
+++ b/assets/js/base/components/product-rating/style.scss
@@ -1,9 +1,11 @@
+$line-height: 1.618;
+
 .wc-block-components-product-rating {
 	display: block;
 	line-height: 1;
 
 	span {
-		line-height: 1.618;
+		line-height: $line-height;
 	}
 
 	&__stars {
@@ -12,7 +14,7 @@
 		position: relative;
 		width: 5.3em;
 		height: 1.618em;
-		line-height: 1.618;
+		line-height: $line-height;
 		font-size: 1em;
 		/* stylelint-disable-next-line font-family-no-missing-generic-family-keyword */
 		font-family: star;
@@ -80,7 +82,7 @@
 		position: relative;
 		width: 1.5em;
 		height: 1.618em;
-		line-height: 1.618;
+		line-height: $line-height;
 		font-size: 1em;
 		/* stylelint-disable-next-line font-family-no-missing-generic-family-keyword */
 		font-family: star;


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Fixes #11360. This PR introduces a small change to align the "no reviews" text with the star. The change is very small.

Regarding the other points to address:
### Let’s double-check that we have a character limit for the title and it takes only one line.

We implemented this, improving the prompt.

### Some images look blurry. Would it be possible to have images with a higher resolution, please?

I am not sure if we can do something related to this topic cc @nefeline 



## Why

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Add a post.
2. Add the Product Collection 3 Columns pattern.
3. Ensure that the "no reviews" text is aligned with the star.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|![image](https://github.com/woocommerce/woocommerce-blocks/assets/4463174/46d1bbff-cd70-49d2-9bab-eec6c192931d)|![image](https://github.com/woocommerce/woocommerce-blocks/assets/4463174/20ac9c8f-2976-4fb7-95e6-50547b659096)|

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [ ] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Add suggested changelog entry here.
