### PR TITLE
Store Customization > Enhance the Hero Product Split pattern

### DIFF
--- a/patterns/hero-product-split.php
+++ b/patterns/hero-product-split.php
@@ -15,7 +15,7 @@ $hero_title = $content['titles'][0]['default'] ?? '';
 <!-- wp:media-text {"align":"full","mediaPosition":"right","mediaType":"image","mediaSizeSlug":"full","imageFill":false,"style":{"spacing":{"margin":{"bottom":"80px"}}}} -->
 <div class="wp-block-media-text alignfull has-media-on-the-right is-stacked-on-mobile" style="margin-bottom:80px">
 	<div class="wp-block-media-text__content">
-		<!-- wp:heading -->
+		<!-- wp:heading {"level":3} -->
 		<h3 class="wp-block-heading"><?php echo esc_html( $hero_title ); ?></h3>
 		<!-- /wp:heading -->
 

--- a/patterns/hero-product-split.php
+++ b/patterns/hero-product-split.php
@@ -12,11 +12,11 @@ $images  = PatternsHelper::get_pattern_images( 'woocommerce-blocks/hero-product-
 $hero_title = $content['titles'][0]['default'] ?? '';
 ?>
 
-<!-- wp:media-text {"align":"full","mediaPosition":"right","mediaType":"image","mediaSizeSlug":"full","imageFill":false} -->
-<div class="wp-block-media-text alignfull has-media-on-the-right is-stacked-on-mobile">
+<!-- wp:media-text {"align":"full","mediaPosition":"right","mediaType":"image","mediaSizeSlug":"full","imageFill":false,"style":{"spacing":{"margin":{"bottom":"80px"}}}} -->
+<div class="wp-block-media-text alignfull has-media-on-the-right is-stacked-on-mobile" style="margin-bottom:80px">
 	<div class="wp-block-media-text__content">
 		<!-- wp:heading -->
-		<h2 class="wp-block-heading"><?php echo esc_html( $hero_title ); ?></h2>
+		<h3 class="wp-block-heading"><?php echo esc_html( $hero_title ); ?></h3>
 		<!-- /wp:heading -->
 
 		<!-- wp:buttons {"style":{"spacing":{"margin":{"bottom":"var:preset|spacing|40"}}}} -->


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Update the margin-bottom and the size of the text in the Hero Product Split pattern from h2 to h3 as requested by design during the CYS call and discussed on p1698679358952629-slack-C053716F2H2 .

## Why

Enhance the pattern for usage within the CYS flow.

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Create a new post
2. Insert the Hero Product Split pattern
3. Make sure things are working as expected on the editor side
4. Save the post and access the frontend: make sure things are working as expected over there as well.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|  <img width="683" alt="Screenshot 2023-10-30 at 22 17 34" src="https://github.com/woocommerce/woocommerce-blocks/assets/15730971/56c6c94d-6151-4611-8db1-48da5412f857">  |  <img width="683" alt="Screenshot 2023-10-30 at 22 17 50" src="https://github.com/woocommerce/woocommerce-blocks/assets/15730971/112c668f-b081-4d81-b9d4-c6072b67d838">  |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Enhance the Hero Product Split pattern