### PR TITLE
Continue validating schema after validating nested properties

### DIFF
--- a/src/StoreApi/Schemas/V1/AbstractSchema.php
+++ b/src/StoreApi/Schemas/V1/AbstractSchema.php
@@ -173,12 +173,18 @@ abstract class AbstractSchema {
 				}
 
 				if ( ! $result || is_wp_error( $result ) ) {
+					// If schema validation fails, we return here as we don't need to validate any deeper.
 					return $result;
 				}
 
 				if ( isset( $property_value['properties'] ) ) {
 					$validate_callback = $this->get_recursive_validate_callback( $property_value['properties'] );
-					return $validate_callback( $current_value, $request, $param . ' > ' . $property_key );
+					$result            = $validate_callback( $current_value, $request, $param . ' > ' . $property_key );
+
+					if ( ! $result || is_wp_error( $result ) ) {
+						// If schema validation fails, we return here as we don't need to validate any deeper.
+						return $result;
+					}
 				}
 			}
 


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

https://github.com/woocommerce/woocommerce-blocks/issues/11446 reported than when multiple extensions register data in the Store API, required field validation only runs for the first item in the schema. This PR fixes this behaviour.

Fixes #11446

## Why

Multiple extensions may be using Store API at once, so this ensures all validation runs recursively.

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

This requires code, so this should only be tested by developers.

1.  Testing code:

Add this to functions.php or the main plugin file:

```php
woocommerce_store_api_register_endpoint_data(
	array(
		'endpoint'        => \Automattic\WooCommerce\StoreApi\Schemas\V1\CheckoutSchema::IDENTIFIER,
		'namespace'       => 'my-extension-test',
		'schema_callback' => function () {
			return [
				'my_field' => array(
					'description' => 'test 1',
					'type'        => 'string',
					'context'     => array( 'view', 'edit' ),
					'default'     => '',
				)
			];
		},
	)
);

woocommerce_store_api_register_endpoint_data(
	array(
		'endpoint'        => \Automattic\WooCommerce\StoreApi\Schemas\V1\CheckoutSchema::IDENTIFIER,
		'namespace'       => 'my-extension-test-2',
		'schema_callback' => function () {
			return [
				'my_field' => array(
					'description' => 'test 2',
					'type'        => 'string',
					'context'     => array( 'view', 'edit' ),
					'required'    => true,
				)
			];
		},
	)
);
```

This registers 2 additional schemas on the checkout route.

2. Try to place an order. You will get an error notice: `extensions > my-extension-test is not of type object.`
3. Open console and run this: `wp.data.dispatch( 'wc/store/checkout' ).__internalSetExtensionData( 'my-extension-test', { 'my_field': 'test' } );` This adds data for the first schema.
4. Place order again. **This time you'll see `extensions > my-extension-test-2 is not of type object.`**. This is what was fixed.
5. Open console and run this: `wp.data.dispatch( 'wc/store/checkout' ).__internalSetExtensionData( 'my-extension-test-2', { 'my_field': 'test' } );` This adds data for the second schema.
6. Place order again. It should go through successfully.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [x] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:

* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:

* [ ] This PR has a UI change and has been cross-browser tested at different viewport sizes on both the frontend and in the editor.
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog

> Store API/Blocks Extensibility: Fix recursive extension schema validation.
