### PR TITLE
Fix styling of Classic Cart and Checkout Blocks on regular pages

### DIFF
--- a/src/BlockTypesController.php
+++ b/src/BlockTypesController.php
@@ -90,6 +90,8 @@ final class BlockTypesController {
 				}
 			}
 		}
+
+		return false;
 	}
 
 	/**

--- a/src/BlockTypesController.php
+++ b/src/BlockTypesController.php
@@ -52,6 +52,44 @@ final class BlockTypesController {
 		add_action( 'woocommerce_login_form_end', array( $this, 'redirect_to_field' ) );
 		add_filter( 'widget_types_to_hide_from_legacy_widget_block', array( $this, 'hide_legacy_widgets_with_block_equivalent' ) );
 		add_action( 'woocommerce_delete_product_transients', array( $this, 'delete_product_transients' ) );
+		add_filter(
+			'woocommerce_is_checkout',
+			function( $return ) {
+				return $return || $this->has_block_variation( 'woocommerce/classic-shortcode', 'shortcode', 'checkout' );
+			}
+		);
+		add_filter(
+			'woocommerce_is_cart',
+			function( $return ) {
+				return $return || $this->has_block_variation( 'woocommerce/classic-shortcode', 'shortcode', 'cart' );
+			}
+		);
+	}
+
+	/**
+	 * Check if the current post has a block with a specific attribute value.
+	 *
+	 * @param string $block_id The block ID to check for.
+	 * @param string $attribute The attribute to check.
+	 * @param string $value The value to check for.
+	 * @return boolean
+	 */
+	private function has_block_variation( $block_id, $attribute, $value ) {
+		$post = get_post();
+
+		if ( ! $post ) {
+			return false;
+		}
+
+		if ( has_block( $block_id, $post->ID ) ) {
+			$blocks = (array) parse_blocks( $post->post_content );
+
+			foreach ( $blocks as $block ) {
+				if ( isset( $block['attrs'][ $attribute ] ) && $value === $block['attrs'][ $attribute ] ) {
+					return true;
+				}
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

When the classic shortcode block (classic cart or classic checkout variation) is used on a page that is not set as the main cart and checkout page, the styling is broken. This PR fixes this.

## Why

The blocks can be inserted on any page, or the assigned page may change.

## Testing Instructions

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Create a new page
2. Insert the classic checkout block
3. Add something to your cart and visit the new page
4. Confirm it looks correct and you can place an order
5. Repeat for the classic cart block on another new page

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|     ![Screenshot 2023-11-08 at 13 01 51](https://github.com/woocommerce/woocommerce-blocks/assets/90977/291fbf55-24e6-4374-a248-8f66f6a8e5c5) |    ![Screenshot 2023-11-08 at 13 01 31](https://github.com/woocommerce/woocommerce-blocks/assets/90977/6e5c9700-9ee7-4705-a709-4091a216baa6) |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog

> Fix Classic Cart/Checkout styling on non-cart and checkout pages
