### PR TITLE
Fix PHP warning after `upgrader_process_complete`

### DIFF
--- a/src/BlockPatterns.php
+++ b/src/BlockPatterns.php
@@ -250,7 +250,7 @@ class BlockPatterns {
 	 * @param array        $options  Array of bulk item update data.
 	 */
 	public function schedule_on_plugin_update( $upgrader_object, $options ) {
-		if ( 'update' === $options['action'] && 'plugin' === $options['type'] ) {
+		if ( 'update' === $options['action'] && 'plugin' === $options['type'] && isset( $options['plugins'] ) ) {
 			foreach ( $options['plugins'] as $plugin ) {
 				if ( str_contains( $plugin, 'woocommerce-gutenberg-products-block.php' ) || str_contains( $plugin, 'woocommerce.php' ) ) {
 					$business_description = get_option( 'woo_ai_describe_store_description' );


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

This PR adds a missing condition when `'plugins'` key is not set in the `$options` array.

## Why

To avoid a PHP warning:
```[07-Nov-2023 02:31:56 UTC] PHP Warning:  Undefined array key "plugins" in /srv/htdocs/wp-content/plugins/woocommerce/packages/woocommerce-blocks/src/BlockPatterns.php on line 254
[07-Nov-2023 02:31:56 UTC] PHP Warning:  foreach() argument must be of type array|object, null given in /srv/htdocs/wp-content/plugins/woocommerce/packages/woocommerce-blocks/src/BlockPatterns.php on line 254
```
<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

**This is just a way of simulating the triggering of the `schedule_on_plugin_update` with the parameters that are causing the warning, since it runs on updating the plugin, this is an easier way of testing this particular case.**

1. Add the following code to the `woocommerce-gutenberg-products-block.php` file.
```php
function test_condition() {
	$bp = new \Automattic\WooCommerce\Blocks\BlockPatterns(
		new \Automattic\WooCommerce\Blocks\Domain\Package( '', '', new \Automattic\WooCommerce\Blocks\Domain\Services\FeatureGating() )
	);

	$bp->schedule_on_plugin_update(
		null,
		array(
			'action' => 'update',
			'type'   => 'plugin',
		)
	);
}

add_action( 'admin_init', 'test_condition' );
```

2. Visit your store admin page.
3. Check the `debug.log` and make sure there's no PHP warning there.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [x] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

