### PR TITLE
Store Customization > Ensure the price for products is also AI-generated 

### DIFF
--- a/src/Patterns/ProductUpdater.php
+++ b/src/Patterns/ProductUpdater.php
@@ -251,6 +251,7 @@ class ProductUpdater {
 
 		$product->set_name( $ai_generated_product_content['title'] );
 		$product->set_description( $ai_generated_product_content['description'] );
+		$product->set_regular_price( $ai_generated_product_content['price'] );
 
 		require_once ABSPATH . 'wp-admin/includes/media.php';
 		require_once ABSPATH . 'wp-admin/includes/file.php';
@@ -292,6 +293,7 @@ class ProductUpdater {
 			$products_information_list[] = [
 				'title'       => 'A product title',
 				'description' => 'A product description',
+				'price'       => 'The product price',
 				'image'       => [
 					'src' => esc_url( $image_src ),
 					'alt' => esc_attr( $image_alt ),
@@ -329,11 +331,14 @@ class ProductUpdater {
 
 		$expected_results_format = [];
 		foreach ( $products_information_list as $index => $product ) {
-			$expected_results_format[ $index ] = '';
+			$expected_results_format[ $index ] = [
+				'title' => '',
+				'price' => '',
+			];
 		}
 
 		$formatted_prompt = sprintf(
-			"Generate two-words titles for products using the following prompts for each one of them: '%s'. Ensure each entry is unique and does not repeat the given examples. Do not include backticks or the word json in the response. Here's an example format: '%s'.",
+			"Generate two-words titles and price for products using the following prompts for each one of them: '%s'. Ensure each entry is unique and does not repeat the given examples. Ensure each product price is a number and corresponds with the product title that is being advertised. Do not include backticks or the word json in the response. Here's an example format: '%s'.",
 			wp_json_encode( $prompts ),
 			wp_json_encode( $expected_results_format )
 		);
@@ -381,7 +386,8 @@ class ProductUpdater {
 			}
 
 			foreach ( $products_information_list as $index => $product_information ) {
-				$products_information_list[ $index ]['title'] = str_replace( '"', '', $completion[ $index ] );
+				$products_information_list[ $index ]['title'] = str_replace( '"', '', $completion[ $index ]['title'] );
+				$products_information_list[ $index ]['price'] = $completion[ $index ]['price'];
 			}
 
 			$success = true;

--- a/src/Patterns/ProductUpdater.php
+++ b/src/Patterns/ProductUpdater.php
@@ -338,8 +338,9 @@ class ProductUpdater {
 		}
 
 		$formatted_prompt = sprintf(
-			"Generate two-words titles and price for products using the following prompts for each one of them: '%s'. Ensure each entry is unique and does not repeat the given examples. Ensure each product price is a number and corresponds with the product title that is being advertised. Do not include backticks or the word json in the response. Here's an example format: '%s'.",
+			"Generate two-words titles and price for products using the following prompts for each one of them: '%s'. Ensure each entry is unique and does not repeat the given examples. Ensure each product price is a number and it's not too low or too high for the corresponding product title being advertised in the following currency: %s. Do not include backticks or the word json in the response. Here's an example format: '%s'.",
 			wp_json_encode( $prompts ),
+			get_woocommerce_currency(),
 			wp_json_encode( $expected_results_format )
 		);
 

--- a/src/Patterns/ProductUpdater.php
+++ b/src/Patterns/ProductUpdater.php
@@ -338,7 +338,7 @@ class ProductUpdater {
 		}
 
 		$formatted_prompt = sprintf(
-			"Generate two-words titles and price for products using the following prompts for each one of them: '%s'. Ensure each entry is unique and does not repeat the given examples. Ensure each product price is a number and it's not too low or too high for the corresponding product title being advertised in the following currency: %s. Do not include backticks or the word json in the response. Here's an example format: '%s'.",
+			"Generate two-words titles and price for products using the following prompts for each one of them: '%s'. Ensure each entry is unique and does not repeat the given examples. It should be a number and it's not too low or too high for the corresponding product title being advertised. Convert the price to this currency: '%s'. Do not include backticks or the word json in the response. Here's an example format: '%s'.",
 			wp_json_encode( $prompts ),
 			get_woocommerce_currency(),
 			wp_json_encode( $expected_results_format )


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

This PR updates the product generation AI prompt to also generate the product price.

## Why

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/11828
Before, we were generating the prices randomly between 5 and 50, which produced some weird results. This way we ensure the prices makes sense with the product

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

### Setup

Please test the feature on a WooExpress install instead of Jurassic Ninja, as the latter can be very limited in terms of server resources and unstable, as other installs can interfere with your own.

- If you already have a pre-configured install, remove the pre-existing WooCommerce Blocks Plugin and upload the one from this zip file: https://wcblocks.wpcomstaging.com/wp-content/uploads/woocommerce-gutenberg-products-block-11859.zip
- Alternatively, create a new WooExpress install from scratch 
- Remove the pre-existing WooCommerce plugin via SSH and
- Install and activate WooCommerce from the following zip file: 
[woocommerce.zip](https://github.com/woocommerce/woocommerce-blocks/files/13415324/woocommerce.zip)
- Install and activate WooCommerce Blocks from the following zip file: https://wcblocks.wpcomstaging.com/wp-content/uploads/woocommerce-gutenberg-products-block-11859.zip
- Install and activate WooCommerce Beta Tester (the plugin is available [within the monorepo](https://github.com/woocommerce/woocommerce/tree/trunk/plugins))
- Head over to `/wp-admin/tools.php?page=woocommerce-admin-test-helper` and enable `customize-store` feature flag:

<img width="1233" alt="Screenshot 2023-10-22 at 10 32 24" src="https://github.com/woocommerce/woocommerce-blocks/assets/15730971/816867c6-34e5-40a1-a87d-f4a7cda46429">

### Test the CYS experience

0. Make sure you don't have any products in your store.
1. Head over to Home > Customize your Store:
 
<img width="1232" alt="Screenshot 2023-10-22 at 09 29 08" src="https://github.com/woocommerce/woocommerce-blocks/assets/15730971/b5d34131-3edc-47ed-a8e4-8e2775ca1bbd">

2. Click on design with AI.
3. Type a description for your business.
4. Make sure six new dummy products are created for your store.
5. **Make sure the generated products have a price that makes sense with the product.**

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [x] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:

* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:

* [ ] This PR has a UI change and has been cross-browser tested at different viewport sizes on both the frontend and in the editor.
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.


