### PR TITLE
Playwright: Add eslint rule to prevent import `test` or `expect` from playwright library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -148,6 +148,7 @@
 				"eslint-import-resolver-webpack": "0.13.2",
 				"eslint-plugin-import": "2.28.1",
 				"eslint-plugin-playwright": "0.15.3",
+				"eslint-plugin-rulesdir": "^0.2.2",
 				"eslint-plugin-woocommerce": "file:bin/eslint-plugin-woocommerce",
 				"eslint-plugin-you-dont-need-lodash-underscore": "6.12.0",
 				"expect-puppeteer": "6.1.1",
@@ -36389,6 +36390,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/eslint-plugin-rulesdir": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-rulesdir/-/eslint-plugin-rulesdir-0.2.2.tgz",
+			"integrity": "sha512-qhBtmrWgehAIQeMDJ+Q+PnOz1DWUZMPeVrI0wE9NZtnpIMFUfh3aPKFYt2saeMSemZRrvUtjWfYwepsC8X+mjQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=4.0.0"
 			}
 		},
 		"node_modules/eslint-plugin-testing-library": {
@@ -85686,6 +85696,12 @@
 			"version": "4.6.0",
 			"dev": true,
 			"requires": {}
+		},
+		"eslint-plugin-rulesdir": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-rulesdir/-/eslint-plugin-rulesdir-0.2.2.tgz",
+			"integrity": "sha512-qhBtmrWgehAIQeMDJ+Q+PnOz1DWUZMPeVrI0wE9NZtnpIMFUfh3aPKFYt2saeMSemZRrvUtjWfYwepsC8X+mjQ==",
+			"dev": true
 		},
 		"eslint-plugin-testing-library": {
 			"version": "5.11.1",

--- a/package.json
+++ b/package.json
@@ -202,6 +202,7 @@
 		"eslint-import-resolver-webpack": "0.13.2",
 		"eslint-plugin-import": "2.28.1",
 		"eslint-plugin-playwright": "0.15.3",
+		"eslint-plugin-rulesdir": "^0.2.2",
 		"eslint-plugin-woocommerce": "file:bin/eslint-plugin-woocommerce",
 		"eslint-plugin-you-dont-need-lodash-underscore": "6.12.0",
 		"expect-puppeteer": "6.1.1",

--- a/tests/e2e/.eslintrc.js
+++ b/tests/e2e/.eslintrc.js
@@ -1,5 +1,5 @@
 const rulesDirPlugin = require( 'eslint-plugin-rulesdir' );
-rulesDirPlugin.RULES_DIR = 'tests/e2e/wc-blocks-eslint-rules';
+rulesDirPlugin.RULES_DIR = `${ __dirname }/wc-blocks-eslint-rules`;
 
 const config = {
 	extends: [ '../../.eslintrc.js', 'plugin:playwright/recommended' ],

--- a/tests/e2e/.eslintrc.js
+++ b/tests/e2e/.eslintrc.js
@@ -1,5 +1,9 @@
+const rulesDirPlugin = require( 'eslint-plugin-rulesdir' );
+rulesDirPlugin.RULES_DIR = 'tests/e2e/wc-blocks-eslint-rules';
+
 const config = {
 	extends: [ '../../.eslintrc.js', 'plugin:playwright/recommended' ],
+	plugins: [ 'rulesdir' ],
 	rules: {
 		'playwright/expect-expect': 'error',
 		'playwright/max-nested-describe': 'error',
@@ -18,6 +22,7 @@ const config = {
 		'playwright/no-wait-for-timeout': 'error',
 		'playwright/prefer-web-first-assertions': 'error',
 		'playwright/valid-expect': 'error',
+		'rulesdir/no-raw-playwright-test-import': 'error',
 	},
 };
 

--- a/tests/e2e/tests/add-to-cart-form/add-to-cart-form.block_theme.spec.ts
+++ b/tests/e2e/tests/add-to-cart-form/add-to-cart-form.block_theme.spec.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { BlockData } from '@woocommerce/e2e-types';
-import { test, expect } from '@woocommerce/e2e-playwright-utils';
+import { expect, test } from '@woocommerce/e2e-playwright-utils';
 import { EditorUtils } from '@woocommerce/e2e-utils';
 
 /**

--- a/tests/e2e/wc-blocks-eslint-rules/no-raw-playwright-test-import.js
+++ b/tests/e2e/wc-blocks-eslint-rules/no-raw-playwright-test-import.js
@@ -1,0 +1,52 @@
+module.exports = {
+	meta: {
+		type: 'problem',
+		docs: {
+			description:
+				'advise using @woocommerce/e2e-playwright-utils for importing test or expect functions',
+			category: 'Possible Errors',
+			recommended: true,
+		},
+		fixable: 'code',
+		schema: [],
+		messages: {
+			unexpected:
+				"Prefer importing { test, expect } from '@woocommerce/e2e-playwright-utils'.",
+		},
+	},
+	create( context ) {
+		return {
+			ImportDeclaration( node ) {
+				if ( node.source.value === '@playwright/test' ) {
+					const functionsNotAllowedToImportFromPlaywright = [
+						'test',
+						'expect',
+					];
+					const testSpecifier = node.specifiers.find(
+						( specifier ) =>
+							specifier.imported &&
+							functionsNotAllowedToImportFromPlaywright.includes(
+								specifier.imported.name
+							)
+					);
+
+					if ( testSpecifier ) {
+						context.report( {
+							node,
+							message:
+								'Import test or expect from @woocommerce/e2e-playwright-utils instead of @playwright/test for additional utilities.',
+							fix( fixer ) {
+								return [
+									fixer.replaceText(
+										node.source,
+										"'@woocommerce/e2e-playwright-utils'"
+									),
+								];
+							},
+						} );
+					}
+				}
+			},
+		};
+	},
+};


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What
This PR adds an Eslint rule to prevent import `test` or `expect` from the Playwright lib and use `@woocommerce/e2e-playwright-utils` instead. This eslint rule also automatically fixes the code by replacing `@playwright/test` with `@woocommerce/e2e-playwright-utils`.

Fixes #10505 

## Why
This is a quality of life improvement, and prevent test authors spending time debugging why utils aren't available

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Go to a playwright test file, such as: `tests/e2e/tests/add-to-cart-form/add-to-cart-form.block_theme.spec.ts`
2. Try importing the `test` or `expect` function from the library `@playwright/test`, for instance:
```
import { expect, test } from '@playwright/test';
```
3. See that an error appears with the message "Import test or expect from @woocommerce/e2e-playwright-utils instead of @playwright/test for additional utilities."
4. Run `eslint --fix` against the file and make sure the code is fixed with the correct import (if your editor runs eslint fix on save, you can save the file and check if the code is fixed).


* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [x] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

**Before**

https://github.com/woocommerce/woocommerce-blocks/assets/20469356/cba929b5-dacb-4759-bcdd-735b4b370950

**After**

https://github.com/woocommerce/woocommerce-blocks/assets/20469356/46ff446b-04fb-4bc2-87b8-b2d5b3ed6a92

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [x] N/A