### PR TITLE
Fix casting error on Utils::wp_version_compare

### DIFF
--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -23,8 +23,8 @@ class Utils {
 		}
 
 		// Replace non-alphanumeric characters with a dot.
-		$version = preg_replace( '/[^0-9a-zA-Z\.]+/i', '.', $version );
 		$current_wp_version = preg_replace( '/[^0-9a-zA-Z\.]+/i', '.', $current_wp_version);
+		$version            = preg_replace( '/[^0-9a-zA-Z\.]+/i', '.', $version );
 
 		return version_compare( $current_wp_version, $version, $operator );
 	}

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -17,6 +17,9 @@ class Utils {
 	 * @return bool|int Returns true if the current WordPress version satisfies the comparison, false otherwise.
 	 */
 	public static function wp_version_compare( $version, $operator = null ) {
+		// Replace non-alphanumeric characters with a dot
+		$version = preg_replace( '/[^0-9a-zA-Z\.]+/i', '.', $version );
+
 		$current_wp_version = get_bloginfo( 'version' );
 		if ( preg_match( '/^([0-9]+\.[0-9]+)/', $current_wp_version, $matches ) ) {
 			$current_wp_version = (float) $matches[1];

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -23,7 +23,7 @@ class Utils {
 		}
 
 		// Replace non-alphanumeric characters with a dot.
-		$current_wp_version = preg_replace( '/[^0-9a-zA-Z\.]+/i', '.', $current_wp_version);
+		$current_wp_version = preg_replace( '/[^0-9a-zA-Z\.]+/i', '.', $current_wp_version );
 		$version            = preg_replace( '/[^0-9a-zA-Z\.]+/i', '.', $version );
 
 		return version_compare( $current_wp_version, $version, $operator );

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -17,7 +17,7 @@ class Utils {
 	 * @return bool|int Returns true if the current WordPress version satisfies the comparison, false otherwise.
 	 */
 	public static function wp_version_compare( $version, $operator = null ) {
-		// Replace non-alphanumeric characters with a dot
+		// Replace non-alphanumeric characters with a dot.
 		$version = preg_replace( '/[^0-9a-zA-Z\.]+/i', '.', $version );
 
 		$current_wp_version = get_bloginfo( 'version' );

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -17,13 +17,14 @@ class Utils {
 	 * @return bool|int Returns true if the current WordPress version satisfies the comparison, false otherwise.
 	 */
 	public static function wp_version_compare( $version, $operator = null ) {
-		// Replace non-alphanumeric characters with a dot.
-		$version = preg_replace( '/[^0-9a-zA-Z\.]+/i', '.', $version );
-
 		$current_wp_version = get_bloginfo( 'version' );
 		if ( preg_match( '/^([0-9]+\.[0-9]+)/', $current_wp_version, $matches ) ) {
 			$current_wp_version = (float) $matches[1];
 		}
+
+		// Replace non-alphanumeric characters with a dot.
+		$version = preg_replace( '/[^0-9a-zA-Z\.]+/i', '.', $version );
+		$current_wp_version = preg_replace( '/[^0-9a-zA-Z\.]+/i', '.', $current_wp_version);
 
 		return version_compare( $current_wp_version, $version, $operator );
 	}


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Fixes #10563

## Why

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

Fix casting error on `Utils::wp_version_compare` when using a different PHP locale.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

While testing with `version_compare` with the French locale I could reproduce the errors mentioned on #10563, it looks like it didn't affect `Utils::wp_version_compare` method but as mentioned here: p1692776050961299/1692773342.122439-slack-C8X6Q7XQU it's fine to fix it defensively.

1. On a PHP 7.4 environment, on WordPress installation root run `php -a`
2. Run `setlocale(LC_ALL, 'fr_FR');`
3. Run `var_dump((float)6.4);`
4. If the output is not `float(6,4)` (with the comma instead of dot), you need to install the fr_FR locale, for Docker you can run it on your container:

```
apt-get update && apt-get install -y locales && apt-get clean
sed -i -e 's/# fr_FR ISO-8859-1/fr_FR ISO-8859-1/' /etc/locale.gen
dpkg-reconfigure --frontend=noninteractive locales
docker-php-ext-install gettext
```

5. If you needed to install the above package, redo the first three steps.
6. Run `require_once 'wp-load.php';`
7. Run `require 'wp-content/plugins/woo-gutenberg-products-block/src/Utils/Utils.php'`
8. Run `var_dump(\Automattic\WooCommerce\Blocks\Utils\Utils::wp_version_compare(6.4, '='));`, changing the parameters, all output should run as expected, to simulate WordPress version you can run: `global $wp_version; $wp_version = '6.4.0';`

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:

* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:

* [ ] This PR has a UI change and has been cross-browser tested at different viewport sizes on both the frontend and in the editor.
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.