### PR TITLE
Product Gallery: Add e2e tests for crop image option

### DIFF
--- a/assets/js/blocks/product-gallery/block-settings/index.tsx
+++ b/assets/js/blocks/product-gallery/block-settings/index.tsx
@@ -69,6 +69,7 @@ export const ProductGalleryBlockSettings = ( {
 							cropImages: ! cropImages,
 						} )
 					}
+					className="wc-block-product-gallery__crop-images"
 				/>
 				<ToggleControl
 					label={ __(

--- a/src/Utils/ProductGalleryUtils.php
+++ b/src/Utils/ProductGalleryUtils.php
@@ -129,8 +129,8 @@ class ProductGalleryUtils {
 		$image_path     = wp_get_original_image_path( $attachment_id );
 		$image_metadata = wp_get_attachment_metadata( $attachment_id );
 
-		// If image doesn't exist, we can't generate the intermediate size. Bail.
-		if ( ! isset( $image_metadata['path'] ) ) {
+		// If image sizes are not available. Bail.
+		if ( ! isset( $image_metadata['width'], $image_metadata['height'] ) ) {
 			return;
 		}
 

--- a/tests/e2e/tests/product-gallery/product-gallery.block_theme.side_effects.spec.ts
+++ b/tests/e2e/tests/product-gallery/product-gallery.block_theme.side_effects.spec.ts
@@ -13,7 +13,12 @@ const blockData = {
 	name: 'woocommerce/product-gallery',
 	selectors: {
 		frontend: {},
-		editor: {},
+		editor: {
+			settings: {
+				cropImagesOption:
+					'.wc-block-product-gallery__crop-images .components-form-toggle__input',
+			},
+		},
 	},
 	slug: 'single-product',
 	productPage: '/product/logo-collection/',
@@ -233,5 +238,46 @@ test.describe( `${ blockData.name }`, () => {
 
 			await expect( page.locator( 'dialog' ) ).toBeHidden();
 		} );
+	} );
+
+	test( 'should show (square) cropped main product images when crop option is enabled', async ( {
+		page,
+		editorUtils,
+		pageObject,
+	} ) => {
+		await pageObject.addProductGalleryBlock( { cleanContent: true } );
+
+		const block = await pageObject.getMainImageBlock( {
+			page: 'editor',
+		} );
+
+		await expect( block ).toBeVisible();
+
+		await page
+			.locator( blockData.selectors.editor.settings.cropImagesOption )
+			.click();
+
+		await editorUtils.saveTemplate();
+
+		await expect(
+			page.locator( blockData.selectors.editor.settings.cropImagesOption )
+		).toBeChecked();
+
+		await page.goto( blockData.productPage, {
+			waitUntil: 'commit',
+		} );
+
+		const image = await page
+			.locator(
+				'img.wc-block-woocommerce-product-gallery-large-image__image'
+			)
+			.first()
+			.boundingBox();
+
+		const height = image?.height;
+		const width = image?.width;
+
+		// Allow 1 pixel of difference.
+		expect( width === height + 1 || width === height - 1 ).toBeTruthy();
 	} );
 } );


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Adds e2e tests for the crop images feature added in https://github.com/woocommerce/woocommerce-blocks/pull/11482

## Why

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

So we can have more confident with out codebase.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

### Local test

1. Ensure your repo is built (`npm run build`) 
2. `npm run env:start`
3. `npx playwright install` (if needed)
4. `npm run test:e2e:side-effects product-gallery.block_theme.side_effects.spec.ts`
5. Ensure the added test passes (`should show (square) cropped main product images when crop option is enabled`)

### CI test

1. Playwright tests should pass below in CI.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Product Gallery: Add e2e test for cropped image option
