### PR TITLE
[Store Customization] Update the "Footer with 3 Menus" pattern to remove the last 2 menus

### DIFF
--- a/patterns/footer-with-3-menus.php
+++ b/patterns/footer-with-3-menus.php
@@ -24,18 +24,6 @@
 						<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"},"style":{"spacing":{"blockGap":"10px"}}} /-->
 					</div>
 					<!-- /wp:column -->
-
-					<!-- wp:column -->
-					<div class="wp-block-column">
-						<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"},"style":{"spacing":{"blockGap":"10px"}}} /-->
-					</div>
-					<!-- /wp:column -->
-
-					<!-- wp:column -->
-					<div class="wp-block-column">
-						<!-- wp:navigation {"overlayMenu":"never","layout":{"type":"flex","orientation":"vertical"},"style":{"spacing":{"blockGap":"10px"}}} /-->
-					</div>
-					<!-- /wp:column -->
 				</div>
 				<!-- /wp:columns -->
 			</div>

--- a/patterns/footer-with-3-menus.php
+++ b/patterns/footer-with-3-menus.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Title: Footer with 3 Menus
+ * Title: Footer with menus
  * Slug: woocommerce-blocks/footer-with-3-menus
  * Categories: WooCommerce
  * Block Types: core/template-part/footer


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

This PR removes the last 2 columns and menus on the "Footer with 3 Menus" pattern.

## Why

As discussed on p1701229495243029/1700666170.703699-slack-C053716F2H2 this is the first step to avoid duplication while we add more pages and are able to have 3 different menus.

Fixes https://github.com/woocommerce/woocommerce-blocks/issues/11847
<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Create a new page or post.
2. Insert the "Footer with 3 Menus".
3. Check it only has one menu.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
| <img width="1407" alt="Screenshot 2023-11-29 at 11 23 27" src="https://github.com/woocommerce/woocommerce-blocks/assets/186112/a2408bf2-bf20-4c03-8388-8e51fbfc9fab"> | <img width="1407" alt="Screenshot 2023-11-29 at 11 23 21" src="https://github.com/woocommerce/woocommerce-blocks/assets/186112/50d4eb2e-a09e-463b-856d-b6ce5e7c4619">|

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:

* [ ] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:

* [ ] This PR has a UI change and has been cross-browser tested at different viewport sizes on both the frontend and in the editor.
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Remove duplicated menus on the "Footer with 3 Menus".