### PR TITLE
Add storybook entry for StoreNotice component

### DIFF
--- a/packages/components/store-notice/stories/index.stories.tsx
+++ b/packages/components/store-notice/stories/index.stories.tsx
@@ -1,0 +1,110 @@
+/**
+ * External dependencies
+ */
+import type { StoryFn, Meta } from '@storybook/react';
+import { NoticeBannerProps } from '@woocommerce/base-components/notice-banner';
+/**
+ * Internal dependencies
+ */
+import StoreNotice from '../';
+
+const availableStatus = [ 'default', 'success', 'error', 'warning', 'info' ];
+
+export default {
+	title: 'External Components/StoreNotice',
+	argTypes: {
+		status: {
+			control: 'radio',
+			options: availableStatus,
+			description:
+				'Status determines the color of the notice and the icon.',
+		},
+		isDismissible: {
+			control: 'boolean',
+			description:
+				'Determines whether the notice can be dismissed by the user. When set to true, a close icon will be displayed on the banner.',
+		},
+		summary: {
+			description:
+				'Optional summary text shown above notice content, used when several notices are listed together.',
+			control: 'text',
+		},
+		className: {
+			description: 'Additional class name to give to the notice.',
+			control: 'text',
+		},
+		spokenMessage: {
+			description:
+				'Optionally provided to change the spoken message for assistive technology. If not provided, the `children` prop will be used as the spoken message.',
+			control: 'text',
+		},
+		politeness: {
+			control: 'radio',
+			options: [ 'polite', 'assertive' ],
+			description:
+				'Determines the level of politeness for the notice for assistive technology.',
+		},
+		children: {
+			description:
+				'The displayed message of a notice. Also used as the spoken message for assistive technology, unless `spokenMessage` is provided as an alternative message.',
+			disable: true,
+		},
+		onRemove: {
+			description:
+				'Function called when dismissing the notice. When the close icon is clicked or the Escape key is pressed, this function will be called.',
+			disable: true,
+		},
+	},
+	component: StoreNotice,
+} as Meta< NoticeBannerProps >;
+
+const Template: StoryFn< NoticeBannerProps > = ( args ) => {
+	return <StoreNotice { ...args } />;
+};
+
+export const Default = Template.bind( {} );
+Default.args = {
+	children: 'This is a default notice',
+	status: 'default',
+	isDismissible: true,
+	summary: undefined,
+	className: undefined,
+	spokenMessage: undefined,
+	politeness: undefined,
+};
+
+export const Error = Template.bind( {} );
+Error.args = {
+	children: 'This is an error notice',
+	status: 'error',
+};
+
+export const Warning = Template.bind( {} );
+Warning.args = {
+	children: 'This is a warning notice',
+	status: 'warning',
+};
+
+export const Info = Template.bind( {} );
+Info.args = {
+	children: 'This is an informational notice',
+	status: 'info',
+};
+
+export const Success = Template.bind( {} );
+Success.args = {
+	children: 'This is a success notice',
+	status: 'success',
+};
+
+export const ErrorSummary = Template.bind( {} );
+ErrorSummary.args = {
+	summary: 'Please fix the following errors',
+	children: (
+		<ul>
+			<li>This is an error notice</li>
+			<li>This is another error notice</li>
+		</ul>
+	),
+	status: 'error',
+};

--- a/packages/components/store-notice/stories/index.stories.tsx
+++ b/packages/components/store-notice/stories/index.stories.tsx
@@ -8,21 +8,19 @@ import { NoticeBannerProps } from '@woocommerce/base-components/notice-banner';
  */
 import StoreNotice from '../';
 
-const availableStatus = [ 'default', 'success', 'error', 'warning', 'info' ];
-
 export default {
 	title: 'External Components/StoreNotice',
 	argTypes: {
 		status: {
 			control: 'radio',
-			options: availableStatus,
+			options: [ 'default', 'success', 'error', 'warning', 'info' ],
 			description:
 				'Status determines the color of the notice and the icon.',
 		},
 		isDismissible: {
 			control: 'boolean',
 			description:
-				'Determines whether the notice can be dismissed by the user. When set to true, a close icon will be displayed on the banner.',
+				'Determines whether the notice can be dismissed by the user. When set to `true`, a close icon will be displayed on the banner.',
 		},
 		summary: {
 			description:
@@ -42,7 +40,7 @@ export default {
 			control: 'radio',
 			options: [ 'polite', 'assertive' ],
 			description:
-				'Determines the level of politeness for the notice for assistive technology.',
+				'Determines the level of politeness for the notice for assistive technology. This will be `polite` for all `status` values except `error` when it will be `assertive`.',
 		},
 		children: {
 			description:

--- a/packages/components/store-notice/stories/index.stories.tsx
+++ b/packages/components/store-notice/stories/index.stories.tsx
@@ -65,30 +65,35 @@ Default.args = {
 	children: 'This is a default notice',
 	status: 'default',
 	isDismissible: true,
+	politeness: 'polite',
 };
 
 export const Error = Template.bind( {} );
 Error.args = {
 	children: 'This is an error notice',
 	status: 'error',
+	politeness: 'assertive',
 };
 
 export const Warning = Template.bind( {} );
 Warning.args = {
 	children: 'This is a warning notice',
 	status: 'warning',
+	politeness: 'polite',
 };
 
 export const Info = Template.bind( {} );
 Info.args = {
 	children: 'This is an informational notice',
 	status: 'info',
+	politeness: 'polite',
 };
 
 export const Success = Template.bind( {} );
 Success.args = {
 	children: 'This is a success notice',
 	status: 'success',
+	politeness: 'polite',
 };
 
 export const ErrorSummary = Template.bind( {} );
@@ -101,4 +106,5 @@ ErrorSummary.args = {
 		</ul>
 	),
 	status: 'error',
+	politeness: 'assertive',
 };

--- a/packages/components/store-notice/stories/index.stories.tsx
+++ b/packages/components/store-notice/stories/index.stories.tsx
@@ -67,10 +67,6 @@ Default.args = {
 	children: 'This is a default notice',
 	status: 'default',
 	isDismissible: true,
-	summary: undefined,
-	className: undefined,
-	spokenMessage: undefined,
-	politeness: undefined,
 };
 
 export const Error = Template.bind( {} );

--- a/packages/components/store-notice/stories/index.stories.tsx
+++ b/packages/components/store-notice/stories/index.stories.tsx
@@ -58,8 +58,8 @@ export default {
 	component: StoreNotice,
 } as Meta< NoticeBannerProps >;
 
-const Template: StoryFn< NoticeBannerProps > = ( args ) => {
-	return <StoreNotice { ...args } />;
+const Template: StoryFn< NoticeBannerProps > = ( { children, ...args } ) => {
+	return <StoreNotice { ...args }>{ children }</StoreNotice>;
 };
 
 export const Default = Template.bind( {} );


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What
This PR adds a storybook entry for the StoreNotice component

Fixes #11691 

## Why
We want to make sure all components available externally have a storybook entry as documentation

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Run `npm run storybook`
2. Check the `StoreNotice` component is there under the `External components` heading
3. Change the props and make sure the notice changes and behaves as expected

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [x] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [x] N/A

## Checklist

Required:

* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:

* [ ] This PR has a UI change and has been cross-browser tested at different viewport sizes on both the frontend and in the editor.
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.
