### PR TITLE
Fix: different collection data request between editor and front end

### DIFF
--- a/assets/js/blocks/collection-filters/edit.tsx
+++ b/assets/js/blocks/collection-filters/edit.tsx
@@ -26,10 +26,6 @@ const Edit = ( { clientId, setAttributes, context }: EditProps ) => {
 		resourceName: 'products/collection-data',
 		query: {
 			...formatQuery( context.query ),
-			page: undefined,
-			per_page: undefined,
-			orderby: undefined,
-			order: undefined,
 			...getQueryParams( currentBlock ),
 		},
 	} );

--- a/assets/js/blocks/collection-filters/utils.ts
+++ b/assets/js/blocks/collection-filters/utils.ts
@@ -23,7 +23,6 @@ export function getQueryParams( block: BlockInstance | null ) {
 export const sharedParams: Array< keyof ProductCollectionQuery > = [
 	'exclude',
 	'offset',
-	'order',
 	'search',
 ];
 
@@ -36,9 +35,6 @@ export const mappedParams: {
 	key: keyof ProductCollectionQuery;
 	map: string;
 }[] = [
-	{ key: 'orderBy', map: 'orderby' },
-	{ key: 'pages', map: 'page' },
-	{ key: 'perPage', map: 'per_page' },
 	{ key: 'woocommerceStockStatus', map: 'stock_status' },
 	{ key: 'woocommerceOnSale', map: 'on_sale' },
 	{ key: 'woocommerceHandPickedProducts', map: 'include' },

--- a/src/BlockTypes/CollectionFilters.php
+++ b/src/BlockTypes/CollectionFilters.php
@@ -125,7 +125,13 @@ final class CollectionFilters extends AbstractBlock {
 		);
 
 		if ( ! empty( $response['body'] ) ) {
-			return $response['body'];
+			$normalized_response = array();
+
+			foreach ( $response['body'] as $key => $data ) {
+				$normalized_response[ $key ] = (array) $data;
+			}
+
+			return $normalized_response;
 		}
 
 		return array();
@@ -172,16 +178,13 @@ final class CollectionFilters extends AbstractBlock {
 		/**
 		 * The following params can be passed directly to Store API endpoints.
 		 */
-		$shared_params = array( 'exclude', 'offset', 'order', 'search' );
+		$shared_params = array( 'exclude', 'offset', 'search' );
 
 		/**
 		 * The following params just need to transform the key, their value can
 		 * be passed as it is to the Store API.
 		 */
 		$mapped_params = array(
-			'orderBy'                       => 'orderby',
-			'pages'                         => 'page',
-			'perPage'                       => 'per_page',
 			'woocommerceStockStatus'        => 'stock_status',
 			'woocommerceOnSale'             => 'on_sale',
 			'woocommerceHandPickedProducts' => 'include',
@@ -241,7 +244,16 @@ final class CollectionFilters extends AbstractBlock {
 		 */
 		$params['catalog_visibility'] = is_search() ? 'search' : 'visible';
 
-		return array_filter( $params );
+		/**
+		* `false` values got removed from `add_query_arg`, so we need to convert
+		* them to numeric.
+		*/
+		return array_map(
+			function( $param ) {
+				return is_bool( $param ) ? +$param : $param;
+			},
+			$params
+		);
 	}
 
 }

--- a/src/BlockTypes/CollectionPriceFilter.php
+++ b/src/BlockTypes/CollectionPriceFilter.php
@@ -36,8 +36,8 @@ final class CollectionPriceFilter extends AbstractBlock {
 		$price_range = $block->context['collectionData']['price_range'];
 
 		$wrapper_attributes  = get_block_wrapper_attributes();
-		$min_range           = $price_range->min_price / 10 ** $price_range->currency_minor_unit;
-		$max_range           = $price_range->max_price / 10 ** $price_range->currency_minor_unit;
+		$min_range           = $price_range['min_price'] / 10 ** $price_range['currency_minor_unit'];
+		$max_range           = $price_range['max_price'] / 10 ** $price_range['currency_minor_unit'];
 		$min_price           = intval( get_query_var( self::MIN_PRICE_QUERY_VAR, $min_range ) );
 		$max_price           = intval( get_query_var( self::MAX_PRICE_QUERY_VAR, $max_range ) );
 		$formatted_min_price = wc_price( $min_price, array( 'decimals' => 0 ) );


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

This PR:
- fixes an issue in the `CollectionFilters` class that makes the request on the frontend differ from the corresponding one in the editor.
- Updates the query transform utility on both frontend and in the editor to remove the unnecessary tranformation of following keys: `order`, `orderBy`, `perPage`, `page`.
- Normalizes the data returned from the Store API to associative array only, which unifies the data strucutre between editor and frontend.
- Updates the `CollectionPriceFilter` render method to consume array instead of object

## Why

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Check the collection data in the filter block context to make sure editor and frontend have the same data.
2. Ensure there i no error/warning.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Add suggested changelog entry here.
