### PR TITLE
Enable new notice styles for all themes

### DIFF
--- a/assets/js/base/components/notice-banner/style.scss
+++ b/assets/js/base/components/notice-banner/style.scss
@@ -70,6 +70,7 @@
 		background-color: $gray-800;
 		flex-shrink: 0;
 		flex-grow: 0;
+		height: 100%;
 	}
 
 	> .wc-block-components-button {

--- a/assets/js/base/components/notice-banner/style.scss
+++ b/assets/js/base/components/notice-banner/style.scss
@@ -46,7 +46,7 @@
 		.wc-forward {
 			float: right;
 			color: $gray-800 !important;
-			background: transparent;
+			background: transparent !important; // For transparent notice button in Twenty Twenty-One theme.
 			padding: 0 !important;
 			margin: 0;
 			border: 0;

--- a/src/Domain/Services/Notices.php
+++ b/src/Domain/Services/Notices.php
@@ -38,23 +38,12 @@ class Notices {
 	}
 
 	/**
-	 * Set all hooks related to adding Checkout Draft order functionality to Woo Core. This is only enabled if the user
-	 * is using the new block based cart/checkout.
+	 * Initialize notice hooks.
 	 */
 	public function init() {
-		if ( CartCheckoutUtils::is_cart_block_default() || CartCheckoutUtils::is_checkout_block_default() ) {
-			add_filter( 'woocommerce_kses_notice_allowed_tags', [ $this, 'add_kses_notice_allowed_tags' ] );
-			add_filter( 'wc_get_template', [ $this, 'get_notices_template' ], 10, 5 );
-			add_action(
-				'wp_head',
-				function() {
-					// These pages may return notices in ajax responses, so we need the styles to be ready.
-					if ( is_cart() || is_checkout() ) {
-						wp_enqueue_style( 'wc-blocks-style' );
-					}
-				}
-			);
-		}
+		add_filter( 'woocommerce_kses_notice_allowed_tags', [ $this, 'add_kses_notice_allowed_tags' ] );
+		add_filter( 'wc_get_template', [ $this, 'get_notices_template' ], 10, 5 );
+		add_action( 'wp_head', [ $this, 'enqueue_notice_styles' ] );
 	}
 
 	/**
@@ -100,5 +89,14 @@ class Notices {
 			wp_enqueue_style( 'wc-blocks-style' );
 		}
 		return $template;
+	}
+
+	/**
+	 * Replaces all notices with the new block based notices.
+	 *
+	 * @return void
+	 */
+	public function enqueue_notice_styles() {
+		wp_enqueue_style( 'wc-blocks-style' );
 	}
 }


### PR DESCRIPTION
## What

Display new notice styles for the shortcode-based cart and checkout.

Fixes #12042

## Why

In #8659, @mikejolley updated the shopper notice styles. Until now, these styles were only visible when the store was using the Cart or the Checkout block. This PR ensures that the new styles are now applied universally, regardless of whether the store uses a Cart or Checkout block.

## Testing Instructions

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Install and activate the [Code Snippets](https://wordpress.org/plugins/code-snippets/) plugin.
2. Add the following code snippet to the site:
```php
add_action( 'woocommerce_before_cart', 'test_notice_styles' );
add_action( 'woocommerce_before_checkout_form', 'test_notice_styles' );
function test_notice_styles() {
  if ( function_exists( 'wc_add_notice' ) ) {
    wc_add_notice( 'Error notice with link #1 <a href="#">Click me</a>', 'error' );
    wc_add_notice( 'Error notice with link #2 <a href="#">Click me</a>', 'error' );
    wc_add_notice( 'Error notice with link #3 <a href="#">Click me</a>', 'error' );
    wc_add_notice( 'Error notice with button #1 <a class="wc-forward">Click me</a>', 'error' );
    wc_add_notice( 'Error notice with button #2 <a class="wc-forward">Click me</a>', 'error' );
    wc_add_notice( 'Error notice with button #3 <a class="wc-forward">Click me</a>', 'error' );
    wc_add_notice( 'Success notice with link <a href="#">Do the thing</a>', 'success' );		
    wc_add_notice( 'Success notice with button <a class="wc-forward">Click me</a>', 'success' );		
    wc_add_notice( 'Info notice with link <a href="#">Click me</a>', 'notice' );		
    wc_add_notice( 'Info notice with button <a class="wc-forward">Click me</a>', 'notice' );
  }
}
```
3. Install the following themes:
    - [Twenty Twenty-One](https://wordpress.org/themes/twentytwentyone/) (classic theme)
    - [Twenty Twenty](https://wordpress.org/themes/twentytwenty/) (classic theme)
    - [Twenty Nineteen](https://wordpress.org/themes/twentynineteen/) (classic theme)
    - [Twenty Seventeen](https://wordpress.org/themes/twentyseventeen/) (classic theme)
    - [Twenty Sixteen](https://wordpress.org/themes/twentysixteen/) (classic theme)
    - [Twenty Fifteen](https://wordpress.org/themes/twentyfifteen/) (classic theme)
    - [Twenty Fourteen](https://wordpress.org/themes/twentyfourteen/) (classic theme)
    - [Twenty Thirteen](https://wordpress.org/themes/twentythirteen/) (classic theme)
    - [Twenty Twelve](https://wordpress.org/themes/twentytwelve/) (classic theme)
    - [Twenty Eleven](https://wordpress.org/themes/twentyeleven/) (classic theme)
    - [Twenty Ten](https://wordpress.org/themes/twentyten/) (classic theme)
4. Activate the Twenty Twenty-One theme.
5. Create a test page and add the following shortcode to it:
```
[woocommerce_cart]
```
6. Create a test page and add the following shortcode to it:
```
[woocommerce_checkout]
```
7. Go to `/wp-admin/admin.php?page=wc-settings&tab=advanced` and verify that no Cart page or Checkout page is selected:

<img width="667" alt="Screenshot 2023-12-05 at 13 07 45" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/40ef1dc8-f5b6-4ec3-82cd-6463798d92e0">

8. Go to the frontend and add a product to the cart.
9. Check the notices in the shortcode-based cart and checkout page against all themes that have been installed in step 3.
10. Verify that the notices look consistent in all default themes.

> [!TIP]
> Optional: Install and activate the [SMNTCS Themes List View](https://wordpress.org/plugins/smntcs-theme-list-view/) plugin to easily switch between installed themes.

> [!IMPORTANT]
> Please note that when using the Twenty Twelve and Twenty Twenty themes the indentation for the error message list items needs to be adjusted. This fix will take place in  https://github.com/woocommerce/woocommerce.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<details>
<summary>Twenty Twenty-One</summary>
<br>

<table>
<tr>
<td valign="top">Before:
<br><br>
<img width="2560" alt="Screenshot 2023-12-04 at 18 05 49" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/273fba66-945d-4160-8fae-5c116e414fe5">
</td>
<td valign="top">After:
<br><br>
<img width="2560" alt="Screenshot 2023-12-05 at 13 05 13" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/2fce71b4-2423-4a06-88e8-2a7e3d75f983">
</td>
</tr>
</table>
</details>

<details>
<summary>Twenty Twenty</summary>
<br>
<table>
<tr>
<td valign="top">Before:
<br><br>
<img width="2560" alt="Screenshot 2023-12-04 at 18 07 09" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/9b985ac5-3db0-4323-a1be-d1616ccc28e2">
</td>
<td valign="top">After:
<br><br>
<img width="2560" alt="Screenshot 2023-12-05 at 13 06 40" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/73143635-91a5-4568-9f55-11f71625fb4d">
</td>
</tr>
</table>
</details>

<details>
<summary>Twenty Nineteen</summary>
<br>
<table>
<tr>
<td valign="top">Before:
<br><br>
<img width="2560" alt="Screenshot 2023-12-04 at 18 07 55" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/e8132b26-72c8-45d0-a7df-1e766b67de3a">
</td>
<td valign="top">After:
<br><br>
<img width="2560" alt="Screenshot 2023-12-05 at 13 09 30" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/499142b4-bc2b-40f8-8d23-e0a3ac60744e">
</td>
</tr>
</table>
</details>

<details>
<summary>Twenty Seventeen</summary>
<br>
<table>
<tr>
<td valign="top">Before:
<br><br>
<img width="2560" alt="Screenshot 2023-12-04 at 18 08 46" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/661c1c32-0546-47ab-b690-1598568aab35">
</td>
<td valign="top">After:
<br><br>
<img width="2560" alt="Screenshot 2023-12-05 at 13 10 17" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/239d8f50-1b1a-4568-979f-a110e1c4e5e7">
</td>
</tr>
</table>
</details>

<details>
<summary>Twenty Sixteen</summary>
<br>
<table>
<tr>
<td valign="top">Before:
<br><br>
<img width="2560" alt="Screenshot 2023-12-04 at 18 09 26" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/9d87e6d5-a0b7-4176-bcb4-dade96369a73">
</td>
<td valign="top">After:
<br><br>
<img width="2560" alt="Screenshot 2023-12-05 at 13 10 57" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/9f0a8974-236c-40b7-8cc6-55626ca27f36">
</td>
</tr>
</table>
</details>

<details>
<summary>Twenty Fifteen</summary>
<br>
<table>
<tr>
<td valign="top">Before:
<br><br>
<img width="2560" alt="Screenshot 2023-12-04 at 18 10 08" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/f1b2376a-e7d9-4250-b1b3-23977bcefe22">
</td>
<td valign="top">After:
<br><br>
<img width="2560" alt="Screenshot 2023-12-05 at 13 12 18" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/15e3d11d-5e5d-4afa-8586-9ac397491e82">
</td>
</tr>
</table>
</details>

<details>
<summary>Twenty Fourteen</summary>
<br>
<table>
<tr>
<td valign="top">Before:
<br><br>
<img width="2560" alt="Screenshot 2023-12-04 at 18 10 40" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/1081a4f1-4c27-47de-a57e-a6579a047968">
</td>
<td valign="top">After:
<br><br>
<img width="2560" alt="Screenshot 2023-12-05 at 13 13 01" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/8d74f512-c570-4fe7-8393-5c8873efdef6">
</td>
</tr>
</table>
</details>

<details>
<summary>Twenty Thirteen</summary>
<br>
<table>
<tr>
<td valign="top">Before:
<br><br>
<img width="2560" alt="Screenshot 2023-12-04 at 18 11 10" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/2105b9ce-9263-4f72-a83d-2a7589772b14">
</td>
<td valign="top">After:
<br><br>
<img width="2560" alt="Screenshot 2023-12-05 at 13 13 40" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/0ea72f33-291b-4e92-876a-ca676d81466b">
</td>
</tr>
</table>
</details>

<details>
<summary>Twenty Twelve</summary>
<br>
<table>
<tr>
<td valign="top">Before:
<br><br>
<img width="2560" alt="Screenshot 2023-12-04 at 18 11 54" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/f635755d-735b-4385-9487-590254ae45ce">
</td>
<td valign="top">After:
<br><br>
<img width="2560" alt="Screenshot 2023-12-05 at 13 14 42" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/20c759f3-e4e9-4a40-96d3-91d30394b763">
</td>
</tr>
</table>
</details>

<details>
<summary>Twenty Eleven</summary>
<br>
<table>
<tr>
<td valign="top">Before:
<br><br>
<img width="2560" alt="Screenshot 2023-12-04 at 18 12 27" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/79408638-87bd-4700-aa18-49ee72f87f5f">
</td>
<td valign="top">After:
<br><br>
<img width="2560" alt="Screenshot 2023-12-05 at 13 15 35" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/888e62f3-2389-42be-a03d-a537e5a5825a">
</td>
</tr>
</table>
</details>

<details>
<summary>Twenty Ten</summary>
<br>
<table>
<tr>
<td valign="top">Before:
<br><br>
<img width="2560" alt="Screenshot 2023-12-04 at 18 12 59" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/2c22f7c9-640b-471f-b671-b2d34bc5c864">
</td>
<td valign="top">After:
<br><br>
<img width="2560" alt="Screenshot 2023-12-05 at 13 16 13" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/1260db3a-1181-4524-a3c3-ffebe985c136">
</td>
</tr>
</table>
</details>

### Cross-browser compatibility

<img width="2560" alt="Screenshot 2023-12-05 at 13 20 44" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/3b2b05b3-6ca2-4036-863f-fd490d4c0526">

## WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:

* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:

* [x] This PR has a UI change and has been cross-browser tested at different viewport sizes on both the frontend and in the editor.
* [x] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog

> Enable new notice styles for all themes
