### PR TITLE
[CYS] Fix decoding issue and pattern

### DIFF
--- a/patterns/featured-products-fresh-and-tasty.php
+++ b/patterns/featured-products-fresh-and-tasty.php
@@ -18,6 +18,7 @@ $first_title        = $content['titles'][0]['default'] ?? '';
 $first_description  = $content['descriptions'][0]['default'] ?? '';
 $second_description = $content['descriptions'][1]['default'] ?? '';
 $third_description  = $content['descriptions'][2]['default'] ?? '';
+$fourth_description = $content['descriptions'][3]['default'] ?? '';
 ?>
 
 <!-- wp:heading {"level":3,"align":"wide"} -->
@@ -129,7 +130,7 @@ $third_description  = $content['descriptions'][2]['default'] ?? '';
 			<!-- wp:column {"width":"67%","style":{"typography":{"fontWeight":"600"}},"layout":{"type":"constrained","justifyContent":"left"}} -->
 			<div class="wp-block-column" style="font-weight:600;flex-basis:67%">
 				<!-- wp:paragraph {"fontSize":"small"} -->
-				<p class="has-small-font-size"><?php echo esc_html( $content['descriptions'][0]['default'] ); ?></p>
+				<p class="has-small-font-size"><?php echo esc_html( $fourth_description ); ?></p>
 				<!-- /wp:paragraph -->
 			</div>
 			<!-- /wp:column -->

--- a/src/Patterns/PatternsHelper.php
+++ b/src/Patterns/PatternsHelper.php
@@ -147,7 +147,7 @@ class PatternsHelper {
 			return new WP_Error( 'missing_patterns_dictionary', __( 'The patterns dictionary is missing.', 'woo-gutenberg-products-block' ) );
 		}
 
-		$patterns_dictionary = json_decode( $patterns_dictionary_file, true );
+		$patterns_dictionary = wp_json_file_decode( $patterns_dictionary_file, array( 'associative' => true ) );
 
 		if ( ! empty( $pattern_slug ) ) {
 			foreach ( $patterns_dictionary as $pattern_dictionary ) {


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

This PR does two things:
- Fix the decoding of the `dictionary.json` file, before it was trying to decode the file path, not the actual file.
- Fix an empty pattern description on the `Featured Products: Fresh & Tasty` pattern.

## Why

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/11695
Fixes https://github.com/woocommerce/woocommerce-blocks/issues/11696

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. On a fresh install (it should not have the `patterns_ai_data` post created).
2. Insert the `Featured Products: Fresh & Tasty` pattern and make sure it has all the default text content, nothing is empty.
3. Insert a few other WooCommerce Blocks patterns and check all of them have all the text content as well.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

