### PR TITLE
Add Storybook entry for `TotalsWrapper`

### DIFF
--- a/packages/components/totals-wrapper/docs/docs.mdx
+++ b/packages/components/totals-wrapper/docs/docs.mdx
@@ -1,0 +1,15 @@
+import { Canvas, Meta, ArgTypes, Primary, Source, Controls } from '@storybook/blocks';
+
+import * as TotalsWrapperStories from '../stories/index.stories.tsx';
+
+<Meta name="Docs" of={ TotalsWrapperStories } />
+
+# TotalsWrapper
+
+A wrapper to go around any items displayed in the "Totals" area of the Cart/Checkout blocks. Usually it comes with additional padding so the component rendered inside it doesn't need to add its own padding. If this is being used to wrap a Slot (for use in Slot/Fill patterns) then no padding will be applied.
+
+<Primary />
+
+### Props
+
+<Controls />

--- a/packages/components/totals-wrapper/index.tsx
+++ b/packages/components/totals-wrapper/index.tsx
@@ -10,7 +10,7 @@ import type { ReactNode } from 'react';
  */
 import './style.scss';
 
-interface TotalsWrapperProps {
+export interface TotalsWrapperProps {
 	children: ReactNode;
 	/* If this TotalsWrapper is being used to wrap a Slot */
 	slotWrapper?: boolean;

--- a/packages/components/totals-wrapper/stories/index.stories.tsx
+++ b/packages/components/totals-wrapper/stories/index.stories.tsx
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import type { StoryFn, Meta } from '@storybook/react';
+
+/**
+ * Internal dependencies
+ */
+import TotalsWrapper, { TotalsWrapperProps } from '..';
+
+export default {
+	title: 'External Components/Totals/TotalsWrapper',
+	component: TotalsWrapper,
+	argTypes: {
+		className: {
+			control: 'text',
+			table: {
+				type: {
+					summary: 'string',
+				},
+			},
+		},
+		children: {
+			control: null,
+			table: {
+				type: {
+					summary: 'React.Children',
+				},
+			},
+		},
+		slotWrapper: {
+			control: 'boolean',
+			table: {
+				type: {
+					summary: 'boolean',
+				},
+			},
+			description:
+				'True if this `TotalsWrapper` is being used to wrap a Slot/Fill',
+		},
+	},
+} as Meta< TotalsWrapperProps >;
+const Template: StoryFn< TotalsWrapperProps > = ( args ) => {
+	return (
+		<TotalsWrapper { ...args }>
+			<div>Custom totals content</div>
+		</TotalsWrapper>
+	);
+};
+
+export const Default = Template.bind( {} );
+Default.args = {};

--- a/storybook/main.js
+++ b/storybook/main.js
@@ -9,6 +9,7 @@ module.exports = {
 		'../assets/js/**/stories/*.stories.@(js|jsx|ts|tsx)',
 		'../packages/**/stories/*.stories.@(js|jsx|ts|tsx)',
 		'../assets/js/**/*.mdx',
+		'../packages/**/*.mdx',
 	],
 	addons: [
 		'@storybook/addon-essentials',


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

This PR is based on `move/totals`. When https://github.com/woocommerce/woocommerce-blocks/pull/11773 is merged this will be rebased on `trunk`.

Adds Storybook entry for `TotalsWrapper`, updates the paths that are searched for docs `.mdx` files to include the packages.

Fixes #11688

## Why

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->
To showcase the component and provide a level of documentation.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Run `npm run storybook` and go to `localhost:6006`
2. Go to `External Components/Totals/TotalsWrapper`
3. Ensure it renders correctly and the component and docs show correctly too. It should look like this.

<img width="762" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/5656702/f6cfb853-5ccf-4730-ba58-66b7b5759947">


* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [x] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [x] N/A

## Checklist

Required:

* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:

* [ ] This PR has a UI change and has been cross-browser tested at different viewport sizes on both the frontend and in the editor.
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Skipping
