### PR TITLE
Add Storybook entry for `Panel`

### DIFF
--- a/packages/components/panel/index.tsx
+++ b/packages/components/panel/index.tsx
@@ -11,12 +11,12 @@ import type { ReactNode, ReactElement } from 'react';
  */
 import './style.scss';
 
-interface PanelProps {
-	children?: ReactNode;
-	className?: string;
+export interface PanelProps {
+	children: ReactNode;
+	className?: string | undefined;
 	initialOpen?: boolean;
 	hasBorder?: boolean;
-	title?: ReactNode;
+	title: ReactNode;
 	titleTag?: keyof JSX.IntrinsicElements;
 }
 

--- a/packages/components/panel/stories/index.stories.tsx
+++ b/packages/components/panel/stories/index.stories.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import type { StoryFn, Meta } from '@storybook/react';
+import { useArgs } from '@storybook/preview-api';
 
 /**
  * Internal dependencies
@@ -61,8 +62,18 @@ export default {
 } as Meta< PanelProps >;
 
 const Template: StoryFn< PanelProps > = ( args ) => {
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	let [ { titleTag }, _ ] = useArgs();
+
+	titleTag = ( titleTag || 'div' ).replace( /\n/g, '' );
+	if (
+		document.createElement( titleTag.toUpperCase() ).toString() ===
+		'[object HTMLUnknownElement]'
+	) {
+		titleTag = 'div';
+	}
 	return (
-		<Panel { ...args }>
+		<Panel { ...args } titleTag={ titleTag }>
 			<div style={ { paddingBottom: '.750em' } }>
 				This is the content rendered inside the panel.
 			</div>

--- a/packages/components/panel/stories/index.stories.tsx
+++ b/packages/components/panel/stories/index.stories.tsx
@@ -1,0 +1,93 @@
+/**
+ * External dependencies
+ */
+import type { StoryFn, Meta } from '@storybook/react';
+
+/**
+ * Internal dependencies
+ */
+import Panel, { type PanelProps } from '..';
+
+export default {
+	title: 'External Components/Panel',
+	component: Panel,
+	argTypes: {
+		children: {
+			control: 'null',
+			description: "The content element to display in the panel's body",
+			table: {
+				type: {
+					summary: 'ReactNode',
+				},
+			},
+		},
+		className: {
+			description: 'Additional CSS classes to be added to the panel.',
+			control: 'text',
+			table: {
+				type: {
+					summary: 'string',
+				},
+			},
+		},
+		initialOpen: {
+			description: 'Whether the panel body should be visible by default.',
+			table: {
+				type: {
+					summary: 'boolean',
+				},
+			},
+		},
+		title: {
+			control: 'null',
+			description: "The React element to display as the panel's title",
+			table: {
+				type: {
+					summary: 'ReactNode',
+				},
+			},
+		},
+		titleTag: {
+			control: 'text',
+			description:
+				'The HTML tag used to display the title element. Defaults to `div`.',
+			table: {
+				type: {
+					summary: 'string',
+				},
+			},
+		},
+	},
+} as Meta< PanelProps >;
+
+const Template: StoryFn< PanelProps > = ( args ) => {
+	return (
+		<Panel { ...args }>
+			<div style={ { paddingBottom: '.750em' } }>
+				This is the content rendered inside the panel.
+			</div>
+		</Panel>
+	);
+};
+
+export const Default = Template.bind( {} );
+Default.args = {
+	title: (
+		<div style={ { paddingBottom: '.375em', marginBottom: '.375em' } }>
+			Title
+		</div>
+	),
+	hasBorder: true,
+	initialOpen: false,
+};
+
+export const InitialOpen = Template.bind( {} );
+InitialOpen.args = {
+	title: (
+		<div style={ { paddingBottom: '.375em', marginBottom: '.375em' } }>
+			Title
+		</div>
+	),
+	hasBorder: true,
+	initialOpen: true,
+};


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Adds a Storybook entry for the `Panel` component.

Fixes #11692

## Why

To showcase the component and provide a level of documentation.

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Run `npm run storybook` and go to `localhost:6006`
2. Check the `External Components/Panel` and change the controls.
3. Ensure it works OK and the component is showcased well.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [x] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [x] N/A

## Checklist

Required:

* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:

* [ ] This PR has a UI change and has been cross-browser tested at different viewport sizes on both the frontend and in the editor.
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Skipping
