### PR TITLE
Switch to NoticeBanner component inside Store Notices Block placeholder

### DIFF
--- a/assets/js/blocks/store-notices/edit.tsx
+++ b/assets/js/blocks/store-notices/edit.tsx
@@ -3,7 +3,7 @@
  */
 import { useBlockProps } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import { Notice } from '@wordpress/components';
+import NoticeBanner from '@woocommerce/base-components/notice-banner';
 
 /**
  * Internal dependencies
@@ -17,12 +17,12 @@ const Edit = (): JSX.Element => {
 
 	return (
 		<div { ...blockProps }>
-			<Notice status="info" isDismissible={ false }>
+			<NoticeBanner status="info" isDismissible={ false }>
 				{ __(
 					'Notices added by WooCommerce or extensions will show up here.',
 					'woo-gutenberg-products-block'
 				) }
-			</Notice>
+			</NoticeBanner>
 		</div>
 	);
 };


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

For the "store notices" block we show a placeholder notice where notices will appear. This was using the Gutenberg notices component, but to better reflect the frontend we can use the NoticeBanner component instead.

Fixes #11869

## Why

Improved appearance that reflects the frontend experience.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Insert the Store Notices Block inside a page
2. Confirm it has an informational notice appearance (blue banner)

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|    ![Screenshot 2023-11-23 at 12 21 56](https://github.com/woocommerce/woocommerce-blocks/assets/90977/3d68acba-08e3-4207-b29a-2debc38f5e5f) |     ![Screenshot 2023-11-23 at 12 21 15](https://github.com/woocommerce/woocommerce-blocks/assets/90977/3cb98e30-22d4-44ac-8a0b-dc2abbb6d113) |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:

* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:

* [ ] This PR has a UI change and has been cross-browser tested at different viewport sizes on both the frontend and in the editor.
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Switch to NoticeBanner component inside Store Notices Block placeholder
