### PR TITLE
Add `Textarea` entry to Storybook

### DIFF
--- a/packages/components/textarea/index.tsx
+++ b/packages/components/textarea/index.tsx
@@ -8,7 +8,7 @@ import classnames from 'classnames';
  */
 import './style.scss';
 
-interface TextareaProps {
+export interface TextareaProps {
 	className?: string;
 	disabled: boolean;
 	onTextChange: ( newText: string ) => void;

--- a/packages/components/textarea/stories/index.stories.tsx
+++ b/packages/components/textarea/stories/index.stories.tsx
@@ -1,0 +1,77 @@
+/**
+ * External dependencies
+ */
+import type { Meta, StoryFn } from '@storybook/react';
+import { useArgs } from '@storybook/preview-api';
+
+/**
+ * Internal dependencies
+ */
+import Textarea, { type TextareaProps } from '..';
+import '../style.scss';
+
+export default {
+	title: 'Checkout Components/Textarea',
+	component: Textarea,
+	argTypes: {
+		className: {
+			control: 'text',
+			table: {
+				type: {
+					summary: 'string',
+				},
+			},
+			description: 'Additional class names to add to the textarea.',
+		},
+		value: {
+			control: 'text',
+			table: {
+				type: {
+					summary: 'string',
+				},
+			},
+			description: 'The value in the textarea.',
+		},
+		disabled: {
+			control: 'boolean',
+			table: {
+				type: {
+					summary: 'boolean',
+				},
+			},
+			description: 'Whether the textarea is disabled.',
+		},
+		placeholder: {
+			control: 'text',
+			table: {
+				type: {
+					summary: 'string',
+				},
+			},
+			description:
+				'The placeholder text to show when no value has been entered.',
+		},
+	},
+} as Meta< TextareaProps >;
+
+const Template: StoryFn< TextareaProps > = ( args ) => {
+	const [ { value }, updateArgs ] = useArgs();
+	return (
+		<Textarea
+			{ ...args }
+			value={ value }
+			onTextChange={ ( newValue: string ) =>
+				updateArgs( { value: newValue } )
+			}
+		/>
+	);
+};
+
+export const Default = Template.bind( {} );
+
+Default.args = {
+	className: '',
+	disabled: false,
+	placeholder: 'Enter some text here',
+	value: '',
+};


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Adds a storybook entry for the `Textarea` component we recently exported.

## Why

To showcase the component and provide a level of documentation.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Run `npm run storybook`
2. Open `localhost:6006` and check the `Checkout Components/Textarea` component.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [x] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [x] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Skipping.
