### PR TITLE
Preserve shrinkColumns value when switching the layout type of Product Collection

### DIFF
--- a/assets/js/blocks/product-collection/inspector-controls/layout-options-control.tsx
+++ b/assets/js/blocks/product-collection/inspector-controls/layout-options-control.tsx
@@ -19,7 +19,7 @@ import {
 /**
  * Internal dependencies
  */
-import { DisplayLayoutControlProps, LayoutOptions } from '../types';
+import { DisplayLayoutToolbarProps, LayoutOptions } from '../types';
 
 const getHelpText = ( layoutOptions: LayoutOptions ) => {
 	switch ( layoutOptions ) {
@@ -40,13 +40,14 @@ const getHelpText = ( layoutOptions: LayoutOptions ) => {
 
 const DEFAULT_VALUE = LayoutOptions.GRID;
 
-const LayoutOptionsControl = ( props: DisplayLayoutControlProps ) => {
-	const { type, columns } = props.displayLayout;
+const LayoutOptionsControl = ( props: DisplayLayoutToolbarProps ) => {
+	const { type, columns, shrinkColumns } = props.displayLayout;
 	const setDisplayLayout = ( displayLayout: LayoutOptions ) => {
 		props.setAttributes( {
 			displayLayout: {
 				type: displayLayout,
 				columns,
+				shrinkColumns,
 			},
 		} );
 	};

--- a/assets/js/blocks/product-collection/toolbar-controls/display-layout-toolbar.tsx
+++ b/assets/js/blocks/product-collection/toolbar-controls/display-layout-toolbar.tsx
@@ -11,10 +11,11 @@ import { list, grid } from '@wordpress/icons';
 import {
 	DisplayLayoutToolbarProps,
 	ProductCollectionDisplayLayout,
+	LayoutOptions,
 } from '../types';
 
 const DisplayLayoutToolbar = ( props: DisplayLayoutToolbarProps ) => {
-	const { type, columns } = props.displayLayout;
+	const { type, columns, shrinkColumns } = props.displayLayout;
 	const setDisplayLayout = (
 		displayLayout: ProductCollectionDisplayLayout
 	) => {
@@ -25,14 +26,24 @@ const DisplayLayoutToolbar = ( props: DisplayLayoutToolbarProps ) => {
 		{
 			icon: list,
 			title: __( 'List view', 'woo-gutenberg-products-block' ),
-			onClick: () => setDisplayLayout( { type: 'list', columns } ),
-			isActive: type === 'list',
+			onClick: () =>
+				setDisplayLayout( {
+					type: LayoutOptions.STACK,
+					columns,
+					shrinkColumns,
+				} ),
+			isActive: type === LayoutOptions.STACK,
 		},
 		{
 			icon: grid,
 			title: __( 'Grid view', 'woo-gutenberg-products-block' ),
-			onClick: () => setDisplayLayout( { type: 'flex', columns } ),
-			isActive: type === 'flex',
+			onClick: () =>
+				setDisplayLayout( {
+					type: LayoutOptions.GRID,
+					columns,
+					shrinkColumns,
+				} ),
+			isActive: type === LayoutOptions.GRID,
 		},
 	];
 

--- a/assets/js/blocks/product-collection/types.ts
+++ b/assets/js/blocks/product-collection/types.ts
@@ -25,7 +25,7 @@ export enum LayoutOptions {
 export interface ProductCollectionDisplayLayout {
 	type: LayoutOptions;
 	columns: number;
-	shrinkColumns?: boolean;
+	shrinkColumns: boolean;
 }
 
 export enum ETimeFrameOperator {


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

The "Shrink columns to fit" option was not preserved on product Collection when switched from Grid view to Stack view and the opposite.

This PR makes that values preserved.

Additionally, it improves TS typing of related attributes.

## Why

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

Switching view should not revert the "Shrink columns to fit" to false.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Go to Editor
2. Add Product Collection block
3. Enable "Shrink columns to fit" option
4. Switch view from Grid to Stack and back to Grid - try both Inspector Controls and Toolbar option (red rectangles on the screenshot).
![Screen Shot 2023-11-22 at 17 03 21 PM](https://github.com/woocommerce/woocommerce-blocks/assets/20098064/ea3a20da-f4c5-49cc-acff-de600139ca28)
5. When switching back to Grid view, "Shrink columns to fit" should be still ENABLED
6. Repeat with the option DISABLED


* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:

* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:

* [ ] This PR has a UI change and has been cross-browser tested at different viewport sizes on both the frontend and in the editor.
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Product Collection: preserve "Shrink columns to fit" value when switching views
