### PR TITLE
Improve readability of order note

### DIFF
--- a/assets/js/blocks/order-confirmation/shipping-address/style.scss
+++ b/assets/js/blocks/order-confirmation/shipping-address/style.scss
@@ -14,6 +14,7 @@
 		margin-top: 0 !important;
 	}
 }
+.wc-block-order-confirmation-order-note,
 .wc-block-order-confirmation-shipping-address {
 	border: 1px solid $universal-border-light;
 	border-radius: $universal-border-radius;
@@ -29,5 +30,12 @@
 		&:last-child {
 			margin-bottom: 0;
 		}
+	}
+}
+.wc-block-order-confirmation-order-note {
+	margin-top: $gap * 3;
+
+	.wc-block-order-confirmation-order-note__label {
+		font-weight: bold;
 	}
 }

--- a/assets/js/blocks/order-confirmation/totals/style.scss
+++ b/assets/js/blocks/order-confirmation/totals/style.scss
@@ -8,16 +8,20 @@
 		border: 1px solid $universal-border-light;
 		border-spacing: 0;
 		border-radius: $universal-border-radius;
-		border-collapse: collapse;
 		th,
 		td {
-			border: 1px solid $universal-border-light;
+			border-top: 1px solid $universal-border-light;
 			border-right-width: 0;
 			border-left-width: 0;
 			padding: $gap;
 			margin: 0;
 			text-align: left;
 			font-weight: inherit;
+			border-radius: 0;
+
+		}
+		thead th {
+			border-top: 0;
 		}
 		thead,
 		tfoot th {

--- a/src/BlockTypes/OrderConfirmation/Totals.php
+++ b/src/BlockTypes/OrderConfirmation/Totals.php
@@ -46,9 +46,9 @@ class Totals extends AbstractOrderConfirmationBlock {
 				</tbody>
 				<tfoot>
 					' . $this->render_order_details_table_totals( $order ) . '
-					' . $this->render_order_details_table_customer_note( $order ) . '
-				</tfoot>
-			</table>
+					</tfoot>
+					</table>
+			' . $this->render_order_details_customer_note( $order ) . '
 			' . $this->get_hook_content( 'woocommerce_order_details_after_order_table', [ $order ] ) . '
 			' . $this->get_hook_content( 'woocommerce_after_order_details', [ $order ] ) . '
 		';
@@ -99,10 +99,10 @@ class Totals extends AbstractOrderConfirmationBlock {
 	protected function render_order_details_table_items( $order ) {
 		$return      = '';
 		$order_items = array_filter(
-			// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+		// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 			$order->get_items( apply_filters( 'woocommerce_purchase_order_item_types', 'line_item' ) ),
 			function( $item ) {
-				// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
+                // phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 				return apply_filters( 'woocommerce_order_item_visible', true, $item );
 			}
 		);
@@ -216,14 +216,16 @@ class Totals extends AbstractOrderConfirmationBlock {
 	 * @param \WC_Order $order Order object.
 	 * @return string
 	 */
-	protected function render_order_details_table_customer_note( $order ) {
+	protected function render_order_details_customer_note( $order ) {
 		if ( ! $order->get_customer_note() ) {
 			return '';
 		}
 
-		return '<tr>
-			<th class="wc-block-order-confirmation-totals__label" scope="row">' . esc_html__( 'Note:', 'woo-gutenberg-products-block' ) . '</th>
-			<td class="wc-block-order-confirmation-totals__note">' . wp_kses_post( nl2br( wptexturize( $order->get_customer_note() ) ) ) . '</td>
-		</tr>';
+		return '<div class="wc-block-order-confirmation-order-note">' .
+					'<p class="wc-block-order-confirmation-order-note__label">' .
+						esc_html__( 'Note:', 'woo-gutenberg-products-block' ) .
+					'</p>' .
+					'<p>' . wp_kses_post( nl2br( wptexturize( $order->get_customer_note() ) ) ) . '</p>' .
+				'</div>';
 	}
 }


### PR DESCRIPTION
## What

Fixes #11674

- Moved the order notes into a separate section.
- Fixed the border radius of the order details table.

## Why

In #11674, I reported that the order note is difficult to read when the text is right aligned and suggested to left align the text. In https://github.com/woocommerce/woocommerce-blocks/issues/11674#issuecomment-1823174361, @elizaan36 proposed to decouple the order note from the table.

## Testing Instructions

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Add a product to your cart and go to the checkout.
2. Add an order note and place the order.
3. Verify that the order note is visible below the order detail table.
4. Verify that the order detail table has the same border radius as the order note section.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<table>
<tr>
<td valign="top">Before:
<br><br>
<img width="1138" alt="Screenshot 2023-11-27 at 14 37 44" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/14b932c9-4c0a-40d0-a9f2-7ffff81836c4">

</td>
<td valign="top">After:
<br><br>
<img width="1135" alt="Screenshot 2023-11-27 at 14 36 28" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/a3f53c2a-15eb-4c65-b890-fbf818890feb"></td>
</tr>
</table>

### Cross-browser testing

<img width="2560" alt="Screenshot 2023-11-27 at 14 35 02" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/f5181817-f2f0-4945-9b28-aa76a6f1cba7">

- Left: Chrome
- Center: Safari
- Right: Firefox

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:

* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:

* [x] This PR has a UI change and has been cross-browser tested at different viewport sizes on both the frontend and in the editor.
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog

> Update: Improve the readability of the order note.
