### PR TITLE
Improve checkout filters arguments description

### DIFF
--- a/docs/third-party-developers/extensibility/checkout-block/available-filters.md
+++ b/docs/third-party-developers/extensibility/checkout-block/available-filters.md
@@ -2,717 +2,124 @@
 
 ## Table of Contents <!-- omit in toc -->
 
--   [Cart Line Items](#cart-line-items)
--   [Order Summary Items](#order-summary-items)
--   [Totals footer item (in Mini-Cart, Cart and Checkout)](#totals-footer-item-in-mini-cart-cart-and-checkout)
+-   [Cart Line Items filters](#cart-line-items-filters)
+-   [Order Summary Items filters](#order-summary-items-filters)
+-   [Totals Footer Item filter](#totals-footer-item-filter)
+-   [Checkout and place order button](#checkout-and-place-order-button)
 -   [Coupons](#coupons)
--   [Proceed to Checkout Button Label](#proceed-to-checkout-button-label)
--   [Proceed to Checkout Button Link](#proceed-to-checkout-button-link)
--   [Place Order Button Label](#place-order-button-label)
--   [Additional Cart Checkout inner block types](#additional-cart-checkout-inner-block-types)
--   [Examples](#examples)
-    -   [Changing the wording and the link on the "Proceed to Checkout" button when a specific item is in the Cart](#changing-the-wording-and-the-link-on-the-proceed-to-checkout-button-when-a-specific-item-is-in-the-cart)
-    -   [Allowing blocks in specific areas in the Cart and Checkout blocks](#allowing-blocks-in-specific-areas-in-the-cart-and-checkout-blocks)
-    -   [Changing the wording of the Totals label in the Mini-Cart, Cart and Checkout](#changing-the-wording-of-the-totals-label-in-the-mini-cart-cart-and-checkout)
-    -   [Changing the format of the item's single price](#changing-the-format-of-the-items-single-price)
-    -   [Change the name of a coupon](#change-the-name-of-a-coupon)
-    -   [Prevent a snackbar notice from appearing for coupons](#prevent-a-snackbar-notice-from-appearing-for-coupons)
-    -   [Hide the "Remove item" link on a cart item](#hide-the-remove-item-link-on-a-cart-item)
-    -   [Change the label of the Place Order button](#change-the-label-of-the-place-order-button)
+-   [Additional Cart and Checkout inner block types filter](#additional-cart-and-checkout-inner-block-types-filter)
+-   [Combined filters](#combined-filters)
 -   [Troubleshooting](#troubleshooting)
 
 This document lists the filters that are currently available to extensions and offers usage information for each one of them. Information on registering filters can be found on the [Checkout - Filter Registry](../../../../packages/checkout/filter-registry/README.md) page.
 
-## Cart Line Items
+## Cart Line Items filters
 
-Line items refer to each item listed in the cart or checkout. For instance, the "Sunglasses" and "Beanie with Logo" in this image are the line items.
+The following [Cart Line Items filters](./available-filters/cart-line-items.md) are available:
 
-![Cart Line Items](https://user-images.githubusercontent.com/17236129/192795735-bd6e8494-e5c9-4384-b6a4-092a579c4755.png)
+-   [`cartItemClass`](./available-filters/cart-line-items.md#cartitemclass)
+-   [`cartItemPrice`](./available-filters/cart-line-items.md#cartitemprice)
+-   [`itemName`](./available-filters/cart-line-items.md#itemname)
+-   [`saleBadgePriceFormat`](./available-filters/cart-line-items.md#salebadgepriceformat)
+-   [`showRemoveItemLink`](./available-filters/cart-line-items.md#showremoveitemlink)
+-   [`subtotalPriceFormat`](./available-filters/cart-line-items.md#subtotalpriceformat)
 
-The following filters are available for line items:
+The following screenshot shows which parts the individual filters affect:
 
-| Filter name            | Description                                                                                                                            | Return type                                                                           |
-| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| `itemName`             | Used to change the name of the item before it is rendered onto the page                                                                | `string`                                                                              |
-| `cartItemPrice`        | This is the price of the item, multiplied by the number of items in the cart.                                                          | `string` and **must** contain the substring `<price/>` where the price should appear. |
-| `cartItemClass`        | This is the className of the item cell.                                                                                                | `string`                                                                              |
-| `subtotalPriceFormat`  | This is the price of a single item. Irrespective of the number in the cart, this value will always be the current price of _one_ item. | `string` and **must** contain the substring `<price/>` where the price should appear. |
-| `showRemoveItemLink`   | Toggles the display of the "Remove item" link from the cart line item. Default: `true`                                                 | `boolean`                                                                             |
-| `saleBadgePriceFormat` | This is the amount of money saved when buying this item. It is the difference between the item's regular price and its sale price.     | `string` and **must** contain the substring `<price/>` where the price should appear. |
+![Cart Line Items](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-26-at-13.12.33.png)
 
-Each of these filters has the following arguments passed to it: `{ context: 'cart', cartItem: CartItem }` ([CartItem](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/c00da597efe4c16fcf5481c213d8052ec5df3766/assets/js/type-defs/cart.ts#L113))
+## Order Summary Items filters
 
-### itemName
+The following [Order Summary Items filters](./available-filters/order-summary-items.md) are available:
 
-```ts
-const { registerCheckoutFilters } = window.wc.blocksCheckout;
- 
-// Adjust item name of the cart line items.
-registerCheckoutFilters( 'example-extension', {
-  itemName: ( value, extensions, args ) => {
-    // Return early since this filter is not being applied in the Cart context.
-    // We must return the original value we received here.
-    if ( args?.context !== 'cart' ) {
-      return value;
-    }
-    return '🪴 ' + value + ' 🪴';
-  }
-} );
-```
+-   [`cartItemClass`](./available-filters/order-summary-items.md#cartitemclass)
+-   [`cartItemPrice`](./available-filters/order-summary-items.md#cartitemprice)
+-   [`itemName`](./available-filters/order-summary-items.md#itemname)
+-   [`subtotalPriceFormat`](./available-filters/order-summary-items.md#subtotalpriceformat)
 
-| Before                                                                                                                                   | After                                                                                                                                    |
-| ---------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| <img width="761" alt="image" src="https://user-images.githubusercontent.com/6242098/268245369-6cd0aad9-4a7e-45e1-915b-3294db101246.png"> | <img width="761" alt="image" src="https://user-images.githubusercontent.com/3323310/267216388-08bc3af0-6290-4ec4-b7f5-5ee21d66ed7f.png"> |
+The following screenshot shows which parts the individual filters affect:
 
-### cartItemPrice
+![Order Summary Items](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-26-at-16.29.45.png)
 
-```ts
-const { registerCheckoutFilters } = window.wc.blocksCheckout;
- 
-// Adjust cart item price of the cart line items.
-registerCheckoutFilters( 'example-extension', {
-  cartItemPrice: ( value, extensions, args ) => {
-    // Return early since this filter is not being applied in the Cart context.
-    // We must return the original value we received here.
-    if ( args?.context !== 'cart' ) {
-      return value;
-    }
-    return '<price/> for all items';
-  }
-} );
-```
+## Totals Footer Item filter
 
-| Before                                                                                                                                   | After                                                                                                                                    |
-| ---------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| <img width="761" alt="image" src="https://user-images.githubusercontent.com/6242098/268245369-6cd0aad9-4a7e-45e1-915b-3294db101246.png"> | <img width="761" alt="image" src="https://user-images.githubusercontent.com/3323310/267218100-6f427b42-f985-4724-a537-8f83d9eff84a.png"> |
+The following [Totals Footer Item filter](./available-filters/totals-footer-item.md) is available:
 
-### cartItemClass
+-   [totalLabel](./available-filters/totals-footer-item.md#totallabel)
 
-```ts
-const { registerCheckoutFilters } = window.wc.blocksCheckout;
- 
-// Adjust cart item class of the cart line items.
-registerCheckoutFilters( 'example-extension', {
-  cartItemClass: ( value, extensions, args ) => {
-    // Return early since this filter is not being applied in the Cart context.
-    // We must return the original value we received here.
-    if ( args?.context !== 'cart' ) {
-      return value;
-    }
-    return 'my-custom-class';
-  }
-} );
-```
+## Checkout and place order button
 
-| Before                                                                                                                                   | After                                                                                                                                    |
-| ---------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| <img width="761" alt="image" src="https://user-images.githubusercontent.com/6242098/268705467-6059c77a-6375-4087-a3e5-485d7077ac54.png"> | <img width="761" alt="image" src="https://user-images.githubusercontent.com/3323310/267219896-58ed0551-998b-4309-bc22-3f7be84565d6.png"> |
+The following [Checkout and place order button filters](./available-filters/checkout-and-place-order-button.md) are available:
 
-### subtotalPriceFormat
-
-```ts
-const { registerCheckoutFilters } = window.wc.blocksCheckout;
- 
-// Adjust subtotal price format of the cart line items.
-registerCheckoutFilters( 'example-extension', {
-  subtotalPriceFormat: ( value, extensions, args ) => {
-    // Return early since this filter is not being applied in the Cart context.
-    // We must return the original value we received here.
-    if ( args?.context !== 'cart' ) {
-      return value;
-    }
-    return '<price/> per item';
-  }
-} );
-```
-
-| Before                                                                                                                                   | After                                                                                                                                    |
-| ---------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| <img width="761" alt="image" src="https://user-images.githubusercontent.com/6242098/268294925-a014c8d7-4c26-4a0a-8f4c-f74a8240bbb4.png"> | <img width="761" alt="image" src="https://user-images.githubusercontent.com/3323310/267226443-67f089bd-95d0-49f8-81f4-df2fec1a3d69.png"> |
-
-### showRemoveItemLink
-
-```ts
-const { registerCheckoutFilters } = window.wc.blocksCheckout;
- 
-// Show remove item link of the cart line items.
-registerCheckoutFilters( 'example-extension', {
-  showRemoveItemLink: ( value, extensions, args ) => {
-    // Return early since this filter is not being applied in the Cart context.
-    // We must return the original value we received here.
-    if ( args?.context !== 'cart' ) {
-      return value;
-    }
-    return false;
-  }
-} );
-```
-
-| Before                                                                                                                                   | After                                                                                                                                    |
-| ---------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| <img width="761" alt="image" src="https://user-images.githubusercontent.com/6242098/268295858-ec76f525-e2cf-468c-9634-ae9e84e5aa48.png"> | <img width="761" alt="image" src="https://user-images.githubusercontent.com/6242098/268295935-3171cd92-33f1-4182-b875-bc7e422771a0.png"> |
-
-### saleBadgePriceFormat
-
-```ts
-const { registerCheckoutFilters } = window.wc.blocksCheckout;
- 
-// Adjust sale badge price format of the cart line items.
-registerCheckoutFilters( 'example-extension', {
-  saleBadgePriceFormat: ( value, extensions, args ) => {
-    // Return early since this filter is not being applied in the Cart context.
-    // We must return the original value we received here.
-    if ( args?.context !== 'cart' ) {
-      return value;
-    }
-    return '<price/> per item';
-  }
-} );
-```
-
-| Before                                                                                                                                   | After                                                                                                                                    |
-| ---------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| <img width="761" alt="image" src="https://user-images.githubusercontent.com/6242098/268295858-ec76f525-e2cf-468c-9634-ae9e84e5aa48.png"> | <img width="761" alt="image" src="https://user-images.githubusercontent.com/3323310/267230515-d5e9d791-2429-4cac-b4fb-106a3dbe07ce.png"> |
-
-## Order Summary Items
-
-In the Checkout block, there is a sidebar that contains a summary of what the customer is about to purchase. There are some filters available to modify the way certain elements are displayed on each item. The sale badges are not shown here, so those filters are not applied in the Order Summary.
-
-![Order Summary Items](https://user-images.githubusercontent.com/5656702/117026942-1b014d80-acf4-11eb-8515-b9b777d96a74.png)
-
-| Filter name           | Description                                                                                                                            | Return type                                                                           |
-| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
-| `itemName`            | Used to change the name of the item before it is rendered onto the page                                                                | `string`                                                                              |
-| `cartItemPrice`       | This is the price of the item, multiplied by the number of items in the cart.                                                          | `string` and **must** contain the substring `<price/>` where the price should appear. |
-| `cartItemClass`       | This is the className of the item cell.                                                                                                | `string`                                                                              |
-| `subtotalPriceFormat` | This is the price of a single item. Irrespective of the number in the cart, this value will always be the current price of _one_ item. | `string` and **must** contain the substring `<price/>` where the price should appear. |
-
-Each of these filters has the following additional arguments passed to it: `{ context: 'summary', cartItem: CartItem }` ([CartItem](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/c00da597efe4c16fcf5481c213d8052ec5df3766/assets/js/type-defs/cart.ts#L113))
-
-### subtotalPriceFormat
-
-A code snippet to adjust subtotal price format of the order summary items can be found below:
-
-```ts
-const { registerCheckoutFilters } = window.wc.blocksCheckout;
- 
-// Adjust subtotal price format of the order summary items.
-registerCheckoutFilters( 'example-extension', {
-  subtotalPriceFormat: ( value, extensions, args ) => {
-    // Return early since this filter is not being applied in the Summary context.
-    // We must return the original value we received here.
-    if ( args?.context !== 'summary' ) {
-      return value;
-    }
-    return '<price/> per item';
-  }
-} );
-```
-
-| Before                                                                                                                                   | After                                                                                                                                    |
-| ---------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| <img width="789" alt="image" src="https://user-images.githubusercontent.com/6242098/268092313-d981f064-f274-4175-8291-1671ed55535b.png"> | <img width="761" alt="image" src="https://user-images.githubusercontent.com/3323310/267265204-7afbbe1a-de1a-4696-a2d9-881de3016060.png"> |
-
-### itemName
-
-A code snippet to adjust the item name of the order summary items can be found below:
-
-```ts
-const { registerCheckoutFilters } = window.wc.blocksCheckout;
- 
-// Adjust item name of the order summary items.
-registerCheckoutFilters( 'example-extension', {
-  itemName: ( value, extensions, args ) => {
-    // Return early since this filter is not being applied in the Summary context.
-    // We must return the original value we received here.
-    if ( args?.context !== 'summary' ) {
-      return value;
-    }
-    return '🪴 ' + value + ' 🪴';
-  }
-} );
-```
-
-| Before                                                                                                                                   | After                                                                                                                                    |
-| ---------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| <img width="789" alt="image" src="https://user-images.githubusercontent.com/6242098/268092313-d981f064-f274-4175-8291-1671ed55535b.png"> | <img width="761" alt="image" src="https://user-images.githubusercontent.com/3323310/267250835-6f4dade5-b4fe-4e55-a639-61b85f41ef28.png"> |
-
-### cartItemPrice
-
-A code snippet to adjust the cart item price of the order summary items can be found below:
-
-```ts
-const { registerCheckoutFilters } = window.wc.blocksCheckout;
- 
-// Adjust cart item price of the order summary items.
-registerCheckoutFilters( 'example-extension', {
-  cartItemPrice: ( value, extensions, args ) => {
-    // Return early since this filter is not being applied in the Summary context.
-    // We must return the original value we received here.
-    if ( args?.context !== 'summary' ) {
-      return value;
-    }
-    return '<price/> for all items';
-  }
-} );
-```
-
-| Before                                                                                                                                   | After                                                                                                                                    |
-| ---------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| <img width="789" alt="image" src="https://user-images.githubusercontent.com/6242098/268092313-d981f064-f274-4175-8291-1671ed55535b.png"> | <img width="761" alt="image" src="https://user-images.githubusercontent.com/3323310/267262765-a0d9e26c-51c0-4101-ae80-b626f8dd1f00.png"> |
-
-### cartItemClass
-
-A code snippet to adjust the cart item class of the order summary items can be found below:
-
-```ts
-const { registerCheckoutFilters } = window.wc.blocksCheckout;
- 
-// Adjust cart item class of the order summary items.
-registerCheckoutFilters( 'example-extension', {
-  cartItemClass: ( value, extensions, args ) => {
-    // Return early since this filter is not being applied in the Summary context.
-    // We must return the original value we received here.
-    if ( args?.context !== 'summary' ) {
-      return value;
-    }
-    return 'my-custom-class';
-  }
-} );
-```
-
-| Before                                                                                                                                   | After                                                                                                                                    |
-| ---------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| <img width="789" alt="image" src="https://user-images.githubusercontent.com/6242098/268092313-d981f064-f274-4175-8291-1671ed55535b.png"> | <img width="761" alt="image" src="https://user-images.githubusercontent.com/3323310/267264072-cd665949-ef82-497d-8c88-7391082dc431.png"> |
-
-## Totals footer item (in Mini-Cart, Cart and Checkout)
-
-The word 'Total' that precedes the amount due, present in both the Cart _and_ Checkout blocks, is also passed through filters.
-
-| Filter name  | Description                                                                                                   | Return type |
-| ------------ | ------------------------------------------------------------------------------------------------------------- | ----------- |
-| `totalLabel` | This is the label for the cart total. It defaults to 'Total' (or the word for 'Total' if using translations). | `string`    |
-
-There are no additional arguments passed to this filter.
-
-```ts
-const { registerCheckoutFilters } = window.wc.blocksCheckout;
- 
-// Adjust the total label.
-registerCheckoutFilters( 'example-extension', {
-  totalLabel: ( value, extensions, args ) => {
-    return 'Deposit due today';
-  }
-} );
-```
-
-| Before                                                                                                                                   | After                                                                                                                                    |
-| ---------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| <img width="789" alt="image" src="https://user-images.githubusercontent.com/3323310/267275008-91bd6aeb-4824-4f8c-80ec-79bc63185bc6.png"> | <img width="761" alt="image" src="https://user-images.githubusercontent.com/3323310/267274984-721e0be5-31a6-4190-947c-326462d6fd98.png"> |
+-   [proceedToCheckoutButtonLabel](./available-filters/checkout-and-place-order-button.md#proceedtocheckoutbuttonlabel)
+-   [proceedToCheckoutButtonLink](./available-filters/checkout-and-place-order-button.md#proceedtocheckoutbuttonlink)
+-   [placeOrderButtonLabel](./available-filters/checkout-and-place-order-button.md#placeorderbuttonlabel)
 
 ## Coupons
 
-The current functionality is to display the coupon codes in the Cart and Checkout sidebars. This could be undesirable if you dynamically generate a coupon code that is not user-friendly. It may, therefore, be desirable to change the way this code is displayed. To achieve this, the filter `coupons` exists. This filter could also be used to show or hide coupons. This filter must _not_ be used to alter the value/totals of a coupon. This will not carry through to the Cart totals.
+The following [Coupon filters](./available-filters/coupons.md) are available:
 
-| Filter name | Description                                                | Return type    |
-| ----------- | ---------------------------------------------------------- | -------------- |
-| `coupons`   | This is an array of coupons currently applied to the cart. | `CartCoupon[]` |
+-   [`coupons`](./available-filters/coupons.md#coupons-1)
+-   [`showApplyCouponNotice`](./available-filters/coupons.md#showapplycouponnotice)
+-   [`showRemoveCouponNotice`](./available-filters/coupons.md#showremovecouponnotice)
 
-The additional argument supplied to this filter is: `{ context: 'summary' }`. A `CartCoupon` has the following shape:
+## Additional Cart and Checkout inner block types filter
 
-```ts
-CartCoupon {
-  code: string
-  label: string
-  discount_type: string
-  totals: {
-    currency_code: string
-    currency_decimal_separator: string
-    currency_minor_unit: number
-    currency_prefix: string
-    currency_suffix: string
-    currency_symbol: string
-    currency_thousand_separator: string
-    total_discount: string
-    total_discount_tax: string
-  }
-}
-```
+The following [Additional Cart and Checkout inner block types filter](./available-filters/additional-cart-checkout-inner-block-types.md) is available:
 
-A code snippet to replace coupon label for matching coupon(s) can be found below:
+-   [`additionalCartCheckoutInnerBlockTypes`](./available-filters/additional-cart-checkout-inner-block-types.md#additionalcartcheckoutinnerblocktypes)
 
-```ts
-const { registerCheckoutFilters } = window.wc.blocksCheckout;
- 
-// Replace coupon label for matching coupon(s).
-registerCheckoutFilters( 'example-extension', {
-    coupons: ( coupons ) => {
-        return coupons.map( ( coupon ) => {
-            // Regex to match autocoupon then unlimited undersores and numbers
-            if ( ! coupon.label.match( /autocoupon(?:_\d+)+/ ) ) {
-                return coupon;
-            }
-            return {
-                ...coupon,
-                label: 'Automatic coupon',
-            };
-        } );
-    }
-} );
-```
+## Combined filters
 
-| Before                                                                                                                                   | After                                                                                                                                    |
-| ---------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| <img width="789" alt="image" src="https://user-images.githubusercontent.com/3323310/267266272-bb6ff77e-7c40-46f7-8d66-a7825ea78fff.png"> | <img width="761" alt="image" src="https://user-images.githubusercontent.com/3323310/267266261-029f993a-cf32-4f9b-abb5-af05df2477cd.png"> |
-
-## Proceed to Checkout Button Label
-
-The Cart block contains a button which is labelled 'Proceed to Checkout' by default. It can be changed using the following filter.
-
-| Filter name                    | Description                                         | Return type |
-| ------------------------------ | --------------------------------------------------- | ----------- |
-| `proceedToCheckoutButtonLabel` | The wanted label of the Proceed to Checkout button. | `string`    |
-
-```ts
-const { registerCheckoutFilters } = window.wc.blocksCheckout;
- 
-// Adjust the proceed to checkout button label.
-registerCheckoutFilters( 'example-extension', {
-  proceedToCheckoutButtonLabel: ( value, extensions, args ) => {
-    if ( ! args?.cart.items ) {
-      return value;
-    }
- 
-    const isSunglassesInCart = args?.cart.items.some(
-      ( item ) => item.name === 'Sunglasses'
-    );
- 
-    // Return the default value if sunglasses is not in the cart.
-    if ( ! isSunglassesInCart ) {
-      return value;
-    }
- 
-    return 'Proceed to 😎 checkout';
-  }
-} );
-```
-
-| Before                                                                                                                                   | After                                                                                                                                    |
-| ---------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| <img width="761" alt="image" src="https://user-images.githubusercontent.com/6242098/268078493-9e338a2e-953f-4e1f-b547-ad5b4343b4bb.png"> | <img width="761" alt="image" src="https://user-images.githubusercontent.com/3323310/267269678-2d2ccd6b-edb4-4bec-952d-19dcae105fdd.png"> |
-
-## Proceed to Checkout Button Link
-
-The Cart block contains a button which is labelled 'Proceed to Checkout' and links to the Checkout page by default, but can be changed using the following filter. This filter has the current cart passed to it in the third parameter.
-
-| Filter name                   | Description                                                 | Return type |
-| ----------------------------- | ----------------------------------------------------------- | ----------- |
-| `proceedToCheckoutButtonLink` | The URL that the Proceed to Checkout button should link to. | `string`    |
-
-```ts
-const { registerCheckoutFilters } = window.wc.blocksCheckout;
- 
-// Adjust the proceed to checkout button link.
-registerCheckoutFilters( 'example-extension', {
-  proceedToCheckoutButtonLink: ( value, extensions, args ) => {
-    if ( ! args?.cart.items ) {
-      return value;
-    }
- 
-    const isSunglassesInCart = args?.cart.items.some(
-      ( item ) => item.name === 'Sunglasses'
-    );
- 
-    // Return the default value if sunglasses is not in the cart.
-    if ( ! isSunglassesInCart ) {
-      return value;
-    }
- 
-    return '/sunglasses-checkout';
-  }
-} );
-```
-
-<img width="761" alt="image" src="https://user-images.githubusercontent.com/3323310/267270560-2964d529-771d-4d00-9fff-646b15d59cbf.png">
-
-## Place Order Button Label
-
-The Checkout block contains a button which is labelled 'Place Order' by default, but can be changed using the following filter. This filter has the current cart passed to it in the third parameter.
-
-| Filter name             | Description                                 | Return type |
-| ----------------------- | ------------------------------------------- | ----------- |
-| `placeOrderButtonLabel` | The wanted label of the Place Order button. | `string`    |
-
-```ts
-const { registerCheckoutFilters } = window.wc.blocksCheckout;
- 
-// Adjust the place order button label.
-registerCheckoutFilters( 'example-extension', {
-  placeOrderButtonLabel: ( value, extensions, args ) => {
-    return '💰 Pay now 💰';
-  }
-} );
-```
-
-| Before                                                                                                                                   | After                                                                                                                                    |
-| ---------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| <img width="761" alt="image" src="https://github.com/masteradhoc/woocommerce-blocks/assets/6242098/5703a5a6-39f4-4c29-a176-1a80412e3de9"> | <img width="761" alt="image" src="https://user-images.githubusercontent.com/3323310/267271739-3a8babc4-2848-424b-bc4a-8137eb2b2746.png"> |
-
-## Additional Cart Checkout inner block types
-
-The Cart and Checkout blocks are made up of inner blocks. These inner blocks areas allow certain block types to be added as children. By default, only `core/paragraph`, `core/image`, and `core/separator` are available to add.
-
-By using the `additionalCartCheckoutInnerBlockTypes` filter it is possible to add items to this array to control what the editor can insert into an inner block.
-
-This filter is called once for each inner block area, so it is possible to be very granular when determining what blocks can be added where. See the [Allowing blocks in specific areas in the Cart and Checkout blocks.](#allowing-blocks-in-specific-areas-in-the-cart-and-checkout-blocks) example for more information.
-
-| Filter name                             | Description                           | Return type |
-| --------------------------------------- | ------------------------------------- | ----------- |
-| `additionalCartCheckoutInnerBlockTypes` | The new array of allowed block types. | `string[]`  |
-
-## Examples
-
-### Changing the wording and the link on the "Proceed to Checkout" button when a specific item is in the Cart
-
-For this example, let's say our store has a checkout page for regular items, and one set up specifically for users purchasing sunglasses. We will use the `wc/store/cart` data store to check whether a specific item (Sunglasses) is in the cart, and if it is, we will change the URL and text on the "Proceed to Checkout" button in the Cart block.
-
-```ts
-registerCheckoutFilters( 'sunglasses-store-extension', {
-	proceedToCheckoutButtonLabel: ( value, extensions, { cart } ) => {
-		if ( ! cart.items ) {
-			return value;
-		}
-		const isSunglassesInCart = cart.items.some(
-			( item ) => item.name === 'Sunglasses'
-		);
-		// Return the default value if sunglasses is not in the cart.
-		if ( ! isSunglassesInCart ) {
-			return value;
-		}
-		return 'Proceed to 😎 checkout';
-	},
-	proceedToCheckoutButtonLink: ( value, extensions, { cart } ) => {
-		if ( ! cart.items ) {
-			return value;
-		}
-		const isSunglassesInCart = cart.items.some(
-			( item ) => item.name === 'Sunglasses'
-		);
-		// Return the default value if sunglasses is not in the cart.
-		if ( ! isSunglassesInCart ) {
-			return value;
-		}
-		return '/sunglasses-checkout';
-	},
-} );
-```
-
-| Before                                                                                                                                   | After                                                                                                                                    |
-| ---------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| <img width="789" alt="image" src="https://user-images.githubusercontent.com/5656702/222575670-a7d1dab8-c93e-477a-b2cc-e463a5de77a6.png"> | <img width="761" alt="image" src="https://user-images.githubusercontent.com/5656702/222572409-de7a6bd6-5a2d-406b-ada9-cc60cc5cca54.png"> |
-
-### Allowing blocks in specific areas in the Cart and Checkout blocks
-
-Let's suppose we want to allow the editor to add some blocks in specific places in the Cart and Checkout blocks.
-
-1. Allow `core/table` to be inserted in the Shipping Address block in the Checkout.
-2. Allow `core/quote` to be inserted in every block area in the Cart and Checkout blocks.
-
-In our extension we could register a filter satisfy both of these conditions like so:
+Filters can also be combined. The following example shows how to combine some of the available filters.
 
 ```tsx
-registerCheckoutFilters( 'newsletter-plugin', {
-	additionalCartCheckoutInnerBlockTypes: ( value, extensions, { block } ) => {
-		// Remove the ability to add `core/separator`
-		value = value.filter( ( blockName ) => blockName !== 'core/separator' );
-
-		// Add core/quote to any inner block area.
-		value.push( 'core/quote' );
-
-		// If the block we're checking is `woocommerce/checkout-shipping-address-block then allow `core/table`.
-		if ( block === 'woocommerce/checkout-shipping-address-block' ) {
-			value.push( 'core/table' );
-		}
-
-		return value;
-	},
-} );
-```
-
-<img width="761" alt="image" src="https://user-images.githubusercontent.com/3323310/267215471-816eb52a-b052-4d98-a69e-e96b01dffd6a.png">
-
-### Changing the wording of the Totals label in the Mini-Cart, Cart and Checkout
-
-For this example, let's suppose we are building an extension that lets customers pay a deposit, and defer the full amount until a later date. To make it easier to understand what the customer is paying and why, let's change the value of `Total` to `Deposit due today`.
-
-1. We need to create a `CheckoutFilterFunction`.
-
-```ts
-const replaceTotalWithDeposit = () => 'Deposit due today';
-```
-
-2. Now we need to register this filter function, and have it executed when the `totalLabel` filter is applied. We can access the `registerCheckoutFilters` function on the `window.wc.blocksCheckout` object. As long as your extension's script is enqueued _after_ WooCommerce Blocks' scripts (i.e. by registering `wc-blocks-checkout` as a dependency), then this will be available.
-
-```ts
 const { registerCheckoutFilters } = window.wc.blocksCheckout;
-registerCheckoutFilters( 'my-hypothetical-deposit-plugin', {
-	totalLabel: replaceTotalWithDeposit,
-} );
-```
 
-| Before                                                                                                                           | After                                                                                                                           |
-| -------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| ![Snackbar notices before](https://user-images.githubusercontent.com/5656702/117032889-cc56b200-acf9-11eb-9bf7-ae5f6a0b1538.png) | ![Snackbar notices after](https://user-images.githubusercontent.com/5656702/117033039-ec867100-acf9-11eb-95d5-50c06bf2923c.png) |
+const isOrderSummaryContext = ( args ) => args?.context === 'summary';
 
-### Changing the format of the item's single price
-
-Let's say we want to add a little bit of text after an item's single price **in the Mini-Cart and Cart blocks only**, just to make sure our customers know that's the price per item.
-
-1. We will need to register a function to be executed when the `subtotalPriceFormat` is applied. Since we only want this to happen in the Cart context, our function will have to check the additional arguments passed to it to ensure the `context` value is `cart`. We can see from the table above, that our function needs to return a string that contains a substring of `<price/>`. This is a placeholder for the numeric value. The Mini-Cart and Cart blocks will interpolate the value into the string we return.
-
-```ts
-const appendTextToPriceInCart = ( value, extensions, args ) => {
-	if ( args?.context !== 'cart' ) {
-		// Return early since this filter is not being applied in the Cart context.
-		// We must return the original value we received here.
-		return value;
+const modifyCartItemClass = ( defaultValue, extensions, args ) => {
+	if ( isOrderSummaryContext( args ) ) {
+		return 'my-custom-class';
 	}
-	return '<price/> per item';
+	return defaultValue;
 };
-```
 
-2. Now we must register it. Refer to the first example for information about `registerCheckoutFilters`.
-
-```ts
-const { registerCheckoutFilters } = window.wc.blocksCheckout;
-registerCheckoutFilters( 'my-hypothetical-price-plugin', {
-	subtotalPriceFormat: appendTextToPriceInCart,
-} );
-```
-
-| Before                                                                                                         | After                                                                                                          |
-| -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| ![image](https://user-images.githubusercontent.com/5656702/117035086-d5488300-acfb-11eb-9954-feb326916168.png) | ![image](https://user-images.githubusercontent.com/5656702/117035616-70415d00-acfc-11eb-98d3-6c8096817e5b.png) |
-
-### Change the name of a coupon
-
-Let's say we're the author of an extension that automatically creates coupons for users, and applies them to the cart when certain items are bought in combination. Due to the internal workings of our extension, our automatically generated coupons are named something like `autocoupon_2020_06_29` - this doesn't look fantastic, so we want to change this to look a bit nicer. Our filtering function may look like this:
-
-```ts
-const filterCoupons = ( coupons ) => {
-	return coupons.map( ( coupon ) => {
-		// Regex to match autocoupon then unlimited undersores and numbers
-		if ( ! coupon.label.match( /autocoupon(?:_\d+)+/ ) ) {
-			return coupon;
-		}
-		return {
-			...coupon,
-			label: 'Automatic coupon',
-		};
-	} );
+const modifyCartItemPrice = ( defaultValue, extensions, args ) => {
+	if ( isOrderSummaryContext( args ) ) {
+		return '<price/> for all items';
+	}
+	return defaultValue;
 };
-```
 
-We'd register our filter like this:
+const modifyItemName = ( defaultValue, extensions, args ) => {
+	if ( isOrderSummaryContext( args ) ) {
+		return `🪴 ${ defaultValue } 🪴`;
+	}
+	return defaultValue;
+};
 
-```ts
-import { registerCheckoutFilters } from '@woocommerce/blocks-checkout';
-
-registerCheckoutFilters( 'automatic-coupon-extension', {
-	coupons: filterCoupons,
-} );
-```
-
-| Before                                                                                                         | After                                                                                                          |
-| -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| ![image](https://user-images.githubusercontent.com/5656702/123768988-bc55eb80-d8c0-11eb-9262-5d629837706d.png) | ![image](https://user-images.githubusercontent.com/5656702/124126048-2c57a380-da72-11eb-9b45-b2cae0cffc37.png) |
-
-### Prevent a snackbar notice from appearing for coupons
-
-If you want to prevent a coupon apply notice from appearing, you can use the `showApplyCouponNotice` filter. If it returns `false` then the notice will not be created.
-
-```ts
-const { registerCheckoutFilters } = window.wc.blocksCheckout;
- 
-// Prevent a couponCode called '10off' from creating a notice when it gets applied.
-registerCheckoutFilters( 'example-extension', {
-  showApplyCouponNotice: ( value, extensions, args ) => {
-    return args?.couponCode === '10off' ? false : value;
-  }
-} );
-```
-
-| Before                                                                                                         | After                                                                                                          |
-| -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| <img width="599" alt="image" src="https://github.com/masteradhoc/woocommerce-blocks/assets/6242098/b091a815-5e6b-45a2-8d2b-d55196afd59e">  | <img width="599" alt="image" src="https://github.com/masteradhoc/woocommerce-blocks/assets/6242098/b967b04b-4065-4aa7-8d16-8ab311c1ccbb"> |
-
-The same can be done with the `showRemoveCouponNotice` filter to prevent a notice when a coupon is removed from the cart.
-
-```ts
-const { registerCheckoutFilters } = window.wc.blocksCheckout;
- 
-// Prevent a couponCode called '10off' from creating a notice when it gets removed.
-registerCheckoutFilters( 'example-extension', {
-  showRemoveCouponNotice: ( value, extensions, args ) => {
-    return args?.couponCode === '10off' ? false : value;
-  }
-} );
-```
-
-| Before                                                                                                         | After                                                                                                          |
-| -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| <img width="598" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/6242098/276a7ece-2189-4636-9f65-4c1fb925c57e"> | <img width="600" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/6242098/1c9cf2c3-83ac-4c0c-bb28-314235ec9247"> |
-
-### Hide the "Remove item" link on a cart item
-
-If you want to stop customers from being able to remove a specific item from their cart **on the front end**, you can do
-this by using the `showRemoveItemLink` filter. If it returns `false` for that line item the link will not show.
-
-An important caveat to note is this does _not_ prevent the item from being removed from the cart using StoreAPI or by
-removing it in the Mini-Cart, or traditional shortcode cart.
-
-```ts
-import { registerCheckoutFilters } from '@woocommerce/blocks-checkout';
+const modifySubtotalPriceFormat = ( defaultValue, extensions, args ) => {
+	if ( isOrderSummaryContext( args ) ) {
+		return '<price/> per item';
+	}
+	return defaultValue;
+};
 
 registerCheckoutFilters( 'example-extension', {
-	showRemoveItemLink: ( value, extensions, { cartItem } ) => {
-		// Prevent items with ID 1 being removed from the cart.
-		return cartItem.id !== 1;
-	},
+	cartItemClass: modifyCartItemClass,
+	cartItemPrice: modifyCartItemPrice,
+	itemName: modifyItemName,
+	subtotalPriceFormat: modifySubtotalPriceFormat,
 } );
 ```
-
-### Change the label of the Place Order button
-
-Let's assume a merchant want to change the label of the Place Order button _Place Order_ to _Pay now_. A merchant can achieve this by using the `placeOrderButtonLabel` filter.
-
-1. We need to get the total price `placeOrderButtonLabel`.
-
-```ts
-const label = () => `Pay now`;
-```
-
-2. Now we have to register this filter function, and have it executed when the `placeOrderButtonLabel` filter is applied. We can access the `registerCheckoutFilters` function on the `window.wc.blocksCheckout` object. As long as your extension's script is enqueued _after_ WooCommerce Blocks' scripts (i.e. by registering `wc-blocks-checkout` as a dependency), then this will be available.
-
-```ts
-const { registerCheckoutFilters } = window.wc.blocksCheckout;
-registerCheckoutFilters( 'custom-place-order-button-label', {
-	placeOrderButtonLabel: label,
-} );
-```
-
-| Before                                                                                                         | After                                                                                                          |
-| -------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
-| ![image](https://user-images.githubusercontent.com/3323310/190539657-f9097cce-5a57-4aa8-92cd-3475d755c991.png) | ![image](https://user-images.githubusercontent.com/3323310/190539830-cac0536f-df97-4773-bfda-129e23cec02a.png) |
 
 ## Troubleshooting
 
 If you are logged in to the store as an administrator, you should be shown an error like this if your filter is not
-working correctly.
+working correctly. The error will also be shown in your console.
 
-![Troubleshooting](https://user-images.githubusercontent.com/5656702/117035848-b4ccf880-acfc-11eb-870a-31ae86dd6496.png)
-
-The error will also be shown in your console.
+![Troubleshooting](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-30-at-10.52.53.png)
 
 <!-- FEEDBACK -->
 
@@ -723,4 +130,3 @@ The error will also be shown in your console.
 🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-blocks/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/third-party-developers/extensibility/checkout-block/available-filters.md)
 
 <!-- /FEEDBACK -->
-

--- a/docs/third-party-developers/extensibility/checkout-block/available-filters.md
+++ b/docs/third-party-developers/extensibility/checkout-block/available-filters.md
@@ -5,8 +5,8 @@
 -   [Cart Line Items filters](#cart-line-items-filters)
 -   [Order Summary Items filters](#order-summary-items-filters)
 -   [Totals Footer Item filter](#totals-footer-item-filter)
--   [Checkout and place order button](#checkout-and-place-order-button)
--   [Coupons](#coupons)
+-   [Checkout and place order button filters](#checkout-and-place-order-button-filters)
+-   [Coupon filters](#coupon-filters)
 -   [Additional Cart and Checkout inner block types filter](#additional-cart-and-checkout-inner-block-types-filter)
 -   [Combined filters](#combined-filters)
 -   [Troubleshooting](#troubleshooting)
@@ -47,7 +47,7 @@ The following [Totals Footer Item filter](./available-filters/totals-footer-item
 
 -   [totalLabel](./available-filters/totals-footer-item.md#totallabel)
 
-## Checkout and place order button
+## Checkout and place order button filters
 
 The following [Checkout and place order button filters](./available-filters/checkout-and-place-order-button.md) are available:
 
@@ -55,7 +55,7 @@ The following [Checkout and place order button filters](./available-filters/chec
 -   [proceedToCheckoutButtonLink](./available-filters/checkout-and-place-order-button.md#proceedtocheckoutbuttonlink)
 -   [placeOrderButtonLabel](./available-filters/checkout-and-place-order-button.md#placeorderbuttonlabel)
 
-## Coupons
+## Coupon filters
 
 The following [Coupon filters](./available-filters/coupons.md) are available:
 

--- a/docs/third-party-developers/extensibility/checkout-block/available-filters/additional-cart-checkout-inner-block-types.md
+++ b/docs/third-party-developers/extensibility/checkout-block/available-filters/additional-cart-checkout-inner-block-types.md
@@ -73,9 +73,21 @@ To call this filter within the editor, wrap the filter registration in a `DOMCon
 
 > 💡 Filters can be also combined. See [Combined filters](../available-filters.md#combined-filters) for an example.
 
-### Screenshot <!-- omit in toc -->
+### Screenshots <!-- omit in toc -->
 
-![Additional Cart and Checkout inner block types filter](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-26-at-18.20.37.png)
+<table>
+<tr>
+<td valign="top">Before:
+<br><br>
+<img width="367" alt="Before applying the Additional Cart and Checkout inner block types filter" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/0d4560c8-c2b1-4ed8-8aee-469b248ccb08">
+
+</td>
+<td valign="top">After:
+<br><br>
+<img width="366" alt="After applying the Additional Cart and Checkout inner block types filter" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/d38cd568-6c8c-4158-9269-d8dffdf66988">
+</td>
+</tr>
+</table>
 
 <!-- FEEDBACK -->
 

--- a/docs/third-party-developers/extensibility/checkout-block/available-filters/additional-cart-checkout-inner-block-types.md
+++ b/docs/third-party-developers/extensibility/checkout-block/available-filters/additional-cart-checkout-inner-block-types.md
@@ -37,6 +37,15 @@ In our extension we could register a filter satisfy both of these conditions lik
 
 ```tsx
 document.addEventListener( 'DOMContentLoaded', function () {
+	/**
+	 * Optional: Import `registerCheckoutFilters` using ES module syntax if you are using
+	 * @woocommerce/dependency-extraction-webpack-plugin for enhanced dependency management.
+	 *
+	 * Replace the line below with the following import statement:
+	 * import { registerCheckoutFilters } from '@woocommerce/checkout-data';
+	 *
+	 * @see https://www.npmjs.com/package/@woocommerce/dependency-extraction-webpack-plugin
+	 */
 	const { registerCheckoutFilters } = window.wc.blocksCheckout;
 
 	const modifyAdditionalInnerBlockTypes = (

--- a/docs/third-party-developers/extensibility/checkout-block/available-filters/additional-cart-checkout-inner-block-types.md
+++ b/docs/third-party-developers/extensibility/checkout-block/available-filters/additional-cart-checkout-inner-block-types.md
@@ -1,0 +1,77 @@
+# Additional Cart and Checkout inner block types
+
+The following Additional Cart and Checkout inner block types filter is available:
+
+-   [`additionalCartCheckoutInnerBlockTypes`](#additionalcartcheckoutinnerblocktypes)
+
+## `additionalCartCheckoutInnerBlockTypes`
+
+### Description <!-- omit in toc -->
+
+The Cart and Checkout blocks are made up of inner blocks. These inner blocks areas allow certain block types to be added as children. By default, only `core/paragraph`, `core/image`, and `core/separator` are available to add.
+
+By using the `additionalCartCheckoutInnerBlockTypes` filter it is possible to add items to this array to control what the editor can into an inner block.
+
+This filter is called once for each inner block area, so it is possible to be very granular when determining what blocks can be added where.
+
+### Parameters <!-- omit in toc -->
+
+-   _defaultValue_ `array` (default: `[]`) - The default value of the filter.
+-   _extensions_ `object` (default: `{}`) - The extensions object.
+-   _args_ `object` - The arguments object with the following key:
+    -   _block_ `string` - The block name of the inner block area, e.g. `woocommerce/checkout-shipping-address-block`.
+-   _validation_ `boolean` or `Error` - Checks if the returned value is an arry of strings. If an error occurs, it will be thrown.
+
+### Returns <!-- omit in toc -->
+
+-   `array` - The modified array with allowed block types for the corresponding inner block area.
+
+### Code example <!-- omit in toc -->
+
+Let's suppose we want to allow the editor to add some blocks in specific places in the Cart and Checkout blocks.
+
+1. Allow `core/quote` to be inserted in every block area in the Cart and Checkout blocks.
+2. Allow `core/table` to be inserted in the Shipping Address block in the Checkout.
+
+In our extension we could register a filter satisfy both of these conditions like so:
+
+```tsx
+document.addEventListener( 'DOMContentLoaded', function () {
+	const { registerCheckoutFilters } = window.wc.blocksCheckout;
+
+	const modifyAdditionalInnerBlockTypes = (
+		defaultValue,
+		extensions,
+		args,
+		validation
+	) => {
+		defaultValue.push( 'core/quote' );
+
+		if ( args?.block === 'woocommerce/checkout-shipping-address-block' ) {
+			defaultValue.push( 'core/table' );
+		}
+
+		return defaultValue;
+	};
+
+	registerCheckoutFilters( 'example-extension', {
+		additionalCartCheckoutInnerBlockTypes: modifyAdditionalInnerBlockTypes,
+	} );
+} );
+```
+
+To call this filter within the editor, wrap the filter registration in a `DOMContentLoaded` event listener and ensure the code runs in the admin panel.
+
+> 💡 Filters can be also combined. See [Combined filters](../available-filters.md#combined-filters) for an example.
+
+### Screenshot <!-- omit in toc -->
+
+![Additional Cart and Checkout inner block types filter](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-26-at-18.20.37.png)
+
+<!-- FEEDBACK -->
+
+---
+
+[We're hiring!](https://woocommerce.com/careers/) Come work with us!
+
+🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-blocks/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/third-party-developers/extensibility/checkout-block/available-filters/additional-cart-checkout-inner-block-types.md)

--- a/docs/third-party-developers/extensibility/checkout-block/available-filters/cart-line-items.md
+++ b/docs/third-party-developers/extensibility/checkout-block/available-filters/cart-line-items.md
@@ -1,0 +1,612 @@
+# Cart Line Items
+
+The following Cart Line Items filters are available:
+
+-   [`cartItemClass`](#cartitemclass)
+-   [`cartItemPrice`](#cartitemprice)
+-   [`itemName`](#itemname)
+-   [`saleBadgePriceFormat`](#salebadgepriceformat)
+-   [`showRemoveItemLink`](#showremoveitemlink)
+-   [`subtotalPriceFormat`](#subtotalpriceformat)
+
+The following objects are shared between the filters:
+
+-   [Cart object](#cart-object)
+-   [Cart Item object](#cart-item-object)
+
+The following screenshot shows which parts the individual filters affect:
+
+![Cart Line Items](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-26-at-13.12.33.png)
+
+## `cartItemClass`
+
+### Description <!-- omit in toc -->
+
+The `cartItemClass` filter allows to change the cart item class.
+
+### Parameters <!-- omit in toc -->
+
+-   _defaultValue_ `object` (default: `''`) - The default cart item class.
+-   _extensions_ `object` (default: `{}`) - The extensions object.
+-   _args_ `object` - The arguments object with the following keys:
+    -   _cart_ `object` - The cart object from `wc/store/cart`, see [Cart object](cart-object).
+    -   _cartItem_ `object` - The cart item object from `wc/store/cart`, see [Cart Item object](#cart-item-object).
+    -   _context_ `string` (allowed values: `cart` or `summary`) - The context of the item.
+
+### Returns <!-- omit in toc -->
+
+-   `string` - The modified cart item class, or an empty string.
+
+### Code examples <!-- omit in toc -->
+
+#### Basic example <!-- omit in toc -->
+
+```tsx
+const { registerCheckoutFilters } = window.wc.blocksCheckout;
+
+const modifyCartItemClass = ( defaultValue, extensions, args ) => {
+	const isCartContext = args?.context === 'cart';
+
+	if ( ! isCartContext ) {
+		return defaultValue;
+	}
+
+	return 'my-custom-class';
+};
+
+registerCheckoutFilters( 'example-extension', {
+	cartItemClass: modifyCartItemClass,
+} );
+```
+
+#### Advanced example <!-- omit in toc -->
+
+```tsx
+const { registerCheckoutFilters } = window.wc.blocksCheckout;
+
+const modifyCartItemClass = ( defaultValue, extensions, args ) => {
+	const isCartContext = args?.context === 'cart';
+
+	if ( ! isCartContext ) {
+		return defaultValue;
+	}
+
+	if ( args?.cartItem?.name === 'Beanie with Logo' ) {
+		return 'cool-class';
+	}
+
+	if ( args?.cartItem?.name === 'Sunglasses' ) {
+		return 'hot-class';
+	}
+
+	return 'my-custom-class';
+};
+
+registerCheckoutFilters( 'example-extension', {
+	cartItemClass: modifyCartItemClass,
+} );
+```
+
+> 💡 Filters can be also combined. See [Combined filters](../available-filters.md#combined-filters) for an example.
+
+### Screenshot <!-- omit in toc -->
+
+![Cart Item Class filter](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-26-at-14.14.17.png)
+
+## `cartItemPrice`
+
+### Description <!-- omit in toc -->
+
+The `cartItemPrice` filter allows to format the cart item price.
+
+### Parameters <!-- omit in toc -->
+
+-   _defaultValue_ `string` (default: `<price/>`) - The default cart item price.
+-   _extensions_ `object` (default: `{}`) - The extensions object.
+-   _args_ `object` - The arguments object with the following keys:
+    -   _cart_ `object` - The cart object from `wc/store/cart`, see [Cart object](#cart-object).
+    -   _cartItem_ `object` - The cart item object from `wc/store/cart`, see [Cart Item object](#cart-item-object).
+    -   _context_ `string` (allowed values: `cart` or `summary`) - The context of the item.
+-   _validation_ `boolean` - Checks if the return value contains the substring `<price/>`.
+
+### Returns <!-- omit in toc -->
+
+-   `string` - The modified format of the cart item price, which must contain the substring `<price/>`, or the original price format.
+
+### Code examples <!-- omit in toc -->
+
+#### Basic example <!-- omit in toc -->
+
+```tsx
+const { registerCheckoutFilters } = window.wc.blocksCheckout;
+
+const modifyCartItemPrice = ( defaultValue, extensions, args, validation ) => {
+	const isCartContext = args?.context === 'cart';
+
+	if ( ! isCartContext ) {
+		return defaultValue;
+	}
+
+	return '<price/> for all items';
+};
+
+registerCheckoutFilters( 'example-extension', {
+	cartItemPrice: modifyCartItemPrice,
+} );
+```
+
+#### Advanced example <!-- omit in toc -->
+
+```tsx
+const { registerCheckoutFilters } = window.wc.blocksCheckout;
+
+const modifyCartItemPrice = ( defaultValue, extensions, args, validation ) => {
+	const isCartContext = args?.context === 'cart';
+
+	if ( ! isCartContext ) {
+		return defaultValue;
+	}
+
+	if ( args?.cartItem?.name === 'Beanie with Logo' ) {
+		return '<price/> to keep you ☀️';
+	}
+
+	if ( args?.cartItem?.name === 'Sunglasses' ) {
+		return '<price/> to keep you ❄️';
+	}
+
+	return '<price/> for all items';
+};
+
+registerCheckoutFilters( 'example-extension', {
+	cartItemPrice: modifyCartItemPrice,
+} );
+```
+
+> 💡 Filters can be also combined. See [Combined filters](../available-filters.md#combined-filters) for an example.
+
+### Screenshot <!-- omit in toc -->
+
+![Cart Item Price filter](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-26-at-14.00.16.png)
+
+## `itemName`
+
+### Description <!-- omit in toc -->
+
+The `itemName` filter allows to change the cart item name.
+
+### Parameters <!-- omit in toc -->
+
+-   _defaultValue_ `string` - The default cart item name.
+-   _extensions_ `object` (default: `{}`) - The extensions object.
+-   _args_ `object` - The arguments object with the following keys:
+    -   _cart_ `object` - The cart object from `wc/store/cart`, see [Cart object](#cart-object).
+    -   _cartItem_ `object` - The cart item object from `wc/store/cart`, see [Cart Item object](#cart-item-object).
+    -   _context_ `string` (allowed values: `cart` or `summary`) - The context of the item.
+
+### Returns <!-- omit in toc -->
+
+-   `string` - The original or modified cart item name.
+
+### Code examples <!-- omit in toc -->
+
+#### Basic example <!-- omit in toc -->
+
+```tsx
+const { registerCheckoutFilters } = window.wc.blocksCheckout;
+
+const modifyItemName = ( defaultValue, extensions, args ) => {
+	const isCartContext = args?.context === 'cart';
+
+	if ( ! isCartContext ) {
+		return defaultValue;
+	}
+
+	return `🪴 ${ defaultValue } 🪴`;
+};
+
+registerCheckoutFilters( 'example-extension', {
+	itemName: modifyItemName,
+} );
+```
+
+#### Advanced example <!-- omit in toc -->
+
+```tsx
+const { registerCheckoutFilters } = window.wc.blocksCheckout;
+
+const modifyItemName = ( defaultValue, extensions, args ) => {
+	const isCartContext = args?.context === 'cart';
+
+	if ( ! isCartContext ) {
+		return defaultValue;
+	}
+
+	if ( args?.cartItem?.name === 'Beanie with Logo' ) {
+		return `⛷️ ${ defaultValue } ⛷️`;
+	}
+
+	if ( args?.cartItem?.name === 'Sunglasses' ) {
+		return `🏄‍♂️ ${ defaultValue } 🏄‍♂️`;
+	}
+
+	return `🪴 ${ defaultValue } 🪴`;
+};
+
+registerCheckoutFilters( 'example-extension', {
+	itemName: modifyItemName,
+} );
+```
+
+> 💡 Filters can be also combined. See [Combined filters](../available-filters.md#combined-filters) for an example.
+
+### Screenshot <!-- omit in toc -->
+
+![Item Name filter](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-26-at-12.22.21.png)
+
+## `saleBadgePriceFormat`
+
+### Description <!-- omit in toc -->
+
+The `saleBadgePriceFormat` filter allows to format the cart item sale badge price.
+
+### Parameters <!-- omit in toc -->
+
+-   _defaultValue_ `string` (default: `<price/>`) - The default cart item sale badge price.
+-   _extensions_ `object` (default: `{}`) - The extensions object.
+-   _args_ `object` - The arguments object with the following keys:
+    -   _cart_ `object` - The cart object from `wc/store/cart`, see [Cart object](#cart-object).
+    -   _cartItem_ `object` - The cart item object from `wc/store/cart`, see [Cart Item object](#cart-item-object).
+    -   _context_ `string` (allowed values: `cart` or `summary`) - The context of the item.
+-   _validation_ `boolean` - Checks if the return value contains the substring `<price/>`.
+
+### Returns <!-- omit in toc -->
+
+-   `string` - The modified format of the cart item sale badge price, which must contain the substring `<price/>`, or the original price format.
+
+### Code examples <!-- omit in toc -->
+
+```tsx
+const { registerCheckoutFilters } = window.wc.blocksCheckout;
+
+const modifySaleBadgePriceFormat = (
+	defaultValue,
+	extensions,
+	args,
+	validation
+) => {
+	const isCartContext = args?.context === 'cart';
+
+	if ( ! isCartContext ) {
+		return defaultValue;
+	}
+
+	return '<price/> per item';
+};
+
+registerCheckoutFilters( 'example-extension', {
+	saleBadgePriceFormat: modifySaleBadgePriceFormat,
+} );
+```
+
+#### Advanced example <!-- omit in toc -->
+
+```tsx
+const { registerCheckoutFilters } = window.wc.blocksCheckout;
+
+const modifySaleBadgePriceFormat = (
+	defaultValue,
+	extensions,
+	args,
+	validation
+) => {
+	const isCartContext = args?.context === 'cart';
+
+	if ( ! isCartContext ) {
+		return defaultValue;
+	}
+
+	if ( args?.cartItem?.name === 'Beanie with Logo' ) {
+		return '<price/> per item while keeping warm';
+	}
+
+	if ( args?.cartItem?.name === 'Sunglasses' ) {
+		return '<price/> per item while looking cool';
+	}
+
+	return '<price/> per item';
+};
+
+registerCheckoutFilters( 'example-extension', {
+	saleBadgePriceFormat: modifySaleBadgePriceFormat,
+} );
+```
+
+> 💡 Filters can be also combined. See [Combined filters](../available-filters.md#combined-filters) for an example.
+
+### Screenshot <!-- omit in toc -->
+
+![Sale Badge Price Format filter](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-26-at-15.16.20.png)
+
+## `showRemoveItemLink`
+
+### Description <!-- omit in toc -->
+
+The `showRemoveItemLink` is used to show or hide the cart item remove link.
+
+### Parameters <!-- omit in toc -->
+
+-   _defaultValue_ (type: `boolean`, default: `true`) - The default value of the remove link.
+-   _extensions_ `object` (default: `{}`) - The extensions object.
+-   _args_ `object` - The arguments object with the following keys:
+    -   _cart_ `object` - The cart object from `wc/store/cart`, see [Cart object](#cart-object).
+    -   _cartItem_ `object` - The cart item object from `wc/store/cart`, see [Cart Item object](#cart-item-object).
+    -   _context_ `string` (allowed values: `cart` or `summary`) - The context of the item.
+
+### Returns <!-- omit in toc -->
+
+-   `boolean` - `true` if the cart item remove link should be shown, `false` otherwise.
+
+### Code examples <!-- omit in toc -->
+
+#### Basic example <!-- omit in toc -->
+
+```tsx
+const { registerCheckoutFilters } = window.wc.blocksCheckout;
+
+const modifyShowRemoveItemLink = ( defaultValue, extensions, args ) => {
+	const isCartContext = args?.context === 'cart';
+
+	if ( ! isCartContext ) {
+		return defaultValue;
+	}
+
+	return false;
+};
+
+registerCheckoutFilters( 'example-extension', {
+	showRemoveItemLink: modifyShowRemoveItemLink,
+} );
+```
+
+#### Advanced example <!-- omit in toc -->
+
+```tsx
+const { registerCheckoutFilters } = window.wc.blocksCheckout;
+
+const modifyShowRemoveItemLink = ( defaultValue, extensions, args ) => {
+	const isCartContext = args?.context === 'cart';
+
+	if ( ! isCartContext ) {
+		return defaultValue;
+	}
+
+	if ( args?.cartItem?.name === 'Beanie with Logo' ) {
+		return false;
+	}
+
+	if ( args?.cartItem?.name === 'Sunglasses' ) {
+		return false;
+	}
+
+	return true;
+};
+
+registerCheckoutFilters( 'example-extension', {
+	showRemoveItemLink: modifyShowRemoveItemLink,
+} );
+```
+
+> 💡 Filters can be also combined. See [Combined filters](../available-filters.md#combined-filters) for an example.
+
+### Screenshot <!-- omit in toc -->
+
+![Show Remove Item Link filter](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-26-at-14.48.44.png)
+
+## `subtotalPriceFormat`
+
+### Description <!-- omit in toc -->
+
+The `subtotalPriceFormat` filter allows to format the cart item subtotal price.
+
+### Parameters <!-- omit in toc -->
+
+-   _defaultValue_ `string` (default: `<price/>`) - The default cart item subtotal price.
+-   _extensions_ `object` (default: `{}`) - The extensions object.
+-   _args_ `object` - The arguments object with the following keys:
+    -   _cart_ `object` - The cart object from `wc/store/cart`, see [Cart object](#cart-object).
+    -   _cartItem_ `object` - The cart item object from `wc/store/cart`, see [Cart Item object](#cart-item-object).
+    -   _context_ `string` (allowed values: `cart` or `summary`) - The context of the item.
+-   _validation_ `boolean` - Checks if the return value contains the substring `<price/>`.
+
+### Returns <!-- omit in toc -->
+
+-   `string` - The modified format of the cart item subtotal price, which must contain the substring `<price/>`, or the original price format.
+
+### Code examples <!-- omit in toc -->
+
+#### Basic example <!-- omit in toc -->
+
+```tsx
+const { registerCheckoutFilters } = window.wc.blocksCheckout;
+
+const modifySubtotalPriceFormat = (
+	defaultValue,
+	extensions,
+	args,
+	validation
+) => {
+	const isCartContext = args?.context === 'cart';
+
+	if ( ! isCartContext ) {
+		return defaultValue;
+	}
+
+	return '<price/> per item';
+};
+
+registerCheckoutFilters( 'example-extension', {
+	subtotalPriceFormat: modifySubtotalPriceFormat,
+} );
+```
+
+#### Advanced example <!-- omit in toc -->
+
+```tsx
+const { registerCheckoutFilters } = window.wc.blocksCheckout;
+
+const modifySubtotalPriceFormat = (
+	defaultValue,
+	extensions,
+	args,
+	validation
+) => {
+	const isCartContext = args?.context === 'cart';
+
+	if ( ! isCartContext ) {
+		return defaultValue;
+	}
+
+	if ( args?.cartItem?.name === 'Beanie with Logo' ) {
+		return '<price/> per warm beanie';
+	}
+
+	if ( args?.cartItem?.name === 'Sunglasses' ) {
+		return '<price/> per cool sunglasses';
+	}
+
+	return '<price/> per item';
+};
+
+registerCheckoutFilters( 'example-extension', {
+	subtotalPriceFormat: modifySubtotalPriceFormat,
+} );
+```
+
+> 💡 Filters can be also combined. See [Combined filters](../available-filters.md#combined-filters) for an example.
+
+### Screenshot <!-- omit in toc -->
+
+![Subtotal Price Format filter](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-26-at-14.42.08.png)
+
+## Cart object
+
+The Cart object of the filters above has the following keys:
+
+-   _billingAddress_ `object` - The billing address object with the following keys:
+    -   _address_1_ `string` - The first line of the address.
+    -   _address_2_ `string` - The second line of the address.
+    -   _city_ `string` - The city of the address.
+    -   _company_ `string` - The company of the address.
+    -   _country_ `string` - The country of the address.
+    -   _email_ `string` - The email of the address.
+    -   _first_name_ `string` - The first name of the address.
+    -   _last_name_ `string` - The last name of the address.
+    -   _phone_ `string` - The phone of the address.
+    -   _postcode_ `string` - The postcode of the address.
+    -   _state_ `string` - The state of the address.
+-   _billingData_ `object` - The billing data object with the same keys as the `billingAddress` object.
+-   _cartCoupons_ `array` - The cart coupons array.
+-   _cartErrors_ `array` - The cart errors array.
+-   _cartFees_ `array` - The cart fees array.
+-   _cartHasCalculatedShipping_ `boolean` - Whether the cart has calculated shipping.
+-   _cartIsLoading_ `boolean` - Whether the cart is loading.
+-   _cartItemErrors_ `array` - The cart item errors array.
+-   _cartItems_ `array` - The cart items array with cart item objects, see [Cart Item object](#cart-item-object).
+-   _cartItemsCount_ `number` - The cart items count.
+-   _cartItemsWeight_ `number` - The cart items weight.
+-   _cartNeedsPayment_ `boolean` - Whether the cart needs payment.
+-   _cartNeedsShipping_ `boolean` - Whether the cart needs shipping.
+-   _cartTotals_ `object` - The cart totals object with the following keys:
+    -   _currency_code_ `string` - The currency code.
+    -   _currency_decimal_separator_ `string` - The currency decimal separator.
+    -   _currency_minor_unit_ `number` - The currency minor unit.
+    -   _currency_prefix_ `string` - The currency prefix.
+    -   _currency_suffix_ `string` - The currency suffix.
+    -   _currency_symbol_ `string` - The currency symbol.
+    -   _currency_thousand_separator_ `string` - The currency thousand separator.
+    -   _tax_lines_ `array` - The tax lines array with tax line objects with the following keys:
+        -   _name_ `string` - The name of the tax line.
+        -   _price_ `number` - The price of the tax line.
+        -   _rate_ `string` - The rate ID of the tax line.
+    -   _total_discount_ `string` - The total discount.
+    -   _total_discount_tax_ `string` - The total discount tax.
+    -   _total_fees_ `string` - The total fees.
+    -   _total_fees_tax_ `string` - The total fees tax.
+    -   _total_items_ `string` - The total items.
+    -   _total_items_tax_ `string` - The total items tax.
+    -   _total_price_ `string` - The total price.
+    -   _total_shipping_ `string` - The total shipping.
+    -   _total_shipping_tax_ `string` - The total shipping tax.
+    -   _total_tax_ `string` - The total tax.
+-   _crossSellsProducts_ `array` - The cross sells products array with cross sells product objects.
+-   _extensions_ `object` (default: `{}`) - The extensions object.
+-   _isLoadingRates_ `boolean` - Whether the cart is loading rates.
+-   _paymentRequirements_ `array` - The payment requirements array.
+-   _shippingAddress_ `object` - The shipping address object with the same keys as the `billingAddress` object.
+-   _shippingRates_ `array` - The shipping rates array.
+
+## Cart Item object
+
+The Cart Item object of the filters above has the following keys:
+
+-   _backorders_allowed_ `boolean` - Whether backorders are allowed.
+-   _catalog_visibility_ `string` - The catalog visibility.
+-   _decsription_ `string` - The cart item description.
+-   _extensions_ `object` (default: `{}`) - The extensions object.
+-   _id_ `number` - The item ID.
+-   _images_ `array` - The item images array.
+-   _item_data_ `array` - The item data array.
+-   _key_ `string` - The item key.
+-   _low_stock_remaining_ `number` - The low stock remaining.
+-   _name_ `string` - The item name.
+-   _permalink_ `string` - The item permalink.
+-   _prices_ `object` - The item prices object with the following keys:
+    -   _currency_code_ `string` - The currency code.
+    -   _currency_decimal_separator_ `string` - The currency decimal separator.
+    -   _currency_minor_unit_ `number` - The currency minor unit.
+    -   _currency_prefix_ `string` - The currency prefix.
+    -   _currency_suffix_ `string` - The currency suffix.
+    -   _currency_symbol_ `string` - The currency symbol.
+    -   _currency_thousand_separator_ `string` - The currency thousand separator.
+    -   _price_ `string` - The price.
+    -   _price_range_ `string` - The price range.
+    -   _raw_prices_ `object` - The raw prices object with the following keys:
+        -   _precision_ `number` - The precision.
+        -   _price_ `number` - The price.
+        -   _regular_price_ `number` - The regular price.
+        -   _sale_price_ `number` - The sale price.
+    -   _regular_price_ `string` - The regular price.
+    -   _sale_price_ `string` - The sale price.
+-   _quantity_ `number` - The item quantity.
+-   _quantity_limits_ `object` - The item quantity limits object with the following keys:
+    -   _editable_ `boolean` - Whether the quantity is editable.
+    -   _maximum_ `number` - The maximum quantity.
+    -   _minimum_ `number` - The minimum quantity.
+    -   _multiple_of_ `number` - The multiple of quantity.
+-   _short_description_ `string` - The item short description.
+-   _show_backorder_badge_ `boolean` - Whether to show the backorder badge.
+-   _sku_ `string` - The item SKU.
+-   _sold_individually_ `boolean` - Whether the item is sold individually.
+-   _totals_ `object` - The item totals object with the following keys:
+    -   _currency_code_ `string` - The currency code.
+    -   _currency_decimal_separator_ `string` - The currency decimal separator.
+    -   _currency_minor_unit_ `number` - The currency minor unit.
+    -   _currency_prefix_ `string` - The currency prefix.
+    -   _currency_suffix_ `string` - The currency suffix.
+    -   _currency_symbol_ `string` - The currency symbol.
+    -   _currency_thousand_separator_ `string` - The currency thousand separator.
+    -   _line_subtotal_ `string` - The line subtotal.
+    -   _line_subtotal_tax_ `string` - The line subtotal tax.
+    -   _line_total_ `string` - The line total.
+    -   _line_total_tax_ `string` - The line total tax.
+-   _type_ `string` - The item type.
+-   _variation_ `array` - The item variation array.
+
+<!-- FEEDBACK -->
+
+---
+
+[We're hiring!](https://woocommerce.com/careers/) Come work with us!
+
+🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-blocks/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/third-party-developers/extensibility/checkout-block/available-filters/cart-line-items.md)

--- a/docs/third-party-developers/extensibility/checkout-block/available-filters/cart-line-items.md
+++ b/docs/third-party-developers/extensibility/checkout-block/available-filters/cart-line-items.md
@@ -29,7 +29,7 @@ The `cartItemClass` filter allows to change the cart item class.
 -   _defaultValue_ `object` (default: `''`) - The default cart item class.
 -   _extensions_ `object` (default: `{}`) - The extensions object.
 -   _args_ `object` - The arguments object with the following keys:
-    -   _cart_ `object` - The cart object from `wc/store/cart`, see [Cart object](cart-object).
+    -   _cart_ `object` - The cart object from `wc/store/cart`, see [Cart object](#cart-object).
     -   _cartItem_ `object` - The cart item object from `wc/store/cart`, see [Cart Item object](#cart-item-object).
     -   _context_ `string` (allowed values: `cart` or `summary`) - The context of the item.
 

--- a/docs/third-party-developers/extensibility/checkout-block/available-filters/cart-line-items.md
+++ b/docs/third-party-developers/extensibility/checkout-block/available-filters/cart-line-items.md
@@ -107,9 +107,20 @@ registerCheckoutFilters( 'example-extension', {
 
 > 💡 Filters can be also combined. See [Combined filters](../available-filters.md#combined-filters) for an example.
 
-### Screenshot <!-- omit in toc -->
+### Screenshots <!-- omit in toc -->
 
-![Cart Item Class filter](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-26-at-14.14.17.png)
+<table>
+<tr>
+<td valign="top">Before:
+<br><br>
+<img width="676" alt="Before applying the Cart Item Class filter" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/a587a6ce-d051-4ed0-bba5-815b5d72179d">
+</td>
+<td valign="top">After:
+<br><br>
+<img width="677" alt="After applying the Cart Item Class filter" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/9b25eeae-6d81-4e28-b177-32f942e1d0c2">
+</td>
+</tr>
+</table>
 
 ## `cartItemPrice`
 
@@ -183,9 +194,20 @@ registerCheckoutFilters( 'example-extension', {
 
 > 💡 Filters can be also combined. See [Combined filters](../available-filters.md#combined-filters) for an example.
 
-### Screenshot <!-- omit in toc -->
+### Screenshots <!-- omit in toc -->
 
-![Cart Item Price filter](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-26-at-14.00.16.png)
+<table>
+<tr>
+<td valign="top">Before:
+<br><br>
+<img width="673" alt="Before applying the Cart Item Price filter" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/78fdaabe-cb21-4697-bc64-56d0b95a501b">
+</td>
+<td valign="top">After:
+<br><br>
+<img width="675" alt="After applying the Cart Item Price filter" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/bbaeb68a-492e-41e7-87b7-4b8b05ca3709">
+</td>
+</tr>
+</table>
 
 ## `itemName`
 
@@ -258,9 +280,21 @@ registerCheckoutFilters( 'example-extension', {
 
 > 💡 Filters can be also combined. See [Combined filters](../available-filters.md#combined-filters) for an example.
 
-### Screenshot <!-- omit in toc -->
+### Screenshots <!-- omit in toc -->
 
-![Item Name filter](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-26-at-12.22.21.png)
+<table>
+<tr>
+<td valign="top">Before:
+<br><br>
+<img width="682" alt="Before applying the Item Name filter" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/97d0f501-138e-4448-93df-a4d865b524e6">
+</td>
+<td valign="top">After:
+<br><br>
+<img width="683" alt="After applying the Item Name filter" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/69381932-d064-4e8f-b378-c2477fef56ae">
+
+</td>
+</tr>
+</table>
 
 ## `saleBadgePriceFormat`
 
@@ -342,9 +376,20 @@ registerCheckoutFilters( 'example-extension', {
 
 > 💡 Filters can be also combined. See [Combined filters](../available-filters.md#combined-filters) for an example.
 
-### Screenshot <!-- omit in toc -->
+### Screenshots <!-- omit in toc -->
 
-![Sale Badge Price Format filter](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-26-at-15.16.20.png)
+<table>
+<tr>
+<td valign="top">Before:
+<br><br>
+<img width="670" alt="Before applying the Sale Badge Price Format filter" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/d2aeb206-e620-44e0-93c1-31484cfcdca6">
+</td>
+<td valign="top">After:
+<br><br>
+<img width="677" alt="After applying the Sale Badge Price Format filter" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/6b929695-5d89-433b-8694-b9201a7c0519">
+</td>
+</tr>
+</table>
 
 ## `showRemoveItemLink`
 
@@ -417,9 +462,20 @@ registerCheckoutFilters( 'example-extension', {
 
 > 💡 Filters can be also combined. See [Combined filters](../available-filters.md#combined-filters) for an example.
 
-### Screenshot <!-- omit in toc -->
+### Screenshots <!-- omit in toc -->
 
-![Show Remove Item Link filter](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-26-at-14.48.44.png)
+<table>
+<tr>
+<td valign="top">Before:
+<br><br>
+<img width="668" alt="Before applying the Show Remove Item Link filter" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/a4254f3b-f056-47ad-b34a-d5f6d5500e56">
+</td>
+<td valign="top">After:
+<br><br>
+<img width="669" alt="After applying the Show Remove Item Link filter" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/32c55dc7-ef65-4f35-ab90-9533bc79d362">
+</td>
+</tr>
+</table>
 
 ## `subtotalPriceFormat`
 
@@ -503,9 +559,20 @@ registerCheckoutFilters( 'example-extension', {
 
 > 💡 Filters can be also combined. See [Combined filters](../available-filters.md#combined-filters) for an example.
 
-### Screenshot <!-- omit in toc -->
+### Screenshots <!-- omit in toc -->
 
-![Subtotal Price Format filter](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-26-at-14.42.08.png)
+<table>
+<tr>
+<td valign="top">Before:
+<br><br>
+<img width="668" alt="Before applying the Subtotal Price Format filter" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/a392cb24-4c40-4e25-8396-bf4971830e22">
+</td>
+<td valign="top">After:
+<br><br>
+<img width="670" alt="After applying the Subtotal Price Format filter" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/af69b26f-662a-4ef9-a288-3713b6e46373">
+</td>
+</tr>
+</table>
 
 ## Cart object
 

--- a/docs/third-party-developers/extensibility/checkout-block/available-filters/cart-line-items.md
+++ b/docs/third-party-developers/extensibility/checkout-block/available-filters/cart-line-items.md
@@ -42,6 +42,15 @@ The `cartItemClass` filter allows to change the cart item class.
 #### Basic example <!-- omit in toc -->
 
 ```tsx
+/**
+ * Optional: Import `registerCheckoutFilters` using ES module syntax if you are using
+ * @woocommerce/dependency-extraction-webpack-plugin for enhanced dependency management.
+ *
+ * Replace the line below with the following import statement:
+ * import { registerCheckoutFilters } from '@woocommerce/checkout-data';
+ *
+ * @see https://www.npmjs.com/package/@woocommerce/dependency-extraction-webpack-plugin
+ */
 const { registerCheckoutFilters } = window.wc.blocksCheckout;
 
 const modifyCartItemClass = ( defaultValue, extensions, args ) => {
@@ -62,6 +71,15 @@ registerCheckoutFilters( 'example-extension', {
 #### Advanced example <!-- omit in toc -->
 
 ```tsx
+/**
+ * Optional: Import `registerCheckoutFilters` using ES module syntax if you are using
+ * @woocommerce/dependency-extraction-webpack-plugin for enhanced dependency management.
+ *
+ * Replace the line below with the following import statement:
+ * import { registerCheckoutFilters } from '@woocommerce/checkout-data';
+ *
+ * @see https://www.npmjs.com/package/@woocommerce/dependency-extraction-webpack-plugin
+ */
 const { registerCheckoutFilters } = window.wc.blocksCheckout;
 
 const modifyCartItemClass = ( defaultValue, extensions, args ) => {

--- a/docs/third-party-developers/extensibility/checkout-block/available-filters/checkout-and-place-order-button.md
+++ b/docs/third-party-developers/extensibility/checkout-block/available-filters/checkout-and-place-order-button.md
@@ -33,6 +33,15 @@ The `proceedToCheckoutButtonLabel` filter allows change the label of the "Procee
 #### Basic example <!-- omit in toc -->
 
 ```ts
+/**
+ * Optional: Import `registerCheckoutFilters` using ES module syntax if you are using
+ * @woocommerce/dependency-extraction-webpack-plugin for enhanced dependency management.
+ *
+ * Replace the line below with the following import statement:
+ * import { registerCheckoutFilters } from '@woocommerce/checkout-data';
+ *
+ * @see https://www.npmjs.com/package/@woocommerce/dependency-extraction-webpack-plugin
+ */
 const { registerCheckoutFilters } = window.wc.blocksCheckout;
 
 const modifyProceedToCheckoutButtonLabel = (
@@ -55,6 +64,15 @@ registerCheckoutFilters( 'example-extension', {
 #### Advanced example <!-- omit in toc -->
 
 ```ts
+/**
+ * Optional: Import `registerCheckoutFilters` using ES module syntax if you are using
+ * @woocommerce/dependency-extraction-webpack-plugin for enhanced dependency management.
+ *
+ * Replace the line below with the following import statement:
+ * import { registerCheckoutFilters } from '@woocommerce/checkout-data';
+ *
+ * @see https://www.npmjs.com/package/@woocommerce/dependency-extraction-webpack-plugin
+ */
 const { registerCheckoutFilters } = window.wc.blocksCheckout;
 
 const modifyProceedToCheckoutButtonLabel = (
@@ -110,6 +128,15 @@ The `proceedToCheckoutButtonLink` filter allows change the link of the "Proceed 
 #### Basic example <!-- omit in toc -->
 
 ```ts
+/**
+ * Optional: Import `registerCheckoutFilters` using ES module syntax if you are using
+ * @woocommerce/dependency-extraction-webpack-plugin for enhanced dependency management.
+ *
+ * Replace the line below with the following import statement:
+ * import { registerCheckoutFilters } from '@woocommerce/checkout-data';
+ *
+ * @see https://www.npmjs.com/package/@woocommerce/dependency-extraction-webpack-plugin
+ */
 const { registerCheckoutFilters } = window.wc.blocksCheckout;
 
 const modifyProceedToCheckoutButtonLink = (
@@ -132,6 +159,15 @@ registerCheckoutFilters( 'example-extension', {
 #### Advanced example <!-- omit in toc -->
 
 ```ts
+/**
+ * Optional: Import `registerCheckoutFilters` using ES module syntax if you are using
+ * @woocommerce/dependency-extraction-webpack-plugin for enhanced dependency management.
+ *
+ * Replace the line below with the following import statement:
+ * import { registerCheckoutFilters } from '@woocommerce/checkout-data';
+ *
+ * @see https://www.npmjs.com/package/@woocommerce/dependency-extraction-webpack-plugin
+ */
 const { registerCheckoutFilters } = window.wc.blocksCheckout;
 
 const modifyProceedToCheckoutButtonLink = (
@@ -183,6 +219,15 @@ The `placeOrderButtonLabel` filter allows change the label of the "Place order" 
 ### Code example <!-- omit in toc -->
 
 ```ts
+/**
+ * Optional: Import `registerCheckoutFilters` using ES module syntax if you are using
+ * @woocommerce/dependency-extraction-webpack-plugin for enhanced dependency management.
+ *
+ * Replace the line below with the following import statement:
+ * import { registerCheckoutFilters } from '@woocommerce/checkout-data';
+ *
+ * @see https://www.npmjs.com/package/@woocommerce/dependency-extraction-webpack-plugin
+ */
 const { registerCheckoutFilters } = window.wc.blocksCheckout;
 
 const modifyPlaceOrderButtonLabel = ( defaultValue, extensions ) => {

--- a/docs/third-party-developers/extensibility/checkout-block/available-filters/checkout-and-place-order-button.md
+++ b/docs/third-party-developers/extensibility/checkout-block/available-filters/checkout-and-place-order-button.md
@@ -9,6 +9,7 @@ The following Checkout and place order button filters are available:
 The following objects are shared between the filters:
 
 -   [Cart object](#cart-object)
+-   [Cart Item object](#cart-item-object)
 
 ## `proceedToCheckoutButtonLabel`
 
@@ -255,7 +256,7 @@ The Cart object of the filters above has the following keys:
     -   _total_shipping_tax_ `string` - The total shipping tax.
     -   _total_tax_ `string` - The total tax.
 
-## Cart Item object <!-- omit in toc -->
+## Cart Item object
 
 The Cart Item object of the filters above has the following keys:
 

--- a/docs/third-party-developers/extensibility/checkout-block/available-filters/checkout-and-place-order-button.md
+++ b/docs/third-party-developers/extensibility/checkout-block/available-filters/checkout-and-place-order-button.md
@@ -102,9 +102,20 @@ registerCheckoutFilters( 'example-extension', {
 
 > 💡 Filters can be also combined. See [Combined filters](../available-filters.md#combined-filters) for an example.
 
-### Screenshot <!-- omit in toc -->
+### Screenshots <!-- omit in toc -->
 
-![Proceed To Checkout Button Label filter](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-27-at-14.33.45.png)
+<table>
+<tr>
+<td valign="top">Before:
+<br><br>
+<img width="379" alt="Before applying the Proceed To Checkout Button Label filter" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/fb0216c1-a091-4d58-b443-f49ccff98ed8">
+</td>
+<td valign="top">After:
+<br><br>
+<img width="379" alt="After applying the Proceed To Checkout Button Label filter" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/ef15b6df-fbd7-43e7-a359-b4adfbba961a">
+</td>
+</tr>
+</table>
 
 ## `proceedToCheckoutButtonLink`
 
@@ -197,9 +208,20 @@ registerCheckoutFilters( 'example-extension', {
 
 > 💡 Filters can be also combined. See [Combined filters](../available-filters.md#combined-filters) for an example.
 
-### Screenshot <!-- omit in toc -->
+### Screenshots <!-- omit in toc -->
 
-![Proceed To Checkout Button Link filter](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-27-at-16.57.09.png)
+<table>
+<tr>
+<td valign="top">Before:
+<br><br>
+<img width="380" alt="Before applying the Proceed To Checkout Button Link filter" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/3f657e0f-4fcc-4746-a554-64221e071b2e">
+</td>
+<td valign="top">After:
+<br><br>
+<img width="384" alt="After applying the Proceed To Checkout Button Link filter" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/064df213-439e-4d8f-b29c-55962604cb97">
+</td>
+</tr>
+</table>
 
 ## `placeOrderButtonLabel`
 
@@ -241,9 +263,20 @@ registerCheckoutFilters( 'example-extension', {
 
 > 💡 Filters can be also combined. See [Combined filters](../available-filters.md#combined-filters) for an example.
 
-### Screenshot <!-- omit in toc -->
+### Screenshots <!-- omit in toc -->
 
-![Place Order Button Label filter](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-27-at-18.39.14.png)
+<table>
+<tr>
+<td valign="top">Before:
+<br><br>
+<img width="358" alt="Before applying the Place Order Button Label filter" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/aa6d9b65-4d56-45f7-8162-a6bbfe171250">
+</td>
+<td valign="top">After:
+<br><br>
+<img width="358" alt="After applying the Place Order Button Label filter" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/a5cc2572-16e7-4781-a5ab-5d6cdced2ff6">
+</td>
+</tr>
+</table>
 
 <!-- FEEDBACK -->
 

--- a/docs/third-party-developers/extensibility/checkout-block/available-filters/checkout-and-place-order-button.md
+++ b/docs/third-party-developers/extensibility/checkout-block/available-filters/checkout-and-place-order-button.md
@@ -1,0 +1,319 @@
+# Checkout and place order button
+
+The following Checkout and place order button filters are available:
+
+-   [`proceedToCheckoutButtonLabel`](#proceedtocheckoutbuttonlabel)
+-   [`proceedToCheckoutButtonLink`](#proceedtocheckoutbuttonlink)
+-   [`placeOrderButtonLabel`](#placeorderbuttonlabel)
+
+The following objects are shared between the filters:
+
+-   [Cart object](#cart-object)
+
+## `proceedToCheckoutButtonLabel`
+
+### Description <!-- omit in toc -->
+
+The `proceedToCheckoutButtonLabel` filter allows change the label of the "Proceed to checkout" button.
+
+### Parameters <!-- omit in toc -->
+
+-   _defaultValue_ `string` (default: `Proceed to Checkout`) - The label of the "Proceed to checkout" button.
+-   _extensions_ `object` (default: `{}`) - The extensions object.
+-   _args_ `object` - The arguments object with the following keys:
+    -   _cart_ `object` - The cart object from `wc/store/cart`, see [Cart object](#cart-object).
+
+### Returns <!-- omit in toc -->
+
+-   `string` - The label of the "Proceed to checkout" button.
+
+### Code examples <!-- omit in toc -->
+
+#### Basic example <!-- omit in toc -->
+
+```ts
+const { registerCheckoutFilters } = window.wc.blocksCheckout;
+
+const modifyProceedToCheckoutButtonLabel = (
+	defaultValue,
+	extensions,
+	args
+) => {
+	if ( ! args?.cart.items ) {
+		return defaultValue;
+	}
+
+	return 'Go to checkout';
+};
+
+registerCheckoutFilters( 'example-extension', {
+	proceedToCheckoutButtonLabel: modifyProceedToCheckoutButtonLabel,
+} );
+```
+
+#### Advanced example <!-- omit in toc -->
+
+```ts
+const { registerCheckoutFilters } = window.wc.blocksCheckout;
+
+const modifyProceedToCheckoutButtonLabel = (
+	defaultValue,
+	extensions,
+	args
+) => {
+	if ( ! args?.cart.items ) {
+		return defaultValue;
+	}
+
+	const isSunglassesInCart = args?.cart.items.some(
+		( item ) => item.name === 'Sunglasses'
+	);
+
+	if ( isSunglassesInCart ) {
+		return '😎 Proceed to checkout 😎';
+	}
+
+	return defaultValue;
+};
+
+registerCheckoutFilters( 'example-extension', {
+	proceedToCheckoutButtonLabel: modifyProceedToCheckoutButtonLabel,
+} );
+```
+
+> 💡 Filters can be also combined. See [Combined filters](../available-filters.md#combined-filters) for an example.
+
+### Screenshot <!-- omit in toc -->
+
+![Proceed To Checkout Button Label filter](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-27-at-14.33.45.png)
+
+## `proceedToCheckoutButtonLink`
+
+### Description <!-- omit in toc -->
+
+The `proceedToCheckoutButtonLink` filter allows change the link of the "Proceed to checkout" button.
+
+### Parameters <!-- omit in toc -->
+
+-   _defaultValue_ `string` (default: `/checkout`) - The link of the "Proceed to checkout" button.
+-   _extensions_ `object` (default: `{}`) - The extensions object.
+-   _args_ `object` - The arguments object with the following keys:
+    -   _cart_ `object` - The cart object from `wc/store/cart`, see [Cart object](../available-filters.md#cart-object).
+
+### Returns <!-- omit in toc -->
+
+-   `string` - The link of the "Proceed to checkout" button.
+
+### Code examples <!-- omit in toc -->
+
+#### Basic example <!-- omit in toc -->
+
+```ts
+const { registerCheckoutFilters } = window.wc.blocksCheckout;
+
+const modifyProceedToCheckoutButtonLink = (
+	defaultValue,
+	extensions,
+	args
+) => {
+	if ( ! args?.cart.items ) {
+		return defaultValue;
+	}
+
+	return '/custom-checkout';
+};
+
+registerCheckoutFilters( 'example-extension', {
+	proceedToCheckoutButtonLink: modifyProceedToCheckoutButtonLink,
+} );
+```
+
+#### Advanced example <!-- omit in toc -->
+
+```ts
+const { registerCheckoutFilters } = window.wc.blocksCheckout;
+
+const modifyProceedToCheckoutButtonLink = (
+	defaultValue,
+	extensions,
+	args
+) => {
+	if ( ! args?.cart.items ) {
+		return defaultValue;
+	}
+
+	const isSunglassesInCart = args?.cart.items.some(
+		( item ) => item.name === 'Sunglasses'
+	);
+
+	if ( isSunglassesInCart ) {
+		return '/custom-checkout';
+	}
+
+	return defaultValue;
+};
+
+registerCheckoutFilters( 'example-extension', {
+	proceedToCheckoutButtonLink: modifyProceedToCheckoutButtonLink,
+} );
+```
+
+> 💡 Filters can be also combined. See [Combined filters](../available-filters.md#combined-filters) for an example.
+
+### Screenshot <!-- omit in toc -->
+
+![Proceed To Checkout Button Link filter](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-27-at-16.57.09.png)
+
+## `placeOrderButtonLabel`
+
+### Description <!-- omit in toc -->
+
+The `placeOrderButtonLabel` filter allows change the label of the "Place order" button.
+
+### Parameters <!-- omit in toc -->
+
+-   _defaultValue_ (type: `string`, default: `Place order`) - The label of the "Place order" button.
+-   _extensions_ `object` (default: `{}`) - The extensions object.
+
+### Returns <!-- omit in toc -->
+
+-   `string` - The label of the "Place order" button.
+
+### Code example <!-- omit in toc -->
+
+```ts
+const { registerCheckoutFilters } = window.wc.blocksCheckout;
+
+const modifyPlaceOrderButtonLabel = ( defaultValue, extensions ) => {
+	return '😎 Pay now 😎';
+};
+
+registerCheckoutFilters( 'example-extension', {
+	placeOrderButtonLabel: modifyPlaceOrderButtonLabel,
+} );
+```
+
+> 💡 Filters can be also combined. See [Combined filters](../available-filters.md#combined-filters) for an example.
+
+### Screenshot <!-- omit in toc -->
+
+![Place Order Button Label filter](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-27-at-18.39.14.png)
+
+<!-- FEEDBACK -->
+
+## Cart object
+
+The Cart object of the filters above has the following keys:
+
+-   _billingAddress_ `object` - The billing address object with the following keys:
+    -   _address_1_ `string` - The first line of the address.
+    -   _address_2_ `string` - The second line of the address.
+    -   _city_ `string` - The city of the address.
+    -   _company_ `string` - The company of the address.
+    -   _country_ `string` - The country of the address.
+    -   _email_ `string` - The email of the address.
+    -   _first_name_ `string` - The first name of the address.
+    -   _last_name_ `string` - The last name of the address.
+    -   _phone_ `string` - The phone of the address.
+    -   _postcode_ `string` - The postcode of the address.
+    -   _state_ `string` - The state of the address.
+-   _coupons_ `array` - The coupons array.
+-   _crossSells_ `array` - The cross sell items array.
+-   _errors_ `array` - The errors array.
+-   _extensions_ `object` (default: `{}`) - The extensions object.
+-   _fees_ `array` - The fees array.
+-   _hasCalculatedShipping_ `boolean` - Whether the cart has calculated shipping.
+-   _items_ `array` - The cart items array with cart item objects, see [Cart Item object](#cart-item-object).
+-   _itemsCount_ `number` - The number of items in the cart.
+-   _itemsWeight_ `number` - The total weight of the cart items.
+-   _needsPayment_ `boolean` - Whether the cart needs payment.
+-   _needsShipping_ `boolean` - Whether the cart needs shipping.
+-   _paymentMethods_ `array` - The payment methods array.
+-   _paymentRequirements_ `array` - The payment requirements array.
+-   _shippingAddress_ `object` - The shipping address object with the same keys as the billing address object.
+-   _shippingRates_ `array` - The shipping rates array.
+-   _totals_ `object` - The totals object with the following keys:
+    -   _currency_code_ `string` - The currency code.
+    -   _currency_decimal_separator_ `string` - The currency decimal separator.
+    -   _currency_minor_unit_ `number` - The currency minor unit.
+    -   _currency_prefix_ `string` - The currency prefix.
+    -   _currency_suffix_ `string` - The currency suffix.
+    -   _currency_symbol_ `string` - The currency symbol.
+    -   _currency_thousand_separator_ `string` - The currency thousand separator.
+    -   _tax_lines_ `array` - The tax lines array of objects with the following keys:
+        -   _name_ `string` - The tax name.
+        -   _price_ `string` - The tax price.
+        -   _rate_ `string` - The tax rate.
+    -   _total_discount_ `string` - The total discount.
+    -   _total_discount_tax_ `string` - The total discount tax.
+    -   _total_fee_ `string` - The total fee.
+    -   _total_fee_tax_ `string` - The total fee tax.
+    -   _total_items_ `string` - The total items.
+    -   _total_items_tax_ `string` - The total items tax.
+    -   _total_price_ `string` - The total price.
+    -   _total_shipping_ `string` - The total shipping.
+    -   _total_shipping_tax_ `string` - The total shipping tax.
+    -   _total_tax_ `string` - The total tax.
+
+## Cart Item object <!-- omit in toc -->
+
+The Cart Item object of the filters above has the following keys:
+
+-   _backorders_allowed_ `boolean` - Whether backorders are allowed.
+-   _catalog_visibility_ `string` - The catalog visibility.
+-   _decsription_ `string` - The cart item description.
+-   _extensions_ `object` (default: `{}`) - The extensions object.
+-   _id_ `number` - The item ID.
+-   _images_ `array` - The item images array.
+-   _item_data_ `array` - The item data array.
+-   _key_ `string` - The item key.
+-   _low_stock_remaining_ `number` - The low stock remaining.
+-   _name_ `string` - The item name.
+-   _permalink_ `string` - The item permalink.
+-   _prices_ `object` - The item prices object with the following keys:
+    -   _currency_code_ `string` - The currency code.
+    -   _currency_decimal_separator_ `string` - The currency decimal separator.
+    -   _currency_minor_unit_ `number` - The currency minor unit.
+    -   _currency_prefix_ `string` - The currency prefix.
+    -   _currency_suffix_ `string` - The currency suffix.
+    -   _currency_symbol_ `string` - The currency symbol.
+    -   _currency_thousand_separator_ `string` - The currency thousand separator.
+    -   _price_ `string` - The price.
+    -   _price_range_ `string` - The price range.
+    -   _raw_prices_ `object` - The raw prices object with the following keys:
+        -   _precision_ `number` - The precision.
+        -   _price_ `number` - The price.
+        -   _regular_price_ `number` - The regular price.
+        -   _sale_price_ `number` - The sale price.
+    -   _regular_price_ `string` - The regular price.
+    -   _sale_price_ `string` - The sale price.
+-   _quantity_ `number` - The item quantity.
+-   _quantity_limits_ `object` - The item quantity limits object with the following keys:
+    -   _editable_ `boolean` - Whether the quantity is editable.
+    -   _maximum_ `number` - The maximum quantity.
+    -   _minimum_ `number` - The minimum quantity.
+    -   _multiple_of_ `number` - The multiple of quantity.
+-   _short_description_ `string` - The item short description.
+-   _show_backorder_badge_ `boolean` - Whether to show the backorder badge.
+-   _sku_ `string` - The item SKU.
+-   _sold_individually_ `boolean` - Whether the item is sold individually.
+-   _totals_ `object` - The item totals object with the following keys:
+    -   _currency_code_ `string` - The currency code.
+    -   _currency_decimal_separator_ `string` - The currency decimal separator.
+    -   _currency_minor_unit_ `number` - The currency minor unit.
+    -   _currency_prefix_ `string` - The currency prefix.
+    -   _currency_suffix_ `string` - The currency suffix.
+    -   _currency_symbol_ `string` - The currency symbol.
+    -   _currency_thousand_separator_ `string` - The currency thousand separator.
+    -   _line_subtotal_ `string` - The line subtotal.
+    -   _line_subtotal_tax_ `string` - The line subtotal tax.
+    -   _line_total_ `string` - The line total.
+    -   _line_total_tax_ `string` - The line total tax.
+-   _type_ `string` - The item type.
+-   _variation_ `array` - The item variation array.
+
+---
+
+[We're hiring!](https://woocommerce.com/careers/) Come work with us!
+
+🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-blocks/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/third-party-developers/extensibility/checkout-block/available-filters/checkout-and-place-order-button.md)

--- a/docs/third-party-developers/extensibility/checkout-block/available-filters/coupons.md
+++ b/docs/third-party-developers/extensibility/checkout-block/available-filters/coupons.md
@@ -38,6 +38,15 @@ The current functionality is to display the coupon codes in the Cart and Checkou
 ### Code example <!-- omit in toc -->
 
 ```ts
+/**
+ * Optional: Import `registerCheckoutFilters` using ES module syntax if you are using
+ * @woocommerce/dependency-extraction-webpack-plugin for enhanced dependency management.
+ *
+ * Replace the line below with the following import statement:
+ * import { registerCheckoutFilters } from '@woocommerce/checkout-data';
+ *
+ * @see https://www.npmjs.com/package/@woocommerce/dependency-extraction-webpack-plugin
+ */
 const { registerCheckoutFilters } = window.wc.blocksCheckout;
 
 const modifyCoupons = ( coupons, extensions, args ) => {
@@ -87,6 +96,15 @@ registerCheckoutFilters( 'example-extension', {
 #### Basic example <!-- omit in toc -->
 
 ```ts
+/**
+ * Optional: Import `registerCheckoutFilters` using ES module syntax if you are using
+ * @woocommerce/dependency-extraction-webpack-plugin for enhanced dependency management.
+ *
+ * Replace the line below with the following import statement:
+ * import { registerCheckoutFilters } from '@woocommerce/checkout-data';
+ *
+ * @see https://www.npmjs.com/package/@woocommerce/dependency-extraction-webpack-plugin
+ */
 const { registerCheckoutFilters } = window.wc.blocksCheckout;
 
 const modifyShowApplyCouponNotice = ( defaultValue, extensions, args ) => {
@@ -101,6 +119,15 @@ registerCheckoutFilters( 'example-extension', {
 #### Advanced example <!-- omit in toc -->
 
 ```ts
+/**
+ * Optional: Import `registerCheckoutFilters` using ES module syntax if you are using
+ * @woocommerce/dependency-extraction-webpack-plugin for enhanced dependency management.
+ *
+ * Replace the line below with the following import statement:
+ * import { registerCheckoutFilters } from '@woocommerce/checkout-data';
+ *
+ * @see https://www.npmjs.com/package/@woocommerce/dependency-extraction-webpack-plugin
+ */
 const { registerCheckoutFilters } = window.wc.blocksCheckout;
 
 const modifyShowApplyCouponNotice = ( defaultValue, extensions, args ) => {
@@ -145,6 +172,15 @@ registerCheckoutFilters( 'example-extension', {
 #### Basic example <!-- omit in toc -->
 
 ```ts
+/**
+ * Optional: Import `registerCheckoutFilters` using ES module syntax if you are using
+ * @woocommerce/dependency-extraction-webpack-plugin for enhanced dependency management.
+ *
+ * Replace the line below with the following import statement:
+ * import { registerCheckoutFilters } from '@woocommerce/checkout-data';
+ *
+ * @see https://www.npmjs.com/package/@woocommerce/dependency-extraction-webpack-plugin
+ */
 const { registerCheckoutFilters } = window.wc.blocksCheckout;
 
 const modifyShowRemoveCouponNotice = ( defaultValue, extensions, args ) => {
@@ -159,6 +195,15 @@ registerCheckoutFilters( 'example-extension', {
 #### Advanced example <!-- omit in toc -->
 
 ```ts
+/**
+ * Optional: Import `registerCheckoutFilters` using ES module syntax if you are using
+ * @woocommerce/dependency-extraction-webpack-plugin for enhanced dependency management.
+ *
+ * Replace the line below with the following import statement:
+ * import { registerCheckoutFilters } from '@woocommerce/checkout-data';
+ *
+ * @see https://www.npmjs.com/package/@woocommerce/dependency-extraction-webpack-plugin
+ */
 const { registerCheckoutFilters } = window.wc.blocksCheckout;
 
 const modifyShowRemoveCouponNotice = ( defaultValue, extensions, args ) => {

--- a/docs/third-party-developers/extensibility/checkout-block/available-filters/coupons.md
+++ b/docs/third-party-developers/extensibility/checkout-block/available-filters/coupons.md
@@ -1,0 +1,191 @@
+# Coupons
+
+The following Coupon filters are available:
+
+-   [`coupons`](#coupons-1)
+-   [`showApplyCouponNotice`](#showapplycouponnotice)
+-   [`showRemoveCouponNotice`](#showremovecouponnotice)
+
+## `coupons`
+
+### Description <!-- omit in toc -->
+
+The current functionality is to display the coupon codes in the Cart and Checkout sidebars. This could be undesirable if you dynamically generate a coupon code that is not user-friendly. It may, therefore, be desirable to change the way this code is displayed. To achieve this, the filter `coupons` exists. This filter could also be used to show or hide coupons. This filter must _not_ be used to alter the value/totals of a coupon. This will not carry through to the Cart totals.
+
+### Parameters <!-- omit in toc -->
+
+-   _coupons_ `object` - The coupons object with the following keys:
+    -   _code_ `string` - The coupon code.
+    -   _discount_type_ `string` - The type of discount. Can be `percent` or `fixed_cart`.
+    -   _totals_ `object` - The totals object with the following keys:
+        -   _currency_code_ `string` - The currency code.
+        -   _currency_decimal_separator_ `string` - The currency decimal separator.
+        -   _currency_minor_unit_ `number` - The currency minor unit.
+        -   _currency_prefix_ `string` - The currency prefix.
+        -   _currency_suffix_ `string` - The currency suffix.
+        -   _currency_symbol_ `string` - The currency symbol.
+        -   _currency_thousand_separator_ `string` - The currency thousand separator.
+        -   _total_discount_ `string` - The total discount.
+        -   _total_discount_tax_ `string` - The total discount tax.
+-   _extensions_ `object` (default: `{}`) - The extensions object.
+-   _args_ `object` - The arguments object with the following key:
+    -   _context_ `string` (default: `summary`) - The context of the item.
+
+### Returns <!-- omit in toc -->
+
+-   `array` - The coupons array of objects with the same keys as above.
+
+### Code example <!-- omit in toc -->
+
+```ts
+const { registerCheckoutFilters } = window.wc.blocksCheckout;
+
+const modifyCoupons = ( coupons, extensions, args ) => {
+	return coupons.map( ( coupon ) => {
+		if ( ! coupon.label.match( /autocoupon(?:_\d+)+/ ) ) {
+			return coupon;
+		}
+
+		return {
+			...coupon,
+			label: 'Automatic coupon',
+		};
+	} );
+};
+
+registerCheckoutFilters( 'example-extension', {
+	coupons: modifyCoupons,
+} );
+```
+
+> 💡 Filters can be also combined. See [Combined filters](../available-filters.md#combined-filters) for an example.
+
+### Screenshot <!-- omit in toc -->
+
+![Coupons filter](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-27-at-19.10.47.png)
+
+![Coupons filter](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-27-at-19.14.23.png)
+
+## `showApplyCouponNotice`
+
+### Description <!-- omit in toc -->
+
+### Parameters <!-- omit in toc -->
+
+-   _value_ `boolean` (default: `true`) - Weather to show the apply coupon notice.
+-   _extensions_ `object` (default: `{}`) - The extensions object.
+-   _args_ `object` - The arguments object with the following keys:
+    -   _context_ `string` (allowed values: `wc/cart` and `wc/checkout`) - The context of the coupon notice.
+    -   _code_ `string` - The coupon code.
+
+### Returns <!-- omit in toc -->
+
+-   `boolean` - Weather to show the apply coupon notice.
+
+### Code examples <!-- omit in toc -->
+
+#### Basic example <!-- omit in toc -->
+
+```ts
+const { registerCheckoutFilters } = window.wc.blocksCheckout;
+
+const modifyShowApplyCouponNotice = ( defaultValue, extensions, args ) => {
+	return false;
+};
+
+registerCheckoutFilters( 'example-extension', {
+	showApplyCouponNotice: modifyShowApplyCouponNotice,
+} );
+```
+
+#### Advanced example <!-- omit in toc -->
+
+```ts
+const { registerCheckoutFilters } = window.wc.blocksCheckout;
+
+const modifyShowApplyCouponNotice = ( defaultValue, extensions, args ) => {
+	if ( args?.couponCode === '10off' ) {
+		return false;
+	}
+
+	return defaultValue;
+};
+
+registerCheckoutFilters( 'example-extension', {
+	showApplyCouponNotice: modifyShowApplyCouponNotice,
+} );
+```
+
+> 💡 Filters can be also combined. See [Combined filters](../available-filters.md#combined-filters) for an example.
+
+### Screenshot <!-- omit in toc -->
+
+![Show Apply Coupon Notice filter](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-27-at-21.09.19.png)
+
+![Show Apply Coupon Notice filter](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-27-at-21.11.35.png)
+
+## `showRemoveCouponNotice`
+
+### Description <!-- omit in toc -->
+
+### Parameters <!-- omit in toc -->
+
+-   _value_ `boolean` (default: `true`) - Weather to show the remove coupon notice.
+-   _extensions_ `object` (default: `{}`) - The extensions object.
+-   _args_ `object` - The arguments object with the following keys:
+    -   _context_ `string` (allowed values: `wc/cart` and `wc/checkout`) - The context of the coupon notice.
+    -   _code_ `string` - The coupon code.
+
+### Returns <!-- omit in toc -->
+
+-   `boolean` - Weather to show the apply coupon notice.
+
+### Code examples <!-- omit in toc -->
+
+#### Basic example <!-- omit in toc -->
+
+```ts
+const { registerCheckoutFilters } = window.wc.blocksCheckout;
+
+const modifyShowRemoveCouponNotice = ( defaultValue, extensions, args ) => {
+	return false;
+};
+
+registerCheckoutFilters( 'example-extension', {
+	showRemoveCouponNotice: modifyShowRemoveCouponNotice,
+} );
+```
+
+#### Advanced example <!-- omit in toc -->
+
+```ts
+const { registerCheckoutFilters } = window.wc.blocksCheckout;
+
+const modifyShowRemoveCouponNotice = ( defaultValue, extensions, args ) => {
+	if ( args?.couponCode === '10off' ) {
+		return false;
+	}
+
+	return defaultValue;
+};
+
+registerCheckoutFilters( 'example-extension', {
+	showRemoveCouponNotice: modifyShowRemoveCouponNotice,
+} );
+```
+
+> 💡 Filters can be also combined. See [Combined filters](../available-filters.md#combined-filters) for an example.
+
+### Screenshot <!-- omit in toc -->
+
+![Show Remove Coupon Notice filter](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-27-at-21.03.43.png)
+
+![Show Remove Coupon Notice filter](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-27-at-21.05.29.png)
+
+<!-- FEEDBACK -->
+
+---
+
+[We're hiring!](https://woocommerce.com/careers/) Come work with us!
+
+🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-blocks/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/third-party-developers/extensibility/checkout-block/available-filters/coupons.md)

--- a/docs/third-party-developers/extensibility/checkout-block/available-filters/coupons.md
+++ b/docs/third-party-developers/extensibility/checkout-block/available-filters/coupons.md
@@ -69,11 +69,20 @@ registerCheckoutFilters( 'example-extension', {
 
 > 💡 Filters can be also combined. See [Combined filters](../available-filters.md#combined-filters) for an example.
 
-### Screenshot <!-- omit in toc -->
+### Screenshots <!-- omit in toc -->
 
-![Coupons filter](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-27-at-19.10.47.png)
-
-![Coupons filter](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-27-at-19.14.23.png)
+<table>
+<tr>
+<td valign="top">Before:
+<br><br>
+<img width="385" alt="Before applying the Coupons filter" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/6cab1aff-e4b9-4909-b81c-5726c6a20c40">
+</td>
+<td valign="top">After:
+<br><br>
+<img width="382" alt="After applying the Coupons filter" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/b053304c-179a-4d54-821d-5ad5e7dccafc">
+</td>
+</tr>
+</table>
 
 ## `showApplyCouponNotice`
 
@@ -145,11 +154,20 @@ registerCheckoutFilters( 'example-extension', {
 
 > 💡 Filters can be also combined. See [Combined filters](../available-filters.md#combined-filters) for an example.
 
-### Screenshot <!-- omit in toc -->
+### Screenshots <!-- omit in toc -->
 
-![Show Apply Coupon Notice filter](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-27-at-21.09.19.png)
-
-![Show Apply Coupon Notice filter](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-27-at-21.11.35.png)
+<table>
+<tr>
+<td valign="top">Before:
+<br><br>
+<img width="648" alt="Before applying the Show Apply Coupon Notice filter" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/374d4899-61f3-49b2-ae04-5541d4c130c2">
+</td>
+<td valign="top">After:
+<br><br>
+<img width="662" alt="After applying the Show Apply Coupon Notice filter" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/c35dbd9b-eee4-4afe-9a29-9c554d467729">
+</td>
+</tr>
+</table>
 
 ## `showRemoveCouponNotice`
 
@@ -221,11 +239,20 @@ registerCheckoutFilters( 'example-extension', {
 
 > 💡 Filters can be also combined. See [Combined filters](../available-filters.md#combined-filters) for an example.
 
-### Screenshot <!-- omit in toc -->
+### Screenshots <!-- omit in toc -->
 
-![Show Remove Coupon Notice filter](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-27-at-21.03.43.png)
-
-![Show Remove Coupon Notice filter](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-27-at-21.05.29.png)
+<table>
+<tr>
+<td valign="top">Before:
+<br><br>
+<img width="648" alt="Before applying the Show Remove Coupon Notice filter" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/9d8607fa-ab20-4181-b70b-7954e7aa49cb">
+</td>
+<td valign="top">After:
+<br><br>
+<img width="648" alt="After applying the Show Remove Coupon Notice filter" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/83d5f65f-c4f3-4707-a250-077952514931">
+</td>
+</tr>
+</table>
 
 <!-- FEEDBACK -->
 

--- a/docs/third-party-developers/extensibility/checkout-block/available-filters/order-summary-items.md
+++ b/docs/third-party-developers/extensibility/checkout-block/available-filters/order-summary-items.md
@@ -105,9 +105,20 @@ registerCheckoutFilters( 'example-extension', {
 
 > 💡 Filters can be also combined. See [Combined filters](../available-filters.md#combined-filters) for an example.
 
-### Screenshot <!-- omit in toc -->
+### Screenshots <!-- omit in toc -->
 
-![Cart Item Class filter](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-26-at-17.04.43.png)
+<table>
+<tr>
+<td valign="top">Before:
+<br><br>
+<img width="377" alt="Before applying the Cart Item Class filter" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/ff555a84-8d07-4889-97e1-8f7d50d47350">
+</td>
+<td valign="top">After:
+<br><br>
+<img width="383" alt="After applying the Cart Item Class filter" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/183809d8-03dc-466d-a415-d8d2062d880f">
+</td>
+</tr>
+</table>
 
 ## `cartItemPrice`
 
@@ -199,9 +210,20 @@ registerCheckoutFilters( 'example-extension', {
 
 > 💡 Filters can be also combined. See [Combined filters](../available-filters.md#combined-filters) for an example.
 
-### Screenshot <!-- omit in toc -->
+### Screenshots <!-- omit in toc -->
 
-![Cart Item Price filter](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-26-at-17.06.32.png)
+<table>
+<tr>
+<td valign="top">Before:
+<br><br>
+<img width="381" alt="Before applying the Cart Item Price filter" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/58137fc4-884d-4783-9275-5f78abec1473">
+</td>
+<td valign="top">After:
+<br><br>
+<img width="382" alt="Before applying the Cart Item Price filter" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/fb502b74-6447-49a8-8d35-241e738f089d">
+</td>
+</tr>
+</table>
 
 ## `itemName`
 
@@ -292,9 +314,20 @@ registerCheckoutFilters( 'example-extension', {
 
 > 💡 Filters can be also combined. See [Combined filters](../available-filters.md#combined-filters) for an example.
 
-### Screenshot <!-- omit in toc -->
+### Screenshots <!-- omit in toc -->
 
-![Item Name filter](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-26-at-17.07.54.png)
+<table>
+<tr>
+<td valign="top">Before:
+<br><br>
+<img width="389" alt="Before applying the Item Name filter" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/3dc0bda7-fccf-4f35-a2e2-aa04e616563a">
+</td>
+<td valign="top">After:
+<br><br>
+<img width="383" alt="After applying the Item Name filter" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/c96b8394-03a7-45f6-813b-5335f4bf83b5">
+</td>
+</tr>
+</table>
 
 ## `subtotalPriceFormat`
 
@@ -396,9 +429,20 @@ registerCheckoutFilters( 'example-extension', {
 
 > 💡 Filters can be also combined. See [Combined filters](../available-filters.md#combined-filters) for an example.
 
-### Screenshot <!-- omit in toc -->
+### Screenshots <!-- omit in toc -->
 
-![Subtotal Price Format filter](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-26-at-17.09.00.png)
+<table>
+<tr>
+<td valign="top">Before:
+<br><br>
+<img width="382" alt="Before applying the Subtotal Price Format filter" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/3574e7ae-9857-4651-ac9e-e6b597e3a589">
+</td>
+<td valign="top">After:
+<br><br>
+<img width="390" alt="After applying the Subtotal Price Format filter" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/94e18439-6d6b-44a4-ade1-8302c5984641">
+</td>
+</tr>
+</table>
 
 ## Cart object
 

--- a/docs/third-party-developers/extensibility/checkout-block/available-filters/order-summary-items.md
+++ b/docs/third-party-developers/extensibility/checkout-block/available-filters/order-summary-items.md
@@ -1,0 +1,451 @@
+# Order Summary Items
+
+The following Order Summary Items filters are available:
+
+-   [`cartItemClass`](#cartitemclass)
+-   [`cartItemPrice`](#cartitemprice)
+-   [`itemName`](#itemname)
+-   [`subtotalPriceFormat`](#subtotalpriceformat)
+
+The following objects are shared between the filters:
+
+-   [Cart object](#cart-object)
+-   [Cart Item object](#cart-item-object)
+
+The following screenshot shows which parts the individual filters affect:
+
+![Order Summary Items](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-26-at-16.29.45.png)
+
+## `cartItemClass`
+
+### Description <!-- omit in toc -->
+
+The `cartItemClass` filter allows to change the order summary item class.
+
+### Parameters <!-- omit in toc -->
+
+-   _defaultValue_ `string` (default: `''`) - The default order summary item class.
+-   _extensions_ `object` (default: `{}`) - The extensions object.
+-   _args_ `object` - The arguments object with the following keys:
+    -   _cart_ `object` - The cart object from `wc/store/cart`, see [Cart object](#cart-object).
+    -   _cartItem_ `object` - The order summary item object from `wc/store/cart`, see [order summary item object](#cart-item-object).
+    -   _context_ `string` (allowed values: `cart` or `summary`) - The context of the item.
+
+### Returns <!-- omit in toc -->
+
+-   `string` - The modified order summary item class, or an empty string.
+
+### Code examples <!-- omit in toc -->
+
+#### Basic example <!-- omit in toc -->
+
+```tsx
+const { registerCheckoutFilters } = window.wc.blocksCheckout;
+
+const modifyCartItemClass = ( defaultValue, extensions, args ) => {
+	const isOrderSummaryContext = args?.context === 'summary';
+
+	if ( ! isOrderSummaryContext ) {
+		return defaultValue;
+	}
+
+	return 'my-custom-class';
+};
+
+registerCheckoutFilters( 'example-extension', {
+	cartItemClass: modifyCartItemClass,
+} );
+```
+
+#### Advanced example <!-- omit in toc -->
+
+```tsx
+const { registerCheckoutFilters } = window.wc.blocksCheckout;
+
+const modifyCartItemClass = ( defaultValue, extensions, args ) => {
+	const isOrderSummaryContext = args?.context === 'summary';
+
+	if ( ! isOrderSummaryContext ) {
+		return defaultValue;
+	}
+
+	if ( args?.cartItem?.name === 'Beanie with Logo' ) {
+		return 'cool-class';
+	}
+
+	if ( args?.cartItem?.name === 'Sunglasses' ) {
+		return 'hot-class';
+	}
+
+	return 'my-custom-class';
+};
+
+registerCheckoutFilters( 'example-extension', {
+	cartItemClass: modifyCartItemClass,
+} );
+```
+
+> 💡 Filters can be also combined. See [Combined filters](../available-filters.md#combined-filters) for an example.
+
+### Screenshot <!-- omit in toc -->
+
+![Cart Item Class filter](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-26-at-17.04.43.png)
+
+## `cartItemPrice`
+
+### Description <!-- omit in toc -->
+
+The `cartItemPrice` filter allows to format the order summary item price.
+
+### Parameters <!-- omit in toc -->
+
+-   _defaultValue_ `string` (default: `<price/>`) - The default order summary item price.
+-   _extensions_ `object` (default: `{}`) - The extensions object.
+-   _args_ `object` - The arguments object with the following keys:
+    -   _cart_ `object` - The cart object from `wc/store/cart`, see [Cart object](#cart-object).
+    -   _cartItem_ `object` - The order summary item object from `wc/store/cart`, see [order summary item object](#cart-item-object).
+    -   _context_ `string` (allowed values: `cart` or `summary`) - The context of the item.
+-   _validation_ `boolean` - Checks if the return value contains the substring `<price/>`.
+
+### Returns <!-- omit in toc -->
+
+-   `string` - The modified format of the order summary item price, which must contain the substring `<price/>`, or the original price format.
+
+### Code examples <!-- omit in toc -->
+
+#### Basic example <!-- omit in toc -->
+
+```tsx
+const { registerCheckoutFilters } = window.wc.blocksCheckout;
+
+const modifyCartItemPrice = ( defaultValue, extensions, args, validation ) => {
+	const isOrderSummaryContext = args?.context === 'summary';
+
+	if ( ! isOrderSummaryContext ) {
+		return defaultValue;
+	}
+
+	return '<price/> for all items';
+};
+
+registerCheckoutFilters( 'example-extension', {
+	cartItemPrice: modifyCartItemPrice,
+} );
+```
+
+#### Advanced example <!-- omit in toc -->
+
+```tsx
+const { registerCheckoutFilters } = window.wc.blocksCheckout;
+
+const modifyCartItemPrice = ( defaultValue, extensions, args, validation ) => {
+	const isOrderSummaryContext = args?.context === 'summary';
+
+	if ( ! isOrderSummaryContext ) {
+		return defaultValue;
+	}
+
+	if ( args?.cartItem?.name === 'Beanie with Logo' ) {
+		return '<price/> to keep you ☀️';
+	}
+
+	if ( args?.cartItem?.name === 'Sunglasses' ) {
+		return '<price/> to keep you ❄️';
+	}
+
+	return '<price/> for all items';
+};
+
+registerCheckoutFilters( 'example-extension', {
+	cartItemPrice: modifyCartItemPrice,
+} );
+```
+
+> 💡 Filters can be also combined. See [Combined filters](../available-filters.md#combined-filters) for an example.
+
+### Screenshot <!-- omit in toc -->
+
+![Cart Item Price filter](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-26-at-17.06.32.png)
+
+## `itemName`
+
+### Description <!-- omit in toc -->
+
+The `itemName` filter allows to change the order summary item name.
+
+### Parameters <!-- omit in toc -->
+
+-   _defaultValue_ `string` - The default order summary item name.
+-   _extensions_ `object` (default: `{}`) - The extensions object.
+-   _args_ `object` - The arguments object with the following keys:
+    -   _cart_ `object` - The cart object from `wc/store/cart`, see [Cart object](#cart-object).
+    -   _cartItem_ `object` - The order summary item object from `wc/store/cart`, see [order summary item object](#cart-item-object).
+    -   _context_ `string` (allowed values: `cart` or `summary`) - The context of the item.
+
+### Returns <!-- omit in toc -->
+
+-   `string` - The original or modified order summary item name.
+
+### Code examples <!-- omit in toc -->
+
+#### Basic example <!-- omit in toc -->
+
+```tsx
+const { registerCheckoutFilters } = window.wc.blocksCheckout;
+
+const modifyItemName = ( defaultValue, extensions, args ) => {
+	const isOrderSummaryContext = args?.context === 'summary';
+
+	if ( ! isOrderSummaryContext ) {
+		return defaultValue;
+	}
+
+	return `🪴 ${ defaultValue } 🪴`;
+};
+
+registerCheckoutFilters( 'example-extension', {
+	itemName: modifyItemName,
+} );
+```
+
+#### Advanced example <!-- omit in toc -->
+
+```tsx
+const { registerCheckoutFilters } = window.wc.blocksCheckout;
+
+const modifyItemName = ( defaultValue, extensions, args ) => {
+	const isOrderSummaryContext = args?.context === 'summary';
+
+	if ( ! isOrderSummaryContext ) {
+		return defaultValue;
+	}
+
+	if ( args?.cartItem?.name === 'Beanie with Logo' ) {
+		return `⛷️ ${ defaultValue } ⛷️`;
+	}
+
+	if ( args?.cartItem?.name === 'Sunglasses' ) {
+		return `🏄‍♂️ ${ defaultValue } 🏄‍♂️`;
+	}
+
+	return `🪴 ${ defaultValue } 🪴`;
+};
+
+registerCheckoutFilters( 'example-extension', {
+	itemName: modifyItemName,
+} );
+```
+
+> 💡 Filters can be also combined. See [Combined filters](../available-filters.md#combined-filters) for an example.
+
+### Screenshot <!-- omit in toc -->
+
+![Item Name filter](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-26-at-17.07.54.png)
+
+## `subtotalPriceFormat`
+
+### Description <!-- omit in toc -->
+
+The `subtotalPriceFormat` filter allows to format the order summary item subtotal price.
+
+### Parameters <!-- omit in toc -->
+
+-   _defaultValue_ `string` (default: `<price/>`) - The default order summary item subtotal price.
+-   _extensions_ `object` (default: `{}`) - The extensions object.
+-   _args_ `object` - The arguments object with the following keys:
+    -   _cart_ `object` - The cart object from `wc/store/cart`, see [Cart object](#cart-object).
+    -   _cartItem_ `object` - The order summary item object from `wc/store/cart`, see [order summary item object](#cart-item-object).
+    -   _context_ `string` (allowed values: `cart` or `summary`) - The context of the item.
+-   _validation_ `boolean` - Checks if the return value contains the substring `<price/>`.
+
+### Returns <!-- omit in toc -->
+
+-   `string` - The modified format of the order summary item subtotal price, which must contain the substring `<price/>`, or the original price format.
+
+### Code examples <!-- omit in toc -->
+
+#### Basic example <!-- omit in toc -->
+
+```tsx
+const { registerCheckoutFilters } = window.wc.blocksCheckout;
+
+const modifySubtotalPriceFormat = (
+	defaultValue,
+	extensions,
+	args,
+	validation
+) => {
+	const isOrderSummaryContext = args?.context === 'summary';
+
+	if ( ! isOrderSummaryContext ) {
+		return defaultValue;
+	}
+
+	return '<price/> per item';
+};
+
+registerCheckoutFilters( 'example-extension', {
+	subtotalPriceFormat: modifySubtotalPriceFormat,
+} );
+```
+
+#### Advanced example <!-- omit in toc -->
+
+```tsx
+const { registerCheckoutFilters } = window.wc.blocksCheckout;
+
+const modifySubtotalPriceFormat = (
+	defaultValue,
+	extensions,
+	args,
+	validation
+) => {
+	const isOrderSummaryContext = args?.context === 'summary';
+
+	if ( ! isOrderSummaryContext ) {
+		return defaultValue;
+	}
+
+	if ( args?.cartItem?.name === 'Beanie with Logo' ) {
+		return '<price/> per warm beanie';
+	}
+
+	if ( args?.cartItem?.name === 'Sunglasses' ) {
+		return '<price/> per cool sunglasses';
+	}
+
+	return '<price/> per item';
+};
+
+registerCheckoutFilters( 'example-extension', {
+	subtotalPriceFormat: modifySubtotalPriceFormat,
+} );
+```
+
+> 💡 Filters can be also combined. See [Combined filters](../available-filters.md#combined-filters) for an example.
+
+### Screenshot <!-- omit in toc -->
+
+![Subtotal Price Format filter](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-26-at-17.09.00.png)
+
+## Cart object
+
+The Cart object of the filters above has the following keys:
+
+-   _billingAddress_ `object` - The billing address object with the following keys:
+    -   _address_1_ `string` - The first line of the address.
+    -   _address_2_ `string` - The second line of the address.
+    -   _city_ `string` - The city of the address.
+    -   _company_ `string` - The company of the address.
+    -   _country_ `string` - The country of the address.
+    -   _email_ `string` - The email of the address.
+    -   _first_name_ `string` - The first name of the address.
+    -   _last_name_ `string` - The last name of the address.
+    -   _phone_ `string` - The phone of the address.
+    -   _postcode_ `string` - The postcode of the address.
+    -   _state_ `string` - The state of the address.
+-   _billingData_ `object` - The billing data object with the same keys as the `billingAddress` object.
+-   _cartCoupons_ `array` - The cart coupons array.
+-   _cartErrors_ `array` - The cart errors array.
+-   _cartFees_ `array` - The cart fees array.
+-   _cartHasCalculatedShipping_ `boolean` - Whether the cart has calculated shipping.
+-   _cartIsLoading_ `boolean` - Whether the cart is loading.
+-   _cartItemErrors_ `array` - The cart item errors array.
+-   _cartItems_ `array` - The cart items array with cart item objects, see [Cart Item object](#cart-item-object).
+-   _cartItemsCount_ `number` - The cart items count.
+-   _cartItemsWeight_ `number` - The cart items weight.
+-   _cartNeedsPayment_ `boolean` - Whether the cart needs payment.
+-   _cartNeedsShipping_ `boolean` - Whether the cart needs shipping.
+-   _cartTotals_ `object` - The cart totals object with the following keys:
+    -   _currency_code_ `string` - The currency code.
+    -   _currency_decimal_separator_ `string` - The currency decimal separator.
+    -   _currency_minor_unit_ `number` - The currency minor unit.
+    -   _currency_prefix_ `string` - The currency prefix.
+    -   _currency_suffix_ `string` - The currency suffix.
+    -   _currency_symbol_ `string` - The currency symbol.
+    -   _currency_thousand_separator_ `string` - The currency thousand separator.
+    -   _tax_lines_ `array` - The tax lines array with tax line objects with the following keys:
+        -   _name_ `string` - The name of the tax line.
+        -   _price_ `number` - The price of the tax line.
+        -   _rate_ `string` - The rate ID of the tax line.
+    -   _total_discount_ `string` - The total discount.
+    -   _total_discount_tax_ `string` - The total discount tax.
+    -   _total_fees_ `string` - The total fees.
+    -   _total_fees_tax_ `string` - The total fees tax.
+    -   _total_items_ `string` - The total items.
+    -   _total_items_tax_ `string` - The total items tax.
+    -   _total_price_ `string` - The total price.
+    -   _total_shipping_ `string` - The total shipping.
+    -   _total_shipping_tax_ `string` - The total shipping tax.
+    -   _total_tax_ `string` - The total tax.
+-   _crossSellsProducts_ `array` - The cross sells products array with cross sells product objects.
+-   _extensions_ `object` (default: `{}`) - The extensions object.
+-   _isLoadingRates_ `boolean` - Whether the cart is loading rates.
+-   _paymentRequirements_ `array` - The payment requirements array.
+-   _shippingAddress_ `object` - The shipping address object with the same keys as the `billingAddress` object.
+-   _shippingRates_ `array` - The shipping rates array.
+
+## Cart Item object
+
+The Cart Item object of the filters above has the following keys:
+
+-   _backorders_allowed_ `boolean` - Whether backorders are allowed.
+-   _catalog_visibility_ `string` - The catalog visibility.
+-   _decsription_ `string` - The cart item description.
+-   _extensions_ `object` (default: `{}`) - The extensions object.
+-   _id_ `number` - The item ID.
+-   _images_ `array` - The item images array.
+-   _item_data_ `array` - The item data array.
+-   _key_ `string` - The item key.
+-   _low_stock_remaining_ `number` - The low stock remaining.
+-   _name_ `string` - The item name.
+-   _permalink_ `string` - The item permalink.
+-   _prices_ `object` - The item prices object with the following keys:
+    -   _currency_code_ `string` - The currency code.
+    -   _currency_decimal_separator_ `string` - The currency decimal separator.
+    -   _currency_minor_unit_ `number` - The currency minor unit.
+    -   _currency_prefix_ `string` - The currency prefix.
+    -   _currency_suffix_ `string` - The currency suffix.
+    -   _currency_symbol_ `string` - The currency symbol.
+    -   _currency_thousand_separator_ `string` - The currency thousand separator.
+    -   _price_ `string` - The price.
+    -   _price_range_ `string` - The price range.
+    -   _raw_prices_ `object` - The raw prices object with the following keys:
+        -   _precision_ `number` - The precision.
+        -   _price_ `number` - The price.
+        -   _regular_price_ `number` - The regular price.
+        -   _sale_price_ `number` - The sale price.
+    -   _regular_price_ `string` - The regular price.
+    -   _sale_price_ `string` - The sale price.
+-   _quantity_ `number` - The item quantity.
+-   _quantity_limits_ `object` - The item quantity limits object with the following keys:
+    -   _editable_ `boolean` - Whether the quantity is editable.
+    -   _maximum_ `number` - The maximum quantity.
+    -   _minimum_ `number` - The minimum quantity.
+    -   _multiple_of_ `number` - The multiple of quantity.
+-   _short_description_ `string` - The item short description.
+-   _show_backorder_badge_ `boolean` - Whether to show the backorder badge.
+-   _sku_ `string` - The item SKU.
+-   _sold_individually_ `boolean` - Whether the item is sold individually.
+-   _totals_ `object` - The item totals object with the following keys:
+    -   _currency_code_ `string` - The currency code.
+    -   _currency_decimal_separator_ `string` - The currency decimal separator.
+    -   _currency_minor_unit_ `number` - The currency minor unit.
+    -   _currency_prefix_ `string` - The currency prefix.
+    -   _currency_suffix_ `string` - The currency suffix.
+    -   _currency_symbol_ `string` - The currency symbol.
+    -   _currency_thousand_separator_ `string` - The currency thousand separator.
+    -   _line_subtotal_ `string` - The line subtotal.
+    -   _line_subtotal_tax_ `string` - The line subtotal tax.
+    -   _line_total_ `string` - The line total.
+    -   _line_total_tax_ `string` - The line total tax.
+-   _type_ `string` - The item type.
+-   _variation_ `array` - The item variation array.
+
+<!-- FEEDBACK -->
+
+---
+
+[We're hiring!](https://woocommerce.com/careers/) Come work with us!
+
+🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-blocks/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/third-party-developers/extensibility/checkout-block/available-filters/order-summary-items.md)

--- a/docs/third-party-developers/extensibility/checkout-block/available-filters/order-summary-items.md
+++ b/docs/third-party-developers/extensibility/checkout-block/available-filters/order-summary-items.md
@@ -40,6 +40,15 @@ The `cartItemClass` filter allows to change the order summary item class.
 #### Basic example <!-- omit in toc -->
 
 ```tsx
+/**
+ * Optional: Import `registerCheckoutFilters` using ES module syntax if you are using
+ * @woocommerce/dependency-extraction-webpack-plugin for enhanced dependency management.
+ *
+ * Replace the line below with the following import statement:
+ * import { registerCheckoutFilters } from '@woocommerce/checkout-data';
+ *
+ * @see https://www.npmjs.com/package/@woocommerce/dependency-extraction-webpack-plugin
+ */
 const { registerCheckoutFilters } = window.wc.blocksCheckout;
 
 const modifyCartItemClass = ( defaultValue, extensions, args ) => {
@@ -60,6 +69,15 @@ registerCheckoutFilters( 'example-extension', {
 #### Advanced example <!-- omit in toc -->
 
 ```tsx
+/**
+ * Optional: Import `registerCheckoutFilters` using ES module syntax if you are using
+ * @woocommerce/dependency-extraction-webpack-plugin for enhanced dependency management.
+ *
+ * Replace the line below with the following import statement:
+ * import { registerCheckoutFilters } from '@woocommerce/checkout-data';
+ *
+ * @see https://www.npmjs.com/package/@woocommerce/dependency-extraction-webpack-plugin
+ */
 const { registerCheckoutFilters } = window.wc.blocksCheckout;
 
 const modifyCartItemClass = ( defaultValue, extensions, args ) => {
@@ -116,6 +134,15 @@ The `cartItemPrice` filter allows to format the order summary item price.
 #### Basic example <!-- omit in toc -->
 
 ```tsx
+/**
+ * Optional: Import `registerCheckoutFilters` using ES module syntax if you are using
+ * @woocommerce/dependency-extraction-webpack-plugin for enhanced dependency management.
+ *
+ * Replace the line below with the following import statement:
+ * import { registerCheckoutFilters } from '@woocommerce/checkout-data';
+ *
+ * @see https://www.npmjs.com/package/@woocommerce/dependency-extraction-webpack-plugin
+ */
 const { registerCheckoutFilters } = window.wc.blocksCheckout;
 
 const modifyCartItemPrice = ( defaultValue, extensions, args, validation ) => {
@@ -136,6 +163,15 @@ registerCheckoutFilters( 'example-extension', {
 #### Advanced example <!-- omit in toc -->
 
 ```tsx
+/**
+ * Optional: Import `registerCheckoutFilters` using ES module syntax if you are using
+ * @woocommerce/dependency-extraction-webpack-plugin for enhanced dependency management.
+ *
+ * Replace the line below with the following import statement:
+ * import { registerCheckoutFilters } from '@woocommerce/checkout-data';
+ *
+ * @see https://www.npmjs.com/package/@woocommerce/dependency-extraction-webpack-plugin
+ */
 const { registerCheckoutFilters } = window.wc.blocksCheckout;
 
 const modifyCartItemPrice = ( defaultValue, extensions, args, validation ) => {
@@ -191,6 +227,15 @@ The `itemName` filter allows to change the order summary item name.
 #### Basic example <!-- omit in toc -->
 
 ```tsx
+/**
+ * Optional: Import `registerCheckoutFilters` using ES module syntax if you are using
+ * @woocommerce/dependency-extraction-webpack-plugin for enhanced dependency management.
+ *
+ * Replace the line below with the following import statement:
+ * import { registerCheckoutFilters } from '@woocommerce/checkout-data';
+ *
+ * @see https://www.npmjs.com/package/@woocommerce/dependency-extraction-webpack-plugin
+ */
 const { registerCheckoutFilters } = window.wc.blocksCheckout;
 
 const modifyItemName = ( defaultValue, extensions, args ) => {
@@ -211,6 +256,15 @@ registerCheckoutFilters( 'example-extension', {
 #### Advanced example <!-- omit in toc -->
 
 ```tsx
+/**
+ * Optional: Import `registerCheckoutFilters` using ES module syntax if you are using
+ * @woocommerce/dependency-extraction-webpack-plugin for enhanced dependency management.
+ *
+ * Replace the line below with the following import statement:
+ * import { registerCheckoutFilters } from '@woocommerce/checkout-data';
+ *
+ * @see https://www.npmjs.com/package/@woocommerce/dependency-extraction-webpack-plugin
+ */
 const { registerCheckoutFilters } = window.wc.blocksCheckout;
 
 const modifyItemName = ( defaultValue, extensions, args ) => {
@@ -267,6 +321,15 @@ The `subtotalPriceFormat` filter allows to format the order summary item subtota
 #### Basic example <!-- omit in toc -->
 
 ```tsx
+/**
+ * Optional: Import `registerCheckoutFilters` using ES module syntax if you are using
+ * @woocommerce/dependency-extraction-webpack-plugin for enhanced dependency management.
+ *
+ * Replace the line below with the following import statement:
+ * import { registerCheckoutFilters } from '@woocommerce/checkout-data';
+ *
+ * @see https://www.npmjs.com/package/@woocommerce/dependency-extraction-webpack-plugin
+ */
 const { registerCheckoutFilters } = window.wc.blocksCheckout;
 
 const modifySubtotalPriceFormat = (
@@ -292,6 +355,15 @@ registerCheckoutFilters( 'example-extension', {
 #### Advanced example <!-- omit in toc -->
 
 ```tsx
+/**
+ * Optional: Import `registerCheckoutFilters` using ES module syntax if you are using
+ * @woocommerce/dependency-extraction-webpack-plugin for enhanced dependency management.
+ *
+ * Replace the line below with the following import statement:
+ * import { registerCheckoutFilters } from '@woocommerce/checkout-data';
+ *
+ * @see https://www.npmjs.com/package/@woocommerce/dependency-extraction-webpack-plugin
+ */
 const { registerCheckoutFilters } = window.wc.blocksCheckout;
 
 const modifySubtotalPriceFormat = (

--- a/docs/third-party-developers/extensibility/checkout-block/available-filters/totals-footer-item.md
+++ b/docs/third-party-developers/extensibility/checkout-block/available-filters/totals-footer-item.md
@@ -1,0 +1,170 @@
+# Totals Footer Item
+
+The following Totals Footer Item filter is available:
+
+-   [totalLabel](#totallabel)
+
+## `totalLabel`
+
+The following object is used in the filter:
+
+-   [Cart object](#cart-object)
+
+### Description <!-- omit in toc -->
+
+The `totalLabel` filter allows you to change the label of the total item in the footer of the Cart and Checkout blocks.
+
+### Parameters <!-- omit in toc -->
+
+-   _defaultValue_ `string` (default: `Total`) - The total label.
+-   _extensions_ `object` (default: `{}`) - The extensions object.
+-   _args_ `object` - The arguments object with the following keys:
+    -   _cart_ `object` - The cart object from `wc/store/cart`, see [Cart object](#cart-object).
+
+### Returns <!-- omit in toc -->
+
+-   `string` - The updated total label.
+
+### Code example <!-- omit in toc -->
+
+```ts
+const { registerCheckoutFilters } = window.wc.blocksCheckout;
+
+const modifyTotalLabel = ( defaultValue, extensions, args ) => {
+	return 'Deposit due today';
+};
+
+registerCheckoutFilters( 'example-extension', {
+	totalLabel: modifyTotalLabel,
+} );
+```
+
+> 💡 Filters can be also combined. See [Combined filters](../available-filters.md#combined-filters) for an example.
+
+### Screenshots <!-- omit in toc -->
+
+![Total Label filter](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-27-at-14.17.38.png)
+
+![Total Label filter](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-27-at-14.19.32.png)
+
+## Cart object
+
+The Cart object of the filters above has the following keys:
+
+-   _billingAddress_ `object` - The billing address object with the following keys:
+    -   _address_1_ `string` - The first line of the address.
+    -   _address_2_ `string` - The second line of the address.
+    -   _city_ `string` - The city of the address.
+    -   _company_ `string` - The company of the address.
+    -   _country_ `string` - The country of the address.
+    -   _email_ `string` - The email of the address.
+    -   _first_name_ `string` - The first name of the address.
+    -   _last_name_ `string` - The last name of the address.
+    -   _phone_ `string` - The phone of the address.
+    -   _postcode_ `string` - The postcode of the address.
+    -   _state_ `string` - The state of the address.
+-   _billingData_ `object` - The billing data object with the same keys as the `billingAddress` object.
+-   _cartCoupons_ `array` - The cart coupons array.
+-   _cartErrors_ `array` - The cart errors array.
+-   _cartFees_ `array` - The cart fees array.
+-   _cartHasCalculatedShipping_ `boolean` - Whether the cart has calculated shipping.
+-   _cartIsLoading_ `boolean` - Whether the cart is loading.
+-   _cartItemErrors_ `array` - The cart item errors array.
+-   _cartItems_ `array` - The cart items array with cart item objects, see [Cart Item object](#cart-item-object).
+-   _cartItemsCount_ `number` - The cart items count.
+-   _cartItemsWeight_ `number` - The cart items weight.
+-   _cartNeedsPayment_ `boolean` - Whether the cart needs payment.
+-   _cartNeedsShipping_ `boolean` - Whether the cart needs shipping.
+-   _cartTotals_ `object` - The cart totals object with the following keys:
+    -   _currency_code_ `string` - The currency code.
+    -   _currency_decimal_separator_ `string` - The currency decimal separator.
+    -   _currency_minor_unit_ `number` - The currency minor unit.
+    -   _currency_prefix_ `string` - The currency prefix.
+    -   _currency_suffix_ `string` - The currency suffix.
+    -   _currency_symbol_ `string` - The currency symbol.
+    -   _currency_thousand_separator_ `string` - The currency thousand separator.
+    -   _tax_lines_ `array` - The tax lines array with tax line objects with the following keys:
+        -   _name_ `string` - The name of the tax line.
+        -   _price_ `number` - The price of the tax line.
+        -   _rate_ `string` - The rate ID of the tax line.
+    -   _total_discount_ `string` - The total discount.
+    -   _total_discount_tax_ `string` - The total discount tax.
+    -   _total_fees_ `string` - The total fees.
+    -   _total_fees_tax_ `string` - The total fees tax.
+    -   _total_items_ `string` - The total items.
+    -   _total_items_tax_ `string` - The total items tax.
+    -   _total_price_ `string` - The total price.
+    -   _total_shipping_ `string` - The total shipping.
+    -   _total_shipping_tax_ `string` - The total shipping tax.
+    -   _total_tax_ `string` - The total tax.
+-   _crossSellsProducts_ `array` - The cross sells products array with cross sells product objects.
+-   _extensions_ `object` (default: `{}`) - The extensions object.
+-   _isLoadingRates_ `boolean` - Whether the cart is loading rates.
+-   _paymentRequirements_ `array` - The payment requirements array.
+-   _shippingAddress_ `object` - The shipping address object with the same keys as the `billingAddress` object.
+-   _shippingRates_ `array` - The shipping rates array.
+
+## Cart Item object <!-- omit in toc -->
+
+The Cart Item object of the filters above has the following keys:
+
+-   _backorders_allowed_ `boolean` - Whether backorders are allowed.
+-   _catalog_visibility_ `string` - The catalog visibility.
+-   _decsription_ `string` - The cart item description.
+-   _extensions_ `object` (default: `{}`) - The extensions object.
+-   _id_ `number` - The item ID.
+-   _images_ `array` - The item images array.
+-   _item_data_ `array` - The item data array.
+-   _key_ `string` - The item key.
+-   _low_stock_remaining_ `number` - The low stock remaining.
+-   _name_ `string` - The item name.
+-   _permalink_ `string` - The item permalink.
+-   _prices_ `object` - The item prices object with the following keys:
+    -   _currency_code_ `string` - The currency code.
+    -   _currency_decimal_separator_ `string` - The currency decimal separator.
+    -   _currency_minor_unit_ `number` - The currency minor unit.
+    -   _currency_prefix_ `string` - The currency prefix.
+    -   _currency_suffix_ `string` - The currency suffix.
+    -   _currency_symbol_ `string` - The currency symbol.
+    -   _currency_thousand_separator_ `string` - The currency thousand separator.
+    -   _price_ `string` - The price.
+    -   _price_range_ `string` - The price range.
+    -   _raw_prices_ `object` - The raw prices object with the following keys:
+        -   _precision_ `number` - The precision.
+        -   _price_ `number` - The price.
+        -   _regular_price_ `number` - The regular price.
+        -   _sale_price_ `number` - The sale price.
+    -   _regular_price_ `string` - The regular price.
+    -   _sale_price_ `string` - The sale price.
+-   _quantity_ `number` - The item quantity.
+-   _quantity_limits_ `object` - The item quantity limits object with the following keys:
+    -   _editable_ `boolean` - Whether the quantity is editable.
+    -   _maximum_ `number` - The maximum quantity.
+    -   _minimum_ `number` - The minimum quantity.
+    -   _multiple_of_ `number` - The multiple of quantity.
+-   _short_description_ `string` - The item short description.
+-   _show_backorder_badge_ `boolean` - Whether to show the backorder badge.
+-   _sku_ `string` - The item SKU.
+-   _sold_individually_ `boolean` - Whether the item is sold individually.
+-   _totals_ `object` - The item totals object with the following keys:
+    -   _currency_code_ `string` - The currency code.
+    -   _currency_decimal_separator_ `string` - The currency decimal separator.
+    -   _currency_minor_unit_ `number` - The currency minor unit.
+    -   _currency_prefix_ `string` - The currency prefix.
+    -   _currency_suffix_ `string` - The currency suffix.
+    -   _currency_symbol_ `string` - The currency symbol.
+    -   _currency_thousand_separator_ `string` - The currency thousand separator.
+    -   _line_subtotal_ `string` - The line subtotal.
+    -   _line_subtotal_tax_ `string` - The line subtotal tax.
+    -   _line_total_ `string` - The line total.
+    -   _line_total_tax_ `string` - The line total tax.
+-   _type_ `string` - The item type.
+-   _variation_ `array` - The item variation array.
+
+<!-- FEEDBACK -->
+
+---
+
+[We're hiring!](https://woocommerce.com/careers/) Come work with us!
+
+🐞 Found a mistake, or have a suggestion? [Leave feedback about this document here.](https://github.com/woocommerce/woocommerce-blocks/issues/new?assignees=&labels=type%3A+documentation&template=--doc-feedback.md&title=Feedback%20on%20./docs/third-party-developers/extensibility/checkout-block/available-filters/totals-footer-item.md)

--- a/docs/third-party-developers/extensibility/checkout-block/available-filters/totals-footer-item.md
+++ b/docs/third-party-developers/extensibility/checkout-block/available-filters/totals-footer-item.md
@@ -29,6 +29,15 @@ The `totalLabel` filter allows you to change the label of the total item in the 
 ### Code example <!-- omit in toc -->
 
 ```ts
+/**
+ * Optional: Import `registerCheckoutFilters` using ES module syntax if you are using
+ * @woocommerce/dependency-extraction-webpack-plugin for enhanced dependency management.
+ *
+ * Replace the line below with the following import statement:
+ * import { registerCheckoutFilters } from '@woocommerce/checkout-data';
+ *
+ * @see https://www.npmjs.com/package/@woocommerce/dependency-extraction-webpack-plugin
+ */
 const { registerCheckoutFilters } = window.wc.blocksCheckout;
 
 const modifyTotalLabel = ( defaultValue, extensions, args ) => {

--- a/docs/third-party-developers/extensibility/checkout-block/available-filters/totals-footer-item.md
+++ b/docs/third-party-developers/extensibility/checkout-block/available-filters/totals-footer-item.md
@@ -6,9 +6,10 @@ The following Totals Footer Item filter is available:
 
 ## `totalLabel`
 
-The following object is used in the filter:
+The following objects are used in the filter:
 
 -   [Cart object](#cart-object)
+-   [Cart Item object](#cart-item-object)
 
 ### Description <!-- omit in toc -->
 
@@ -104,7 +105,7 @@ The Cart object of the filters above has the following keys:
 -   _shippingAddress_ `object` - The shipping address object with the same keys as the `billingAddress` object.
 -   _shippingRates_ `array` - The shipping rates array.
 
-## Cart Item object <!-- omit in toc -->
+## Cart Item object
 
 The Cart Item object of the filters above has the following keys:
 

--- a/docs/third-party-developers/extensibility/checkout-block/available-filters/totals-footer-item.md
+++ b/docs/third-party-developers/extensibility/checkout-block/available-filters/totals-footer-item.md
@@ -53,9 +53,18 @@ registerCheckoutFilters( 'example-extension', {
 
 ### Screenshots <!-- omit in toc -->
 
-![Total Label filter](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-27-at-14.17.38.png)
-
-![Total Label filter](https://woocommerce.com/wp-content/uploads/2023/10/Screenshot-2023-10-27-at-14.19.32.png)
+<table>
+<tr>
+<td valign="top">Before:
+<br><br>
+<img width="361" alt="Before applying the Total Label filter" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/5b2fb8ab-db84-4ed0-a676-d5203edc84d2">
+</td>
+<td valign="top">After:
+<br><br>
+<img width="355" alt="After applying the Total Label filter" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/07955eea-cb17-48e9-9cb5-6548dd6a3b24">
+</td>
+</tr>
+</table>
 
 ## Cart object
 


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Improve the description of the arguments passed to the checkout filters.

Fixes #10551 
Fixes #9385

## Why

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

Currently, the arguments passed to the checkout filters are not documented properly. This makes it challenging for an external developer on how to use these filters correctly. This PR aims to improve the documentation of the arguments passed to the checkout filters.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Look up the *.md files of this PR.
2. Verify that all arguments are documented correctly.
3. Verify that the docs do not contain broken links.
4. Verify that all screenshots contain alt tags.
5. Verify that all footer links _"🐞 Found a mistake, or have a suggestion?"_ link to the corresponding docs.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [x] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

n/a

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [x] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [x] This PR has had any necessary documentation added/updated.

## Changelog

n/a