### PR TITLE
e2e: Add hacky workaround for product image gallery

### DIFF
--- a/tests/e2e/bin/scripts/parallel/products.sh
+++ b/tests/e2e/bin/scripts/parallel/products.sh
@@ -5,3 +5,11 @@
 ###################################################################################################
 wp import wp-content/plugins/woocommerce/sample-data/sample_products.xml --authors=skip
 wp wc tool run regenerate_product_lookup_tables --user=1
+
+# This is a hacky work around to fix product gallery images not being imported
+# This sets up the product Hoodie to have product gallery images for e2e testing
+post_id=$(wp post list --post_type=product --field=ID --name="Hoodie" --format=ids)
+image1=$(wp post list --post_type=attachment --field=ID --name="hoodie-with-logo-2.jpg" --format=ids)
+image2=$(wp post list --post_type=attachment --field=ID --name="hoodie-green-1.jpg" --format=ids)
+image3=$(wp post list --post_type=attachment --field=ID --name="hoodie-2.jpg" --format=ids)
+wp post meta update $post_id _product_image_gallery "$image1,$image2,$image3"


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Adds hacky work around to configure the Hoodie product with product image gallery.

## Why

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

This is so that we can add e2e tests that tests for functions that utilizes the product gallery images and not have the tests being flaky due to the product gallery images not imported/setup correctly.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. `npm run env:start`
2. `npm run test:e2e`
3. Ensure there are no issues with the addition of this change
4. Login to localhost:8889/wp-admin
5. Go to the product named Hoodie and ensure you see 3 images in the product gallery section
6. Ensure CI tests are passing below

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [x] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> N/A
