### PR TITLE
Reviews by Product: fix reviews count not appearing in product selector

### DIFF
--- a/assets/js/blocks/reviews/reviews-by-product/edit.tsx
+++ b/assets/js/blocks/reviews/reviews-by-product/edit.tsx
@@ -38,26 +38,30 @@ const ReviewsByProductEditor = ( {
 		return (
 			<SearchListItem
 				{ ...args }
+				item={ {
+					...item,
+					count: item.details.review_count,
+				} }
 				countLabel={ sprintf(
 					/* translators: %d is the review count. */
 					_n(
 						'%d review',
 						'%d reviews',
-						item.review_count,
+						item.details.review_count,
 						'woo-gutenberg-products-block'
 					),
-					item.review_count
+					item.details.review_count
 				) }
 				aria-label={ sprintf(
 					/* translators: %1$s is the item name, and %2$d is the number of reviews for the item. */
 					_n(
 						'%1$s, has %2$d review',
 						'%1$s, has %2$d reviews',
-						item.review_count,
+						item.details.review_count,
 						'woo-gutenberg-products-block'
 					),
 					item.name,
-					item.review_count
+					item.details.review_count
 				) }
 			/>
 		);


### PR DESCRIPTION
## What

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/11974.

## Why

The product selector that is shown in the editor when inserting a Reviews by Product block didn't show the reviews count and had an incorrect `aria-label` value.

## Testing Instructions

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Create a post or page.
2. Add the Reviews by Product block.
3. Verify the number of reviews next to the product names:

<img src="https://github.com/woocommerce/woocommerce-blocks/assets/3616980/099d4c8a-c2bb-4615-9006-c3283924f768" alt="" width="646" />

4. Using the browser Inspector (<kbd>F12</kbd>), select one of the checkboxes.
5. Verify the value of the `aria-label` shows the correct value (`<product_name>, has <reviews_count> reviews`). Ie: `Hoodie with Logo, has 1 review`.

<img src="https://github.com/woocommerce/woocommerce-blocks/assets/3616980/afc4aeaa-6fea-4fac-ad54-2e03f8e02e1a" alt="" width="321" />

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

| Before | After |
| ------ | ----- |
|        |       |

## WooCommerce Visibility

Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:

* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:

* [ ] This PR has a UI change and has been cross-browser tested at different viewport sizes on both the frontend and in the editor.
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [x] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Reviews by Product: add reviews count in the product selector
