### PR TITLE
Refactor default editing state for customer address fields

### DIFF
--- a/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/block.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/block.tsx
@@ -17,6 +17,7 @@ import type {
 import { StoreNoticesContainer } from '@woocommerce/blocks-components';
 import { useSelect } from '@wordpress/data';
 import { CART_STORE_KEY } from '@woocommerce/block-data';
+import isShallowEqual from '@wordpress/is-shallow-equal';
 
 /**
  * Internal dependencies
@@ -29,17 +30,19 @@ const Block = ( {
 	showPhoneField = false,
 	requireCompanyField = false,
 	requirePhoneField = false,
-	forceEditing = false,
 }: {
 	showCompanyField: boolean;
 	showApartmentField: boolean;
 	showPhoneField: boolean;
 	requireCompanyField: boolean;
 	requirePhoneField: boolean;
-	forceEditing?: boolean;
 } ): JSX.Element => {
-	const { billingAddress, setShippingAddress, useBillingAsShipping } =
-		useCheckoutAddress();
+	const {
+		shippingAddress,
+		billingAddress,
+		setShippingAddress,
+		useBillingAsShipping,
+	} = useCheckoutAddress();
 	const { isEditor } = useEditorContext();
 
 	// Syncs shipping address with billing address if "Force shipping to the customer billing address" is enabled.
@@ -95,6 +98,20 @@ const Block = ( {
 			cartDataLoaded: store.hasFinishedResolution( 'getCartData' ),
 		};
 	} );
+
+	// Default editing state for CustomerAddress component comes from the current address and whether or not we're in the editor.
+	const hasAddress = !! (
+		billingAddress.address_1 &&
+		( billingAddress.first_name || billingAddress.last_name )
+	);
+	const { email, ...billingAddressWithoutEmail } = billingAddress;
+	const billingMatchesShipping = isShallowEqual(
+		billingAddressWithoutEmail,
+		shippingAddress
+	);
+	const defaultEditingAddress =
+		isEditor || ! hasAddress || billingMatchesShipping;
+
 	return (
 		<>
 			<StoreNoticesContainer context={ noticeContext } />
@@ -103,6 +120,7 @@ const Block = ( {
 					<CustomerAddress
 						addressFieldsConfig={ addressFieldsConfig }
 						forceEditing={ forceEditing }
+						defaultEditing={ defaultEditingAddress }
 					/>
 				) : null }
 			</WrapperComponent>

--- a/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/block.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/block.tsx
@@ -119,7 +119,6 @@ const Block = ( {
 				{ cartDataLoaded ? (
 					<CustomerAddress
 						addressFieldsConfig={ addressFieldsConfig }
-						forceEditing={ forceEditing }
 						defaultEditing={ defaultEditingAddress }
 					/>
 				) : null }

--- a/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/customer-address.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/customer-address.tsx
@@ -43,8 +43,9 @@ const CustomerAddress = ( {
 			invalidProps: Object.keys( billingAddress )
 				.filter( ( key ) => {
 					return (
+						key !== 'email' &&
 						store.getValidationError( 'billing_' + key ) !==
-						undefined
+							undefined
 					);
 				} )
 				.filter( Boolean ),

--- a/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/customer-address.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/customer-address.tsx
@@ -20,10 +20,10 @@ import AddressCard from '../../address-card';
 
 const CustomerAddress = ( {
 	addressFieldsConfig,
-	forceEditing = false,
+	defaultEditing = false,
 }: {
 	addressFieldsConfig: Record< keyof AddressFields, Partial< AddressField > >;
-	forceEditing?: boolean;
+	defaultEditing?: boolean;
 } ) => {
 	const {
 		defaultAddressFields,
@@ -33,11 +33,7 @@ const CustomerAddress = ( {
 		useBillingAsShipping,
 	} = useCheckoutAddress();
 	const { dispatchCheckoutEvent } = useStoreEvents();
-	const hasAddress = !! (
-		billingAddress.address_1 &&
-		( billingAddress.first_name || billingAddress.last_name )
-	);
-	const [ editing, setEditing ] = useState( ! hasAddress || forceEditing );
+	const [ editing, setEditing ] = useState( defaultEditing );
 
 	// Forces editing state if store has errors.
 	const { hasValidationErrors, invalidProps } = useSelect( ( select ) => {

--- a/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/frontend.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-billing-address-block/frontend.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { useRef, useEffect } from '@wordpress/element';
 import { withFilteredAttributes } from '@woocommerce/shared-hocs';
 import { FormStep } from '@woocommerce/blocks-components';
 import { useCheckoutAddress } from '@woocommerce/base-context/hooks';
@@ -43,21 +42,8 @@ const FrontendBlock = ( {
 		showCompanyField,
 		showPhoneField,
 	} = useCheckoutBlockContext();
-	const {
-		showBillingFields,
-		forcedBillingAddress,
-		useBillingAsShipping,
-		useShippingAsBilling,
-	} = useCheckoutAddress();
-
-	// If initial state was true, force editing to true so address fields are visible if the useShippingAsBilling option is unchecked.
-	const toggledUseShippingAsBilling = useRef( useShippingAsBilling );
-
-	useEffect( () => {
-		if ( useShippingAsBilling ) {
-			toggledUseShippingAsBilling.current = true;
-		}
-	}, [ useShippingAsBilling ] );
+	const { showBillingFields, forcedBillingAddress, useBillingAsShipping } =
+		useCheckoutAddress();
 
 	if ( ! showBillingFields && ! useBillingAsShipping ) {
 		return null;
@@ -86,7 +72,6 @@ const FrontendBlock = ( {
 				showCompanyField={ showCompanyField }
 				showPhoneField={ showPhoneField }
 				requirePhoneField={ requirePhoneField }
-				forceEditing={ toggledUseShippingAsBilling.current }
 			/>
 			{ children }
 		</FormStep>

--- a/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/block.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/block.tsx
@@ -109,6 +109,9 @@ const Block = ( {
 		};
 	} );
 
+	// Default editing state for CustomerAddress component comes from the current address and whether or not we're in the editor.
+	const defaultEditingAddress = isEditor || ! hasAddress;
+
 	return (
 		<>
 			<StoreNoticesContainer context={ noticeContext } />
@@ -116,6 +119,7 @@ const Block = ( {
 				{ cartDataLoaded ? (
 					<CustomerAddress
 						addressFieldsConfig={ addressFieldsConfig }
+						defaultEditing={ defaultEditingAddress }
 					/>
 				) : null }
 			</WrapperComponent>

--- a/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/customer-address.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-shipping-address-block/customer-address.tsx
@@ -3,11 +3,7 @@
  */
 import { useState, useCallback, useEffect } from '@wordpress/element';
 import { AddressForm } from '@woocommerce/base-components/cart-checkout';
-import {
-	useCheckoutAddress,
-	useStoreEvents,
-	useEditorContext,
-} from '@woocommerce/base-context';
+import { useCheckoutAddress, useStoreEvents } from '@woocommerce/base-context';
 import type {
 	ShippingAddress,
 	AddressField,
@@ -24,8 +20,10 @@ import AddressCard from '../../address-card';
 
 const CustomerAddress = ( {
 	addressFieldsConfig,
+	defaultEditing = false,
 }: {
 	addressFieldsConfig: Record< keyof AddressFields, Partial< AddressField > >;
+	defaultEditing?: boolean;
 } ) => {
 	const {
 		defaultAddressFields,
@@ -35,12 +33,7 @@ const CustomerAddress = ( {
 		useShippingAsBilling,
 	} = useCheckoutAddress();
 	const { dispatchCheckoutEvent } = useStoreEvents();
-	const { isEditor } = useEditorContext();
-	const hasAddress = !! (
-		shippingAddress.address_1 &&
-		( shippingAddress.first_name || shippingAddress.last_name )
-	);
-	const [ editing, setEditing ] = useState( ! hasAddress || isEditor );
+	const [ editing, setEditing ] = useState( defaultEditing );
 
 	// Forces editing state if store has errors.
 	const { hasValidationErrors, invalidProps } = useSelect( ( select ) => {


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Fixes the default editing state of the address fields so that:

1. Editing is true if the address is incomplete
2. Editing is true if within the editor
3. Editing is true for the billing address if the current billing address matches the current shipping address. This is so that when you toggle "Use same address for billing" you can edit right away

Fixes #11726

## Why

Editing should be true in the editor so changes to fields are visible.

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

Please test all cases in at least Chrome and Firefox, since Firefox behaviour can differ.

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Go to admin and edit the checkout page
4. Switch between "Local Pickup" and "Shipping" in the preview. Ensure fields for shipping address/billing address remain visible.
5. Go to the frontend checkout as a guest user. Fields should start open.
6. Fill out the address fields and refresh the checkout. Fields should condense.
7. Toggle the "Use same address for billing" checkbox. Fields should be open.
8. Fill out the billing address using different data to shipping address then refresh the page. Address should be condensed.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:

* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:

* [x] This PR has a UI change and has been cross-browser tested at different viewport sizes on both the frontend and in the editor.
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog

> Fix billing address condensed address state in the editor and in Firefox.
