### PR TITLE
Don't register or unregister if block can't be found

### DIFF
--- a/assets/js/atomic/utils/blocks-registration-manager/blocks-registration-manager.ts
+++ b/assets/js/atomic/utils/blocks-registration-manager/blocks-registration-manager.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { getBlockType } from '@wordpress/blocks';
+
+/**
  * Internal dependencies
  */
 import {
@@ -108,6 +113,11 @@ export class BlockRegistrationManager
 			) {
 				continue;
 			}
+
+			if ( ! getBlockType( blockWithRestrictionName ) ) {
+				continue;
+			}
+
 			this.blockRegistrationStrategy = BLOCKS_WITH_RESTRICTION[
 				blockWithRestrictionName
 			].isVariationBlock
@@ -130,6 +140,10 @@ export class BlockRegistrationManager
 	 */
 	registerBlocksAfterLeavingRestrictedArea() {
 		for ( const unregisteredBlockName of this.unregisteredBlocks ) {
+			if ( ! getBlockType( unregisteredBlockName ) ) {
+				continue;
+			}
+
 			const restrictedBlockData =
 				BLOCKS_WITH_RESTRICTION[ unregisteredBlockName ];
 			this.blockRegistrationStrategy = BLOCKS_WITH_RESTRICTION[


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Fixes an issue with https://github.com/woocommerce/woocommerce-blocks/pull/11664

The PR caused a console error `blocks.min.js?ver=7204d43123223474471a:3 Block "woocommerce/product-gallery" is not registered.` because `product-gallery` is under an experimental flag and production builds does not register experimental blocks.

## Why

To prevent errors in the console.

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

#### Test 1: Single Product template
1. From your WordPress dashboard, go to Appearance > Themes. Select a block-based theme like "Twenty-twenty Three," "Twenty-twenty Four," etc.
2. On the left-hand side menu, click on Appearance > Editor > Templates
3. Find and select the 'Single Product' template from the list.
4. When the Classic Product Template renders, click on Transform into Blocks. This will transform the Classic template in a block template if you haven't done it before.
5. Inside the Page editor, click on the '+' button to add a new block.
6. In the block library that pops up, search for the 'Product Gallery' block. Click on it to add the block to the template.
7. Make sure the Product Gallery block can be added to the editor.
8. Click on Save.
9. Visit a product page of a Variable Product and make sure the block is working as expected.

#### Test 2: Posts
1. From your WordPress dashboard, go to Appearance > Themes. Select a block-based theme like "Twenty-twenty Three," "Twenty-twenty Four," etc.
2. On the left-hand side menu, click on Posts > Add new.
5. Inside the Page editor, click on the '+' button to add a new block.
6. In the block library that pops up, search for the 'Product Gallery' block.
7. Make sure the Product Gallery block DOES NOT appear and cannot be added to the editor.

#### Test 3: Pages
1. From your WordPress dashboard, go to Appearance > Themes. Select a block-based theme like "Twenty-twenty Three," "Twenty-twenty Four," etc.
2. On the left-hand side menu, click on Pages > Add new.
5. Inside the Page editor, click on the '+' button to add a new block.
6. In the block library that pops up, search for the 'Product Gallery' block.
7. Make sure the Product Gallery block DOES NOT appear and cannot be added to the editor.

#### Test 4:
1. Re-build with `npm run build:deploy` so that only production blocks are built.
2. Go to add a new post and check the console to make sure no errors are displayed.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental
* [ ] N/A