### PR TITLE
Hook `woocommerce_single_product_summary` action to `core/post-excerpt` block

### DIFF
--- a/src/Templates/SingleProductTemplateCompatibility.php
+++ b/src/Templates/SingleProductTemplateCompatibility.php
@@ -55,8 +55,6 @@ class SingleProductTemplateCompatibility extends AbstractTemplateCompatibility {
 	 * Since that there is a custom logic for the first and last block, we have to inject the hooks manually.
 	 * The first block supports the following hooks:
 	 * woocommerce_before_single_product
-	 * woocommerce_before_single_product_summary
-	 * woocommerce_single_product_summary
 	 *
 	 * The last block supports the following hooks:
 	 * woocommerce_after_single_product
@@ -71,7 +69,6 @@ class SingleProductTemplateCompatibility extends AbstractTemplateCompatibility {
 			'before' => array(
 				'woocommerce_before_main_content'   => $this->hook_data['woocommerce_before_main_content'],
 				'woocommerce_before_single_product' => $this->hook_data['woocommerce_before_single_product'],
-				'woocommerce_before_single_product_summary' => $this->hook_data['woocommerce_before_single_product_summary'],
 			),
 			'after'  => array(),
 		);
@@ -198,7 +195,7 @@ class SingleProductTemplateCompatibility extends AbstractTemplateCompatibility {
 				),
 			),
 			'woocommerce_before_single_product_summary' => array(
-				'block_names' => array(),
+				'block_names' => array( 'core/post-excerpt' ),
 				'position'    => 'before',
 				'hooked'      => array(
 					'woocommerce_show_product_sale_flash' => 10,

--- a/src/Templates/SingleProductTemplateCompatibility.php
+++ b/src/Templates/SingleProductTemplateCompatibility.php
@@ -69,10 +69,9 @@ class SingleProductTemplateCompatibility extends AbstractTemplateCompatibility {
 	private function inject_hook_to_first_and_last_blocks( $block_content, $block, $block_hooks ) {
 		$first_block_hook = array(
 			'before' => array(
-				'woocommerce_before_main_content'    => $this->hook_data['woocommerce_before_main_content'],
-				'woocommerce_before_single_product'  => $this->hook_data['woocommerce_before_single_product'],
+				'woocommerce_before_main_content'   => $this->hook_data['woocommerce_before_main_content'],
+				'woocommerce_before_single_product' => $this->hook_data['woocommerce_before_single_product'],
 				'woocommerce_before_single_product_summary' => $this->hook_data['woocommerce_before_single_product_summary'],
-				'woocommerce_single_product_summary' => $this->hook_data['woocommerce_single_product_summary'],
 			),
 			'after'  => array(),
 		);
@@ -207,7 +206,7 @@ class SingleProductTemplateCompatibility extends AbstractTemplateCompatibility {
 				),
 			),
 			'woocommerce_single_product_summary'        => array(
-				'block_names' => array(),
+				'block_names' => array( 'core/post-excerpt' ),
 				'position'    => 'before',
 				'hooked'      => array(
 					'woocommerce_template_single_title'   => 5,

--- a/tests/e2e/tests/single-product-template/compatibility-plugin.php
+++ b/tests/e2e/tests/single-product-template/compatibility-plugin.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Plugin Name: Compatibility Layer Plugin
+ * Description: Adds custom content to the Shop page with Product Collection included
+ * @package     WordPress
+ */
+
+add_action(
+	'woocommerce_before_main_content',
+	function () {
+		echo '<p data-testid="woocommerce_before_main_content">
+			Hook: woocommerce_before_main_content
+		</p>';
+	}
+);
+
+add_action(
+	'woocommerce_sidebar',
+	function () {
+		echo '<p data-testid="woocommerce_sidebar">
+			Hook: woocommerce_sidebar
+		</p>';
+	}
+);
+
+add_action(
+	'woocommerce_before_single_product',
+	function () {
+		echo '<p data-testid="woocommerce_before_single_product">
+			Hook: woocommerce_before_single_product
+		</p>';
+	}
+);
+
+add_action(
+	'woocommerce_before_single_product_summary',
+	function () {
+		echo '<p data-testid="woocommerce_before_single_product_summary">
+			Hook: woocommerce_before_single_product_summary
+		</p>';
+	}
+);
+
+add_action(
+	'woocommerce_single_product_summary',
+	function () {
+		echo '<p data-testid="woocommerce_single_product_summary">
+			Hook: woocommerce_single_product_summary
+		</p>';
+	}
+);
+
+add_action(
+	'woocommerce_before_add_to_cart_button',
+	function () {
+		echo '<p data-testid="woocommerce_before_add_to_cart_button">
+			Hook: woocommerce_before_add_to_cart_button
+		</p>';
+	}
+);
+
+
+add_action(
+	'woocommerce_product_meta_start',
+	function () {
+		echo '<p data-testid="woocommerce_product_meta_start">
+			Hook: woocommerce_product_meta_start
+		</p>';
+	}
+);
+
+add_action(
+	'woocommerce_product_meta_end',
+	function () {
+		echo '<p data-testid="woocommerce_product_meta_end">
+			Hook: woocommerce_product_meta_end
+		</p>';
+	}
+);
+
+add_action(
+	'woocommerce_share',
+	function () {
+		echo '<p data-testid="woocommerce_share">
+			Hook: woocommerce_share
+		</p>';
+	}
+);
+
+add_action(
+	'woocommerce_after_single_product_summary',
+	function () {
+		echo '<p data-testid="woocommerce_after_single_product_summary">
+			Hook: woocommerce_after_single_product_summary
+		</p>';
+	}
+);
+
+add_action(
+	'woocommerce_after_single_product',
+	function () {
+		echo '<p data-testid="woocommerce_after_single_product">
+			Hook: woocommerce_after_single_product
+		</p>';
+	}
+);
+
+add_action(
+	'woocommerce_after_main_content',
+	function () {
+		echo '<p data-testid="woocommerce_after_main_content">
+			Hook: woocommerce_after_main_content
+		</p>';
+	}
+);

--- a/tests/e2e/tests/single-product-template/single-product-template-compatibility-layer.spec.ts
+++ b/tests/e2e/tests/single-product-template/single-product-template-compatibility-layer.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * External dependencies
+ */
+import { test, expect } from '@woocommerce/e2e-playwright-utils';
+import {
+	installPluginFromPHPFile,
+	uninstallPluginFromPHPFile,
+} from '@woocommerce/e2e-mocks/custom-plugins';
+
+/**
+ * Internal dependencies
+ */
+
+type Scenario = {
+	title: string;
+	dataTestId: string;
+	content: string;
+	amount: number;
+};
+
+const singleOccurranceScenarios: Scenario[] = [
+	{
+		title: 'Before Single Product',
+		dataTestId: 'woocommerce_before_single_product',
+		content: 'Hook: woocommerce_before_single_product',
+		amount: 1,
+	},
+	{
+		title: 'Before Add To Cart Button',
+		dataTestId: 'woocommerce_before_add_to_cart_button',
+		content: 'Hook: woocommerce_before_add_to_cart_button',
+		amount: 1,
+	},
+	{
+		title: 'Single Product Summary',
+		dataTestId: 'woocommerce_single_product_summary',
+		content: 'Hook: woocommerce_single_product_summary',
+		amount: 1,
+	},
+	{
+		title: 'Product Meta Start',
+		dataTestId: 'woocommerce_product_meta_start',
+		content: 'Hook: woocommerce_product_meta_start',
+		amount: 1,
+	},
+	{
+		title: 'After Single Product Summary',
+		dataTestId: 'woocommerce_after_single_product_summary',
+		content: 'Hook: woocommerce_after_single_product_summary',
+		amount: 1,
+	},
+	{
+		title: 'After Single Product',
+		dataTestId: 'woocommerce_after_single_product',
+		content: 'Hook: woocommerce_after_single_product',
+		amount: 1,
+	},
+];
+
+const compatiblityPluginFileName = 'compatibility-plugin.php';
+
+test.describe( 'Compatibility Layer with Product Collection block', () => {
+	test.beforeAll( async () => {
+		await installPluginFromPHPFile(
+			`${ __dirname }/${ compatiblityPluginFileName }`
+		);
+	} );
+
+	test.describe(
+		'Product Archive with Product Collection block',
+		async () => {
+			test.beforeAll( async ( { page } ) => {
+				await page.goto( '/product/hoodie/' );
+			} );
+
+			for ( const scenario of singleOccurranceScenarios ) {
+				test( `${ scenario.title } is attached to the page`, async ( {
+					page,
+				} ) => {
+					const hooks = page.getByTestId( scenario.dataTestId );
+
+					await expect( hooks ).toHaveCount( scenario.amount );
+					await expect( hooks ).toHaveText( scenario.content );
+				} );
+			}
+		}
+	);
+} );
+
+test.afterAll( async ( { requestUtils } ) => {
+	await uninstallPluginFromPHPFile(
+		`${ __dirname }/${ compatiblityPluginFileName }`
+	);
+	await requestUtils.deleteAllTemplates( 'wp_template' );
+} );

--- a/tests/e2e/tests/single-product-template/single-product-template-compatibility-layer.spec.ts
+++ b/tests/e2e/tests/single-product-template/single-product-template-compatibility-layer.spec.ts
@@ -20,9 +20,27 @@ type Scenario = {
 
 const singleOccurranceScenarios: Scenario[] = [
 	{
+		title: 'Before Main Content',
+		dataTestId: 'woocommerce_before_main_content',
+		content: 'Hook: woocommerce_before_main_content',
+		amount: 1,
+	},
+	{
+		title: 'Sidebar',
+		dataTestId: 'woocommerce_sidebar',
+		content: 'Hook: woocommerce_sidebar',
+		amount: 1,
+	},
+	{
 		title: 'Before Single Product',
 		dataTestId: 'woocommerce_before_single_product',
 		content: 'Hook: woocommerce_before_single_product',
+		amount: 1,
+	},
+	{
+		title: 'Before Single Product Summary',
+		dataTestId: 'woocommerce_before_single_product_summary',
+		content: 'Hook: woocommerce_before_single_product_summary',
 		amount: 1,
 	},
 	{
@@ -41,6 +59,18 @@ const singleOccurranceScenarios: Scenario[] = [
 		title: 'Product Meta Start',
 		dataTestId: 'woocommerce_product_meta_start',
 		content: 'Hook: woocommerce_product_meta_start',
+		amount: 1,
+	},
+	{
+		title: 'Product Meta End',
+		dataTestId: 'woocommerce_product_meta_end',
+		content: 'Hook: woocommerce_product_meta_end',
+		amount: 1,
+	},
+	{
+		title: 'Share',
+		dataTestId: 'woocommerce_share',
+		content: 'Hook: woocommerce_share',
 		amount: 1,
 	},
 	{


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Fixes #11985

## Why

This PR hooks the `woocommerce_single_product_summary` action to the Product Summary block. 

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Ensure that you are using a block theme.
2. Add this hook:
```
add_action('woocommerce_single_product_summary', function() {
	echo 'woocommerce_single_product_summary';
});
```
4. Ensure that the string `woocommerce_single_product_summary` is visible before the Product Summary 

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|![image](https://github.com/woocommerce/woocommerce-blocks/assets/4463174/8489872a-7f4b-4bcd-8345-144672a793e3)|![image](https://github.com/woocommerce/woocommerce-blocks/assets/4463174/328adbb7-19af-4b96-ab1e-395e40414738)|

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:

* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:

* [ ] This PR has a UI change and has been cross-browser tested at different viewport sizes on both the frontend and in the editor.
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Hook the `woocommerce_single_product_summary` action to the Product Summary block. 

