### PR TITLE
Store Customization > Update the AI Prompts and structure of requests for Patterns, Products and Images

### DIFF
--- a/src/Images/Pexels.php
+++ b/src/Images/Pexels.php
@@ -47,7 +47,7 @@ class Pexels {
 	 * @return mixed|\WP_Error
 	 */
 	private function define_search_term( $ai_connection, $token, $business_description ) {
-		$prompt = sprintf( 'Based on the description "%s", provide a one-word product description for the store\'s item. Do not include any adjectives or descriptions of the qualities of the product. The returned word should be simple.', $business_description );
+		$prompt = sprintf( 'Based on the description "%s", summarize what the store is selling in one word. Do not include any adjectives or descriptions of the qualities of the product. The returned word should be simple.', $business_description );
 
 		$response = $ai_connection->fetch_ai_response( $token, $prompt );
 

--- a/src/Images/Pexels.php
+++ b/src/Images/Pexels.php
@@ -81,7 +81,7 @@ class Pexels {
 	 * @return mixed|\WP_Error
 	 */
 	private function define_search_term( $ai_connection, $token, $business_description ) {
-		$prompt = sprintf( 'Based on the description "%s", count how many different products the store is selling and generate comma-separated words that precisely describe them. Do not separate compound words. The returned words should be as accurate as possible to describe the products sold. Do not include any adjectives or descriptions of the qualities of the product. The returned word should be simple. Do not add any explanations.', $business_description );
+		$prompt = sprintf( 'Based on the description "%s", generate one compound word that precisely describe them. The returned words should be as accurate as possible to describe the products sold. Do not include any adjectives or descriptions of the qualities of the product. The returned word should be simple. Do not add any explanations.', $business_description );
 
 		$response = $ai_connection->fetch_ai_response( $token, $prompt );
 

--- a/src/Images/Pexels.php
+++ b/src/Images/Pexels.php
@@ -47,7 +47,7 @@ class Pexels {
 	 * @return mixed|\WP_Error
 	 */
 	private function define_search_term( $ai_connection, $token, $business_description ) {
-		$prompt = sprintf( 'Based on the description "%s", summarize what the store is selling in one word. Do not include any adjectives or descriptions of the qualities of the product. The returned word should be simple.', $business_description );
+		$prompt = sprintf( 'Based on the description "%s", summarize what the store is selling in one word. The generated word should not be an abbreviation. Do not include any adjectives or descriptions of the qualities of the product. The returned word should be simple.', $business_description );
 
 		$response = $ai_connection->fetch_ai_response( $token, $prompt );
 

--- a/src/Patterns/PatternUpdater.php
+++ b/src/Patterns/PatternUpdater.php
@@ -209,7 +209,7 @@ class PatternUpdater {
 	 * @return array|WP_Error The patterns with images.
 	 */
 	private function get_patterns_with_images( $selected_images ) {
-		$patterns_dictionary = $this->get_patterns_dictionary();
+		$patterns_dictionary = self::get_patterns_dictionary();
 
 		if ( is_wp_error( $patterns_dictionary ) ) {
 			return $patterns_dictionary;
@@ -251,7 +251,7 @@ class PatternUpdater {
 	 *
 	 * @return mixed|WP_Error|null
 	 */
-	private function get_patterns_dictionary() {
+	public static function get_patterns_dictionary() {
 		$patterns_dictionary = plugin_dir_path( __FILE__ ) . 'dictionary.json';
 
 		if ( ! file_exists( $patterns_dictionary ) ) {

--- a/src/Patterns/PatternsHelper.php
+++ b/src/Patterns/PatternsHelper.php
@@ -74,10 +74,11 @@ class PatternsHelper {
 
 		return $image;
 	}
+
 	/**
 	 * Returns the post that has the generated data by the AI for the patterns.
 	 *
-	 * @return WP_Post|null
+	 * @return int|\WP_Post|null
 	 */
 	public static function get_patterns_ai_data_post() {
 		$arg = array(
@@ -90,7 +91,7 @@ class PatternsHelper {
 		$query = new \WP_Query( $arg );
 
 		$posts = $query->get_posts();
-		return isset( $posts[0] ) ? $posts[0] : null;
+		return $posts[0] ?? null;
 	}
 
 	/**
@@ -125,7 +126,6 @@ class PatternsHelper {
 	 * @return mixed|WP_Error|null
 	 */
 	private static function get_patterns_dictionary( $pattern_slug = null ) {
-
 		$patterns_ai_data_post = self::get_patterns_ai_data_post();
 
 		if ( isset( $patterns_ai_data_post ) ) {

--- a/src/Patterns/ProductUpdater.php
+++ b/src/Patterns/ProductUpdater.php
@@ -55,12 +55,6 @@ class ProductUpdater {
 			}
 		}
 
-		if ( is_wp_error( $response ) ) {
-			$error_msg = $response;
-		} elseif ( empty( $response ) || ! isset( $response['completion'] ) ) {
-			$error_msg = new \WP_Error( 'missing_completion_key', __( 'The response from the AI service is empty or missing the completion key.', 'woo-gutenberg-products-block' ) );
-		}
-
 		if ( isset( $error_msg ) ) {
 			return $error_msg;
 		}

--- a/src/Patterns/dictionary.json
+++ b/src/Patterns/dictionary.json
@@ -208,7 +208,7 @@
 			"titles": [
 				{
 					"default": "Get cozy this fall with knit sweaters",
-					"ai_prompt": "An impact phrase with less than 40 characters that advertises the displayed product: {image.0}"
+					"ai_prompt": "An impact phrase with less than 40 characters that advertises the product the store is selling"
 				}
 			]
 		}
@@ -360,7 +360,7 @@
 			"titles": [
 				{
 					"default": "Our newest arrivals",
-					"ai_prompt": "An impact phrase that advertises the displayed product collection"
+					"ai_prompt": "An impact phrase with less than 20 characters that advertises the displayed product collection"
 				}
 			]
 		}
@@ -494,7 +494,7 @@
 			"titles": [
 				{
 					"default": "Follow us on social media",
-					"ai_prompt": "An phrase that advertises the social media accounts"
+					"ai_prompt": "A phrase with less than 30 characters that advertises the social media accounts"
 				}
 			]
 		}

--- a/src/Patterns/dictionary.json
+++ b/src/Patterns/dictionary.json
@@ -208,7 +208,7 @@
 			"titles": [
 				{
 					"default": "Get cozy this fall with knit sweaters",
-					"ai_prompt": "An impact phrase that advertises the displayed product: {image.0}"
+					"ai_prompt": "An impact phrase with less than 40 characters that advertises the displayed product: {image.0}"
 				}
 			]
 		}
@@ -548,19 +548,19 @@
 			"titles": [
 				{
 					"default": "What our customers say",
-					"ai_prompt": "A title that advertises the set of testimonials"
+					"ai_prompt": "A title with less than 30 characters that advertises the set of testimonials"
 				},
 				{
-					"default": "Great experience",
-					"ai_prompt": "A title that advertises a customer product review"
+					"default": "I had a great experience",
+					"ai_prompt": "A title with less than 30 characters that advertises a customer product review"
 				},
 				{
 					"default": "LOVE IT",
-					"ai_prompt": "A title that advertises a customer product review"
+					"ai_prompt": "A title with less than 30 characters that advertises a customer product review"
 				},
 				{
 					"default": "Awesome couch",
-					"ai_prompt": "A title that advertises a customer product review"
+					"ai_prompt": "A title with less than 30 characters that advertises a customer product review"
 				}
 			],
 			"descriptions": [

--- a/src/Patterns/dictionary.json
+++ b/src/Patterns/dictionary.json
@@ -132,33 +132,33 @@
 			"titles": [
 				{
 					"default": "New in: 3-in-1 parka",
-					"ai_prompt": "An impact phrase that advertises the displayed product: {image.0}. The title must have less than 30 characters"
+					"ai_prompt": "Generate a title that highlights one of the qualities of the product being sold. The title must have only 2 or 3 words."
 				},
 				{
 					"default": "Waterproof Membrane",
-					"ai_prompt": "A title describing the first displayed product feature. The title must have only 2 or 3 words."
+					"ai_prompt": "Generate a title that highlights one of the qualities of the product being sold. The title must have only 2 or 3 words."
 				},
 				{
 					"default": "Expert Craftsmanship",
-					"ai_prompt": "A title describing the second displayed product feature. The title must have only 2 or 3 words."
+					"ai_prompt": "Generate a title that highlights one of the qualities of the product being sold. The title must have only 2 or 3 words."
 				},
 				{
 					"default": "Durable Fabric",
-					"ai_prompt": "A title describing the third displayed product feature. The title must have only 2 or 3 words."
+					"ai_prompt": "Generate a title that highlights one of the qualities of the product being sold. The title must have only 2 or 3 words."
 				}
 			],
 			"descriptions": [
 				{
 					"default": "Never worry about the weather again. Keep yourself dry, warm, and looking stylish.",
-					"ai_prompt": "A description of the first displayed product feature. The description must have less than 120 characters."
+					"ai_prompt": "Craft a catchy product description under 120 characters emphasizing one of its qualities."
 				},
 				{
 					"default": "Our products are made with expert craftsmanship and attention to detail.",
-					"ai_prompt": "A description of the second displayed product feature. The description must have less than 120 characters."
+					"ai_prompt": "Craft a catchy product description under 120 characters emphasizing one of its qualities."
 				},
 				{
 					"default": "We use only the highest-quality materials in our products, ensuring that they look great.",
-					"ai_prompt": "A description of the third displayed product feature. The description must have less than 120 characters."
+					"ai_prompt": "Craft a catchy product description under 120 characters emphasizing one of its qualities."
 				}
 			]
 		}
@@ -552,29 +552,29 @@
 				},
 				{
 					"default": "Great experience",
-					"ai_prompt": "A title that advertises the first testimonial"
+					"ai_prompt": "A title that advertises a customer product review"
 				},
 				{
 					"default": "LOVE IT",
-					"ai_prompt": "A title that advertises the second testimonial"
+					"ai_prompt": "A title that advertises a customer product review"
 				},
 				{
 					"default": "Awesome couch",
-					"ai_prompt": "A title that advertises the third testimonial"
+					"ai_prompt": "A title that advertises a customer product review"
 				}
 			],
 			"descriptions": [
 				{
 					"default": "In the end the couch wasn't exactly what I was looking for but my experience with the Burrow team was excellent. First in providing a discount when the couch was delayed.",
-					"ai_prompt": "A description of the first testimonial. The testimonial must have less than 200 characters."
+					"ai_prompt": "A customer product review with less than 200 characters."
 				},
 				{
 					"default": "Great couch. color as advertise. seat is nice and firm. Easy to put together. Versatile. Bought one for my mother in law as well. And she loves hers!",
-					"ai_prompt": "A description of the second testimonial. The testimonial must have less than 200 characters."
+					"ai_prompt": "A customer product review with less than 200 characters."
 				},
 				{
 					"default": "I got the kind sofa. The look and feel is high quality, and I enjoy that it is a medium level of firmness. Assembly took a little longer than I expected, and it came in 4 boxes.",
-					"ai_prompt": "A description of the third testimonial. The testimonial must have less than 200 characters."
+					"ai_prompt": "A customer product review with less than 200 characters."
 				}
 			]
 		}

--- a/src/Patterns/dictionary.json
+++ b/src/Patterns/dictionary.json
@@ -348,7 +348,7 @@
 			"titles": [
 				{
 					"default": "Our newest arrivals",
-					"ai_prompt": "An impact phrase that advertises the displayed product collection"
+					"ai_prompt": "An impact phrase with less than 20 characters that advertises the displayed product collection"
 				}
 			]
 		}


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

On this PR, a series of changes were made to ensure the AI-generated content for products and patterns is more accurate and also introduce a significant performance boost by breaking down the multiple parallel requests to AI even further, ensuring it returns the expected results faster.

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/11686

## Why

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->
These changes are required to guarantee a better experience for the store owner when using the CYS flow for building their store.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

### Setup

- If you already have a pre-configured WordPress install, remove the pre-existing WooCommerce Blocks Plugin and upload the one from this zip file: [woocommerce-gutenberg-products-block.zip](https://github.com/woocommerce/woocommerce-blocks/files/13299024/woocommerce-gutenberg-products-block.zip)

Or alternatively, create a new WordPress install from scratch (make sure the install is a Jurassic Ninja install or equivalent. Otherwise you won't be able to connect with Jetpack to test this PR).

- Install and activate WooCommerce from the following zip file: [woocommerce.zip](https://github.com/woocommerce/woocommerce-blocks/files/13299011/woocommerce.zip)
- Install and activate WooCommerce Blocks from the following zip file: [woocommerce-gutenberg-products-block.zip](https://github.com/woocommerce/woocommerce-blocks/files/13299024/woocommerce-gutenberg-products-block.zip)

- Install and activate Jetpack.
- In your wp-admin, you should see the following section for Jetpack:

<img width="1232" alt="Screenshot 2023-10-22 at 09 29 08" src="https://user-images.githubusercontent.com/15730971/267093030-fc804759-f724-4fa2-829d-7bfd441962ec.png">

- Click on "Set up Jetpack" and make sure the connection is successful:

<img width="1232" alt="Screenshot 2023-10-22 at 09 29 08" src="https://user-images.githubusercontent.com/15730971/267093371-661ee4c5-a0ac-40fd-9e5e-835a0e4c1cb7.png">

- Install and activate Woo AI (the plugin is available [within the monorepo](https://github.com/woocommerce/woocommerce/tree/trunk/plugins))
- Install and activate WooCommerce Beta Tester (the plugin is available [within the monorepo](https://github.com/woocommerce/woocommerce/tree/trunk/plugins))
- Head over to `/wp-admin/tools.php?page=woocommerce-admin-test-helper` and enable `customize-store` feature flag:

<img width="1233" alt="Screenshot 2023-10-22 at 10 32 24" src="https://github.com/woocommerce/woocommerce-blocks/assets/15730971/816867c6-34e5-40a1-a87d-f4a7cda46429">

### Test the CYS experience

1. Head over to Home > Customize your Store:
 
<img width="1232" alt="Screenshot 2023-10-22 at 09 29 08" src="https://github.com/woocommerce/woocommerce-blocks/assets/15730971/b5d34131-3edc-47ed-a8e4-8e2775ca1bbd">

2. Click on design with AI.
3. Type a description for your business.
4. Make sure the AI content is properly generated and images are assigned to patterns and products based on the description provided.
5. Repeat the same test multiple times with different business descriptions to ensure content is consistently updated every time.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->


https://github.com/woocommerce/woocommerce-blocks/assets/15730971/c58bb673-a8e3-4883-9b80-0b9507cbde47




## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Customize your Store > Update the AI Prompts and structure of requests for Patterns, Products, and Images.