### PR TITLE
Product Collection: Fix the PHP Warning after migrating from Products (Beta)

### DIFF
--- a/src/BlockTypes/ProductCollection.php
+++ b/src/BlockTypes/ProductCollection.php
@@ -302,6 +302,7 @@ class ProductCollection extends AbstractBlock {
 		);
 
 		$is_on_sale          = $query['woocommerceOnSale'] ?? false;
+		$product_attributes  = $query['woocommerceAttributes'] ?? [];
 		$taxonomies_query    = $this->get_filter_by_taxonomies_query( $query['tax_query'] ?? [] );
 		$handpicked_products = $query['woocommerceHandPickedProducts'] ?? [];
 
@@ -311,7 +312,7 @@ class ProductCollection extends AbstractBlock {
 				'on_sale'             => $is_on_sale,
 				'stock_status'        => $query['woocommerceStockStatus'],
 				'orderby'             => $query['orderBy'],
-				'product_attributes'  => $query['woocommerceAttributes'],
+				'product_attributes'  => $product_attributes,
 				'taxonomies_query'    => $taxonomies_query,
 				'handpicked_products' => $handpicked_products,
 			),


### PR DESCRIPTION
## What

Fixes woocommerce/woocommerce-blocks#11437

## Why

This PR fixes the PHP warning present after utilizing the `Upgrade to Product Collection` link in `Products (Beta)` block: `Warning: Undefined array key "woocommerceAttributes" in /srv/users/user7f63c11d/apps/user7f63c11d/public/wp-content/plugins/woocommerce-gutenberg-products-block/src/BlockTypes/ProductCollection.php on line 313`

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Create a new page or post.
2. Add the `Large Image Product Gallery` pattern.
3. Use the `Upgrade to Product Collection` option in the sidebar and save the page.
4. Ensure there are no warnings in the editor and the front end.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|<img width="1177" alt="Cursor_i_Large_Image_Product_Gallery_Pattern_–_newproductgallery" src="https://github.com/woocommerce/woocommerce-blocks/assets/905781/2c0a11e3-f95a-4cb1-9ab1-543092efda93">|<img width="1065" alt="Large_Image_Product_Gallery_Pattern_–_newproductgallery" src="https://github.com/woocommerce/woocommerce-blocks/assets/905781/45e66d1f-5f84-4820-ab88-5bf597b6202f">|

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Product Collection: Fix the PHP Warning present after migrating from Products (Beta).
