### PR TITLE
Ensure that the "Remove Item" link on Cart block has a hover state

### DIFF
--- a/assets/css/abstracts/_mixins.scss
+++ b/assets/css/abstracts/_mixins.scss
@@ -171,18 +171,22 @@ $fontSizes: (
 	text-decoration: underline;
 }
 
+@mixin hover-effect() {
+	&:hover {
+		text-decoration: none;
+		color: inherit;
+		cursor: pointer;
+	}
+}
+
 // Reset <button> style so we can use link style for action buttons in filter blocks
 @mixin filter-link-button() {
 	@include link-button();
+	@include hover-effect();
 	@include font-size(small);
 	text-decoration: underline;
 	font-weight: normal;
 	color: inherit;
-
-	&:hover {
-		text-decoration: none;
-		color: inherit;
-	}
 }
 
 // Makes sure long words are broken if they overflow the container.

--- a/assets/js/base/components/cart-checkout/cart-line-items-table/style.scss
+++ b/assets/js/base/components/cart-checkout/cart-line-items-table/style.scss
@@ -34,7 +34,8 @@ table.wc-block-cart-items {
 		}
 		.wc-block-cart-item__quantity {
 			.wc-block-cart-item__remove-link {
-				@include link-button;
+				@include link-button();
+				@include hover-effect();
 				@include font-size( smaller );
 
 				text-transform: none;


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

This PR introduces the following mixin:

```scss
@mixin hover-effect() {
	&:hover {
		text-decoration: none;
		color: inherit;
		cursor: pointer;
	}
}
``` 

> **Important**
> This PR also impacts #7357 by reusing the new mixin. The link previously modified in #7357 will now also present `cursor: pointer` on hover.
>
> cc: @thealexandrelara (Please review the cursor addition as it alters your PR.)

Fixes #10639

## Why

As mentioned in #10639, the "Remove Item" link on the Cart block does not have a hover state. This PR ensures that the "Remove Item" link has a hover state.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Create a test page and add a few filters and the Products (beta) block to it.
2. Create another test page and add the Cart block to it.
3. Go to the first test page with the Products (beta) block. 
4. Select one of the filters and hover over the `Reset` link.
5. Verify that this PR does not introduce a regression.
6. Add a product to the cart.
7. Go to the second test page with the Cart block.
8. Hover over the "Remove Item" link and verify that it has a hover state.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

n/a

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog

> Fix: Add hover state to "Remove Item" link on Cart block.