### PR TITLE
Product Button: always enqueue the store

### DIFF
--- a/src/BlockTypes/ProductButton.php
+++ b/src/BlockTypes/ProductButton.php
@@ -77,11 +77,25 @@ class ProductButton extends AbstractBlock {
 		$post_id = isset( $block->context['postId'] ) ? $block->context['postId'] : '';
 		$product = wc_get_product( $post_id );
 
+		wc_store(
+			array(
+				'state' => array(
+					'woocommerce' => array(
+						'inTheCartText' => sprintf(
+							/* translators: %s: product number. */
+							__( '%s in cart', 'woo-gutenberg-products-block' ),
+							'###'
+						),
+					),
+				),
+			)
+		);
+
 		if ( $product ) {
 			$number_of_items_in_cart = $this->get_cart_item_quantities_by_product_id( $product->get_id() );
 			$more_than_one_item      = $number_of_items_in_cart > 0;
 			$initial_product_text    = $more_than_one_item ? sprintf(
-				/* translators: %s: product number. */
+			/* translators: %s: product number. */
 				__( '%s in cart', 'woo-gutenberg-products-block' ),
 				$number_of_items_in_cart
 			) : $product->add_to_cart_text();
@@ -105,20 +119,6 @@ class ProductButton extends AbstractBlock {
 						'product_type_' . $product->get_type(),
 						esc_attr( $styles_and_classes['classes'] ),
 					)
-				)
-			);
-
-			wc_store(
-				array(
-					'state' => array(
-						'woocommerce' => array(
-							'inTheCartText' => sprintf(
-								/* translators: %s: product number. */
-								__( '%s in cart', 'woo-gutenberg-products-block' ),
-								'###'
-							),
-						),
-					),
 				)
 			);
 


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Fixes https://github.com/woocommerce/woocommerce/issues/41115

## Why

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

When the "product-button-interactivity-frontend.js" is loaded, the script expects to have access to the `state` variable. Currently, we create the `state` variable only if the product exists. This is not right, because, in the case of the Product Collection block, the script is loaded even if any product is rendered on the page (#11857).


## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Add Price Filter.
3. Add Product Collection.
3. Go to frontend.
4. Set the price filters in a way that there are no products displayed, for example, slide min price fully to the right.
5. Open the console.
6. Ensure no error is visible.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:

* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:

* [ ] This PR has a UI change and has been cross-browser tested at different viewport sizes on both the frontend and in the editor.
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Product Button: always enqueue the store.
