### PR TITLE
Fix strings in classic-checkout modal window

### DIFF
--- a/assets/js/editor-components/incompatible-extension-notice/modal.tsx
+++ b/assets/js/editor-components/incompatible-extension-notice/modal.tsx
@@ -12,7 +12,7 @@ export const ModalContent = ( {
 		return (
 			<p>
 				{ __(
-					'If you continue, the cart block will be replaced with the classic experience powered by shortcodes. This means that you may lose customizations that you did to the cart block.',
+					'If you continue, the cart block will be replaced with the classic experience powered by shortcodes. This means that you may lose customizations that you made to the cart block.',
 					'woo-gutenberg-products-block'
 				) }
 			</p>

--- a/assets/js/editor-components/incompatible-extension-notice/modal.tsx
+++ b/assets/js/editor-components/incompatible-extension-notice/modal.tsx
@@ -12,7 +12,7 @@ export const ModalContent = ( {
 		return (
 			<p>
 				{ __(
-					'If you continue, the cart block will be replaced with the classic experience powered by shortcode. This means that you may lose customizations and updates you did to the cart block.',
+					'If you continue, the cart block will be replaced with the classic experience powered by shortcodes. This means that you may lose customizations that you did to the cart block.',
 					'woo-gutenberg-products-block'
 				) }
 			</p>
@@ -23,7 +23,7 @@ export const ModalContent = ( {
 		<>
 			<p>
 				{ __(
-					'If you continue, the checkout block be replaced with the classic experience powered by shortcode. This means that you may lose:',
+					'If you continue, the checkout block will be replaced with the classic experience powered by shortcodes. This means that you may lose:',
 					'woo-gutenberg-products-block'
 				) }
 			</p>


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

There are 2 poorly worded strings in the classic checkout modal. This changes them.

```diff
- If you continue, the cart block will be replaced with the classic experience powered by shortcode. This means that you may lose customizations and updates you did to the cart block.
+ If you continue, the cart block will be replaced with the classic experience powered by shortcodes. This means that you may lose customizations that you did to the cart block.
```

```diff
- If you continue, the checkout block be replaced with the classic experience powered by shortcode. This means that you may lose:
+ If you continue, the checkout block will be replaced with the classic experience powered by shortcodes. This means that you may lose:
```

Fixes #11701

## Why

Improved language.

## Testing Instructions

1. Install and activate an incompatible extension e.g. [helper-plugin-1.zip](https://github.com/woocommerce/woocommerce-blocks/files/12701036/helper-plugin-1.zip)
2. Edit the checkout page. Ensure its using blocks, if its not, insert the checkout block and refresh
3. In the inspector you should see an incompatible extension notice. Click "Switch to classic checkout"
4. In the modal window, verify the next reads "If you continue, the checkout block will be replaced with the classic experience powered by shortcodes. This means that you may lose:"

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:

* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:

* [ ] This PR has a UI change and has been cross-browser tested at different viewport sizes on both the frontend and in the editor.
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog

> Fix typo in classic checkout modal
