### PR TITLE
Fix address block invalidations in the editor and address card display in Firefox

### DIFF
--- a/assets/js/base/components/cart-checkout/address-form/address-form.tsx
+++ b/assets/js/base/components/cart-checkout/address-form/address-form.tsx
@@ -15,7 +15,7 @@ import {
 	ShippingStateInput,
 } from '@woocommerce/base-components/state-input';
 import { useEffect, useMemo, useRef } from '@wordpress/element';
-import { withInstanceId } from '@wordpress/compose';
+import { useInstanceId } from '@wordpress/compose';
 import { useShallowEqual } from '@woocommerce/base-hooks';
 import { defaultAddressFields } from '@woocommerce/settings';
 import isShallowEqual from '@wordpress/is-shallow-equal';
@@ -44,11 +44,12 @@ const AddressForm = ( {
 	id = '',
 	fields = defaultFields,
 	fieldConfig = {} as FieldConfig,
-	instanceId,
 	onChange,
 	type = 'shipping',
 	values,
 }: AddressFormProps ): JSX.Element => {
+	const instanceId = useInstanceId( AddressForm );
+
 	// Track incoming props.
 	const currentFields = useShallowEqual( fields );
 	const currentFieldConfig = useShallowEqual( fieldConfig );
@@ -99,7 +100,7 @@ const AddressForm = ( {
 		fieldsRef.current?.postcode?.revalidate();
 	}, [ currentCountry ] );
 
-	id = id || instanceId;
+	id = id || `${ instanceId }`;
 
 	return (
 		<div id={ id } className="wc-block-components-address-form">
@@ -206,4 +207,4 @@ const AddressForm = ( {
 	);
 };
 
-export default withInstanceId( AddressForm );
+export default AddressForm;

--- a/assets/js/base/components/cart-checkout/address-form/types.ts
+++ b/assets/js/base/components/cart-checkout/address-form/types.ts
@@ -26,8 +26,6 @@ export type AddressFormFields = {
 export interface AddressFormProps {
 	// Id for component.
 	id?: string;
-	// Unique id for form.
-	instanceId: string;
 	// Type of form (billing or shipping).
 	type?: AddressType;
 	// Array of fields in form.

--- a/assets/js/blocks/checkout/address-card/index.tsx
+++ b/assets/js/blocks/checkout/address-card/index.tsx
@@ -17,10 +17,12 @@ const AddressCard = ( {
 	address,
 	onEdit,
 	target,
+	showPhoneField,
 }: {
 	address: CartShippingAddress | CartBillingAddress;
 	onEdit: () => void;
 	target: string;
+	showPhoneField: boolean;
 } ): JSX.Element | null => {
 	return (
 		<div className="wc-block-components-address-card">
@@ -44,7 +46,7 @@ const AddressCard = ( {
 							<span key={ `address-` + index }>{ field }</span>
 						) ) }
 				</div>
-				{ address.phone ? (
+				{ address.phone && showPhoneField ? (
 					<div
 						key={ `address-phone` }
 						className="wc-block-components-address-card__address-section"

--- a/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/block.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/block.tsx
@@ -15,6 +15,8 @@ import type {
 	AddressFields,
 } from '@woocommerce/settings';
 import { StoreNoticesContainer } from '@woocommerce/blocks-checkout';
+import { useSelect } from '@wordpress/data';
+import { CART_STORE_KEY } from '@woocommerce/block-data';
 
 /**
  * Internal dependencies
@@ -81,16 +83,24 @@ const Block = ( {
 		? [ noticeContexts.BILLING_ADDRESS, noticeContexts.SHIPPING_ADDRESS ]
 		: [ noticeContexts.BILLING_ADDRESS ];
 
+	const { cartDataLoaded } = useSelect( ( select ) => {
+		const store = select( CART_STORE_KEY );
+		return {
+			cartDataLoaded: store.hasFinishedResolution( 'getCartData' ),
+		};
+	} );
 	return (
 		<>
 			<StoreNoticesContainer context={ noticeContext } />
 			<WrapperComponent>
-				<CustomerAddress
-					addressFieldsConfig={ addressFieldsConfig }
-					showPhoneField={ showPhoneField }
-					requirePhoneField={ requirePhoneField }
-					forceEditing={ forceEditing }
-				/>
+				{ cartDataLoaded ? (
+					<CustomerAddress
+						addressFieldsConfig={ addressFieldsConfig }
+						showPhoneField={ showPhoneField }
+						requirePhoneField={ requirePhoneField }
+						forceEditing={ forceEditing }
+					/>
+				) : null }
 			</WrapperComponent>
 		</>
 	);

--- a/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/customer-address.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/customer-address.tsx
@@ -97,9 +97,10 @@ const CustomerAddress = ( {
 				onEdit={ () => {
 					setEditing( true );
 				} }
+				showPhoneField={ showPhoneField }
 			/>
 		),
-		[ billingAddress ]
+		[ billingAddress, showPhoneField ]
 	);
 
 	const renderAddressFormComponent = useCallback(

--- a/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/block.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/block.tsx
@@ -19,6 +19,8 @@ import type {
 	AddressField,
 	AddressFields,
 } from '@woocommerce/settings';
+import { useSelect } from '@wordpress/data';
+import { CART_STORE_KEY } from '@woocommerce/block-data';
 
 /**
  * Internal dependencies
@@ -96,15 +98,24 @@ const Block = ( {
 		( shippingAddress.first_name || shippingAddress.last_name )
 	);
 
+	const { cartDataLoaded } = useSelect( ( select ) => {
+		const store = select( CART_STORE_KEY );
+		return {
+			cartDataLoaded: store.hasFinishedResolution( 'getCartData' ),
+		};
+	} );
+
 	return (
 		<>
 			<StoreNoticesContainer context={ noticeContext } />
 			<WrapperComponent>
-				<CustomerAddress
-					addressFieldsConfig={ addressFieldsConfig }
-					showPhoneField={ showPhoneField }
-					requirePhoneField={ requirePhoneField }
-				/>
+				{ cartDataLoaded ? (
+					<CustomerAddress
+						addressFieldsConfig={ addressFieldsConfig }
+						showPhoneField={ showPhoneField }
+						requirePhoneField={ requirePhoneField }
+					/>
+				) : null }
 			</WrapperComponent>
 			{ hasAddress && (
 				<CheckboxControl

--- a/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/customer-address.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/customer-address.tsx
@@ -3,7 +3,11 @@
  */
 import { useState, useCallback, useEffect } from '@wordpress/element';
 import { AddressForm } from '@woocommerce/base-components/cart-checkout';
-import { useCheckoutAddress, useStoreEvents } from '@woocommerce/base-context';
+import {
+	useCheckoutAddress,
+	useStoreEvents,
+	useEditorContext,
+} from '@woocommerce/base-context';
 import type {
 	ShippingAddress,
 	AddressField,
@@ -38,11 +42,12 @@ const CustomerAddress = ( {
 		useShippingAsBilling,
 	} = useCheckoutAddress();
 	const { dispatchCheckoutEvent } = useStoreEvents();
+	const { isEditor } = useEditorContext();
 	const hasAddress = !! (
 		shippingAddress.address_1 &&
 		( shippingAddress.first_name || shippingAddress.last_name )
 	);
-	const [ editing, setEditing ] = useState( ! hasAddress );
+	const [ editing, setEditing ] = useState( ! hasAddress || isEditor );
 
 	// Forces editing state if store has errors.
 	const { hasValidationErrors, invalidProps } = useSelect( ( select ) => {
@@ -103,9 +108,10 @@ const CustomerAddress = ( {
 				onEdit={ () => {
 					setEditing( true );
 				} }
+				showPhoneField={ showPhoneField }
 			/>
 		),
-		[ shippingAddress ]
+		[ shippingAddress, showPhoneField ]
 	);
 
 	const renderAddressFormComponent = useCallback(

--- a/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/customer-address.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/customer-address.tsx
@@ -147,9 +147,11 @@ const CustomerAddress = ( {
 			dispatchCheckoutEvent,
 			onChangeAddress,
 			requirePhoneField,
+			setBillingPhone,
 			setShippingPhone,
 			shippingAddress,
 			showPhoneField,
+			useShippingAsBilling,
 		]
 	);
 

--- a/packages/checkout/components/text-input/types.ts
+++ b/packages/checkout/components/text-input/types.ts
@@ -26,6 +26,8 @@ export interface ValidatedTextInputProps
 	label?: string | undefined;
 	// Field value.
 	value: string;
+	// Other sibling fields that should be validated together.
+	values: string[];
 	// If true, validation errors will be shown.
 	showError?: boolean;
 	// Error message to display alongside the field regardless of validation.


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

This PR fixes some issues with the address card and address form components.

The first issue caused block invalidation due to the custom validation function changing on every render. I fixed this by implementing a ref.

Fixes #11583

The second issue only affected firefox and would cause the collapsed address component to never render. This was fixed by waiting for cart data to load before mounting.

Fixes #11650

This change also negated the need for https://github.com/woocommerce/woocommerce-blocks/pull/11062 so we should test for regressions.

The final change was to ensure the address is never collapsed in admin so form changes are visible, and to correctly hide the phone value on the frontend if that field is toggled off.

## Testing Instructions

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Edit the checkout page
2. Address form should not be condensed
3. Toggle company/phone. Leave phone on. There should be no block errors.
4. Save changes and visit the checkout on the frontend (add something to cart if needed)
5. As a logged in user the address form should be condensed and phone should be visible. If no, fill out the form and place an order.
6. After placing the order go back to checkout and repeat the previous step. Phone should be visible in the condensed address component.
7. Go back to the editor and turn off the phone field. Save and go back to the frontend checkout. Ensure phone is hidden from the condensed address component.

**Firefox testing**

1. Add an item to the cart and go to checkout using Firefox
2. Fill out the form, then refresh the page.
3. The condensed address component is shown.
4. Edit the address. Ensure fields are populated with correct values.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog

> Fixed address components in Firefox, and editing of address form in the editor.
