### PR TITLE
Translate Related Products heading in Single Product template

### DIFF
--- a/assets/js/blocks/product-query/variations/related-products.tsx
+++ b/assets/js/blocks/product-query/variations/related-products.tsx
@@ -57,6 +57,7 @@ export const INNER_BLOCKS_TEMPLATE: InnerBlockTemplate[] = [
 		{
 			level: 2,
 			content: __( 'Related products', 'woo-gutenberg-products-block' ),
+			style: { spacing: { margin: { top: '1rem', bottom: '1rem' } } },
 		},
 	],
 	[

--- a/patterns/related-products.php
+++ b/patterns/related-products.php
@@ -14,8 +14,8 @@
 			<!-- wp:heading {"style":{"spacing":{"margin":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}}} -->
 			<h2 class="wp-block-heading" style="margin-top:var(--wp--preset--spacing--30);margin-bottom:var(--wp--preset--spacing--30)">
 				<?php
-					esc_html__(
-						'Related Products',
+					echo esc_html__(
+						'Related products',
 						'woo-gutenberg-products-block'
 					)
 					?>

--- a/patterns/related-products.php
+++ b/patterns/related-products.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Title: Related Products
+ * Slug: woocommerce-blocks/related-products
+ * Categories: WooCommerce
+ * Inserter: false
+ */
+?>
+
+<!-- wp:woocommerce/related-products {"align":"wide"} -->
+<div class="wp-block-woocommerce-related-products alignwide">
+		<!-- wp:query {"queryId":0,"query":{"perPage":5,"pages":0,"offset":0,"postType":"product","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"flex","columns":5},"namespace":"woocommerce/related-products","lock":{"remove":true,"move":true}} -->
+		<div class="wp-block-query">
+			<!-- wp:heading -->
+			<h2 class="wp-block-heading">
+				<?php
+					echo sprintf(
+						esc_html__(
+							'Related Products',
+							'woo-gutenberg-products-block'
+						)
+					);
+					?>
+			</h2>
+			<!-- /wp:heading -->
+
+			<!-- wp:post-template {"className":"products-block-post-template","__woocommerceNamespace":"woocommerce/product-query/product-template"} -->
+			<!-- wp:woocommerce/product-image {"isDescendentOfQueryLoop":true} /-->
+
+			<!-- wp:post-title {"textAlign":"center","level":3,"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-query/product-title"} /-->
+
+			<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"center","fontSize":"small","style":{"spacing":{"margin":{"bottom":"1rem"}}}} /-->
+
+			<!-- wp:woocommerce/product-button {"isDescendentOfQueryLoop":true,"textAlign":"center","fontSize":"small","style":{"spacing":{"margin":{"bottom":"1rem"}}}} /-->
+			<!-- /wp:post-template -->
+		</div>
+		<!-- /wp:query -->
+	</div>
+	<!-- /wp:woocommerce/related-products -->

--- a/patterns/related-products.php
+++ b/patterns/related-products.php
@@ -11,8 +11,8 @@
 <div class="wp-block-woocommerce-related-products alignwide">
 		<!-- wp:query {"queryId":0,"query":{"perPage":5,"pages":0,"offset":0,"postType":"product","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"flex","columns":5},"namespace":"woocommerce/related-products","lock":{"remove":true,"move":true}} -->
 		<div class="wp-block-query">
-			<!-- wp:heading -->
-			<h2 class="wp-block-heading">
+			<!-- wp:heading {"style":{"spacing":{"margin":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}}} -->
+			<h2 class="wp-block-heading" style="margin-top:var(--wp--preset--spacing--30);margin-bottom:var(--wp--preset--spacing--30)">
 				<?php
 					echo sprintf(
 						esc_html__(

--- a/patterns/related-products.php
+++ b/patterns/related-products.php
@@ -14,12 +14,10 @@
 			<!-- wp:heading {"style":{"spacing":{"margin":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30"}}}} -->
 			<h2 class="wp-block-heading" style="margin-top:var(--wp--preset--spacing--30);margin-bottom:var(--wp--preset--spacing--30)">
 				<?php
-					echo sprintf(
-						esc_html__(
-							'Related Products',
-							'woo-gutenberg-products-block'
-						)
-					);
+					esc_html__(
+						'Related Products',
+						'woo-gutenberg-products-block'
+					)
 					?>
 			</h2>
 			<!-- /wp:heading -->

--- a/templates/templates/blockified/single-product.html
+++ b/templates/templates/blockified/single-product.html
@@ -45,27 +45,7 @@
 
 	<!-- wp:woocommerce/product-details {"align":"wide"} /-->
 
-	<!-- wp:woocommerce/related-products {"align":"wide"} -->
-	<div class="wp-block-woocommerce-related-products alignwide">
-		<!-- wp:query {"queryId":0,"query":{"perPage":5,"pages":0,"offset":0,"postType":"product","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":false},"displayLayout":{"type":"flex","columns":5},"namespace":"woocommerce/related-products","lock":{"remove":true,"move":true}} -->
-		<div class="wp-block-query">
-			<!-- wp:heading -->
-			<h2 class="wp-block-heading">Related products</h2>
-			<!-- /wp:heading -->
-
-			<!-- wp:post-template {"className":"products-block-post-template","__woocommerceNamespace":"woocommerce/product-query/product-template"} -->
-			<!-- wp:woocommerce/product-image {"isDescendentOfQueryLoop":true} /-->
-
-			<!-- wp:post-title {"textAlign":"center","level":3,"fontSize":"medium","__woocommerceNamespace":"woocommerce/product-query/product-title"} /-->
-
-			<!-- wp:woocommerce/product-price {"isDescendentOfQueryLoop":true,"textAlign":"center","fontSize":"small","style":{"spacing":{"margin":{"bottom":"1rem"}}}} /-->
-
-			<!-- wp:woocommerce/product-button {"isDescendentOfQueryLoop":true,"textAlign":"center","fontSize":"small","style":{"spacing":{"margin":{"bottom":"1rem"}}}} /-->
-			<!-- /wp:post-template -->
-		</div>
-		<!-- /wp:query -->
-	</div>
-	<!-- /wp:woocommerce/related-products -->
+	<!-- wp:pattern {"slug":"woocommerce/related-products"} /-->
 </div>
 <!-- /wp:group -->
 

--- a/templates/templates/blockified/single-product.html
+++ b/templates/templates/blockified/single-product.html
@@ -45,7 +45,7 @@
 
 	<!-- wp:woocommerce/product-details {"align":"wide"} /-->
 
-	<!-- wp:pattern {"slug":"woocommerce/related-products"} /-->
+	<!-- wp:pattern {"slug":"woocommerce-blocks/related-products"} /-->
 </div>
 <!-- /wp:group -->
 


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

1. Extract Related Products block with heading to a separate pattern so heading can be translated. Reuse the pattern in the Single Products template.

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/11677

2. Add margin around the heading

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/11507

## Why

1. Related Products heading was used in template file which is HTML file and i11n functions cannot be used there. Hence it's been extracted to a pattern (PHP) file and translated.
2. In addition the top and bottom margin was added by default. This is added in two places since:
  - the default blockified template is taken from `/woocommerce-blocks/templates/templates/blockified/single-product.html` file
  - when transforming Classic Template into blockified one the Related Products block is in use.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

#### Prerequisites
1. Make sure your store is using DEFAULT blockified template. It may require creating a new store
2. Change your store language to something else than English (e.g. Spanish - Espanol)
3. You may need to update the translations (go to Dashboard -> Updates -> Update translations)

#### Default template
1 Go to Editor and edit "Single Product" template (Producto individual)
2. Check the Related Products heading is translated and has top and bottom margin

#### Transform from classic template
1 Go to Editor and edit "Single Product" template (Producto individual)
2. Remove the content and add classic template: "WooCommerce Single Product Block"
3. Focus on it and click "Transform into blocks"
4. Check the Related Products heading is translated and has top and bottom margin

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|    <img width="946" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/20098064/6243d080-d113-47f0-9695-44f861b10638">    |    <img width="883" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/20098064/735019b4-6153-48d6-b827-8927cb6638ae">   |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Related Products: Make the heading translated when in blockified Single Product template
