### PR TITLE
Store Customization > Ensure AI content is generated for newly created products.

### DIFF
--- a/src/AI/Connection.php
+++ b/src/AI/Connection.php
@@ -83,10 +83,10 @@ class Connection {
 		$responses = Requests::request_multiple( $requests, array( 'timeout' => $timeout ) );
 
 		$processed_responses = array();
+
 		foreach ( $responses as $key => $response ) {
 			if ( is_wp_error( $response ) || is_a( $response, Exception::class ) ) {
-				$processed_responses[ $key ] = null;
-				continue;
+				return new WP_Error( 'failed-to-connect-with-the-ai-endpoint', esc_html__( 'Failed to connect with the AI endpoint: try again later.', 'woo-gutenberg-products-block' ) );
 			}
 
 			$processed_responses[ $key ] = json_decode( $response->body, true );

--- a/src/Patterns/ProductUpdater.php
+++ b/src/Patterns/ProductUpdater.php
@@ -82,7 +82,7 @@ class ProductUpdater {
 
 		$dummy_products       = $this->fetch_product_ids( 'dummy' );
 		$dummy_products_count = count( $dummy_products );
-		$products_to_create   = max( 6, 6 - $real_products_count - $dummy_products_count );
+		$products_to_create   = max( 0, 6 - $real_products_count - $dummy_products_count );
 
 		while ( $products_to_create > 0 ) {
 			$this->create_new_product();
@@ -141,10 +141,12 @@ class ProductUpdater {
 
 		$timestamp_created  = strtotime( $formatted_date_created );
 		$timestamp_modified = strtotime( $formatted_date_modified );
+		$timestamp_current  = time();
 
-		$dummy_product_not_modified = abs( $timestamp_modified - $timestamp_created ) < 60;
+		$dummy_product_recently_modified = abs( $timestamp_current - $timestamp_modified ) < 10;
+		$dummy_product_not_modified      = abs( $timestamp_modified - $timestamp_created ) < 60;
 
-		if ( $current_product_hash === $ai_modified_product_hash || $dummy_product_not_modified ) {
+		if ( $current_product_hash === $ai_modified_product_hash || $dummy_product_not_modified || $dummy_product_recently_modified ) {
 			return true;
 		}
 

--- a/src/Patterns/dictionary.json
+++ b/src/Patterns/dictionary.json
@@ -78,15 +78,15 @@
 			"titles": [
 				{
 					"default": "Cupcakes",
-					"ai_prompt": "The title of the first featured category: {image.0}"
+					"ai_prompt": "A title with less than 20 characters for the featured category: {image.0}"
 				},
 				{
 					"default": "Sweet Danish",
-					"ai_prompt": "The title of the second featured category: {image.1}"
+					"ai_prompt": "A title with less than 20 characters for the featured category: {image.1}"
 				},
 				{
 					"default": "Warm Bread",
-					"ai_prompt": "The title of the third featured category: {image.2}"
+					"ai_prompt": "A title with less than 20 characters for the featured category: {image.2}"
 				}
 			]
 		}

--- a/src/StoreApi/Routes/V1/AI/Product.php
+++ b/src/StoreApi/Routes/V1/AI/Product.php
@@ -69,37 +69,10 @@ class Product extends AbstractRoute {
 	 * @return bool|string|\WP_Error|\WP_REST_Response
 	 */
 	protected function get_route_post_response( \WP_REST_Request $request ) {
-		$product_updater = new ProductUpdater();
-		$dummy_products  = $product_updater->fetch_dummy_products_to_update();
+		$product_updater     = new ProductUpdater();
+		$product_information = $request['products_information'] ?? array();
 
-		if ( empty( $dummy_products ) ) {
-			return rest_ensure_response(
-				array(
-					'ai_content_generated' => true,
-				)
-			);
-		}
-
-		$index = $request['index'];
-		if ( ! is_numeric( $index ) ) {
-			return rest_ensure_response(
-				array(
-					'ai_content_generated' => false,
-				)
-			);
-		}
-
-		$products_information = $request['products_information'] ?? array();
-
-		if ( ! isset( $dummy_products[ $index ] ) ) {
-			return rest_ensure_response(
-				array(
-					'ai_content_generated' => false,
-				)
-			);
-		}
-
-		$product_updater->update_product_content( $dummy_products[ $index ], $products_information );
+		$product_updater->update_product_content( $product_information );
 
 		return rest_ensure_response(
 			array(

--- a/src/StoreApi/Routes/V1/AI/Product.php
+++ b/src/StoreApi/Routes/V1/AI/Product.php
@@ -72,6 +72,14 @@ class Product extends AbstractRoute {
 		$product_updater     = new ProductUpdater();
 		$product_information = $request['products_information'] ?? array();
 
+		if ( empty( $product_information ) ) {
+			return rest_ensure_response(
+				array(
+					'ai_content_generated' => true,
+				)
+			);
+		}
+
 		$product_updater->update_product_content( $product_information );
 
 		return rest_ensure_response(

--- a/src/StoreApi/Routes/V1/AI/Products.php
+++ b/src/StoreApi/Routes/V1/AI/Products.php
@@ -89,20 +89,6 @@ class Products extends AbstractRoute {
 			$business_description = get_option( 'woo_ai_describe_store_description' );
 		}
 
-		$last_business_description = get_option( 'last_business_description_with_ai_content_generated' );
-
-		if ( $last_business_description === $business_description ) {
-			return rest_ensure_response(
-				$this->prepare_item_for_response(
-					[
-						'ai_content_generated' => true,
-						'product_content'      => null,
-					],
-					$request
-				)
-			);
-		}
-
 		$ai_connection = new Connection();
 
 		$site_id = $ai_connection->get_site_id();


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Ensure the method responsible for fetching the collection of dummy products to be updated by AI `fetch_dummy_products_to_update` is not invoked on the `product` endpoint but on the `products` endpoint instead. This solves the regression where this method would be invoked multiple times (for each product), resulting in too many products being programmatically updated on each request and not all of them having AI-managed/generated content assigned to them.

Fixes #

## Why

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1.
2.
3.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Store Customization > Ensure AI content is generated for newly created products.
