### PR TITLE
Update Jetpack WooCommerce Analytics module integration to check for changed template names

### DIFF
--- a/src/Domain/Services/JetpackWooCommerceAnalytics.php
+++ b/src/Domain/Services/JetpackWooCommerceAnalytics.php
@@ -274,6 +274,16 @@ class JetpackWooCommerceAnalytics {
 			$checkout_template = get_block_template( $checkout_template_id );
 		}
 
+		// Something failed with the template retrieval, return early with 0 values rather than let a warning appear.
+		if ( ! $cart_template || ! $checkout_template ) {
+			return array(
+				'cart_page_contains_cart_block'         => 0,
+				'cart_page_contains_cart_shortcode'     => 0,
+				'checkout_page_contains_checkout_block' => 0,
+				'checkout_page_contains_checkout_shortcode' => 0,
+			);
+		}
+
 		// Update the info transient with data we got from the templates, if the site isn't using WC Blocks we
 		// won't be doing this so no concern about overwriting.
 		// Sites that load this code will be loading it on a page using the relevant block, but we still need to check

--- a/src/Domain/Services/JetpackWooCommerceAnalytics.php
+++ b/src/Domain/Services/JetpackWooCommerceAnalytics.php
@@ -249,16 +249,16 @@ class JetpackWooCommerceAnalytics {
 		$checkout_template    = null;
 		$cart_template_id     = null;
 		$checkout_template_id = null;
-		$templates            = $this->block_templates_controller->get_block_templates( array( 'cart', 'checkout' ) );
+		$templates            = $this->block_templates_controller->get_block_templates( array( 'cart', 'checkout', 'page-checkout', 'page-cart' ) );
 		$guest_checkout       = ucfirst( get_option( 'woocommerce_enable_guest_checkout', 'No' ) );
 		$create_account       = ucfirst( get_option( 'woocommerce_enable_signup_and_login_from_checkout', 'No' ) );
 
 		foreach ( $templates as $template ) {
-			if ( 'cart' === $template->slug ) {
+			if ( 'cart' === $template->slug || 'page-cart' === $template->slug ) {
 				$cart_template_id = ( $template->id );
 				continue;
 			}
-			if ( 'checkout' === $template->slug ) {
+			if ( 'checkout' === $template->slug || 'page-checkout' === $template->slug ) {
 				$checkout_template_id = ( $template->id );
 			}
 		}


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

There is a PHP Warning when WooCommerce Cart/Checkout templates were not found. The templates are now called page-checkout and page-cart and the code has been updated to look for them.

## Why

To prevent the warning

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

- Ensure your store is set up to use and record WooCommerce Analytics
- Add items to your cart and go to a page with the Checkout block on
- Ensure no PHP Warnings are logged

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [x] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Prevent PHP warnings when using Jetpack WooCommerce Analytics module.
