### PR TITLE
fix: store notices always shows as an error type #11768

### DIFF
--- a/packages/components/store-notices-container/store-notices.tsx
+++ b/packages/components/store-notices-container/store-notices.tsx
@@ -127,7 +127,7 @@ const StoreNotices = ( {
 						key: string;
 					} = {
 						key: `store-notice-${ status }`,
-						status: 'error',
+						status,
 						onRemove: () => {
 							noticeGroup.forEach( ( notice ) => {
 								removeNotice( notice.id, notice.context );


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

This PR will fix #11768 
Reviewer : @opr 

## Why

There's an issue with the store-notice-container when you try to create the container
it always shows an error type, for example, if you run 
```
wp.data.dispatch('core/notices').createSuccessNotice( 'This is a success message, it should show in green!', { context: 'wc/cart' } )
```
in the web dev console in the cart/checkout block page, it'll show
![Screenshot 2023-11-24 at 09 15 27](https://github.com/woocommerce/woocommerce-blocks/assets/4479106/cddb89e8-36a2-4326-8953-88851f39973b)

what we want is something like
![Screenshot 2023-11-24 at 10 25 10](https://github.com/woocommerce/woocommerce-blocks/assets/4479106/ff9c2ee9-67d2-4cd1-8498-19793c148b72)

you can find more detail within the issue #11768 

the issue is due to : 
- [noticeProps](https://github.com/woocommerce/woocommerce-blocks/blob/e4df7408dff52b244af70f86e991d60634af72a5/packages/components/store-notices-container/store-notices.tsx#L130) `status` is set to `error` instead of using `status` variable

so to fix this we need to change the `noticeProps` to something like this : 
```javascript
const noticeProps: Omit<NoticeBannerProps, 'children'> & {
    key: string;
} = {
    key: `store-notice-${status}`,
    status,
    onRemove: () => {
        noticeGroup.forEach((notice) => {
            removeNotice(notice.id, notice.context);
        });
    },
};
```

This PR will affect cart & checkout block page that uses the [StoreNotices](https://github.com/woocommerce/woocommerce-blocks/blob/e4df7408dff52b244af70f86e991d60634af72a5/packages/components/store-notices-container/store-notices.tsx) component

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

Steps to reproduce the behavior:

1. Go to the Cart block.
2. In the web dev console type: `wp.data.dispatch('core/notices').createSuccessNotice( 'This is a success message, it should show in green!', { context: 'wc/cart' } )`
3. See the "success" notice display in green.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
| ![Screenshot 2023-11-24 at 09 15 27](https://github.com/woocommerce/woocommerce-blocks/assets/4479106/cddb89e8-36a2-4326-8953-88851f39973b)  |  ![Screenshot 2023-11-24 at 10 25 10](https://github.com/woocommerce/woocommerce-blocks/assets/4479106/ff9c2ee9-67d2-4cd1-8498-19793c148b72)  |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:

* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:

* [ ] This PR has a UI change and has been cross-browser tested at different viewport sizes on both the frontend and in the editor.
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Ensure the correct styling is applied based on notice type when displaying `StoreNotice` components.