### PR TITLE
[CYS] Fix `Product Collection 4 Columns` pattern button height

### DIFF
--- a/assets/js/atomic/blocks/product-elements/button/style.scss
+++ b/assets/js/atomic/blocks/product-elements/button/style.scss
@@ -72,6 +72,7 @@
 		word-break: break-word;
 		width: 150px;
 		overflow: hidden;
+		line-height: inherit;
 
 		span {
 


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

The buttons on the `Product Collection 4 Columns` looked different when changing the font on Woo Express sites.
Inheriting the line height fixes the issue.

## Why

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/11513
<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Create a new page or post and insert the `Product Collection 4 Columns` pattern.
2. Check the button height looks like the screenshot below.

<img width="241" alt="Screenshot 2023-11-02 at 15 46 32" src="https://github.com/woocommerce/woocommerce-blocks/assets/186112/922e0069-6c59-4044-9fb7-cf2e0337a1b9">

Only for devs:
3. Check also on this site, on this page https://wordpress.com/post/woo-superbly-magnificent-cherryblossom6.wpcomstaging.com/62 on the editor and the front-end.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="242" alt="Screenshot 2023-11-02 at 15 47 30" src="https://github.com/woocommerce/woocommerce-blocks/assets/186112/95c046b2-962c-4b02-9701-e469d6509bef"> | <img width="247" alt="Screenshot 2023-11-02 at 15 48 51" src="https://github.com/woocommerce/woocommerce-blocks/assets/186112/32e26afe-fee9-4894-919a-b820e9a630db"> |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Update the "Add to Cart Button" to inherit the line-height.
