### PR TITLE
Optimise shipping notice

### DIFF
--- a/assets/js/base/components/cart-checkout/totals/shipping/shipping-placeholder.tsx
+++ b/assets/js/base/components/cart-checkout/totals/shipping/shipping-placeholder.tsx
@@ -2,6 +2,8 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { useCustomerData } from '@woocommerce/base-context/hooks';
+import { isAddressComplete } from '@woocommerce/base-utils';
 
 /**
  * Internal dependencies
@@ -21,20 +23,28 @@ export const ShippingPlaceholder = ( {
 	setIsShippingCalculatorOpen,
 	isCheckout = false,
 }: ShippingPlaceholderProps ): JSX.Element => {
+	const { shippingAddress } = useCustomerData();
+	const addressComplete = isAddressComplete( shippingAddress );
+
 	if ( ! showCalculator ) {
-		return (
-			<em>
-				{ isCheckout
-					? __(
-							'No shipping options available',
-							'woo-gutenberg-products-block'
-					  )
-					: __(
-							'Calculated during checkout',
-							'woo-gutenberg-products-block'
-					  ) }
-			</em>
+		let message = __(
+			'Calculated during checkout',
+			'woo-gutenberg-products-block'
 		);
+
+		if ( isCheckout ) {
+			message = addressComplete
+				? __(
+						'No shipping options available',
+						'woo-gutenberg-products-block'
+				  )
+				: __(
+						'Add an address for shipping options',
+						'woo-gutenberg-products-block'
+				  );
+		}
+
+		return <>{ message }</>;
 	}
 
 	return (

--- a/assets/js/base/components/cart-checkout/totals/shipping/test/shipping-placeholder.tsx
+++ b/assets/js/base/components/cart-checkout/totals/shipping/test/shipping-placeholder.tsx
@@ -19,7 +19,7 @@ describe( 'ShippingPlaceholder', () => {
 			/>
 		);
 		expect(
-			screen.getByText( 'No shipping options available' )
+			screen.getByText( 'Add an address for shipping options' )
 		).toBeInTheDocument();
 		rerender(
 			<ShippingPlaceholder

--- a/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/block.tsx
+++ b/assets/js/blocks/checkout/inner-blocks/checkout-shipping-methods-block/block.tsx
@@ -88,12 +88,16 @@ const Block = ( { noShippingPlaceholder = null } ): ReactElement | null => {
 
 	if ( ! hasCalculatedShipping && ! shippingRatesPackageCount ) {
 		return (
-			<p>
+			<NoticeBanner
+				isDismissible={ false }
+				className="wc-block-components-shipping-rates-control__no-results-notice"
+				status="warning"
+			>
 				{ __(
 					'Shipping options will be displayed here after entering your full shipping address.',
 					'woo-gutenberg-products-block'
 				) }
-			</p>
+			</NoticeBanner>
 		);
 	}
 	const addressComplete = isAddressComplete( shippingAddress );


### PR DESCRIPTION
## What

Fixes woocommerce/woocommerce#42422 
Fixes woocommerce/woocommerce#42124

- Show the warning notice `Shipping options will be displayed here after entering your full shipping address.` in the **Shipping options** section on the **Checkout block** when no address has been provided.
- Show the plain text `Add an address for shipping options` in the **Order summary** section on the **Checkout block** when no address has been provided.
- Keep the plain text `No shipping options available` in the **Order summary** section on the **Checkout block** when an address has been provided, but no shipping option is available for this location.

## Why

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

In the **Checkout block**, replacing the plain text `Shipping options will be displayed here after entering your full shipping address.` in the **Shipping options** section with a warning notice enhances its visibility, especially when no address is provided. This change ensures that the buyer does not overlook this crucial information.

Additionally, in the **Order summary** section, displaying `-` can be confusing, both when no address is provided or when a  provided address lacks shipping options. Instead, showing `Add an address for shipping options` in the absence of an address or `No shipping options available` for addresses without available shipping options clearly informs the buyer of the next steps or limitations.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Create a test page and add the Checkout block to it.
2. Go to `/wp-admin/admin.php?page=wc-settings&tab=shipping&section` and add the following shipping zone:
```
Zone name: NL
Zone regions: Netherlands
Shipping methods: Free shipping
```
3. Open the frontend in an incognito window and 
4. Add a product to the cart.
5. Go to the test page with the Checkout block.
6. Verify that the text `Shipping options will be displayed here after entering your full shipping address.` within the **Shipping option** section is displayed as a warning notice.

<img width="675" alt="Screenshot 2023-11-29 at 17 44 34" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/869bbb41-f3bb-43b3-b75c-434e755643a1">

8. Verify that the plain text `Add an address for shipping options` is visible in the **Order summary** section when no address has been provided.

<img width="386" alt="Screenshot 2023-11-29 at 17 45 29" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/9adc73d5-391c-447e-b5bf-94083f6ca48a">

10. Verify that the plain text `No shipping options available` is visible in the **Order summary** section when the following shipping address has been provided:
```
Country: Germany
Postal code: 69120
City: Heidelberg
```
<img width="373" alt="Screenshot 2023-11-29 at 17 46 02" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/0c5f7c04-2b25-4a95-975b-5ff6ea8ec3ec">

11. Verify that the text `There are no shipping options available. Please check your shipping address.` within the **Shipping option** section is still displayed as a warning notice.

<img width="677" alt="Screenshot 2023-11-29 at 17 46 50" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/7499683e-740b-476d-9c86-6efa3105e3ec">

12. Verify that both the Shipping options section and the Order summary section show free shipping when the following shipping address has been provided:
```
Country: Netherlands
Postal code: 8881 AW
City: West-Terschelling
```
<img width="691" alt="Screenshot 2023-11-29 at 17 51 54" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/aadf60c9-0da3-4008-96de-d10c29ce8ad5">

<img width="376" alt="Screenshot 2023-11-29 at 17 52 03" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/cd12362f-e703-4fe5-9a8d-4ffa58eadd31">

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:

* [ ] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:

* [ ] This PR has a UI change and has been cross-browser tested at different viewport sizes on both the frontend and in the editor.
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Add suggested changelog entry here.
