### PR TITLE
Add checkout-header template to the correct area in site editor

### DIFF
--- a/src/Utils/BlockTemplateUtils.php
+++ b/src/Utils/BlockTemplateUtils.php
@@ -183,7 +183,8 @@ class BlockTemplateUtils {
 
 	/**
 	 * Build a unified template object based on a theme file.
-	 * Important: This method is an almost identical duplicate from wp-includes/block-template-utils.php as it was not intended for public use. It has been modified to build templates from plugins rather than themes.
+	 *
+	 * @internal Important: This method is an almost identical duplicate from wp-includes/block-template-utils.php as it was not intended for public use. It has been modified to build templates from plugins rather than themes.
 	 *
 	 * @param array|object $template_file Theme file.
 	 * @param string       $template_type wp_template or wp_template_part.
@@ -223,8 +224,16 @@ class BlockTemplateUtils {
 		$template->area           = 'uncategorized';
 
 		// Force the Mini-Cart template part to be in the Mini-Cart template part area.
-		if ( 'wp_template_part' === $template_type && 'mini-cart' === $template_file->slug ) {
-			$template->area = 'mini-cart';
+		// @todo When this class is refactored, move title, description, and area definition to the template classes (CheckoutHeaderTemplate, MiniCartTemplate, etc).
+		if ( 'wp_template_part' === $template_type ) {
+			switch ( $template_file->slug ) {
+				case 'mini-cart':
+					$template->area = 'mini-cart';
+					break;
+				case 'checkout-header':
+					$template->area = 'header';
+					break;
+			}
 		}
 		return $template;
 	}


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Adds the checkout-header template part under the "header" area in the site editor.

## Why

Organisation.

## Testing Instructions

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Go to Appearance > Editor > Patterns
2. Click "headers" under the template parts section
3. Checkout checkout-header is visible

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

![Screenshot 2023-11-01 at 11 50 35](https://github.com/woocommerce/woocommerce-blocks/assets/90977/beacd016-9a9b-47b9-a1f7-c8c2c758783a)

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog

> Move checkout-header template part under the headers section in the site editor.
