### PR TITLE
Update check for classic vs. block theme in the Jetpack WooCommerce Analytics integration

### DIFF
--- a/src/Domain/Services/JetpackWooCommerceAnalytics.php
+++ b/src/Domain/Services/JetpackWooCommerceAnalytics.php
@@ -245,6 +245,33 @@ class JetpackWooCommerceAnalytics {
 			return $info;
 		}
 
+		if ( ! wp_is_block_theme() ) {
+			$cart_page_id     = wc_get_page_id( 'cart' );
+			$checkout_page_id = wc_get_page_id( 'checkout' );
+
+			$info = array(
+				'cart_page_contains_cart_block'         => $this->post_contains_text(
+					$cart_page_id,
+					'<!-- wp:woocommerce/cart'
+				),
+				'cart_page_contains_cart_shortcode'     => $this->post_contains_text(
+					$cart_page_id,
+					'[woocommerce_cart]'
+				),
+				'checkout_page_contains_checkout_block' => $this->post_contains_text(
+					$checkout_page_id,
+					'<!-- wp:woocommerce/checkout'
+				),
+				'checkout_page_contains_checkout_shortcode' => $this->post_contains_text(
+					$checkout_page_id,
+					'[woocommerce_checkout]'
+				),
+			);
+
+			set_transient( $transient_name, $info, DAY_IN_SECONDS );
+			return $info;
+		}
+
 		$cart_template        = null;
 		$checkout_template    = null;
 		$cart_template_id     = null;

--- a/src/Domain/Services/JetpackWooCommerceAnalytics.php
+++ b/src/Domain/Services/JetpackWooCommerceAnalytics.php
@@ -253,19 +253,19 @@ class JetpackWooCommerceAnalytics {
 				'cart_page_contains_cart_block'         => $this->post_contains_text(
 					$cart_page_id,
 					'<!-- wp:woocommerce/cart'
-				),
+				) ? 1 : 0,
 				'cart_page_contains_cart_shortcode'     => $this->post_contains_text(
 					$cart_page_id,
 					'[woocommerce_cart]'
-				),
+				) ? 1 : 0,
 				'checkout_page_contains_checkout_block' => $this->post_contains_text(
 					$checkout_page_id,
 					'<!-- wp:woocommerce/checkout'
-				),
+				) ? 1 : 0,
 				'checkout_page_contains_checkout_shortcode' => $this->post_contains_text(
 					$checkout_page_id,
 					'[woocommerce_checkout]'
-				),
+				) ? 1 : 0,
 			);
 
 			set_transient( $transient_name, $info, DAY_IN_SECONDS );
@@ -316,10 +316,10 @@ class JetpackWooCommerceAnalytics {
 		// Sites that load this code will be loading it on a page using the relevant block, but we still need to check
 		// the other page to see if it's using the block or shortcode.
 		$info = array(
-			'cart_page_contains_cart_block'             => str_contains( $cart_template->content, '<!-- wp:woocommerce/cart' ),
-			'cart_page_contains_cart_shortcode'         => str_contains( $cart_template->content, '[woocommerce_cart]' ),
-			'checkout_page_contains_checkout_block'     => str_contains( $checkout_template->content, '<!-- wp:woocommerce/checkout' ),
-			'checkout_page_contains_checkout_shortcode' => str_contains( $checkout_template->content, '[woocommerce_checkout]' ),
+			'cart_page_contains_cart_block'             => str_contains( $cart_template->content, '<!-- wp:woocommerce/cart' ) ? 1 : 0,
+			'cart_page_contains_cart_shortcode'         => str_contains( $cart_template->content, '[woocommerce_cart]' ) ? 1 : 0,
+			'checkout_page_contains_checkout_block'     => str_contains( $checkout_template->content, '<!-- wp:woocommerce/checkout' ) ? 1 : 0,
+			'checkout_page_contains_checkout_shortcode' => str_contains( $checkout_template->content, '[woocommerce_checkout]' ) ? 1 : 0,
 			'additional_blocks_on_cart_page'            => $this->get_additional_blocks(
 				$cart_template->content,
 				array( 'woocommerce/cart' )

--- a/src/Domain/Services/JetpackWooCommerceAnalytics.php
+++ b/src/Domain/Services/JetpackWooCommerceAnalytics.php
@@ -397,4 +397,36 @@ class JetpackWooCommerceAnalytics {
 
 		return $served;
 	}
+
+	/**
+	 * Search a specific post for text content.
+	 *
+	 * Note: similar code is in a WooCommerce core PR:
+	 * https://github.com/woocommerce/woocommerce/pull/25932
+	 *
+	 * @param integer $post_id The id of the post to search.
+	 * @param string  $text    The text to search for.
+	 * @return integer 1 if post contains $text (otherwise 0).
+	 */
+	public function post_contains_text( $post_id, $text ) {
+		global $wpdb;
+
+		// Search for the text anywhere in the post.
+		$wildcarded = "%{$text}%";
+
+		// No better way to search post content without having filters expanding blocks.
+		// This is already cached up in the parent function.
+		$result = $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->prepare(
+				"
+				SELECT COUNT( * ) FROM {$wpdb->prefix}posts
+				WHERE ID=%d
+				AND {$wpdb->prefix}posts.post_content LIKE %s
+				",
+				array( $post_id, $wildcarded )
+			)
+		);
+
+		return ( '0' !== $result ) ? 1 : 0;
+	}
 }

--- a/src/Domain/Services/JetpackWooCommerceAnalytics.php
+++ b/src/Domain/Services/JetpackWooCommerceAnalytics.php
@@ -254,18 +254,24 @@ class JetpackWooCommerceAnalytics {
 					$cart_page_id,
 					'<!-- wp:woocommerce/cart'
 				) ? 1 : 0,
-				'cart_page_contains_cart_shortcode'     => $this->post_contains_text(
+				'cart_page_contains_cart_shortcode'     => ( $this->post_contains_text(
 					$cart_page_id,
 					'[woocommerce_cart]'
-				) ? 1 : 0,
+				) || $this->post_contains_text(
+					$cart_page_id,
+					'<!-- wp:woocommerce/classic-shortcode'
+				) ) ? 1 : 0,
 				'checkout_page_contains_checkout_block' => $this->post_contains_text(
 					$checkout_page_id,
 					'<!-- wp:woocommerce/checkout'
 				) ? 1 : 0,
-				'checkout_page_contains_checkout_shortcode' => $this->post_contains_text(
+				'checkout_page_contains_checkout_shortcode' => ( $this->post_contains_text(
 					$checkout_page_id,
 					'[woocommerce_checkout]'
-				) ? 1 : 0,
+				) || $this->post_contains_text(
+					$checkout_page_id,
+					'<!-- wp:woocommerce/classic-shortcode'
+				) ) ? 1 : 0,
 			);
 
 			set_transient( $transient_name, $info, DAY_IN_SECONDS );
@@ -317,9 +323,9 @@ class JetpackWooCommerceAnalytics {
 		// the other page to see if it's using the block or shortcode.
 		$info = array(
 			'cart_page_contains_cart_block'             => str_contains( $cart_template->content, '<!-- wp:woocommerce/cart' ) ? 1 : 0,
-			'cart_page_contains_cart_shortcode'         => str_contains( $cart_template->content, '[woocommerce_cart]' ) ? 1 : 0,
+			'cart_page_contains_cart_shortcode'         => ( str_contains( $cart_template->content, '[woocommerce_cart]' ) || str_contains( $cart_template->content, '<!-- wp:woocommerce/classic-shortcode' ) ) ? 1 : 0,
 			'checkout_page_contains_checkout_block'     => str_contains( $checkout_template->content, '<!-- wp:woocommerce/checkout' ) ? 1 : 0,
-			'checkout_page_contains_checkout_shortcode' => str_contains( $checkout_template->content, '[woocommerce_checkout]' ) ? 1 : 0,
+			'checkout_page_contains_checkout_shortcode' => ( str_contains( $checkout_template->content, '[woocommerce_checkout]' ) || str_contains( $checkout_template->content, '<!-- wp:woocommerce/classic-shortcode' ) ) ? 1 : 0,
 			'additional_blocks_on_cart_page'            => $this->get_additional_blocks(
 				$cart_template->content,
 				array( 'woocommerce/cart' )

--- a/src/Domain/Services/JetpackWooCommerceAnalytics.php
+++ b/src/Domain/Services/JetpackWooCommerceAnalytics.php
@@ -389,6 +389,17 @@ class JetpackWooCommerceAnalytics {
 			'create_account'                            => 'Yes' === $create_account ? 'Yes' : 'No',
 			'store_currency'                            => get_woocommerce_currency(),
 		);
+
+		$is_cart_using_page_content     = str_contains( $cart_template->content, '<!-- wp:woocommerce/page-content-wrapper {"page":"cart"}' );
+		$is_checkout_using_page_content = str_contains( $checkout_template->content, '<!-- wp:woocommerce/page-content-wrapper {"page":"checkout"}' );
+
+		if ( $is_cart_using_page_content ) {
+			$info = array_merge( $info, $this->get_cart_page_block_usage( $cart_page_id ) );
+		}
+		if ( $is_checkout_using_page_content ) {
+			$info = array_merge( $info, $this->get_checkout_page_block_usage( $checkout_page_id ) );
+		}
+
 		set_transient( $transient_name, $info, DAY_IN_SECONDS );
 		return array_merge( $this->get_common_properties(), $info );
 	}

--- a/src/Domain/Services/JetpackWooCommerceAnalytics.php
+++ b/src/Domain/Services/JetpackWooCommerceAnalytics.php
@@ -230,6 +230,31 @@ class JetpackWooCommerceAnalytics {
 	}
 
 	/**
+	 * Gets an array containing the block or shortcode use properties for the Cart page.
+	 *
+	 * @param int $cart_page_id The Cart page's ID.
+	 * @return int[]            An array containing the block or shortcode use properties for the Cart page.
+	 */
+	public function get_cart_page_block_usage( $cart_page_id ) {
+		$new_info = array();
+
+		$new_info['cart_page_contains_cart_block'] = $this->post_contains_text(
+			$cart_page_id,
+			'<!-- wp:woocommerce/cart'
+		) ? 1 : 0;
+
+		$new_info['cart_page_contains_cart_shortcode'] = ( $this->post_contains_text(
+			$cart_page_id,
+			'[woocommerce_cart]'
+		) || $this->post_contains_text(
+			$cart_page_id,
+			'<!-- wp:woocommerce/classic-shortcode'
+		) ) ? 1 : 0;
+
+		return $new_info;
+	}
+
+	/**
 	 * Get info about the cart & checkout pages, in particular whether the store is using shortcodes or Gutenberg blocks.
 	 * This info is cached in a transient.
 	 *

--- a/src/Domain/Services/JetpackWooCommerceAnalytics.php
+++ b/src/Domain/Services/JetpackWooCommerceAnalytics.php
@@ -295,33 +295,15 @@ class JetpackWooCommerceAnalytics {
 			return $info;
 		}
 
-		if ( ! wp_is_block_theme() ) {
-			$cart_page_id     = wc_get_page_id( 'cart' );
-			$checkout_page_id = wc_get_page_id( 'checkout' );
+		$cart_page_id     = wc_get_page_id( 'cart' );
+		$checkout_page_id = wc_get_page_id( 'checkout' );
 
-			$info = array(
-				'cart_page_contains_cart_block'         => $this->post_contains_text(
-					$cart_page_id,
-					'<!-- wp:woocommerce/cart'
-				) ? 1 : 0,
-				'cart_page_contains_cart_shortcode'     => ( $this->post_contains_text(
-					$cart_page_id,
-					'[woocommerce_cart]'
-				) || $this->post_contains_text(
-					$cart_page_id,
-					'<!-- wp:woocommerce/classic-shortcode'
-				) ) ? 1 : 0,
-				'checkout_page_contains_checkout_block' => $this->post_contains_text(
-					$checkout_page_id,
-					'<!-- wp:woocommerce/checkout'
-				) ? 1 : 0,
-				'checkout_page_contains_checkout_shortcode' => ( $this->post_contains_text(
-					$checkout_page_id,
-					'[woocommerce_checkout]'
-				) || $this->post_contains_text(
-					$checkout_page_id,
-					'<!-- wp:woocommerce/classic-shortcode'
-				) ) ? 1 : 0,
+		if ( ! wp_is_block_theme() ) {
+
+			$info = array_merge(
+				array(),
+				$this->get_cart_page_block_usage( $cart_page_id ),
+				$this->get_checkout_page_block_usage( $checkout_page_id )
 			);
 
 			set_transient( $transient_name, $info, DAY_IN_SECONDS );

--- a/src/Domain/Services/JetpackWooCommerceAnalytics.php
+++ b/src/Domain/Services/JetpackWooCommerceAnalytics.php
@@ -255,6 +255,31 @@ class JetpackWooCommerceAnalytics {
 	}
 
 	/**
+	 * Gets an array containing the block or shortcode use properties for the Checkout page.
+	 *
+	 * @param int $checkout_page_id The Checkout page's ID.
+	 * @return int[]                An array containing the block or shortcode use properties for the Checkout page.
+	 */
+	public function get_checkout_page_block_usage( $checkout_page_id ) {
+		$new_info = array();
+
+		$new_info['checkout_page_contains_checkout_block'] = $this->post_contains_text(
+			$checkout_page_id,
+			'<!-- wp:woocommerce/checkout'
+		) ? 1 : 0;
+
+		$new_info['checkout_page_contains_checkout_shortcode'] = ( $this->post_contains_text(
+			$checkout_page_id,
+			'[woocommerce_checkout]'
+		) || $this->post_contains_text(
+			$checkout_page_id,
+			'<!-- wp:woocommerce/classic-shortcode'
+		) ) ? 1 : 0;
+
+		return $new_info;
+	}
+
+	/**
 	 * Get info about the cart & checkout pages, in particular whether the store is using shortcodes or Gutenberg blocks.
 	 * This info is cached in a transient.
 	 *


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

- Adds a check to determine if a classic theme is in use. That way we will only query the Cart/Checkout pages and not the templates when determining block vs. shortcode use and additional blocks used in the WooCommerce Analytics module.
- Updates the type of the `cart_page_contains_cart_block`, `cart_page_contains_cart_shortcode`, `checkout_page_contains_checkout_block`, and `checkout_page_contains_checkout_shortcode` properties so it is always a `0` or `1` rather than `true` or `false`.

## Why

The data relating to Cart/Checkout and the shortcode or block use is not tracked reliably, this PR should improve the reliability of this data.

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

*Please note, the properties for the Cart/Checkout Shortcode/Blocks use is fetched only once per day, and is stored in a transient, you will need to clear the `woocommerce_blocks_jetpack_woocommerce_analytics_cart_checkout_info_cache` transient while testing to ensure the most up to date data*

- Using a classic theme (e.g. Storefront) edit your Cart and Checkout pages, set them to be using the Cart and Checkout _blocks_.
- Add items to your cart and check out. On the order confirmation page is where the `woocommerceanalytics_order_confirmation_view` event should be fired.
- Using tracks vigilante (p7H4VZ-3cB-p2), ensure the following properties on the `woocommerceanalytics_order_confirmation_view` event contain:
  - `cart_page_contains_cart_block`: `1`
  - `cart_page_contains_cart_shortcode`: `0`
  - `checkout_page_contains_checkout_block`: `1`
  - `checkout_page_contains_checkout_shortcode`: `0`
- Change your Cart/Checkout pages to use the shortcode block (enter `[woocommerce_cart]` on the Cart page, and `[woocommerce_checkout]` on the Checkout page).
- Repeat the steps above and expect the following data:
  - `cart_page_contains_cart_block`: `0`
  - `cart_page_contains_cart_shortcode`: `1`
  - `checkout_page_contains_checkout_block`: `0`
  - `checkout_page_contains_checkout_shortcode`: `1`

Switch to a block theme and repeat the above steps, however edit the Cart/Checkout templates rather than the pages.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [x] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Update accuracy of WooCommerce Analytics events
