### PR TITLE
Fix "Large footer" left spacing

### DIFF
--- a/patterns/footer-large.php
+++ b/patterns/footer-large.php
@@ -16,11 +16,11 @@
 			<!-- wp:group {"style":{"spacing":{"blockGap":"8px"}},"layout":{"type":"flex","orientation":"vertical"}} -->
 			<div class="wp-block-group"><!-- wp:site-logo /-->
 				<!-- wp:heading {"level":5,"style":{"typography":{"textTransform":"none"},"spacing":{"margin":{"top":"40px"}}}} -->
-				<h5 class="wp-block-heading" style="margin-top:40px;text-transform:none">Join the community</h5>
+				<h5 class="wp-block-heading" style="margin-top:40px;text-transform:none"><?php esc_html_e( 'Join the community', 'woo-gutenberg-products-block' ); ?></h5>
 				<!-- /wp:heading -->
 
 				<!-- wp:paragraph {"style":{"spacing":{"margin":{"bottom":"40px"}}}} -->
-				<p style="margin-bottom:40px">Learn about new products and discounts</p>
+				<p style="margin-bottom:40px"><?php esc_html_e( 'Learn about new products and discounts', 'woo-gutenberg-products-block' ); ?></p>
 				<!-- /wp:paragraph -->
 
 				<!-- wp:social-links {"size":"has-small-icon-size","style":{"spacing":{"blockGap":{"left":"16px"}}},"className":"is-style-logos-only"} -->

--- a/patterns/footer-large.php
+++ b/patterns/footer-large.php
@@ -14,20 +14,14 @@
 		<!-- wp:column {"width":"60%","style":{"spacing":{"padding":{"right":"50px"}}}} -->
 		<div class="wp-block-column" style="padding-right:50px;flex-basis:60%">
 			<!-- wp:group {"style":{"spacing":{"blockGap":"8px"}},"layout":{"type":"flex","orientation":"vertical"}} -->
-			<div class="wp-block-group">
-				<!-- wp:site-logo /-->
+			<div class="wp-block-group"><!-- wp:site-logo /-->
+				<!-- wp:heading {"level":5,"style":{"typography":{"textTransform":"none"},"spacing":{"margin":{"top":"40px"}}}} -->
+				<h5 class="wp-block-heading" style="margin-top:40px;text-transform:none">Join the community</h5>
+				<!-- /wp:heading -->
 
-				<!-- wp:group {"style":{"spacing":{"margin":{"top":"40px","bottom":"40px"},"blockGap":"12px"}},"layout":{"type":"constrained"}} -->
-				<div class="wp-block-group" style="margin-top:40px;margin-bottom:40px">
-					<!-- wp:heading {"level":5,"style":{"typography":{"textTransform":"none"}}} -->
-					<h5 class="wp-block-heading" style="text-transform:none"><?php esc_html_e( 'Join the community', 'woo-gutenberg-products-block' ); ?></h5>
-					<!-- /wp:heading -->
-
-					<!-- wp:paragraph -->
-					<p><?php esc_html_e( 'Learn about new products and discounts', 'woo-gutenberg-products-block' ); ?></p>
-					<!-- /wp:paragraph -->
-				</div>
-				<!-- /wp:group -->
+				<!-- wp:paragraph {"style":{"spacing":{"margin":{"bottom":"40px"}}}} -->
+				<p style="margin-bottom:40px">Learn about new products and discounts</p>
+				<!-- /wp:paragraph -->
 
 				<!-- wp:social-links {"size":"has-small-icon-size","style":{"spacing":{"blockGap":{"left":"16px"}}},"className":"is-style-logos-only"} -->
 				<ul class="wp-block-social-links has-small-icon-size is-style-logos-only">


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Remove the extra space left to the `Join the community` block.
<img width="707" alt="Screenshot 2023-10-31 at 12 56 33" src="https://github.com/woocommerce/woocommerce-blocks/assets/186112/fa4c0335-9c13-44e1-a599-36ee21663e2c">

## Why

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Create a new page or post and insert the `Large footer` pattern.
2. Check there's no space.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Improve the "Large footer" spacing.
