### PR TITLE
Replace phpcs rule

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 	"require-dev": {
 		"phpunit/phpunit": "9.6.13",
 		"phpunit/php-code-coverage": "9.2.29",
-		"woocommerce/woocommerce-sniffs": "0.1.3",
+		"woocommerce/woocommerce-sniffs": "1.0.0",
 		"phpdocumentor/reflection": "3.0.1",
 		"yoast/phpunit-polyfills": "2.0.0",
 		"nikic/php-parser": "4.16.0 as 1.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -1,3303 +1,3452 @@
 {
-    "_readme": [
-        "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
-        "This file is @generated automatically"
-    ],
-    "content-hash": "cc276b92e545efcc29db6103d53b6480",
-    "packages": [
-        {
-            "name": "automattic/jetpack-a8c-mc-stats",
-            "version": "v1.4.22",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Automattic/jetpack-a8c-mc-stats.git",
-                "reference": "d7fdf2fc7ae33d75e24e82d81269e33ec718446f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-a8c-mc-stats/zipball/d7fdf2fc7ae33d75e24e82d81269e33ec718446f",
-                "reference": "d7fdf2fc7ae33d75e24e82d81269e33ec718446f",
-                "shasum": ""
-            },
-            "require-dev": {
-                "automattic/jetpack-changelogger": "^3.3.9",
-                "yoast/phpunit-polyfills": "1.1.0"
-            },
-            "suggest": {
-                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
-            },
-            "type": "jetpack-library",
-            "extra": {
-                "autotagger": true,
-                "mirror-repo": "Automattic/jetpack-a8c-mc-stats",
-                "changelogger": {
-                    "link-template": "https://github.com/Automattic/jetpack-a8c-mc-stats/compare/v${old}...v${new}"
-                },
-                "branch-alias": {
-                    "dev-trunk": "1.4.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Used to record internal usage stats for Automattic. Not visible to site owners.",
-            "support": {
-                "source": "https://github.com/Automattic/jetpack-a8c-mc-stats/tree/v1.4.22"
-            },
-            "time": "2023-09-19T18:18:33+00:00"
-        },
-        {
-            "name": "automattic/jetpack-admin-ui",
-            "version": "v0.2.25",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Automattic/jetpack-admin-ui.git",
-                "reference": "d9566f47ab310d675779273eeead6d0ca64fff82"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-admin-ui/zipball/d9566f47ab310d675779273eeead6d0ca64fff82",
-                "reference": "d9566f47ab310d675779273eeead6d0ca64fff82",
-                "shasum": ""
-            },
-            "require-dev": {
-                "automattic/jetpack-changelogger": "^3.3.11",
-                "automattic/jetpack-logo": "^1.6.3",
-                "automattic/wordbless": "dev-master",
-                "yoast/phpunit-polyfills": "1.1.0"
-            },
-            "suggest": {
-                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
-            },
-            "type": "jetpack-library",
-            "extra": {
-                "autotagger": true,
-                "mirror-repo": "Automattic/jetpack-admin-ui",
-                "textdomain": "jetpack-admin-ui",
-                "changelogger": {
-                    "link-template": "https://github.com/Automattic/jetpack-admin-ui/compare/${old}...${new}"
-                },
-                "branch-alias": {
-                    "dev-trunk": "0.2.x-dev"
-                },
-                "version-constants": {
-                    "::PACKAGE_VERSION": "src/class-admin-menu.php"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Generic Jetpack wp-admin UI elements",
-            "support": {
-                "source": "https://github.com/Automattic/jetpack-admin-ui/tree/v0.2.25"
-            },
-            "time": "2023-11-14T16:36:17+00:00"
-        },
-        {
-            "name": "automattic/jetpack-autoloader",
-            "version": "v2.12.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Automattic/jetpack-autoloader.git",
-                "reference": "632b69cfc73ed5505f2b03165e7f68d414d0da12"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/632b69cfc73ed5505f2b03165e7f68d414d0da12",
-                "reference": "632b69cfc73ed5505f2b03165e7f68d414d0da12",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": "^1.1 || ^2.0"
-            },
-            "require-dev": {
-                "automattic/jetpack-changelogger": "^3.3.11",
-                "yoast/phpunit-polyfills": "1.1.0"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "autotagger": true,
-                "class": "Automattic\\Jetpack\\Autoloader\\CustomAutoloaderPlugin",
-                "mirror-repo": "Automattic/jetpack-autoloader",
-                "changelogger": {
-                    "link-template": "https://github.com/Automattic/jetpack-autoloader/compare/v${old}...v${new}"
-                },
-                "version-constants": {
-                    "::VERSION": "src/AutoloadGenerator.php"
-                },
-                "branch-alias": {
-                    "dev-trunk": "2.12.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Automattic\\Jetpack\\Autoloader\\": "src"
-                },
-                "classmap": [
-                    "src/AutoloadGenerator.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Creates a custom autoloader for a plugin or theme.",
-            "keywords": [
-                "autoload",
-                "autoloader",
-                "composer",
-                "jetpack",
-                "plugin",
-                "wordpress"
-            ],
-            "support": {
-                "source": "https://github.com/Automattic/jetpack-autoloader/tree/v2.12.0"
-            },
-            "time": "2023-09-28T18:33:34+00:00"
-        },
-        {
-            "name": "automattic/jetpack-config",
-            "version": "v1.15.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Automattic/jetpack-config.git",
-                "reference": "6cf8d61a972530322c9b62f7375fff83342c38f9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-config/zipball/6cf8d61a972530322c9b62f7375fff83342c38f9",
-                "reference": "6cf8d61a972530322c9b62f7375fff83342c38f9",
-                "shasum": ""
-            },
-            "require-dev": {
-                "automattic/jetpack-changelogger": "^3.3.9"
-            },
-            "suggest": {
-                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
-            },
-            "type": "jetpack-library",
-            "extra": {
-                "autotagger": true,
-                "mirror-repo": "Automattic/jetpack-config",
-                "textdomain": "jetpack-config",
-                "changelogger": {
-                    "link-template": "https://github.com/Automattic/jetpack-config/compare/v${old}...v${new}"
-                },
-                "branch-alias": {
-                    "dev-trunk": "1.15.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Jetpack configuration package that initializes other packages and configures Jetpack's functionality. Can be used as a base for all variants of Jetpack package usage.",
-            "support": {
-                "source": "https://github.com/Automattic/jetpack-config/tree/v1.15.4"
-            },
-            "time": "2023-09-19T18:18:30+00:00"
-        },
-        {
-            "name": "automattic/jetpack-connection",
-            "version": "v1.60.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Automattic/jetpack-connection.git",
-                "reference": "fc99f0a4d8839b69341a25f9059b872d426f3e9d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-connection/zipball/fc99f0a4d8839b69341a25f9059b872d426f3e9d",
-                "reference": "fc99f0a4d8839b69341a25f9059b872d426f3e9d",
-                "shasum": ""
-            },
-            "require": {
-                "automattic/jetpack-a8c-mc-stats": "^1.4.22",
-                "automattic/jetpack-admin-ui": "^0.2.25",
-                "automattic/jetpack-constants": "^1.6.23",
-                "automattic/jetpack-redirect": "^1.7.27",
-                "automattic/jetpack-roles": "^1.4.25",
-                "automattic/jetpack-status": "^1.19.0"
-            },
-            "require-dev": {
-                "automattic/jetpack-changelogger": "^3.3.11",
-                "automattic/wordbless": "@dev",
-                "brain/monkey": "2.6.1",
-                "yoast/phpunit-polyfills": "1.1.0"
-            },
-            "suggest": {
-                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
-            },
-            "type": "jetpack-library",
-            "extra": {
-                "autotagger": true,
-                "mirror-repo": "Automattic/jetpack-connection",
-                "textdomain": "jetpack-connection",
-                "version-constants": {
-                    "::PACKAGE_VERSION": "src/class-package-version.php"
-                },
-                "changelogger": {
-                    "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
-                },
-                "branch-alias": {
-                    "dev-trunk": "1.60.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "legacy",
-                    "src/",
-                    "src/webhooks"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Everything needed to connect to the Jetpack infrastructure",
-            "support": {
-                "source": "https://github.com/Automattic/jetpack-connection/tree/v1.60.1"
-            },
-            "time": "2023-11-14T16:36:48+00:00"
-        },
-        {
-            "name": "automattic/jetpack-constants",
-            "version": "v1.6.23",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Automattic/jetpack-constants.git",
-                "reference": "0825fb1fa94956f26adebc01be0d716a0fd3ade0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-constants/zipball/0825fb1fa94956f26adebc01be0d716a0fd3ade0",
-                "reference": "0825fb1fa94956f26adebc01be0d716a0fd3ade0",
-                "shasum": ""
-            },
-            "require-dev": {
-                "automattic/jetpack-changelogger": "^3.3.8",
-                "brain/monkey": "2.6.1",
-                "yoast/phpunit-polyfills": "1.1.0"
-            },
-            "suggest": {
-                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
-            },
-            "type": "jetpack-library",
-            "extra": {
-                "autotagger": true,
-                "mirror-repo": "Automattic/jetpack-constants",
-                "changelogger": {
-                    "link-template": "https://github.com/Automattic/jetpack-constants/compare/v${old}...v${new}"
-                },
-                "branch-alias": {
-                    "dev-trunk": "1.6.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "A wrapper for defining constants in a more testable way.",
-            "support": {
-                "source": "https://github.com/Automattic/jetpack-constants/tree/v1.6.23"
-            },
-            "time": "2023-08-23T17:56:35+00:00"
-        },
-        {
-            "name": "automattic/jetpack-redirect",
-            "version": "v1.7.27",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Automattic/jetpack-redirect.git",
-                "reference": "43dd3ae2bef71281fe70f62733bfaa44c988f1b1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-redirect/zipball/43dd3ae2bef71281fe70f62733bfaa44c988f1b1",
-                "reference": "43dd3ae2bef71281fe70f62733bfaa44c988f1b1",
-                "shasum": ""
-            },
-            "require": {
-                "automattic/jetpack-status": "^1.18.4"
-            },
-            "require-dev": {
-                "automattic/jetpack-changelogger": "^3.3.9",
-                "brain/monkey": "2.6.1",
-                "yoast/phpunit-polyfills": "1.1.0"
-            },
-            "suggest": {
-                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
-            },
-            "type": "jetpack-library",
-            "extra": {
-                "autotagger": true,
-                "mirror-repo": "Automattic/jetpack-redirect",
-                "changelogger": {
-                    "link-template": "https://github.com/Automattic/jetpack-redirect/compare/v${old}...v${new}"
-                },
-                "branch-alias": {
-                    "dev-trunk": "1.7.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Utilities to build URLs to the jetpack.com/redirect/ service",
-            "support": {
-                "source": "https://github.com/Automattic/jetpack-redirect/tree/v1.7.27"
-            },
-            "time": "2023-09-19T18:19:22+00:00"
-        },
-        {
-            "name": "automattic/jetpack-roles",
-            "version": "v1.4.25",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Automattic/jetpack-roles.git",
-                "reference": "708b33f16a879fc2ab5939a972c968c9aeefbe38"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-roles/zipball/708b33f16a879fc2ab5939a972c968c9aeefbe38",
-                "reference": "708b33f16a879fc2ab5939a972c968c9aeefbe38",
-                "shasum": ""
-            },
-            "require-dev": {
-                "automattic/jetpack-changelogger": "^3.3.9",
-                "brain/monkey": "2.6.1",
-                "yoast/phpunit-polyfills": "1.1.0"
-            },
-            "suggest": {
-                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
-            },
-            "type": "jetpack-library",
-            "extra": {
-                "autotagger": true,
-                "mirror-repo": "Automattic/jetpack-roles",
-                "changelogger": {
-                    "link-template": "https://github.com/Automattic/jetpack-roles/compare/v${old}...v${new}"
-                },
-                "branch-alias": {
-                    "dev-trunk": "1.4.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Utilities, related with user roles and capabilities.",
-            "support": {
-                "source": "https://github.com/Automattic/jetpack-roles/tree/v1.4.25"
-            },
-            "time": "2023-09-19T18:18:38+00:00"
-        },
-        {
-            "name": "automattic/jetpack-status",
-            "version": "v1.19.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Automattic/jetpack-status.git",
-                "reference": "3281c2311752e9df1b2809d8feacb7bf7b9b7b8d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-status/zipball/3281c2311752e9df1b2809d8feacb7bf7b9b7b8d",
-                "reference": "3281c2311752e9df1b2809d8feacb7bf7b9b7b8d",
-                "shasum": ""
-            },
-            "require": {
-                "automattic/jetpack-constants": "^1.6.23"
-            },
-            "require-dev": {
-                "automattic/jetpack-changelogger": "^3.3.11",
-                "automattic/jetpack-ip": "^0.1.6",
-                "brain/monkey": "2.6.1",
-                "yoast/phpunit-polyfills": "1.1.0"
-            },
-            "suggest": {
-                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
-            },
-            "type": "jetpack-library",
-            "extra": {
-                "autotagger": true,
-                "mirror-repo": "Automattic/jetpack-status",
-                "changelogger": {
-                    "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
-                },
-                "branch-alias": {
-                    "dev-trunk": "1.19.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Used to retrieve information about the current status of Jetpack and the site overall.",
-            "support": {
-                "source": "https://github.com/Automattic/jetpack-status/tree/v1.19.0"
-            },
-            "time": "2023-11-13T13:50:12+00:00"
-        },
-        {
-            "name": "composer/installers",
-            "version": "v1.12.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/installers.git",
-                "reference": "d20a64ed3c94748397ff5973488761b22f6d3f19"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/installers/zipball/d20a64ed3c94748397ff5973488761b22f6d3f19",
-                "reference": "d20a64ed3c94748397ff5973488761b22f6d3f19",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": "^1.0 || ^2.0"
-            },
-            "replace": {
-                "roundcube/plugin-installer": "*",
-                "shama/baton": "*"
-            },
-            "require-dev": {
-                "composer/composer": "1.6.* || ^2.0",
-                "composer/semver": "^1 || ^3",
-                "phpstan/phpstan": "^0.12.55",
-                "phpstan/phpstan-phpunit": "^0.12.16",
-                "symfony/phpunit-bridge": "^4.2 || ^5",
-                "symfony/process": "^2.3"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "Composer\\Installers\\Plugin",
-                "branch-alias": {
-                    "dev-main": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Composer\\Installers\\": "src/Composer/Installers"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Kyle Robinson Young",
-                    "email": "kyle@dontkry.com",
-                    "homepage": "https://github.com/shama"
-                }
-            ],
-            "description": "A multi-framework Composer library installer",
-            "homepage": "https://composer.github.io/installers/",
-            "keywords": [
-                "Craft",
-                "Dolibarr",
-                "Eliasis",
-                "Hurad",
-                "ImageCMS",
-                "Kanboard",
-                "Lan Management System",
-                "MODX Evo",
-                "MantisBT",
-                "Mautic",
-                "Maya",
-                "OXID",
-                "Plentymarkets",
-                "Porto",
-                "RadPHP",
-                "SMF",
-                "Starbug",
-                "Thelia",
-                "Whmcs",
-                "WolfCMS",
-                "agl",
-                "aimeos",
-                "annotatecms",
-                "attogram",
-                "bitrix",
-                "cakephp",
-                "chef",
-                "cockpit",
-                "codeigniter",
-                "concrete5",
-                "croogo",
-                "dokuwiki",
-                "drupal",
-                "eZ Platform",
-                "elgg",
-                "expressionengine",
-                "fuelphp",
-                "grav",
-                "installer",
-                "itop",
-                "joomla",
-                "known",
-                "kohana",
-                "laravel",
-                "lavalite",
-                "lithium",
-                "magento",
-                "majima",
-                "mako",
-                "mediawiki",
-                "miaoxing",
-                "modulework",
-                "modx",
-                "moodle",
-                "osclass",
-                "pantheon",
-                "phpbb",
-                "piwik",
-                "ppi",
-                "processwire",
-                "puppet",
-                "pxcms",
-                "reindex",
-                "roundcube",
-                "shopware",
-                "silverstripe",
-                "sydes",
-                "sylius",
-                "symfony",
-                "tastyigniter",
-                "typo3",
-                "wordpress",
-                "yawik",
-                "zend",
-                "zikula"
-            ],
-            "support": {
-                "issues": "https://github.com/composer/installers/issues",
-                "source": "https://github.com/composer/installers/tree/v1.12.0"
-            },
-            "funding": [
-                {
-                    "url": "https://packagist.com",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/composer",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2021-09-13T08:19:44+00:00"
-        }
-    ],
-    "packages-dev": [
-        {
-            "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v0.7.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
-                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
-                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": "^1.0 || ^2.0",
-                "php": ">=5.3",
-                "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
-            },
-            "require-dev": {
-                "composer/composer": "*",
-                "php-parallel-lint/php-parallel-lint": "^1.3.1",
-                "phpcompatibility/php-compatibility": "^9.0"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
-            },
-            "autoload": {
-                "psr-4": {
-                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Franck Nijhof",
-                    "email": "franck.nijhof@dealerdirect.com",
-                    "homepage": "http://www.frenck.nl",
-                    "role": "Developer / IT Manager"
-                },
-                {
-                    "name": "Contributors",
-                    "homepage": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer/graphs/contributors"
-                }
-            ],
-            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
-            "homepage": "http://www.dealerdirect.com",
-            "keywords": [
-                "PHPCodeSniffer",
-                "PHP_CodeSniffer",
-                "code quality",
-                "codesniffer",
-                "composer",
-                "installer",
-                "phpcbf",
-                "phpcs",
-                "plugin",
-                "qa",
-                "quality",
-                "standard",
-                "standards",
-                "style guide",
-                "stylecheck",
-                "tests"
-            ],
-            "support": {
-                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
-                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
-            },
-            "time": "2022-02-04T12:51:07+00:00"
-        },
-        {
-            "name": "doctrine/instantiator",
-            "version": "1.5.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
-                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1 || ^8.0"
-            },
-            "require-dev": {
-                "doctrine/coding-standard": "^9 || ^11",
-                "ext-pdo": "*",
-                "ext-phar": "*",
-                "phpbench/phpbench": "^0.16 || ^1",
-                "phpstan/phpstan": "^1.4",
-                "phpstan/phpstan-phpunit": "^1",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "vimeo/psalm": "^4.30 || ^5.4"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com",
-                    "homepage": "https://ocramius.github.io/"
-                }
-            ],
-            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
-            "keywords": [
-                "constructor",
-                "instantiate"
-            ],
-            "support": {
-                "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/1.5.0"
-            },
-            "funding": [
-                {
-                    "url": "https://www.doctrine-project.org/sponsorship.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://www.patreon.com/phpdoctrine",
-                    "type": "patreon"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-12-30T00:15:36+00:00"
-        },
-        {
-            "name": "erusev/parsedown",
-            "version": "1.7.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/erusev/parsedown.git",
-                "reference": "cb17b6477dfff935958ba01325f2e8a2bfa6dab3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/erusev/parsedown/zipball/cb17b6477dfff935958ba01325f2e8a2bfa6dab3",
-                "reference": "cb17b6477dfff935958ba01325f2e8a2bfa6dab3",
-                "shasum": ""
-            },
-            "require": {
-                "ext-mbstring": "*",
-                "php": ">=5.3.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.8.35"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "Parsedown": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Emanuil Rusev",
-                    "email": "hello@erusev.com",
-                    "homepage": "http://erusev.com"
-                }
-            ],
-            "description": "Parser for Markdown.",
-            "homepage": "http://parsedown.org",
-            "keywords": [
-                "markdown",
-                "parser"
-            ],
-            "support": {
-                "issues": "https://github.com/erusev/parsedown/issues",
-                "source": "https://github.com/erusev/parsedown/tree/1.7.x"
-            },
-            "time": "2019-12-30T22:54:17+00:00"
-        },
-        {
-            "name": "hamcrest/hamcrest-php",
-            "version": "v2.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/hamcrest/hamcrest-php.git",
-                "reference": "8c3d0a3f6af734494ad8f6fbbee0ba92422859f3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/8c3d0a3f6af734494ad8f6fbbee0ba92422859f3",
-                "reference": "8c3d0a3f6af734494ad8f6fbbee0ba92422859f3",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3|^7.0|^8.0"
-            },
-            "replace": {
-                "cordoval/hamcrest-php": "*",
-                "davedevelopment/hamcrest-php": "*",
-                "kodova/hamcrest-php": "*"
-            },
-            "require-dev": {
-                "phpunit/php-file-iterator": "^1.4 || ^2.0",
-                "phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.1-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "hamcrest"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "This is the PHP port of Hamcrest Matchers",
-            "keywords": [
-                "test"
-            ],
-            "support": {
-                "issues": "https://github.com/hamcrest/hamcrest-php/issues",
-                "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.0.1"
-            },
-            "time": "2020-07-09T08:09:16+00:00"
-        },
-        {
-            "name": "johnbillion/wp-parser-lib",
-            "version": "1.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/johnbillion/wp-parser-lib.git",
-                "reference": "46ed07365f8bd22f1edc828f9cfeed0c0f2c7d07"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/johnbillion/wp-parser-lib/zipball/46ed07365f8bd22f1edc828f9cfeed0c0f2c7d07",
-                "reference": "46ed07365f8bd22f1edc828f9cfeed0c0f2c7d07",
-                "shasum": ""
-            },
-            "require": {
-                "composer/installers": "~1.0",
-                "erusev/parsedown": "~1.7",
-                "php": ">=5.4",
-                "phpdocumentor/reflection": "~3.0"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "lib/runner.php"
-                ],
-                "classmap": [
-                    "lib"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "Ryan McCue",
-                    "homepage": "http://ryanmccue.info",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Contributors",
-                    "homepage": "https://github.com/johnbillion/wp-parser-lib/graphs/contributors"
-                }
-            ],
-            "description": "File scanning and hook parsing functionality from WP Parser.",
-            "homepage": "https://github.com/johnbillion/wp-parser-lib",
-            "keywords": [
-                "wordpress"
-            ],
-            "support": {
-                "issues": "https://github.com/johnbillion/wp-parser-lib/issues",
-                "source": "https://github.com/johnbillion/wp-parser-lib/tree/1.3.0"
-            },
-            "time": "2022-01-27T13:57:08+00:00"
-        },
-        {
-            "name": "mockery/mockery",
-            "version": "1.6.6",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/mockery/mockery.git",
-                "reference": "b8e0bb7d8c604046539c1115994632c74dcb361e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/mockery/mockery/zipball/b8e0bb7d8c604046539c1115994632c74dcb361e",
-                "reference": "b8e0bb7d8c604046539c1115994632c74dcb361e",
-                "shasum": ""
-            },
-            "require": {
-                "hamcrest/hamcrest-php": "^2.0.1",
-                "lib-pcre": ">=7.0",
-                "php": ">=7.3"
-            },
-            "conflict": {
-                "phpunit/phpunit": "<8.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^8.5 || ^9.6.10",
-                "psalm/plugin-phpunit": "^0.18.4",
-                "symplify/easy-coding-standard": "^11.5.0",
-                "vimeo/psalm": "^4.30"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "library/helpers.php",
-                    "library/Mockery.php"
-                ],
-                "psr-4": {
-                    "Mockery\\": "library/Mockery"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Pádraic Brady",
-                    "email": "padraic.brady@gmail.com",
-                    "homepage": "https://github.com/padraic",
-                    "role": "Author"
-                },
-                {
-                    "name": "Dave Marshall",
-                    "email": "dave.marshall@atstsolutions.co.uk",
-                    "homepage": "https://davedevelopment.co.uk",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Nathanael Esayeas",
-                    "email": "nathanael.esayeas@protonmail.com",
-                    "homepage": "https://github.com/ghostwriter",
-                    "role": "Lead Developer"
-                }
-            ],
-            "description": "Mockery is a simple yet flexible PHP mock object framework",
-            "homepage": "https://github.com/mockery/mockery",
-            "keywords": [
-                "BDD",
-                "TDD",
-                "library",
-                "mock",
-                "mock objects",
-                "mockery",
-                "stub",
-                "test",
-                "test double",
-                "testing"
-            ],
-            "support": {
-                "docs": "https://docs.mockery.io/",
-                "issues": "https://github.com/mockery/mockery/issues",
-                "rss": "https://github.com/mockery/mockery/releases.atom",
-                "security": "https://github.com/mockery/mockery/security/advisories",
-                "source": "https://github.com/mockery/mockery"
-            },
-            "time": "2023-08-09T00:03:52+00:00"
-        },
-        {
-            "name": "myclabs/deep-copy",
-            "version": "1.11.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
-                "reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1 || ^8.0"
-            },
-            "conflict": {
-                "doctrine/collections": "<1.6.8",
-                "doctrine/common": "<2.13.3 || >=3,<3.2.2"
-            },
-            "require-dev": {
-                "doctrine/collections": "^1.6.8",
-                "doctrine/common": "^2.13.3 || ^3.2.2",
-                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/DeepCopy/deep_copy.php"
-                ],
-                "psr-4": {
-                    "DeepCopy\\": "src/DeepCopy/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Create deep copies (clones) of your objects",
-            "keywords": [
-                "clone",
-                "copy",
-                "duplicate",
-                "object",
-                "object graph"
-            ],
-            "support": {
-                "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.11.1"
-            },
-            "funding": [
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-03-08T13:26:56+00:00"
-        },
-        {
-            "name": "nikic/php-parser",
-            "version": "v4.16.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "19526a33fb561ef417e822e85f08a00db4059c17"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/19526a33fb561ef417e822e85f08a00db4059c17",
-                "reference": "19526a33fb561ef417e822e85f08a00db4059c17",
-                "shasum": ""
-            },
-            "require": {
-                "ext-tokenizer": "*",
-                "php": ">=7.0"
-            },
-            "require-dev": {
-                "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
-            },
-            "bin": [
-                "bin/php-parse"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.9-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "PhpParser\\": "lib/PhpParser"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Nikita Popov"
-                }
-            ],
-            "description": "A PHP parser written in PHP",
-            "keywords": [
-                "parser",
-                "php"
-            ],
-            "support": {
-                "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.16.0"
-            },
-            "time": "2023-06-25T14:52:30+00:00"
-        },
-        {
-            "name": "phar-io/manifest",
-            "version": "2.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phar-io/manifest.git",
-                "reference": "97803eca37d319dfa7826cc2437fc020857acb53"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/97803eca37d319dfa7826cc2437fc020857acb53",
-                "reference": "97803eca37d319dfa7826cc2437fc020857acb53",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "ext-phar": "*",
-                "ext-xmlwriter": "*",
-                "phar-io/version": "^3.0.1",
-                "php": "^7.2 || ^8.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Arne Blankerts",
-                    "email": "arne@blankerts.de",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Sebastian Heuer",
-                    "email": "sebastian@phpeople.de",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
-            "support": {
-                "issues": "https://github.com/phar-io/manifest/issues",
-                "source": "https://github.com/phar-io/manifest/tree/2.0.3"
-            },
-            "time": "2021-07-20T11:28:43+00:00"
-        },
-        {
-            "name": "phar-io/version",
-            "version": "3.2.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phar-io/version.git",
-                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
-                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2 || ^8.0"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Arne Blankerts",
-                    "email": "arne@blankerts.de",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Sebastian Heuer",
-                    "email": "sebastian@phpeople.de",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "Developer"
-                }
-            ],
-            "description": "Library for handling version information and constraints",
-            "support": {
-                "issues": "https://github.com/phar-io/version/issues",
-                "source": "https://github.com/phar-io/version/tree/3.2.1"
-            },
-            "time": "2022-02-21T01:04:05+00:00"
-        },
-        {
-            "name": "phpcompatibility/php-compatibility",
-            "version": "9.3.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
-                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9fb324479acf6f39452e0655d2429cc0d3914243",
-                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3",
-                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
-            },
-            "conflict": {
-                "squizlabs/php_codesniffer": "2.6.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
-            },
-            "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
-                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
-            },
-            "type": "phpcodesniffer-standard",
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "LGPL-3.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "Wim Godden",
-                    "homepage": "https://github.com/wimg",
-                    "role": "lead"
-                },
-                {
-                    "name": "Juliette Reinders Folmer",
-                    "homepage": "https://github.com/jrfnl",
-                    "role": "lead"
-                },
-                {
-                    "name": "Contributors",
-                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
-                }
-            ],
-            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
-            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
-            "keywords": [
-                "compatibility",
-                "phpcs",
-                "standards"
-            ],
-            "support": {
-                "issues": "https://github.com/PHPCompatibility/PHPCompatibility/issues",
-                "source": "https://github.com/PHPCompatibility/PHPCompatibility"
-            },
-            "time": "2019-12-27T09:44:58+00:00"
-        },
-        {
-            "name": "phpcompatibility/phpcompatibility-paragonie",
-            "version": "1.3.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
-                "reference": "bba5a9dfec7fcfbd679cfaf611d86b4d3759da26"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/bba5a9dfec7fcfbd679cfaf611d86b4d3759da26",
-                "reference": "bba5a9dfec7fcfbd679cfaf611d86b4d3759da26",
-                "shasum": ""
-            },
-            "require": {
-                "phpcompatibility/php-compatibility": "^9.0"
-            },
-            "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
-                "paragonie/random_compat": "dev-master",
-                "paragonie/sodium_compat": "dev-master"
-            },
-            "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
-                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
-            },
-            "type": "phpcodesniffer-standard",
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "LGPL-3.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "Wim Godden",
-                    "role": "lead"
-                },
-                {
-                    "name": "Juliette Reinders Folmer",
-                    "role": "lead"
-                }
-            ],
-            "description": "A set of rulesets for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by the Paragonie polyfill libraries.",
-            "homepage": "http://phpcompatibility.com/",
-            "keywords": [
-                "compatibility",
-                "paragonie",
-                "phpcs",
-                "polyfill",
-                "standards",
-                "static analysis"
-            ],
-            "support": {
-                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/issues",
-                "source": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie"
-            },
-            "time": "2022-10-25T01:46:02+00:00"
-        },
-        {
-            "name": "phpcompatibility/phpcompatibility-wp",
-            "version": "2.1.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
-                "reference": "b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5",
-                "reference": "b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5",
-                "shasum": ""
-            },
-            "require": {
-                "phpcompatibility/php-compatibility": "^9.0",
-                "phpcompatibility/phpcompatibility-paragonie": "^1.0"
-            },
-            "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7"
-            },
-            "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
-                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
-            },
-            "type": "phpcodesniffer-standard",
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "LGPL-3.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "Wim Godden",
-                    "role": "lead"
-                },
-                {
-                    "name": "Juliette Reinders Folmer",
-                    "role": "lead"
-                }
-            ],
-            "description": "A ruleset for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by WordPress.",
-            "homepage": "http://phpcompatibility.com/",
-            "keywords": [
-                "compatibility",
-                "phpcs",
-                "standards",
-                "static analysis",
-                "wordpress"
-            ],
-            "support": {
-                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityWP/issues",
-                "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
-            },
-            "time": "2022-10-24T09:00:36+00:00"
-        },
-        {
-            "name": "phpdocumentor/reflection",
-            "version": "3.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/Reflection.git",
-                "reference": "793bfd92d9a0fc96ae9608fb3e947c3f59fb3a0d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/Reflection/zipball/793bfd92d9a0fc96ae9608fb3e947c3f59fb3a0d",
-                "reference": "793bfd92d9a0fc96ae9608fb3e947c3f59fb3a0d",
-                "shasum": ""
-            },
-            "require": {
-                "nikic/php-parser": "^1.0",
-                "php": ">=5.3.3",
-                "phpdocumentor/reflection-docblock": "~2.0",
-                "psr/log": "~1.0"
-            },
-            "require-dev": {
-                "behat/behat": "~2.4",
-                "mockery/mockery": "~0.8",
-                "phpunit/phpunit": "~4.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "phpDocumentor": [
-                        "src/",
-                        "tests/unit/",
-                        "tests/mocks/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Reflection library to do Static Analysis for PHP Projects",
-            "homepage": "http://www.phpdoc.org",
-            "keywords": [
-                "phpDocumentor",
-                "phpdoc",
-                "reflection",
-                "static analysis"
-            ],
-            "support": {
-                "issues": "https://github.com/phpDocumentor/Reflection/issues",
-                "source": "https://github.com/phpDocumentor/Reflection/tree/master"
-            },
-            "time": "2016-05-21T08:42:32+00:00"
-        },
-        {
-            "name": "phpdocumentor/reflection-docblock",
-            "version": "2.0.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "e6a969a640b00d8daa3c66518b0405fb41ae0c4b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/e6a969a640b00d8daa3c66518b0405fb41ae0c4b",
-                "reference": "e6a969a640b00d8daa3c66518b0405fb41ae0c4b",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.0"
-            },
-            "suggest": {
-                "dflydev/markdown": "~1.0",
-                "erusev/parsedown": "~1.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "phpDocumentor": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "mike.vanriel@naenius.com"
-                }
-            ],
-            "support": {
-                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/release/2.x"
-            },
-            "time": "2016-01-25T08:17:30+00:00"
-        },
-        {
-            "name": "phpunit/php-code-coverage",
-            "version": "9.2.29",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "6a3a87ac2bbe33b25042753df8195ba4aa534c76"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/6a3a87ac2bbe33b25042753df8195ba4aa534c76",
-                "reference": "6a3a87ac2bbe33b25042753df8195ba4aa534c76",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "ext-libxml": "*",
-                "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.15",
-                "php": ">=7.3",
-                "phpunit/php-file-iterator": "^3.0.3",
-                "phpunit/php-text-template": "^2.0.2",
-                "sebastian/code-unit-reverse-lookup": "^2.0.2",
-                "sebastian/complexity": "^2.0",
-                "sebastian/environment": "^5.1.2",
-                "sebastian/lines-of-code": "^1.0.3",
-                "sebastian/version": "^3.0.1",
-                "theseer/tokenizer": "^1.2.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3"
-            },
-            "suggest": {
-                "ext-pcov": "PHP extension that provides line coverage",
-                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "9.2-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
-            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
-            "keywords": [
-                "coverage",
-                "testing",
-                "xunit"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.29"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2023-09-19T04:57:46+00:00"
-        },
-        {
-            "name": "phpunit/php-file-iterator",
-            "version": "3.0.6",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
-                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
-            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
-            "keywords": [
-                "filesystem",
-                "iterator"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2021-12-02T12:48:52+00:00"
-        },
-        {
-            "name": "phpunit/php-invoker",
-            "version": "3.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
-                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "ext-pcntl": "*",
-                "phpunit/phpunit": "^9.3"
-            },
-            "suggest": {
-                "ext-pcntl": "*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.1-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Invoke callables with a timeout",
-            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
-            "keywords": [
-                "process"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
-                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-09-28T05:58:55+00:00"
-        },
-        {
-            "name": "phpunit/php-text-template",
-            "version": "2.0.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
-                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Simple template engine.",
-            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
-            "keywords": [
-                "template"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-10-26T05:33:50+00:00"
-        },
-        {
-            "name": "phpunit/php-timer",
-            "version": "5.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
-                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Utility class for timing",
-            "homepage": "https://github.com/sebastianbergmann/php-timer/",
-            "keywords": [
-                "timer"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-10-26T13:16:10+00:00"
-        },
-        {
-            "name": "phpunit/phpunit",
-            "version": "9.6.13",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "f3d767f7f9e191eab4189abe41ab37797e30b1be"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f3d767f7f9e191eab4189abe41ab37797e30b1be",
-                "reference": "f3d767f7f9e191eab4189abe41ab37797e30b1be",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/instantiator": "^1.3.1 || ^2",
-                "ext-dom": "*",
-                "ext-json": "*",
-                "ext-libxml": "*",
-                "ext-mbstring": "*",
-                "ext-xml": "*",
-                "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.10.1",
-                "phar-io/manifest": "^2.0.3",
-                "phar-io/version": "^3.0.2",
-                "php": ">=7.3",
-                "phpunit/php-code-coverage": "^9.2.28",
-                "phpunit/php-file-iterator": "^3.0.5",
-                "phpunit/php-invoker": "^3.1.1",
-                "phpunit/php-text-template": "^2.0.3",
-                "phpunit/php-timer": "^5.0.2",
-                "sebastian/cli-parser": "^1.0.1",
-                "sebastian/code-unit": "^1.0.6",
-                "sebastian/comparator": "^4.0.8",
-                "sebastian/diff": "^4.0.3",
-                "sebastian/environment": "^5.1.3",
-                "sebastian/exporter": "^4.0.5",
-                "sebastian/global-state": "^5.0.1",
-                "sebastian/object-enumerator": "^4.0.3",
-                "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^3.2",
-                "sebastian/version": "^3.0.2"
-            },
-            "suggest": {
-                "ext-soap": "To be able to generate mocks based on WSDL files",
-                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
-            },
-            "bin": [
-                "phpunit"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "9.6-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "src/Framework/Assert/Functions.php"
-                ],
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "The PHP Unit Testing framework.",
-            "homepage": "https://phpunit.de/",
-            "keywords": [
-                "phpunit",
-                "testing",
-                "xunit"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.13"
-            },
-            "funding": [
-                {
-                    "url": "https://phpunit.de/sponsors.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-09-19T05:39:22+00:00"
-        },
-        {
-            "name": "psr/log",
-            "version": "1.1.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/log.git",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
-                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Log\\": "Psr/Log/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for logging libraries",
-            "homepage": "https://github.com/php-fig/log",
-            "keywords": [
-                "log",
-                "psr",
-                "psr-3"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/log/tree/1.1.4"
-            },
-            "time": "2021-05-03T11:20:27+00:00"
-        },
-        {
-            "name": "sebastian/cli-parser",
-            "version": "1.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/442e7c7e687e42adc03470c7b668bc4b2402c0b2",
-                "reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Library for parsing CLI options",
-            "homepage": "https://github.com/sebastianbergmann/cli-parser",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.1"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-09-28T06:08:49+00:00"
-        },
-        {
-            "name": "sebastian/code-unit",
-            "version": "1.0.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
-                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Collection of value objects that represent the PHP code units",
-            "homepage": "https://github.com/sebastianbergmann/code-unit",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-10-26T13:08:54+00:00"
-        },
-        {
-            "name": "sebastian/code-unit-reverse-lookup",
-            "version": "2.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
-                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Looks up which function or method a line of code belongs to",
-            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-09-28T05:30:19+00:00"
-        },
-        {
-            "name": "sebastian/comparator",
-            "version": "4.0.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/fa0f136dd2334583309d32b62544682ee972b51a",
-                "reference": "fa0f136dd2334583309d32b62544682ee972b51a",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3",
-                "sebastian/diff": "^4.0",
-                "sebastian/exporter": "^4.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
-                    "name": "Jeff Welch",
-                    "email": "whatthejeff@gmail.com"
-                },
-                {
-                    "name": "Volker Dusch",
-                    "email": "github@wallbash.com"
-                },
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@2bepublished.at"
-                }
-            ],
-            "description": "Provides the functionality to compare PHP values for equality",
-            "homepage": "https://github.com/sebastianbergmann/comparator",
-            "keywords": [
-                "comparator",
-                "compare",
-                "equality"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.8"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2022-09-14T12:41:17+00:00"
-        },
-        {
-            "name": "sebastian/complexity",
-            "version": "2.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/739b35e53379900cc9ac327b2147867b8b6efd88",
-                "reference": "739b35e53379900cc9ac327b2147867b8b6efd88",
-                "shasum": ""
-            },
-            "require": {
-                "nikic/php-parser": "^4.7",
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Library for calculating the complexity of PHP code units",
-            "homepage": "https://github.com/sebastianbergmann/complexity",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/complexity/issues",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.2"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-10-26T15:52:27+00:00"
-        },
-        {
-            "name": "sebastian/diff",
-            "version": "4.0.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
-                "reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3",
-                "symfony/process": "^4.2 || ^5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
-                    "name": "Kore Nordmann",
-                    "email": "mail@kore-nordmann.de"
-                }
-            ],
-            "description": "Diff implementation",
-            "homepage": "https://github.com/sebastianbergmann/diff",
-            "keywords": [
-                "diff",
-                "udiff",
-                "unidiff",
-                "unified diff"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/diff/issues",
-                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.5"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2023-05-07T05:35:17+00:00"
-        },
-        {
-            "name": "sebastian/environment",
-            "version": "5.1.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
-                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3"
-            },
-            "suggest": {
-                "ext-posix": "*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.1-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Provides functionality to handle HHVM/PHP environments",
-            "homepage": "http://www.github.com/sebastianbergmann/environment",
-            "keywords": [
-                "Xdebug",
-                "environment",
-                "hhvm"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/environment/issues",
-                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2023-02-03T06:03:51+00:00"
-        },
-        {
-            "name": "sebastian/exporter",
-            "version": "4.0.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
-                "reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3",
-                "sebastian/recursion-context": "^4.0"
-            },
-            "require-dev": {
-                "ext-mbstring": "*",
-                "phpunit/phpunit": "^9.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
-                    "name": "Jeff Welch",
-                    "email": "whatthejeff@gmail.com"
-                },
-                {
-                    "name": "Volker Dusch",
-                    "email": "github@wallbash.com"
-                },
-                {
-                    "name": "Adam Harvey",
-                    "email": "aharvey@php.net"
-                },
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
-                }
-            ],
-            "description": "Provides the functionality to export PHP variables for visualization",
-            "homepage": "https://www.github.com/sebastianbergmann/exporter",
-            "keywords": [
-                "export",
-                "exporter"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/exporter/issues",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.5"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2022-09-14T06:03:37+00:00"
-        },
-        {
-            "name": "sebastian/global-state",
-            "version": "5.0.6",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bde739e7565280bda77be70044ac1047bc007e34"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bde739e7565280bda77be70044ac1047bc007e34",
-                "reference": "bde739e7565280bda77be70044ac1047bc007e34",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
-            },
-            "require-dev": {
-                "ext-dom": "*",
-                "phpunit/phpunit": "^9.3"
-            },
-            "suggest": {
-                "ext-uopz": "*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Snapshotting of global state",
-            "homepage": "http://www.github.com/sebastianbergmann/global-state",
-            "keywords": [
-                "global state"
-            ],
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.6"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2023-08-02T09:26:13+00:00"
-        },
-        {
-            "name": "sebastian/lines-of-code",
-            "version": "1.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/c1c2e997aa3146983ed888ad08b15470a2e22ecc",
-                "reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc",
-                "shasum": ""
-            },
-            "require": {
-                "nikic/php-parser": "^4.6",
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Library for counting the lines of code in PHP source code",
-            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.3"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-11-28T06:42:11+00:00"
-        },
-        {
-            "name": "sebastian/object-enumerator",
-            "version": "4.0.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
-                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3",
-                "sebastian/object-reflector": "^2.0",
-                "sebastian/recursion-context": "^4.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
-            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-10-26T13:12:34+00:00"
-        },
-        {
-            "name": "sebastian/object-reflector",
-            "version": "2.0.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
-                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Allows reflection of object attributes, including inherited and non-public ones",
-            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-10-26T13:14:26+00:00"
-        },
-        {
-            "name": "sebastian/recursion-context",
-            "version": "4.0.5",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
-                "reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
-                    "name": "Jeff Welch",
-                    "email": "whatthejeff@gmail.com"
-                },
-                {
-                    "name": "Adam Harvey",
-                    "email": "aharvey@php.net"
-                }
-            ],
-            "description": "Provides functionality to recursively process PHP variables",
-            "homepage": "https://github.com/sebastianbergmann/recursion-context",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.5"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2023-02-03T06:07:39+00:00"
-        },
-        {
-            "name": "sebastian/resource-operations",
-            "version": "3.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
-                "reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                }
-            ],
-            "description": "Provides a list of PHP built-in functions that operate on resources",
-            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
-                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.3"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-09-28T06:45:17+00:00"
-        },
-        {
-            "name": "sebastian/type",
-            "version": "3.2.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
-                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^9.5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.2-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Collection of value objects that represent the types of the PHP type system",
-            "homepage": "https://github.com/sebastianbergmann/type",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2023-02-03T06:13:03+00:00"
-        },
-        {
-            "name": "sebastian/version",
-            "version": "3.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
-                "reference": "c6c1022351a901512170118436c764e473f6de8c",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
-            "homepage": "https://github.com/sebastianbergmann/version",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/version/issues",
-                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2020-09-28T06:39:44+00:00"
-        },
-        {
-            "name": "squizlabs/php_codesniffer",
-            "version": "3.7.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
-                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
-                "shasum": ""
-            },
-            "require": {
-                "ext-simplexml": "*",
-                "ext-tokenizer": "*",
-                "ext-xmlwriter": "*",
-                "php": ">=5.4.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
-            },
-            "bin": [
-                "bin/phpcs",
-                "bin/phpcbf"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.x-dev"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Greg Sherwood",
-                    "role": "lead"
-                }
-            ],
-            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
-            "keywords": [
-                "phpcs",
-                "standards",
-                "static analysis"
-            ],
-            "support": {
-                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
-                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
-                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
-            },
-            "time": "2023-02-22T23:07:41+00:00"
-        },
-        {
-            "name": "theseer/tokenizer",
-            "version": "1.2.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
-                "reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
-                "shasum": ""
-            },
-            "require": {
-                "ext-dom": "*",
-                "ext-tokenizer": "*",
-                "ext-xmlwriter": "*",
-                "php": "^7.2 || ^8.0"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Arne Blankerts",
-                    "email": "arne@blankerts.de",
-                    "role": "Developer"
-                }
-            ],
-            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
-            "support": {
-                "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.2.2"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/theseer",
-                    "type": "github"
-                }
-            ],
-            "time": "2023-11-20T00:12:19+00:00"
-        },
-        {
-            "name": "woocommerce/woocommerce-sniffs",
-            "version": "0.1.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/woocommerce/woocommerce-sniffs.git",
-                "reference": "4576d54595614d689bc4436acff8baaece3c5bb0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-sniffs/zipball/4576d54595614d689bc4436acff8baaece3c5bb0",
-                "reference": "4576d54595614d689bc4436acff8baaece3c5bb0",
-                "shasum": ""
-            },
-            "require": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
-                "php": ">=7.0",
-                "phpcompatibility/phpcompatibility-wp": "^2.1.0",
-                "wp-coding-standards/wpcs": "^2.3.0"
-            },
-            "type": "phpcodesniffer-standard",
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Claudio Sanches",
-                    "email": "claudio@automattic.com"
-                }
-            ],
-            "description": "WooCommerce sniffs",
-            "keywords": [
-                "phpcs",
-                "standards",
-                "woocommerce",
-                "wordpress"
-            ],
-            "support": {
-                "issues": "https://github.com/woocommerce/woocommerce-sniffs/issues",
-                "source": "https://github.com/woocommerce/woocommerce-sniffs/tree/0.1.3"
-            },
-            "time": "2022-02-17T15:34:51+00:00"
-        },
-        {
-            "name": "wp-coding-standards/wpcs",
-            "version": "2.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "7da1894633f168fe244afc6de00d141f27517b62"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
-                "reference": "7da1894633f168fe244afc6de00d141f27517b62",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^3.3.1"
-            },
-            "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
-                "phpcompatibility/php-compatibility": "^9.0",
-                "phpcsstandards/phpcsdevtools": "^1.0",
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
-            },
-            "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
-            },
-            "type": "phpcodesniffer-standard",
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Contributors",
-                    "homepage": "https://github.com/WordPress/WordPress-Coding-Standards/graphs/contributors"
-                }
-            ],
-            "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
-            "keywords": [
-                "phpcs",
-                "standards",
-                "wordpress"
-            ],
-            "support": {
-                "issues": "https://github.com/WordPress/WordPress-Coding-Standards/issues",
-                "source": "https://github.com/WordPress/WordPress-Coding-Standards",
-                "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
-            },
-            "time": "2020-05-13T23:57:56+00:00"
-        },
-        {
-            "name": "wp-hooks/generator",
-            "version": "0.9.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/wp-hooks/generator.git",
-                "reference": "6c7f173d85452db52a59a3a6bb943cbe7d845cde"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/wp-hooks/generator/zipball/6c7f173d85452db52a59a3a6bb943cbe7d845cde",
-                "reference": "6c7f173d85452db52a59a3a6bb943cbe7d845cde",
-                "shasum": ""
-            },
-            "require": {
-                "ext-libxml": "*",
-                "johnbillion/wp-parser-lib": "^1.3.0",
-                "php": ">=7"
-            },
-            "replace": {
-                "johnbillion/wp-hooks-generator": "*"
-            },
-            "require-dev": {
-                "oomphinc/composer-installers-extender": "^2",
-                "opis/json-schema": "^1"
-            },
-            "bin": [
-                "bin/wp-hooks-generator"
-            ],
-            "type": "library",
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-3.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "John Blackbourn",
-                    "homepage": "https://johnblackbourn.com/"
-                }
-            ],
-            "description": "Generates a JSON representation of the WordPress actions and filters in your code",
-            "support": {
-                "issues": "https://github.com/wp-hooks/generator/issues",
-                "source": "https://github.com/wp-hooks/generator/tree/0.9.0"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sponsors/johnbillion",
-                    "type": "github"
-                }
-            ],
-            "time": "2022-07-03T12:35:07+00:00"
-        },
-        {
-            "name": "yoast/phpunit-polyfills",
-            "version": "2.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
-                "reference": "c758753e8f9dac251fed396a73c8305af3f17922"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/c758753e8f9dac251fed396a73c8305af3f17922",
-                "reference": "c758753e8f9dac251fed396a73c8305af3f17922",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.6",
-                "phpunit/phpunit": "^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0"
-            },
-            "require-dev": {
-                "yoast/yoastcs": "^2.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "2.x-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "phpunitpolyfills-autoload.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Team Yoast",
-                    "email": "support@yoast.com",
-                    "homepage": "https://yoast.com"
-                },
-                {
-                    "name": "Contributors",
-                    "homepage": "https://github.com/Yoast/PHPUnit-Polyfills/graphs/contributors"
-                }
-            ],
-            "description": "Set of polyfills for changed PHPUnit functionality to allow for creating PHPUnit cross-version compatible tests",
-            "homepage": "https://github.com/Yoast/PHPUnit-Polyfills",
-            "keywords": [
-                "phpunit",
-                "polyfill",
-                "testing"
-            ],
-            "support": {
-                "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
-                "source": "https://github.com/Yoast/PHPUnit-Polyfills"
-            },
-            "time": "2023-06-06T20:28:24+00:00"
-        }
-    ],
-    "aliases": [
-        {
-            "package": "nikic/php-parser",
-            "version": "4.16.0.0",
-            "alias": "1.0.0",
-            "alias_normalized": "1.0.0.0"
-        }
-    ],
-    "minimum-stability": "dev",
-    "stability-flags": [],
-    "prefer-stable": true,
-    "prefer-lowest": false,
-    "platform": {
-        "ext-hash": "*",
-        "ext-json": "*"
-    },
-    "platform-dev": [],
-    "platform-overrides": {
-        "php": "7.4.33"
-    },
-    "plugin-api-version": "2.6.0"
+	"_readme": [
+		"This file locks the dependencies of your project to a known state",
+		"Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+		"This file is @generated automatically"
+	],
+	"content-hash": "cc276b92e545efcc29db6103d53b6480",
+	"packages": [
+		{
+			"name": "automattic/jetpack-a8c-mc-stats",
+			"version": "v1.4.22",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/Automattic/jetpack-a8c-mc-stats.git",
+				"reference": "d7fdf2fc7ae33d75e24e82d81269e33ec718446f"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/Automattic/jetpack-a8c-mc-stats/zipball/d7fdf2fc7ae33d75e24e82d81269e33ec718446f",
+				"reference": "d7fdf2fc7ae33d75e24e82d81269e33ec718446f",
+				"shasum": ""
+			},
+			"require-dev": {
+				"automattic/jetpack-changelogger": "^3.3.9",
+				"yoast/phpunit-polyfills": "1.1.0"
+			},
+			"suggest": {
+				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+			},
+			"type": "jetpack-library",
+			"extra": {
+				"autotagger": true,
+				"mirror-repo": "Automattic/jetpack-a8c-mc-stats",
+				"changelogger": {
+					"link-template": "https://github.com/Automattic/jetpack-a8c-mc-stats/compare/v${old}...v${new}"
+				},
+				"branch-alias": {
+					"dev-trunk": "1.4.x-dev"
+				}
+			},
+			"autoload": {
+				"classmap": [
+					"src/"
+				]
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"GPL-2.0-or-later"
+			],
+			"description": "Used to record internal usage stats for Automattic. Not visible to site owners.",
+			"support": {
+				"source": "https://github.com/Automattic/jetpack-a8c-mc-stats/tree/v1.4.22"
+			},
+			"time": "2023-09-19T18:18:33+00:00"
+		},
+		{
+			"name": "automattic/jetpack-admin-ui",
+			"version": "v0.2.25",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/Automattic/jetpack-admin-ui.git",
+				"reference": "d9566f47ab310d675779273eeead6d0ca64fff82"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/Automattic/jetpack-admin-ui/zipball/d9566f47ab310d675779273eeead6d0ca64fff82",
+				"reference": "d9566f47ab310d675779273eeead6d0ca64fff82",
+				"shasum": ""
+			},
+			"require-dev": {
+				"automattic/jetpack-changelogger": "^3.3.11",
+				"automattic/jetpack-logo": "^1.6.3",
+				"automattic/wordbless": "dev-master",
+				"yoast/phpunit-polyfills": "1.1.0"
+			},
+			"suggest": {
+				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+			},
+			"type": "jetpack-library",
+			"extra": {
+				"autotagger": true,
+				"mirror-repo": "Automattic/jetpack-admin-ui",
+				"textdomain": "jetpack-admin-ui",
+				"changelogger": {
+					"link-template": "https://github.com/Automattic/jetpack-admin-ui/compare/${old}...${new}"
+				},
+				"branch-alias": {
+					"dev-trunk": "0.2.x-dev"
+				},
+				"version-constants": {
+					"::PACKAGE_VERSION": "src/class-admin-menu.php"
+				}
+			},
+			"autoload": {
+				"classmap": [
+					"src/"
+				]
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"GPL-2.0-or-later"
+			],
+			"description": "Generic Jetpack wp-admin UI elements",
+			"support": {
+				"source": "https://github.com/Automattic/jetpack-admin-ui/tree/v0.2.25"
+			},
+			"time": "2023-11-14T16:36:17+00:00"
+		},
+		{
+			"name": "automattic/jetpack-autoloader",
+			"version": "v2.12.0",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/Automattic/jetpack-autoloader.git",
+				"reference": "632b69cfc73ed5505f2b03165e7f68d414d0da12"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/632b69cfc73ed5505f2b03165e7f68d414d0da12",
+				"reference": "632b69cfc73ed5505f2b03165e7f68d414d0da12",
+				"shasum": ""
+			},
+			"require": {
+				"composer-plugin-api": "^1.1 || ^2.0"
+			},
+			"require-dev": {
+				"automattic/jetpack-changelogger": "^3.3.11",
+				"yoast/phpunit-polyfills": "1.1.0"
+			},
+			"type": "composer-plugin",
+			"extra": {
+				"autotagger": true,
+				"class": "Automattic\\Jetpack\\Autoloader\\CustomAutoloaderPlugin",
+				"mirror-repo": "Automattic/jetpack-autoloader",
+				"changelogger": {
+					"link-template": "https://github.com/Automattic/jetpack-autoloader/compare/v${old}...v${new}"
+				},
+				"version-constants": {
+					"::VERSION": "src/AutoloadGenerator.php"
+				},
+				"branch-alias": {
+					"dev-trunk": "2.12.x-dev"
+				}
+			},
+			"autoload": {
+				"psr-4": {
+					"Automattic\\Jetpack\\Autoloader\\": "src"
+				},
+				"classmap": [
+					"src/AutoloadGenerator.php"
+				]
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"GPL-2.0-or-later"
+			],
+			"description": "Creates a custom autoloader for a plugin or theme.",
+			"keywords": [
+				"autoload",
+				"autoloader",
+				"composer",
+				"jetpack",
+				"plugin",
+				"wordpress"
+			],
+			"support": {
+				"source": "https://github.com/Automattic/jetpack-autoloader/tree/v2.12.0"
+			},
+			"time": "2023-09-28T18:33:34+00:00"
+		},
+		{
+			"name": "automattic/jetpack-config",
+			"version": "v1.15.4",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/Automattic/jetpack-config.git",
+				"reference": "6cf8d61a972530322c9b62f7375fff83342c38f9"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/Automattic/jetpack-config/zipball/6cf8d61a972530322c9b62f7375fff83342c38f9",
+				"reference": "6cf8d61a972530322c9b62f7375fff83342c38f9",
+				"shasum": ""
+			},
+			"require-dev": {
+				"automattic/jetpack-changelogger": "^3.3.9"
+			},
+			"suggest": {
+				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+			},
+			"type": "jetpack-library",
+			"extra": {
+				"autotagger": true,
+				"mirror-repo": "Automattic/jetpack-config",
+				"textdomain": "jetpack-config",
+				"changelogger": {
+					"link-template": "https://github.com/Automattic/jetpack-config/compare/v${old}...v${new}"
+				},
+				"branch-alias": {
+					"dev-trunk": "1.15.x-dev"
+				}
+			},
+			"autoload": {
+				"classmap": [
+					"src/"
+				]
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"GPL-2.0-or-later"
+			],
+			"description": "Jetpack configuration package that initializes other packages and configures Jetpack's functionality. Can be used as a base for all variants of Jetpack package usage.",
+			"support": {
+				"source": "https://github.com/Automattic/jetpack-config/tree/v1.15.4"
+			},
+			"time": "2023-09-19T18:18:30+00:00"
+		},
+		{
+			"name": "automattic/jetpack-connection",
+			"version": "v1.60.1",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/Automattic/jetpack-connection.git",
+				"reference": "fc99f0a4d8839b69341a25f9059b872d426f3e9d"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/Automattic/jetpack-connection/zipball/fc99f0a4d8839b69341a25f9059b872d426f3e9d",
+				"reference": "fc99f0a4d8839b69341a25f9059b872d426f3e9d",
+				"shasum": ""
+			},
+			"require": {
+				"automattic/jetpack-a8c-mc-stats": "^1.4.22",
+				"automattic/jetpack-admin-ui": "^0.2.25",
+				"automattic/jetpack-constants": "^1.6.23",
+				"automattic/jetpack-redirect": "^1.7.27",
+				"automattic/jetpack-roles": "^1.4.25",
+				"automattic/jetpack-status": "^1.19.0"
+			},
+			"require-dev": {
+				"automattic/jetpack-changelogger": "^3.3.11",
+				"automattic/wordbless": "@dev",
+				"brain/monkey": "2.6.1",
+				"yoast/phpunit-polyfills": "1.1.0"
+			},
+			"suggest": {
+				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+			},
+			"type": "jetpack-library",
+			"extra": {
+				"autotagger": true,
+				"mirror-repo": "Automattic/jetpack-connection",
+				"textdomain": "jetpack-connection",
+				"version-constants": {
+					"::PACKAGE_VERSION": "src/class-package-version.php"
+				},
+				"changelogger": {
+					"link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
+				},
+				"branch-alias": {
+					"dev-trunk": "1.60.x-dev"
+				}
+			},
+			"autoload": {
+				"classmap": [
+					"legacy",
+					"src/",
+					"src/webhooks"
+				]
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"GPL-2.0-or-later"
+			],
+			"description": "Everything needed to connect to the Jetpack infrastructure",
+			"support": {
+				"source": "https://github.com/Automattic/jetpack-connection/tree/v1.60.1"
+			},
+			"time": "2023-11-14T16:36:48+00:00"
+		},
+		{
+			"name": "automattic/jetpack-constants",
+			"version": "v1.6.23",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/Automattic/jetpack-constants.git",
+				"reference": "0825fb1fa94956f26adebc01be0d716a0fd3ade0"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/Automattic/jetpack-constants/zipball/0825fb1fa94956f26adebc01be0d716a0fd3ade0",
+				"reference": "0825fb1fa94956f26adebc01be0d716a0fd3ade0",
+				"shasum": ""
+			},
+			"require-dev": {
+				"automattic/jetpack-changelogger": "^3.3.8",
+				"brain/monkey": "2.6.1",
+				"yoast/phpunit-polyfills": "1.1.0"
+			},
+			"suggest": {
+				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+			},
+			"type": "jetpack-library",
+			"extra": {
+				"autotagger": true,
+				"mirror-repo": "Automattic/jetpack-constants",
+				"changelogger": {
+					"link-template": "https://github.com/Automattic/jetpack-constants/compare/v${old}...v${new}"
+				},
+				"branch-alias": {
+					"dev-trunk": "1.6.x-dev"
+				}
+			},
+			"autoload": {
+				"classmap": [
+					"src/"
+				]
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"GPL-2.0-or-later"
+			],
+			"description": "A wrapper for defining constants in a more testable way.",
+			"support": {
+				"source": "https://github.com/Automattic/jetpack-constants/tree/v1.6.23"
+			},
+			"time": "2023-08-23T17:56:35+00:00"
+		},
+		{
+			"name": "automattic/jetpack-redirect",
+			"version": "v1.7.27",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/Automattic/jetpack-redirect.git",
+				"reference": "43dd3ae2bef71281fe70f62733bfaa44c988f1b1"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/Automattic/jetpack-redirect/zipball/43dd3ae2bef71281fe70f62733bfaa44c988f1b1",
+				"reference": "43dd3ae2bef71281fe70f62733bfaa44c988f1b1",
+				"shasum": ""
+			},
+			"require": {
+				"automattic/jetpack-status": "^1.18.4"
+			},
+			"require-dev": {
+				"automattic/jetpack-changelogger": "^3.3.9",
+				"brain/monkey": "2.6.1",
+				"yoast/phpunit-polyfills": "1.1.0"
+			},
+			"suggest": {
+				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+			},
+			"type": "jetpack-library",
+			"extra": {
+				"autotagger": true,
+				"mirror-repo": "Automattic/jetpack-redirect",
+				"changelogger": {
+					"link-template": "https://github.com/Automattic/jetpack-redirect/compare/v${old}...v${new}"
+				},
+				"branch-alias": {
+					"dev-trunk": "1.7.x-dev"
+				}
+			},
+			"autoload": {
+				"classmap": [
+					"src/"
+				]
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"GPL-2.0-or-later"
+			],
+			"description": "Utilities to build URLs to the jetpack.com/redirect/ service",
+			"support": {
+				"source": "https://github.com/Automattic/jetpack-redirect/tree/v1.7.27"
+			},
+			"time": "2023-09-19T18:19:22+00:00"
+		},
+		{
+			"name": "automattic/jetpack-roles",
+			"version": "v1.4.25",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/Automattic/jetpack-roles.git",
+				"reference": "708b33f16a879fc2ab5939a972c968c9aeefbe38"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/Automattic/jetpack-roles/zipball/708b33f16a879fc2ab5939a972c968c9aeefbe38",
+				"reference": "708b33f16a879fc2ab5939a972c968c9aeefbe38",
+				"shasum": ""
+			},
+			"require-dev": {
+				"automattic/jetpack-changelogger": "^3.3.9",
+				"brain/monkey": "2.6.1",
+				"yoast/phpunit-polyfills": "1.1.0"
+			},
+			"suggest": {
+				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+			},
+			"type": "jetpack-library",
+			"extra": {
+				"autotagger": true,
+				"mirror-repo": "Automattic/jetpack-roles",
+				"changelogger": {
+					"link-template": "https://github.com/Automattic/jetpack-roles/compare/v${old}...v${new}"
+				},
+				"branch-alias": {
+					"dev-trunk": "1.4.x-dev"
+				}
+			},
+			"autoload": {
+				"classmap": [
+					"src/"
+				]
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"GPL-2.0-or-later"
+			],
+			"description": "Utilities, related with user roles and capabilities.",
+			"support": {
+				"source": "https://github.com/Automattic/jetpack-roles/tree/v1.4.25"
+			},
+			"time": "2023-09-19T18:18:38+00:00"
+		},
+		{
+			"name": "automattic/jetpack-status",
+			"version": "v1.19.0",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/Automattic/jetpack-status.git",
+				"reference": "3281c2311752e9df1b2809d8feacb7bf7b9b7b8d"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/Automattic/jetpack-status/zipball/3281c2311752e9df1b2809d8feacb7bf7b9b7b8d",
+				"reference": "3281c2311752e9df1b2809d8feacb7bf7b9b7b8d",
+				"shasum": ""
+			},
+			"require": {
+				"automattic/jetpack-constants": "^1.6.23"
+			},
+			"require-dev": {
+				"automattic/jetpack-changelogger": "^3.3.11",
+				"automattic/jetpack-ip": "^0.1.6",
+				"brain/monkey": "2.6.1",
+				"yoast/phpunit-polyfills": "1.1.0"
+			},
+			"suggest": {
+				"automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+			},
+			"type": "jetpack-library",
+			"extra": {
+				"autotagger": true,
+				"mirror-repo": "Automattic/jetpack-status",
+				"changelogger": {
+					"link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
+				},
+				"branch-alias": {
+					"dev-trunk": "1.19.x-dev"
+				}
+			},
+			"autoload": {
+				"classmap": [
+					"src/"
+				]
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"GPL-2.0-or-later"
+			],
+			"description": "Used to retrieve information about the current status of Jetpack and the site overall.",
+			"support": {
+				"source": "https://github.com/Automattic/jetpack-status/tree/v1.19.0"
+			},
+			"time": "2023-11-13T13:50:12+00:00"
+		},
+		{
+			"name": "composer/installers",
+			"version": "v1.12.0",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/composer/installers.git",
+				"reference": "d20a64ed3c94748397ff5973488761b22f6d3f19"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/composer/installers/zipball/d20a64ed3c94748397ff5973488761b22f6d3f19",
+				"reference": "d20a64ed3c94748397ff5973488761b22f6d3f19",
+				"shasum": ""
+			},
+			"require": {
+				"composer-plugin-api": "^1.0 || ^2.0"
+			},
+			"replace": {
+				"roundcube/plugin-installer": "*",
+				"shama/baton": "*"
+			},
+			"require-dev": {
+				"composer/composer": "1.6.* || ^2.0",
+				"composer/semver": "^1 || ^3",
+				"phpstan/phpstan": "^0.12.55",
+				"phpstan/phpstan-phpunit": "^0.12.16",
+				"symfony/phpunit-bridge": "^4.2 || ^5",
+				"symfony/process": "^2.3"
+			},
+			"type": "composer-plugin",
+			"extra": {
+				"class": "Composer\\Installers\\Plugin",
+				"branch-alias": {
+					"dev-main": "1.x-dev"
+				}
+			},
+			"autoload": {
+				"psr-4": {
+					"Composer\\Installers\\": "src/Composer/Installers"
+				}
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"MIT"
+			],
+			"authors": [
+				{
+					"name": "Kyle Robinson Young",
+					"email": "kyle@dontkry.com",
+					"homepage": "https://github.com/shama"
+				}
+			],
+			"description": "A multi-framework Composer library installer",
+			"homepage": "https://composer.github.io/installers/",
+			"keywords": [
+				"Craft",
+				"Dolibarr",
+				"Eliasis",
+				"Hurad",
+				"ImageCMS",
+				"Kanboard",
+				"Lan Management System",
+				"MODX Evo",
+				"MantisBT",
+				"Mautic",
+				"Maya",
+				"OXID",
+				"Plentymarkets",
+				"Porto",
+				"RadPHP",
+				"SMF",
+				"Starbug",
+				"Thelia",
+				"Whmcs",
+				"WolfCMS",
+				"agl",
+				"aimeos",
+				"annotatecms",
+				"attogram",
+				"bitrix",
+				"cakephp",
+				"chef",
+				"cockpit",
+				"codeigniter",
+				"concrete5",
+				"croogo",
+				"dokuwiki",
+				"drupal",
+				"eZ Platform",
+				"elgg",
+				"expressionengine",
+				"fuelphp",
+				"grav",
+				"installer",
+				"itop",
+				"joomla",
+				"known",
+				"kohana",
+				"laravel",
+				"lavalite",
+				"lithium",
+				"magento",
+				"majima",
+				"mako",
+				"mediawiki",
+				"miaoxing",
+				"modulework",
+				"modx",
+				"moodle",
+				"osclass",
+				"pantheon",
+				"phpbb",
+				"piwik",
+				"ppi",
+				"processwire",
+				"puppet",
+				"pxcms",
+				"reindex",
+				"roundcube",
+				"shopware",
+				"silverstripe",
+				"sydes",
+				"sylius",
+				"symfony",
+				"tastyigniter",
+				"typo3",
+				"wordpress",
+				"yawik",
+				"zend",
+				"zikula"
+			],
+			"support": {
+				"issues": "https://github.com/composer/installers/issues",
+				"source": "https://github.com/composer/installers/tree/v1.12.0"
+			},
+			"funding": [
+				{
+					"url": "https://packagist.com",
+					"type": "custom"
+				},
+				{
+					"url": "https://github.com/composer",
+					"type": "github"
+				},
+				{
+					"url": "https://tidelift.com/funding/github/packagist/composer/composer",
+					"type": "tidelift"
+				}
+			],
+			"time": "2021-09-13T08:19:44+00:00"
+		}
+	],
+	"packages-dev": [
+		{
+			"name": "dealerdirect/phpcodesniffer-composer-installer",
+			"version": "v1.0.0",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/PHPCSStandards/composer-installer.git",
+				"reference": "4be43904336affa5c2f70744a348312336afd0da"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/4be43904336affa5c2f70744a348312336afd0da",
+				"reference": "4be43904336affa5c2f70744a348312336afd0da",
+				"shasum": ""
+			},
+			"require": {
+				"composer-plugin-api": "^1.0 || ^2.0",
+				"php": ">=5.4",
+				"squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
+			},
+			"require-dev": {
+				"composer/composer": "*",
+				"ext-json": "*",
+				"ext-zip": "*",
+				"php-parallel-lint/php-parallel-lint": "^1.3.1",
+				"phpcompatibility/php-compatibility": "^9.0",
+				"yoast/phpunit-polyfills": "^1.0"
+			},
+			"type": "composer-plugin",
+			"extra": {
+				"class": "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+			},
+			"autoload": {
+				"psr-4": {
+					"PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+				}
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"MIT"
+			],
+			"authors": [
+				{
+					"name": "Franck Nijhof",
+					"email": "franck.nijhof@dealerdirect.com",
+					"homepage": "http://www.frenck.nl",
+					"role": "Developer / IT Manager"
+				},
+				{
+					"name": "Contributors",
+					"homepage": "https://github.com/PHPCSStandards/composer-installer/graphs/contributors"
+				}
+			],
+			"description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+			"homepage": "http://www.dealerdirect.com",
+			"keywords": [
+				"PHPCodeSniffer",
+				"PHP_CodeSniffer",
+				"code quality",
+				"codesniffer",
+				"composer",
+				"installer",
+				"phpcbf",
+				"phpcs",
+				"plugin",
+				"qa",
+				"quality",
+				"standard",
+				"standards",
+				"style guide",
+				"stylecheck",
+				"tests"
+			],
+			"support": {
+				"issues": "https://github.com/PHPCSStandards/composer-installer/issues",
+				"source": "https://github.com/PHPCSStandards/composer-installer"
+			},
+			"time": "2023-01-05T11:28:13+00:00"
+		},
+		{
+			"name": "doctrine/instantiator",
+			"version": "1.5.0",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/doctrine/instantiator.git",
+				"reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
+				"reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
+				"shasum": ""
+			},
+			"require": {
+				"php": "^7.1 || ^8.0"
+			},
+			"require-dev": {
+				"doctrine/coding-standard": "^9 || ^11",
+				"ext-pdo": "*",
+				"ext-phar": "*",
+				"phpbench/phpbench": "^0.16 || ^1",
+				"phpstan/phpstan": "^1.4",
+				"phpstan/phpstan-phpunit": "^1",
+				"phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+				"vimeo/psalm": "^4.30 || ^5.4"
+			},
+			"type": "library",
+			"autoload": {
+				"psr-4": {
+					"Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+				}
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"MIT"
+			],
+			"authors": [
+				{
+					"name": "Marco Pivetta",
+					"email": "ocramius@gmail.com",
+					"homepage": "https://ocramius.github.io/"
+				}
+			],
+			"description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+			"homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+			"keywords": [
+				"constructor",
+				"instantiate"
+			],
+			"support": {
+				"issues": "https://github.com/doctrine/instantiator/issues",
+				"source": "https://github.com/doctrine/instantiator/tree/1.5.0"
+			},
+			"funding": [
+				{
+					"url": "https://www.doctrine-project.org/sponsorship.html",
+					"type": "custom"
+				},
+				{
+					"url": "https://www.patreon.com/phpdoctrine",
+					"type": "patreon"
+				},
+				{
+					"url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+					"type": "tidelift"
+				}
+			],
+			"time": "2022-12-30T00:15:36+00:00"
+		},
+		{
+			"name": "erusev/parsedown",
+			"version": "1.7.4",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/erusev/parsedown.git",
+				"reference": "cb17b6477dfff935958ba01325f2e8a2bfa6dab3"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/erusev/parsedown/zipball/cb17b6477dfff935958ba01325f2e8a2bfa6dab3",
+				"reference": "cb17b6477dfff935958ba01325f2e8a2bfa6dab3",
+				"shasum": ""
+			},
+			"require": {
+				"ext-mbstring": "*",
+				"php": ">=5.3.0"
+			},
+			"require-dev": {
+				"phpunit/phpunit": "^4.8.35"
+			},
+			"type": "library",
+			"autoload": {
+				"psr-0": {
+					"Parsedown": ""
+				}
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"MIT"
+			],
+			"authors": [
+				{
+					"name": "Emanuil Rusev",
+					"email": "hello@erusev.com",
+					"homepage": "http://erusev.com"
+				}
+			],
+			"description": "Parser for Markdown.",
+			"homepage": "http://parsedown.org",
+			"keywords": [
+				"markdown",
+				"parser"
+			],
+			"support": {
+				"issues": "https://github.com/erusev/parsedown/issues",
+				"source": "https://github.com/erusev/parsedown/tree/1.7.x"
+			},
+			"time": "2019-12-30T22:54:17+00:00"
+		},
+		{
+			"name": "hamcrest/hamcrest-php",
+			"version": "v2.0.1",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/hamcrest/hamcrest-php.git",
+				"reference": "8c3d0a3f6af734494ad8f6fbbee0ba92422859f3"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/hamcrest/hamcrest-php/zipball/8c3d0a3f6af734494ad8f6fbbee0ba92422859f3",
+				"reference": "8c3d0a3f6af734494ad8f6fbbee0ba92422859f3",
+				"shasum": ""
+			},
+			"require": {
+				"php": "^5.3|^7.0|^8.0"
+			},
+			"replace": {
+				"cordoval/hamcrest-php": "*",
+				"davedevelopment/hamcrest-php": "*",
+				"kodova/hamcrest-php": "*"
+			},
+			"require-dev": {
+				"phpunit/php-file-iterator": "^1.4 || ^2.0",
+				"phpunit/phpunit": "^4.8.36 || ^5.7 || ^6.5 || ^7.0"
+			},
+			"type": "library",
+			"extra": {
+				"branch-alias": {
+					"dev-master": "2.1-dev"
+				}
+			},
+			"autoload": {
+				"classmap": [
+					"hamcrest"
+				]
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"BSD-3-Clause"
+			],
+			"description": "This is the PHP port of Hamcrest Matchers",
+			"keywords": [
+				"test"
+			],
+			"support": {
+				"issues": "https://github.com/hamcrest/hamcrest-php/issues",
+				"source": "https://github.com/hamcrest/hamcrest-php/tree/v2.0.1"
+			},
+			"time": "2020-07-09T08:09:16+00:00"
+		},
+		{
+			"name": "johnbillion/wp-parser-lib",
+			"version": "1.3.0",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/johnbillion/wp-parser-lib.git",
+				"reference": "46ed07365f8bd22f1edc828f9cfeed0c0f2c7d07"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/johnbillion/wp-parser-lib/zipball/46ed07365f8bd22f1edc828f9cfeed0c0f2c7d07",
+				"reference": "46ed07365f8bd22f1edc828f9cfeed0c0f2c7d07",
+				"shasum": ""
+			},
+			"require": {
+				"composer/installers": "~1.0",
+				"erusev/parsedown": "~1.7",
+				"php": ">=5.4",
+				"phpdocumentor/reflection": "~3.0"
+			},
+			"type": "library",
+			"autoload": {
+				"files": [
+					"lib/runner.php"
+				],
+				"classmap": [
+					"lib"
+				]
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"GPL-2.0-or-later"
+			],
+			"authors": [
+				{
+					"name": "Ryan McCue",
+					"homepage": "http://ryanmccue.info",
+					"role": "Developer"
+				},
+				{
+					"name": "Contributors",
+					"homepage": "https://github.com/johnbillion/wp-parser-lib/graphs/contributors"
+				}
+			],
+			"description": "File scanning and hook parsing functionality from WP Parser.",
+			"homepage": "https://github.com/johnbillion/wp-parser-lib",
+			"keywords": [
+				"wordpress"
+			],
+			"support": {
+				"issues": "https://github.com/johnbillion/wp-parser-lib/issues",
+				"source": "https://github.com/johnbillion/wp-parser-lib/tree/1.3.0"
+			},
+			"time": "2022-01-27T13:57:08+00:00"
+		},
+		{
+			"name": "mockery/mockery",
+			"version": "1.6.6",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/mockery/mockery.git",
+				"reference": "b8e0bb7d8c604046539c1115994632c74dcb361e"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/mockery/mockery/zipball/b8e0bb7d8c604046539c1115994632c74dcb361e",
+				"reference": "b8e0bb7d8c604046539c1115994632c74dcb361e",
+				"shasum": ""
+			},
+			"require": {
+				"hamcrest/hamcrest-php": "^2.0.1",
+				"lib-pcre": ">=7.0",
+				"php": ">=7.3"
+			},
+			"conflict": {
+				"phpunit/phpunit": "<8.0"
+			},
+			"require-dev": {
+				"phpunit/phpunit": "^8.5 || ^9.6.10",
+				"psalm/plugin-phpunit": "^0.18.4",
+				"symplify/easy-coding-standard": "^11.5.0",
+				"vimeo/psalm": "^4.30"
+			},
+			"type": "library",
+			"autoload": {
+				"files": [
+					"library/helpers.php",
+					"library/Mockery.php"
+				],
+				"psr-4": {
+					"Mockery\\": "library/Mockery"
+				}
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"BSD-3-Clause"
+			],
+			"authors": [
+				{
+					"name": "Pádraic Brady",
+					"email": "padraic.brady@gmail.com",
+					"homepage": "https://github.com/padraic",
+					"role": "Author"
+				},
+				{
+					"name": "Dave Marshall",
+					"email": "dave.marshall@atstsolutions.co.uk",
+					"homepage": "https://davedevelopment.co.uk",
+					"role": "Developer"
+				},
+				{
+					"name": "Nathanael Esayeas",
+					"email": "nathanael.esayeas@protonmail.com",
+					"homepage": "https://github.com/ghostwriter",
+					"role": "Lead Developer"
+				}
+			],
+			"description": "Mockery is a simple yet flexible PHP mock object framework",
+			"homepage": "https://github.com/mockery/mockery",
+			"keywords": [
+				"BDD",
+				"TDD",
+				"library",
+				"mock",
+				"mock objects",
+				"mockery",
+				"stub",
+				"test",
+				"test double",
+				"testing"
+			],
+			"support": {
+				"docs": "https://docs.mockery.io/",
+				"issues": "https://github.com/mockery/mockery/issues",
+				"rss": "https://github.com/mockery/mockery/releases.atom",
+				"security": "https://github.com/mockery/mockery/security/advisories",
+				"source": "https://github.com/mockery/mockery"
+			},
+			"time": "2023-08-09T00:03:52+00:00"
+		},
+		{
+			"name": "myclabs/deep-copy",
+			"version": "1.11.1",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/myclabs/DeepCopy.git",
+				"reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
+				"reference": "7284c22080590fb39f2ffa3e9057f10a4ddd0e0c",
+				"shasum": ""
+			},
+			"require": {
+				"php": "^7.1 || ^8.0"
+			},
+			"conflict": {
+				"doctrine/collections": "<1.6.8",
+				"doctrine/common": "<2.13.3 || >=3,<3.2.2"
+			},
+			"require-dev": {
+				"doctrine/collections": "^1.6.8",
+				"doctrine/common": "^2.13.3 || ^3.2.2",
+				"phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+			},
+			"type": "library",
+			"autoload": {
+				"files": [
+					"src/DeepCopy/deep_copy.php"
+				],
+				"psr-4": {
+					"DeepCopy\\": "src/DeepCopy/"
+				}
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"MIT"
+			],
+			"description": "Create deep copies (clones) of your objects",
+			"keywords": [
+				"clone",
+				"copy",
+				"duplicate",
+				"object",
+				"object graph"
+			],
+			"support": {
+				"issues": "https://github.com/myclabs/DeepCopy/issues",
+				"source": "https://github.com/myclabs/DeepCopy/tree/1.11.1"
+			},
+			"funding": [
+				{
+					"url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+					"type": "tidelift"
+				}
+			],
+			"time": "2023-03-08T13:26:56+00:00"
+		},
+		{
+			"name": "nikic/php-parser",
+			"version": "v4.16.0",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/nikic/PHP-Parser.git",
+				"reference": "19526a33fb561ef417e822e85f08a00db4059c17"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/19526a33fb561ef417e822e85f08a00db4059c17",
+				"reference": "19526a33fb561ef417e822e85f08a00db4059c17",
+				"shasum": ""
+			},
+			"require": {
+				"ext-tokenizer": "*",
+				"php": ">=7.0"
+			},
+			"require-dev": {
+				"ircmaxell/php-yacc": "^0.0.7",
+				"phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+			},
+			"bin": [
+				"bin/php-parse"
+			],
+			"type": "library",
+			"extra": {
+				"branch-alias": {
+					"dev-master": "4.9-dev"
+				}
+			},
+			"autoload": {
+				"psr-4": {
+					"PhpParser\\": "lib/PhpParser"
+				}
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"BSD-3-Clause"
+			],
+			"authors": [
+				{
+					"name": "Nikita Popov"
+				}
+			],
+			"description": "A PHP parser written in PHP",
+			"keywords": [
+				"parser",
+				"php"
+			],
+			"support": {
+				"issues": "https://github.com/nikic/PHP-Parser/issues",
+				"source": "https://github.com/nikic/PHP-Parser/tree/v4.16.0"
+			},
+			"time": "2023-06-25T14:52:30+00:00"
+		},
+		{
+			"name": "phar-io/manifest",
+			"version": "2.0.3",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/phar-io/manifest.git",
+				"reference": "97803eca37d319dfa7826cc2437fc020857acb53"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/phar-io/manifest/zipball/97803eca37d319dfa7826cc2437fc020857acb53",
+				"reference": "97803eca37d319dfa7826cc2437fc020857acb53",
+				"shasum": ""
+			},
+			"require": {
+				"ext-dom": "*",
+				"ext-phar": "*",
+				"ext-xmlwriter": "*",
+				"phar-io/version": "^3.0.1",
+				"php": "^7.2 || ^8.0"
+			},
+			"type": "library",
+			"extra": {
+				"branch-alias": {
+					"dev-master": "2.0.x-dev"
+				}
+			},
+			"autoload": {
+				"classmap": [
+					"src/"
+				]
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"BSD-3-Clause"
+			],
+			"authors": [
+				{
+					"name": "Arne Blankerts",
+					"email": "arne@blankerts.de",
+					"role": "Developer"
+				},
+				{
+					"name": "Sebastian Heuer",
+					"email": "sebastian@phpeople.de",
+					"role": "Developer"
+				},
+				{
+					"name": "Sebastian Bergmann",
+					"email": "sebastian@phpunit.de",
+					"role": "Developer"
+				}
+			],
+			"description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+			"support": {
+				"issues": "https://github.com/phar-io/manifest/issues",
+				"source": "https://github.com/phar-io/manifest/tree/2.0.3"
+			},
+			"time": "2021-07-20T11:28:43+00:00"
+		},
+		{
+			"name": "phar-io/version",
+			"version": "3.2.1",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/phar-io/version.git",
+				"reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+				"reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+				"shasum": ""
+			},
+			"require": {
+				"php": "^7.2 || ^8.0"
+			},
+			"type": "library",
+			"autoload": {
+				"classmap": [
+					"src/"
+				]
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"BSD-3-Clause"
+			],
+			"authors": [
+				{
+					"name": "Arne Blankerts",
+					"email": "arne@blankerts.de",
+					"role": "Developer"
+				},
+				{
+					"name": "Sebastian Heuer",
+					"email": "sebastian@phpeople.de",
+					"role": "Developer"
+				},
+				{
+					"name": "Sebastian Bergmann",
+					"email": "sebastian@phpunit.de",
+					"role": "Developer"
+				}
+			],
+			"description": "Library for handling version information and constraints",
+			"support": {
+				"issues": "https://github.com/phar-io/version/issues",
+				"source": "https://github.com/phar-io/version/tree/3.2.1"
+			},
+			"time": "2022-02-21T01:04:05+00:00"
+		},
+		{
+			"name": "phpcompatibility/php-compatibility",
+			"version": "9.3.5",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
+				"reference": "9fb324479acf6f39452e0655d2429cc0d3914243"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9fb324479acf6f39452e0655d2429cc0d3914243",
+				"reference": "9fb324479acf6f39452e0655d2429cc0d3914243",
+				"shasum": ""
+			},
+			"require": {
+				"php": ">=5.3",
+				"squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
+			},
+			"conflict": {
+				"squizlabs/php_codesniffer": "2.6.2"
+			},
+			"require-dev": {
+				"phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
+			},
+			"suggest": {
+				"dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+				"roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+			},
+			"type": "phpcodesniffer-standard",
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"LGPL-3.0-or-later"
+			],
+			"authors": [
+				{
+					"name": "Wim Godden",
+					"homepage": "https://github.com/wimg",
+					"role": "lead"
+				},
+				{
+					"name": "Juliette Reinders Folmer",
+					"homepage": "https://github.com/jrfnl",
+					"role": "lead"
+				},
+				{
+					"name": "Contributors",
+					"homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
+				}
+			],
+			"description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
+			"homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+			"keywords": [
+				"compatibility",
+				"phpcs",
+				"standards"
+			],
+			"support": {
+				"issues": "https://github.com/PHPCompatibility/PHPCompatibility/issues",
+				"source": "https://github.com/PHPCompatibility/PHPCompatibility"
+			},
+			"time": "2019-12-27T09:44:58+00:00"
+		},
+		{
+			"name": "phpcompatibility/phpcompatibility-paragonie",
+			"version": "1.3.2",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
+				"reference": "bba5a9dfec7fcfbd679cfaf611d86b4d3759da26"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/bba5a9dfec7fcfbd679cfaf611d86b4d3759da26",
+				"reference": "bba5a9dfec7fcfbd679cfaf611d86b4d3759da26",
+				"shasum": ""
+			},
+			"require": {
+				"phpcompatibility/php-compatibility": "^9.0"
+			},
+			"require-dev": {
+				"dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+				"paragonie/random_compat": "dev-master",
+				"paragonie/sodium_compat": "dev-master"
+			},
+			"suggest": {
+				"dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+				"roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+			},
+			"type": "phpcodesniffer-standard",
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"LGPL-3.0-or-later"
+			],
+			"authors": [
+				{
+					"name": "Wim Godden",
+					"role": "lead"
+				},
+				{
+					"name": "Juliette Reinders Folmer",
+					"role": "lead"
+				}
+			],
+			"description": "A set of rulesets for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by the Paragonie polyfill libraries.",
+			"homepage": "http://phpcompatibility.com/",
+			"keywords": [
+				"compatibility",
+				"paragonie",
+				"phpcs",
+				"polyfill",
+				"standards",
+				"static analysis"
+			],
+			"support": {
+				"issues": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/issues",
+				"source": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie"
+			},
+			"time": "2022-10-25T01:46:02+00:00"
+		},
+		{
+			"name": "phpcompatibility/phpcompatibility-wp",
+			"version": "2.1.4",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
+				"reference": "b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5",
+				"reference": "b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5",
+				"shasum": ""
+			},
+			"require": {
+				"phpcompatibility/php-compatibility": "^9.0",
+				"phpcompatibility/phpcompatibility-paragonie": "^1.0"
+			},
+			"require-dev": {
+				"dealerdirect/phpcodesniffer-composer-installer": "^0.7"
+			},
+			"suggest": {
+				"dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+				"roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+			},
+			"type": "phpcodesniffer-standard",
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"LGPL-3.0-or-later"
+			],
+			"authors": [
+				{
+					"name": "Wim Godden",
+					"role": "lead"
+				},
+				{
+					"name": "Juliette Reinders Folmer",
+					"role": "lead"
+				}
+			],
+			"description": "A ruleset for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by WordPress.",
+			"homepage": "http://phpcompatibility.com/",
+			"keywords": [
+				"compatibility",
+				"phpcs",
+				"standards",
+				"static analysis",
+				"wordpress"
+			],
+			"support": {
+				"issues": "https://github.com/PHPCompatibility/PHPCompatibilityWP/issues",
+				"source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
+			},
+			"time": "2022-10-24T09:00:36+00:00"
+		},
+		{
+			"name": "phpcsstandards/phpcsextra",
+			"version": "1.1.2",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
+				"reference": "746c3190ba8eb2f212087c947ba75f4f5b9a58d5"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/746c3190ba8eb2f212087c947ba75f4f5b9a58d5",
+				"reference": "746c3190ba8eb2f212087c947ba75f4f5b9a58d5",
+				"shasum": ""
+			},
+			"require": {
+				"php": ">=5.4",
+				"phpcsstandards/phpcsutils": "^1.0.8",
+				"squizlabs/php_codesniffer": "^3.7.1"
+			},
+			"require-dev": {
+				"php-parallel-lint/php-console-highlighter": "^1.0",
+				"php-parallel-lint/php-parallel-lint": "^1.3.2",
+				"phpcsstandards/phpcsdevcs": "^1.1.6",
+				"phpcsstandards/phpcsdevtools": "^1.2.1",
+				"phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0"
+			},
+			"type": "phpcodesniffer-standard",
+			"extra": {
+				"branch-alias": {
+					"dev-stable": "1.x-dev",
+					"dev-develop": "1.x-dev"
+				}
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"LGPL-3.0-or-later"
+			],
+			"authors": [
+				{
+					"name": "Juliette Reinders Folmer",
+					"homepage": "https://github.com/jrfnl",
+					"role": "lead"
+				},
+				{
+					"name": "Contributors",
+					"homepage": "https://github.com/PHPCSStandards/PHPCSExtra/graphs/contributors"
+				}
+			],
+			"description": "A collection of sniffs and standards for use with PHP_CodeSniffer.",
+			"keywords": [
+				"PHP_CodeSniffer",
+				"phpcbf",
+				"phpcodesniffer-standard",
+				"phpcs",
+				"standards",
+				"static analysis"
+			],
+			"support": {
+				"issues": "https://github.com/PHPCSStandards/PHPCSExtra/issues",
+				"source": "https://github.com/PHPCSStandards/PHPCSExtra"
+			},
+			"time": "2023-09-20T22:06:18+00:00"
+		},
+		{
+			"name": "phpcsstandards/phpcsutils",
+			"version": "1.0.8",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
+				"reference": "69465cab9d12454e5e7767b9041af0cd8cd13be7"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/69465cab9d12454e5e7767b9041af0cd8cd13be7",
+				"reference": "69465cab9d12454e5e7767b9041af0cd8cd13be7",
+				"shasum": ""
+			},
+			"require": {
+				"dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
+				"php": ">=5.4",
+				"squizlabs/php_codesniffer": "^3.7.1 || 4.0.x-dev@dev"
+			},
+			"require-dev": {
+				"ext-filter": "*",
+				"php-parallel-lint/php-console-highlighter": "^1.0",
+				"php-parallel-lint/php-parallel-lint": "^1.3.2",
+				"phpcsstandards/phpcsdevcs": "^1.1.6",
+				"yoast/phpunit-polyfills": "^1.0.5 || ^2.0.0"
+			},
+			"type": "phpcodesniffer-standard",
+			"extra": {
+				"branch-alias": {
+					"dev-stable": "1.x-dev",
+					"dev-develop": "1.x-dev"
+				}
+			},
+			"autoload": {
+				"classmap": [
+					"PHPCSUtils/"
+				]
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"LGPL-3.0-or-later"
+			],
+			"authors": [
+				{
+					"name": "Juliette Reinders Folmer",
+					"homepage": "https://github.com/jrfnl",
+					"role": "lead"
+				},
+				{
+					"name": "Contributors",
+					"homepage": "https://github.com/PHPCSStandards/PHPCSUtils/graphs/contributors"
+				}
+			],
+			"description": "A suite of utility functions for use with PHP_CodeSniffer",
+			"homepage": "https://phpcsutils.com/",
+			"keywords": [
+				"PHP_CodeSniffer",
+				"phpcbf",
+				"phpcodesniffer-standard",
+				"phpcs",
+				"phpcs3",
+				"standards",
+				"static analysis",
+				"tokens",
+				"utility"
+			],
+			"support": {
+				"docs": "https://phpcsutils.com/",
+				"issues": "https://github.com/PHPCSStandards/PHPCSUtils/issues",
+				"source": "https://github.com/PHPCSStandards/PHPCSUtils"
+			},
+			"time": "2023-07-16T21:39:41+00:00"
+		},
+		{
+			"name": "phpdocumentor/reflection",
+			"version": "3.0.1",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/phpDocumentor/Reflection.git",
+				"reference": "793bfd92d9a0fc96ae9608fb3e947c3f59fb3a0d"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/phpDocumentor/Reflection/zipball/793bfd92d9a0fc96ae9608fb3e947c3f59fb3a0d",
+				"reference": "793bfd92d9a0fc96ae9608fb3e947c3f59fb3a0d",
+				"shasum": ""
+			},
+			"require": {
+				"nikic/php-parser": "^1.0",
+				"php": ">=5.3.3",
+				"phpdocumentor/reflection-docblock": "~2.0",
+				"psr/log": "~1.0"
+			},
+			"require-dev": {
+				"behat/behat": "~2.4",
+				"mockery/mockery": "~0.8",
+				"phpunit/phpunit": "~4.0"
+			},
+			"type": "library",
+			"extra": {
+				"branch-alias": {
+					"dev-master": "1.0.x-dev"
+				}
+			},
+			"autoload": {
+				"psr-0": {
+					"phpDocumentor": [
+						"src/",
+						"tests/unit/",
+						"tests/mocks/"
+					]
+				}
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"MIT"
+			],
+			"description": "Reflection library to do Static Analysis for PHP Projects",
+			"homepage": "http://www.phpdoc.org",
+			"keywords": [
+				"phpDocumentor",
+				"phpdoc",
+				"reflection",
+				"static analysis"
+			],
+			"support": {
+				"issues": "https://github.com/phpDocumentor/Reflection/issues",
+				"source": "https://github.com/phpDocumentor/Reflection/tree/master"
+			},
+			"time": "2016-05-21T08:42:32+00:00"
+		},
+		{
+			"name": "phpdocumentor/reflection-docblock",
+			"version": "2.0.5",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+				"reference": "e6a969a640b00d8daa3c66518b0405fb41ae0c4b"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/e6a969a640b00d8daa3c66518b0405fb41ae0c4b",
+				"reference": "e6a969a640b00d8daa3c66518b0405fb41ae0c4b",
+				"shasum": ""
+			},
+			"require": {
+				"php": ">=5.3.3"
+			},
+			"require-dev": {
+				"phpunit/phpunit": "~4.0"
+			},
+			"suggest": {
+				"dflydev/markdown": "~1.0",
+				"erusev/parsedown": "~1.0"
+			},
+			"type": "library",
+			"extra": {
+				"branch-alias": {
+					"dev-master": "2.0.x-dev"
+				}
+			},
+			"autoload": {
+				"psr-0": {
+					"phpDocumentor": [
+						"src/"
+					]
+				}
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"MIT"
+			],
+			"authors": [
+				{
+					"name": "Mike van Riel",
+					"email": "mike.vanriel@naenius.com"
+				}
+			],
+			"support": {
+				"issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
+				"source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/release/2.x"
+			},
+			"time": "2016-01-25T08:17:30+00:00"
+		},
+		{
+			"name": "phpunit/php-code-coverage",
+			"version": "9.2.29",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+				"reference": "6a3a87ac2bbe33b25042753df8195ba4aa534c76"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/6a3a87ac2bbe33b25042753df8195ba4aa534c76",
+				"reference": "6a3a87ac2bbe33b25042753df8195ba4aa534c76",
+				"shasum": ""
+			},
+			"require": {
+				"ext-dom": "*",
+				"ext-libxml": "*",
+				"ext-xmlwriter": "*",
+				"nikic/php-parser": "^4.15",
+				"php": ">=7.3",
+				"phpunit/php-file-iterator": "^3.0.3",
+				"phpunit/php-text-template": "^2.0.2",
+				"sebastian/code-unit-reverse-lookup": "^2.0.2",
+				"sebastian/complexity": "^2.0",
+				"sebastian/environment": "^5.1.2",
+				"sebastian/lines-of-code": "^1.0.3",
+				"sebastian/version": "^3.0.1",
+				"theseer/tokenizer": "^1.2.0"
+			},
+			"require-dev": {
+				"phpunit/phpunit": "^9.3"
+			},
+			"suggest": {
+				"ext-pcov": "PHP extension that provides line coverage",
+				"ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+			},
+			"type": "library",
+			"extra": {
+				"branch-alias": {
+					"dev-master": "9.2-dev"
+				}
+			},
+			"autoload": {
+				"classmap": [
+					"src/"
+				]
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"BSD-3-Clause"
+			],
+			"authors": [
+				{
+					"name": "Sebastian Bergmann",
+					"email": "sebastian@phpunit.de",
+					"role": "lead"
+				}
+			],
+			"description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+			"homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+			"keywords": [
+				"coverage",
+				"testing",
+				"xunit"
+			],
+			"support": {
+				"issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+				"security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+				"source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.29"
+			},
+			"funding": [
+				{
+					"url": "https://github.com/sebastianbergmann",
+					"type": "github"
+				}
+			],
+			"time": "2023-09-19T04:57:46+00:00"
+		},
+		{
+			"name": "phpunit/php-file-iterator",
+			"version": "3.0.6",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+				"reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+				"reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+				"shasum": ""
+			},
+			"require": {
+				"php": ">=7.3"
+			},
+			"require-dev": {
+				"phpunit/phpunit": "^9.3"
+			},
+			"type": "library",
+			"extra": {
+				"branch-alias": {
+					"dev-master": "3.0-dev"
+				}
+			},
+			"autoload": {
+				"classmap": [
+					"src/"
+				]
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"BSD-3-Clause"
+			],
+			"authors": [
+				{
+					"name": "Sebastian Bergmann",
+					"email": "sebastian@phpunit.de",
+					"role": "lead"
+				}
+			],
+			"description": "FilterIterator implementation that filters files based on a list of suffixes.",
+			"homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+			"keywords": [
+				"filesystem",
+				"iterator"
+			],
+			"support": {
+				"issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+				"source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+			},
+			"funding": [
+				{
+					"url": "https://github.com/sebastianbergmann",
+					"type": "github"
+				}
+			],
+			"time": "2021-12-02T12:48:52+00:00"
+		},
+		{
+			"name": "phpunit/php-invoker",
+			"version": "3.1.1",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/sebastianbergmann/php-invoker.git",
+				"reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+				"reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+				"shasum": ""
+			},
+			"require": {
+				"php": ">=7.3"
+			},
+			"require-dev": {
+				"ext-pcntl": "*",
+				"phpunit/phpunit": "^9.3"
+			},
+			"suggest": {
+				"ext-pcntl": "*"
+			},
+			"type": "library",
+			"extra": {
+				"branch-alias": {
+					"dev-master": "3.1-dev"
+				}
+			},
+			"autoload": {
+				"classmap": [
+					"src/"
+				]
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"BSD-3-Clause"
+			],
+			"authors": [
+				{
+					"name": "Sebastian Bergmann",
+					"email": "sebastian@phpunit.de",
+					"role": "lead"
+				}
+			],
+			"description": "Invoke callables with a timeout",
+			"homepage": "https://github.com/sebastianbergmann/php-invoker/",
+			"keywords": [
+				"process"
+			],
+			"support": {
+				"issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+				"source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+			},
+			"funding": [
+				{
+					"url": "https://github.com/sebastianbergmann",
+					"type": "github"
+				}
+			],
+			"time": "2020-09-28T05:58:55+00:00"
+		},
+		{
+			"name": "phpunit/php-text-template",
+			"version": "2.0.4",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/sebastianbergmann/php-text-template.git",
+				"reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+				"reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+				"shasum": ""
+			},
+			"require": {
+				"php": ">=7.3"
+			},
+			"require-dev": {
+				"phpunit/phpunit": "^9.3"
+			},
+			"type": "library",
+			"extra": {
+				"branch-alias": {
+					"dev-master": "2.0-dev"
+				}
+			},
+			"autoload": {
+				"classmap": [
+					"src/"
+				]
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"BSD-3-Clause"
+			],
+			"authors": [
+				{
+					"name": "Sebastian Bergmann",
+					"email": "sebastian@phpunit.de",
+					"role": "lead"
+				}
+			],
+			"description": "Simple template engine.",
+			"homepage": "https://github.com/sebastianbergmann/php-text-template/",
+			"keywords": [
+				"template"
+			],
+			"support": {
+				"issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+				"source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+			},
+			"funding": [
+				{
+					"url": "https://github.com/sebastianbergmann",
+					"type": "github"
+				}
+			],
+			"time": "2020-10-26T05:33:50+00:00"
+		},
+		{
+			"name": "phpunit/php-timer",
+			"version": "5.0.3",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/sebastianbergmann/php-timer.git",
+				"reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+				"reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+				"shasum": ""
+			},
+			"require": {
+				"php": ">=7.3"
+			},
+			"require-dev": {
+				"phpunit/phpunit": "^9.3"
+			},
+			"type": "library",
+			"extra": {
+				"branch-alias": {
+					"dev-master": "5.0-dev"
+				}
+			},
+			"autoload": {
+				"classmap": [
+					"src/"
+				]
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"BSD-3-Clause"
+			],
+			"authors": [
+				{
+					"name": "Sebastian Bergmann",
+					"email": "sebastian@phpunit.de",
+					"role": "lead"
+				}
+			],
+			"description": "Utility class for timing",
+			"homepage": "https://github.com/sebastianbergmann/php-timer/",
+			"keywords": [
+				"timer"
+			],
+			"support": {
+				"issues": "https://github.com/sebastianbergmann/php-timer/issues",
+				"source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+			},
+			"funding": [
+				{
+					"url": "https://github.com/sebastianbergmann",
+					"type": "github"
+				}
+			],
+			"time": "2020-10-26T13:16:10+00:00"
+		},
+		{
+			"name": "phpunit/phpunit",
+			"version": "9.6.13",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/sebastianbergmann/phpunit.git",
+				"reference": "f3d767f7f9e191eab4189abe41ab37797e30b1be"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f3d767f7f9e191eab4189abe41ab37797e30b1be",
+				"reference": "f3d767f7f9e191eab4189abe41ab37797e30b1be",
+				"shasum": ""
+			},
+			"require": {
+				"doctrine/instantiator": "^1.3.1 || ^2",
+				"ext-dom": "*",
+				"ext-json": "*",
+				"ext-libxml": "*",
+				"ext-mbstring": "*",
+				"ext-xml": "*",
+				"ext-xmlwriter": "*",
+				"myclabs/deep-copy": "^1.10.1",
+				"phar-io/manifest": "^2.0.3",
+				"phar-io/version": "^3.0.2",
+				"php": ">=7.3",
+				"phpunit/php-code-coverage": "^9.2.28",
+				"phpunit/php-file-iterator": "^3.0.5",
+				"phpunit/php-invoker": "^3.1.1",
+				"phpunit/php-text-template": "^2.0.3",
+				"phpunit/php-timer": "^5.0.2",
+				"sebastian/cli-parser": "^1.0.1",
+				"sebastian/code-unit": "^1.0.6",
+				"sebastian/comparator": "^4.0.8",
+				"sebastian/diff": "^4.0.3",
+				"sebastian/environment": "^5.1.3",
+				"sebastian/exporter": "^4.0.5",
+				"sebastian/global-state": "^5.0.1",
+				"sebastian/object-enumerator": "^4.0.3",
+				"sebastian/resource-operations": "^3.0.3",
+				"sebastian/type": "^3.2",
+				"sebastian/version": "^3.0.2"
+			},
+			"suggest": {
+				"ext-soap": "To be able to generate mocks based on WSDL files",
+				"ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+			},
+			"bin": [
+				"phpunit"
+			],
+			"type": "library",
+			"extra": {
+				"branch-alias": {
+					"dev-master": "9.6-dev"
+				}
+			},
+			"autoload": {
+				"files": [
+					"src/Framework/Assert/Functions.php"
+				],
+				"classmap": [
+					"src/"
+				]
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"BSD-3-Clause"
+			],
+			"authors": [
+				{
+					"name": "Sebastian Bergmann",
+					"email": "sebastian@phpunit.de",
+					"role": "lead"
+				}
+			],
+			"description": "The PHP Unit Testing framework.",
+			"homepage": "https://phpunit.de/",
+			"keywords": [
+				"phpunit",
+				"testing",
+				"xunit"
+			],
+			"support": {
+				"issues": "https://github.com/sebastianbergmann/phpunit/issues",
+				"security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+				"source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.13"
+			},
+			"funding": [
+				{
+					"url": "https://phpunit.de/sponsors.html",
+					"type": "custom"
+				},
+				{
+					"url": "https://github.com/sebastianbergmann",
+					"type": "github"
+				},
+				{
+					"url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+					"type": "tidelift"
+				}
+			],
+			"time": "2023-09-19T05:39:22+00:00"
+		},
+		{
+			"name": "psr/log",
+			"version": "1.1.4",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/php-fig/log.git",
+				"reference": "d49695b909c3b7628b6289db5479a1c204601f11"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
+				"reference": "d49695b909c3b7628b6289db5479a1c204601f11",
+				"shasum": ""
+			},
+			"require": {
+				"php": ">=5.3.0"
+			},
+			"type": "library",
+			"extra": {
+				"branch-alias": {
+					"dev-master": "1.1.x-dev"
+				}
+			},
+			"autoload": {
+				"psr-4": {
+					"Psr\\Log\\": "Psr/Log/"
+				}
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"MIT"
+			],
+			"authors": [
+				{
+					"name": "PHP-FIG",
+					"homepage": "https://www.php-fig.org/"
+				}
+			],
+			"description": "Common interface for logging libraries",
+			"homepage": "https://github.com/php-fig/log",
+			"keywords": [
+				"log",
+				"psr",
+				"psr-3"
+			],
+			"support": {
+				"source": "https://github.com/php-fig/log/tree/1.1.4"
+			},
+			"time": "2021-05-03T11:20:27+00:00"
+		},
+		{
+			"name": "sebastian/cli-parser",
+			"version": "1.0.1",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/sebastianbergmann/cli-parser.git",
+				"reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/442e7c7e687e42adc03470c7b668bc4b2402c0b2",
+				"reference": "442e7c7e687e42adc03470c7b668bc4b2402c0b2",
+				"shasum": ""
+			},
+			"require": {
+				"php": ">=7.3"
+			},
+			"require-dev": {
+				"phpunit/phpunit": "^9.3"
+			},
+			"type": "library",
+			"extra": {
+				"branch-alias": {
+					"dev-master": "1.0-dev"
+				}
+			},
+			"autoload": {
+				"classmap": [
+					"src/"
+				]
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"BSD-3-Clause"
+			],
+			"authors": [
+				{
+					"name": "Sebastian Bergmann",
+					"email": "sebastian@phpunit.de",
+					"role": "lead"
+				}
+			],
+			"description": "Library for parsing CLI options",
+			"homepage": "https://github.com/sebastianbergmann/cli-parser",
+			"support": {
+				"issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+				"source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.1"
+			},
+			"funding": [
+				{
+					"url": "https://github.com/sebastianbergmann",
+					"type": "github"
+				}
+			],
+			"time": "2020-09-28T06:08:49+00:00"
+		},
+		{
+			"name": "sebastian/code-unit",
+			"version": "1.0.8",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/sebastianbergmann/code-unit.git",
+				"reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
+				"reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+				"shasum": ""
+			},
+			"require": {
+				"php": ">=7.3"
+			},
+			"require-dev": {
+				"phpunit/phpunit": "^9.3"
+			},
+			"type": "library",
+			"extra": {
+				"branch-alias": {
+					"dev-master": "1.0-dev"
+				}
+			},
+			"autoload": {
+				"classmap": [
+					"src/"
+				]
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"BSD-3-Clause"
+			],
+			"authors": [
+				{
+					"name": "Sebastian Bergmann",
+					"email": "sebastian@phpunit.de",
+					"role": "lead"
+				}
+			],
+			"description": "Collection of value objects that represent the PHP code units",
+			"homepage": "https://github.com/sebastianbergmann/code-unit",
+			"support": {
+				"issues": "https://github.com/sebastianbergmann/code-unit/issues",
+				"source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+			},
+			"funding": [
+				{
+					"url": "https://github.com/sebastianbergmann",
+					"type": "github"
+				}
+			],
+			"time": "2020-10-26T13:08:54+00:00"
+		},
+		{
+			"name": "sebastian/code-unit-reverse-lookup",
+			"version": "2.0.3",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+				"reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+				"reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+				"shasum": ""
+			},
+			"require": {
+				"php": ">=7.3"
+			},
+			"require-dev": {
+				"phpunit/phpunit": "^9.3"
+			},
+			"type": "library",
+			"extra": {
+				"branch-alias": {
+					"dev-master": "2.0-dev"
+				}
+			},
+			"autoload": {
+				"classmap": [
+					"src/"
+				]
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"BSD-3-Clause"
+			],
+			"authors": [
+				{
+					"name": "Sebastian Bergmann",
+					"email": "sebastian@phpunit.de"
+				}
+			],
+			"description": "Looks up which function or method a line of code belongs to",
+			"homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+			"support": {
+				"issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+				"source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+			},
+			"funding": [
+				{
+					"url": "https://github.com/sebastianbergmann",
+					"type": "github"
+				}
+			],
+			"time": "2020-09-28T05:30:19+00:00"
+		},
+		{
+			"name": "sebastian/comparator",
+			"version": "4.0.8",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/sebastianbergmann/comparator.git",
+				"reference": "fa0f136dd2334583309d32b62544682ee972b51a"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/fa0f136dd2334583309d32b62544682ee972b51a",
+				"reference": "fa0f136dd2334583309d32b62544682ee972b51a",
+				"shasum": ""
+			},
+			"require": {
+				"php": ">=7.3",
+				"sebastian/diff": "^4.0",
+				"sebastian/exporter": "^4.0"
+			},
+			"require-dev": {
+				"phpunit/phpunit": "^9.3"
+			},
+			"type": "library",
+			"extra": {
+				"branch-alias": {
+					"dev-master": "4.0-dev"
+				}
+			},
+			"autoload": {
+				"classmap": [
+					"src/"
+				]
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"BSD-3-Clause"
+			],
+			"authors": [
+				{
+					"name": "Sebastian Bergmann",
+					"email": "sebastian@phpunit.de"
+				},
+				{
+					"name": "Jeff Welch",
+					"email": "whatthejeff@gmail.com"
+				},
+				{
+					"name": "Volker Dusch",
+					"email": "github@wallbash.com"
+				},
+				{
+					"name": "Bernhard Schussek",
+					"email": "bschussek@2bepublished.at"
+				}
+			],
+			"description": "Provides the functionality to compare PHP values for equality",
+			"homepage": "https://github.com/sebastianbergmann/comparator",
+			"keywords": [
+				"comparator",
+				"compare",
+				"equality"
+			],
+			"support": {
+				"issues": "https://github.com/sebastianbergmann/comparator/issues",
+				"source": "https://github.com/sebastianbergmann/comparator/tree/4.0.8"
+			},
+			"funding": [
+				{
+					"url": "https://github.com/sebastianbergmann",
+					"type": "github"
+				}
+			],
+			"time": "2022-09-14T12:41:17+00:00"
+		},
+		{
+			"name": "sebastian/complexity",
+			"version": "2.0.2",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/sebastianbergmann/complexity.git",
+				"reference": "739b35e53379900cc9ac327b2147867b8b6efd88"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/739b35e53379900cc9ac327b2147867b8b6efd88",
+				"reference": "739b35e53379900cc9ac327b2147867b8b6efd88",
+				"shasum": ""
+			},
+			"require": {
+				"nikic/php-parser": "^4.7",
+				"php": ">=7.3"
+			},
+			"require-dev": {
+				"phpunit/phpunit": "^9.3"
+			},
+			"type": "library",
+			"extra": {
+				"branch-alias": {
+					"dev-master": "2.0-dev"
+				}
+			},
+			"autoload": {
+				"classmap": [
+					"src/"
+				]
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"BSD-3-Clause"
+			],
+			"authors": [
+				{
+					"name": "Sebastian Bergmann",
+					"email": "sebastian@phpunit.de",
+					"role": "lead"
+				}
+			],
+			"description": "Library for calculating the complexity of PHP code units",
+			"homepage": "https://github.com/sebastianbergmann/complexity",
+			"support": {
+				"issues": "https://github.com/sebastianbergmann/complexity/issues",
+				"source": "https://github.com/sebastianbergmann/complexity/tree/2.0.2"
+			},
+			"funding": [
+				{
+					"url": "https://github.com/sebastianbergmann",
+					"type": "github"
+				}
+			],
+			"time": "2020-10-26T15:52:27+00:00"
+		},
+		{
+			"name": "sebastian/diff",
+			"version": "4.0.5",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/sebastianbergmann/diff.git",
+				"reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
+				"reference": "74be17022044ebaaecfdf0c5cd504fc9cd5a7131",
+				"shasum": ""
+			},
+			"require": {
+				"php": ">=7.3"
+			},
+			"require-dev": {
+				"phpunit/phpunit": "^9.3",
+				"symfony/process": "^4.2 || ^5"
+			},
+			"type": "library",
+			"extra": {
+				"branch-alias": {
+					"dev-master": "4.0-dev"
+				}
+			},
+			"autoload": {
+				"classmap": [
+					"src/"
+				]
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"BSD-3-Clause"
+			],
+			"authors": [
+				{
+					"name": "Sebastian Bergmann",
+					"email": "sebastian@phpunit.de"
+				},
+				{
+					"name": "Kore Nordmann",
+					"email": "mail@kore-nordmann.de"
+				}
+			],
+			"description": "Diff implementation",
+			"homepage": "https://github.com/sebastianbergmann/diff",
+			"keywords": [
+				"diff",
+				"udiff",
+				"unidiff",
+				"unified diff"
+			],
+			"support": {
+				"issues": "https://github.com/sebastianbergmann/diff/issues",
+				"source": "https://github.com/sebastianbergmann/diff/tree/4.0.5"
+			},
+			"funding": [
+				{
+					"url": "https://github.com/sebastianbergmann",
+					"type": "github"
+				}
+			],
+			"time": "2023-05-07T05:35:17+00:00"
+		},
+		{
+			"name": "sebastian/environment",
+			"version": "5.1.5",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/sebastianbergmann/environment.git",
+				"reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+				"reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+				"shasum": ""
+			},
+			"require": {
+				"php": ">=7.3"
+			},
+			"require-dev": {
+				"phpunit/phpunit": "^9.3"
+			},
+			"suggest": {
+				"ext-posix": "*"
+			},
+			"type": "library",
+			"extra": {
+				"branch-alias": {
+					"dev-master": "5.1-dev"
+				}
+			},
+			"autoload": {
+				"classmap": [
+					"src/"
+				]
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"BSD-3-Clause"
+			],
+			"authors": [
+				{
+					"name": "Sebastian Bergmann",
+					"email": "sebastian@phpunit.de"
+				}
+			],
+			"description": "Provides functionality to handle HHVM/PHP environments",
+			"homepage": "http://www.github.com/sebastianbergmann/environment",
+			"keywords": [
+				"Xdebug",
+				"environment",
+				"hhvm"
+			],
+			"support": {
+				"issues": "https://github.com/sebastianbergmann/environment/issues",
+				"source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
+			},
+			"funding": [
+				{
+					"url": "https://github.com/sebastianbergmann",
+					"type": "github"
+				}
+			],
+			"time": "2023-02-03T06:03:51+00:00"
+		},
+		{
+			"name": "sebastian/exporter",
+			"version": "4.0.5",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/sebastianbergmann/exporter.git",
+				"reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
+				"reference": "ac230ed27f0f98f597c8a2b6eb7ac563af5e5b9d",
+				"shasum": ""
+			},
+			"require": {
+				"php": ">=7.3",
+				"sebastian/recursion-context": "^4.0"
+			},
+			"require-dev": {
+				"ext-mbstring": "*",
+				"phpunit/phpunit": "^9.3"
+			},
+			"type": "library",
+			"extra": {
+				"branch-alias": {
+					"dev-master": "4.0-dev"
+				}
+			},
+			"autoload": {
+				"classmap": [
+					"src/"
+				]
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"BSD-3-Clause"
+			],
+			"authors": [
+				{
+					"name": "Sebastian Bergmann",
+					"email": "sebastian@phpunit.de"
+				},
+				{
+					"name": "Jeff Welch",
+					"email": "whatthejeff@gmail.com"
+				},
+				{
+					"name": "Volker Dusch",
+					"email": "github@wallbash.com"
+				},
+				{
+					"name": "Adam Harvey",
+					"email": "aharvey@php.net"
+				},
+				{
+					"name": "Bernhard Schussek",
+					"email": "bschussek@gmail.com"
+				}
+			],
+			"description": "Provides the functionality to export PHP variables for visualization",
+			"homepage": "https://www.github.com/sebastianbergmann/exporter",
+			"keywords": [
+				"export",
+				"exporter"
+			],
+			"support": {
+				"issues": "https://github.com/sebastianbergmann/exporter/issues",
+				"source": "https://github.com/sebastianbergmann/exporter/tree/4.0.5"
+			},
+			"funding": [
+				{
+					"url": "https://github.com/sebastianbergmann",
+					"type": "github"
+				}
+			],
+			"time": "2022-09-14T06:03:37+00:00"
+		},
+		{
+			"name": "sebastian/global-state",
+			"version": "5.0.6",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/sebastianbergmann/global-state.git",
+				"reference": "bde739e7565280bda77be70044ac1047bc007e34"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bde739e7565280bda77be70044ac1047bc007e34",
+				"reference": "bde739e7565280bda77be70044ac1047bc007e34",
+				"shasum": ""
+			},
+			"require": {
+				"php": ">=7.3",
+				"sebastian/object-reflector": "^2.0",
+				"sebastian/recursion-context": "^4.0"
+			},
+			"require-dev": {
+				"ext-dom": "*",
+				"phpunit/phpunit": "^9.3"
+			},
+			"suggest": {
+				"ext-uopz": "*"
+			},
+			"type": "library",
+			"extra": {
+				"branch-alias": {
+					"dev-master": "5.0-dev"
+				}
+			},
+			"autoload": {
+				"classmap": [
+					"src/"
+				]
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"BSD-3-Clause"
+			],
+			"authors": [
+				{
+					"name": "Sebastian Bergmann",
+					"email": "sebastian@phpunit.de"
+				}
+			],
+			"description": "Snapshotting of global state",
+			"homepage": "http://www.github.com/sebastianbergmann/global-state",
+			"keywords": [
+				"global state"
+			],
+			"support": {
+				"issues": "https://github.com/sebastianbergmann/global-state/issues",
+				"source": "https://github.com/sebastianbergmann/global-state/tree/5.0.6"
+			},
+			"funding": [
+				{
+					"url": "https://github.com/sebastianbergmann",
+					"type": "github"
+				}
+			],
+			"time": "2023-08-02T09:26:13+00:00"
+		},
+		{
+			"name": "sebastian/lines-of-code",
+			"version": "1.0.3",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/sebastianbergmann/lines-of-code.git",
+				"reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/c1c2e997aa3146983ed888ad08b15470a2e22ecc",
+				"reference": "c1c2e997aa3146983ed888ad08b15470a2e22ecc",
+				"shasum": ""
+			},
+			"require": {
+				"nikic/php-parser": "^4.6",
+				"php": ">=7.3"
+			},
+			"require-dev": {
+				"phpunit/phpunit": "^9.3"
+			},
+			"type": "library",
+			"extra": {
+				"branch-alias": {
+					"dev-master": "1.0-dev"
+				}
+			},
+			"autoload": {
+				"classmap": [
+					"src/"
+				]
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"BSD-3-Clause"
+			],
+			"authors": [
+				{
+					"name": "Sebastian Bergmann",
+					"email": "sebastian@phpunit.de",
+					"role": "lead"
+				}
+			],
+			"description": "Library for counting the lines of code in PHP source code",
+			"homepage": "https://github.com/sebastianbergmann/lines-of-code",
+			"support": {
+				"issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+				"source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.3"
+			},
+			"funding": [
+				{
+					"url": "https://github.com/sebastianbergmann",
+					"type": "github"
+				}
+			],
+			"time": "2020-11-28T06:42:11+00:00"
+		},
+		{
+			"name": "sebastian/object-enumerator",
+			"version": "4.0.4",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/sebastianbergmann/object-enumerator.git",
+				"reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
+				"reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+				"shasum": ""
+			},
+			"require": {
+				"php": ">=7.3",
+				"sebastian/object-reflector": "^2.0",
+				"sebastian/recursion-context": "^4.0"
+			},
+			"require-dev": {
+				"phpunit/phpunit": "^9.3"
+			},
+			"type": "library",
+			"extra": {
+				"branch-alias": {
+					"dev-master": "4.0-dev"
+				}
+			},
+			"autoload": {
+				"classmap": [
+					"src/"
+				]
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"BSD-3-Clause"
+			],
+			"authors": [
+				{
+					"name": "Sebastian Bergmann",
+					"email": "sebastian@phpunit.de"
+				}
+			],
+			"description": "Traverses array structures and object graphs to enumerate all referenced objects",
+			"homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+			"support": {
+				"issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+				"source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+			},
+			"funding": [
+				{
+					"url": "https://github.com/sebastianbergmann",
+					"type": "github"
+				}
+			],
+			"time": "2020-10-26T13:12:34+00:00"
+		},
+		{
+			"name": "sebastian/object-reflector",
+			"version": "2.0.4",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/sebastianbergmann/object-reflector.git",
+				"reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+				"reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+				"shasum": ""
+			},
+			"require": {
+				"php": ">=7.3"
+			},
+			"require-dev": {
+				"phpunit/phpunit": "^9.3"
+			},
+			"type": "library",
+			"extra": {
+				"branch-alias": {
+					"dev-master": "2.0-dev"
+				}
+			},
+			"autoload": {
+				"classmap": [
+					"src/"
+				]
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"BSD-3-Clause"
+			],
+			"authors": [
+				{
+					"name": "Sebastian Bergmann",
+					"email": "sebastian@phpunit.de"
+				}
+			],
+			"description": "Allows reflection of object attributes, including inherited and non-public ones",
+			"homepage": "https://github.com/sebastianbergmann/object-reflector/",
+			"support": {
+				"issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+				"source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+			},
+			"funding": [
+				{
+					"url": "https://github.com/sebastianbergmann",
+					"type": "github"
+				}
+			],
+			"time": "2020-10-26T13:14:26+00:00"
+		},
+		{
+			"name": "sebastian/recursion-context",
+			"version": "4.0.5",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/sebastianbergmann/recursion-context.git",
+				"reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
+				"reference": "e75bd0f07204fec2a0af9b0f3cfe97d05f92efc1",
+				"shasum": ""
+			},
+			"require": {
+				"php": ">=7.3"
+			},
+			"require-dev": {
+				"phpunit/phpunit": "^9.3"
+			},
+			"type": "library",
+			"extra": {
+				"branch-alias": {
+					"dev-master": "4.0-dev"
+				}
+			},
+			"autoload": {
+				"classmap": [
+					"src/"
+				]
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"BSD-3-Clause"
+			],
+			"authors": [
+				{
+					"name": "Sebastian Bergmann",
+					"email": "sebastian@phpunit.de"
+				},
+				{
+					"name": "Jeff Welch",
+					"email": "whatthejeff@gmail.com"
+				},
+				{
+					"name": "Adam Harvey",
+					"email": "aharvey@php.net"
+				}
+			],
+			"description": "Provides functionality to recursively process PHP variables",
+			"homepage": "https://github.com/sebastianbergmann/recursion-context",
+			"support": {
+				"issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+				"source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.5"
+			},
+			"funding": [
+				{
+					"url": "https://github.com/sebastianbergmann",
+					"type": "github"
+				}
+			],
+			"time": "2023-02-03T06:07:39+00:00"
+		},
+		{
+			"name": "sebastian/resource-operations",
+			"version": "3.0.3",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/sebastianbergmann/resource-operations.git",
+				"reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
+				"reference": "0f4443cb3a1d92ce809899753bc0d5d5a8dd19a8",
+				"shasum": ""
+			},
+			"require": {
+				"php": ">=7.3"
+			},
+			"require-dev": {
+				"phpunit/phpunit": "^9.0"
+			},
+			"type": "library",
+			"extra": {
+				"branch-alias": {
+					"dev-master": "3.0-dev"
+				}
+			},
+			"autoload": {
+				"classmap": [
+					"src/"
+				]
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"BSD-3-Clause"
+			],
+			"authors": [
+				{
+					"name": "Sebastian Bergmann",
+					"email": "sebastian@phpunit.de"
+				}
+			],
+			"description": "Provides a list of PHP built-in functions that operate on resources",
+			"homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+			"support": {
+				"issues": "https://github.com/sebastianbergmann/resource-operations/issues",
+				"source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.3"
+			},
+			"funding": [
+				{
+					"url": "https://github.com/sebastianbergmann",
+					"type": "github"
+				}
+			],
+			"time": "2020-09-28T06:45:17+00:00"
+		},
+		{
+			"name": "sebastian/type",
+			"version": "3.2.1",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/sebastianbergmann/type.git",
+				"reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+				"reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+				"shasum": ""
+			},
+			"require": {
+				"php": ">=7.3"
+			},
+			"require-dev": {
+				"phpunit/phpunit": "^9.5"
+			},
+			"type": "library",
+			"extra": {
+				"branch-alias": {
+					"dev-master": "3.2-dev"
+				}
+			},
+			"autoload": {
+				"classmap": [
+					"src/"
+				]
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"BSD-3-Clause"
+			],
+			"authors": [
+				{
+					"name": "Sebastian Bergmann",
+					"email": "sebastian@phpunit.de",
+					"role": "lead"
+				}
+			],
+			"description": "Collection of value objects that represent the types of the PHP type system",
+			"homepage": "https://github.com/sebastianbergmann/type",
+			"support": {
+				"issues": "https://github.com/sebastianbergmann/type/issues",
+				"source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
+			},
+			"funding": [
+				{
+					"url": "https://github.com/sebastianbergmann",
+					"type": "github"
+				}
+			],
+			"time": "2023-02-03T06:13:03+00:00"
+		},
+		{
+			"name": "sebastian/version",
+			"version": "3.0.2",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/sebastianbergmann/version.git",
+				"reference": "c6c1022351a901512170118436c764e473f6de8c"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
+				"reference": "c6c1022351a901512170118436c764e473f6de8c",
+				"shasum": ""
+			},
+			"require": {
+				"php": ">=7.3"
+			},
+			"type": "library",
+			"extra": {
+				"branch-alias": {
+					"dev-master": "3.0-dev"
+				}
+			},
+			"autoload": {
+				"classmap": [
+					"src/"
+				]
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"BSD-3-Clause"
+			],
+			"authors": [
+				{
+					"name": "Sebastian Bergmann",
+					"email": "sebastian@phpunit.de",
+					"role": "lead"
+				}
+			],
+			"description": "Library that helps with managing the version number of Git-hosted PHP projects",
+			"homepage": "https://github.com/sebastianbergmann/version",
+			"support": {
+				"issues": "https://github.com/sebastianbergmann/version/issues",
+				"source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+			},
+			"funding": [
+				{
+					"url": "https://github.com/sebastianbergmann",
+					"type": "github"
+				}
+			],
+			"time": "2020-09-28T06:39:44+00:00"
+		},
+		{
+			"name": "squizlabs/php_codesniffer",
+			"version": "3.7.2",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+				"reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
+				"reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
+				"shasum": ""
+			},
+			"require": {
+				"ext-simplexml": "*",
+				"ext-tokenizer": "*",
+				"ext-xmlwriter": "*",
+				"php": ">=5.4.0"
+			},
+			"require-dev": {
+				"phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+			},
+			"bin": [
+				"bin/phpcs",
+				"bin/phpcbf"
+			],
+			"type": "library",
+			"extra": {
+				"branch-alias": {
+					"dev-master": "3.x-dev"
+				}
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"BSD-3-Clause"
+			],
+			"authors": [
+				{
+					"name": "Greg Sherwood",
+					"role": "lead"
+				}
+			],
+			"description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+			"homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+			"keywords": [
+				"phpcs",
+				"standards",
+				"static analysis"
+			],
+			"support": {
+				"issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
+				"source": "https://github.com/squizlabs/PHP_CodeSniffer",
+				"wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+			},
+			"time": "2023-02-22T23:07:41+00:00"
+		},
+		{
+			"name": "theseer/tokenizer",
+			"version": "1.2.2",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/theseer/tokenizer.git",
+				"reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/theseer/tokenizer/zipball/b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
+				"reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
+				"shasum": ""
+			},
+			"require": {
+				"ext-dom": "*",
+				"ext-tokenizer": "*",
+				"ext-xmlwriter": "*",
+				"php": "^7.2 || ^8.0"
+			},
+			"type": "library",
+			"autoload": {
+				"classmap": [
+					"src/"
+				]
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"BSD-3-Clause"
+			],
+			"authors": [
+				{
+					"name": "Arne Blankerts",
+					"email": "arne@blankerts.de",
+					"role": "Developer"
+				}
+			],
+			"description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+			"support": {
+				"issues": "https://github.com/theseer/tokenizer/issues",
+				"source": "https://github.com/theseer/tokenizer/tree/1.2.2"
+			},
+			"funding": [
+				{
+					"url": "https://github.com/theseer",
+					"type": "github"
+				}
+			],
+			"time": "2023-11-20T00:12:19+00:00"
+		},
+		{
+			"name": "woocommerce/woocommerce-sniffs",
+			"version": "1.0.0",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/woocommerce/woocommerce-sniffs.git",
+				"reference": "3a65b917ff5ab5e65609e5dcb7bc62f9455bbef8"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/woocommerce/woocommerce-sniffs/zipball/3a65b917ff5ab5e65609e5dcb7bc62f9455bbef8",
+				"reference": "3a65b917ff5ab5e65609e5dcb7bc62f9455bbef8",
+				"shasum": ""
+			},
+			"require": {
+				"dealerdirect/phpcodesniffer-composer-installer": "^1.0.0",
+				"php": ">=7.0",
+				"phpcompatibility/phpcompatibility-wp": "^2.1.0",
+				"wp-coding-standards/wpcs": "^3.0.0"
+			},
+			"type": "phpcodesniffer-standard",
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"MIT"
+			],
+			"description": "WooCommerce sniffs",
+			"keywords": [
+				"phpcs",
+				"standards",
+				"static analysis",
+				"woocommerce",
+				"wordpress"
+			],
+			"support": {
+				"issues": "https://github.com/woocommerce/woocommerce-sniffs/issues",
+				"source": "https://github.com/woocommerce/woocommerce-sniffs/tree/1.0.0"
+			},
+			"time": "2023-09-29T13:52:33+00:00"
+		},
+		{
+			"name": "wp-coding-standards/wpcs",
+			"version": "3.0.1",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
+				"reference": "b4caf9689f1a0e4a4c632679a44e638c1c67aff1"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/b4caf9689f1a0e4a4c632679a44e638c1c67aff1",
+				"reference": "b4caf9689f1a0e4a4c632679a44e638c1c67aff1",
+				"shasum": ""
+			},
+			"require": {
+				"ext-filter": "*",
+				"ext-libxml": "*",
+				"ext-tokenizer": "*",
+				"ext-xmlreader": "*",
+				"php": ">=5.4",
+				"phpcsstandards/phpcsextra": "^1.1.0",
+				"phpcsstandards/phpcsutils": "^1.0.8",
+				"squizlabs/php_codesniffer": "^3.7.2"
+			},
+			"require-dev": {
+				"php-parallel-lint/php-console-highlighter": "^1.0.0",
+				"php-parallel-lint/php-parallel-lint": "^1.3.2",
+				"phpcompatibility/php-compatibility": "^9.0",
+				"phpcsstandards/phpcsdevtools": "^1.2.0",
+				"phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+			},
+			"suggest": {
+				"ext-iconv": "For improved results",
+				"ext-mbstring": "For improved results"
+			},
+			"type": "phpcodesniffer-standard",
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"MIT"
+			],
+			"authors": [
+				{
+					"name": "Contributors",
+					"homepage": "https://github.com/WordPress/WordPress-Coding-Standards/graphs/contributors"
+				}
+			],
+			"description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
+			"keywords": [
+				"phpcs",
+				"standards",
+				"static analysis",
+				"wordpress"
+			],
+			"support": {
+				"issues": "https://github.com/WordPress/WordPress-Coding-Standards/issues",
+				"source": "https://github.com/WordPress/WordPress-Coding-Standards",
+				"wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
+			},
+			"funding": [
+				{
+					"url": "https://opencollective.com/thewpcc/contribute/wp-php-63406",
+					"type": "custom"
+				}
+			],
+			"time": "2023-09-14T07:06:09+00:00"
+		},
+		{
+			"name": "wp-hooks/generator",
+			"version": "0.9.0",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/wp-hooks/generator.git",
+				"reference": "6c7f173d85452db52a59a3a6bb943cbe7d845cde"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/wp-hooks/generator/zipball/6c7f173d85452db52a59a3a6bb943cbe7d845cde",
+				"reference": "6c7f173d85452db52a59a3a6bb943cbe7d845cde",
+				"shasum": ""
+			},
+			"require": {
+				"ext-libxml": "*",
+				"johnbillion/wp-parser-lib": "^1.3.0",
+				"php": ">=7"
+			},
+			"replace": {
+				"johnbillion/wp-hooks-generator": "*"
+			},
+			"require-dev": {
+				"oomphinc/composer-installers-extender": "^2",
+				"opis/json-schema": "^1"
+			},
+			"bin": [
+				"bin/wp-hooks-generator"
+			],
+			"type": "library",
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"GPL-3.0-or-later"
+			],
+			"authors": [
+				{
+					"name": "John Blackbourn",
+					"homepage": "https://johnblackbourn.com/"
+				}
+			],
+			"description": "Generates a JSON representation of the WordPress actions and filters in your code",
+			"support": {
+				"issues": "https://github.com/wp-hooks/generator/issues",
+				"source": "https://github.com/wp-hooks/generator/tree/0.9.0"
+			},
+			"funding": [
+				{
+					"url": "https://github.com/sponsors/johnbillion",
+					"type": "github"
+				}
+			],
+			"time": "2022-07-03T12:35:07+00:00"
+		},
+		{
+			"name": "yoast/phpunit-polyfills",
+			"version": "2.0.0",
+			"source": {
+				"type": "git",
+				"url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
+				"reference": "c758753e8f9dac251fed396a73c8305af3f17922"
+			},
+			"dist": {
+				"type": "zip",
+				"url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/c758753e8f9dac251fed396a73c8305af3f17922",
+				"reference": "c758753e8f9dac251fed396a73c8305af3f17922",
+				"shasum": ""
+			},
+			"require": {
+				"php": ">=5.6",
+				"phpunit/phpunit": "^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0"
+			},
+			"require-dev": {
+				"yoast/yoastcs": "^2.3.0"
+			},
+			"type": "library",
+			"extra": {
+				"branch-alias": {
+					"dev-main": "2.x-dev"
+				}
+			},
+			"autoload": {
+				"files": [
+					"phpunitpolyfills-autoload.php"
+				]
+			},
+			"notification-url": "https://packagist.org/downloads/",
+			"license": [
+				"BSD-3-Clause"
+			],
+			"authors": [
+				{
+					"name": "Team Yoast",
+					"email": "support@yoast.com",
+					"homepage": "https://yoast.com"
+				},
+				{
+					"name": "Contributors",
+					"homepage": "https://github.com/Yoast/PHPUnit-Polyfills/graphs/contributors"
+				}
+			],
+			"description": "Set of polyfills for changed PHPUnit functionality to allow for creating PHPUnit cross-version compatible tests",
+			"homepage": "https://github.com/Yoast/PHPUnit-Polyfills",
+			"keywords": [
+				"phpunit",
+				"polyfill",
+				"testing"
+			],
+			"support": {
+				"issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
+				"source": "https://github.com/Yoast/PHPUnit-Polyfills"
+			},
+			"time": "2023-06-06T20:28:24+00:00"
+		}
+	],
+	"aliases": [
+		{
+			"package": "nikic/php-parser",
+			"version": "4.16.0.0",
+			"alias": "1.0.0",
+			"alias_normalized": "1.0.0.0"
+		}
+	],
+	"minimum-stability": "dev",
+	"stability-flags": [],
+	"prefer-stable": true,
+	"prefer-lowest": false,
+	"platform": {
+		"ext-hash": "*",
+		"ext-json": "*"
+	},
+	"platform-dev": [],
+	"platform-overrides": {
+		"php": "7.4.33"
+	},
+	"plugin-api-version": "2.6.0"
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -34,7 +34,7 @@
 		<exclude-pattern>src/*</exclude-pattern>
 	</rule>
 
-	<rule ref="WordPress.PHP.DisallowShortTernary.Found">
+	<rule ref="Universal.Operators.DisallowShortTernary.Found">
 		<exclude-pattern>src/*</exclude-pattern>
 		<exclude-pattern>tests/*</exclude-pattern>
 	</rule>


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

This PR replaces the removed `WordPress.PHP.DisallowShortTernary` in favor of `Universal.Operators.DisallowShortTernary`.

Ref: https://github.com/WordPress/WordPress-Coding-Standards/blob/7722c0b8a6f4eb615be4ba8ebe22ed92a5fa87d7/CHANGELOG.md?plain=1#L231

## Why

Since the rule is removed, it is causing an error such as this in the VS Code editor ![file.png](https://github.com/woocommerce/woocommerce-blocks/assets/2132595/01a615be-bc18-4b04-8089-f7835dc82bab)
<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Note

I am not sure why we're trying to exclude the `src/*` [folder](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/phpcs.xml#L38) since this is the folder where the bulk of the PHP files lives. I would think this is exactly the place we should lint? Perhaps you know cc @nielslange 

~~Also this is blocked by WooCommerce Sniffs need to be first updated to version `1.0.0` so we can use WP coding standards version `^3.0.0`.~~

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Have PHPCS installed globally.
2. Install the WooCommerce Sniffs `composer global require woocommerce/woocommerce-sniffs --dev` (version 1.0.0)
3. Add the PHPCS extension to your VS Code.
4. Change the execution path of the PHPCS extension to point to your globally installed PHPCS (use `which phpcs` to find the path).
5. Set the PHPCS extension standard to `WooCommerce-Core` in the `settings.json` like `"phpcs.standard": "WooCommerce-Core"`.
6. Open up a PHP file outside of `/src/*` and try to add a shorthand ternary operation and ensure PHPCS catches that. You can use `$foobar = true ?: false;`.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [x] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [x] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> N/A