### PR TITLE
Use wp_post table instead wp_option to store patterns data generated by AI

### DIFF
--- a/src/BlockPatterns.php
+++ b/src/BlockPatterns.php
@@ -267,7 +267,7 @@ class BlockPatterns {
 	 * @param array        $options  Array of bulk item update data.
 	 */
 	public function schedule_on_plugin_update( $upgrader_object, $options ) {
-		if ( 'update' === $options['action'] && 'plugin' === $options['type'] ) {
+		if ( 'update' === $options['action'] && 'plugin' === $options['type'] && isset( $options['plugins'] ) ) {
 			foreach ( $options['plugins'] as $plugin ) {
 				if ( str_contains( $plugin, 'woocommerce-gutenberg-products-block.php' ) || str_contains( $plugin, 'woocommerce.php' ) ) {
 					$business_description = get_option( 'woo_ai_describe_store_description' );

--- a/src/BlockPatterns.php
+++ b/src/BlockPatterns.php
@@ -33,8 +33,9 @@ use Automattic\WooCommerce\Blocks\Patterns\ProductUpdater;
  * @internal
  */
 class BlockPatterns {
-	const SLUG_REGEX            = '/^[A-z0-9\/_-]+$/';
-	const COMMA_SEPARATED_REGEX = '/[\s,]+/';
+	const SLUG_REGEX                 = '/^[A-z0-9\/_-]+$/';
+	const COMMA_SEPARATED_REGEX      = '/[\s,]+/';
+	const PATTERNS_AI_DATA_POST_TYPE = 'patterns_ai_data';
 
 	/**
 	 * Path to the patterns directory.
@@ -91,6 +92,22 @@ class BlockPatterns {
 		if ( ! class_exists( 'WP_Block_Patterns_Registry' ) ) {
 			return;
 		}
+
+		register_post_type(
+			self::PATTERNS_AI_DATA_POST_TYPE,
+			array(
+				'labels'           => array(
+					'name'          => __( 'Patterns AI Data', 'woo-gutenberg-products-block' ),
+					'singular_name' => __( 'Patterns AI Data', 'woo-gutenberg-products-block' ),
+				),
+				'public'           => false,
+				'hierarchical'     => false,
+				'rewrite'          => false,
+				'query_var'        => false,
+				'delete_with_user' => false,
+				'can_export'       => true,
+			)
+		);
 
 		$default_headers = array(
 			'title'         => 'Title',
@@ -250,7 +267,7 @@ class BlockPatterns {
 	 * @param array        $options  Array of bulk item update data.
 	 */
 	public function schedule_on_plugin_update( $upgrader_object, $options ) {
-		if ( 'update' === $options['action'] && 'plugin' === $options['type'] && isset( $options['plugins'] ) ) {
+		if ( 'update' === $options['action'] && 'plugin' === $options['type'] ) {
 			foreach ( $options['plugins'] as $plugin ) {
 				if ( str_contains( $plugin, 'woocommerce-gutenberg-products-block.php' ) || str_contains( $plugin, 'woocommerce.php' ) ) {
 					$business_description = get_option( 'woo_ai_describe_store_description' );

--- a/src/Patterns/PatternUpdater.php
+++ b/src/Patterns/PatternUpdater.php
@@ -45,7 +45,7 @@ class PatternUpdater {
 
 		$updated_content = PatternsHelper::upsert_patterns_ai_data_post( $patterns_with_images_and_content );
 
-		if ( ! $updated_content ) {
+		if ( is_wp_error( $updated_content ) ) {
 			return new WP_Error( 'failed_to_update_patterns_content', __( 'Failed to update patterns content.', 'woo-gutenberg-products-block' ) );
 		}
 

--- a/src/Patterns/PatternUpdater.php
+++ b/src/Patterns/PatternUpdater.php
@@ -42,11 +42,13 @@ class PatternUpdater {
 			return new WP_Error( 'failed_to_set_pattern_content', __( 'Failed to set the pattern content.', 'woo-gutenberg-products-block' ) );
 		}
 
-		if ( get_option( self::WC_BLOCKS_PATTERNS_CONTENT ) === $patterns_with_images_and_content ) {
+		$patterns_dictionary = PatternsHelper::get_patterns_ai_data();
+
+		if ( isset( $patterns_dictionary->post_content ) && json_decode( $patterns_dictionary->post_content ) === $patterns_with_images_and_content ) {
 			return true;
 		}
 
-		$updated_content = update_option( self::WC_BLOCKS_PATTERNS_CONTENT, $patterns_with_images_and_content );
+		$updated_content = PatternsHelper::upsert_patterns_ai_data( $patterns_with_images_and_content );
 
 		if ( ! $updated_content ) {
 			return new WP_Error( 'failed_to_update_patterns_content', __( 'Failed to update patterns content.', 'woo-gutenberg-products-block' ) );

--- a/src/Patterns/PatternUpdater.php
+++ b/src/Patterns/PatternUpdater.php
@@ -11,11 +11,6 @@ use WP_Error;
 class PatternUpdater {
 
 	/**
-	 * The patterns content option name.
-	 */
-	const WC_BLOCKS_PATTERNS_CONTENT = 'wc_blocks_patterns_content';
-
-	/**
 	 * Creates the patterns content for the given vertical.
 	 *
 	 * @param Connection      $ai_connection The AI connection.

--- a/src/Patterns/PatternUpdater.php
+++ b/src/Patterns/PatternUpdater.php
@@ -42,13 +42,13 @@ class PatternUpdater {
 			return new WP_Error( 'failed_to_set_pattern_content', __( 'Failed to set the pattern content.', 'woo-gutenberg-products-block' ) );
 		}
 
-		$patterns_dictionary = PatternsHelper::get_patterns_ai_data();
+		$patterns_ai_data_post = PatternsHelper::get_patterns_ai_data_post();
 
-		if ( isset( $patterns_dictionary->post_content ) && json_decode( $patterns_dictionary->post_content ) === $patterns_with_images_and_content ) {
+		if ( isset( $patterns_ai_data_post->post_content ) && json_decode( $patterns_ai_data_post->post_content ) === $patterns_with_images_and_content ) {
 			return true;
 		}
 
-		$updated_content = PatternsHelper::upsert_patterns_ai_data( $patterns_with_images_and_content );
+		$updated_content = PatternsHelper::upsert_patterns_ai_data_post( $patterns_with_images_and_content );
 
 		if ( ! $updated_content ) {
 			return new WP_Error( 'failed_to_update_patterns_content', __( 'Failed to update patterns content.', 'woo-gutenberg-products-block' ) );

--- a/src/Patterns/PatternsHelper.php
+++ b/src/Patterns/PatternsHelper.php
@@ -105,7 +105,7 @@ class PatternsHelper {
 
 		if ( isset( $patterns_ai_data_post ) ) {
 			$patterns_ai_data_post->post_content = wp_json_encode( $patterns_dictionary );
-			return wp_update_post( $patterns_ai_data_post );
+			return wp_update_post( $patterns_ai_data_post, true );
 		} else {
 			$patterns_ai_data_post = array(
 				'post_title'   => 'Patterns AI Data',
@@ -113,7 +113,7 @@ class PatternsHelper {
 				'post_status'  => 'publish',
 				'post_type'    => 'patterns_ai_data',
 			);
-			return wp_insert_post( $patterns_ai_data_post );
+			return wp_insert_post( $patterns_ai_data_post, true );
 		}
 	}
 

--- a/src/Patterns/PatternsHelper.php
+++ b/src/Patterns/PatternsHelper.php
@@ -103,21 +103,17 @@ class PatternsHelper {
 	public static function upsert_patterns_ai_data_post( $patterns_dictionary ) {
 		$patterns_ai_data_post = self::get_patterns_ai_data_post();
 
-		try {
-			if ( isset( $patterns_ai_data_post ) ) {
-				$patterns_ai_data_post->post_content = wp_json_encode( $patterns_dictionary );
-				wp_update_post( $patterns_ai_data_post );
-			} else {
-				$patterns_ai_data_post = array(
-					'post_title'   => 'Patterns AI Data',
-					'post_content' => wp_json_encode( $patterns_dictionary ),
-					'post_status'  => 'publish',
-					'post_type'    => 'patterns_ai_data',
-				);
-				wp_insert_post( $patterns_ai_data_post );
-			}
-		} catch ( \WP_Error $e ) {
-			return $e;
+		if ( isset( $patterns_ai_data_post ) ) {
+			$patterns_ai_data_post->post_content = wp_json_encode( $patterns_dictionary );
+			return wp_update_post( $patterns_ai_data_post );
+		} else {
+			$patterns_ai_data_post = array(
+				'post_title'   => 'Patterns AI Data',
+				'post_content' => wp_json_encode( $patterns_dictionary ),
+				'post_status'  => 'publish',
+				'post_type'    => 'patterns_ai_data',
+			);
+			return wp_insert_post( $patterns_ai_data_post );
 		}
 	}
 

--- a/src/Patterns/PatternsHelper.php
+++ b/src/Patterns/PatternsHelper.php
@@ -79,7 +79,7 @@ class PatternsHelper {
 	 *
 	 * @return WP_Post|null
 	 */
-	public static function get_patterns_ai_data() {
+	public static function get_patterns_ai_data_post() {
 		$arg = array(
 			'post_type'      => 'patterns_ai_data',
 			'posts_per_page' => 1,
@@ -98,24 +98,27 @@ class PatternsHelper {
 	 *
 	 * @param array $patterns_dictionary The patterns dictionary.
 	 *
-	 * @return void
+	 * @return WP_Error|null
 	 */
-	public static function upsert_patterns_ai_data( $patterns_dictionary ) {
-		$patterns = self::get_patterns_ai_data();
+	public static function upsert_patterns_ai_data_post( $patterns_dictionary ) {
+		$patterns_ai_data_post = self::get_patterns_ai_data_post();
 
-		if ( isset( $patterns ) ) {
-			$patterns->post_content = wp_json_encode( $patterns_dictionary );
-			wp_update_post( $patterns );
-		} else {
-			$patterns = array(
-				'post_title'   => 'Patterns AI Data',
-				'post_content' => wp_json_encode( $patterns_dictionary ),
-				'post_status'  => 'publish',
-				'post_type'    => 'patterns_ai_data',
-			);
-			wp_insert_post( $patterns );
+		try {
+			if ( isset( $patterns_ai_data_post ) ) {
+				$patterns_ai_data_post->post_content = wp_json_encode( $patterns_dictionary );
+				wp_update_post( $patterns_ai_data_post );
+			} else {
+				$patterns_ai_data_post = array(
+					'post_title'   => 'Patterns AI Data',
+					'post_content' => wp_json_encode( $patterns_dictionary ),
+					'post_status'  => 'publish',
+					'post_type'    => 'patterns_ai_data',
+				);
+				wp_insert_post( $patterns_ai_data_post );
+			}
+		} catch ( \WP_Error $e ) {
+			return $e;
 		}
-
 	}
 
 	/**
@@ -127,10 +130,10 @@ class PatternsHelper {
 	 */
 	private static function get_patterns_dictionary( $pattern_slug = null ) {
 
-		$patterns_dictionary_post = self::get_patterns_ai_data();
-		$patterns_dictionary      = json_decode( $patterns_dictionary_post->post_content, true );
+		$patterns_ai_data_post = self::get_patterns_ai_data_post();
 
-		if ( ! empty( $patterns_dictionary ) ) {
+		if ( isset( $patterns_ai_data_post ) ) {
+			$patterns_dictionary = json_decode( $patterns_ai_data_post->post_content, true );
 			if ( empty( $pattern_slug ) ) {
 				return $patterns_dictionary;
 			}
@@ -148,7 +151,7 @@ class PatternsHelper {
 			return new WP_Error( 'missing_patterns_dictionary', __( 'The patterns dictionary is missing.', 'woo-gutenberg-products-block' ) );
 		}
 
-		$patterns_dictionary = wp_json_file_decode( $patterns_dictionary_file, array( 'associative' => true ) );
+		$patterns_dictionary = json_decode( $patterns_dictionary_file, true );
 
 		if ( ! empty( $pattern_slug ) ) {
 			foreach ( $patterns_dictionary as $pattern_dictionary ) {


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

In some circumstances, we noticed that the content of `wc_blocks_patterns_content` in wp_option is cached before a value is set. This causes the `get_option` returns an empty value even if the value was set in the database.

We decided to migrate from the wp_option approach to register a new post_type called `patterns_ai_data` to store the data generated by the AI.

We expect that for each WordPress website, there will exist only **ONE** entry of this post_type.

## Why

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->


_Please consider any edge cases this change may have, and also other areas of the product this may impact._

- Install and activate [this version](https://github.com/woocommerce/woocommerce-blocks/files/13283461/woocommerce.zip) of WooCommerce.
- Install and activate WooCommerce Blocks from the following zip file: [woocommerce-gutenberg-products-block.zip](https://github.com/woocommerce/woocommerce-blocks/files/13283944/woocommerce-gutenberg-products-block.zip)
- Install and activate Jetpack.
- In your wp-admin, you should see the following section for Jetpack:

<img width="1232" alt="Screenshot 2023-10-22 at 09 29 08" src="https://user-images.githubusercontent.com/15730971/267093030-fc804759-f724-4fa2-829d-7bfd441962ec.png">

- Click on "Set up Jetpack" and make sure the connection is successful:

<img width="1232" alt="Screenshot 2023-10-22 at 09 29 08" src="https://user-images.githubusercontent.com/15730971/267093371-661ee4c5-a0ac-40fd-9e5e-835a0e4c1cb7.png">

- Install and activate WooCommerce Beta Tester (the plugin is available [within the monorepo](https://github.com/woocommerce/woocommerce/tree/trunk/plugins))
- Head over to `/wp-admin/tools.php?page=woocommerce-admin-test-helper` and enable `customize-store` feature flag:

<img width="1233" alt="Screenshot 2023-10-22 at 10 32 24" src="https://github.com/woocommerce/woocommerce-blocks/assets/15730971/816867c6-34e5-40a1-a87d-f4a7cda46429">

### Test the AI-managed images

1. Head over to Home > Customize your Store:
 
<img width="1232" alt="Screenshot 2023-10-22 at 09 29 08" src="https://github.com/woocommerce/woocommerce-blocks/assets/15730971/b5d34131-3edc-47ed-a8e4-8e2775ca1bbd">

2. Click on design with AI.
3. Type a description for your business.
4. Make sure the AI content is properly generated and images are assigned to patterns and products based on the description provided.
5. Redo the store configuration with another description.
6. Ensure that the patterns are updated.

## Performance

During my investigation, I noticed that the query runs only one time (this means that the result is cached)

![image](https://github.com/woocommerce/woocommerce-blocks/assets/4463174/597e2fa4-4eb8-4901-923e-016326b66921)

Futhermore, this approach is used from WordPress for custom_css and global_styles: [documentation](https://developer.wordpress.org/reference/functions/register_post_type/#reserved-post-types).




* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [ ] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Add suggested changelog entry here.
