### PR TITLE
Adjust nesting so page wraps the main group block

### DIFF
--- a/templates/templates/blockified/page-cart.html
+++ b/templates/templates/blockified/page-cart.html
@@ -1,13 +1,10 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
-
-<!-- wp:group {"tagName":"main","layout":{"inherit":true,"type":"constrained"}} -->
+<!-- wp:woocommerce/page-content-wrapper {"page":"cart"} -->
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
 <main class="wp-block-group">
-	<!-- wp:woocommerce/page-content-wrapper {"page":"cart"} -->
 	<!-- wp:post-title {"align":"wide", "level":1} /-->
-
 	<!-- wp:post-content {"align":"wide"} /-->
-	<!-- /wp:woocommerce/page-content-wrapper -->
 </main>
 <!-- /wp:group -->
-
+<!-- /wp:woocommerce/page-content-wrapper -->
 <!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/templates/templates/blockified/page-checkout.html
+++ b/templates/templates/blockified/page-checkout.html
@@ -1,11 +1,9 @@
 <!-- wp:template-part {"slug":"checkout-header","theme":"woocommerce/woocommerce","tagName":"header"} /-->
-
-<!-- wp:group {"tagName":"main","layout":{"inherit":true,"type":"constrained"}} -->
+<!-- wp:woocommerce/page-content-wrapper {"page":"checkout"} -->
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
 <main class="wp-block-group">
-	<!-- wp:woocommerce/page-content-wrapper {"page":"checkout"} -->
 	<!-- wp:post-title {"align":"wide", "level":1} /-->
-
 	<!-- wp:post-content {"align":"wide"} /-->
-	<!-- /wp:woocommerce/page-content-wrapper -->
 </main>
 <!-- /wp:group -->
+<!-- /wp:woocommerce/page-content-wrapper -->

--- a/templates/templates/page-cart.html
+++ b/templates/templates/page-cart.html
@@ -1,13 +1,10 @@
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
-
-<!-- wp:group {"tagName":"main","layout":{"inherit":true,"type":"constrained"}} -->
+<!-- wp:woocommerce/page-content-wrapper {"page":"cart"} -->
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
 <main class="wp-block-group">
-	<!-- wp:woocommerce/page-content-wrapper {"page":"cart"} -->
 	<!-- wp:post-title {"align":"wide", "level":1} /-->
-
 	<!-- wp:post-content {"align":"wide"} /-->
-	<!-- /wp:woocommerce/page-content-wrapper -->
 </main>
 <!-- /wp:group -->
-
+<!-- /wp:woocommerce/page-content-wrapper -->
 <!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->

--- a/templates/templates/page-checkout.html
+++ b/templates/templates/page-checkout.html
@@ -1,11 +1,9 @@
 <!-- wp:template-part {"slug":"checkout-header","theme":"woocommerce/woocommerce","tagName":"header"} /-->
-
-<!-- wp:group {"tagName":"main","layout":{"inherit":true,"type":"constrained"}} -->
+<!-- wp:woocommerce/page-content-wrapper {"page":"checkout"} -->
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
 <main class="wp-block-group">
-	<!-- wp:woocommerce/page-content-wrapper {"page":"checkout"} -->
 	<!-- wp:post-title {"align":"wide", "level":1} /-->
-
 	<!-- wp:post-content {"align":"wide"} /-->
-	<!-- /wp:woocommerce/page-content-wrapper -->
 </main>
 <!-- /wp:group -->
+<!-- /wp:woocommerce/page-content-wrapper -->


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

I could not completely replicate the issue in #11774 because cart/checkout blocks default to `wide` width, however, I did find that as reported, the layout controls which control page width were not respected by the content area where the page title/checkout block were placed.

It seems that this was due to how blocks were nested. We had this structure:

```
Header
Group
—Cart Page
——Post Title
——Post Content
Footer
```

The `Group` contrains children, but the `Cart Page` block had no alignment or width options, so this was not passed down the hierarchy.

By swapping this around to:

```
Header
Cart Page
—Group
——Post Title
——Post Content
Footer
```

The group correctly constrains the child blocks and widths are applied.

This is hard to explain but this should help. In this example, I've set the global wide width as follows:

![Screenshot 2023-12-05 at 13 58 37](https://github.com/woocommerce/woocommerce-blocks/assets/90977/b1d2d4dc-4942-4590-99c4-1a246046be39)

| Before | After |
| ------ | ----- |
|   ![Screenshot 2023-12-05 at 14 00 38](https://github.com/woocommerce/woocommerce-blocks/assets/90977/672642a6-b858-401d-8948-24f18b384662) |    ![Screenshot 2023-12-05 at 13 59 40](https://github.com/woocommerce/woocommerce-blocks/assets/90977/aef03640-b9f8-47aa-b730-d248fde94197)   |

Notice the width of the header vs the width of the content.

Fixes #11774

## Why

Content should respect the global styles/widths.

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Using a block theme (TT4) go into the site editor. Edit Templates > Page:Cart.
2. If this template has customisations, reset them.
3. Open the styles panel > layout and set the wide width to something narrow. Notice the header and content widths change.
4. Save the template and check the frontend matches.
5. Repeat for Page: Checkout.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:

* [ ] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:

* [ ] This PR has a UI change and has been cross-browser tested at different viewport sizes on both the frontend and in the editor.
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog

> Made default cart and checkout templates inherit global width styles.
