### PR TITLE
Update link to GH PRs

### DIFF
--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           id: 80943895
-          body: "Nightly release auto generated everyday at 12:01 AM UTC. \n\n[PRs merged since last nightly build](https://github.com/woocommerce/woocommerce-blocks/pulls?q=is%3Apr+closed%3A%3E${{ steps.date.outputs.date }}+is%3Amerged)"
+          body: "Nightly release auto generated everyday at 12:01 AM UTC. \n\n[PRs merged since last nightly build](https://github.com/woocommerce/woocommerce-blocks/pulls?q=is%3Apr+closed%3A>%3D{{ steps.date.outputs.date }}+is%3Amerged)"
           spacing: 0
           replacebody: true
   update:


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What
In a recent https://github.com/woocommerce/woocommerce-blocks/pull/11431, I added a link to the nightly release that shows the PRs merged that day. There is an error in that link. It should be `>= yesterday's date`, not `> yesterday's date`. This fixes that.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Copy the link on line 59 of `.github/workflows/nightly-builds.yml` file
2. Replace `{{ steps.date.outputs.date }}` with yesterday's date, in the format `YYYY-MM-DD`. 
3. Check the link takes you to a filtered list of PRs that start from yesterday.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [x] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.