### PR TITLE
Fix Reviews blocks not being rendered

### DIFF
--- a/src/StoreApi/Schemas/V1/ProductReviewSchema.php
+++ b/src/StoreApi/Schemas/V1/ProductReviewSchema.php
@@ -170,7 +170,7 @@ class ProductReviewSchema extends AbstractSchema {
 			'product_permalink'      => get_permalink( (int) $review->comment_post_ID ),
 			'product_image'          => $this->image_attachment_schema->get_item_response( get_post_thumbnail_id( (int) $review->comment_post_ID ) ),
 			'reviewer'               => $review->comment_author,
-			'review'                 => wp_autop( $review->comment_content ),
+			'review'                 => wpautop( $review->comment_content ),
 			'rating'                 => $rating,
 			'verified'               => wc_review_is_from_verified_owner( $review->comment_ID ),
 			'reviewer_avatar_urls'   => rest_get_avatar_urls( $review->comment_author_email ),


### PR DESCRIPTION
## What

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/11912.

## Why

Reviews blocks were showing an error in the editor and were not rendered at all in the frontend. This PR should fix it.

It looks like this bug was introduced in https://github.com/woocommerce/woocommerce-blocks/pull/11473.

## Testing Instructions

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Make sure you have at least one review in your store.
2. Create a post or page and add the All Reviews, Reviews by Category and Reviews by Product blocks (in the last two, select the category/product which have reviews).
3. Verify no errors are shown in the editor.
4. Verify the blocks are rendered properly in the frontend.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

Before | After
--- | ---
<img src="https://github.com/woocommerce/woocommerce-blocks/assets/3616980/d3128bdc-b4cd-4304-a593-61dd8b09bf97" alt="Reviews blocks showing an error in the editor" width="539" /> | <img src="https://github.com/woocommerce/woocommerce-blocks/assets/3616980/6ad74a86-f5a8-4440-a3b3-e890efb8329b" alt="Reviews blocks showing no error in the editor" width="539" />

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:

* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:

* [ ] This PR has a UI change and has been cross-browser tested at different viewport sizes on both the frontend and in the editor.
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog

> Fix All Reviews, Reviews by Product and Reviews by Category blocks not being rendered
