### PR TITLE
Essential Header Dark pattern: Fix color contrast issues in TT4

### DIFF
--- a/patterns/header-essential-dark.php
+++ b/patterns/header-essential-dark.php
@@ -11,8 +11,8 @@
 	<!-- wp:group {"style":{"spacing":{"blockGap":"40px"}},"layout":{"type":"flex","flexWrap":"wrap"}} -->
 	<div class="wp-block-group">
 		<!-- wp:site-logo {"shouldSyncIcon":false} /-->
-		<!-- wp:search {"label":"<?php esc_html_e( 'Search', 'woo-gutenberg-products-block' ); ?>","showLabel":false,"placeholder":"<?php esc_html_e( 'Search', 'woo-gutenberg-products-block' ); ?>","buttonText":"<?php esc_html_e( 'Search', 'woo-gutenberg-products-block' ); ?>","buttonUseIcon":true,"query":{"post_type":"product"},"width":100,"widthUnit":"%"} /-->
-		<!-- wp:navigation {"textColor":"background","layout":{"type":"flex","justifyContent":"center"}} /-->
+		<!-- wp:search {"label":"<?php esc_html_e( 'Search', 'woo-gutenberg-products-block' ); ?>","showLabel":false,"placeholder":"<?php esc_html_e( 'Search', 'woo-gutenberg-products-block' ); ?>","buttonText":"<?php esc_html_e( 'Search', 'woo-gutenberg-products-block' ); ?>","buttonUseIcon":true,"query":{"post_type":"product"},"width":100,"widthUnit":"%","backgroundColor":"contrast-2"} /-->
+		<!-- wp:navigation {"textColor":"background","overlayTextColor":"contrast","layout":{"type":"flex","justifyContent":"center"}} /-->
 	</div>
 	<!-- /wp:group -->
 


### PR DESCRIPTION
## What

Fixes #11297

## Why

This PR fixes the color contrast issues in the **Essential Header Dark** pattern with **Twenty Twenty-Four**.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Activate the **Twenty Twenty-Four** theme.
2. Create a new page.
3. Add the **Essential Header Dark** pattern.
4. In the `Navigation` block make sure you have some nested items. (Dropdown menu)
5. Verify that the Search button color contrast is correct both in the editor and the frontend.
6. Verify that the dropdown menu links have a correct color contrast in the frontend.
7. Enable the **Twenty Twenty-Three** theme and repeat all steps to make sure there are no regressions.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

### Before

| Editor | Front end |
| ------ | ----- |
|<img width="1262" alt="Cursor_i_Edit_Page_“Essential_Header_Dark”_‹_newproductgallery_—_WordPress" src="https://github.com/woocommerce/woocommerce-blocks/assets/905781/017490d4-15e1-445d-8a55-971ddf2d1dbd">|<img width="1264" alt="Essential_Header_Dark_–_newproductgallery" src="https://github.com/woocommerce/woocommerce-blocks/assets/905781/20eb5130-b1a9-457a-9a96-6b6f3e0bac42">|


### After

| Editor | Front end |
| ------ | ----- |
|<img width="1267" alt="Edit_Page_“Essential_Header_Dark”_‹_newproductgallery_—_WordPress" src="https://github.com/woocommerce/woocommerce-blocks/assets/905781/92c5399d-23ff-4948-a536-6b68e41b4775">|<img width="1266" alt="Cursor_i_Essential_Header_Dark_–_newproductgallery" src="https://github.com/woocommerce/woocommerce-blocks/assets/905781/47805ca8-ad82-494c-b189-ad900cb43581">|

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Essential Header Dark pattern: Fix color contrast issues in Twenty Twenty-Four.
