### PR TITLE
Fix attempts to count possible non-countable variables or usage of undefined variables

### DIFF
--- a/src/BlockTypes/ProductCollection.php
+++ b/src/BlockTypes/ProductCollection.php
@@ -401,6 +401,7 @@ class ProductCollection extends AbstractBlock {
 		 */
 		if (
 			! empty( $merged_query['post__in'] ) &&
+			is_array( $merged_query['post__in'] ) &&
 			count( $merged_query['post__in'] ) > count( array_unique( $merged_query['post__in'] ) )
 		) {
 			$merged_query['post__in'] = array_unique(

--- a/src/BlockTypes/ProductQuery.php
+++ b/src/BlockTypes/ProductQuery.php
@@ -298,6 +298,7 @@ class ProductQuery extends AbstractBlock {
 		 */
 		if (
 			! empty( $merged_query['post__in'] ) &&
+			is_array( $merged_query['post__in'] ) &&
 			count( $merged_query['post__in'] ) > count( array_unique( $merged_query['post__in'] ) )
 		) {
 			$merged_query['post__in'] = array_unique(

--- a/src/StoreApi/Schemas/V1/ProductReviewSchema.php
+++ b/src/StoreApi/Schemas/V1/ProductReviewSchema.php
@@ -159,7 +159,6 @@ class ProductReviewSchema extends AbstractSchema {
 	 * @return array
 	 */
 	public function get_item_response( $review ) {
-		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
 		$rating  = get_comment_meta( $review->comment_ID, 'rating', true ) === '' ? null : (int) get_comment_meta( $review->comment_ID, 'rating', true );
 		$data    = [
 			'id'                     => (int) $review->comment_ID,
@@ -171,15 +170,11 @@ class ProductReviewSchema extends AbstractSchema {
 			'product_permalink'      => get_permalink( (int) $review->comment_post_ID ),
 			'product_image'          => $this->image_attachment_schema->get_item_response( get_post_thumbnail_id( (int) $review->comment_post_ID ) ),
 			'reviewer'               => $review->comment_author,
-			'review'                 => $review->comment_content,
+			'review'                 => wp_autop( $review->comment_content ),
 			'rating'                 => $rating,
 			'verified'               => wc_review_is_from_verified_owner( $review->comment_ID ),
 			'reviewer_avatar_urls'   => rest_get_avatar_urls( $review->comment_author_email ),
 		];
-
-		if ( 'view' === $context ) {
-			$data['review'] = wpautop( $data['review'] );
-		}
 
 		return $data;
 	}

--- a/src/StoreApi/Schemas/V1/ProductReviewSchema.php
+++ b/src/StoreApi/Schemas/V1/ProductReviewSchema.php
@@ -159,8 +159,8 @@ class ProductReviewSchema extends AbstractSchema {
 	 * @return array
 	 */
 	public function get_item_response( $review ) {
-		$rating  = get_comment_meta( $review->comment_ID, 'rating', true ) === '' ? null : (int) get_comment_meta( $review->comment_ID, 'rating', true );
-		$data    = [
+		$rating = get_comment_meta( $review->comment_ID, 'rating', true ) === '' ? null : (int) get_comment_meta( $review->comment_ID, 'rating', true );
+		return [
 			'id'                     => (int) $review->comment_ID,
 			'date_created'           => wc_rest_prepare_date_response( $review->comment_date ),
 			'formatted_date_created' => get_comment_date( 'F j, Y', $review->comment_ID ),
@@ -175,7 +175,5 @@ class ProductReviewSchema extends AbstractSchema {
 			'verified'               => wc_review_is_from_verified_owner( $review->comment_ID ),
 			'reviewer_avatar_urls'   => rest_get_avatar_urls( $review->comment_author_email ),
 		];
-
-		return $data;
 	}
 }

--- a/src/Templates/SingleProductTemplateCompatibility.php
+++ b/src/Templates/SingleProductTemplateCompatibility.php
@@ -425,7 +425,7 @@ class SingleProductTemplateCompatibility extends AbstractTemplateCompatibility {
 	private static function group_blocks( $parsed_blocks ) {
 		return array_reduce(
 			$parsed_blocks,
-			function( $carry, $block ) {
+			function( array $carry, array $block ) {
 				if ( 'core/template-part' === $block['blockName'] ) {
 					$carry[] = array( $block );
 					return $carry;

--- a/templates/notices/error.php
+++ b/templates/notices/error.php
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-if ( ! $notices ) {
+if ( empty( $notices ) || ! is_array( $notices ) ) {
 	return;
 }
 


### PR DESCRIPTION
## What

This fixes a few miscellaneous small problems where a possibly undefined variable was attempted to be accessed or a variable that wasn't necessarily countable was passed to `count()`

These were found by running Rector with rules specific to finding issues with php8.

## Why

A couple changes are specifically to help a static analysis tool like Rector identify issues.  But others are to be sure that fatal errors won't be throw due to changes in functionality between PHP 7.4 and PHP 8.

## Testing Instructions

These changes are purely code changes that do not effect functionality. 

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [x] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [x] N/A

## Checklist

Required:
* [ ] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Minor fixes for PHP 8.
