### PR TITLE
Reorganise Columns controls and fix undefined problem in Product Collection settings

### DIFF
--- a/assets/js/blocks/product-collection/inspector-controls/columns-control.tsx
+++ b/assets/js/blocks/product-collection/inspector-controls/columns-control.tsx
@@ -56,10 +56,7 @@ const ColumnsControl = ( props: DisplayLayoutToolbarProps ) => {
 		<>
 			<ToolsPanelItem
 				label={ columnsLabel }
-				hasValue={ () =>
-					defaultLayout?.columns !== columns ||
-					defaultLayout?.type !== type
-				}
+				hasValue={ () => defaultLayout?.columns !== columns }
 				isShownByDefault
 				onDeselect={ onPanelDeselect }
 			>

--- a/assets/js/blocks/product-collection/inspector-controls/columns-control.tsx
+++ b/assets/js/blocks/product-collection/inspector-controls/columns-control.tsx
@@ -16,20 +16,12 @@ import {
 import { DisplayLayoutToolbarProps } from '../types';
 import { getDefaultDisplayLayout } from '../constants';
 
-const toggleLabel = __(
-	'Shrink columns to fit',
-	'woo-gutenberg-products-block'
-);
-
+const columnsLabel = __( 'Columns', 'woo-gutenberg-products-block' );
+const toggleLabel = __( 'Responsive', 'woo-gutenberg-products-block' );
 const toggleHelp = __(
-	'Reduce the number of columns to better fit smaller screens and spaces.',
+	'Automatically adjust the number of columns to better fit smaller screens.',
 	'woo-gutenberg-products-block'
 );
-
-const getColumnsLabel = ( shrinkColumns: boolean ) =>
-	shrinkColumns
-		? __( 'Max Columns', 'woo-gutenberg-products-block' )
-		: __( 'Columns', 'woo-gutenberg-products-block' );
 
 const ColumnsControl = ( props: DisplayLayoutToolbarProps ) => {
 	const { type, columns, shrinkColumns } = props.displayLayout;
@@ -63,6 +55,24 @@ const ColumnsControl = ( props: DisplayLayoutToolbarProps ) => {
 	return showColumnsControl ? (
 		<>
 			<ToolsPanelItem
+				label={ columnsLabel }
+				hasValue={ () =>
+					defaultLayout?.columns !== columns ||
+					defaultLayout?.type !== type
+				}
+				isShownByDefault
+				onDeselect={ onPanelDeselect }
+			>
+				<RangeControl
+					label={ columnsLabel }
+					onChange={ onColumnsChange }
+					value={ columns }
+					min={ 2 }
+					max={ Math.max( 6, columns ) }
+				/>
+			</ToolsPanelItem>
+			<ToolsPanelItem
+				label={ toggleLabel }
 				hasValue={ () =>
 					defaultLayout?.shrinkColumns !== shrinkColumns
 				}
@@ -74,22 +84,6 @@ const ColumnsControl = ( props: DisplayLayoutToolbarProps ) => {
 					label={ toggleLabel }
 					help={ toggleHelp }
 					onChange={ onShrinkColumnsToggleChange }
-				/>
-			</ToolsPanelItem>
-			<ToolsPanelItem
-				hasValue={ () =>
-					defaultLayout?.columns !== columns ||
-					defaultLayout?.type !== type
-				}
-				isShownByDefault
-				onDeselect={ onPanelDeselect }
-			>
-				<RangeControl
-					label={ getColumnsLabel( !! shrinkColumns ) }
-					onChange={ onColumnsChange }
-					value={ columns }
-					min={ 2 }
-					max={ Math.max( 6, columns ) }
 				/>
 			</ToolsPanelItem>
 		</>

--- a/tests/e2e/tests/product-collection/product-collection.page.ts
+++ b/tests/e2e/tests/product-collection/product-collection.page.ts
@@ -29,7 +29,7 @@ export const SELECTORS = {
 	onSaleControlLabel: 'Show only products on sale',
 	inheritQueryFromTemplateControl:
 		'.wc-block-product-collection__inherit-query-control',
-	shrinkColumnsToFit: 'Shrink columns to fit',
+	shrinkColumnsToFit: 'Responsive',
 	productSearchLabel: 'Search',
 	productSearchButton: '.wp-block-search__button wp-element-button',
 };


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Improvements to Column controls in Product Collection:

1. Rename "Shrink columns to fit" to "Responsive"
2. Move the setting below "Columns" controls
3. Change description to "Automatically adjust the number of columns to better fit smaller screens."
4. Remove "Max Columns" heading from heading control and always stick to "Columns"
5. Fix `undefined` option that occurred in Product Collection's Inspector Controls settings

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/11561
Fixes https://github.com/woocommerce/woocommerce-blocks/issues/11925

## Why

- points 1. - 4. are UX Improvements raised after product review
- point 5. is a bug fix

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Go to Editor
2. Add Product Collection block
3. Check Inspector Controls
4. "Columns" and "Responsive" look like in the AFTER image:

| Before | After |
| ------ | ----- |
|   <img width="286" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/20098064/decb0d07-f6d6-4881-aa21-602d120c3865">     |   <img width="288" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/20098064/f3a166f5-4c1b-42d2-b2c4-4627f759c7aa">    |

6. Click three dots next to "Settings"
7. There's no `undefined` entry, but "Columns" and "Responsive" like in the AFTER image:

| Before | After |
| ------ | ----- |
|   <img width="289" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/20098064/80c33902-f2da-4474-8658-50fc39dd43fd">     |   
<img width="285" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/20098064/06608aa3-a85d-43ec-b662-4ce6da634905">
    |

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:

* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:

* [ ] This PR has a UI change and has been cross-browser tested at different viewport sizes on both the frontend and in the editor.
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Product Collection: Rename "Shrink columns to fit" option to "Responsive" and improve the setting arrangement
