### PR TITLE
Add missing `woocommerce` classname to Classic Cart/Checkout Blocks container

### DIFF
--- a/src/BlockTypes/ClassicShortcode.php
+++ b/src/BlockTypes/ClassicShortcode.php
@@ -67,7 +67,7 @@ class ClassicShortcode extends AbstractDynamicBlock {
 	 * @return string space-separated list of classes.
 	 */
 	protected function get_container_classes( $attributes = array() ) {
-		$classes = array( 'wp-block-group' );
+		$classes = array( 'woocommerce', 'wp-block-group' );
 
 		if ( isset( $attributes['align'] ) ) {
 			$classes[] = "align{$attributes['align']}";


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Due to a missing `woocommerce` class, its not possible to remove the last item from the cart when using classic cart blocks. The item is removed, but the UI is not updated. 

Fixes #11889

## Why

The JS inside woo core looks for the closest `woocommerce` div when handling replacement via AJAX:

https://github.com/woocommerce/woocommerce/blob/2fc7057e16ca8f0460b8a6e1468149a75fe6d098/plugins/woocommerce/client/legacy/js/frontend/cart.js#L113

Since this class was missing, the markup is not updated.

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

1. Edit the cart page
2. Convert the cart block into a "Classic Cart" block if not already there. You can use block transforms.
3. Save the page and go to the store.
4. Add some items to your cart, then head on to the cart page.
5. Remove each item from the cart using the X
6. The last item should be removed from the cart successfully. You can also "undo" the change and the item will come back.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:

* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:

* [ ] This PR has a UI change and has been cross-browser tested at different viewport sizes on both the frontend and in the editor.
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog

> Add missing `woocommerce` classname to Classic Cart/Checkout Blocks container so UI updates when the cart is emptied.