### PR TITLE
Add support for Order Source Attribution

### DIFF
--- a/assets/js/extensions/order-source-attribution/index.ts
+++ b/assets/js/extensions/order-source-attribution/index.ts
@@ -4,22 +4,12 @@
 import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
 import { dispatch } from '@wordpress/data';
 
-const sb = window.sbjs || {};
+/**
+ * Internal dependencies
+ */
+import { sbjs } from './sourcebuster.d.ts';
+
 dispatch( CHECKOUT_STORE_KEY ).__internalSetExtensionData(
 	'order-source-attribution',
-	{
-		type: sb.get.current.typ,
-		url: sb.get.current_add.rf,
-		utm_campaign: sb.get.current.cmp,
-		utm_source: sb.get.current.src,
-		utm_medium: sb.get.current.mdm,
-		utm_content: sb.get.current.cnt,
-		utm_id: sb.get.current.id,
-		utm_term: sb.get.current.trm,
-		session_entry: sb.get.current_add.ep,
-		session_start_time: sb.get.current_add.fd,
-		session_pages: sb.get.session.pgs,
-		session_count: sb.get.udata.vst,
-		user_agent: sb.get.udata.uag,
-	}
+	sbjs.get()
 );

--- a/assets/js/extensions/order-source-attribution/index.ts
+++ b/assets/js/extensions/order-source-attribution/index.ts
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import { CHECKOUT_STORE_KEY } from '@woocommerce/block-data';
+import { dispatch } from '@wordpress/data';
+
+const sb = window.sbjs || {};
+dispatch( CHECKOUT_STORE_KEY ).__internalSetExtensionData(
+	'order-source-attribution',
+	{
+		type: sb.get.current.typ,
+		url: sb.get.current_add.rf,
+		utm_campaign: sb.get.current.cmp,
+		utm_source: sb.get.current.src,
+		utm_medium: sb.get.current.mdm,
+		utm_content: sb.get.current.cnt,
+		utm_id: sb.get.current.id,
+		utm_term: sb.get.current.trm,
+		session_entry: sb.get.current_add.ep,
+		session_start_time: sb.get.current_add.fd,
+		session_pages: sb.get.session.pgs,
+		session_count: sb.get.udata.vst,
+		user_agent: sb.get.udata.uag,
+	}
+);

--- a/assets/js/extensions/order-source-attribution/sourcebuster.d.ts
+++ b/assets/js/extensions/order-source-attribution/sourcebuster.d.ts
@@ -1,0 +1,72 @@
+declare module 'sourcebuster' {
+	interface SourcebusterReferralsOptions {
+		host?: string;
+		medium?: string;
+		display?: string;
+	}
+
+	interface SourcebusterOrganicsOptions {
+		host?: string;
+		param?: string;
+		display?: string;
+	}
+
+	interface SourcebusterTypeinAttributes {
+		source?: string;
+		medium?: string;
+	}
+
+	interface SourcebusterOptions {
+		lifetime?: number;
+		session_length?: number;
+		domain?: string;
+		isolate?: boolean;
+		referrals?: SourcebusterReferralsOptions[];
+		organics?: SourcebusterOrganicsOptions[];
+		typein_attributes?: SourcebusterTypeinAttributes;
+		timezone_offset?: number;
+		campaign_param?: string;
+		user_ip?: string;
+		callback?: () => void;
+	}
+
+	interface SorucebusterVisitorSource {
+		typ: string;
+		src: string;
+		mdm: string;
+		cmp: string;
+		cnt: string;
+		trm: string;
+	}
+
+	interface SourcebusterVisitorSourceAdditional {
+		fd: string;
+		ep: string;
+		rf: string;
+	}
+
+	interface SourcebusterParams {
+		current: SorucebusterVisitorSource;
+		current_add: SourcebusterVisitorSourceAdditional;
+		first: SorucebusterVisitorSource;
+		first_add: SourcebusterVisitorSourceAdditional;
+		session: {
+			pgs: number;
+			cpg: string;
+		};
+		udata: {
+			vst: number;
+			uip: string;
+			uag: string;
+		};
+	}
+
+	class sbjs {
+		constructor( options?: SourcebusterOptions );
+		get: () => SourcebusterParams;
+	}
+
+	interface Window {
+		sbjs: sbjs;
+	}
+}

--- a/bin/webpack-entries.js
+++ b/bin/webpack-entries.js
@@ -237,6 +237,8 @@ const entries = {
 			'./assets/js/extensions/shipping-methods/pickup-location/index.js',
 		'wc-blocks-jetpack-woocommerce-analytics':
 			'./assets/js/extensions/jetpack/woocommerce-analytics/index.ts',
+		'wc-blocks-order-source-attribution':
+			'./assets/js/extensions/order-source-attribution/index.ts',
 	},
 	editor: {
 		'wc-blocks-classic-template-revert-button':

--- a/src/Domain/Bootstrap.php
+++ b/src/Domain/Bootstrap.php
@@ -42,6 +42,7 @@ use Automattic\WooCommerce\Blocks\Shipping\ShippingController;
 use Automattic\WooCommerce\Blocks\Templates\SingleProductTemplateCompatibility;
 use Automattic\WooCommerce\Blocks\Templates\ArchiveProductTemplatesCompatibility;
 use Automattic\WooCommerce\Blocks\Domain\Services\OnboardingTasks\TasksController;
+use Automattic\WooCommerce\Vendor\League\Container\Exception\NotFoundException;
 
 /**
  * Takes care of bootstrapping the plugin.
@@ -137,7 +138,18 @@ class Bootstrap {
 		$this->container->get( ShippingController::class )->init();
 		$this->container->get( TasksController::class )->init();
 		$this->container->get( JetpackWooCommerceAnalytics::class )->init();
-		$this->container->get( OrderSourceAttribution::class )->init();
+
+		try {
+			$this->container->get( OrderSourceAttribution::class )->init();
+		} catch ( NotFoundException $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+
+			/*
+			 * This will fail until #39701 is merged into WooCommerce core.
+			 *
+			 * @see https://github.com/woocommerce/woocommerce/pull/39701
+			 * @todo Remove this try/catch once the PR is merged.
+			 */
+		}
 
 		// Load assets in admin and on the frontend.
 		if ( ! $is_rest ) {

--- a/src/Domain/Bootstrap.php
+++ b/src/Domain/Bootstrap.php
@@ -33,8 +33,10 @@ use Automattic\WooCommerce\Blocks\Templates\OrderConfirmationTemplate;
 use Automattic\WooCommerce\Blocks\Templates\ProductAttributeTemplate;
 use Automattic\WooCommerce\Blocks\Templates\ProductSearchResultsTemplate;
 use Automattic\WooCommerce\Internal\Features\FeaturesController;
+use Automattic\WooCommerce\Internal\Orders\SourceAttributionController;
 use Automattic\WooCommerce\StoreApi\RoutesController;
 use Automattic\WooCommerce\StoreApi\SchemaController;
+use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
 use Automattic\WooCommerce\StoreApi\StoreApi;
 use Automattic\WooCommerce\Blocks\Shipping\ShippingController;
 use Automattic\WooCommerce\Blocks\Templates\SingleProductTemplateCompatibility;
@@ -135,6 +137,7 @@ class Bootstrap {
 		$this->container->get( ShippingController::class )->init();
 		$this->container->get( TasksController::class )->init();
 		$this->container->get( JetpackWooCommerceAnalytics::class )->init();
+		$this->container->get( OrderSourceAttribution::class )->init();
 
 		// Load assets in admin and on the frontend.
 		if ( ! $is_rest ) {
@@ -162,11 +165,6 @@ class Bootstrap {
 			$this->container->get( ArchiveProductTemplatesCompatibility::class )->init();
 			$this->container->get( SingleProductTemplateCompatibility::class )->init();
 			$this->container->get( Notices::class )->init();
-		}
-
-		// Load assets on frontend only.
-		if ( ! $is_rest && ! is_admin() ) {
-			$this->container->get( OrderSourceAttribution::class )->init();
 		}
 	}
 
@@ -411,10 +409,12 @@ class Bootstrap {
 		$this->container->register(
 			OrderSourceAttribution::class,
 			function( Container $container ) {
-				$features_controller = wc_get_container()->get( FeaturesController::class );
-				$asset_api           = $container->get( AssetApi::class );
-
-				return new OrderSourceAttribution( $asset_api, $features_controller );
+				return new OrderSourceAttribution(
+					$container->get( AssetApi::class ),
+					$container->get( ExtendSchema::class ),
+					wc_get_container()->get( FeaturesController::class ),
+					wc_get_container()->get( SourceAttributionController::class )
+				);
 			}
 		);
 

--- a/src/Domain/Bootstrap.php
+++ b/src/Domain/Bootstrap.php
@@ -411,7 +411,7 @@ class Bootstrap {
 			function( Container $container ) {
 				return new OrderSourceAttribution(
 					$container->get( AssetApi::class ),
-					$container->get( ExtendSchema::class ),
+					$container->get( StoreApi::class )->container()->get( ExtendSchema::class ),
 					wc_get_container()->get( FeaturesController::class ),
 					wc_get_container()->get( SourceAttributionController::class )
 				);

--- a/src/Domain/Services/OrderSourceAttribution.php
+++ b/src/Domain/Services/OrderSourceAttribution.php
@@ -5,6 +5,12 @@ namespace Automattic\WooCommerce\Blocks\Domain\Services;
 
 use Automattic\WooCommerce\Blocks\Assets\Api as AssetApi;
 use Automattic\WooCommerce\Internal\Features\FeaturesController;
+use Automattic\WooCommerce\Internal\Orders\SourceAttributionController;
+use Automattic\WooCommerce\StoreApi\Schemas\ExtendSchema;
+use Automattic\WooCommerce\StoreApi\Schemas\V1\CheckoutSchema;
+use Automattic\WooCommerce\StoreApi\StoreApi;
+use Exception;
+use WP_Error;
 
 /**
  * Class OrderSourceAttribution
@@ -18,24 +24,47 @@ class OrderSourceAttribution {
 	 *
 	 * @var AssetApi
 	 */
-	protected $asset_api;
+	private $asset_api;
 
 	/**
 	 * Instance of the features controller.
 	 *
 	 * @var FeaturesController
 	 */
-	protected $features_controller;
+	private $features_controller;
+
+	/**
+	 * ExtendSchema instance.
+	 *
+	 * @var ExtendSchema
+	 */
+	private $extend_schema;
+
+	/**
+	 * Instance of the source attribution controller.
+	 *
+	 * @var SourceAttributionController
+	 */
+	private $source_attribution_controller;
 
 	/**
 	 * Constructor.
 	 *
-	 * @param AssetApi           $asset_api           Instance of the asset API.
-	 * @param FeaturesController $features_controller Features controller.
+	 * @param AssetApi                    $asset_api                     Instance of the asset API.
+	 * @param ExtendSchema                $extend_schema                 ExtendSchema instance.
+	 * @param FeaturesController          $features_controller           Features controller.
+	 * @param SourceAttributionController $source_attribution_controller Instance of the source attribution controller.
 	 */
-	public function __construct( AssetApi $asset_api, FeaturesController $features_controller ) {
-		$this->asset_api           = $asset_api;
-		$this->features_controller = $features_controller;
+	public function __construct(
+		AssetApi $asset_api,
+		ExtendSchema $extend_schema,
+		FeaturesController $features_controller,
+		SourceAttributionController $source_attribution_controller
+	) {
+		$this->asset_api                     = $asset_api;
+		$this->features_controller           = $features_controller;
+		$this->extend_schema                 = $extend_schema;
+		$this->source_attribution_controller = $source_attribution_controller;
 	}
 
 	/**
@@ -46,6 +75,13 @@ class OrderSourceAttribution {
 	 */
 	public function init() {
 		if ( ! $this->features_controller->feature_is_enabled( 'order_source_attribution' ) ) {
+			return;
+		}
+
+		$this->extend_api();
+
+		// Bail early on admin requests to avoid asset registration.
+		if ( is_admin() ) {
 			return;
 		}
 
@@ -83,5 +119,81 @@ class OrderSourceAttribution {
 	 */
 	private function enqueue_scripts() {
 		wp_enqueue_script( 'wc-blocks-order-source-attribution' );
+	}
+
+	/**
+	 * Extend the Store API.
+	 *
+	 * @return void
+	 */
+	private function extend_api() {
+		try {
+			$this->extend_schema->register_endpoint_data(
+				[
+					'endpoint'        => CheckoutSchema::IDENTIFIER,
+					'namespace'       => 'woocommerce/order-source-attribution',
+					'schema_callback' => $this->get_schema_callback(),
+				]
+			);
+			$this->extend_schema->register_update_callback(
+				[
+					'namespace' => 'woocommerce/order-source-attribution',
+					'callback'  => function( $data ) {
+						// todo: Save the data to the order here.
+					},
+				]
+			);
+		} catch ( Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement
+			// Do nothing.
+		}
+	}
+
+	/**
+	 * Get the schema callback.
+	 *
+	 * @return callable
+	 */
+	private function get_schema_callback() {
+		return function() {
+			$schema = [];
+			$fields = $this->source_attribution_controller->get_fields();
+
+			$validate_callback = function( $value ) {
+				if ( ! is_string( $value ) && null !== $value ) {
+					return new WP_Error(
+						'api-error',
+						sprintf(
+							/* translators: %s is the property type */
+							esc_html__( 'Value of type %s was posted to the source attribution callback', 'woo-gutenberg-products-block' ),
+							gettype( $value )
+						)
+					);
+				}
+
+				return true;
+			};
+
+			$sanitize_callback = function( $value ) {
+				return sanitize_text_field( $value );
+			};
+
+			foreach ( $fields as $field ) {
+				$schema[ $this->source_attribution_controller->get_prefixed_field( $field ) ] = [
+					'description' => sprintf(
+						/* translators: %s is the field name */
+						__( 'Source attribution field: %s', 'woo-gutenberg-products-block' ),
+						esc_html( $field )
+					),
+					'type'        => [ 'string', 'null' ],
+					'context'     => [],
+					'arg_options' => [
+						'validate_callback' => $validate_callback,
+						'sanitize_callback' => $sanitize_callback,
+					],
+				];
+			}
+
+			return $schema;
+		};
 	}
 }

--- a/src/Domain/Services/OrderSourceAttribution.php
+++ b/src/Domain/Services/OrderSourceAttribution.php
@@ -1,0 +1,87 @@
+<?php
+declare( strict_types=1 );
+
+namespace Automattic\WooCommerce\Blocks\Domain\Services;
+
+use Automattic\WooCommerce\Blocks\Assets\Api as AssetApi;
+use Automattic\WooCommerce\Internal\Features\FeaturesController;
+
+/**
+ * Class OrderSourceAttribution
+ *
+ * @since x.x.x
+ */
+class OrderSourceAttribution {
+
+	/**
+	 * Instance of the asset API.
+	 *
+	 * @var AssetApi
+	 */
+	protected $asset_api;
+
+	/**
+	 * Instance of the features controller.
+	 *
+	 * @var FeaturesController
+	 */
+	protected $features_controller;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param AssetApi           $asset_api           Instance of the asset API.
+	 * @param FeaturesController $features_controller Features controller.
+	 */
+	public function __construct( AssetApi $asset_api, FeaturesController $features_controller ) {
+		$this->asset_api           = $asset_api;
+		$this->features_controller = $features_controller;
+	}
+
+	/**
+	 * Hook into WP.
+	 *
+	 * @since x.x.x
+	 * @return void
+	 */
+	public function init() {
+		if ( ! $this->features_controller->feature_is_enabled( 'order_source_attribution' ) ) {
+			return;
+		}
+
+		add_action(
+			'init',
+			function() {
+				$this->register_assets();
+			}
+		);
+
+		add_action(
+			'wp_enqueue_scripts',
+			function() {
+				$this->enqueue_scripts();
+			}
+		);
+	}
+
+	/**
+	 * Register scripts.
+	 */
+	private function register_assets() {
+		$this->asset_api->register_script(
+			'wc-blocks-order-source-attribution',
+			'build/wc-blocks-order-source-attribution.js',
+			[ 'woocommerce-order-source-attribution-js' ]
+		);
+	}
+
+	/**
+	 * Enqueue the Order Source Attribution script.
+	 *
+	 * @since x.x.x
+	 * @return void
+	 */
+	private function enqueue_scripts() {
+		wp_enqueue_script( 'wc-blocks-order-source-attribution' );
+	}
+}


### PR DESCRIPTION
This PR is an effort to bring Order Source Attribution support to the Cart and checkout blocks.
For reference: pe2C5g-JD-p2

Order Source Attribution is a new core feature that will show merchants additional information about the order ( **Order Information ):**

![image](https://github.com/woocommerce/woocommerce-blocks/assets/17271089/fc40de0d-6096-41b9-b83e-02d6ca98188e)


The core implementation of the Order Source Attribution will be delivered using the following PR https://github.com/woocommerce/woocommerce/pull/39701

## Why

Since Blocks-based checkout is now the default we need to provide compatibility with the Order Source Attribution feature.

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

To fully test one needs the WooCommerce core https://github.com/woocommerce/woocommerce/pull/39701. Please use the testing instructions there with the combination of Cart & Checkout blocks instead of the classic flow.

After an order is made:
- The Orders page will have a new column labeled "Origin" that will display the source of the order.
- The Order Edit page will have 2 new meta boxes: Order information and Customer History. These boxes will have more details about the origin of the order, and the complete history for the customer of the order.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [ ] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Add suggested changelog entry here.