### PR TITLE
Fix CSS class name for dark mode in validation notice

### DIFF
--- a/packages/components/validation-input-error/style.scss
+++ b/packages/components/validation-input-error/style.scss
@@ -10,7 +10,7 @@
 	}
 }
 
-.has-dark-mode-palette .wc-block-components-validation-error {
+.has-dark-controls .wc-block-components-validation-error {
 	color: color.adjust($alert-red, $lightness: 30%);
 }
 


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

Dark mode uses slightly different shades of red for validation errors and input borders, but the selector was wrong causing the text to be miscolored.

Fixes #11738

## Why

Fixes the selector so the text is legible.

## Testing Instructions

1. Edit the checkout page. Select the checkout block and toggle on "dark mode inputs" in the sidebar. Save.
2. Add something to cart and go through checkout.
3. Leave a required address field blank.
4. Confirm the input border and error notice are the same color (light red).

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

![Screenshot 2023-12-04 at 16 18 38](https://github.com/woocommerce/woocommerce-blocks/assets/90977/ef6c7726-bbc1-4626-a185-8bec534bdd9f)

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:

* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:

* [ ] This PR has a UI change and has been cross-browser tested at different viewport sizes on both the frontend and in the editor.
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Fix CSS class name for dark mode in validation notice
