### PR TITLE
[Store Customization] Update product slug when updating the title and flush cache

### DIFF
--- a/src/Patterns/ProductUpdater.php
+++ b/src/Patterns/ProductUpdater.php
@@ -254,17 +254,18 @@ class ProductUpdater {
 			return;
 		}
 
-		$product->set_name( $ai_generated_product_content['title'] );
-		$product->set_description( $ai_generated_product_content['description'] );
-		$product->set_regular_price( $ai_generated_product_content['price'] );
-		$new_slug = sanitize_title( $ai_generated_product_content['title'] );
-
 		wp_update_post(
 			array(
-				'ID'        => $product->get_id(),
-				'post_name' => $new_slug,
+				'ID'           => $product->get_id(),
+				'post_title'   => $ai_generated_product_content['title'],
+				'post_content' => $ai_generated_product_content['description'],
+				'post_name'    => sanitize_title( $ai_generated_product_content['title'] ),
+				'meta_input'   => array(
+					'_regular_price' => $ai_generated_product_content['price'],
+				),
 			)
 		);
+		flush_rewrite_rules();
 
 		require_once ABSPATH . 'wp-admin/includes/media.php';
 		require_once ABSPATH . 'wp-admin/includes/file.php';

--- a/src/Patterns/ProductUpdater.php
+++ b/src/Patterns/ProductUpdater.php
@@ -257,6 +257,14 @@ class ProductUpdater {
 		$product->set_name( $ai_generated_product_content['title'] );
 		$product->set_description( $ai_generated_product_content['description'] );
 		$product->set_regular_price( $ai_generated_product_content['price'] );
+		$new_slug = sanitize_title( $ai_generated_product_content['title'] );
+
+		wp_update_post(
+			array(
+				'ID'        => $product->get_id(),
+				'post_name' => $new_slug,
+			)
+		);
 
 		require_once ABSPATH . 'wp-admin/includes/media.php';
 		require_once ABSPATH . 'wp-admin/includes/file.php';

--- a/src/Patterns/ProductUpdater.php
+++ b/src/Patterns/ProductUpdater.php
@@ -52,11 +52,6 @@ class ProductUpdater {
 
 		$products_information_list = $this->assign_ai_selected_images_to_dummy_products( $dummy_products_to_update, $images );
 
-		$check = $this->check_products_link( $dummy_products_to_update );
-		if ( is_wp_error( $check ) ) {
-			return $check;
-		}
-
 		return $this->assign_ai_generated_content_to_dummy_products( $ai_connection, $token, $products_information_list, $business_description );
 	}
 
@@ -415,27 +410,5 @@ class ProductUpdater {
 		return array(
 			'product_content' => $products_information_list,
 		);
-	}
-
-	/**
-	 * Check if the product link is valid by making a request to the product URL.
-	 *
-	 * @param array $products The products.
-	 *
-	 * @return null|WP_Error Null if the product link is valid. An error if the product link is invalid.
-	 */
-	private function check_products_link( array $products ) {
-		$product_url = $products[0]->get_permalink();
-
-		$response = wp_remote_get( $product_url );
-		if ( is_wp_error( $response ) ) {
-			return new \WP_Error( 'failed_to_retrieve_product', __( 'Failed to retrieve product', 'woo-gutenberg-products-block' ) );
-		} else {
-			if ( 404 === wp_remote_retrieve_response_code( $response ) ) {
-				flush_rewrite_rules();
-			}
-		}
-
-		return null;
 	}
 }


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

This PR updates the product slug when updating the dummy product titles and flushes the permalinks cache after it.

## Why

Before doing this we ended up with a product with AI-generated titles but the permalinks corresponding to the dummy titles (like `my-awesome-product-3`). This fixes that issue and the 404 on products that occur on occasion.
Fixes https://github.com/woocommerce/woocommerce-blocks/issues/11831

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

Please test the feature on a WooExpress install instead of Jurassic Ninja, as the latter can be very limited in terms of server resources and unstable, as other installs can interfere with your own.

- If you already have a pre-configured install, remove the pre-existing WooCommerce Blocks Plugin and upload the one from this zip file: https://wcblocks.wpcomstaging.com/wp-content/uploads/woocommerce-gutenberg-products-block-11952.zip
- Alternatively, create a new WooExpress install from scratch 
- Remove the pre-existing WooCommerce plugin via SSH and
- Install and activate WooCommerce.
- Install and activate WooCommerce Blocks from the following zip file: https://wcblocks.wpcomstaging.com/wp-content/uploads/woocommerce-gutenberg-products-block-11952.zip
- Install and activate WooCommerce Beta Tester (the plugin is available [within the monorepo](https://github.com/woocommerce/woocommerce/tree/trunk/plugins))
- Head over to `/wp-admin/tools.php?page=woocommerce-admin-test-helper` and enable `customize-store` feature flag:

<img width="1233" alt="Screenshot 2023-10-22 at 10 32 24" src="https://github.com/woocommerce/woocommerce-blocks/assets/15730971/816867c6-34e5-40a1-a87d-f4a7cda46429">

### Test the CYS experience

0. Make sure you don't have any products in your store.
1. Head over to Home > Customize your Store:
 
<img width="1232" alt="Screenshot 2023-10-22 at 09 29 08" src="https://github.com/woocommerce/woocommerce-blocks/assets/15730971/b5d34131-3edc-47ed-a8e4-8e2775ca1bbd">

2. Click on design with AI.
3. Type a description for your business.
4. Make sure six new dummy products are created for your store.
5. **Make sure the generated products have an AI-generated title and a matching slug in their urls**


* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [x] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:

* [ ] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:

* [ ] This PR has a UI change and has been cross-browser tested at different viewport sizes on both the frontend and in the editor.
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->


