### PR TITLE
Product Gallery: Fix limited images displayed in the dialog

### DIFF
--- a/assets/js/blocks/product-gallery/frontend.tsx
+++ b/assets/js/blocks/product-gallery/frontend.tsx
@@ -182,10 +182,15 @@ interactivityApiStore( {
 			},
 			handleNextImageButtonClick: ( store: Store ) => {
 				const { context } = store;
-				const imagesIds = context.woocommerce[ context.woocommerce.isDialogOpen ? 'dialogVisibleImagesIds' : 'visibleImagesIds' ];
+				const imagesIds =
+					context.woocommerce[
+						context.woocommerce.isDialogOpen
+							? 'dialogVisibleImagesIds'
+							: 'visibleImagesIds'
+					];
 				const selectedImageIdIndex = imagesIds.indexOf(
-						context.woocommerce.selectedImage
-					);
+					context.woocommerce.selectedImage
+				);
 				const nextImageIndex = Math.min(
 					selectedImageIdIndex + 1,
 					imagesIds.length - 1
@@ -195,15 +200,21 @@ interactivityApiStore( {
 			},
 			handlePreviousImageButtonClick: ( store: Store ) => {
 				const { context } = store;
-				const imagesIds = context.woocommerce[ context.woocommerce.isDialogOpen ? 'dialogVisibleImagesIds' : 'visibleImagesIds' ];
+				const imagesIds =
+					context.woocommerce[
+						context.woocommerce.isDialogOpen
+							? 'dialogVisibleImagesIds'
+							: 'visibleImagesIds'
+					];
 				const selectedImageIdIndex = imagesIds.indexOf(
-						context.woocommerce.selectedImage
-					);
+					context.woocommerce.selectedImage
+				);
 				const previousImageIndex = Math.max(
 					selectedImageIdIndex - 1,
 					0
 				);
-				context.woocommerce.selectedImage = imagesIds[ previousImageIndex ];
+				context.woocommerce.selectedImage =
+					imagesIds[ previousImageIndex ];
 			},
 		},
 	},

--- a/assets/js/blocks/product-gallery/frontend.tsx
+++ b/assets/js/blocks/product-gallery/frontend.tsx
@@ -12,6 +12,7 @@ export interface ProductGalleryInteractivityApiContext {
 		selectedImage: string;
 		imageId: string;
 		visibleImagesIds: string[];
+		dialogVisibleImagesIds: string[];
 		isDialogOpen: boolean;
 		productId: string;
 	};
@@ -181,30 +182,28 @@ interactivityApiStore( {
 			},
 			handleNextImageButtonClick: ( store: Store ) => {
 				const { context } = store;
-				const selectedImageIdIndex =
-					context.woocommerce.visibleImagesIds.indexOf(
+				const imagesIds = context.woocommerce[ context.woocommerce.isDialogOpen ? 'dialogVisibleImagesIds' : 'visibleImagesIds' ];
+				const selectedImageIdIndex = imagesIds.indexOf(
 						context.woocommerce.selectedImage
 					);
 				const nextImageIndex = Math.min(
 					selectedImageIdIndex + 1,
-					context.woocommerce.visibleImagesIds.length - 1
+					imagesIds.length - 1
 				);
 
-				context.woocommerce.selectedImage =
-					context.woocommerce.visibleImagesIds[ nextImageIndex ];
+				context.woocommerce.selectedImage = imagesIds[ nextImageIndex ];
 			},
 			handlePreviousImageButtonClick: ( store: Store ) => {
 				const { context } = store;
-				const selectedImageIdIndex =
-					context.woocommerce.visibleImagesIds.indexOf(
+				const imagesIds = context.woocommerce[ context.woocommerce.isDialogOpen ? 'dialogVisibleImagesIds' : 'visibleImagesIds' ];
+				const selectedImageIdIndex = imagesIds.indexOf(
 						context.woocommerce.selectedImage
 					);
 				const previousImageIndex = Math.max(
 					selectedImageIdIndex - 1,
 					0
 				);
-				context.woocommerce.selectedImage =
-					context.woocommerce.visibleImagesIds[ previousImageIndex ];
+				context.woocommerce.selectedImage = imagesIds[ previousImageIndex ];
 			},
 		},
 	},

--- a/src/BlockTypes/ProductGallery.php
+++ b/src/BlockTypes/ProductGallery.php
@@ -138,12 +138,12 @@ class ProductGallery extends AbstractBlock {
 				wp_json_encode(
 					array(
 						'woocommerce' => array(
-							'selectedImage'                   => $product->get_image_id(),
-							'visibleImagesIds'                => ProductGalleryUtils::get_product_gallery_image_ids( $product, $number_of_thumbnails, true ),
-							'dialogVisibleImagesIds'          => ProductGalleryUtils::get_product_gallery_image_ids( $product, null, false ),
+							'selectedImage'          => $product->get_image_id(),
+							'visibleImagesIds'       => ProductGalleryUtils::get_product_gallery_image_ids( $product, $number_of_thumbnails, true ),
+							'dialogVisibleImagesIds' => ProductGalleryUtils::get_product_gallery_image_ids( $product, null, false ),
 							'mouseIsOverPreviousOrNextButton' => false,
-							'isDialogOpen'                    => false,
-							'productId'                       => $product_id,
+							'isDialogOpen'           => false,
+							'productId'              => $product_id,
 						),
 					)
 				)

--- a/src/BlockTypes/ProductGallery.php
+++ b/src/BlockTypes/ProductGallery.php
@@ -138,11 +138,12 @@ class ProductGallery extends AbstractBlock {
 				wp_json_encode(
 					array(
 						'woocommerce' => array(
-							'selectedImage'    => $product->get_image_id(),
-							'visibleImagesIds' => ProductGalleryUtils::get_product_gallery_image_ids( $product, $number_of_thumbnails, true ),
+							'selectedImage'                   => $product->get_image_id(),
+							'visibleImagesIds'                => ProductGalleryUtils::get_product_gallery_image_ids( $product, $number_of_thumbnails, true ),
+							'dialogVisibleImagesIds'          => ProductGalleryUtils::get_product_gallery_image_ids( $product, null, false ),
 							'mouseIsOverPreviousOrNextButton' => false,
-							'isDialogOpen'     => false,
-							'productId'        => $product_id,
+							'isDialogOpen'                    => false,
+							'productId'                       => $product_id,
 						),
 					)
 				)


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/11291

The available thumbnails in the dialog were not able to be navigated.

## Why

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

So users can see all the available thumbnails in the dialog.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Go to Appearance->Editor->Templates->Single Product Template.
2. (Convert the template from Classic if necessary). Add the Product Gallery Block. Left default settings.
3. In the frontend, choose a product that has at least 5 product gallery images.
4. Click on the main product image to open up the dialog box.
5. Click on the next navigation button and ensure you can scroll through ALL the product gallery images.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> N/A
