### PR TITLE
Update notice for default cart and checkout

### DIFF
--- a/assets/js/editor-components/default-notice/index.tsx
+++ b/assets/js/editor-components/default-notice/index.tsx
@@ -98,30 +98,46 @@ export function DefaultNotice( { block }: { block: string } ) {
 		saveEntityRecord,
 		slug,
 	] );
-	const noticeContent = createInterpolateElement(
-		__(
-			'If you would like to use this block as your default <blockTypeLink/>, <updateLink>update your page settings</updateLink>.',
-			'woo-gutenberg-products-block'
-		),
-		{
-			blockTypeLink: (
-				<span>
-					{ block === 'checkout'
-						? __( 'checkout', 'woo-gutenberg-products-block' )
-						: __( 'cart', 'woo-gutenberg-products-block' ) }
-				</span>
+
+	let noticeContent;
+	if ( block === 'checkout' ) {
+		noticeContent = createInterpolateElement(
+			__(
+				'If you would like to use this block as your default checkout, <a>update your page settings</a>.',
+				'woo-gutenberg-products-block'
 			),
-			updateLink: (
-				// eslint-disable-next-line jsx-a11y/anchor-is-valid
-				<a href="#" onClick={ updatePage }>
-					{ __(
-						'update your page settings',
-						'woo-gutenberg-products-block'
-					) }
-				</a>
+			{
+				a: (
+					// eslint-disable-next-line jsx-a11y/anchor-is-valid
+					<a href="#" onClick={ updatePage }>
+						{ __(
+							'update your page settings',
+							'woo-gutenberg-products-block'
+						) }
+					</a>
+				),
+			}
+		);
+	} else {
+		noticeContent = createInterpolateElement(
+			__(
+				'If you would like to use this block as your default cart, <a>update your page settings</a>.',
+				'woo-gutenberg-products-block'
 			),
-		}
-	);
+			{
+				a: (
+					// eslint-disable-next-line jsx-a11y/anchor-is-valid
+					<a href="#" onClick={ updatePage }>
+						{ __(
+							'update your page settings',
+							'woo-gutenberg-products-block'
+						) }
+					</a>
+				),
+			}
+		);
+	}
+
 	// Avoid showing the notice on the site editor, if already set, or if dismissed earlier.
 	if (
 		( typeof pagenow === 'string' && pagenow === 'site-editor' ) ||

--- a/assets/js/editor-components/default-notice/index.tsx
+++ b/assets/js/editor-components/default-notice/index.tsx
@@ -5,10 +5,15 @@ import { __ } from '@wordpress/i18n';
 import { store as editorStore } from '@wordpress/editor';
 import triggerFetch from '@wordpress/api-fetch';
 import { store as coreStore } from '@wordpress/core-data';
-import { Notice, Button } from '@wordpress/components';
+import { Notice } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { CHECKOUT_PAGE_ID, CART_PAGE_ID } from '@woocommerce/block-settings';
-import { useCallback, useState } from '@wordpress/element';
+import {
+	useCallback,
+	useState,
+	createInterpolateElement,
+} from '@wordpress/element';
+
 /**
  * Internal dependencies
  */
@@ -23,40 +28,21 @@ export function DefaultNotice( { block }: { block: string } ) {
 			? 'woocommerce_checkout_page_id'
 			: 'woocommerce_cart_page_id';
 
-	const noticeContent =
-		block === 'checkout'
-			? __(
-					'If you would like to use this block as your default checkout, update your page settings',
-					'woo-gutenberg-products-block'
-			  )
-			: __(
-					'If you would like to use this block as your default cart, update your page settings',
-					'woo-gutenberg-products-block'
-			  );
-
 	// Everything below works the same for Cart/Checkout
 	const { saveEntityRecord } = useDispatch( coreStore );
 	const { editPost, savePost } = useDispatch( editorStore );
-	const { slug, isLoadingPage, postPublished, currentPostId } = useSelect(
-		( select ) => {
-			const { getEntityRecord, isResolving } = select( coreStore );
-			const { isCurrentPostPublished, getCurrentPostId } =
-				select( editorStore );
-			return {
-				slug:
-					getEntityRecord( 'postType', 'page', ORIGINAL_PAGE_ID )
-						?.slug || block,
-				isLoadingPage: isResolving( 'getEntityRecord', [
-					'postType',
-					'page',
-					ORIGINAL_PAGE_ID,
-				] ),
-				postPublished: isCurrentPostPublished(),
-				currentPostId: getCurrentPostId(),
-			};
-		},
-		[]
-	);
+	const { slug, postPublished, currentPostId } = useSelect( ( select ) => {
+		const { getEntityRecord } = select( coreStore );
+		const { isCurrentPostPublished, getCurrentPostId } =
+			select( editorStore );
+		return {
+			slug:
+				getEntityRecord( 'postType', 'page', ORIGINAL_PAGE_ID )?.slug ||
+				block,
+			postPublished: isCurrentPostPublished(),
+			currentPostId: getCurrentPostId(),
+		};
+	}, [] );
 	const [ settingStatus, setStatus ] = useState( 'pristine' );
 	const updatePage = useCallback( () => {
 		setStatus( 'updating' );
@@ -112,6 +98,30 @@ export function DefaultNotice( { block }: { block: string } ) {
 		saveEntityRecord,
 		slug,
 	] );
+	const noticeContent = createInterpolateElement(
+		__(
+			'If you would like to use this block as your default <blockTypeLink/>, <updateLink>update your page settings</updateLink>.',
+			'woo-gutenberg-products-block'
+		),
+		{
+			blockTypeLink: (
+				<span>
+					{ block === 'checkout'
+						? __( 'checkout', 'woo-gutenberg-products-block' )
+						: __( 'cart', 'woo-gutenberg-products-block' ) }
+				</span>
+			),
+			updateLink: (
+				// eslint-disable-next-line jsx-a11y/anchor-is-valid
+				<a href="#" onClick={ updatePage }>
+					{ __(
+						'update your page settings',
+						'woo-gutenberg-products-block'
+					) }
+				</a>
+			),
+		}
+	);
 	// Avoid showing the notice on the site editor, if already set, or if dismissed earlier.
 	if (
 		( typeof pagenow === 'string' && pagenow === 'site-editor' ) ||
@@ -123,7 +133,7 @@ export function DefaultNotice( { block }: { block: string } ) {
 	return (
 		<Notice
 			className="wc-default-page-notice"
-			status={ settingStatus === 'updated' ? 'success' : 'warning' }
+			status={ settingStatus === 'updated' ? 'success' : 'info' }
 			onRemove={ () => setStatus( 'dismissed' ) }
 			spokenMessage={
 				settingStatus === 'updated'
@@ -139,18 +149,6 @@ export function DefaultNotice( { block }: { block: string } ) {
 			) : (
 				<>
 					<p>{ noticeContent }</p>
-					<Button
-						onClick={ updatePage }
-						variant="secondary"
-						isBusy={ settingStatus === 'updating' }
-						disabled={ isLoadingPage }
-						isSmall={ true }
-					>
-						{ __(
-							'Update your page settings',
-							'woo-gutenberg-products-block'
-						) }
-					</Button>
 				</>
 			) }
 		</Notice>


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Fixes #11777

## Why

In p1699988291133359/1699592175.220079-slack-C02UBB1EPEF, @elizaan36 asked to replace the button in the <DefaultNotice> component with an inline link and to display an info notice instead of a warning notice.

## Testing Instructions

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Create a test page and add the Cart block to it.
2. Open the settings sidebar.
3. Select the Cart block.
4. Verify that the notice _"If you would like to use this block as your default cart, [update your page settings](#)."_ no longer appears as a warning (yellow border and background), but as info (blue border, white background).
5. Click the link _"[update your page settings](#)"_.
6. Verify that the notice _"Page settings updated"_ becomes visible.
7. Repeat steps 1. until 6. with the Checkout block. In step 4., the message should say _"... as your default checkout, ..."_ instead of _"... as your default cart, ..."_.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

### Cart block

<table>
<tr>
<td valign="top">Before:
<br><br>
<img width="292" alt="Screenshot 2023-11-21 at 18 17 37" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/22e60e36-9818-4a0a-8393-5b5cd53f25d0">
</td>
<td valign="top">After:
<br><br>
<img width="293" alt="Screenshot 2023-11-21 at 17 57 27" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/e5ca3c95-f17a-47a0-b6e9-23395cc14144">
</td>
</tr>
</table>

### Checkout block

<table>
<tr>
<td valign="top">Before:
<br><br>
<img width="293" alt="Screenshot 2023-11-21 at 18 11 48" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/161a9bb4-626d-49d5-bf93-bc03a2d1d8dc">
</td>
<td valign="top">After:
<br><br>
<img width="295" alt="Screenshot 2023-11-21 at 18 08 52" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/cea552a4-4fd0-427a-8517-0e3eff105f9d">
</td>
</tr>
</table>

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:

* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:

* [x] This PR has a UI change and has been cross-browser tested at different viewport sizes on both the frontend and in the editor.
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog

> Update notice for default cart and checkout