### PR TITLE
Enhancement/New blockified Order Confirmation on new installs with block-based themes

### DIFF
--- a/src/BlockTypes/OrderConfirmation/AbstractOrderConfirmationBlock.php
+++ b/src/BlockTypes/OrderConfirmation/AbstractOrderConfirmationBlock.php
@@ -10,6 +10,17 @@ use Automattic\WooCommerce\Blocks\Utils\StyleAttributesUtils;
  */
 abstract class AbstractOrderConfirmationBlock extends AbstractBlock {
 	/**
+	 * Initialize this block type.
+	 *
+	 * - Hook into WP lifecycle.
+	 * - Register the block with WordPress.
+	 */
+	protected function initialize() {
+		parent::initialize();
+		add_action( 'wp_loaded', array( $this, 'register_patterns' ) );
+	}
+
+	/**
 	 * Get the content from a hook and return it.
 	 *
 	 * @param string $hook Hook name.
@@ -243,5 +254,48 @@ abstract class AbstractOrderConfirmationBlock extends AbstractBlock {
 	 */
 	protected function get_block_type_script( $key = null ) {
 		return null;
+	}
+
+	/**
+	 * Register block pattern for Order Confirmation to make it translatable.
+	 */
+	public function register_patterns() {
+
+		register_block_pattern(
+			'woocommerce/order-confirmation-totals-heading',
+			array(
+				'title'    => '',
+				'inserter' => false,
+				'content'  => '<!-- wp:heading {"level":3,"style":{"typography":{"fontSize":"24px"}}} --><h3 class="wp-block-heading" style="font-size:24px">' . esc_html__( 'Order details', 'woo-gutenberg-products-block' ) . '</h3><!-- /wp:heading -->',
+			)
+		);
+
+		register_block_pattern(
+			'woocommerce/order-confirmation-downloads-heading',
+			array(
+				'title'    => '',
+				'inserter' => false,
+				'content'  => '<!-- wp:heading {"level":3,"style":{"typography":{"fontSize":"24px"}}} --><h3 class="wp-block-heading" style="font-size:24px">' . esc_html__( 'Downloads', 'woo-gutenberg-products-block' ) . '</h3><!-- /wp:heading -->',
+			)
+		);
+
+		register_block_pattern(
+			'woocommerce/order-confirmation-shipping-heading',
+			array(
+				'title'    => '',
+				'inserter' => false,
+				'content'  => '<!-- wp:heading {"level":3,"style":{"typography":{"fontSize":"24px"}}} --><h3 class="wp-block-heading" style="font-size:24px">' . esc_html__( 'Shipping address', 'woo-gutenberg-products-block' ) . '</h3><!-- /wp:heading -->',
+			)
+		);
+
+		register_block_pattern(
+			'woocommerce/order-confirmation-billing-heading',
+			array(
+				'title'    => '',
+				'inserter' => false,
+				'content'  => '<!-- wp:heading {"level":3,"style":{"typography":{"fontSize":"24px"}}} --><h3 class="wp-block-heading" style="font-size:24px">' . esc_html__( 'Billing address', 'woo-gutenberg-products-block' ) . '</h3><!-- /wp:heading -->',
+			)
+		);
+
 	}
 }

--- a/templates/templates/blockified/order-confirmation.html
+++ b/templates/templates/blockified/order-confirmation.html
@@ -1,7 +1,49 @@
 <!-- wp:template-part {"slug":"header"} /-->
-<!-- wp:group {"tagName": "main", "layout":{"inherit":true,"type":"constrained"}} -->
-<main class="wp-block-group">
-	<!-- wp:woocommerce/legacy-template {"template":"order-confirmation"} /-->
-</main>
+
+<!-- wp:group {"tagName":"main","layout":{"inherit":true,"type":"constrained"}} -->
+<main class="wp-block-group"><!-- wp:woocommerce/order-confirmation-status {"fontSize":"large"} /-->
+
+	<!-- wp:woocommerce/order-confirmation-summary /-->
+
+	<!-- wp:woocommerce/order-confirmation-totals-wrapper {"align":"wide"} -->
+	<!-- wp:heading {"level":3,"style":{"typography":{"fontSize":"24px"}}} -->
+	<h3 class="wp-block-heading" style="font-size:24px">Order details</h3>
+	<!-- /wp:heading -->
+
+	<!-- wp:woocommerce/order-confirmation-totals {"lock":{"remove":true}} /-->
+	<!-- /wp:woocommerce/order-confirmation-totals-wrapper -->
+
+	<!-- wp:woocommerce/order-confirmation-downloads-wrapper {"align":"wide"} -->
+	<!-- wp:heading {"level":3,"style":{"typography":{"fontSize":"24px"}}} -->
+	<h3 class="wp-block-heading" style="font-size:24px">Downloads</h3>
+	<!-- /wp:heading -->
+
+	<!-- wp:woocommerce/order-confirmation-downloads {"lock":{"remove":true}} /-->
+	<!-- /wp:woocommerce/order-confirmation-downloads-wrapper -->
+
+	<!-- wp:columns {"align":"wide","className":"woocommerce-order-confirmation-address-wrapper"} -->
+	<div class="wp-block-columns alignwide woocommerce-order-confirmation-address-wrapper"><!-- wp:column -->
+		<div class="wp-block-column"><!-- wp:woocommerce/order-confirmation-shipping-wrapper {"align":"wide"} -->
+			<!-- wp:heading {"level":3,"style":{"typography":{"fontSize":"24px"}}} -->
+			<h3 class="wp-block-heading" style="font-size:24px">Shipping address</h3>
+			<!-- /wp:heading -->
+
+			<!-- wp:woocommerce/order-confirmation-shipping-address {"lock":{"remove":true}} /-->
+			<!-- /wp:woocommerce/order-confirmation-shipping-wrapper --></div>
+		<!-- /wp:column -->
+
+		<!-- wp:column -->
+		<div class="wp-block-column"><!-- wp:woocommerce/order-confirmation-billing-wrapper {"align":"wide"} -->
+			<!-- wp:heading {"level":3,"style":{"typography":{"fontSize":"24px"}}} -->
+			<h3 class="wp-block-heading" style="font-size:24px">Billing address</h3>
+			<!-- /wp:heading -->
+
+			<!-- wp:woocommerce/order-confirmation-billing-address {"lock":{"remove":true}} /-->
+			<!-- /wp:woocommerce/order-confirmation-billing-wrapper --></div>
+		<!-- /wp:column --></div>
+	<!-- /wp:columns -->
+
+	<!-- wp:woocommerce/order-confirmation-additional-information /--></main>
 <!-- /wp:group -->
+
 <!-- wp:template-part {"slug":"footer"} /-->

--- a/templates/templates/blockified/order-confirmation.html
+++ b/templates/templates/blockified/order-confirmation.html
@@ -6,17 +6,13 @@
 	<!-- wp:woocommerce/order-confirmation-summary /-->
 
 	<!-- wp:woocommerce/order-confirmation-totals-wrapper {"align":"wide"} -->
-	<!-- wp:heading {"level":3,"style":{"typography":{"fontSize":"24px"}}} -->
-	<h3 class="wp-block-heading" style="font-size:24px">Order details</h3>
-	<!-- /wp:heading -->
+	<!-- wp:pattern {"slug":"woocommerce/order-confirmation-totals-heading"} /-->
 
 	<!-- wp:woocommerce/order-confirmation-totals {"lock":{"remove":true}} /-->
 	<!-- /wp:woocommerce/order-confirmation-totals-wrapper -->
 
 	<!-- wp:woocommerce/order-confirmation-downloads-wrapper {"align":"wide"} -->
-	<!-- wp:heading {"level":3,"style":{"typography":{"fontSize":"24px"}}} -->
-	<h3 class="wp-block-heading" style="font-size:24px">Downloads</h3>
-	<!-- /wp:heading -->
+	<!-- wp:pattern {"slug":"woocommerce/order-confirmation-downloads-heading"} /-->
 
 	<!-- wp:woocommerce/order-confirmation-downloads {"lock":{"remove":true}} /-->
 	<!-- /wp:woocommerce/order-confirmation-downloads-wrapper -->
@@ -24,9 +20,7 @@
 	<!-- wp:columns {"align":"wide","className":"woocommerce-order-confirmation-address-wrapper"} -->
 	<div class="wp-block-columns alignwide woocommerce-order-confirmation-address-wrapper"><!-- wp:column -->
 		<div class="wp-block-column"><!-- wp:woocommerce/order-confirmation-shipping-wrapper {"align":"wide"} -->
-			<!-- wp:heading {"level":3,"style":{"typography":{"fontSize":"24px"}}} -->
-			<h3 class="wp-block-heading" style="font-size:24px">Shipping address</h3>
-			<!-- /wp:heading -->
+			<!-- wp:pattern {"slug":"woocommerce/order-confirmation-shipping-heading"} /-->
 
 			<!-- wp:woocommerce/order-confirmation-shipping-address {"lock":{"remove":true}} /-->
 			<!-- /wp:woocommerce/order-confirmation-shipping-wrapper --></div>
@@ -34,9 +28,7 @@
 
 		<!-- wp:column -->
 		<div class="wp-block-column"><!-- wp:woocommerce/order-confirmation-billing-wrapper {"align":"wide"} -->
-			<!-- wp:heading {"level":3,"style":{"typography":{"fontSize":"24px"}}} -->
-			<h3 class="wp-block-heading" style="font-size:24px">Billing address</h3>
-			<!-- /wp:heading -->
+			<!-- wp:pattern {"slug":"woocommerce/order-confirmation-billing-heading"} /-->
 
 			<!-- wp:woocommerce/order-confirmation-billing-address {"lock":{"remove":true}} /-->
 			<!-- /wp:woocommerce/order-confirmation-billing-wrapper --></div>

--- a/templates/templates/order-confirmation.html
+++ b/templates/templates/order-confirmation.html
@@ -1,7 +1,49 @@
 <!-- wp:template-part {"slug":"header"} /-->
-<!-- wp:group {"tagName": "main", "layout":{"inherit":true,"type":"constrained"}} -->
-<main class="wp-block-group">
-	<!-- wp:woocommerce/legacy-template {"template":"order-confirmation"} /-->
-</main>
+
+<!-- wp:group {"tagName":"main","layout":{"inherit":true,"type":"constrained"}} -->
+<main class="wp-block-group"><!-- wp:woocommerce/order-confirmation-status {"fontSize":"large"} /-->
+
+	<!-- wp:woocommerce/order-confirmation-summary /-->
+
+	<!-- wp:woocommerce/order-confirmation-totals-wrapper {"align":"wide"} -->
+	<!-- wp:heading {"level":3,"style":{"typography":{"fontSize":"24px"}}} -->
+	<h3 class="wp-block-heading" style="font-size:24px">Order details</h3>
+	<!-- /wp:heading -->
+
+	<!-- wp:woocommerce/order-confirmation-totals {"lock":{"remove":true}} /-->
+	<!-- /wp:woocommerce/order-confirmation-totals-wrapper -->
+
+	<!-- wp:woocommerce/order-confirmation-downloads-wrapper {"align":"wide"} -->
+	<!-- wp:heading {"level":3,"style":{"typography":{"fontSize":"24px"}}} -->
+	<h3 class="wp-block-heading" style="font-size:24px">Downloads</h3>
+	<!-- /wp:heading -->
+
+	<!-- wp:woocommerce/order-confirmation-downloads {"lock":{"remove":true}} /-->
+	<!-- /wp:woocommerce/order-confirmation-downloads-wrapper -->
+
+	<!-- wp:columns {"align":"wide","className":"woocommerce-order-confirmation-address-wrapper"} -->
+	<div class="wp-block-columns alignwide woocommerce-order-confirmation-address-wrapper"><!-- wp:column -->
+		<div class="wp-block-column"><!-- wp:woocommerce/order-confirmation-shipping-wrapper {"align":"wide"} -->
+			<!-- wp:heading {"level":3,"style":{"typography":{"fontSize":"24px"}}} -->
+			<h3 class="wp-block-heading" style="font-size:24px">Shipping address</h3>
+			<!-- /wp:heading -->
+
+			<!-- wp:woocommerce/order-confirmation-shipping-address {"lock":{"remove":true}} /-->
+			<!-- /wp:woocommerce/order-confirmation-shipping-wrapper --></div>
+		<!-- /wp:column -->
+
+		<!-- wp:column -->
+		<div class="wp-block-column"><!-- wp:woocommerce/order-confirmation-billing-wrapper {"align":"wide"} -->
+			<!-- wp:heading {"level":3,"style":{"typography":{"fontSize":"24px"}}} -->
+			<h3 class="wp-block-heading" style="font-size:24px">Billing address</h3>
+			<!-- /wp:heading -->
+
+			<!-- wp:woocommerce/order-confirmation-billing-address {"lock":{"remove":true}} /-->
+			<!-- /wp:woocommerce/order-confirmation-billing-wrapper --></div>
+		<!-- /wp:column --></div>
+	<!-- /wp:columns -->
+
+	<!-- wp:woocommerce/order-confirmation-additional-information /--></main>
 <!-- /wp:group -->
+
 <!-- wp:template-part {"slug":"footer"} /-->

--- a/templates/templates/order-confirmation.html
+++ b/templates/templates/order-confirmation.html
@@ -6,17 +6,13 @@
 	<!-- wp:woocommerce/order-confirmation-summary /-->
 
 	<!-- wp:woocommerce/order-confirmation-totals-wrapper {"align":"wide"} -->
-	<!-- wp:heading {"level":3,"style":{"typography":{"fontSize":"24px"}}} -->
-	<h3 class="wp-block-heading" style="font-size:24px">Order details</h3>
-	<!-- /wp:heading -->
+	<!-- wp:pattern {"slug":"woocommerce/order-confirmation-totals-heading"} /-->
 
 	<!-- wp:woocommerce/order-confirmation-totals {"lock":{"remove":true}} /-->
 	<!-- /wp:woocommerce/order-confirmation-totals-wrapper -->
 
 	<!-- wp:woocommerce/order-confirmation-downloads-wrapper {"align":"wide"} -->
-	<!-- wp:heading {"level":3,"style":{"typography":{"fontSize":"24px"}}} -->
-	<h3 class="wp-block-heading" style="font-size:24px">Downloads</h3>
-	<!-- /wp:heading -->
+	<!-- wp:pattern {"slug":"woocommerce/order-confirmation-downloads-heading"} /-->
 
 	<!-- wp:woocommerce/order-confirmation-downloads {"lock":{"remove":true}} /-->
 	<!-- /wp:woocommerce/order-confirmation-downloads-wrapper -->
@@ -24,9 +20,7 @@
 	<!-- wp:columns {"align":"wide","className":"woocommerce-order-confirmation-address-wrapper"} -->
 	<div class="wp-block-columns alignwide woocommerce-order-confirmation-address-wrapper"><!-- wp:column -->
 		<div class="wp-block-column"><!-- wp:woocommerce/order-confirmation-shipping-wrapper {"align":"wide"} -->
-			<!-- wp:heading {"level":3,"style":{"typography":{"fontSize":"24px"}}} -->
-			<h3 class="wp-block-heading" style="font-size:24px">Shipping address</h3>
-			<!-- /wp:heading -->
+			<!-- wp:pattern {"slug":"woocommerce/order-confirmation-shipping-heading"} /-->
 
 			<!-- wp:woocommerce/order-confirmation-shipping-address {"lock":{"remove":true}} /-->
 			<!-- /wp:woocommerce/order-confirmation-shipping-wrapper --></div>
@@ -34,9 +28,7 @@
 
 		<!-- wp:column -->
 		<div class="wp-block-column"><!-- wp:woocommerce/order-confirmation-billing-wrapper {"align":"wide"} -->
-			<!-- wp:heading {"level":3,"style":{"typography":{"fontSize":"24px"}}} -->
-			<h3 class="wp-block-heading" style="font-size:24px">Billing address</h3>
-			<!-- /wp:heading -->
+			<!-- wp:pattern {"slug":"woocommerce/order-confirmation-billing-heading"} /-->
 
 			<!-- wp:woocommerce/order-confirmation-billing-address {"lock":{"remove":true}} /-->
 			<!-- /wp:woocommerce/order-confirmation-billing-wrapper --></div>


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

This PR the new blockified Order Confirmation on new installs with a blocks-enabled theme.

Closes #11623 

## Why

This is part of pdFofs-1sE-p2 which enables the new block-based Checkout experience.

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. On a brand new WC installation enable a block based theme (eg TT3)
2. Place a dummy order
3. Verify the Thank you page displayed after placing an order renders the new blockified Order Confirmation. See attached printscreen
4. Change the website language. Repeat steps 2 & 3 and verify that the headings get properly translated.
5. Go to Appearance > Site Editor > Templates > Manage all templates. Verify that the blockified Order Confirmation displays properly, saving changes work and they get reflected on a new order.

<img width="1361" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/17236129/f619ccaa-d2dc-4189-8760-86837cf4014f">


* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [ ] WooCommerce Core
* [x] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Enabled the new blockified Order Confirmation by default for block-based themes