### PR TITLE
Add Storybook entry for `FormattedMonetaryAmount`

### DIFF
--- a/packages/components/formatted-monetary-amount/index.tsx
+++ b/packages/components/formatted-monetary-amount/index.tsx
@@ -15,10 +15,10 @@ import type { Currency } from '@woocommerce/types';
  */
 import './style.scss';
 
-interface FormattedMonetaryAmountProps
-	extends Omit< NumberFormatProps, 'onValueChange' > {
+export interface FormattedMonetaryAmountProps
+	extends Omit< NumberFormatProps, 'onValueChange' | 'displayType' > {
 	className?: string;
-	displayType?: NumberFormatProps[ 'displayType' ];
+	displayType?: NumberFormatProps[ 'displayType' ] | undefined;
 	allowNegative?: boolean;
 	isAllowed?: ( formattedValue: NumberFormatValues ) => boolean;
 	value: number | string; // Value of money amount.

--- a/packages/components/formatted-monetary-amount/index.tsx
+++ b/packages/components/formatted-monetary-amount/index.tsx
@@ -55,6 +55,8 @@ type CustomFormattedMonetaryAmountProps = Omit<
  * FormattedMonetaryAmount component.
  *
  * Takes a price and returns a formatted price using the NumberFormat component.
+ *
+ * More detailed docs on the additional props can be found here:https://s-yadav.github.io/react-number-format/docs/intro
  */
 const FormattedMonetaryAmount = ( {
 	className,

--- a/packages/components/formatted-monetary-amount/stories/index.tsx
+++ b/packages/components/formatted-monetary-amount/stories/index.tsx
@@ -1,0 +1,119 @@
+/**
+ * External dependencies
+ */
+import type { Story, Meta } from '@storybook/react';
+import { useArgs } from '@storybook/client-api';
+
+/**
+ * Internal dependencies
+ */
+import FormattedMonetaryAmount, { type FormattedMonetaryAmountProps } from '..';
+
+export default {
+	title: 'WooCommerce Blocks/@woocommerce-blocks-components/FormattedMonetaryAmount',
+	component: FormattedMonetaryAmount,
+	argTypes: {
+		className: {
+			control: 'text',
+			table: {
+				type: {
+					summary: 'string',
+				},
+			},
+		},
+		currency: {
+			table: {
+				type: {
+					summary: 'object',
+				},
+			},
+			control: 'object',
+			description:
+				'The currency object used to describe how the monetary amount should be displayed.',
+		},
+		displayType: {
+			table: {
+				type: {
+					summary: 'input | text',
+				},
+			},
+			control: 'select',
+			options: [ 'input', 'text' ],
+			defaultValue: 'text',
+			description:
+				'Whether this should be an input or just a text display.',
+		},
+		value: {
+			control: 'number',
+			table: {
+				type: {
+					summary: 'number',
+				},
+			},
+			defaultValue: 1234,
+			description:
+				'The raw value of the currency, it will be formatted depending on the props of this component.',
+		},
+		isAllowed: {
+			control: 'function',
+			table: {
+				type: {
+					summary: 'function',
+				},
+			},
+			if: { arg: 'displayType', eq: 'input' },
+			description:
+				'A checker function to validate the input value. If this function returns false, the onChange method will not get triggered and the input value will not change.',
+		},
+		allowNegative: {
+			control: 'boolean',
+			table: {
+				type: {
+					summary: 'boolean',
+				},
+			},
+			description: 'Whether negative numbers can be entered',
+		},
+		onValueChange: {
+			table: {
+				type: {
+					summary: 'function',
+				},
+			},
+			action: 'changed',
+		},
+		style: {
+			control: 'object',
+			table: {
+				type: {
+					summary: 'object',
+				},
+			},
+		},
+	},
+} as Meta< FormattedMonetaryAmountProps >;
+
+const Template: Story< FormattedMonetaryAmountProps > = ( args ) => {
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	const [ _, updateArgs ] = useArgs();
+	const onValueChange = ( unit: number ) => {
+		updateArgs( { value: unit } );
+	};
+
+	return (
+		<FormattedMonetaryAmount { ...args } onValueChange={ onValueChange } />
+	);
+};
+
+export const Default = Template.bind( {} );
+Default.args = {
+	currency: {
+		minorUnit: 2,
+		code: 'USD',
+		decimalSeparator: '.',
+		prefix: '$',
+		suffix: '',
+		symbol: '$',
+		thousandSeparator: ',',
+	},
+};


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Adds a storybook entry for the `FormattedMonetaryAmount` component we recently exported.

## Why

To showcase the component and provide a level of documentation.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Run `npm run storybook`
2. Open `localhost:6006` and check the `WooCommerce Blocks/@woocommerce-blocks-components/FormattedMonetaryAmount` component.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [x] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [x] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Skipping.
