### PR TITLE
Update the checkout order endpoint allowed order statuses for payment complete

### DIFF
--- a/src/StoreApi/Routes/V1/CheckoutOrder.php
+++ b/src/StoreApi/Routes/V1/CheckoutOrder.php
@@ -100,7 +100,7 @@ class CheckoutOrder extends AbstractCartRoute {
 		$order_id    = absint( $request['id'] );
 		$this->order = wc_get_order( $order_id );
 
-		if ( ! $this->order->needs_payment() ) {
+		if ( ! $this->order || ! $this->order->needs_payment() ) {
 			return new \WP_Error(
 				'invalid_order_update_status',
 				__( 'This order cannot be paid for.', 'woo-gutenberg-products-block' )

--- a/src/StoreApi/Routes/V1/CheckoutOrder.php
+++ b/src/StoreApi/Routes/V1/CheckoutOrder.php
@@ -100,7 +100,7 @@ class CheckoutOrder extends AbstractCartRoute {
 		$order_id    = absint( $request['id'] );
 		$this->order = wc_get_order( $order_id );
 
-		if ( $this->order->get_status() !== 'pending' && $this->order->get_status() !== 'failed' ) {
+		if ( ! $this->order->needs_payment() ) {
 			return new \WP_Error(
 				'invalid_order_update_status',
 				__( 'This order cannot be paid for.', 'woo-gutenberg-products-block' )


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What
The checkout order endpoint requires that the order status is either `failed` or `pending` so we can pay for the order.  For plugin compatibility, we should allow custom order status, for example, `scheduled` from WooCommerce Deposits.

Fixes https://github.com/Automattic/woopay/issues/2374

## Why
- We could check if it's `complete,` `processing,` `refunded,` etc., then we show the error, but we might miss other plugin's statuses.
- We could use `woocommerce_valid_order_statuses_for_payment_complete` filter, but `needs_payment` includes the filter, so it's a better approach.
<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

Test `scheduled`, `failed`, `pending`, etc order statuses.

* Test checkout as a guest
1. Install and activate a plugin with pay-for-order flow. (ex WooCommerce-Deposits)
2. Return `true` on `check_nonce`
3. Create a product with payment plans and purchase the product
4. Go to WooCommerce -> Orders, find the `scheduled` orders, and copy the `Customer payment page` link
5. As a guest, open the `Customer payment page` to go to the pay-for-order page
6. Copy the `key` from the URL
7. Use Postman to test this endpoint `http://merchant.local/wp-json/wc/store/checkout/YOUR_ORDER_NUMBER?key=YOUR_KEY&billing_email=YOUR_BILLING_EMAIL`
8. Make sure on Postman the authorization type set to `No Auth`
9. POST to checkout the order. ex:
```
{
  "billing_address": {
        "first_name": "Test",
        "last_name": "TestBilling",
        "company": "",
        "address_1": "123 test",
        "address_2": "",
        "city": "San Diego",
        "state": "CA",
        "postcode": "92103",
        "country": "US",
        "email": "test@hacker.com",
        "phone": ""
    },
    "shipping_address": {
        "first_name": "Test",
        "last_name": "Test Last",
        "company": "",
        "address_1": "123 test",
        "address_2": "",
        "city": "San Diego",
        "state": "CA",
        "postcode": "92103",
        "country": "US",
        "email": "test@hacker.com",
        "phone": ""
    },
  "payment_method": "cod"
}
```

* Test checkout as an existing customer
1. Go back to WooCommerce->Orders and use the same order you created above
2. Set status: `Pending payment` and Customer: `Existing customer`
3. Go to WooCommerce -> Settings -> Advanced -> Rest API
5. Add key with the customer email, read/write permission, copy the Consumer key and secret to Postman
6. On Postman, change the authorization type to OAuth 1.0, and paste the key and secret
7. Remove the `key` and `billing_email`params and send the request
8. Send the request again and should see below message
<img width="471" alt="Screen Shot 2023-12-01 at 5 31 57 PM" src="https://github.com/woocommerce/woocommerce-blocks/assets/56378160/1b48617a-f620-408c-ac30-bf108c01b728">



* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|        |       |

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:

* [ ] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:

* [ ] This PR has a UI change and has been cross-browser tested at different viewport sizes on both the frontend and in the editor.
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Update the checkout order endpoint allowed order statuses for payment complete
