### PR TITLE
Block Hooks: Auto insert the Mini Cart block into the themes header template part

### DIFF
--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -73,6 +73,7 @@ class MiniCart extends AbstractBlock {
 		parent::initialize();
 		add_action( 'wp_loaded', array( $this, 'register_empty_cart_message_block_pattern' ) );
 		add_action( 'wp_print_footer_scripts', array( $this, 'print_lazy_load_scripts' ), 2 );
+		add_filter( 'hooked_block_types', array( $this, 'auto_insert_into_header_template_part' ), 10, 4 );
 	}
 
 	/**
@@ -586,5 +587,29 @@ class MiniCart extends AbstractBlock {
 	 */
 	public function should_not_render_mini_cart( array $attributes ) {
 		return isset( $attributes['cartAndCheckoutRenderStyle'] ) && 'hidden' !== $attributes['cartAndCheckoutRenderStyle'];
+	}
+
+	/**
+	 * Uses Block Hooks to automatically insert the Mini Cart block after the Navigation block in the header template part.
+	 *
+	 * @param array              $hooked_blocks Blocks to be hooked.
+	 * @param string             $position Where to hook the block in relation to its anchor.
+	 * @param string             $anchor_block The anchor block where we are hooking the Mini Cart block.
+	 * @param \WP_Block_Template $context The context of the block.
+	 *
+	 * @return array
+	 */
+	public function auto_insert_into_header_template_part( $hooked_blocks, $position, $anchor_block, $context ) {
+		if ( $context instanceof \WP_Block_Template ) {
+			if (
+				'core/navigation' === $anchor_block &&
+				'after' === $position &&
+				'header' === $context->area
+			) {
+				$hooked_blocks[] = 'woocommerce/mini-cart';
+			}
+		}
+
+		return $hooked_blocks;
 	}
 }

--- a/src/BlockTypes/MiniCart.php
+++ b/src/BlockTypes/MiniCart.php
@@ -606,7 +606,7 @@ class MiniCart extends AbstractBlock {
 				'after' === $position &&
 				'header' === $context->area
 			) {
-				$hooked_blocks[] = 'woocommerce/mini-cart';
+				$hooked_blocks[] = $this->namespace . '/' . $this->block_name;
 			}
 		}
 


### PR DESCRIPTION
# EXPERIMENTAL: DO NOT MERGE

<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Automatically inserts the Mini Cart block into the themes header template part

Fixes #

## Why

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

Most online stores have a mini cart in the headers, auto inserting this means that the merchant doesn't have to do this himself.

You are able to insert this via `block.json` and specifying the `core/navigation` block as the anchor block but the problem with that approach is that everywhere that block is used we will auto insert the Mini Cart. Using this approach we can be a bit more specific and just target the `core/navigation` block in the themes header template part.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Load your website and check that the Mini Cart block is present in the header after the navigation
2. Load the Editor and check that it is in the correct position in this context too.
3. Check that it looks acceptable. The risk of doing this means we do not have full control over how it is going to look since we are inserting it into every website irrespective of theme used so it could look odd in certain themes by wrapping onto another line due to spacing.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Mini Cart: Auto insert into header using Block Hooks.
