### PR TITLE
[PHP 8.1 Compatibility] Check That Data is Countable in ProductQuery BlockType

### DIFF
--- a/src/BlockTypes/ProductQuery.php
+++ b/src/BlockTypes/ProductQuery.php
@@ -298,7 +298,7 @@ class ProductQuery extends AbstractBlock {
 		 */
 		if (
 			! empty( $merged_query['post__in'] ) &&
-			count( $merged_query['post__in'] ) > count( array_unique( $merged_query['post__in'] ) )
+			( is_countable( $merged_query['post__in'] ) ? count( $merged_query['post__in'] ) : 0 ) > count( array_unique( $merged_query['post__in'] ) )
 		) {
 			$merged_query['post__in'] = array_unique(
 				array_diff(
@@ -392,7 +392,7 @@ class ProductQuery extends AbstractBlock {
 			function ( $carry, $item ) {
 				$taxonomy = sanitize_title( $item['taxonomy'] );
 
-				if ( ! key_exists( $taxonomy, $carry ) ) {
+				if ( ! array_key_exists( $taxonomy, $carry ) ) {
 					$carry[ $taxonomy ] = array(
 						'field'    => 'term_id',
 						'operator' => 'IN',


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Use `is_countable()` before using `count()` on data in the ProductQuery block type.

Additionally, replace `key_exists` with `array_key_exists`. The former is an alias to the latter so it makes sense to adjust and appease the Rector rules.

Fixes #11666

## Why

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

Rector has reported issues with using `count()` in places there could be potentially non-countable data which can result in a fatal error.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Add a Product Query block type to your site
2. Regression test and ensure there are no regressions or fatal errors as a result of this change.
3. Run the Rector linting (see p7H4VZ-4x1-p2) against `/src/BlockTypes/ProductQuery.php` and confirm there is no `CountOnNullRector` or `RenameFunctionRector` error.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Add suggested changelog entry here.