### PR TITLE
Pass order ID to woocommerce_before_thankyou hook

### DIFF
--- a/src/BlockTypes/OrderConfirmation/Status.php
+++ b/src/BlockTypes/OrderConfirmation/Status.php
@@ -64,7 +64,7 @@ class Status extends AbstractOrderConfirmationBlock {
 			return '<p>' . wp_kses_post( apply_filters( 'woocommerce_thankyou_order_received_text', esc_html__( 'Thank you. Your order has been received.', 'woo-gutenberg-products-block' ), null ) ) . '</p>';
 		}
 
-		$content = $this->get_hook_content( 'woocommerce_before_thankyou', [ $order ] );
+		$content = $this->get_hook_content( 'woocommerce_before_thankyou', [ $order->get_id() ] );
 		$status  = $order->get_status();
 
 		// Unlike the core handling, this includes some extra messaging for completed orders so the text is appropriate for other order statuses.


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Fixes #11851 

Compatibility issue with `woocommerce_before_thankyou` hook

## Why

This commit resolves a compatibility issue where the `woocommerce_before_thankyou` hook was receiving an order object instead of an order ID. By passing the order ID directly using `$order->get_id()`, this change ensures backward compatibility with plugins that expect an integer order ID, since that is what WooCommerce has always passed.

## Testing Instructions

1. Implement a function that expects an integer for the order ID, attached to the woocommerce_before_thankyou hook. Example function:
```php
function example_function( int $order_id ): void {
    // Function logic that expects $order_id to be an integer
}
add_action( 'woocommerce_before_thankyou', 'example_function' );
```

2. Place an order on the WooCommerce store.
3. Confirm that it doesn't throw a type error

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

N/A

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [X] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:

* [X] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [X] This PR is assigned to a milestone.

Conditional:

* [ ] This PR has a UI change and has been cross-browser tested at different viewport sizes on both the frontend and in the editor.
* [X] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Fixed an issue where woocommerce_before_thankyou hook passed an order object instead of an order ID
