### PR TITLE
Investigate E2E CI caching issue

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -75,7 +75,7 @@ jobs:
         run: npx playwright install --with-deps
 
       - name: Load wp-env
-        run: npm run env:start
+        run: npm run env:restart
 
       - name: Run Playwright tests
         run: npm run test:e2e -- --config=tests/e2e/${{ matrix.config.file }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -75,7 +75,7 @@ jobs:
         run: npx playwright install --with-deps
 
       - name: Load wp-env
-        run: npm run env:restart
+        run: npm run env:start
 
       - name: Run Playwright tests
         run: npm run test:e2e -- --config=tests/e2e/${{ matrix.config.file }}

--- a/assets/js/blocks/page-content-wrapper/index.tsx
+++ b/assets/js/blocks/page-content-wrapper/index.tsx
@@ -26,7 +26,7 @@ const Edit = ( {
 	setAttributes: ( attrs: BlockAttributes ) => void;
 } ) => {
 	const TEMPLATE: InnerBlockTemplate[] = [
-		[ 'core/post-title', { align: 'wide' } ],
+		[ 'core/post-title', { align: 'wide', level: 1 } ],
 		[ 'core/post-content', { align: 'wide' } ],
 	];
 

--- a/src/Utils/BlockTemplateMigrationUtils.php
+++ b/src/Utils/BlockTemplateMigrationUtils.php
@@ -69,7 +69,7 @@ class BlockTemplateMigrationUtils {
 		$default_template_content = '
 			<!-- wp:group {"layout":{"inherit":true,"type":"constrained"}} -->
 				<div class="wp-block-group"><!-- wp:woocommerce/page-content-wrapper {"page":"' . $template_slug . '"} -->
-				<!-- wp:post-title {"align":"wide"} /-->
+				<!-- wp:post-title {"align":"wide", "level":1} /-->
 				<!-- wp:post-content {"align":"wide"} /-->
 				<!-- /wp:woocommerce/page-content-wrapper --></div>
 			<!-- /wp:group -->

--- a/tests/e2e/tests/templates/cart-template.block_theme.spec.ts
+++ b/tests/e2e/tests/templates/cart-template.block_theme.spec.ts
@@ -25,9 +25,7 @@ test.describe( 'Test the cart template', async () => {
 		).toBeVisible();
 	} );
 
-	// Remove the skip once this ticket is resolved: https://github.com/woocommerce/woocommerce-blocks/issues/11671
-	// eslint-disable-next-line playwright/no-skipped-test
-	test.skip( 'Template can be accessed from the page editor', async ( {
+	test( 'Template can be accessed from the page editor', async ( {
 		admin,
 		editor,
 		page,

--- a/tests/e2e/tests/templates/cart-template.block_theme.spec.ts
+++ b/tests/e2e/tests/templates/cart-template.block_theme.spec.ts
@@ -48,6 +48,7 @@ test.describe( 'Test the cart template', async () => {
 		).toBeVisible();
 		await editor.openDocumentSettingsSidebar();
 		await page.getByLabel( 'Template options' ).click();
+		await page.getByRole( 'button', { name: 'Edit template' } ).click();
 		await expect(
 			editor.canvas.locator( 'h1:has-text("Cart")' ).first()
 		).toBeVisible();

--- a/tests/e2e/tests/templates/cart-template.block_theme.spec.ts
+++ b/tests/e2e/tests/templates/cart-template.block_theme.spec.ts
@@ -39,7 +39,7 @@ test.describe( 'Test the cart template', async () => {
 			editor.canvas.locator( 'h1:has-text("Cart")' ).first()
 		).toBeVisible();
 		await editor.openDocumentSettingsSidebar();
-		await page.getByRole( 'button', { name: 'Edit template' } ).click();
+		await page.getByLabel( 'Template options' ).click();
 		await expect(
 			editor.canvas.locator( 'h1:has-text("Cart")' ).first()
 		).toBeVisible();

--- a/tests/e2e/tests/templates/cart-template.block_theme.spec.ts
+++ b/tests/e2e/tests/templates/cart-template.block_theme.spec.ts
@@ -17,8 +17,6 @@ test.describe( 'Test the cart template', async () => {
 			postId: templatePath,
 			postType: templateType,
 		} );
-		await page.getByRole( 'button', { name: /Templates/i } ).click();
-		await page.getByRole( 'button', { name: /Page: Cart/i } ).click();
 		await editorUtils.enterEditMode();
 		await editorUtils.closeWelcomeGuideModal();
 		await expect(
@@ -78,14 +76,11 @@ test.describe( 'Test editing the cart template', async () => {
 		admin,
 		editorUtils,
 		editor,
-		page,
 	} ) => {
 		await admin.visitSiteEditor( {
 			postId: templatePath,
 			postType: templateType,
 		} );
-		await page.getByRole( 'button', { name: /Templates/i } ).click();
-		await page.getByRole( 'button', { name: /Page: Checkout/i } ).click();
 		await editorUtils.enterEditMode();
 		await editorUtils.closeWelcomeGuideModal();
 		await editor.setContent(

--- a/tests/e2e/tests/templates/cart-template.block_theme.spec.ts
+++ b/tests/e2e/tests/templates/cart-template.block_theme.spec.ts
@@ -20,7 +20,7 @@ test.describe( 'Test the cart template', async () => {
 		await expect(
 			page
 				.frameLocator( 'iframe[title="Editor canvas"i]' )
-				.locator( 'h2:has-text("Cart")' )
+				.locator( 'h1:has-text("Cart")' )
 				.first()
 		).toBeVisible();
 	} );
@@ -38,12 +38,12 @@ test.describe( 'Test the cart template', async () => {
 		await editor.page.getByRole( 'button', { name: /Cart/i } ).click();
 		await editorUtils.enterEditMode();
 		await expect(
-			editor.canvas.locator( 'h2:has-text("Cart")' ).first()
+			editor.canvas.locator( 'h1:has-text("Cart")' ).first()
 		).toBeVisible();
 		await editor.openDocumentSettingsSidebar();
 		await page.getByRole( 'button', { name: 'Edit template' } ).click();
 		await expect(
-			editor.canvas.locator( 'h2:has-text("Cart")' ).first()
+			editor.canvas.locator( 'h1:has-text("Cart")' ).first()
 		).toBeVisible();
 	} );
 
@@ -53,7 +53,7 @@ test.describe( 'Test the cart template', async () => {
 		await expect(
 			admin.page
 				.frameLocator( 'iframe[title="Editor canvas"i]' )
-				.locator( 'h2:has-text("Cart")' )
+				.locator( 'h1:has-text("Cart")' )
 				.first()
 		).toBeVisible();
 	} );

--- a/tests/e2e/tests/templates/cart-template.block_theme.spec.ts
+++ b/tests/e2e/tests/templates/cart-template.block_theme.spec.ts
@@ -13,7 +13,10 @@ test.describe( 'Test the cart template', async () => {
 		page,
 		editorUtils,
 	} ) => {
-		await admin.visitSiteEditor();
+		await admin.visitSiteEditor( {
+			postId: templatePath,
+			postType: templateType,
+		} );
 		await page.getByRole( 'button', { name: /Templates/i } ).click();
 		await page.getByRole( 'button', { name: /Page: Cart/i } ).click();
 		await editorUtils.enterEditMode();
@@ -32,7 +35,10 @@ test.describe( 'Test the cart template', async () => {
 		page,
 		editorUtils,
 	} ) => {
-		await admin.visitSiteEditor();
+		await admin.visitSiteEditor( {
+			postId: templatePath,
+			postType: templateType,
+		} );
 		await editor.page.getByRole( 'button', { name: /Pages/i } ).click();
 		await editor.page.getByRole( 'button', { name: /Cart/i } ).click();
 		await editorUtils.enterEditMode();
@@ -71,7 +77,10 @@ test.describe( 'Test editing the cart template', async () => {
 		editor,
 		page,
 	} ) => {
-		await admin.visitSiteEditor();
+		await admin.visitSiteEditor( {
+			postId: templatePath,
+			postType: templateType,
+		} );
 		await page.getByRole( 'button', { name: /Templates/i } ).click();
 		await page.getByRole( 'button', { name: /Page: Checkout/i } ).click();
 		await editorUtils.enterEditMode();

--- a/tests/e2e/tests/templates/cart-template.block_theme.spec.ts
+++ b/tests/e2e/tests/templates/cart-template.block_theme.spec.ts
@@ -29,7 +29,9 @@ test.describe( 'Test the cart template', async () => {
 		).toBeVisible();
 	} );
 
-	test( 'Template can be accessed from the page editor', async ( {
+	// Remove the skip once this ticket is resolved: https://github.com/woocommerce/woocommerce-blocks/issues/11671
+	// eslint-disable-next-line playwright/no-skipped-test
+	test.skip( 'Template can be accessed from the page editor', async ( {
 		admin,
 		editor,
 		page,

--- a/tests/e2e/tests/templates/cart-template.block_theme.spec.ts
+++ b/tests/e2e/tests/templates/cart-template.block_theme.spec.ts
@@ -17,6 +17,7 @@ test.describe( 'Test the cart template', async () => {
 		await page.getByRole( 'button', { name: /Templates/i } ).click();
 		await page.getByRole( 'button', { name: /Page: Cart/i } ).click();
 		await editorUtils.enterEditMode();
+		await editorUtils.closeWelcomeGuideModal();
 		await expect(
 			page
 				.frameLocator( 'iframe[title="Editor canvas"i]' )
@@ -35,6 +36,7 @@ test.describe( 'Test the cart template', async () => {
 		await editor.page.getByRole( 'button', { name: /Pages/i } ).click();
 		await editor.page.getByRole( 'button', { name: /Cart/i } ).click();
 		await editorUtils.enterEditMode();
+		await editorUtils.closeWelcomeGuideModal();
 		await expect(
 			editor.canvas.locator( 'h1:has-text("Cart")' ).first()
 		).toBeVisible();
@@ -73,6 +75,7 @@ test.describe( 'Test editing the cart template', async () => {
 		await page.getByRole( 'button', { name: /Templates/i } ).click();
 		await page.getByRole( 'button', { name: /Page: Checkout/i } ).click();
 		await editorUtils.enterEditMode();
+		await editorUtils.closeWelcomeGuideModal();
 		await editor.setContent(
 			'<!-- wp:woocommerce/classic-shortcode {"shortcode":"cart"} /-->'
 		);
@@ -99,6 +102,7 @@ test.describe( 'Test editing the cart template', async () => {
 			postType: templateType,
 		} );
 		await editorUtils.enterEditMode();
+		await editorUtils.closeWelcomeGuideModal();
 		await editorUtils.editor.insertBlock( {
 			name: 'core/paragraph',
 			attributes: { content: 'Hello World in the template' },

--- a/tests/e2e/tests/templates/checkout-header-template-part.block_theme.spec.ts
+++ b/tests/e2e/tests/templates/checkout-header-template-part.block_theme.spec.ts
@@ -35,6 +35,7 @@ test.describe( 'Test the checkout header template part', async () => {
 			postType: templateType,
 		} );
 		await editorUtils.enterEditMode();
+		await editorUtils.closeWelcomeGuideModal();
 		await editorUtils.editor.insertBlock( {
 			name: 'core/paragraph',
 			attributes: { content: 'Hello World in the header' },

--- a/tests/e2e/tests/templates/checkout-template.block_theme.spec.ts
+++ b/tests/e2e/tests/templates/checkout-template.block_theme.spec.ts
@@ -25,9 +25,7 @@ test.describe( 'Test the checkout template', async () => {
 		).toBeVisible();
 	} );
 
-	// Remove the skip once this ticket is resolved: https://github.com/woocommerce/woocommerce-blocks/issues/11671
-	// eslint-disable-next-line playwright/no-skipped-test
-	test.skip( 'Template can be accessed from the page editor', async ( {
+	test( 'Template can be accessed from the page editor', async ( {
 		admin,
 		editor,
 		page,

--- a/tests/e2e/tests/templates/checkout-template.block_theme.spec.ts
+++ b/tests/e2e/tests/templates/checkout-template.block_theme.spec.ts
@@ -48,6 +48,7 @@ test.describe( 'Test the checkout template', async () => {
 		).toBeVisible();
 		await editor.openDocumentSettingsSidebar();
 		await page.getByLabel( 'Template options' ).click();
+		await page.getByRole( 'button', { name: 'Edit template' } ).click();
 		await expect(
 			editor.canvas.locator( 'h1:has-text("Checkout")' ).first()
 		).toBeVisible();

--- a/tests/e2e/tests/templates/checkout-template.block_theme.spec.ts
+++ b/tests/e2e/tests/templates/checkout-template.block_theme.spec.ts
@@ -29,7 +29,9 @@ test.describe( 'Test the checkout template', async () => {
 		).toBeVisible();
 	} );
 
-	test( 'Template can be accessed from the page editor', async ( {
+	// Remove the skip once this ticket is resolved: https://github.com/woocommerce/woocommerce-blocks/issues/11671
+	// eslint-disable-next-line playwright/no-skipped-test
+	test.skip( 'Template can be accessed from the page editor', async ( {
 		admin,
 		editor,
 		page,

--- a/tests/e2e/tests/templates/checkout-template.block_theme.spec.ts
+++ b/tests/e2e/tests/templates/checkout-template.block_theme.spec.ts
@@ -17,8 +17,6 @@ test.describe( 'Test the checkout template', async () => {
 			postId: templatePath,
 			postType: templateType,
 		} );
-		await page.getByRole( 'button', { name: /Templates/i } ).click();
-		await page.getByRole( 'button', { name: /Page: Checkout/i } ).click();
 		await editorUtils.enterEditMode();
 		await editorUtils.closeWelcomeGuideModal();
 		await expect(
@@ -78,14 +76,11 @@ test.describe( 'Test editing the checkout template', async () => {
 		admin,
 		editorUtils,
 		editor,
-		page,
 	} ) => {
 		await admin.visitSiteEditor( {
 			postId: templatePath,
 			postType: templateType,
 		} );
-		await page.getByRole( 'button', { name: /Templates/i } ).click();
-		await page.getByRole( 'button', { name: /Page: Checkout/i } ).click();
 		await editorUtils.enterEditMode();
 		await editorUtils.closeWelcomeGuideModal();
 		await editor.setContent(

--- a/tests/e2e/tests/templates/checkout-template.block_theme.spec.ts
+++ b/tests/e2e/tests/templates/checkout-template.block_theme.spec.ts
@@ -39,7 +39,7 @@ test.describe( 'Test the checkout template', async () => {
 			editor.canvas.locator( 'h1:has-text("Checkout")' ).first()
 		).toBeVisible();
 		await editor.openDocumentSettingsSidebar();
-		await page.getByRole( 'button', { name: 'Edit template' } ).click();
+		await page.getByLabel( 'Template options' ).click();
 		await expect(
 			editor.canvas.locator( 'h1:has-text("Checkout")' ).first()
 		).toBeVisible();

--- a/tests/e2e/tests/templates/checkout-template.block_theme.spec.ts
+++ b/tests/e2e/tests/templates/checkout-template.block_theme.spec.ts
@@ -13,7 +13,10 @@ test.describe( 'Test the checkout template', async () => {
 		page,
 		editorUtils,
 	} ) => {
-		await admin.visitSiteEditor();
+		await admin.visitSiteEditor( {
+			postId: templatePath,
+			postType: templateType,
+		} );
 		await page.getByRole( 'button', { name: /Templates/i } ).click();
 		await page.getByRole( 'button', { name: /Page: Checkout/i } ).click();
 		await editorUtils.enterEditMode();
@@ -32,7 +35,10 @@ test.describe( 'Test the checkout template', async () => {
 		page,
 		editorUtils,
 	} ) => {
-		await admin.visitSiteEditor();
+		await admin.visitSiteEditor( {
+			postId: templatePath,
+			postType: templateType,
+		} );
 		await editor.page.getByRole( 'button', { name: /Pages/i } ).click();
 		await editor.page.getByRole( 'button', { name: /Checkout/i } ).click();
 		await editorUtils.enterEditMode();
@@ -71,7 +77,10 @@ test.describe( 'Test editing the checkout template', async () => {
 		editor,
 		page,
 	} ) => {
-		await admin.visitSiteEditor();
+		await admin.visitSiteEditor( {
+			postId: templatePath,
+			postType: templateType,
+		} );
 		await page.getByRole( 'button', { name: /Templates/i } ).click();
 		await page.getByRole( 'button', { name: /Page: Checkout/i } ).click();
 		await editorUtils.enterEditMode();

--- a/tests/e2e/tests/templates/checkout-template.block_theme.spec.ts
+++ b/tests/e2e/tests/templates/checkout-template.block_theme.spec.ts
@@ -17,6 +17,7 @@ test.describe( 'Test the checkout template', async () => {
 		await page.getByRole( 'button', { name: /Templates/i } ).click();
 		await page.getByRole( 'button', { name: /Page: Checkout/i } ).click();
 		await editorUtils.enterEditMode();
+		await editorUtils.closeWelcomeGuideModal();
 		await expect(
 			page
 				.frameLocator( 'iframe[title="Editor canvas"i]' )
@@ -35,6 +36,7 @@ test.describe( 'Test the checkout template', async () => {
 		await editor.page.getByRole( 'button', { name: /Pages/i } ).click();
 		await editor.page.getByRole( 'button', { name: /Checkout/i } ).click();
 		await editorUtils.enterEditMode();
+		await editorUtils.closeWelcomeGuideModal();
 		await expect(
 			editor.canvas.locator( 'h1:has-text("Checkout")' ).first()
 		).toBeVisible();
@@ -73,6 +75,7 @@ test.describe( 'Test editing the checkout template', async () => {
 		await page.getByRole( 'button', { name: /Templates/i } ).click();
 		await page.getByRole( 'button', { name: /Page: Checkout/i } ).click();
 		await editorUtils.enterEditMode();
+		await editorUtils.closeWelcomeGuideModal();
 		await editor.setContent(
 			'<!-- wp:woocommerce/classic-shortcode {"shortcode":"checkout"} /-->'
 		);
@@ -97,6 +100,7 @@ test.describe( 'Test editing the checkout template', async () => {
 			postType: templateType,
 		} );
 		await editorUtils.enterEditMode();
+		await editorUtils.closeWelcomeGuideModal();
 		await editorUtils.editor.insertBlock( {
 			name: 'core/paragraph',
 			attributes: { content: 'Hello World in the template' },


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Fixes woocommerce/woocommerce-blocks#11819
Fixes woocommerce/woocommerce-blocks#11820

## Why

In this PR, we address issues identified after our recent changes to the Page: Cart and Page: Checkout templates. Previously, in woocommerce/woocommerce-blocks#11029, we updated these pages' heading levels from h2 to h1, and in woocommerce/woocommerce-blocks#11709, we adjusted our E2E tests to align with these changes. However, we observed that the adjusted E2E tests were failing. Upon investigation, we identified the following problems:

- The welcome guide modal was not being closed in certain scenarios.
- With the WordPress 6.4 update, [the `Template options` button had been changed](https://github.com/WordPress/gutenberg/commit/bba4bbf8c998432159c6b1ea7db40bfe4fc23d5d).
- The page-content-wrapper was still loading post titles using the default h2 heading level, which contradicts our recent updates.

This PR aims to resolve these issues, ensuring that our E2E tests reflect the latest template modifications.

## Testing Instructions

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Please ensure that all Playwright E2E tests are passing.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [x] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

n/a

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:

* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:

* [ ] This PR has a UI change and has been cross-browser tested at different viewport sizes on both the frontend and in the editor.
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog

n/a
