### PR TITLE
Fix performance issues with the extension incompatibility notice

### DIFF
--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -343,22 +343,21 @@ class Checkout extends AbstractBlock {
 		}
 
 		if ( $is_block_editor && ! $this->asset_data_registry->exists( 'incompatibleExtensions' ) ) {
-			if ( ! class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) ) {
+			if ( ! class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) || ! function_exists( 'get_plugins' ) ) {
 				return;
 			}
 
-			if ( ! function_exists( 'get_plugin_data' ) ) {
-				require_once ABSPATH . 'wp-admin/includes/plugin.php';
-			}
-
 			$declared_extensions     = \Automattic\WooCommerce\Utilities\FeaturesUtil::get_compatible_plugins_for_feature( 'cart_checkout_blocks' );
+			$all_plugins             = \get_plugins(); // Note that `get_compatible_plugins_for_feature` calls `get_plugins` internally, so this is already in cache.
 			$incompatible_extensions = array_reduce(
 				$declared_extensions['incompatible'],
-				function( $acc, $item ) {
-					$plugin = get_plugin_data( WP_PLUGIN_DIR . '/' . $item );
-					$acc[]  = [
-						'id'    => $plugin['TextDomain'],
-						'title' => $plugin['Name'],
+				function( $acc, $item ) use ( $all_plugins ) {
+					$plugin      = $all_plugins[ $item ] ?? null;
+					$plugin_id   = $plugin['TextDomain'] ?? dirname( $item );
+					$plugin_name = $plugin['Name'] ?? $plugin_id;
+					$acc[]       = [
+						'id'    => $plugin_id,
+						'title' => $plugin_name,
 					];
 					return $acc;
 				},


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

https://github.com/woocommerce/woocommerce-blocks/issues/11582 identified problematic calls to the [`get_plugin_data` function](https://developer.wordpress.org/reference/functions/get_plugin_data/). This function gets headers from plugin files which we use to get the plugin name, but it's uncached.

Instead we can use the [`get_plugins` function.](https://developer.wordpress.org/reference/functions/get_plugins/) This uses `get_plugin_data` internally, but its stored in object cache, and already cached by the time we need it.

Fixes #11582

## Why

Getting data from the cache is less expensive than getting data from the file system.

## Testing Instructions

This tests for regressions in the editor:

1. Install and activate the following three helper plugins:
     - [helper-plugin-1.zip](https://github.com/woocommerce/woocommerce-blocks/files/12701036/helper-plugin-1.zip)
     - [helper-plugin-2.zip](https://github.com/woocommerce/woocommerce-blocks/files/12701039/helper-plugin-2.zip)
     - [helper-plugin-3.zip](https://github.com/woocommerce/woocommerce-blocks/files/12701041/helper-plugin-3.zip)
2. Create a test page and add the Checkout block to it.
3. Open the settings sidebar, if not already open.
4. Verify that the incompatibility notice lists the A → Incompatible Extension, N → Incompatible Extension, and Z → Incompatible Extension extensions

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:

* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:

* [ ] This PR has a UI change and has been cross-browser tested at different viewport sizes on both the frontend and in the editor.
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog

> Fix performance issues with the extension incompatibility notice by using caching.
