### PR TITLE
Fix an issue that caused the Order by select in Reviews blocks to always be disabled

### DIFF
--- a/assets/js/base/components/reviews/review-sort-select/index.tsx
+++ b/assets/js/base/components/reviews/review-sort-select/index.tsx
@@ -12,7 +12,7 @@ import './style.scss';
 
 interface ReviewSortSelectProps {
 	onChange: ChangeEventHandler;
-	readOnly: boolean;
+	readOnly?: boolean;
 	value: 'most-recent' | 'highest-rating' | 'lowest-rating';
 }
 

--- a/assets/js/blocks/reviews/frontend-block.tsx
+++ b/assets/js/blocks/reviews/frontend-block.tsx
@@ -49,7 +49,6 @@ const FrontendBlock = ( {
 				<ReviewSortSelect
 					value={ sortSelectValue }
 					onChange={ onChangeOrderby }
-					readOnly
 				/>
 			) }
 			<ReviewList attributes={ attributes } reviews={ reviews } />


### PR DESCRIPTION
## What

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/11917.

## Why

It was not possible to change the value in the _Order by_ select in Reviews blocks. This PR fixes it.

## Testing Instructions

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Make sure you have at least one review in your store.
2. Create a post or page and add the All Reviews, Reviews by Category and Reviews by Product blocks (in the last two, select the category/product which have reviews).
3. View the page in the frontend.
4. Verify it's possible to change the _Order by_ value and reviews are sorted accordingly.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
| <img src="https://github.com/woocommerce/woocommerce-blocks/assets/3616980/3a5dcd22-2df7-46e9-922f-087fdc295fe9" alt="Reviews blocks with the _Order by_ select disabled" width="539" /> | <img src="https://github.com/woocommerce/woocommerce-blocks/assets/3616980/bc840ae6-76f2-4830-95aa-9dd004e7bf47" alt="Reviews blocks with the _Order by_ select enabled" width="539" /> |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:

* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:

* [ ] This PR has a UI change and has been cross-browser tested at different viewport sizes on both the frontend and in the editor.
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Fix an issue that caused the Order by select in Reviews blocks to always be disabled
