### PR TITLE
Add protection against wrong params in get_block_template_fallback()

### DIFF
--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -183,6 +183,17 @@ class BlockTemplatesController {
 	 * @return object|null
 	 */
 	public function get_block_template_fallback( $template, $id, $template_type ) {
+		// Add protection against invalid ids.
+		if ( ! is_string( $id ) || ! str_contains( $id, '//' ) ) {
+			return null;
+		}
+		// Add protection against invalid template types.
+		if (
+			'wp_template' !== $template_type &&
+			'wp_template_part' !== $template_type
+		) {
+			return null;
+		}
 		$template_name_parts  = explode( '//', $id );
 		list( $theme, $slug ) = $template_name_parts;
 

--- a/src/BlockTemplatesController.php
+++ b/src/BlockTemplatesController.php
@@ -184,7 +184,7 @@ class BlockTemplatesController {
 	 */
 	public function get_block_template_fallback( $template, $id, $template_type ) {
 		// Add protection against invalid ids.
-		if ( ! is_string( $id ) || ! str_contains( $id, '//' ) ) {
+		if ( ! is_string( $id ) || ! strstr( $id, '//' ) ) {
 			return null;
 		}
 		// Add protection against invalid template types.
@@ -194,10 +194,11 @@ class BlockTemplatesController {
 		) {
 			return null;
 		}
-		$template_name_parts  = explode( '//', $id );
-		list( $theme, $slug ) = $template_name_parts;
+		$template_name_parts = explode( '//', $id );
+		$theme               = $template_name_parts[0] ?? '';
+		$slug                = $template_name_parts[1] ?? '';
 
-		if ( ! BlockTemplateUtils::template_is_eligible_for_product_archive_fallback( $slug ) ) {
+		if ( empty( $theme ) || empty( $slug ) || ! BlockTemplateUtils::template_is_eligible_for_product_archive_fallback( $slug ) ) {
 			return null;
 		}
 


### PR DESCRIPTION
## What

Fixes #

## Why

Given that `get_block_template_fallback()` is executed on a filter, we need to add some validation to make sure the parameters received are valid. This PR does that.

## Testing Instructions

### Verify there are no regressions in the Editor

1. Go to a Product Category page in the frontend (ie: `/product-category/clothing/accessories/`).
2. Verify it's displayed with the Product Catalog template.
3. Go to Appearance > Editor > Templates > Product Catalog and make some edits.
4. Go again to the Product Category page in the frontend and verify the changes are applied there as well.

### Verify there are protections against wrong parameters in the filter (to test only by devs)

1. Add this code to `BlockTemplatesController.php` [L62](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/src/BlockTemplatesController.php#L62):
```PHP
$template = apply_filters( 'pre_get_block_template', 'wrong_template', 'wrong_template', 'wp_wrong_template_type' );
```
2. Go to a Product Category page (ie: `/product-category/clothing/accessories/`).
3. Verify there is no PHP warning show on the page.
4. Verify also no PHP error was added to the PHP error log related to that.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## WooCommerce Visibility

Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog

> Fix an error that might appear when `pre_get_block_template` filter was called with wrong params.
