### PR TITLE
Store Customization > Add default size for the site logo to circumvent Gutenberg's default size.

### DIFF
--- a/patterns/footer-large.php
+++ b/patterns/footer-large.php
@@ -15,7 +15,7 @@
 		<div class="wp-block-column" style="padding-right:50px;flex-basis:60%">
 			<!-- wp:group {"style":{"spacing":{"blockGap":"8px"}},"layout":{"type":"flex","orientation":"vertical"}} -->
 			<div class="wp-block-group">
-				<!-- wp:site-logo /-->
+				<!-- wp:site-logo {"width":60} /-->
 
 				<!-- wp:group {"style":{"spacing":{"margin":{"top":"40px","bottom":"40px"},"blockGap":"12px"}},"layout":{"type":"constrained"}} -->
 				<div class="wp-block-group" style="margin-top:40px;margin-bottom:40px">

--- a/patterns/footer-with-3-menus.php
+++ b/patterns/footer-with-3-menus.php
@@ -15,7 +15,7 @@
 		<div class="wp-block-column is-vertically-aligned-top" style="flex-basis:60%">
 			<!-- wp:group {"style":{"spacing":{"blockGap":"32px"}},"layout":{"type":"flex","flexWrap":"wrap","verticalAlignment":"top"}} -->
 			<div class="wp-block-group">
-				<!-- wp:site-logo /-->
+				<!-- wp:site-logo {"width":60} /-->
 
 				<!-- wp:columns {"style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"},"blockGap":{"top":"var:preset|spacing|70","left":"var:preset|spacing|80"}}}} -->
 				<div class="wp-block-columns" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">

--- a/patterns/header-centered-search-pattern.php
+++ b/patterns/header-centered-search-pattern.php
@@ -13,7 +13,7 @@
 	<div class="wp-block-group alignfull sticky-header" style="margin-top:0px;margin-bottom:0px;padding-top:16px;padding-right:2%;padding-bottom:16px;padding-left:2%">
 		<!-- wp:group {"style":{"spacing":{"blockGap":"20px"}},"layout":{"type":"flex","flexWrap":"wrap"}} -->
 		<div class="wp-block-group">
-			<!-- wp:site-logo {"shouldSyncIcon":false} /-->
+			<!-- wp:site-logo {"width":60} /-->
 			<!-- wp:site-title /-->
 		</div>
 		<!-- /wp:group -->

--- a/patterns/header-essential.php
+++ b/patterns/header-essential.php
@@ -11,7 +11,7 @@
 <div class="wp-block-group alignfull" style="padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
 	<!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
 	<div class="wp-block-group">
-		<!-- wp:site-logo /-->
+		<!-- wp:site-logo {"width":60} /-->
 	</div>
 	<!-- /wp:group -->
 


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Ensure the size for the site logo is set as 60px: this is to circumvent Gutenberg's default width, which causes the logo to be bigger than expected in the CYS experience:

https://github.com/WordPress/gutenberg/blob/68d30bc600b85a86328f82c8e3d17780fa3e530d/packages/block-library/src/site-logo/style.scss#L13

The new width (60px), coincidentally, matches the default set for that icon on the Assembler: ideally, when the logo is inserted in the editor, that setting should do the work of configuring the width out-of-the-box, but it isn't, so this is a "hack" solution.

## Why

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

This is a temporary workaround to ensure the size of the icon "matches" the default setting in the pattern assembler; this change should be revisited and removed as soon as the problem is fixed on that end.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Create a new post
2. Insert the **Large Footer**, **Footer with 3 Menus**, **Centered Header Menu with Search** and **Essential Header** patterns.
3. Make sure all of them have the default width set as 60 px:
<img width="1191" alt="Screenshot 2023-10-27 at 17 46 47" src="https://github.com/woocommerce/woocommerce-blocks/assets/15730971/6a88c311-b91e-456d-8e93-5d4702bae806">
4. Save the post and confirm the width is also 60px on the front-end

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

<img width="1301" alt="Screenshot 2023-10-27 at 18 09 50" src="https://github.com/woocommerce/woocommerce-blocks/assets/15730971/77baf3e5-3157-4f8c-a7f0-40a182433724">


## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Set the width for the site logo for the **Large Footer**, **Footer with 3 Menus**, **Centered Header Menu with Search** and **Essential Header** patterns.
