### PR TITLE
Prevent Sale badge overflowing the Product Image in some product grid blocks

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -161,6 +161,13 @@
 
 // Element spacing.
 .wc-block-grid__product {
+	// Prevent link and image taking the full width unnecessarily, which might cause: https://github.com/woocommerce/woocommerce-blocks/issues/11438
+	.wc-block-grid__product-link,
+	.wc-block-grid__product-image {
+		display: inline-block;
+		position: relative;
+	}
+
 	// Not operator necessary for avoid this problem: https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/5925/files#r814043454
 	.wc-block-grid__product-image:not(.wc-block-components-product-image),
 	.wc-block-grid__product-title {


### PR DESCRIPTION
## What

Fixes #11438.

## Why

This PR updates the CSS of the product grids to prevent the _Sale_ badge not being properly aligned with the product image.

There is some more context in https://github.com/woocommerce/woocommerce-blocks/issues/11438.

## Testing Instructions

1. With Twenty-Twenty Four, add the _On Sale Products_, _All Products_ and _Product Collection_ blocks to a page.
2. Set all of them to _Full Width_.
3. Preview that page in the frontend.
4. Verify the _On Sale_ badge doesn't overflow the image.
5. Do some more smoke testing with other themes to verify there are no regressions (I tested TT1, TT2, TT3, TT4 and Storefront).

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

Before | After
--- | ---
![imatge](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/508b1124-9ead-4117-911c-6cb2a4d1b582) | ![imatge](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/5f786d60-dff6-400a-ae16-ea791cc9ae84)

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog

> Prevent Sale badge overflowing the Product Image in some product grid blocks
