### PR TITLE
Fix arguments passed to `woocommerce_before_thankyou` to mirror core hook

### DIFF
--- a/src/BlockTypes/OrderConfirmation/Status.php
+++ b/src/BlockTypes/OrderConfirmation/Status.php
@@ -64,7 +64,7 @@ class Status extends AbstractOrderConfirmationBlock {
 			return '<p>' . wp_kses_post( apply_filters( 'woocommerce_thankyou_order_received_text', esc_html__( 'Thank you. Your order has been received.', 'woo-gutenberg-products-block' ), null ) ) . '</p>';
 		}
 
-		$content = $this->get_hook_content( 'woocommerce_before_thankyou', [ $order ] );
+		$content = $this->get_hook_content( 'woocommerce_before_thankyou', [ $order->get_id() ] );
 		$status  = $order->get_status();
 
 		// Unlike the core handling, this includes some extra messaging for completed orders so the text is appropriate for other order statuses.


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

In core the `woocommerce_before_thankyou` hook accepts an order ID:

https://github.com/woocommerce/woocommerce/blob/f93f2ad3dd958cefaa9e85890fef919ee168cbe5/plugins/woocommerce/templates/checkout/thankyou.php#L28

In blocks we were passing an order object. It's likely this was missed in testing because the extensions using this hook did not care about this parameter or its type.

Fixes #11851

## Why

The hook params should match the legacy hook to avoid type errors.

## Testing Instructions

From the issue (requires code):

1. Implement a function that expects an integer for the order ID, attached to the woocommerce_before_thankyou hook. 

```php
function test_function_11851( int $order_id ): void {
    printf( 'Hello, this is order %d', $order_id );
}
add_action( 'woocommerce_before_thankyou', 'test_function_11851' );
```

2. Place an order on the WooCommerce store.
3. Thanks page should show without errors. Should see `Hello, this is order X`

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [x] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:

* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:

* [ ] This PR has a UI change and has been cross-browser tested at different viewport sizes on both the frontend and in the editor.
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog

> Fixed params passed to `woocommerce_before_thankyou` for block checkout. This should be an order ID, not an order object.
