### PR TITLE
Validate coupon usage against customer id AND emails

### DIFF
--- a/src/StoreApi/Utilities/OrderController.php
+++ b/src/StoreApi/Utilities/OrderController.php
@@ -498,6 +498,7 @@ class OrderController {
 		$tentative_usage_count = $data_store->get_tentative_usages_for_user( $coupon->get_id(), $aliases );
 		return $tentative_usage_count + $usage_count;
 	}
+
 	/**
 	 * Check there is a shipping method if it requires shipping.
 	 *

--- a/src/StoreApi/Utilities/OrderController.php
+++ b/src/StoreApi/Utilities/OrderController.php
@@ -204,18 +204,34 @@ class OrderController {
 			$this->update_order_from_cart( $order );
 
 			// Return exception so customer can review before payment.
-			throw new RouteException(
-				'woocommerce_rest_cart_coupon_errors',
-				sprintf(
-					/* translators: %s Coupon codes. */
-					__( 'Invalid coupons were removed from the cart: "%s"', 'woo-gutenberg-products-block' ),
-					implode( '", "', array_keys( $coupon_errors ) )
-				),
-				409,
-				[
-					'removed_coupons' => $coupon_errors,
-				]
-			);
+			if ( 1 === count( $coupon_errors ) ) {
+				throw new RouteException(
+					'woocommerce_rest_cart_coupon_errors',
+					sprintf(
+						/* translators: %1$s Coupon codes, %2$s Reason */
+						__( '"%1$s" was removed from the cart. %2$s', 'woo-gutenberg-products-block' ),
+						array_keys( $coupon_errors )[0],
+						array_values( $coupon_errors )[0],
+					),
+					409,
+					[
+						'removed_coupons' => $coupon_errors,
+					]
+				);
+			} else {
+				throw new RouteException(
+					'woocommerce_rest_cart_coupon_errors',
+					sprintf(
+						/* translators: %s Coupon codes. */
+						__( 'Invalid coupons were removed from the cart: "%s"', 'woo-gutenberg-products-block' ),
+						implode( '", "', array_keys( $coupon_errors ) )
+					),
+					409,
+					[
+						'removed_coupons' => $coupon_errors,
+					]
+				);
+			}
 		}
 	}
 

--- a/src/StoreApi/Utilities/OrderController.php
+++ b/src/StoreApi/Utilities/OrderController.php
@@ -433,9 +433,17 @@ class OrderController {
 		if ( $coupon_usage_limit > 0 ) {
 			$data_store = $coupon->get_data_store();
 			// First, we check a logged in customer usage count, which happens against their user id, billing email, and account email.
-			if ( get_current_user_id() ) {
+			if ( $order->get_customer_id() ) {
+				$user_data = get_userdata( $order->get_customer_id() );
 				// We get usage per user id and associated emails.
-				$usage_count = $this->get_usage_per_aliases( $coupon, array( $order->get_billing_email(), get_current_user_id(), wp_get_current_user()->user_email ) );
+				$usage_count = $this->get_usage_per_aliases(
+					$coupon,
+					[
+						$order->get_billing_email(),
+						$order->get_customer_id(),
+						$user_data->user_email,
+					]
+				);
 			} else {
 				// Otherwise we check if the email doesn't belong to an existing user.
 				$customer_data_store = \WC_Data_Store::load( 'customer' );
@@ -447,7 +455,14 @@ class OrderController {
 					},
 					$user_ids
 				);
-				$usage_count    = $this->get_usage_per_aliases( $coupon, array_merge( $emails_for_ids, $user_ids, array( $order->get_billing_email() ) ) );
+				$usage_count    = $this->get_usage_per_aliases(
+					$coupon,
+					array_merge(
+						$emails_for_ids,
+						$user_ids,
+						array( $order->get_billing_email() )
+					)
+				);
 			}
 
 			if ( $usage_count >= $coupon_usage_limit ) {

--- a/src/StoreApi/Utilities/OrderController.php
+++ b/src/StoreApi/Utilities/OrderController.php
@@ -467,12 +467,11 @@ class OrderController {
 	public function get_usage_per_aliases( &$coupon, $aliases ) {
 		global $wpdb;
 		$aliases        = array_unique( array_filter( $aliases ) );
-		$aliases_string = "('" . join( "','", $aliases ) . "')";
+		$aliases_string = "('" . join( "','", array_map( 'esc_sql', $aliases ) ) . "')";
 		$usage_count    = $wpdb->get_var(
 			$wpdb->prepare(
-				"SELECT COUNT( meta_id ) FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key = '_used_by' AND meta_value IN %s;",
+				"SELECT COUNT( meta_id ) FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key = '_used_by' AND meta_value IN {$aliases_string};", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 				$coupon->get_id(),
-				$aliases_string
 			)
 		);
 

--- a/src/StoreApi/Utilities/OrderController.php
+++ b/src/StoreApi/Utilities/OrderController.php
@@ -466,14 +466,16 @@ class OrderController {
 	 */
 	public function get_usage_per_aliases( &$coupon, $aliases ) {
 		global $wpdb;
-		$aliases               = implode( ', ', array_map( 'esc_sql', array_unique( array_filter( $aliases ) ) ) );
-		$usage_count           = $wpdb->get_var(
+		$aliases        = array_unique( array_filter( $aliases ) );
+		$aliases_string = "('" . join( "','", $aliases ) . "')";
+		$usage_count    = $wpdb->get_var(
 			$wpdb->prepare(
-				"SELECT COUNT( meta_id ) FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key = '_used_by' AND meta_value IN (%s);",
+				"SELECT COUNT( meta_id ) FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key = '_used_by' AND meta_value IN %s;",
 				$coupon->get_id(),
-				$aliases
+				$aliases_string
 			)
 		);
+
 		$data_store            = $coupon->get_data_store();
 		$tentative_usage_count = $data_store->get_tentative_usages_for_user( $coupon->get_id(), $aliases );
 		return $tentative_usage_count + $usage_count;

--- a/src/StoreApi/Utilities/OrderController.php
+++ b/src/StoreApi/Utilities/OrderController.php
@@ -431,7 +431,6 @@ class OrderController {
 		$coupon_usage_limit = $coupon->get_usage_limit_per_user();
 
 		if ( $coupon_usage_limit > 0 ) {
-			$data_store = $coupon->get_data_store();
 			// First, we check a logged in customer usage count, which happens against their user id, billing email, and account email.
 			if ( $order->get_customer_id() ) {
 				$user_data = get_userdata( $order->get_customer_id() );

--- a/src/StoreApi/Utilities/OrderController.php
+++ b/src/StoreApi/Utilities/OrderController.php
@@ -108,7 +108,7 @@ class OrderController {
 		if ( $order->get_customer_id() ) {
 			$customer = new \WC_Customer( $order->get_customer_id() );
 			$customer->set_props(
-				array(
+				[
 					'billing_first_name'  => $order->get_billing_first_name(),
 					'billing_last_name'   => $order->get_billing_last_name(),
 					'billing_company'     => $order->get_billing_company(),
@@ -130,7 +130,7 @@ class OrderController {
 					'shipping_postcode'   => $order->get_shipping_postcode(),
 					'shipping_country'    => $order->get_shipping_country(),
 					'shipping_phone'      => $order->get_shipping_phone(),
-				)
+				]
 			);
 
 			$customer->save();
@@ -173,18 +173,18 @@ class OrderController {
 	 */
 	protected function validate_coupons( \WC_Order $order ) {
 		$coupon_codes  = $order->get_coupon_codes();
-		$coupons       = array_filter( array_map( array( $this, 'get_coupon' ), $coupon_codes ) );
-		$validators    = array( 'validate_coupon_email_restriction', 'validate_coupon_usage_limit' );
-		$coupon_errors = array();
+		$coupons       = array_filter( array_map( [ $this, 'get_coupon' ], $coupon_codes ) );
+		$validators    = [ 'validate_coupon_email_restriction', 'validate_coupon_usage_limit' ];
+		$coupon_errors = [];
 
 		foreach ( $coupons as $coupon ) {
 			try {
 				array_walk(
 					$validators,
 					function( $validator, $index, $params ) {
-						call_user_func_array( array( $this, $validator ), $params );
+						call_user_func_array( [ $this, $validator ], $params );
 					},
-					array( $coupon, $order )
+					[ $coupon, $order ]
 				);
 			} catch ( Exception $error ) {
 				$coupon_errors[ $coupon->get_code() ] = $error->getMessage();
@@ -212,9 +212,9 @@ class OrderController {
 					implode( '", "', array_keys( $coupon_errors ) )
 				),
 				409,
-				array(
+				[
 					'removed_coupons' => $coupon_errors,
-				)
+				]
 			);
 		}
 	}
@@ -270,9 +270,9 @@ class OrderController {
 					$shipping_address['country']
 				),
 				400,
-				array(
+				[
 					'allowed_countries' => array_keys( wc()->countries->get_shipping_countries() ),
-				)
+				]
 			);
 		}
 
@@ -285,9 +285,9 @@ class OrderController {
 					$billing_address['country']
 				),
 				400,
-				array(
+				[
 					'allowed_countries' => array_keys( wc()->countries->get_allowed_countries() ),
-				)
+				]
 			);
 		}
 
@@ -300,7 +300,7 @@ class OrderController {
 			return;
 		}
 
-		$errors_by_code = array();
+		$errors_by_code = [];
 		$error_codes    = $errors->get_error_codes();
 		foreach ( $error_codes as $code ) {
 			$errors_by_code[ $code ] = $errors->get_error_messages( $code );
@@ -316,9 +316,9 @@ class OrderController {
 					'shipping' === $code ? __( 'shipping address', 'woo-gutenberg-products-block' ) : __( 'billing address', 'woo-gutenberg-products-block' )
 				),
 				400,
-				array(
+				[
 					'errors' => $errors_by_code,
-				)
+				]
 			);
 		}
 	}
@@ -343,50 +343,50 @@ class OrderController {
 	 */
 	protected function validate_address_fields( $address, $address_type, \WP_Error $errors ) {
 		$all_locales    = wc()->countries->get_country_locale();
-		$current_locale = isset( $all_locales[ $address['country'] ] ) ? $all_locales[ $address['country'] ] : array();
+		$current_locale = isset( $all_locales[ $address['country'] ] ) ? $all_locales[ $address['country'] ] : [];
 
 		/**
 		 * We are not using wc()->counties->get_default_address_fields() here because that is filtered. Instead, this array
 		 * is based on assets/js/base/components/cart-checkout/address-form/default-address-fields.js
 		 */
-		$address_fields = array(
-			'first_name' => array(
+		$address_fields = [
+			'first_name' => [
 				'label'    => __( 'First name', 'woo-gutenberg-products-block' ),
 				'required' => true,
-			),
-			'last_name'  => array(
+			],
+			'last_name'  => [
 				'label'    => __( 'Last name', 'woo-gutenberg-products-block' ),
 				'required' => true,
-			),
-			'company'    => array(
+			],
+			'company'    => [
 				'label'    => __( 'Company', 'woo-gutenberg-products-block' ),
 				'required' => false,
-			),
-			'address_1'  => array(
+			],
+			'address_1'  => [
 				'label'    => __( 'Address', 'woo-gutenberg-products-block' ),
 				'required' => true,
-			),
-			'address_2'  => array(
+			],
+			'address_2'  => [
 				'label'    => __( 'Apartment, suite, etc.', 'woo-gutenberg-products-block' ),
 				'required' => false,
-			),
-			'country'    => array(
+			],
+			'country'    => [
 				'label'    => __( 'Country/Region', 'woo-gutenberg-products-block' ),
 				'required' => true,
-			),
-			'city'       => array(
+			],
+			'city'       => [
 				'label'    => __( 'City', 'woo-gutenberg-products-block' ),
 				'required' => true,
-			),
-			'state'      => array(
+			],
+			'state'      => [
 				'label'    => __( 'State/County', 'woo-gutenberg-products-block' ),
 				'required' => true,
-			),
-			'postcode'   => array(
+			],
+			'postcode'   => [
 				'label'    => __( 'Postal code', 'woo-gutenberg-products-block' ),
 				'required' => true,
-			),
-		);
+			],
+		];
 
 		if ( $current_locale ) {
 			foreach ( $current_locale as $key => $field ) {
@@ -415,7 +415,7 @@ class OrderController {
 	protected function validate_coupon_email_restriction( \WC_Coupon $coupon, \WC_Order $order ) {
 		$restrictions = $coupon->get_email_restrictions();
 
-		if ( ! empty( $restrictions ) && $order->get_billing_email() && ! wc()->cart->is_coupon_emails_allowed( array( $order->get_billing_email() ), $restrictions ) ) {
+		if ( ! empty( $restrictions ) && $order->get_billing_email() && ! wc()->cart->is_coupon_emails_allowed( [ $order->get_billing_email() ], $restrictions ) ) {
 			throw new Exception( $coupon->get_coupon_error( \WC_Coupon::E_WC_COUPON_NOT_YOURS_REMOVED ) );
 		}
 	}
@@ -490,7 +490,7 @@ class OrderController {
 		if ( ! $needs_shipping || ! is_array( $chosen_shipping_methods ) ) {
 			return;
 		}
-		$arr = [];
+
 		foreach ( $chosen_shipping_methods as $chosen_shipping_method ) {
 			if ( false === $chosen_shipping_method ) {
 				throw new RouteException(
@@ -661,7 +661,7 @@ class OrderController {
 	 */
 	protected function update_addresses_from_cart( \WC_Order $order ) {
 		$order->set_props(
-			array(
+			[
 				'billing_first_name'  => wc()->customer->get_billing_first_name(),
 				'billing_last_name'   => wc()->customer->get_billing_last_name(),
 				'billing_company'     => wc()->customer->get_billing_company(),
@@ -683,7 +683,7 @@ class OrderController {
 				'shipping_postcode'   => wc()->customer->get_shipping_postcode(),
 				'shipping_country'    => wc()->customer->get_shipping_country(),
 				'shipping_phone'      => wc()->customer->get_shipping_phone(),
-			)
+			]
 		);
 	}
 }

--- a/src/StoreApi/Utilities/OrderController.php
+++ b/src/StoreApi/Utilities/OrderController.php
@@ -479,7 +479,7 @@ class OrderController {
 	 *
 	 * @return integer
 	 */
-	private function get_usage_per_aliases( &$coupon, $aliases ) {
+	private function get_usage_per_aliases( $coupon, $aliases ) {
 		global $wpdb;
 		$aliases        = array_unique( array_filter( $aliases ) );
 		$aliases_string = "('" . implode( "','", array_map( 'esc_sql', $aliases ) ) . "')";

--- a/src/StoreApi/Utilities/OrderController.php
+++ b/src/StoreApi/Utilities/OrderController.php
@@ -485,7 +485,8 @@ class OrderController {
 		$aliases_string = "('" . implode( "','", array_map( 'esc_sql', $aliases ) ) . "')";
 		$usage_count    = $wpdb->get_var(
 			$wpdb->prepare(
-				"SELECT COUNT( meta_id ) FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key = '_used_by' AND meta_value IN {$aliases_string};", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				"SELECT COUNT( meta_id ) FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key = '_used_by' AND meta_value IN {$aliases_string};",
 				$coupon->get_id(),
 			)
 		);

--- a/src/StoreApi/Utilities/OrderController.php
+++ b/src/StoreApi/Utilities/OrderController.php
@@ -482,7 +482,7 @@ class OrderController {
 	private function get_usage_per_aliases( &$coupon, $aliases ) {
 		global $wpdb;
 		$aliases        = array_unique( array_filter( $aliases ) );
-		$aliases_string = "('" . join( "','", array_map( 'esc_sql', $aliases ) ) . "')";
+		$aliases_string = "('" . implode( "','", array_map( 'esc_sql', $aliases ) ) . "')";
 		$usage_count    = $wpdb->get_var(
 			$wpdb->prepare(
 				"SELECT COUNT( meta_id ) FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key = '_used_by' AND meta_value IN {$aliases_string};", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared

--- a/src/StoreApi/Utilities/OrderController.php
+++ b/src/StoreApi/Utilities/OrderController.php
@@ -479,7 +479,7 @@ class OrderController {
 	 *
 	 * @return integer
 	 */
-	public function get_usage_per_aliases( &$coupon, $aliases ) {
+	private function get_usage_per_aliases( &$coupon, $aliases ) {
 		global $wpdb;
 		$aliases        = array_unique( array_filter( $aliases ) );
 		$aliases_string = "('" . join( "','", array_map( 'esc_sql', $aliases ) ) . "')";

--- a/src/StoreApi/Utilities/OrderController.php
+++ b/src/StoreApi/Utilities/OrderController.php
@@ -446,7 +446,13 @@ class OrderController {
 				// This will get us any user ids for this billing email.
 				$user_ids              = $customer_data_store->get_user_ids_for_billing_email( array( $order->get_billing_email() ) );
 				$usage_count_per_id    = $this->get_coupon_usage_per_user_ids( $coupon, $user_ids );
-				$usage_count_per_email = $this->get_coupon_usage_per_emails( $coupon, array( $order->get_billing_email() ) );
+				$emails_for_ids        = array_map(
+					function( $user_id ) {
+						return get_userdata( $user_id )->user_email;
+					},
+					$user_ids
+				);
+				$usage_count_per_email = $this->get_coupon_usage_per_emails( $coupon, array_merge( $emails_for_ids, array( $order->get_billing_email() ) ) );
 
 				$usage_count = $usage_count_per_id + $usage_count_per_email;
 

--- a/src/StoreApi/Utilities/OrderController.php
+++ b/src/StoreApi/Utilities/OrderController.php
@@ -491,7 +491,8 @@ class OrderController {
 			)
 		);
 
-		$data_store            = $coupon->get_data_store();
+		$data_store = $coupon->get_data_store();
+		// Coupons can be held for an x amount of time before being applied to an order, so we need to check if it's already being held in (maybe via another flow).
 		$tentative_usage_count = $data_store->get_tentative_usages_for_user( $coupon->get_id(), $aliases );
 		return $tentative_usage_count + $usage_count;
 	}

--- a/src/StoreApi/Utilities/OrderController.php
+++ b/src/StoreApi/Utilities/OrderController.php
@@ -108,7 +108,7 @@ class OrderController {
 		if ( $order->get_customer_id() ) {
 			$customer = new \WC_Customer( $order->get_customer_id() );
 			$customer->set_props(
-				[
+				array(
 					'billing_first_name'  => $order->get_billing_first_name(),
 					'billing_last_name'   => $order->get_billing_last_name(),
 					'billing_company'     => $order->get_billing_company(),
@@ -130,7 +130,7 @@ class OrderController {
 					'shipping_postcode'   => $order->get_shipping_postcode(),
 					'shipping_country'    => $order->get_shipping_country(),
 					'shipping_phone'      => $order->get_shipping_phone(),
-				]
+				)
 			);
 
 			$customer->save();
@@ -173,18 +173,18 @@ class OrderController {
 	 */
 	protected function validate_coupons( \WC_Order $order ) {
 		$coupon_codes  = $order->get_coupon_codes();
-		$coupons       = array_filter( array_map( [ $this, 'get_coupon' ], $coupon_codes ) );
-		$validators    = [ 'validate_coupon_email_restriction', 'validate_coupon_usage_limit' ];
-		$coupon_errors = [];
+		$coupons       = array_filter( array_map( array( $this, 'get_coupon' ), $coupon_codes ) );
+		$validators    = array( 'validate_coupon_email_restriction', 'validate_coupon_usage_limit' );
+		$coupon_errors = array();
 
 		foreach ( $coupons as $coupon ) {
 			try {
 				array_walk(
 					$validators,
 					function( $validator, $index, $params ) {
-						call_user_func_array( [ $this, $validator ], $params );
+						call_user_func_array( array( $this, $validator ), $params );
 					},
-					[ $coupon, $order ]
+					array( $coupon, $order )
 				);
 			} catch ( Exception $error ) {
 				$coupon_errors[ $coupon->get_code() ] = $error->getMessage();
@@ -212,9 +212,9 @@ class OrderController {
 					implode( '", "', array_keys( $coupon_errors ) )
 				),
 				409,
-				[
+				array(
 					'removed_coupons' => $coupon_errors,
-				]
+				)
 			);
 		}
 	}
@@ -270,9 +270,9 @@ class OrderController {
 					$shipping_address['country']
 				),
 				400,
-				[
+				array(
 					'allowed_countries' => array_keys( wc()->countries->get_shipping_countries() ),
-				]
+				)
 			);
 		}
 
@@ -285,9 +285,9 @@ class OrderController {
 					$billing_address['country']
 				),
 				400,
-				[
+				array(
 					'allowed_countries' => array_keys( wc()->countries->get_allowed_countries() ),
-				]
+				)
 			);
 		}
 
@@ -300,7 +300,7 @@ class OrderController {
 			return;
 		}
 
-		$errors_by_code = [];
+		$errors_by_code = array();
 		$error_codes    = $errors->get_error_codes();
 		foreach ( $error_codes as $code ) {
 			$errors_by_code[ $code ] = $errors->get_error_messages( $code );
@@ -316,9 +316,9 @@ class OrderController {
 					'shipping' === $code ? __( 'shipping address', 'woo-gutenberg-products-block' ) : __( 'billing address', 'woo-gutenberg-products-block' )
 				),
 				400,
-				[
+				array(
 					'errors' => $errors_by_code,
-				]
+				)
 			);
 		}
 	}
@@ -343,50 +343,50 @@ class OrderController {
 	 */
 	protected function validate_address_fields( $address, $address_type, \WP_Error $errors ) {
 		$all_locales    = wc()->countries->get_country_locale();
-		$current_locale = isset( $all_locales[ $address['country'] ] ) ? $all_locales[ $address['country'] ] : [];
+		$current_locale = isset( $all_locales[ $address['country'] ] ) ? $all_locales[ $address['country'] ] : array();
 
 		/**
 		 * We are not using wc()->counties->get_default_address_fields() here because that is filtered. Instead, this array
 		 * is based on assets/js/base/components/cart-checkout/address-form/default-address-fields.js
 		 */
-		$address_fields = [
-			'first_name' => [
+		$address_fields = array(
+			'first_name' => array(
 				'label'    => __( 'First name', 'woo-gutenberg-products-block' ),
 				'required' => true,
-			],
-			'last_name'  => [
+			),
+			'last_name'  => array(
 				'label'    => __( 'Last name', 'woo-gutenberg-products-block' ),
 				'required' => true,
-			],
-			'company'    => [
+			),
+			'company'    => array(
 				'label'    => __( 'Company', 'woo-gutenberg-products-block' ),
 				'required' => false,
-			],
-			'address_1'  => [
+			),
+			'address_1'  => array(
 				'label'    => __( 'Address', 'woo-gutenberg-products-block' ),
 				'required' => true,
-			],
-			'address_2'  => [
+			),
+			'address_2'  => array(
 				'label'    => __( 'Apartment, suite, etc.', 'woo-gutenberg-products-block' ),
 				'required' => false,
-			],
-			'country'    => [
+			),
+			'country'    => array(
 				'label'    => __( 'Country/Region', 'woo-gutenberg-products-block' ),
 				'required' => true,
-			],
-			'city'       => [
+			),
+			'city'       => array(
 				'label'    => __( 'City', 'woo-gutenberg-products-block' ),
 				'required' => true,
-			],
-			'state'      => [
+			),
+			'state'      => array(
 				'label'    => __( 'State/County', 'woo-gutenberg-products-block' ),
 				'required' => true,
-			],
-			'postcode'   => [
+			),
+			'postcode'   => array(
 				'label'    => __( 'Postal code', 'woo-gutenberg-products-block' ),
 				'required' => true,
-			],
-		];
+			),
+		);
 
 		if ( $current_locale ) {
 			foreach ( $current_locale as $key => $field ) {
@@ -415,7 +415,7 @@ class OrderController {
 	protected function validate_coupon_email_restriction( \WC_Coupon $coupon, \WC_Order $order ) {
 		$restrictions = $coupon->get_email_restrictions();
 
-		if ( ! empty( $restrictions ) && $order->get_billing_email() && ! wc()->cart->is_coupon_emails_allowed( [ $order->get_billing_email() ], $restrictions ) ) {
+		if ( ! empty( $restrictions ) && $order->get_billing_email() && ! wc()->cart->is_coupon_emails_allowed( array( $order->get_billing_email() ), $restrictions ) ) {
 			throw new Exception( $coupon->get_coupon_error( \WC_Coupon::E_WC_COUPON_NOT_YOURS_REMOVED ) );
 		}
 	}
@@ -431,13 +431,75 @@ class OrderController {
 		$coupon_usage_limit = $coupon->get_usage_limit_per_user();
 
 		if ( $coupon_usage_limit > 0 ) {
-			$data_store  = $coupon->get_data_store();
-			$usage_count = $order->get_customer_id() ? $data_store->get_usage_by_user_id( $coupon, $order->get_customer_id() ) : $data_store->get_usage_by_email( $coupon, $order->get_billing_email() );
+			$data_store = $coupon->get_data_store();
+			// First, we check a logged in customer usage count, which happens against their user id, billing email, and account email.
+			if ( get_current_user_id() ) {
+				// First we get a count of usage by user id.
+				$usage_count_per_id = $data_store->get_usage_by_user_id( $coupon, get_current_user_id() );
+				// Then we get usage for all user emails, the order billing email can be different from the one the user created the account with, we still need to check both.
+				$usage_count_per_email = $this->get_coupon_usage_per_emails( $coupon, array( $order->get_billing_email(), wp_get_current_user()->user_email ) );
+				$usage_count           = $usage_count_per_id + $usage_count_per_email;
+
+			} else {
+				// Otherwise we check if the email doesn't belong to an existing user.
+				$customer_data_store = \WC_Data_Store::load( 'customer' );
+				// This will get us any user ids for this billing email.
+				$user_ids              = $customer_data_store->get_user_ids_for_billing_email( array( $order->get_billing_email() ) );
+				$usage_count_per_id    = $this->get_coupon_usage_per_user_ids( $coupon, $user_ids );
+				$usage_count_per_email = $this->get_coupon_usage_per_emails( $coupon, array( $order->get_billing_email() ) );
+
+				$usage_count = $usage_count_per_id + $usage_count_per_email;
+
+			}
 
 			if ( $usage_count >= $coupon_usage_limit ) {
 				throw new Exception( $coupon->get_coupon_error( \WC_Coupon::E_WC_COUPON_USAGE_LIMIT_REACHED ) );
 			}
 		}
+	}
+
+	/**
+	 * Get the usage count for a coupon by user ids.
+	 *
+	 * @param \WC_Coupon $coupon Coupon object applied to the cart.
+	 * @param array      $user_ids Array of user ids.
+	 *
+	 * @return int
+	 */
+	private function get_coupon_usage_per_user_ids( $coupon, $user_ids ) {
+		$data_store = $coupon->get_data_store();
+		$usage      = 0;
+		$user_ids   = array_unique( array_map( 'absint', $user_ids ) );
+		foreach ( $user_ids as $user_id ) {
+			$usage += $data_store->get_usage_by_user_id( $coupon, $user_id );
+		}
+		return $usage;
+	}
+
+	/**
+	 * Get the usage count for a coupon by emails.
+	 *
+	 * @param \WC_Coupon $coupon Coupon object applied to the cart.
+	 * @param array      $emails Array of emails.
+	 *
+	 * @return int
+	 */
+	private function get_coupon_usage_per_emails( $coupon, $emails ) {
+		$data_store = $coupon->get_data_store();
+		$usage      = 0;
+		$emails     = array_unique(
+			array_map(
+				'sanitize_email',
+				array_map(
+					'strtolower',
+					$emails
+				)
+			)
+		);
+		foreach ( $emails as $email ) {
+			$usage += $data_store->get_usage_by_email( $coupon, $email );
+		}
+		return $usage;
 	}
 
 	/**
@@ -458,7 +520,7 @@ class OrderController {
 					'woocommerce_rest_invalid_shipping_option',
 					__( 'Sorry, this order requires a shipping option.', 'woo-gutenberg-products-block' ),
 					400,
-					[]
+					array()
 				);
 			}
 		}
@@ -622,7 +684,7 @@ class OrderController {
 	 */
 	protected function update_addresses_from_cart( \WC_Order $order ) {
 		$order->set_props(
-			[
+			array(
 				'billing_first_name'  => wc()->customer->get_billing_first_name(),
 				'billing_last_name'   => wc()->customer->get_billing_last_name(),
 				'billing_company'     => wc()->customer->get_billing_company(),
@@ -644,7 +706,7 @@ class OrderController {
 				'shipping_postcode'   => wc()->customer->get_shipping_postcode(),
 				'shipping_country'    => wc()->customer->get_shipping_country(),
 				'shipping_phone'      => wc()->customer->get_shipping_phone(),
-			]
+			)
 		);
 	}
 }

--- a/src/StoreApi/Utilities/OrderController.php
+++ b/src/StoreApi/Utilities/OrderController.php
@@ -451,7 +451,8 @@ class OrderController {
 				$user_ids       = $customer_data_store->get_user_ids_for_billing_email( array( $order->get_billing_email() ) );
 				$emails_for_ids = array_map(
 					function( $user_id ) {
-						return get_userdata( $user_id )->user_email;
+						$user_data = get_userdata( $user_id );
+						return $user_data ? $user_data->user_email : '';
 					},
 					$user_ids
 				);

--- a/src/StoreApi/Utilities/OrderController.php
+++ b/src/StoreApi/Utilities/OrderController.php
@@ -441,7 +441,7 @@ class OrderController {
 					[
 						$order->get_billing_email(),
 						$order->get_customer_id(),
-						$user_data->user_email,
+						$user_data ? $user_data->user_email : '',
 					]
 				);
 			} else {


### PR DESCRIPTION
WooCommerce would register coupon usage based on 2 elements, a user id if the customer has one, or the billing email.

There was an edge case in which a coupon can be used twice, once logged in with user id, and once logged out with billing email.

For the purpose of this fix, we consider emails to belong to a single user, so even as guest, it can't be used.

So in this PR, I check the coupon usage against a customer id, their billing email, and the account email (if those last 2 differ).

For a logged out customer, I first check if the email belongs to an existing user, and check its usage as well, as well as the billing email usage.

Fixes #11850

## Testing Instructions

### From logged in to logged out
1. Create a new coupon and limit its usage to 1 per customer.
2. Logged in, with an email you remember, place an order using that coupon, it should pass.
3. Logged out, using the same email, try placing an order with that coupon, you should get a top level error "coupon_name" was removed from the cart. Coupon usage limit has been reached.".

### User email vs billing email
1. Create a new coupon and limit its usage to 1 per customer.
2. Logged in, with an user email you remember, place an order using that coupon, and a different billing email. It should pass.
3. Logged out, using the same user email (not the billing email), try placing an order with that coupon, you should get a top level error "coupon_name" was removed from the cart. Coupon usage limit has been reached.".

### From logged out to logged in
1. Create a new coupon and limit its usage to 1 per customer.
4. Logged out, use the coupon with an email you remember, that email should belong to an existing user.
5. You should be able to place the order fine.
6. Logged in with the user that own that email.
7. Go to checkout, add the coupon, using the same email, try to place the order.
8. You should get a top level error.
9. Change your billing email to something else, add the coupon again.
10. Try to place the order, you should get an error.

### General regression testing
1. Create a new coupon and limit its usage to 1 per customer.
2. Logged in, with an email you remember, place an order using that coupon, it should pass.
3. Logged in again, back to checkout, change your email, and try adding the coupon, you should get an inline error that you can't use the coupon.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:

* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Enhance validation for limited use coupons and guest users.
