### PR TITLE
Decrease modal width

### DIFF
--- a/assets/js/editor-components/incompatible-extension-notice/editor.scss
+++ b/assets/js/editor-components/incompatible-extension-notice/editor.scss
@@ -86,6 +86,8 @@ ul.cross-list {
 }
 
 .wc-blocks-incompatible-extensions-notice-modal-content {
+	max-width: 480px;
+
 	p {
 		margin-top: 0;
 	}


### PR DESCRIPTION
## What

Fixes #11994

## Why

The current modal for switching to classic cart or checkout exceeds 800px in width and varies based on content, impacting readability. Implementing a max-width of 480px will ensure consistency and improve readability across both Cart and Checkout blocks.

## Testing Instructions

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Install and activate the following helper plugin:
[helper-plugin-01.zip](https://github.com/woocommerce/woocommerce-blocks/files/13522252/helper-plugin-01.zip)
2. Create a test page and add the Cart block to it.
3. Select the Cart block and open the sidebar.
4. Click the button `Switch to classic cart` in the incompatible extension notice.
5. Verify that the model has a max-width of 480px.
6. Replace the Cart block with the Checkout block.
7. Select the Checkout block and open the sidebar.
8. Click the button `Switch to classic checkout`.
9. Verify that this model also has a max-width of 480px.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<table>
<tr>
<td valign="top">Before:
<br><br>
<img width="1280" alt="Screenshot 2023-12-01 at 14 23 02" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/c1ce59b3-1d5d-4072-bd5b-aec8804cccca">
</td>
<td valign="top">After:
<br><br>
<img width="1280" alt="Screenshot 2023-12-01 at 14 24 20" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/a491a946-0a4f-4b5e-b94f-958a4efb2789">
</td>
</tr>
</table>

### Cross-browser compatibility

> [!NOTE]
> Left: Chrome
> Middle: Firefox
> Right: Safari

<img width="2560" alt="Screenshot 2023-12-01 at 14 33 28" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/e1b15fde-3d4c-4ecc-9f71-399737705c4d">


## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:

* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [x] This PR is assigned to a milestone.

Conditional:

* [x] This PR has a UI change and has been cross-browser tested at different viewport sizes on both the frontend and in the editor.
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog

> Limit modal width to 480px.