### PR TITLE
Fix spacing on the "Minimal header" pattern

### DIFF
--- a/patterns/header-minimal.php
+++ b/patterns/header-minimal.php
@@ -19,14 +19,7 @@
 	<!-- wp:group {"style":{"spacing":{"blockGap":"8px"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"right"}} -->
 	<div class="wp-block-group">
 		<!-- wp:woocommerce/mini-cart {"hasHiddenPrice":true} /-->
-		<!-- wp:group {"style":{"spacing":{"blockGap":"16px"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-		<div class="wp-block-group">
-			<!-- wp:navigation {"overlayMenu":"always","layout":{"type":"flex","justifyContent":"left"}} /-->
-			<!-- wp:separator {"className":"is-style-wide"} -->
-			<hr class="wp-block-separator has-alpha-channel-opacity is-style-wide"/>
-			<!-- /wp:separator -->
-		</div>
-		<!-- /wp:group -->
+		<!-- wp:navigation {"overlayMenu":"always","layout":{"type":"flex","justifyContent":"left"}} /-->
 	</div>
 	<!-- /wp:group -->
 </div>


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Removes the group and spacer wrapping the navigation block to get rid of the extra right space.

## Why

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/11467
<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Create a new page or post and insert the `Minimal header` pattern.
2. Make sure there's no space at the right of the navigation block, as in the after screenshot below (note the blue color was added just to make it easier to visualize the space).

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|   <img width="1381" alt="Screenshot 2023-10-27 at 11 51 26" src="https://github.com/woocommerce/woocommerce-blocks/assets/186112/9037fbc8-cc75-4b36-8ab7-ebd089dc81bf">     |      <img width="1370" alt="Screenshot 2023-10-27 at 11 51 36" src="https://github.com/woocommerce/woocommerce-blocks/assets/186112/76dba159-e330-4cb0-9d5a-2640e3dae639"> |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Fix spacing on the "Minimal header" pattern.
