### PR TITLE
Update Feedback link on Cart and Checkout blocks

### DIFF
--- a/assets/js/editor-components/feedback-prompt/index.tsx
+++ b/assets/js/editor-components/feedback-prompt/index.tsx
@@ -71,17 +71,7 @@ export const CartCheckoutFeedbackPrompt = () => (
 			'We are currently working on improving our cart and checkout blocks to provide merchants with the tools and customization options they need.',
 			'woo-gutenberg-products-block'
 		) }
-		url="https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?template=--cart-checkout-feedback.md"
-	/>
-);
-
-export const LegacyFeedbackPrompt = () => (
-	<FeedbackPrompt
-		text={ __(
-			'We are working on a better editing experience that will replace classic blocks. Keep an eye out for updates!',
-			'woo-gutenberg-products-block'
-		) }
-		url="https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/new?template=--classic-block-feedback.md"
+		url="https://github.com/woocommerce/woocommerce/discussions/new?category=checkout-flow&labels=type%3A+product%20feedback"
 	/>
 );
 


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Fixes woocommerce/woocommerce-blocks#11990 <!-- Add the issue number that this PR addresses -->

## Why

The `Give us your feedback` link currently points to the WooCommerce Blocks repo instead of WooCommerce repo discussions. 

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Create pages and add the Cart Block and Checkout block
2. Select each of those blocks
3. Verify that the Give us your feedback link (see printscreen) now directs to [https://github.com/woocommerce/woocommerce/discussions/new?category=checkout-flow&labels=type%3A+product%20feedback](https://github.com/woocommerce/woocommerce/discussions/new?category=checkout-flow&labels=type%3A+product%20feedback).

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->


<img width="326" alt="image" src="https://github.com/woocommerce/woocommerce-blocks/assets/17236129/933251ca-c3bd-41ae-b46d-77d1c18e89da">


## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:

* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:

* [ ] This PR has a UI change and has been cross-browser tested at different viewport sizes on both the frontend and in the editor.
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interface, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Update the "Give us your feedback" link to point to the WooCommerce repo discussions
