### PR TITLE
Add: Interactivity Active Filters block

### DIFF
--- a/assets/js/blocks/collection-filters/block.json
+++ b/assets/js/blocks/collection-filters/block.json
@@ -14,7 +14,8 @@
 		"reusable": false
 	},
 	"usesContext": [
-		"query"
+		"query",
+		"queryId"
 	],
 	"providesContext": {
 		"collectionData": "collectionData"

--- a/assets/js/blocks/collection-filters/edit.tsx
+++ b/assets/js/blocks/collection-filters/edit.tsx
@@ -9,6 +9,7 @@ import type { AttributeSetting } from '@woocommerce/types';
 const ATTRIBUTES = getSetting< AttributeSetting[] >( 'attributes', [] );
 
 const template = [
+	[ 'woocommerce/collection-active-filters', {} ],
 	[
 		'core/heading',
 		{

--- a/assets/js/blocks/collection-filters/inner-blocks/active-filters/block.json
+++ b/assets/js/blocks/collection-filters/inner-blocks/active-filters/block.json
@@ -17,7 +17,7 @@
 		"interactivity": true
 	},
 	"usesContext": [
-		"collectionData"
+		"queryId"
 	],
 	"attributes": {
 		"displayStyle": {

--- a/assets/js/blocks/collection-filters/inner-blocks/active-filters/block.json
+++ b/assets/js/blocks/collection-filters/inner-blocks/active-filters/block.json
@@ -1,0 +1,28 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"name": "woocommerce/collection-active-filters",
+	"version": "1.0.0",
+	"title": "Collection Active Filters",
+	"description": "Display the currently active filters.",
+	"category": "woocommerce",
+	"keywords": [
+		"WooCommerce"
+	],
+	"textdomain": "woo-gutenberg-products-block",
+	"apiVersion": 2,
+	"ancestor": [
+		"woocommerce/collection-filters"
+	],
+	"supports": {
+		"interactivity": true
+	},
+	"usesContext": [
+		"collectionData"
+	],
+	"attributes": {
+		"displayStyle": {
+			"type": "string",
+			"default": "list"
+		}
+	}
+}

--- a/assets/js/blocks/collection-filters/inner-blocks/active-filters/components/inspector.tsx
+++ b/assets/js/blocks/collection-filters/inner-blocks/active-filters/components/inspector.tsx
@@ -1,0 +1,55 @@
+/**
+ * External dependencies
+ */
+import { InspectorControls } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+import {
+	PanelBody,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+} from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import type { EditProps, BlockAttributes } from '../types';
+
+export const Inspector = ( { attributes, setAttributes }: EditProps ) => {
+	const { displayStyle } = attributes;
+
+	return (
+		<InspectorControls>
+			<PanelBody
+				title={ __(
+					'Display Settings',
+					'woo-gutenberg-products-block'
+				) }
+			>
+				<ToggleGroupControl
+					label={ __(
+						'Display Style',
+						'woo-gutenberg-products-block'
+					) }
+					value={ displayStyle }
+					onChange={ ( value: BlockAttributes[ 'displayStyle' ] ) =>
+						setAttributes( {
+							displayStyle: value,
+						} )
+					}
+					className="wc-block-active-filter__style-toggle"
+				>
+					<ToggleGroupControlOption
+						value="list"
+						label={ __( 'List', 'woo-gutenberg-products-block' ) }
+					/>
+					<ToggleGroupControlOption
+						value="chips"
+						label={ __( 'Chips', 'woo-gutenberg-products-block' ) }
+					/>
+				</ToggleGroupControl>
+			</PanelBody>
+		</InspectorControls>
+	);
+};

--- a/assets/js/blocks/collection-filters/inner-blocks/active-filters/components/removable-list-item.tsx
+++ b/assets/js/blocks/collection-filters/inner-blocks/active-filters/components/removable-list-item.tsx
@@ -1,0 +1,77 @@
+/**
+ * External dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { Label, RemovableChip } from '@woocommerce/blocks-components';
+import { Icon, closeSmall } from '@wordpress/icons';
+
+interface RemovableListItemProps {
+	type: string;
+	name: string;
+	prefix?: string | JSX.Element;
+	showLabel?: boolean;
+	isLoading?: boolean;
+	displayStyle: string;
+	removeCallback?: () => void;
+}
+
+export const RemovableListItem = ( {
+	type,
+	name,
+	prefix = '',
+	removeCallback = () => null,
+	showLabel = true,
+	displayStyle,
+}: RemovableListItemProps ) => {
+	const prefixedName = prefix ? (
+		<>
+			{ prefix }
+			&nbsp;
+			{ name }
+		</>
+	) : (
+		name
+	);
+	const removeText = sprintf(
+		/* translators: %s attribute value used in the filter. For example: yellow, green, small, large. */
+		__( 'Remove %s filter', 'woo-gutenberg-products-block' ),
+		name
+	);
+
+	return (
+		<li
+			className="wc-block-active-filters__list-item"
+			key={ type + ':' + name }
+		>
+			{ showLabel && (
+				<span className="wc-block-active-filters__list-item-type">
+					{ type + ': ' }
+				</span>
+			) }
+			{ displayStyle === 'chips' ? (
+				<RemovableChip
+					element="span"
+					text={ prefixedName }
+					onRemove={ removeCallback }
+					radius="large"
+					ariaLabel={ removeText }
+				/>
+			) : (
+				<span className="wc-block-active-filters__list-item-name">
+					<button
+						className="wc-block-active-filters__list-item-remove"
+						onClick={ removeCallback }
+					>
+						<Icon
+							className="wc-block-components-chip__remove-icon"
+							icon={ closeSmall }
+							size={ 16 }
+						/>
+						<Label screenReaderLabel={ removeText } />
+					</button>
+					{ prefixedName }
+				</span>
+			) }
+		</li>
+	);
+};

--- a/assets/js/blocks/collection-filters/inner-blocks/active-filters/edit.tsx
+++ b/assets/js/blocks/collection-filters/inner-blocks/active-filters/edit.tsx
@@ -2,24 +2,46 @@
  * External dependencies
  */
 import { useBlockProps } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+import classNames from 'classnames';
+import { Disabled } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
 import { EditProps } from './types';
 import { Inspector } from './components/inspector';
+import { RemovableListItem } from './components/removable-list-item';
 
 const Edit = ( props: EditProps ) => {
 	const { displayStyle } = props.attributes;
 
 	const blockProps = useBlockProps( {
-		className: `style-${ displayStyle }`,
+		className: 'wc-block-active-filters',
 	} );
 
 	return (
 		<div { ...blockProps }>
 			<Inspector { ...props } />
-			Active filters
+			<Disabled>
+				<ul
+					className={ classNames( 'wc-block-active-filters__list', {
+						'wc-block-active-filters__list--chips':
+							displayStyle === 'chips',
+					} ) }
+				>
+					<RemovableListItem
+						type={ __( 'Size', 'woo-gutenberg-products-block' ) }
+						name={ __( 'Small', 'woo-gutenberg-products-block' ) }
+						displayStyle={ displayStyle }
+					/>
+					<RemovableListItem
+						type={ __( 'Color', 'woo-gutenberg-products-block' ) }
+						name={ __( 'Blue', 'woo-gutenberg-products-block' ) }
+						displayStyle={ displayStyle }
+					/>
+				</ul>
+			</Disabled>
 		</div>
 	);
 };

--- a/assets/js/blocks/collection-filters/inner-blocks/active-filters/edit.tsx
+++ b/assets/js/blocks/collection-filters/inner-blocks/active-filters/edit.tsx
@@ -1,0 +1,27 @@
+/**
+ * External dependencies
+ */
+import { useBlockProps } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { EditProps } from './types';
+import { Inspector } from './components/inspector';
+
+const Edit = ( props: EditProps ) => {
+	const { displayStyle } = props.attributes;
+
+	const blockProps = useBlockProps( {
+		className: `style-${ displayStyle }`,
+	} );
+
+	return (
+		<div { ...blockProps }>
+			<Inspector { ...props } />
+			Active filters
+		</div>
+	);
+};
+
+export default Edit;

--- a/assets/js/blocks/collection-filters/inner-blocks/active-filters/frontend.ts
+++ b/assets/js/blocks/collection-filters/inner-blocks/active-filters/frontend.ts
@@ -1,0 +1,22 @@
+/**
+ * External dependencies
+ */
+import { store, navigate, getContext } from '@woocommerce/interactivity';
+
+type ActiveFiltersContext = {
+	queryId: number;
+	params: string[];
+};
+
+store( 'woocommerce/collection-active-filters', {
+	actions: {
+		clearAll: () => {
+			const { params } = getContext< ActiveFiltersContext >();
+			const url = new URL( window.location.href );
+			const { searchParams } = url;
+
+			params.forEach( ( param ) => searchParams.delete( param ) );
+			navigate( url.href );
+		},
+	},
+} );

--- a/assets/js/blocks/collection-filters/inner-blocks/active-filters/index.tsx
+++ b/assets/js/blocks/collection-filters/inner-blocks/active-filters/index.tsx
@@ -10,6 +10,7 @@ import { toggle } from '@woocommerce/icons';
  */
 import metadata from './block.json';
 import Edit from './edit';
+import './style.scss';
 
 registerBlockType( metadata, {
 	icon: {

--- a/assets/js/blocks/collection-filters/inner-blocks/active-filters/index.tsx
+++ b/assets/js/blocks/collection-filters/inner-blocks/active-filters/index.tsx
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+import { Icon } from '@wordpress/icons';
+import { toggle } from '@woocommerce/icons';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import Edit from './edit';
+
+registerBlockType( metadata, {
+	icon: {
+		src: (
+			<Icon
+				icon={ toggle }
+				className="wc-block-editor-components-block-icon"
+			/>
+		),
+	},
+	edit: Edit,
+} );

--- a/assets/js/blocks/collection-filters/inner-blocks/active-filters/style.scss
+++ b/assets/js/blocks/collection-filters/inner-blocks/active-filters/style.scss
@@ -1,0 +1,179 @@
+.wc-block-active-filters {
+	margin-bottom: $gap-large;
+	overflow: hidden;
+
+	.wc-block-active-filters__clear-all {
+		@include filter-link-button();
+		@include font-size(small);
+		border: none;
+		margin-top: 15px;
+		padding: 0;
+		cursor: pointer;
+		float: right;
+
+		&,
+		&:hover,
+		&:focus,
+		&:active {
+			background: transparent;
+			color: inherit;
+		}
+	}
+
+	.wc-block-active-filters__clear-all-placeholder {
+		@include placeholder();
+		display: inline-block;
+		width: 80px;
+		height: 1em;
+		float: right;
+		border-radius: 0;
+	}
+
+	.wc-block-active-filters__list {
+		margin: 0 0 $gap-smallest;
+		padding: 0;
+		list-style: none outside;
+		clear: both;
+
+		&.wc-block-active-filters--loading {
+			margin-top: $gap-small;
+			display: flex;
+			flex-direction: column;
+			flex-wrap: nowrap;
+
+			&.wc-block-active-filters__list--chips {
+				flex-direction: row;
+				flex-wrap: wrap;
+				align-items: flex-end;
+				gap: 0 10px;
+			}
+		}
+
+		li {
+			margin: 9px 0 0;
+			padding: 0;
+			list-style: none outside;
+
+			ul {
+				margin: 0;
+				padding: 0;
+				list-style: none outside;
+			}
+
+			&:first-child {
+				.wc-block-active-filters__list-item-type {
+					margin: 0;
+				}
+			}
+		}
+		> li:first-child {
+			margin: 0;
+		}
+		li.show-loading-state-list {
+			display: inline-block;
+
+			> span {
+				@include placeholder();
+				display: inline-block;
+				box-shadow: none;
+				border-radius: 0;
+				height: 1em;
+				width: 100%;
+			}
+		}
+
+		li.show-loading-state-chips {
+			display: inline-block;
+
+			> span {
+				@include placeholder();
+				display: inline-block;
+				box-shadow: none;
+				border-radius: 13px;
+				height: 1em;
+				width: 100%;
+				min-width: 70px;
+				margin-right: 15px !important;
+			}
+
+			&:last-of-type > span {
+				margin-right: 0 !important;
+			}
+
+			&:nth-child(3) {
+				flex-grow: 1;
+				max-width: 200px;
+			}
+		}
+
+		> .wc-block-active-filters__list-item .wc-block-active-filters__list-item-name {
+			margin: 9px 0 0;
+		}
+	}
+
+	.wc-block-active-filters__list-item-type {
+		@include font-size(smaller);
+		font-weight: bold;
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+		margin: $gap 0 0;
+		display: block;
+	}
+
+	.wc-block-active-filters__list-item-operator {
+		font-weight: normal;
+		font-style: italic;
+	}
+
+	.wc-block-active-filters__list-item-name {
+		@include font-size(small);
+		display: flex;
+		align-items: center;
+		position: relative;
+		padding: 0;
+	}
+
+	.wc-block-active-filters__list-item-remove {
+		@include font-size(smaller);
+		background: $gray-200;
+		border: 0;
+		border-radius: 25px;
+		appearance: none;
+		padding: 0;
+		height: 16px;
+		width: 16px;
+		line-height: 16px;
+		margin: 0 0.5em 0 0;
+		color: currentColor;
+
+		&:hover,
+		&:focus {
+			background: $gray-600;
+
+			.wc-block-components-chip__remove-icon {
+				fill: #fff;
+			}
+		}
+
+		&:disabled {
+			color: $gray-200;
+			cursor: not-allowed;
+		}
+	}
+
+	.wc-block-active-filters__list--chips {
+		ul,
+		li {
+			display: inline;
+		}
+
+		.wc-block-active-filters__list-item-type {
+			display: none;
+		}
+
+		.wc-block-components-chip {
+			margin-top: em($gap-small * 0.25);
+			margin-bottom: em($gap-small * 0.25);
+		}
+	}
+}

--- a/assets/js/blocks/collection-filters/inner-blocks/active-filters/types.ts
+++ b/assets/js/blocks/collection-filters/inner-blocks/active-filters/types.ts
@@ -1,0 +1,10 @@
+/**
+ * External dependencies
+ */
+import { BlockEditProps } from '@wordpress/blocks';
+
+export type BlockAttributes = {
+	displayStyle: 'list' | 'chips';
+};
+
+export type EditProps = BlockEditProps< BlockAttributes >;

--- a/assets/js/blocks/collection-filters/inner-blocks/active-filters/utils.ts
+++ b/assets/js/blocks/collection-filters/inner-blocks/active-filters/utils.ts
@@ -1,3 +1,0 @@
-/**
- * External dependencies
- */

--- a/assets/js/blocks/collection-filters/inner-blocks/active-filters/utils.ts
+++ b/assets/js/blocks/collection-filters/inner-blocks/active-filters/utils.ts
@@ -1,0 +1,3 @@
+/**
+ * External dependencies
+ */

--- a/assets/js/blocks/collection-filters/inner-blocks/attribute-filter/components/attribute-checkbox-list.tsx
+++ b/assets/js/blocks/collection-filters/inner-blocks/attribute-filter/components/attribute-checkbox-list.tsx
@@ -14,7 +14,7 @@ export const AttributeCheckboxList = ( {
 	showCounts,
 }: Props ) => (
 	<CheckboxList
-		className="attribute-checkbox-list"
+		className="wc-block-attribute-filter style-list"
 		onChange={ () => null }
 		options={ attributeTerms.map( ( term ) => ( {
 			label: (

--- a/assets/js/blocks/collection-filters/inner-blocks/attribute-filter/components/attribute-dropdown.tsx
+++ b/assets/js/blocks/collection-filters/inner-blocks/attribute-filter/components/attribute-dropdown.tsx
@@ -9,7 +9,7 @@ type Props = {
 	label: string;
 };
 export const AttributeDropdown = ( { label }: Props ) => (
-	<div className="attribute-dropdown">
+	<div className="wc-block-attribute-filter style-dropdown">
 		<FormTokenField
 			suggestions={ [] }
 			placeholder={ sprintf(

--- a/assets/js/blocks/collection-filters/inner-blocks/attribute-filter/frontend.ts
+++ b/assets/js/blocks/collection-filters/inner-blocks/attribute-filter/frontend.ts
@@ -11,6 +11,10 @@ type AttributeFilterContext = {
 	selectType: 'single' | 'multiple';
 };
 
+interface ActiveAttributeFilterContext extends AttributeFilterContext {
+	value: string;
+}
+
 function getUrl(
 	selectedTerms: string[],
 	slug: string,
@@ -86,6 +90,16 @@ store( 'woocommerce/collection-attribute-filter', {
 					context.queryType
 				)
 			);
+		},
+		removeFilter: () => {
+			const { attributeSlug, queryType, value } =
+				getContext< ActiveAttributeFilterContext >();
+
+			let selectedTerms = getSelectedTermsFromUrl( attributeSlug );
+
+			selectedTerms = selectedTerms.filter( ( item ) => item !== value );
+
+			navigate( getUrl( selectedTerms, attributeSlug, queryType ) );
 		},
 	},
 } );

--- a/assets/js/blocks/collection-filters/inner-blocks/attribute-filter/style.scss
+++ b/assets/js/blocks/collection-filters/inner-blocks/attribute-filter/style.scss
@@ -3,7 +3,7 @@
 @import "../../../../../../packages/components/checkbox-control/style";
 
 .wp-block-woocommerce-collection-attribute-filter {
-	.attribute-dropdown {
+	.style-dropdown {
 		position: relative;
 
 		> svg {

--- a/assets/js/blocks/collection-filters/inner-blocks/stock-filter/frontend.ts
+++ b/assets/js/blocks/collection-filters/inner-blocks/stock-filter/frontend.ts
@@ -53,5 +53,24 @@ store( 'woocommerce/collection-stock-filter', {
 
 			navigate( getUrl( filtersArr.join( ',' ) ) );
 		},
+		removeFilter: () => {
+			const { value } = getContext< { value: string } >();
+			// get the active filters from the url:
+			const url = new URL( window.location.href );
+			const currentFilters =
+				url.searchParams.get( 'filter_stock_status' ) || '';
+
+			// split out the active filters into an array.
+			const filtersArr =
+				currentFilters === '' ? [] : currentFilters.split( ',' );
+
+			const index = filtersArr.indexOf( value );
+
+			if ( index > -1 ) {
+				filtersArr.splice( index, 1 );
+			}
+
+			navigate( getUrl( filtersArr.join( ',' ) ) );
+		},
 	},
 } );

--- a/assets/js/blocks/collection-filters/save.tsx
+++ b/assets/js/blocks/collection-filters/save.tsx
@@ -1,11 +1,8 @@
 /**
  * External dependencies
  */
-import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
+import { InnerBlocks } from '@wordpress/block-editor';
 
 export default function save() {
-	const blockProps = useBlockProps.save();
-	const innerBlockProps = useInnerBlocksProps.save( blockProps );
-
-	return <nav { ...innerBlockProps } />;
+	return <InnerBlocks.Content />;
 }

--- a/bin/webpack-entries.js
+++ b/bin/webpack-entries.js
@@ -109,6 +109,10 @@ const blocks = {
 		customDir: 'collection-filters/inner-blocks/attribute-filter',
 		isExperimental: true,
 	},
+	'collection-active-filters': {
+		customDir: 'collection-filters/inner-blocks/active-filters',
+		isExperimental: true,
+	},
 	'order-confirmation-summary': {
 		customDir: 'order-confirmation/summary',
 	},

--- a/src/BlockTypes/CollectionActiveFilters.php
+++ b/src/BlockTypes/CollectionActiveFilters.php
@@ -1,0 +1,29 @@
+<?php
+namespace Automattic\WooCommerce\Blocks\BlockTypes;
+
+use Automattic\WooCommerce\Blocks\InteractivityComponents\Dropdown;
+
+/**
+ * CollectionAttributeFilter class.
+ */
+final class CollectionActiveFilters extends AbstractBlock {
+
+	/**
+	 * Block name.
+	 *
+	 * @var string
+	 */
+	protected $block_name = 'collection-active-filters';
+
+	/**
+	 * Render the block.
+	 *
+	 * @param array    $attributes Block attributes.
+	 * @param string   $content    Block content.
+	 * @param WP_Block $block      Block instance.
+	 * @return string Rendered block type output.
+	 */
+	protected function render( $attributes, $content, $block ) {
+		return $content;
+	}
+}

--- a/src/BlockTypes/CollectionActiveFilters.php
+++ b/src/BlockTypes/CollectionActiveFilters.php
@@ -8,6 +8,17 @@ use Automattic\WooCommerce\Blocks\InteractivityComponents\Dropdown;
  */
 final class CollectionActiveFilters extends AbstractBlock {
 
+	const LIST_TEMPLATE = '<li><span class="wc-block-active-filters__list-item-type">%1$s: </span><ul>%2$s</ul></li>';
+	const ITEM_TEMPLATE = '<li class="wc-block-active-filters__list-item">
+		<span class="wc-block-active-filters__list-item-name">
+			<button class="wc-block-active-filters__list-item-remove" %3$s>
+				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" class="wc-block-components-chip__remove-icon" aria-hidden="true" focusable="false"><path d="M12 13.06l3.712 3.713 1.061-1.06L13.061 12l3.712-3.712-1.06-1.06L12 10.938 8.288 7.227l-1.061 1.06L10.939 12l-3.712 3.712 1.06 1.061L12 13.061z"></path></svg>
+				<span class="screen-reader-text">%2$s</span>
+			</button>
+			%1$s
+		</span>
+	</li>';
+
 	/**
 	 * Block name.
 	 *
@@ -24,6 +35,51 @@ final class CollectionActiveFilters extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		return $content;
+		$active_filters = apply_filters( 'collection_active_filters_data', array(), $block->context['queryId'] );
+
+		if ( empty( $active_filters ) ) {
+			return $content;
+		}
+
+		$filter_content = array_reduce( $active_filters, function( $acc, $filter ) {
+
+			$items_content = array_reduce( $filter['options' ], function( $acc, $option ) {
+
+				$attributes = array_reduce(
+					array_keys( $option['attributes'] ),
+					function( $acc, $key ) use ( $option ) {
+						$acc .= sprintf( ' %1$s="%2$s"', $key, $option['attributes'][ $key ] );
+						return $acc;
+					},
+					'' );
+
+				$acc .= sprintf(
+					self::ITEM_TEMPLATE,
+					$option['title'],
+					sprintf( 'Remove %s filter', $option['title'] ),
+					$attributes
+				);
+
+				return $acc;
+			}, '' );
+
+			$acc .= sprintf(
+				self::LIST_TEMPLATE,
+				$filter['type'],
+				$items_content
+			);
+
+			return $acc;
+		}, '' );
+
+		return sprintf(
+			'<div %1$s><ul class="wc-block-active-filters__list">%2$s</ul></div>',
+			get_block_wrapper_attributes(
+				array(
+					'class' => 'wc-block-active-filters',
+				)
+			),
+			$filter_content
+		);
 	}
 }

--- a/src/BlockTypes/CollectionActiveFilters.php
+++ b/src/BlockTypes/CollectionActiveFilters.php
@@ -21,7 +21,7 @@ final class CollectionActiveFilters extends AbstractBlock {
 	const CHIP_ITEM_TEMPLATE = '<li class="wc-block-active-filters__list-item">
 		<span class="is-removable wc-block-components-chip wc-block-components-chip--radius-large">
 			<span aria-hidden="false" class="wc-block-components-chip__text">%1$s</span>
-				<button class="wc-block-components-chip__remove" aria-label="%2$s" %3$s>
+			<button class="wc-block-components-chip__remove" aria-label="%2$s" %3$s>
 				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" role="img" class="wc-block-components-chip__remove-icon" aria-hidden="true" focusable="false"><path d="M12 13.06l3.712 3.713 1.061-1.06L13.061 12l3.712-3.712-1.06-1.06L12 10.938 8.288 7.227l-1.061 1.06L10.939 12l-3.712 3.712 1.06 1.061L12 13.061z"></path></svg>
 			</button>
 		</span>
@@ -56,14 +56,14 @@ final class CollectionActiveFilters extends AbstractBlock {
 				$element_attributes = array_reduce(
 					array_keys( $option['attributes'] ),
 					function( $acc, $key ) use ( $option ) {
-						$acc .= sprintf( ' %1$s="%2$s"', $key, $option['attributes'][ $key ] );
+						$acc .= sprintf( ' %1$s="%2$s"', esc_attr( $key ), esc_attr( $option['attributes'][ $key ] ) );
 						return $acc;
 					},
 					'' );
 
 				$acc .= sprintf(
 					$attributes['displayStyle'] === 'chips' ? self::CHIP_ITEM_TEMPLATE : self::LIST_ITEM_TEMPLATE,
-					$option['title'],
+					esc_html( $option['title'] ),
 					sprintf( 'Remove %s filter', $option['title'] ),
 					$element_attributes
 				);
@@ -73,7 +73,7 @@ final class CollectionActiveFilters extends AbstractBlock {
 
 			$acc .= sprintf(
 				self::LIST_TEMPLATE,
-				$filter['type'],
+				esc_attr( $filter['type'] ),
 				$items_content
 			);
 
@@ -85,6 +85,7 @@ final class CollectionActiveFilters extends AbstractBlock {
 			get_block_wrapper_attributes(
 				array(
 					'class' => 'wc-block-active-filters',
+					'data-wc-interactive' => wp_json_encode( array( 'namespace' => 'woocommerce/collection-active-filters' ) ),
 				)
 			),
 			$filter_content,
@@ -103,6 +104,10 @@ final class CollectionActiveFilters extends AbstractBlock {
 		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : '';
 
 		$parsed_url   = wp_parse_url( esc_url_raw( $request_uri ) );
+
+		if ( empty( $parsed_url['query'] ) ) {
+			return array();
+		}
 
 		parse_str( $parsed_url['query'], $params );
 

--- a/src/BlockTypes/CollectionActiveFilters.php
+++ b/src/BlockTypes/CollectionActiveFilters.php
@@ -61,9 +61,9 @@ final class CollectionActiveFilters extends AbstractBlock {
 		 *		),
 		 *	);
 		 *
-		 * @param array $data   The active filter data
+		 * @param array $data   The active filters data
 		 * @param array $params The query param parsed from the URL.
-		 * @return array
+		 * @return array Active filters data.
 		 */
 		$active_filters = apply_filters( 'collection_active_filters_data', array(), $this->get_filter_query_params( $block->context['queryId'] ) );
 

--- a/src/BlockTypes/CollectionActiveFilters.php
+++ b/src/BlockTypes/CollectionActiveFilters.php
@@ -9,13 +9,21 @@ use Automattic\WooCommerce\Blocks\InteractivityComponents\Dropdown;
 final class CollectionActiveFilters extends AbstractBlock {
 
 	const LIST_TEMPLATE = '<li><span class="wc-block-active-filters__list-item-type">%1$s: </span><ul>%2$s</ul></li>';
-	const ITEM_TEMPLATE = '<li class="wc-block-active-filters__list-item">
+	const LIST_ITEM_TEMPLATE = '<li class="wc-block-active-filters__list-item">
 		<span class="wc-block-active-filters__list-item-name">
 			<button class="wc-block-active-filters__list-item-remove" %3$s>
 				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" class="wc-block-components-chip__remove-icon" aria-hidden="true" focusable="false"><path d="M12 13.06l3.712 3.713 1.061-1.06L13.061 12l3.712-3.712-1.06-1.06L12 10.938 8.288 7.227l-1.061 1.06L10.939 12l-3.712 3.712 1.06 1.061L12 13.061z"></path></svg>
 				<span class="screen-reader-text">%2$s</span>
 			</button>
 			%1$s
+		</span>
+	</li>';
+	const CHIP_ITEM_TEMPLATE = '<li class="wc-block-active-filters__list-item">
+		<span class="is-removable wc-block-components-chip wc-block-components-chip--radius-large">
+			<span aria-hidden="false" class="wc-block-components-chip__text">%1$s</span>
+				<button class="wc-block-components-chip__remove" aria-label="%2$s" %3$s>
+				<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="16" height="16" role="img" class="wc-block-components-chip__remove-icon" aria-hidden="true" focusable="false"><path d="M12 13.06l3.712 3.713 1.061-1.06L13.061 12l3.712-3.712-1.06-1.06L12 10.938 8.288 7.227l-1.061 1.06L10.939 12l-3.712 3.712 1.06 1.061L12 13.061z"></path></svg>
+			</button>
 		</span>
 	</li>';
 
@@ -41,11 +49,11 @@ final class CollectionActiveFilters extends AbstractBlock {
 			return $content;
 		}
 
-		$filter_content = array_reduce( $active_filters, function( $acc, $filter ) {
+		$filter_content = array_reduce( $active_filters, function( $acc, $filter ) use ( $attributes ) {
 
-			$items_content = array_reduce( $filter['options' ], function( $acc, $option ) {
+			$items_content = array_reduce( $filter['options' ], function( $acc, $option ) use ( $attributes ) {
 
-				$attributes = array_reduce(
+				$element_attributes = array_reduce(
 					array_keys( $option['attributes'] ),
 					function( $acc, $key ) use ( $option ) {
 						$acc .= sprintf( ' %1$s="%2$s"', $key, $option['attributes'][ $key ] );
@@ -54,10 +62,10 @@ final class CollectionActiveFilters extends AbstractBlock {
 					'' );
 
 				$acc .= sprintf(
-					self::ITEM_TEMPLATE,
+					$attributes['displayStyle'] === 'chips' ? self::CHIP_ITEM_TEMPLATE : self::LIST_ITEM_TEMPLATE,
 					$option['title'],
 					sprintf( 'Remove %s filter', $option['title'] ),
-					$attributes
+					$element_attributes
 				);
 
 				return $acc;
@@ -73,13 +81,14 @@ final class CollectionActiveFilters extends AbstractBlock {
 		}, '' );
 
 		return sprintf(
-			'<div %1$s><ul class="wc-block-active-filters__list">%2$s</ul></div>',
+			'<div %1$s><ul class="wc-block-active-filters__list %3$s">%2$s</ul></div>',
 			get_block_wrapper_attributes(
 				array(
 					'class' => 'wc-block-active-filters',
 				)
 			),
-			$filter_content
+			$filter_content,
+			$attributes['displayStyle'] === 'chips' ? 'wc-block-active-filters__list--chips' : ''
 		);
 	}
 

--- a/src/BlockTypes/CollectionActiveFilters.php
+++ b/src/BlockTypes/CollectionActiveFilters.php
@@ -35,7 +35,7 @@ final class CollectionActiveFilters extends AbstractBlock {
 	 * @return string Rendered block type output.
 	 */
 	protected function render( $attributes, $content, $block ) {
-		$active_filters = apply_filters( 'collection_active_filters_data', array(), $block->context['queryId'] );
+		$active_filters = apply_filters( 'collection_active_filters_data', array(), $this->get_filter_query_params( $block->context['queryId'] ) );
 
 		if ( empty( $active_filters ) ) {
 			return $content;
@@ -81,5 +81,22 @@ final class CollectionActiveFilters extends AbstractBlock {
 			),
 			$filter_content
 		);
+	}
+
+	/**
+	 * Parse the filter parameters from the URL.
+	 *
+	 * @param int $query_id Query ID.
+	 * @return array Parsed filter params.
+	 */
+	private function get_filter_query_params( $query_id ) {
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : '';
+
+		$parsed_url   = wp_parse_url( esc_url_raw( $request_uri ) );
+
+		parse_str( $parsed_url['query'], $params );
+
+		return $params;
 	}
 }

--- a/src/BlockTypes/CollectionActiveFilters.php
+++ b/src/BlockTypes/CollectionActiveFilters.php
@@ -42,7 +42,29 @@ final class CollectionActiveFilters extends AbstractBlock {
 	 * @param WP_Block $block      Block instance.
 	 * @return string Rendered block type output.
 	 */
+
 	protected function render( $attributes, $content, $block ) {
+		/**
+		 * Filters the active filter data provided by filter blocks.
+		 *
+		 *	$data = array(
+		 *		<id> => array(
+		 *			'type' => string,
+		 *			'options' => array(
+		 *				array(
+		 *					'title' => string,
+		 *					'attributes' => array(
+		 *						<key> => string
+		 *					)
+		 *				)
+		 *			)
+		 *		),
+		 *	);
+		 *
+		 * @param array $data   The active filter data
+		 * @param array $params The query param parsed from the URL.
+		 * @return array
+		 */
 		$active_filters = apply_filters( 'collection_active_filters_data', array(), $this->get_filter_query_params( $block->context['queryId'] ) );
 
 		if ( empty( $active_filters ) ) {

--- a/src/BlockTypes/CollectionActiveFilters.php
+++ b/src/BlockTypes/CollectionActiveFilters.php
@@ -8,7 +8,7 @@ use Automattic\WooCommerce\Blocks\InteractivityComponents\Dropdown;
  */
 final class CollectionActiveFilters extends AbstractBlock {
 
-	const LIST_TEMPLATE = '<li><span class="wc-block-active-filters__list-item-type">%1$s: </span><ul>%2$s</ul></li>';
+	const LIST_TEMPLATE      = '<li><span class="wc-block-active-filters__list-item-type">%1$s: </span><ul>%2$s</ul></li>';
 	const LIST_ITEM_TEMPLATE = '<li class="wc-block-active-filters__list-item">
 		<span class="wc-block-active-filters__list-item-name">
 			<button class="wc-block-active-filters__list-item-remove" %3$s>
@@ -42,24 +42,25 @@ final class CollectionActiveFilters extends AbstractBlock {
 	 * @param WP_Block $block      Block instance.
 	 * @return string Rendered block type output.
 	 */
-
 	protected function render( $attributes, $content, $block ) {
 		/**
 		 * Filters the active filter data provided by filter blocks.
 		 *
-		 *	$data = array(
-		 *		<id> => array(
-		 *			'type' => string,
-		 *			'options' => array(
-		 *				array(
-		 *					'title' => string,
-		 *					'attributes' => array(
-		 *						<key> => string
-		 *					)
-		 *				)
-		 *			)
-		 *		),
-		 *	);
+		 * $data = array(
+		 *     <id> => array(
+		 *         'type' => string,
+		 *         'options' => array(
+		 *             array(
+		 *                 'title' => string,
+		 *                 'attributes' => array(
+		 *                     <key> => string
+		 *                 )
+		 *             )
+		 *         )
+		 *     ),
+		 * );
+		 *
+		 * @since 11.7.0
 		 *
 		 * @param array $data   The active filters data
 		 * @param array $params The query param parsed from the URL.
@@ -71,36 +72,45 @@ final class CollectionActiveFilters extends AbstractBlock {
 			return $content;
 		}
 
-		$filter_content = array_reduce( $active_filters, function( $acc, $filter ) use ( $attributes ) {
+		$filter_content = array_reduce(
+			$active_filters,
+			function( $acc, $filter ) use ( $attributes ) {
 
-			$items_content = array_reduce( $filter['options' ], function( $acc, $option ) use ( $attributes ) {
+				$items_content = array_reduce(
+					$filter['options'],
+					function( $acc, $option ) use ( $attributes ) {
 
-				$element_attributes = array_reduce(
-					array_keys( $option['attributes'] ),
-					function( $acc, $key ) use ( $option ) {
-						$acc .= sprintf( ' %1$s="%2$s"', esc_attr( $key ), esc_attr( $option['attributes'][ $key ] ) );
+						$element_attributes = array_reduce(
+							array_keys( $option['attributes'] ),
+							function( $acc, $key ) use ( $option ) {
+								$acc .= sprintf( ' %1$s="%2$s"', esc_attr( $key ), esc_attr( $option['attributes'][ $key ] ) );
+								return $acc;
+							},
+							''
+						);
+
+						$acc .= sprintf(
+							'chips' === $attributes['displayStyle'] ? self::CHIP_ITEM_TEMPLATE : self::LIST_ITEM_TEMPLATE,
+							wp_kses_post( $option['title'] ),
+							sprintf( 'Remove %s filter', esc_attr( wp_strip_all_tags( $option['title'] ) ) ),
+							$element_attributes
+						);
+
 						return $acc;
 					},
-					'' );
+					''
+				);
 
 				$acc .= sprintf(
-					$attributes['displayStyle'] === 'chips' ? self::CHIP_ITEM_TEMPLATE : self::LIST_ITEM_TEMPLATE,
-					wp_kses_post( $option['title'] ),
-					sprintf( 'Remove %s filter', esc_attr( strip_tags( $option['title'] ) ) ),
-					$element_attributes
+					self::LIST_TEMPLATE,
+					esc_attr( $filter['type'] ),
+					$items_content
 				);
 
 				return $acc;
-			}, '' );
-
-			$acc .= sprintf(
-				self::LIST_TEMPLATE,
-				esc_attr( $filter['type'] ),
-				$items_content
-			);
-
-			return $acc;
-		}, '' );
+			},
+			''
+		);
 
 		$clear_button = sprintf(
 			'<button class="wc-block-active-filters__clear-all" data-wc-on--click="actions.clearAll">
@@ -123,13 +133,13 @@ final class CollectionActiveFilters extends AbstractBlock {
 			</div>',
 			get_block_wrapper_attributes(
 				array(
-					'class' => 'wc-block-active-filters',
+					'class'               => 'wc-block-active-filters',
 					'data-wc-interactive' => wp_json_encode( array( 'namespace' => 'woocommerce/collection-active-filters' ) ),
-					'data-wc-context' => wp_json_encode( $context ),
+					'data-wc-context'     => wp_json_encode( $context ),
 				)
 			),
 			$filter_content,
-			$attributes['displayStyle'] === 'chips' ? 'wc-block-active-filters__list--chips' : '',
+			'chips' === $attributes['displayStyle'] ? 'wc-block-active-filters__list--chips' : '',
 			$clear_button
 		);
 	}
@@ -145,7 +155,7 @@ final class CollectionActiveFilters extends AbstractBlock {
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : '';
 
-		$parsed_url   = wp_parse_url( esc_url_raw( $request_uri ) );
+		$parsed_url = wp_parse_url( esc_url_raw( $request_uri ) );
 
 		if ( empty( $parsed_url['query'] ) ) {
 			return array();

--- a/src/BlockTypes/CollectionActiveFilters.php
+++ b/src/BlockTypes/CollectionActiveFilters.php
@@ -102,16 +102,35 @@ final class CollectionActiveFilters extends AbstractBlock {
 			return $acc;
 		}, '' );
 
+		$clear_button = sprintf(
+			'<button class="wc-block-active-filters__clear-all" data-wc-on--click="actions.clearAll">
+				<span aria-hidden="true">%1$s</span>
+				<span class="screen-reader-text">%2$s</span>
+			</button>',
+			__( 'Clear All', 'woo-gutenberg-products-block' ),
+			__( 'Clear All Filters', 'woo-gutenberg-products-block' )
+		);
+
+		$context = array(
+			'queryId' => $block->context['queryId'],
+			'params'  => array_keys( $this->get_filter_query_params( $block->context['queryId'] ) ),
+		);
+
 		return sprintf(
-			'<div %1$s><ul class="wc-block-active-filters__list %3$s">%2$s</ul></div>',
+			'<div %1$s>
+				<ul class="wc-block-active-filters__list %3$s">%2$s</ul>
+				%4$s
+			</div>',
 			get_block_wrapper_attributes(
 				array(
 					'class' => 'wc-block-active-filters',
 					'data-wc-interactive' => wp_json_encode( array( 'namespace' => 'woocommerce/collection-active-filters' ) ),
+					'data-wc-context' => wp_json_encode( $context ),
 				)
 			),
 			$filter_content,
-			$attributes['displayStyle'] === 'chips' ? 'wc-block-active-filters__list--chips' : ''
+			$attributes['displayStyle'] === 'chips' ? 'wc-block-active-filters__list--chips' : '',
+			$clear_button
 		);
 	}
 
@@ -122,6 +141,7 @@ final class CollectionActiveFilters extends AbstractBlock {
 	 * @return array Parsed filter params.
 	 */
 	private function get_filter_query_params( $query_id ) {
+		// @todo Get the query params based on $query_id
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : '';
 

--- a/src/BlockTypes/CollectionActiveFilters.php
+++ b/src/BlockTypes/CollectionActiveFilters.php
@@ -63,8 +63,8 @@ final class CollectionActiveFilters extends AbstractBlock {
 
 				$acc .= sprintf(
 					$attributes['displayStyle'] === 'chips' ? self::CHIP_ITEM_TEMPLATE : self::LIST_ITEM_TEMPLATE,
-					esc_html( $option['title'] ),
-					sprintf( 'Remove %s filter', $option['title'] ),
+					wp_kses_post( $option['title'] ),
+					sprintf( 'Remove %s filter', esc_attr( strip_tags( $option['title'] ) ) ),
 					$element_attributes
 				);
 

--- a/src/BlockTypes/CollectionAttributeFilter.php
+++ b/src/BlockTypes/CollectionAttributeFilter.php
@@ -24,7 +24,7 @@ final class CollectionAttributeFilter extends AbstractBlock {
 	protected function initialize() {
 		parent::initialize();
 
-		add_filter( 'collection_active_filters_data', function( $active_filters, $params ) {
+		add_filter( 'collection_active_filters_data', function( $data, $params ) {
 			$product_attributes_map = array_reduce(
 				wc_get_attribute_taxonomies(),
 				function( $acc, $attribute_object ) {
@@ -67,13 +67,13 @@ final class CollectionAttributeFilter extends AbstractBlock {
 					);
 				}, $terms );
 
-				$active_filters[ $product_attribute ] = array(
+				$data[ $product_attribute ] = array(
 					'type'    => $product_attributes_map[ $product_attribute ],
 					'options' => $terms,
 				);
 			}
 
-			return $active_filters;
+			return $data;
 		}, 10, 2 );
 	}
 

--- a/src/BlockTypes/CollectionAttributeFilter.php
+++ b/src/BlockTypes/CollectionAttributeFilter.php
@@ -87,8 +87,8 @@ final class CollectionAttributeFilter extends AbstractBlock {
 			);
 
 			$data[ $product_attribute ] = array(
-				'type'    => $product_attributes_map[ $product_attribute ],
-				'options' => $terms,
+				'type'  => $product_attributes_map[ $product_attribute ],
+				'items' => $terms,
 			);
 		}
 

--- a/src/BlockTypes/CollectionAttributeFilter.php
+++ b/src/BlockTypes/CollectionAttributeFilter.php
@@ -24,21 +24,7 @@ final class CollectionAttributeFilter extends AbstractBlock {
 	protected function initialize() {
 		parent::initialize();
 
-		add_filter( 'collection_active_filters_data', function( $active_filters, $query_id ) {
-			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-			$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : '';
-
-			$parsed_url   = wp_parse_url( esc_url_raw( $request_uri ) );
-
-			parse_str( $parsed_url['query'], $params );
-
-			$active_product_attributes = array_reduce( array_keys( $params ), function( $acc, $attribute ) {
-				if ( strpos( $attribute, 'filter_' ) === 0 ) {
-					$acc[] = str_replace( 'filter_', '', $attribute );
-				}
-				return $acc;
-			}, array() );
-
+		add_filter( 'collection_active_filters_data', function( $active_filters, $params ) {
 			$product_attributes_map = array_reduce(
 				wc_get_attribute_taxonomies(),
 				function( $acc, $attribute_object ) {
@@ -47,6 +33,13 @@ final class CollectionAttributeFilter extends AbstractBlock {
 				},
 				array()
 			);
+
+			$active_product_attributes = array_reduce( array_keys( $params ), function( $acc, $attribute ) {
+				if ( strpos( $attribute, 'filter_' ) === 0 ) {
+					$acc[] = str_replace( 'filter_', '', $attribute );
+				}
+				return $acc;
+			}, array() );
 
 			$active_product_attributes = array_filter(
 				$active_product_attributes,

--- a/src/BlockTypes/CollectionAttributeFilter.php
+++ b/src/BlockTypes/CollectionAttributeFilter.php
@@ -56,7 +56,14 @@ final class CollectionAttributeFilter extends AbstractBlock {
 					$term_object = get_term_by( 'slug', $term, "pa_{$product_attribute}" );
 					return array(
 						'title' => $term_object->name,
-						'attributes' => array(),
+						'attributes' => array(
+							'data-wc-on--click' => 'woocommerce/collection-attribute-filter::actions.removeFilter',
+							'data-wc-context'   => 'woocommerce/collection-attribute-filter::' . wp_json_encode( array(
+								'value'         => $term,
+								'attributeSlug' => $product_attribute,
+								'queryType'     => get_query_var( "query_type_{$product_attribute}" ),
+							) ),
+						),
 					);
 				}, $terms );
 

--- a/src/BlockTypes/CollectionAttributeFilter.php
+++ b/src/BlockTypes/CollectionAttributeFilter.php
@@ -24,7 +24,30 @@ final class CollectionAttributeFilter extends AbstractBlock {
 	protected function initialize() {
 		parent::initialize();
 
+		add_filter( 'collection_filter_query_param_keys', array( $this, 'get_filter_query_param_keys' ), 10, 2 );
 		add_filter( 'collection_active_filters_data', array( $this, 'register_active_filters_data' ), 10, 2 );
+	}
+
+	/**
+	 * Register the active filters data.
+	 *
+	 * @param array $filter_param_keys The active filters data.
+	 * @param array $url_param_keys    The query param parsed from the URL.
+	 *
+	 * @return array Active filters param keys.
+	 */
+	public function get_filter_query_param_keys( $filter_param_keys, $url_param_keys ) {
+		$attribute_param_keys = array_filter(
+			$url_param_keys,
+			function( $param ) {
+				return strpos( $param, 'filter_' ) === 0 || strpos( $param, 'query_type_' ) === 0;
+			}
+		);
+
+		return array_merge(
+			$filter_param_keys,
+			$attribute_param_keys
+		);
 	}
 
 	/**

--- a/src/BlockTypes/CollectionAttributeFilter.php
+++ b/src/BlockTypes/CollectionAttributeFilter.php
@@ -30,7 +30,7 @@ final class CollectionAttributeFilter extends AbstractBlock {
 	/**
 	 * Register the active filters data.
 	 *
-	 * @param array $data   The active filters data
+	 * @param array $data   The active filters data.
 	 * @param array $params The query param parsed from the URL.
 	 * @return array Active filters data.
 	 */
@@ -38,18 +38,22 @@ final class CollectionAttributeFilter extends AbstractBlock {
 		$product_attributes_map = array_reduce(
 			wc_get_attribute_taxonomies(),
 			function( $acc, $attribute_object ) {
-				$acc[$attribute_object->attribute_name] = $attribute_object->attribute_label;
+				$acc[ $attribute_object->attribute_name ] = $attribute_object->attribute_label;
 				return $acc;
 			},
 			array()
 		);
 
-		$active_product_attributes = array_reduce( array_keys( $params ), function( $acc, $attribute ) {
-			if ( strpos( $attribute, 'filter_' ) === 0 ) {
-				$acc[] = str_replace( 'filter_', '', $attribute );
-			}
-			return $acc;
-		}, array() );
+		$active_product_attributes = array_reduce(
+			array_keys( $params ),
+			function( $acc, $attribute ) {
+				if ( strpos( $attribute, 'filter_' ) === 0 ) {
+					$acc[] = str_replace( 'filter_', '', $attribute );
+				}
+				return $acc;
+			},
+			array()
+		);
 
 		$active_product_attributes = array_filter(
 			$active_product_attributes,
@@ -61,21 +65,26 @@ final class CollectionAttributeFilter extends AbstractBlock {
 		foreach ( $active_product_attributes as $product_attribute ) {
 			$terms = explode( ',', get_query_var( "filter_{$product_attribute}" ) );
 
-			// Get attribute term by slug
-			$terms = array_map( function( $term ) use ( $product_attribute ) {
-				$term_object = get_term_by( 'slug', $term, "pa_{$product_attribute}" );
-				return array(
-					'title' => $term_object->name,
-					'attributes' => array(
-						'data-wc-on--click' => 'woocommerce/collection-attribute-filter::actions.removeFilter',
-						'data-wc-context'   => 'woocommerce/collection-attribute-filter::' . wp_json_encode( array(
-							'value'         => $term,
-							'attributeSlug' => $product_attribute,
-							'queryType'     => get_query_var( "query_type_{$product_attribute}" ),
-						) ),
-					),
-				);
-			}, $terms );
+			// Get attribute term by slug.
+			$terms = array_map(
+				function( $term ) use ( $product_attribute ) {
+					$term_object = get_term_by( 'slug', $term, "pa_{$product_attribute}" );
+					return array(
+						'title'      => $term_object->name,
+						'attributes' => array(
+							'data-wc-on--click' => 'woocommerce/collection-attribute-filter::actions.removeFilter',
+							'data-wc-context'   => 'woocommerce/collection-attribute-filter::' . wp_json_encode(
+								array(
+									'value'         => $term,
+									'attributeSlug' => $product_attribute,
+									'queryType'     => get_query_var( "query_type_{$product_attribute}" ),
+								)
+							),
+						),
+					);
+				},
+				$terms
+			);
 
 			$data[ $product_attribute ] = array(
 				'type'    => $product_attributes_map[ $product_attribute ],

--- a/src/BlockTypes/CollectionFilters.php
+++ b/src/BlockTypes/CollectionFilters.php
@@ -73,6 +73,31 @@ final class CollectionFilters extends AbstractBlock {
 	}
 
 	/**
+	 * Render the block.
+	 *
+	 * @param array    $attributes Block attributes.
+	 * @param string   $content    Block content.
+	 * @param WP_Block $block      Block instance.
+	 * @return string Rendered block type output.
+	 */
+	protected function render( $attributes, $content, $block ) {
+		$attributes_data = array(
+			'data-wc-interactive' => wp_json_encode( array( 'namespace' => 'woocommerce/collection-filters' ) ),
+			'class'               => 'wc-block-collection-filters',
+		);
+
+		if ( ! isset( $block->context['queryId'] ) ) {
+			$attributes_data['data-wc-navigation-id'] = 'wc-collection-filters';
+		}
+
+		return sprintf(
+			'<nav %1$s>%2$s</nav>',
+			get_block_wrapper_attributes( $attributes_data ),
+			$content
+		);
+	}
+
+	/**
 	 * Modify the context of inner blocks.
 	 *
 	 * @param array    $context The block context.

--- a/src/BlockTypes/CollectionPriceFilter.php
+++ b/src/BlockTypes/CollectionPriceFilter.php
@@ -25,14 +25,14 @@ final class CollectionPriceFilter extends AbstractBlock {
 	protected function initialize() {
 		parent::initialize();
 
-		add_filter( 'collection_active_filters_data', function( $active_filters, $params ) {
-			$min_price           = intval( get_query_var( self::MIN_PRICE_QUERY_VAR, 0 ) );
-			$max_price           = intval( get_query_var( self::MAX_PRICE_QUERY_VAR, 0 ) );
+		add_filter( 'collection_active_filters_data', function( $data, $params ) {
+			$min_price           = intval( $params[ self::MIN_PRICE_QUERY_VAR ] ?? 0 );
+			$max_price           = intval( $params[ self::MAX_PRICE_QUERY_VAR ] ?? 0 );
 			$formatted_min_price = $min_price ? wc_price( $min_price, array( 'decimals' => 0 ) ) : null;
 			$formatted_max_price = $max_price ? wc_price( $max_price, array( 'decimals' => 0 ) ) : null;
 
 			if ( ! $formatted_min_price && ! $formatted_max_price ) {
-				return $active_filters;
+				return $data;
 			}
 
 			if ( $formatted_min_price && $formatted_max_price ) {
@@ -48,7 +48,7 @@ final class CollectionPriceFilter extends AbstractBlock {
 			}
 
 
-			$active_filters[ 'price' ] = array(
+			$data[ 'price' ] = array(
 				'type'    => __( 'Price', 'woo-gutenberg-products-block' ),
 				'options' => array(
 					array(
@@ -60,7 +60,7 @@ final class CollectionPriceFilter extends AbstractBlock {
 				),
 			);
 
-			return $active_filters;
+			return $data;
 		}, 10, 2 );
 	}
 

--- a/src/BlockTypes/CollectionPriceFilter.php
+++ b/src/BlockTypes/CollectionPriceFilter.php
@@ -25,7 +25,30 @@ final class CollectionPriceFilter extends AbstractBlock {
 	protected function initialize() {
 		parent::initialize();
 
+		add_filter( 'collection_filter_query_param_keys', array( $this, 'get_filter_query_param_keys' ), 10, 2 );
 		add_filter( 'collection_active_filters_data', array( $this, 'register_active_filters_data' ), 10, 2 );
+	}
+
+	/**
+	 * Register the active filters data.
+	 *
+	 * @param array $filter_param_keys The active filters data.
+	 * @param array $url_param_keys    The query param parsed from the URL.
+	 *
+	 * @return array Active filters param keys.
+	 */
+	public function get_filter_query_param_keys( $filter_param_keys, $url_param_keys ) {
+		$price_param_keys = array_filter(
+			$url_param_keys,
+			function( $param ) {
+				return self::MIN_PRICE_QUERY_VAR === $param || self::MAX_PRICE_QUERY_VAR === $param;
+			}
+		);
+
+		return array_merge(
+			$filter_param_keys,
+			$price_param_keys
+		);
 	}
 
 	/**

--- a/src/BlockTypes/CollectionPriceFilter.php
+++ b/src/BlockTypes/CollectionPriceFilter.php
@@ -65,8 +65,8 @@ final class CollectionPriceFilter extends AbstractBlock {
 		}
 
 		$data['price'] = array(
-			'type'    => __( 'Price', 'woo-gutenberg-products-block' ),
-			'options' => array(
+			'type'  => __( 'Price', 'woo-gutenberg-products-block' ),
+			'items' => array(
 				array(
 					'title'      => $title,
 					'attributes' => array(

--- a/src/BlockTypes/CollectionPriceFilter.php
+++ b/src/BlockTypes/CollectionPriceFilter.php
@@ -17,6 +17,54 @@ final class CollectionPriceFilter extends AbstractBlock {
 	const MAX_PRICE_QUERY_VAR = 'max_price';
 
 	/**
+	 * Initialize this block type.
+	 *
+	 * - Hook into WP lifecycle.
+	 * - Register the block with WordPress.
+	 */
+	protected function initialize() {
+		parent::initialize();
+
+		add_filter( 'collection_active_filters_data', function( $active_filters, $params ) {
+			$min_price           = intval( get_query_var( self::MIN_PRICE_QUERY_VAR, 0 ) );
+			$max_price           = intval( get_query_var( self::MAX_PRICE_QUERY_VAR, 0 ) );
+			$formatted_min_price = $min_price ? wc_price( $min_price, array( 'decimals' => 0 ) ) : null;
+			$formatted_max_price = $max_price ? wc_price( $max_price, array( 'decimals' => 0 ) ) : null;
+
+			if ( ! $formatted_min_price && ! $formatted_max_price ) {
+				return $active_filters;
+			}
+
+			if ( $formatted_min_price && $formatted_max_price ) {
+				$title = sprintf( __( 'Between %1$s and %2$s', 'woo-gutenberg-products-block' ), $formatted_min_price, $formatted_max_price );
+			}
+
+			if ( ! $formatted_min_price ) {
+				$title = sprintf( __( 'Up to %s', 'woo-gutenberg-products-block' ), $formatted_max_price );
+			}
+
+			if ( ! $formatted_max_price ) {
+				$title = sprintf( __( 'From %s', 'woo-gutenberg-products-block' ), $formatted_min_price );
+			}
+
+
+			$active_filters[ 'price' ] = array(
+				'type'    => __( 'Price', 'woo-gutenberg-products-block' ),
+				'options' => array(
+					array(
+						'title' => $title,
+						'attributes' => array(
+							'data-wc-on--click' => 'woocommerce/collection-price-filter::actions.reset',
+						),
+					),
+				),
+			);
+
+			return $active_filters;
+		}, 10, 2 );
+	}
+
+	/**
 	 * Render the block.
 	 *
 	 * @param array    $attributes Block attributes.

--- a/src/BlockTypes/CollectionPriceFilter.php
+++ b/src/BlockTypes/CollectionPriceFilter.php
@@ -25,43 +25,52 @@ final class CollectionPriceFilter extends AbstractBlock {
 	protected function initialize() {
 		parent::initialize();
 
-		add_filter( 'collection_active_filters_data', function( $data, $params ) {
-			$min_price           = intval( $params[ self::MIN_PRICE_QUERY_VAR ] ?? 0 );
-			$max_price           = intval( $params[ self::MAX_PRICE_QUERY_VAR ] ?? 0 );
-			$formatted_min_price = $min_price ? wc_price( $min_price, array( 'decimals' => 0 ) ) : null;
-			$formatted_max_price = $max_price ? wc_price( $max_price, array( 'decimals' => 0 ) ) : null;
+		add_filter( 'collection_active_filters_data', array( $this, 'register_active_filters_data' ), 10, 2 );
+	}
 
-			if ( ! $formatted_min_price && ! $formatted_max_price ) {
-				return $data;
-			}
+	/**
+	 * Register the active filters data.
+	 *
+	 * @param array $data   The active filters data
+	 * @param array $params The query param parsed from the URL.
+	 * @return array Active filters data.
+	 */
+	public function register_active_filters_data( $data, $params ) {
+		$min_price           = intval( $params[ self::MIN_PRICE_QUERY_VAR ] ?? 0 );
+		$max_price           = intval( $params[ self::MAX_PRICE_QUERY_VAR ] ?? 0 );
+		$formatted_min_price = $min_price ? wc_price( $min_price, array( 'decimals' => 0 ) ) : null;
+		$formatted_max_price = $max_price ? wc_price( $max_price, array( 'decimals' => 0 ) ) : null;
 
-			if ( $formatted_min_price && $formatted_max_price ) {
-				$title = sprintf( __( 'Between %1$s and %2$s', 'woo-gutenberg-products-block' ), $formatted_min_price, $formatted_max_price );
-			}
+		if ( ! $formatted_min_price && ! $formatted_max_price ) {
+			return $data;
+		}
 
-			if ( ! $formatted_min_price ) {
-				$title = sprintf( __( 'Up to %s', 'woo-gutenberg-products-block' ), $formatted_max_price );
-			}
+		if ( $formatted_min_price && $formatted_max_price ) {
+			$title = sprintf( __( 'Between %1$s and %2$s', 'woo-gutenberg-products-block' ), $formatted_min_price, $formatted_max_price );
+		}
 
-			if ( ! $formatted_max_price ) {
-				$title = sprintf( __( 'From %s', 'woo-gutenberg-products-block' ), $formatted_min_price );
-			}
+		if ( ! $formatted_min_price ) {
+			$title = sprintf( __( 'Up to %s', 'woo-gutenberg-products-block' ), $formatted_max_price );
+		}
+
+		if ( ! $formatted_max_price ) {
+			$title = sprintf( __( 'From %s', 'woo-gutenberg-products-block' ), $formatted_min_price );
+		}
 
 
-			$data[ 'price' ] = array(
-				'type'    => __( 'Price', 'woo-gutenberg-products-block' ),
-				'options' => array(
-					array(
-						'title' => $title,
-						'attributes' => array(
-							'data-wc-on--click' => 'woocommerce/collection-price-filter::actions.reset',
-						),
+		$data[ 'price' ] = array(
+			'type'    => __( 'Price', 'woo-gutenberg-products-block' ),
+			'options' => array(
+				array(
+					'title' => $title,
+					'attributes' => array(
+						'data-wc-on--click' => 'woocommerce/collection-price-filter::actions.reset',
 					),
 				),
-			);
+			),
+		);
 
-			return $data;
-		}, 10, 2 );
+		return $data;
 	}
 
 	/**

--- a/src/BlockTypes/CollectionPriceFilter.php
+++ b/src/BlockTypes/CollectionPriceFilter.php
@@ -38,16 +38,20 @@ final class CollectionPriceFilter extends AbstractBlock {
 	public function register_active_filters_data( $data, $params ) {
 		$min_price           = intval( $params[ self::MIN_PRICE_QUERY_VAR ] ?? 0 );
 		$max_price           = intval( $params[ self::MAX_PRICE_QUERY_VAR ] ?? 0 );
-		$formatted_min_price = $min_price ? wc_price( $min_price, array( 'decimals' => 0 ) ) : null;
-		$formatted_max_price = $max_price ? wc_price( $max_price, array( 'decimals' => 0 ) ) : null;
+		$formatted_min_price = $min_price ? wp_strip_all_tags( wc_price( $min_price, array( 'decimals' => 0 ) ) ) : null;
+		$formatted_max_price = $max_price ? wp_strip_all_tags( wc_price( $max_price, array( 'decimals' => 0 ) ) ) : null;
 
 		if ( ! $formatted_min_price && ! $formatted_max_price ) {
 			return $data;
 		}
 
 		if ( $formatted_min_price && $formatted_max_price ) {
-			/* translators: %1$s and %2$s are the formatted minimum and maximum prices respectively. */
-			$title = sprintf( __( 'Between %1$s and %2$s', 'woo-gutenberg-products-block' ), $formatted_min_price, $formatted_max_price );
+			$title = sprintf(
+				/* translators: %1$s and %2$s are the formatted minimum and maximum prices respectively. */
+				__( 'Between %1$s and %2$s', 'woo-gutenberg-products-block' ),
+				$formatted_min_price,
+				$formatted_max_price
+			);
 		}
 
 		if ( ! $formatted_min_price ) {

--- a/src/BlockTypes/CollectionPriceFilter.php
+++ b/src/BlockTypes/CollectionPriceFilter.php
@@ -31,7 +31,7 @@ final class CollectionPriceFilter extends AbstractBlock {
 	/**
 	 * Register the active filters data.
 	 *
-	 * @param array $data   The active filters data
+	 * @param array $data   The active filters data.
 	 * @param array $params The query param parsed from the URL.
 	 * @return array Active filters data.
 	 */
@@ -46,23 +46,25 @@ final class CollectionPriceFilter extends AbstractBlock {
 		}
 
 		if ( $formatted_min_price && $formatted_max_price ) {
+			/* translators: %1$s and %2$s are the formatted minimum and maximum prices respectively. */
 			$title = sprintf( __( 'Between %1$s and %2$s', 'woo-gutenberg-products-block' ), $formatted_min_price, $formatted_max_price );
 		}
 
 		if ( ! $formatted_min_price ) {
+			/* translators: %s is the formatted maximum price. */
 			$title = sprintf( __( 'Up to %s', 'woo-gutenberg-products-block' ), $formatted_max_price );
 		}
 
 		if ( ! $formatted_max_price ) {
+			/* translators: %s is the formatted minimum price. */
 			$title = sprintf( __( 'From %s', 'woo-gutenberg-products-block' ), $formatted_min_price );
 		}
 
-
-		$data[ 'price' ] = array(
+		$data['price'] = array(
 			'type'    => __( 'Price', 'woo-gutenberg-products-block' ),
 			'options' => array(
 				array(
-					'title' => $title,
+					'title'      => $title,
 					'attributes' => array(
 						'data-wc-on--click' => 'woocommerce/collection-price-filter::actions.reset',
 					),

--- a/src/BlockTypes/CollectionStockFilter.php
+++ b/src/BlockTypes/CollectionStockFilter.php
@@ -32,7 +32,7 @@ final class CollectionStockFilter extends AbstractBlock {
 	/**
 	 * Register the active filters data.
 	 *
-	 * @param array $data   The active filters data
+	 * @param array $data   The active filters data.
 	 * @param array $params The query param parsed from the URL.
 	 * @return array Active filters data.
 	 */
@@ -54,7 +54,7 @@ final class CollectionStockFilter extends AbstractBlock {
 		$active_stock_statuses = array_map(
 			function( $status ) use ( $stock_status_options ) {
 				return array(
-					'title' => $stock_status_options[ $status ],
+					'title'      => $stock_status_options[ $status ],
 					'attributes' => array(
 						'data-wc-on--click' => 'woocommerce/collection-stock-filter::actions.removeFilter',
 						'data-wc-context'   => 'woocommerce/collection-stock-filter::' . wp_json_encode( array( 'value' => $status ) ),
@@ -65,7 +65,7 @@ final class CollectionStockFilter extends AbstractBlock {
 		);
 
 		$data['stock'] = array(
-			'type' => __( 'Stock Status', 'woo-gutenberg-products-block' ),
+			'type'    => __( 'Stock Status', 'woo-gutenberg-products-block' ),
 			'options' => $active_stock_statuses,
 		);
 

--- a/src/BlockTypes/CollectionStockFilter.php
+++ b/src/BlockTypes/CollectionStockFilter.php
@@ -26,13 +26,19 @@ final class CollectionStockFilter extends AbstractBlock {
 	protected function initialize() {
 		parent::initialize();
 
-		add_filter( 'collection_active_filters_data', function( $active_filters, $params ) {
+		add_filter( 'collection_active_filters_data', function( $data, $params ) {
 			$stock_status_options = wc_get_product_stock_status_options();
 
-			$active_stock_statuses = array_filter( explode( ',', get_query_var( self::STOCK_STATUS_QUERY_VAR ) ) );
+			if ( empty( $params[ self::STOCK_STATUS_QUERY_VAR ] ) ) {
+				return $data;
+			}
+
+			$active_stock_statuses = array_filter(
+				explode( ',', $params[ self::STOCK_STATUS_QUERY_VAR ] )
+			);
 
 			if ( empty( $active_stock_statuses ) ) {
-				return $active_filters;
+				return $data;
 			}
 
 			$active_stock_statuses = array_map(
@@ -48,12 +54,12 @@ final class CollectionStockFilter extends AbstractBlock {
 				$active_stock_statuses
 			);
 
-			$active_filters['stock'] = array(
+			$data['stock'] = array(
 				'type' => __( 'Stock Status', 'woo-gutenberg-products-block' ),
 				'options' => $active_stock_statuses,
 			);
 
-			return $active_filters;
+			return $data;
 		}, 10, 2 );
 	}
 

--- a/src/BlockTypes/CollectionStockFilter.php
+++ b/src/BlockTypes/CollectionStockFilter.php
@@ -26,7 +26,30 @@ final class CollectionStockFilter extends AbstractBlock {
 	protected function initialize() {
 		parent::initialize();
 
+		add_filter( 'collection_filter_query_param_keys', array( $this, 'get_filter_query_param_keys' ), 10, 2 );
 		add_filter( 'collection_active_filters_data', array( $this, 'register_active_filters_data' ), 10, 2 );
+	}
+
+	/**
+	 * Register the active filters data.
+	 *
+	 * @param array $filter_param_keys The active filters data.
+	 * @param array $url_param_keys    The query param parsed from the URL.
+	 *
+	 * @return array Active filters param keys.
+	 */
+	public function get_filter_query_param_keys( $filter_param_keys, $url_param_keys ) {
+		$stock_param_keys = array_filter(
+			$url_param_keys,
+			function( $param ) {
+				return self::STOCK_STATUS_QUERY_VAR === $param;
+			}
+		);
+
+		return array_merge(
+			$filter_param_keys,
+			$stock_param_keys
+		);
 	}
 
 	/**

--- a/src/BlockTypes/CollectionStockFilter.php
+++ b/src/BlockTypes/CollectionStockFilter.php
@@ -18,6 +18,37 @@ final class CollectionStockFilter extends AbstractBlock {
 	const STOCK_STATUS_QUERY_VAR = 'filter_stock_status';
 
 	/**
+	 * Initialize this block type.
+	 *
+	 * - Hook into WP lifecycle.
+	 * - Register the block with WordPress.
+	 */
+	protected function initialize() {
+		parent::initialize();
+
+		add_filter( 'collection_active_filters_data', function( $active_filters, $params ) {
+			$stock_status_options = wc_get_product_stock_status_options();
+
+			$active_stock_statuses = array_map(
+				function( $status ) use ( $stock_status_options ) {
+					return array(
+						'title' => $stock_status_options[ $status ],
+						'attributes' => array(),
+					);
+				},
+				explode( ',', get_query_var( self::STOCK_STATUS_QUERY_VAR ) )
+			);
+
+			$active_filters['stock'] = array(
+				'type' => __( 'Stock Status', 'woo-gutenberg-products-block' ),
+				'options' => $active_stock_statuses,
+			);
+
+			return $active_filters;
+		}, 10, 2 );
+	}
+
+	/**
 	 * Extra data passed through from server to client for block.
 	 *
 	 * @param array $stock_statuses  Any stock statuses that currently are available from the block.
@@ -112,12 +143,12 @@ final class CollectionStockFilter extends AbstractBlock {
 							<li>
 								<div class="wc-block-components-checkbox wc-block-checkbox-list__checkbox">
 									<label for="<?php echo esc_attr( $stock_count['status'] ); ?>">
-										<input 
-											id="<?php echo esc_attr( $stock_count['status'] ); ?>" 
-											class="wc-block-components-checkbox__input" 
-											type="checkbox" 
-											aria-invalid="false" 
-											data-wc-on--change="actions.updateProducts" 
+										<input
+											id="<?php echo esc_attr( $stock_count['status'] ); ?>"
+											class="wc-block-components-checkbox__input"
+											type="checkbox"
+											aria-invalid="false"
+											data-wc-on--change="actions.updateProducts"
 											value="<?php echo esc_attr( $stock_count['status'] ); ?>"
 											<?php checked( strpos( $selected_stock_status, $stock_count['status'] ) !== false, 1 ); ?>
 										>

--- a/src/BlockTypes/CollectionStockFilter.php
+++ b/src/BlockTypes/CollectionStockFilter.php
@@ -26,41 +26,50 @@ final class CollectionStockFilter extends AbstractBlock {
 	protected function initialize() {
 		parent::initialize();
 
-		add_filter( 'collection_active_filters_data', function( $data, $params ) {
-			$stock_status_options = wc_get_product_stock_status_options();
+		add_filter( 'collection_active_filters_data', array( $this, 'register_active_filters_data' ), 10, 2 );
+	}
 
-			if ( empty( $params[ self::STOCK_STATUS_QUERY_VAR ] ) ) {
-				return $data;
-			}
+	/**
+	 * Register the active filters data.
+	 *
+	 * @param array $data   The active filters data
+	 * @param array $params The query param parsed from the URL.
+	 * @return array Active filters data.
+	 */
+	public function register_active_filters_data( $data, $params ) {
+		$stock_status_options = wc_get_product_stock_status_options();
 
-			$active_stock_statuses = array_filter(
-				explode( ',', $params[ self::STOCK_STATUS_QUERY_VAR ] )
-			);
-
-			if ( empty( $active_stock_statuses ) ) {
-				return $data;
-			}
-
-			$active_stock_statuses = array_map(
-				function( $status ) use ( $stock_status_options ) {
-					return array(
-						'title' => $stock_status_options[ $status ],
-						'attributes' => array(
-							'data-wc-on--click' => 'woocommerce/collection-stock-filter::actions.removeFilter',
-							'data-wc-context'   => 'woocommerce/collection-stock-filter::' . wp_json_encode( array( 'value' => $status ) ),
-						),
-					);
-				},
-				$active_stock_statuses
-			);
-
-			$data['stock'] = array(
-				'type' => __( 'Stock Status', 'woo-gutenberg-products-block' ),
-				'options' => $active_stock_statuses,
-			);
-
+		if ( empty( $params[ self::STOCK_STATUS_QUERY_VAR ] ) ) {
 			return $data;
-		}, 10, 2 );
+		}
+
+		$active_stock_statuses = array_filter(
+			explode( ',', $params[ self::STOCK_STATUS_QUERY_VAR ] )
+		);
+
+		if ( empty( $active_stock_statuses ) ) {
+			return $data;
+		}
+
+		$active_stock_statuses = array_map(
+			function( $status ) use ( $stock_status_options ) {
+				return array(
+					'title' => $stock_status_options[ $status ],
+					'attributes' => array(
+						'data-wc-on--click' => 'woocommerce/collection-stock-filter::actions.removeFilter',
+						'data-wc-context'   => 'woocommerce/collection-stock-filter::' . wp_json_encode( array( 'value' => $status ) ),
+					),
+				);
+			},
+			$active_stock_statuses
+		);
+
+		$data['stock'] = array(
+			'type' => __( 'Stock Status', 'woo-gutenberg-products-block' ),
+			'options' => $active_stock_statuses,
+		);
+
+		return $data;
 	}
 
 	/**

--- a/src/BlockTypes/CollectionStockFilter.php
+++ b/src/BlockTypes/CollectionStockFilter.php
@@ -29,14 +29,23 @@ final class CollectionStockFilter extends AbstractBlock {
 		add_filter( 'collection_active_filters_data', function( $active_filters, $params ) {
 			$stock_status_options = wc_get_product_stock_status_options();
 
+			$active_stock_statuses = array_filter( explode( ',', get_query_var( self::STOCK_STATUS_QUERY_VAR ) ) );
+
+			if ( empty( $active_stock_statuses ) ) {
+				return $active_filters;
+			}
+
 			$active_stock_statuses = array_map(
 				function( $status ) use ( $stock_status_options ) {
 					return array(
 						'title' => $stock_status_options[ $status ],
-						'attributes' => array(),
+						'attributes' => array(
+							'data-wc-on--click' => 'woocommerce/collection-stock-filter::actions.removeFilter',
+							'data-wc-context'   => 'woocommerce/collection-stock-filter::' . wp_json_encode( array( 'value' => $status ) ),
+						),
 					);
 				},
-				explode( ',', get_query_var( self::STOCK_STATUS_QUERY_VAR ) )
+				$active_stock_statuses
 			);
 
 			$active_filters['stock'] = array(

--- a/src/BlockTypes/CollectionStockFilter.php
+++ b/src/BlockTypes/CollectionStockFilter.php
@@ -65,8 +65,8 @@ final class CollectionStockFilter extends AbstractBlock {
 		);
 
 		$data['stock'] = array(
-			'type'    => __( 'Stock Status', 'woo-gutenberg-products-block' ),
-			'options' => $active_stock_statuses,
+			'type'  => __( 'Stock Status', 'woo-gutenberg-products-block' ),
+			'items' => $active_stock_statuses,
 		);
 
 		return $data;

--- a/src/BlockTypesController.php
+++ b/src/BlockTypesController.php
@@ -300,6 +300,7 @@ final class BlockTypesController {
 			$block_types[] = 'CollectionStockFilter';
 			$block_types[] = 'CollectionPriceFilter';
 			$block_types[] = 'CollectionAttributeFilter';
+			$block_types[] = 'CollectionActiveFilters';
 		}
 
 		/**


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

This PR adds the new Active Filters Block powered by Interactivity API. It has the same features as the current one and works with new filter blocks.

Fixes woocommerce/woocommerce#42179

## Why

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Add the `Collection Filters` block into a `Product Collection` block.
2. See the `Collection Active Filters` and other filter blocks added along with the `Collection Filters` block.
3. Toggle the display style, see the editor reacts.
4. Save and test the block on the frontend:
  - It's hidden when no filter applied.
  - It's visible when a filter is applied.
  - Clicking on the remove button of each active filter removes that filter from the URL and update the products grid as well as the corresponding filter block.
  - Clicking on the `Clear All` button remove all filters.
  - Removing a filter from the filter block also remove the corresponding one from the active filter block.
  - See chip and list style work as expected.

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [ ] WooCommerce Core
* [ ] Feature plugin
* [x] Experimental
* [ ] N/A

## Checklist

Required:

* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:

* [ ] This PR has a UI change and has been cross-browser tested at different viewport sizes on both the frontend and in the editor.
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Add suggested changelog entry here.
