### PR TITLE
Tweak the product prompt

### DIFF
--- a/src/Patterns/PatternUpdater.php
+++ b/src/Patterns/PatternUpdater.php
@@ -43,6 +43,10 @@ class PatternUpdater {
 	 * @return bool|WP_Error
 	 */
 	public function generate_content( $ai_connection, $token, $images, $business_description ) {
+		if ( empty( $images ) ) {
+			return new \WP_Error( 'images_not_found', __( 'No images provided for generating AI content.', 'woo-gutenberg-products-block' ) );
+		}
+
 		if ( is_wp_error( $images ) ) {
 			return $images;
 		}

--- a/src/Patterns/ProductUpdater.php
+++ b/src/Patterns/ProductUpdater.php
@@ -321,9 +321,9 @@ class ProductUpdater {
 		$prompts = [];
 		foreach ( $products_information_list as $product_information ) {
 			if ( ! empty( $product_information['image']['alt'] ) ) {
-				$prompts[] = sprintf( 'Generate a product name that exactly matches the following image description: "%s" and also is related to the following business description: "%s". Do not include any adjectives or descriptions of the qualities of the product and always refer to objects or services, not humans. The returned result should not refer to people, only objects.', $product_information['image']['alt'], $business_description );
+				$prompts[] = sprintf( 'Generate a product name for a product that could be sold in a store and could be associated with the following image description: "%s" and also is related to the following business description: "%s". Do not include any adjectives or descriptions of the qualities of the product and always refer to objects or services, not humans. The returned result should not refer to people, only objects.', $product_information['image']['alt'], $business_description );
 			} else {
-				$prompts[] = sprintf( 'Generate a product name that matches the following business description: "%s". Do not include any adjectives or descriptions of the qualities of the product and always refer to objects or services, not humans.', $business_description );
+				$prompts[] = sprintf( 'Generate a product name for a product that could be sold in a store and matches the following business description: "%s". Do not include any adjectives or descriptions of the qualities of the product and always refer to objects or services, not humans.', $business_description );
 			}
 		}
 


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

This PR does some prompt fine-tuning to avoid creating products that are things that cannot be sold in stores (forests, people, etc.).

It also adds a condition to check the images param in the `PatternUpdater` to avoid a fatal error when calling the endpoint without any images: 
`[23-Nov-2023 08:42:10 UTC] PHP Fatal error:  Uncaught TypeError: count(): Argument woocommerce/woocommerce-blocks#12058 ($value) must be of type Countable|array, null given in /public/wp-content/plugins/woocommerce-gutenberg-products-block-11877/src/Patterns/PatternUpdater.php:64`

## Why

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._
- If you already have a pre-configured install, remove the pre-existing WooCommerce Blocks Plugin and upload the one from this zip file: https://wcblocks.wpcomstaging.com/wp-content/uploads/woocommerce-gutenberg-products-block-11903.zip
- Alternatively, create a new WooExpress install from scratch 
- Remove the pre-existing WooCommerce plugin via SSH and
- Install and activate WooCommerce Blocks from the following zip file: https://wcblocks.wpcomstaging.com/wp-content/uploads/woocommerce-gutenberg-products-block-11903.zip
- Install and activate WooCommerce Beta Tester (the plugin is available [within the monorepo](https://github.com/woocommerce/woocommerce/tree/trunk/plugins))
- Go to Settings > General, empty the Site Title and save.
- Head over to `/wp-admin/tools.php?page=woocommerce-admin-test-helper` and enable `customize-store` feature flag:

<img width="1233" alt="Screenshot 2023-10-22 at 10 32 24" src="https://github.com/woocommerce/woocommerce-blocks/assets/15730971/816867c6-34e5-40a1-a87d-f4a7cda46429">

### Test the CYS experience

0. Make sure you don't have any products in your store.
1. Head over to Home > Customize your Store:
 
<img width="1232" alt="Screenshot 2023-10-22 at 09 29 08" src="https://github.com/woocommerce/woocommerce-blocks/assets/15730971/b5d34131-3edc-47ed-a8e4-8e2775ca1bbd">

2. Click on design with AI.
3. Type a description for your business.
4. Make sure the results still make sense and there are no results selling things like forests, beaches, or other things that cannot be sold.
5. Try a few more prompts.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [x] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:

* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:

* [ ] This PR has a UI change and has been cross-browser tested at different viewport sizes on both the frontend and in the editor.
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

