### PR TITLE
Playwright Fixes from the 11.5.x release branch

### DIFF
--- a/tests/e2e/tests/checkout/checkout.page.ts
+++ b/tests/e2e/tests/checkout/checkout.page.ts
@@ -91,8 +91,16 @@ export class CheckoutPage {
 			...this.testData,
 			...overrideAddressDetails,
 		};
-		const selector = `.wc-block-order-confirmation-${ shippingOrBilling }-address`;
-		const addressContainer = this.page.locator( selector );
+
+		const legacySelector = `.woocommerce-column--${ shippingOrBilling }-address`;
+		const blockSelector = `.wc-block-order-confirmation-${ shippingOrBilling }-address`;
+
+		let addressContainer = this.page.locator( blockSelector );
+
+		if ( ! ( await addressContainer.isVisible() ) ) {
+			addressContainer = this.page.locator( legacySelector );
+		}
+
 		await expect(
 			addressContainer.getByText( customerAddressDetails.firstname )
 		).toBeVisible();

--- a/tests/e2e/utils/editor/editor-utils.page.ts
+++ b/tests/e2e/utils/editor/editor-utils.page.ts
@@ -281,16 +281,18 @@ export class EditorUtils {
 	}
 
 	async transformIntoBlocks() {
+		// Select the block, so the button is visible.
+		const block = this.page
+			.locator( `[data-type="woocommerce/legacy-template"]` )
+			.first();
+		await this.editor.selectBlocks( block );
+
 		const isNotTransformedIntoBlocks = await this.page
 			.frameLocator( 'iframe[name="editor-canvas"]' )
 			.getByRole( 'button', { name: 'Transform into blocks' } )
 			.count();
 
 		if ( isNotTransformedIntoBlocks ) {
-			await this.page
-				.frameLocator( 'iframe[name="editor-canvas"]' )
-				.getByRole( 'group' )
-				.click();
 			await this.page
 				.frameLocator( 'iframe[name="editor-canvas"]' )
 				.getByRole( 'button', { name: 'Transform into blocks' } )

--- a/tests/e2e/utils/editor/editor-utils.page.ts
+++ b/tests/e2e/utils/editor/editor-utils.page.ts
@@ -283,20 +283,22 @@ export class EditorUtils {
 	async transformIntoBlocks() {
 		// Select the block, so the button is visible.
 		const block = this.page
+			.frameLocator( 'iframe[name="editor-canvas"]' )
 			.locator( `[data-type="woocommerce/legacy-template"]` )
 			.first();
+
+		if ( ! ( await block.isVisible() ) ) {
+			return;
+		}
+
 		await this.editor.selectBlocks( block );
 
-		const isNotTransformedIntoBlocks = await this.page
-			.frameLocator( 'iframe[name="editor-canvas"]' )
-			.getByRole( 'button', { name: 'Transform into blocks' } )
-			.count();
+		const transformButton = block.getByRole( 'button', {
+			name: 'Transform into blocks',
+		} );
 
-		if ( isNotTransformedIntoBlocks ) {
-			await this.page
-				.frameLocator( 'iframe[name="editor-canvas"]' )
-				.getByRole( 'button', { name: 'Transform into blocks' } )
-				.click();
+		if ( transformButton ) {
+			await transformButton.click();
 
 			// save changes
 			await this.saveSiteEditorEntities();


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Cherry picks some playwright fixes from the https://github.com/woocommerce/woocommerce-blocks/pull/11715 branch.

## Why

Some tests were flakey due to the way order confirmation page was transformed into blocks.

## Testing Instructions

This can be merged if tests pass.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [x] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->
