### PR TITLE
Add to Cart with Options block: fix inconsistency between editor and frontend

### DIFF
--- a/assets/js/atomic/blocks/product-elements/add-to-cart-form/edit.tsx
+++ b/assets/js/atomic/blocks/product-elements/add-to-cart-form/edit.tsx
@@ -4,7 +4,7 @@
 import { useEffect } from '@wordpress/element';
 import { useBlockProps } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import { Button, Disabled, Tooltip } from '@wordpress/components';
+import { Disabled, Tooltip } from '@wordpress/components';
 import { Skeleton } from '@woocommerce/base-components/skeleton';
 import { BlockEditProps } from '@wordpress/blocks';
 
@@ -40,28 +40,25 @@ const Edit = ( props: BlockEditProps< Attributes > ) => {
 				text="Customer will see product add-to-cart options in this space, dependend on the product type. "
 				position="bottom right"
 			>
-				<div className="wc-block-editor-container">
+				<div className="wc-block-editor-add-to-cart-form-container">
 					<Skeleton numberOfLines={ 3 } />
 					<Disabled>
-						<input
-							type={ 'number' }
-							value={ '1' }
-							className={
-								'wc-block-editor-add-to-cart-form__quantity'
-							}
-							readOnly
-						/>
-						<Button
-							variant={ 'primary' }
-							className={
-								'wc-block-editor-add-to-cart-form__button'
-							}
+						<div className="quantity">
+							<input
+								type={ 'number' }
+								value={ '1' }
+								className={ 'input-text qty text' }
+								readOnly
+							/>
+						</div>
+						<button
+							className={ `single_add_to_cart_button button alt wp-element-button` }
 						>
 							{ __(
 								'Add to cart',
 								'woo-gutenberg-products-block'
 							) }
-						</Button>
+						</button>
 					</Disabled>
 				</div>
 			</Tooltip>

--- a/assets/js/atomic/blocks/product-elements/add-to-cart-form/edit.tsx
+++ b/assets/js/atomic/blocks/product-elements/add-to-cart-form/edit.tsx
@@ -37,7 +37,7 @@ const Edit = ( props: BlockEditProps< Attributes > ) => {
 	return (
 		<div { ...blockProps }>
 			<Tooltip
-				text="Customer will see product add-to-cart options in this space, dependend on the product type. "
+				text="Customer will see product add-to-cart options in this space, dependent on the product type. "
 				position="bottom right"
 			>
 				<div className="wc-block-editor-add-to-cart-form-container">

--- a/assets/js/atomic/blocks/product-elements/add-to-cart-form/editor.scss
+++ b/assets/js/atomic/blocks/product-elements/add-to-cart-form/editor.scss
@@ -1,30 +1,4 @@
-.wc-block-editor-add-to-cart-form {
-	display: flex;
-	flex-direction: column;
-	row-gap: $default-block-margin;
-}
-
-input.wc-block-editor-add-to-cart-form__quantity[type="number"] {
-	max-width: 50px;
-	min-height: 23px;
-	float: left;
-	padding: 6px 6px 6px 12px;
-	margin-right: 10px;
-	font-size: 13px;
-	height: inherit;
-}
-
-input[type="number"]::-webkit-inner-spin-button {
-	opacity: 1;
-}
-
-button.components-button.wc-block-add-to-cart-form__button {
-	float: left;
-	padding: 20px 30px;
-	border-radius: 0;
-}
-
-.wc-block-editor-container {
+.wc-block-editor-add-to-cart-form-container {
 	cursor: help;
 	gap: 10px;
 	display: flex;

--- a/assets/js/atomic/blocks/product-elements/add-to-cart-form/style.scss
+++ b/assets/js/atomic/blocks/product-elements/add-to-cart-form/style.scss
@@ -1,4 +1,4 @@
-.wp-block-add-to-cart-form {
+.wc-block-add-to-cart-form {
 	width: unset;
 	/**
 	* This is a base style for the input text element in WooCommerce that prevents inputs from appearing too small.
@@ -8,5 +8,17 @@
 	.input-text {
 		font-size: var(--wp--preset--font-size--small);
 		padding: 0.9rem 1.1rem;
+	}
+
+	.quantity {
+		display: inline-block;
+		float: none;
+		margin-right: 1rem;
+		vertical-align: middle;
+
+		.qty {
+			width: 3.631em;
+			text-align: center;
+		}
 	}
 }

--- a/assets/js/atomic/blocks/product-elements/add-to-cart-form/style.scss
+++ b/assets/js/atomic/blocks/product-elements/add-to-cart-form/style.scss
@@ -13,10 +13,11 @@
 	.quantity {
 		display: inline-block;
 		float: none;
-		margin-right: 1rem;
+		margin-right: 4px;
 		vertical-align: middle;
 
 		.qty {
+			margin-right: 0.5rem;
 			width: 3.631em;
 			text-align: center;
 		}

--- a/src/BlockTypes/AddToCartForm.php
+++ b/src/BlockTypes/AddToCartForm.php
@@ -99,7 +99,7 @@ class AddToCartForm extends AbstractBlock {
 		$product_classname  = $is_descendent_of_single_product_block ? 'product' : '';
 
 		$form = sprintf(
-			'<div class="wp-block-add-to-cart-form %1$s %2$s %3$s" style="%4$s">%5$s</div>',
+			'<div class="wp-block-add-to-cart-form wc-block-add-to-cart-form %1$s %2$s %3$s" style="%4$s">%5$s</div>',
 			esc_attr( $classes_and_styles['classes'] ),
 			esc_attr( $classname ),
 			esc_attr( $product_classname ),


### PR DESCRIPTION
## What

Fixes #11303.

## Why

This PR aligns the markup, classes and styles between the editor and the frontend view of the _Add to Cart with Options_ block, to make sure it looks consistent in both views.

## Testing Instructions

0. Make sure you are using a block theme.
1. In the editor, go to Appearance > Editor > Templates > Single Product. On the frontend, open the page of any simple product.
2. Verify the Add to Cart form looks the same in both views.
3. Test with WP 6.3 & Gutenberg disabled and WP 6.4 & Gutenberg enabled (you can use [this plugin](https://wordpress.org/plugins/wordpress-beta-tester/) to update to WP 6.4 before it's released).
4. Test with different block themes.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

Theme | Before | After |
| --- | ------ | ----- |
Twenty-Twenty Four | ![imatge](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/adfe0986-b0fc-4bbb-a3ef-bf63c1dd8f1e) | ![imatge](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/572d0c9f-8423-472c-889a-77152f806f75) |
Twenty-Twenty Three | ![imatge](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/f5809a80-e5bf-49a5-8fa3-ab95bc44a1dc) | ![imatge](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/dddefa92-4d69-47d9-ba74-a7b852e9703b)
Twenty-Twenty Two | ![imatge](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/09fd26a9-9cca-4c5d-80b3-17be89b3fb8a) | ![imatge](https://github.com/woocommerce/woocommerce-blocks/assets/3616980/98165656-21c9-4fea-8c3d-8fe83e07544a)

## WooCommerce Visibility

Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog

> Add to Cart with Options block: fix inconsistency between editor and frontend styles
