### PR TITLE
Skip template related E2E tests

### DIFF
--- a/tests/e2e/tests/templates/cart-template.block_theme.spec.ts
+++ b/tests/e2e/tests/templates/cart-template.block_theme.spec.ts
@@ -26,7 +26,9 @@ test.describe( 'Test the cart template', async () => {
 		).toBeVisible();
 	} );
 
-	test( 'Template can be accessed from the page editor', async ( {
+	// Remove the skip once this ticket is resolved: https://github.com/woocommerce/woocommerce-blocks/issues/11671
+	// eslint-disable-next-line playwright/no-skipped-test
+	test.skip( 'Template can be accessed from the page editor', async ( {
 		admin,
 		editor,
 		page,

--- a/tests/e2e/tests/templates/checkout-template.block_theme.spec.ts
+++ b/tests/e2e/tests/templates/checkout-template.block_theme.spec.ts
@@ -26,7 +26,9 @@ test.describe( 'Test the checkout template', async () => {
 		).toBeVisible();
 	} );
 
-	test( 'Template can be accessed from the page editor', async ( {
+	// Remove the skip once this ticket is resolved: https://github.com/woocommerce/woocommerce-blocks/issues/11671
+	// eslint-disable-next-line playwright/no-skipped-test
+	test.skip( 'Template can be accessed from the page editor', async ( {
 		admin,
 		editor,
 		page,


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Skip failing E2E tests introduced in WP 6.4. We should remove the `skip` once this ticket is resolved: https://github.com/woocommerce/woocommerce/issues/42119

## Why

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Confirm all tests are passing in this PR

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Add suggested changelog entry here.
