### PR TITLE
Restore checkout header which was reverted in trunk

### DIFF
--- a/templates/parts/checkout-header.html
+++ b/templates/parts/checkout-header.html
@@ -1,9 +1,9 @@
-<!-- wp:group {"layout":{"type":"constrained"}} -->
-<div class="wp-block-group">
+<!-- wp:group {"tagName":"header","area":"header","metadata":{"name":"Checkout Header"},"layout":{"type":"constrained"}} -->
+<header class="wp-block-group">
 	<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"var:preset|spacing|40"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
 	<div class="wp-block-group alignwide" style="padding-bottom:var(--wp--preset--spacing--40)">
 		<!-- wp:site-title {"level":0} /-->
 	</div>
 	<!-- /wp:group -->
-</div>
+</header>
 <!-- /wp:group -->


### PR DESCRIPTION
…ommerce/woocommerce-blocks/commit/500c46f4911ffc065a575275c881e770c94b9f74

<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Puts back the checkout header element which was reverted by https://github.com/woocommerce/woocommerce-blocks/commit/500c46f4911ffc065a575275c881e770c94b9f74

This needs cherry picking into the 11.5.0 release.

## Why

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

1. Appearance > Patterns > Template Parts > Headers
2. Edit checkout header
3. Select outer group. Confirm its "header" under advanced tab, or view the code editor.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [x] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [ ] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog

N.A
