### PR TITLE
Ensure that incompatible notices are displayed in Safari

### DIFF
--- a/assets/js/editor-components/incompatible-extension-notice/editor.scss
+++ b/assets/js/editor-components/incompatible-extension-notice/editor.scss
@@ -18,11 +18,11 @@
 			width: 24px;
 			height: 24px;
 			margin-right: 6px;
-			min-width: max-content;
+			min-width: 24px; // Ensure that notice is visible in Safari. See https://github.com/woocommerce/woocommerce-blocks/issues/11734
 		}
 	}
 	ul {
-		margin: 0 0 1em 1.5em;
+		margin: 0 0 1em 1.2em;
 		padding: 0;
 		list-style: disc outside;
 	}


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Fixes #11734

- Changing `min-width: max-content;` to `min-width: 24px;` to ensure that incompatible notices are displayed in Safari.
- Changing `margin: 0 0 1em 1.5em;` to `margin: 0 0 1em 1.2em;` to ensure that line-breaks, in incompatible extension names, kick in later when using Firefox.

## Why

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

An external contributor reported that the incompatible extension notices are not displayed when using Safari. It turned out that the issue was based on a `min-width` setting, that wasn't correctly interpreted by Safari. This PR fixes this issue, while ensuring that incompatible extension notices remain visible in other browsers.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Install and activate [helper-plugin-1.zip](https://github.com/woocommerce/woocommerce-blocks/files/12701036/helper-plugin-1.zip)
2. Create a test page and add the Cart block.
3. Create a test page and add the Checkout block.
4. Open both test pages using Safari.
5. Click on the Cart block resp. the Checkout block and verify that the incompatible extension notice is visible.
6. Repeat the previous step using Chrome, Firefox and Opera.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<table>
<tr>
<td valign="top">Before:
<br><br>
<img width="1281" alt="Screenshot 2023-11-10 at 21 43 01" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/5a68914b-5306-40fd-8270-af880120aa72">
</td>
<td valign="top">After:
<br><br>
<img width="1282" alt="Screenshot 2023-11-10 at 21 42 18" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/8718c04b-fb9e-4db7-af71-c84d8e304fc1">
</td>
</tr>
</table>

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:
* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Fix: Ensure that incompatible notices are displayed in Safari
