### PR TITLE
Fix the Layout for Shipping and Billing Address Forms in the Checkout Block

### DIFF
--- a/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/style.scss
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/style.scss
@@ -18,11 +18,11 @@
 			display: flex;
 			flex-wrap: wrap;
 			justify-content: space-between;
-			gap: 0 calc(#{$gap-smaller} * 2);
+			gap: 0 calc(#{$gap-smaller} * 2); // Required for spacing especially when using flex-grow
 
 			.wc-block-components-text-input,
 			.wc-block-components-state-input {
-				flex: 1 0 calc(50% - #{$gap-smaller});
+				flex: 1 0 calc(50% - #{$gap-smaller}); // "flex-grow = 1" allows the input to grow to fill the space
 				box-sizing: border-box;
 
 				&:nth-of-type(2),

--- a/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/style.scss
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/style.scss
@@ -21,7 +21,6 @@
 			gap: 0 calc(#{$gap-smaller} * 2);
 
 			.wc-block-components-text-input,
-			.wc-block-components-country-input,
 			.wc-block-components-state-input {
 				flex: 1 0 calc(50% - #{$gap-smaller});
 				box-sizing: border-box;
@@ -34,7 +33,8 @@
 
 			.wc-block-components-address-form__company,
 			.wc-block-components-address-form__address_1,
-			.wc-block-components-address-form__address_2 {
+			.wc-block-components-address-form__address_2,
+			.wc-block-components-country-input {
 				flex: 0 0 100%;
 			}
 		}

--- a/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/style.scss
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-fields-block/style.scss
@@ -18,11 +18,12 @@
 			display: flex;
 			flex-wrap: wrap;
 			justify-content: space-between;
+			gap: 0 calc(#{$gap-smaller} * 2);
 
 			.wc-block-components-text-input,
 			.wc-block-components-country-input,
 			.wc-block-components-state-input {
-				flex: 0 0 calc(50% - #{$gap-smaller});
+				flex: 1 0 calc(50% - #{$gap-smaller});
 				box-sizing: border-box;
 
 				&:nth-of-type(2),


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

 In this PR, we want to remove any empty spaces that can appear in the address form of the Checkout Block. For example:
 
<img width="400" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/14235870/5031e060-f6d9-4e5d-a4af-3a7dfd041b77">

We also want to keep the same layout as the classic checkout (e.g., Japan, Hungary). 

Fixes #10721

## Why

We set the `flex-grow` property to `1`, which allows the item to grow if necessary. It means that the item can expand to occupy available space. Because of this property, we lost the gap between the fields, but thanks to the `gap` property, we can create consistent spacing between flex items (in this case, input fields). 

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Add a product to the cart
2. Go to the Checkout Block
3. Check the shipping or billing address form fields
4. Set the country to `Hungary`. Confirm there are no empty spaces in the form and the layout is the same in the classic checkout
5. Set the country to `Japan`. Confirm the layout is similar to the classic checkout

<img width="450" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/14235870/9d90ce9c-ae2b-434c-8cab-5dca257a9c0d">

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|    <img width="665" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/14235870/5031e060-f6d9-4e5d-a4af-3a7dfd041b77">   |    <img width="665" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/14235870/8322e8b9-b16e-4ef9-a3f5-6729d146cf19">   |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [ ] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Fix the Layout for Shipping and Billing Address Forms in the Checkout Block
