### PR TITLE
Disable test eslint rule for test.ts file

### DIFF
--- a/tests/e2e/playwright-utils/test.ts
+++ b/tests/e2e/playwright-utils/test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable rulesdir/no-raw-playwright-test-import */
 /**
  * External dependencies
  */


### PR DESCRIPTION
With #11475, we introduced a new ESLint rule to ensure that we don't import `test` from the playwright package (nice work). Currently, we still import "test" from the playwright package for the `test.ts` file used to set up the WordPress site. For this reason, currently, the CI job about the JS linting fails.

This PR disables this rule for the `tests.ts` file.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Ensure that the CI job about the JS linting doesn't fail.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->