### PR TITLE
[CYS] Reduce the number of times the patterns dictionary is accessed

### DIFF
--- a/patterns/banner.php
+++ b/patterns/banner.php
@@ -6,8 +6,6 @@
  */
 
 use Automattic\WooCommerce\Blocks\Patterns\PatternsHelper;
-$content = PatternsHelper::get_pattern_content( 'woocommerce-blocks/banner' );
-$images  = PatternsHelper::get_pattern_images( 'woocommerce-blocks/banner' );
 
 $banner_title       = $content['titles'][0]['default'] ?? '';
 $banner_button      = $content['buttons'][0]['default'] ?? '';

--- a/patterns/discount-banner-with-image.php
+++ b/patterns/discount-banner-with-image.php
@@ -6,8 +6,6 @@
  */
 
 use Automattic\WooCommerce\Blocks\Patterns\PatternsHelper;
-$content = PatternsHelper::get_pattern_content( 'woocommerce-blocks/discount-banner-with-image' );
-$images  = PatternsHelper::get_pattern_images( 'woocommerce-blocks/discount-banner-with-image' );
 
 $description = $content['descriptions'][0]['default'] ?? '';
 ?>

--- a/patterns/discount-banner.php
+++ b/patterns/discount-banner.php
@@ -5,9 +5,6 @@
  * Categories: WooCommerce
  */
 
-use Automattic\WooCommerce\Blocks\Patterns\PatternsHelper;
-
-$content     = PatternsHelper::get_pattern_content( 'woocommerce-blocks/discount-banner' );
 $description = $content['descriptions'][0]['default'] ?? '';
 ?>
 

--- a/patterns/featured-category-cover-image.php
+++ b/patterns/featured-category-cover-image.php
@@ -6,8 +6,6 @@
  */
 
 use Automattic\WooCommerce\Blocks\Patterns\PatternsHelper;
-$content = PatternsHelper::get_pattern_content( 'woocommerce-blocks/featured-category-cover-image' );
-$images  = PatternsHelper::get_pattern_images( 'woocommerce-blocks/featured-category-cover-image' );
 
 $image1 = PatternsHelper::get_image_url( $images, 0, 'images/pattern-placeholders/shop-jeans.png' );
 

--- a/patterns/featured-category-focus.php
+++ b/patterns/featured-category-focus.php
@@ -6,8 +6,6 @@
  */
 
 use Automattic\WooCommerce\Blocks\Patterns\PatternsHelper;
-$content = PatternsHelper::get_pattern_content( 'woocommerce-blocks/featured-category-focus' );
-$images  = PatternsHelper::get_pattern_images( 'woocommerce-blocks/featured-category-focus' );
 
 $category_title = $content['titles'][0]['default'] ?? '';
 ?>

--- a/patterns/featured-category-triple.php
+++ b/patterns/featured-category-triple.php
@@ -6,9 +6,7 @@
  */
 
 use Automattic\WooCommerce\Blocks\Patterns\PatternsHelper;
-$content = PatternsHelper::get_pattern_content( 'woocommerce-blocks/featured-category-triple' );
 
-$images = PatternsHelper::get_pattern_images( 'woocommerce-blocks/featured-category-triple' );
 $image1 = PatternsHelper::get_image_url( $images, 0, 'images/pattern-placeholders/sweet-restaurant-celebration-food-chocolate-cupcake.png' );
 $image2 = PatternsHelper::get_image_url( $images, 1, 'images/pattern-placeholders/dish-meal-food-breakfast-dessert-eat.png' );
 $image3 = PatternsHelper::get_image_url( $images, 2, 'images/pattern-placeholders/dish-food-baking-dessert-bread-bakery.png' );

--- a/patterns/featured-products-fresh-and-tasty.php
+++ b/patterns/featured-products-fresh-and-tasty.php
@@ -6,8 +6,6 @@
  */
 
 use Automattic\WooCommerce\Blocks\Patterns\PatternsHelper;
-$content = PatternsHelper::get_pattern_content( 'woocommerce-blocks/featured-products-fresh-and-tasty' );
-$images  = PatternsHelper::get_pattern_images( 'woocommerce-blocks/featured-products-fresh-and-tasty' );
 
 $image1 = PatternsHelper::get_image_url( $images, 0, 'images/pattern-placeholders/sweet-organic-lemons.png' );
 $image2 = PatternsHelper::get_image_url( $images, 1, 'images/pattern-placeholders/fresh-organic-tomatoes.png' );

--- a/patterns/hero-product-3-split.php
+++ b/patterns/hero-product-3-split.php
@@ -7,9 +7,6 @@
 
 use Automattic\WooCommerce\Blocks\Patterns\PatternsHelper;
 
-$content = PatternsHelper::get_pattern_content( 'woocommerce-blocks/hero-product-3-split' );
-$images  = PatternsHelper::get_pattern_images( 'woocommerce-blocks/hero-product-3-split' );
-
 $main_title   = $content['titles'][0]['default'] ?? '';
 $first_title  = $content['titles'][1]['default'] ?? '';
 $second_title = $content['titles'][2]['default'] ?? '';

--- a/patterns/hero-product-chessboard.php
+++ b/patterns/hero-product-chessboard.php
@@ -6,8 +6,6 @@
  */
 
 use Automattic\WooCommerce\Blocks\Patterns\PatternsHelper;
-$content = PatternsHelper::get_pattern_content( 'woocommerce-blocks/hero-product-chessboard' );
-$images  = PatternsHelper::get_pattern_images( 'woocommerce-blocks/hero-product-chessboard' );
 
 $image1 = PatternsHelper::get_image_url( $images, 0, 'images/pattern-placeholders/sweet-restaurant-celebration-food-chocolate-cupcake.png' );
 $image2 = PatternsHelper::get_image_url( $images, 1, 'images/pattern-placeholders/dish-meal-food-breakfast-dessert-eat.png' );

--- a/patterns/hero-product-split.php
+++ b/patterns/hero-product-split.php
@@ -6,8 +6,6 @@
  */
 
 use Automattic\WooCommerce\Blocks\Patterns\PatternsHelper;
-$content = PatternsHelper::get_pattern_content( 'woocommerce-blocks/hero-product-split' );
-$images  = PatternsHelper::get_pattern_images( 'woocommerce-blocks/hero-product-split' );
 
 $hero_title = $content['titles'][0]['default'] ?? '';
 ?>

--- a/patterns/just-arrived-full-hero.php
+++ b/patterns/just-arrived-full-hero.php
@@ -7,9 +7,6 @@
 
 use Automattic\WooCommerce\Blocks\Patterns\PatternsHelper;
 
-$content = PatternsHelper::get_pattern_content( 'woocommerce-blocks/just-arrived-full-hero' );
-$images  = PatternsHelper::get_pattern_images( 'woocommerce-blocks/just-arrived-full-hero' );
-
 $pattern_title       = $content['titles'][0]['default'] ?? '';
 $pattern_description = $content['descriptions'][0]['default'] ?? '';
 $pattern_button      = $content['buttons'][0]['default'] ?? '';

--- a/patterns/product-collection-3-columns.php
+++ b/patterns/product-collection-3-columns.php
@@ -6,8 +6,6 @@
  */
 use Automattic\WooCommerce\Blocks\Patterns\PatternsHelper;
 
-$content = PatternsHelper::get_pattern_content( 'woocommerce-blocks/product-collection-3-columns' );
-
 $products_title = $content['titles'][0]['default'] ?? '';
 ?>
 

--- a/patterns/product-collection-4-columns.php
+++ b/patterns/product-collection-4-columns.php
@@ -6,8 +6,6 @@
  */
 use Automattic\WooCommerce\Blocks\Patterns\PatternsHelper;
 
-$content = PatternsHelper::get_pattern_content( 'woocommerce-blocks/product-collection-4-columns' );
-
 $products_title = $content['titles'][0]['default'] ?? '';
 ?>
 

--- a/patterns/product-collection-5-columns.php
+++ b/patterns/product-collection-5-columns.php
@@ -6,8 +6,6 @@
  */
 use Automattic\WooCommerce\Blocks\Patterns\PatternsHelper;
 
-$content = PatternsHelper::get_pattern_content( 'woocommerce-blocks/product-collection-5-columns' );
-
 $products_title = $content['titles'][0]['default'] ?? '';
 ?>
 

--- a/patterns/product-collection-banner.php
+++ b/patterns/product-collection-banner.php
@@ -6,9 +6,8 @@
  */
 
 use Automattic\WooCommerce\Blocks\Patterns\PatternsHelper;
-$content = PatternsHelper::get_pattern_content( 'woocommerce-blocks/product-collection-banner' );
-$images  = PatternsHelper::get_pattern_images( 'woocommerce-blocks/product-collection-banner' );
-$image   = PatternsHelper::get_image_url( $images, 0, 'images/pattern-placeholders/beach-landscape-sea-coast-nature-person.jpg' );
+
+$image = PatternsHelper::get_image_url( $images, 0, 'images/pattern-placeholders/beach-landscape-sea-coast-nature-person.jpg' );
 
 $first_title       = $content['titles'][0]['default'] ?? '';
 $first_description = $content['descriptions'][0]['default'] ?? '';

--- a/patterns/product-collection-featured-products-5-columns.php
+++ b/patterns/product-collection-featured-products-5-columns.php
@@ -6,7 +6,6 @@
  */
 
 use Automattic\WooCommerce\Blocks\Patterns\PatternsHelper;
-$content = PatternsHelper::get_pattern_content( 'woocommerce-blocks/product-collection-featured-products-5-columns' );
 
 $collection_title = $content['titles'][0]['default'] ?? '';
 ?>

--- a/patterns/product-collections-featured-collection.php
+++ b/patterns/product-collections-featured-collection.php
@@ -7,7 +7,6 @@
  */
 
 use Automattic\WooCommerce\Blocks\Patterns\PatternsHelper;
-$content = PatternsHelper::get_pattern_content( 'woocommerce-blocks/product-collections-featured-collection' );
 
 $collection_title = $content['titles'][0]['default'] ?? '';
 ?>

--- a/patterns/product-collections-featured-collections.php
+++ b/patterns/product-collections-featured-collections.php
@@ -6,8 +6,6 @@
  */
 
 use Automattic\WooCommerce\Blocks\Patterns\PatternsHelper;
-$content = PatternsHelper::get_pattern_content( 'woocommerce-blocks/product-collections-featured-collections' );
-$images  = PatternsHelper::get_pattern_images( 'woocommerce-blocks/product-collections-featured-collections' );
 
 $image1 = PatternsHelper::get_image_url( $images, 0, 'images/pattern-placeholders/technology-white-camera-photography-vintage-photographer.png' );
 $image2 = PatternsHelper::get_image_url( $images, 1, 'images/pattern-placeholders/leather-guitar-typewriter-red-gadget-sofa.png' );

--- a/patterns/product-collections-newest-arrivals.php
+++ b/patterns/product-collections-newest-arrivals.php
@@ -7,7 +7,6 @@
  */
 
 use Automattic\WooCommerce\Blocks\Patterns\PatternsHelper;
-$content = PatternsHelper::get_pattern_content( 'woocommerce-blocks/product-collections-newest-arrivals' );
 
 $first_title  = $content['titles'][0]['default'] ?? '';
 $first_button = $content['buttons'][0]['default'] ?? '';

--- a/patterns/product-featured-2-columns.php
+++ b/patterns/product-featured-2-columns.php
@@ -5,8 +5,6 @@
  * Categories: WooCommerce
  */
 use Automattic\WooCommerce\Blocks\Patterns\PatternsHelper;
-$content = PatternsHelper::get_pattern_content( 'woocommerce-blocks/featured-products-2-cols' );
-$images  = PatternsHelper::get_pattern_images( 'woocommerce-blocks/featured-products-2-cols' );
 
 $first_title       = $content['titles'][0]['default'] ?? '';
 $first_description = $content['descriptions'][0]['default'] ?? '';

--- a/patterns/product-hero-2-col-2-row.php
+++ b/patterns/product-hero-2-col-2-row.php
@@ -7,9 +7,6 @@
 
 use Automattic\WooCommerce\Blocks\Patterns\PatternsHelper;
 
-$content = PatternsHelper::get_pattern_content( 'woocommerce-blocks/product-hero-2-col-2-row' );
-$images  = PatternsHelper::get_pattern_images( 'woocommerce-blocks/product-hero-2-col-2-row' );
-
 $image1 = PatternsHelper::get_image_url( $images, 0, 'images/pattern-placeholders/man-person-winter-photography-statue-coat.png' );
 $image2 = PatternsHelper::get_image_url( $images, 1, 'images/pattern-placeholders/pattern-fashion-clothing-outerwear-wool-scarf.png' );
 

--- a/patterns/product-query-product-gallery.php
+++ b/patterns/product-query-product-gallery.php
@@ -5,9 +5,6 @@
  * Categories: WooCommerce
  * Block Types: core/query/woocommerce/product-query
  */
-use Automattic\WooCommerce\Blocks\Patterns\PatternsHelper;
-
-$content = PatternsHelper::get_pattern_content( 'woocommerce-blocks/product-query-product-gallery' );
 
 $gallery_title = $content['titles'][0]['default'] ?? '';
 ?>

--- a/patterns/shop-by-price.php
+++ b/patterns/shop-by-price.php
@@ -6,7 +6,6 @@
  */
 
 use Automattic\WooCommerce\Blocks\Patterns\PatternsHelper;
-$content = PatternsHelper::get_pattern_content( 'woocommerce-blocks/shop-by-price' );
 
 $first_title  = $content['titles'][0]['default'] ?? '';
 $second_title = $content['titles'][1]['default'] ?? '';

--- a/patterns/small-discount-banner-with-image.php
+++ b/patterns/small-discount-banner-with-image.php
@@ -6,8 +6,6 @@
  */
 
 use Automattic\WooCommerce\Blocks\Patterns\PatternsHelper;
-$content = PatternsHelper::get_pattern_content( 'woocommerce-blocks/small-discount-banner-with-image' );
-$images  = PatternsHelper::get_pattern_images( 'woocommerce-blocks/small-discount-banner-with-image' );
 
 $banner_title = $content['titles'][0]['default'] ?? '';
 ?>

--- a/patterns/social-follow-us-in-social-media.php
+++ b/patterns/social-follow-us-in-social-media.php
@@ -6,8 +6,6 @@
  */
 
 use Automattic\WooCommerce\Blocks\Patterns\PatternsHelper;
-$content = PatternsHelper::get_pattern_content( 'woocommerce-blocks/social-follow-us-in-social-media' );
-$images  = PatternsHelper::get_pattern_images( 'woocommerce-blocks/social-follow-us-in-social-media' );
 
 $image1 = PatternsHelper::get_image_url( $images, 0, 'images/pattern-placeholders/office.png' );
 $image2 = PatternsHelper::get_image_url( $images, 1, 'images/pattern-placeholders/living-room.png' );

--- a/patterns/store-info-alt-image-and-text.php
+++ b/patterns/store-info-alt-image-and-text.php
@@ -6,8 +6,6 @@
  */
 
 use Automattic\WooCommerce\Blocks\Patterns\PatternsHelper;
-$content = PatternsHelper::get_pattern_content( 'woocommerce-blocks/alt-image-and-text' );
-$images  = PatternsHelper::get_pattern_images( 'woocommerce-blocks/alt-image-and-text' );
 
 $image1 = PatternsHelper::get_image_url( $images, 0, 'images/pattern-placeholders/crafting-pots.png' );
 $image2 = PatternsHelper::get_image_url( $images, 1, 'images/pattern-placeholders/hand-made-pots.png' );

--- a/patterns/testimonials-3-columns.php
+++ b/patterns/testimonials-3-columns.php
@@ -7,8 +7,6 @@
 
 use Automattic\WooCommerce\Blocks\Patterns\PatternsHelper;
 
-$content = PatternsHelper::get_pattern_content( 'woocommerce-blocks/testimonials-3-columns' );
-
 $main_header        = $content['titles'][0]['default'] ?? '';
 $first_review       = $content['titles'][1]['default'] ?? '';
 $second_review      = $content['titles'][2]['default'] ?? '';

--- a/patterns/testimonials-single.php
+++ b/patterns/testimonials-single.php
@@ -6,8 +6,6 @@
  */
 
 use Automattic\WooCommerce\Blocks\Patterns\PatternsHelper;
-$content = PatternsHelper::get_pattern_content( 'woocommerce-blocks/testimonials-single' );
-$images  = PatternsHelper::get_pattern_images( 'woocommerce-blocks/testimonials-single' );
 
 $testimonials_title = $content['titles'][0]['default'] ?? '';
 $description        = $content['descriptions'][0]['default'] ?? '';

--- a/src/BlockPatterns.php
+++ b/src/BlockPatterns.php
@@ -4,6 +4,7 @@ namespace Automattic\WooCommerce\Blocks;
 use Automattic\WooCommerce\Blocks\AI\Connection;
 use Automattic\WooCommerce\Blocks\Images\Pexels;
 use Automattic\WooCommerce\Blocks\Domain\Package;
+use Automattic\WooCommerce\Blocks\Patterns\PatternsHelper;
 use Automattic\WooCommerce\Blocks\Patterns\PatternUpdater;
 use Automattic\WooCommerce\Blocks\Patterns\ProductUpdater;
 
@@ -129,6 +130,8 @@ class BlockPatterns {
 			return;
 		}
 
+		$dictionary = PatternsHelper::get_patterns_dictionary();
+
 		foreach ( $files as $file ) {
 			$pattern_data = get_file_data( $file, $default_headers );
 
@@ -226,10 +229,17 @@ class BlockPatterns {
 				$pattern_data['description'] = translate_with_gettext_context( $pattern_data['description'], 'Pattern description', 'woo-gutenberg-products-block' );
 			}
 
+			$pattern_data_from_dictionary = $this->get_pattern_from_dictionary( $dictionary, $pattern_data['slug'] );
+
 			// The actual pattern content is the output of the file.
 			ob_start();
+			if ( ! is_null( $pattern_data_from_dictionary ) ) {
+				$content = $pattern_data_from_dictionary['content'];
+				$images  = $pattern_data_from_dictionary['images'] ?? array();
+			}
 			include $file;
 			$pattern_data['content'] = ob_get_clean();
+
 			if ( ! $pattern_data['content'] ) {
 				continue;
 			}
@@ -353,5 +363,23 @@ class BlockPatterns {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Filter the patterns dictionary to get the pattern data corresponding to the pattern slug.
+	 *
+	 * @param array  $dictionary The patterns dictionary.
+	 * @param string $slug The pattern slug.
+	 *
+	 * @return array|null
+	 */
+	private function get_pattern_from_dictionary( $dictionary, $slug ) {
+		foreach ( $dictionary as $pattern_dictionary ) {
+			if ( $pattern_dictionary['slug'] === $slug ) {
+				return $pattern_dictionary;
+			}
+		}
+
+		return null;
 	}
 }

--- a/src/BlockPatterns.php
+++ b/src/BlockPatterns.php
@@ -233,6 +233,16 @@ class BlockPatterns {
 
 			// The actual pattern content is the output of the file.
 			ob_start();
+
+			/*
+				For patterns that can have AI-generated content, we need to get its content from the dictionary and pass
+				it to the pattern file through the "$content" and "$images" variables.
+				This is to avoid having to access the dictionary for each pattern when it's registered or inserted.
+				Before the "$content" and "$images" variables were populated in each pattern. Since the pattern
+				registration happens in the init hook, the dictionary was being access one for each pattern and
+				for each page load. This way we only do it once on registration.
+				For more context: https://github.com/woocommerce/woocommerce-blocks/pull/11733
+			*/
 			if ( ! is_null( $pattern_data_from_dictionary ) ) {
 				$content = $pattern_data_from_dictionary['content'];
 				$images  = $pattern_data_from_dictionary['images'] ?? array();

--- a/src/Patterns/PatternsHelper.php
+++ b/src/Patterns/PatternsHelper.php
@@ -124,7 +124,7 @@ class PatternsHelper {
 	 *
 	 * @return mixed|WP_Error|null
 	 */
-	private static function get_patterns_dictionary( $pattern_slug = null ) {
+	public static function get_patterns_dictionary( $pattern_slug = null ) {
 
 		$patterns_ai_data_post = self::get_patterns_ai_data_post();
 


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

This PR reduces the number of times the pattern dictionary is accessed: before, each pattern was calling the `get_patterns_dictionary` function at least once (twice for pattern with images). With this PR, we call the function just once, when registering the patterns, and we pass to them the dictionary.

## Why

Since the pattern registration happens in the `init` hook, all these calls are done for each page load, so this change will reduce it.

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. To test the patterns defaults: create a new page or post on a site without the AI patterns set and insert all the following patterns:
```
Banner
Discount Banner
Discount Banner with Image
Featured Category Focus
Featured Category Triple
Featured Products: Fresh & Tasty
Hero Product 3 Split
Hero Product Chessboard
Hero Product Split
Just Arrived Full Hero
Product Collection Banner
Product Collections Featured Collection
Product Collections Featured Collections
Product Collections Newest Arrivals
Product Gallery
Product Collection 3 Columns
Product Collection 4 Columns
Product Collection 5 Columns
Featured Products 2 Columns
Product Hero 2 Column 2 Row
Shop by Price
Small Discount Banner with Image
Social: Follow us on social media
Alternating Image and Text
Testimonials 3 Columns
Testimonials Single
Featured Category Cover Image
Product Collection: Featured Products 5 Columns
```
2. Make sure all the images and text content are there for each pattern.
3. To test the AI patterns: on a JN or Woo Express site with the CYS set up, install this version of WooCommerce Blocks, go through the CYS flow, and repeat steps 1 and 2.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [x] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Improve performance in patterns registration.
