### PR TITLE
Fix font weight of cart totals title in site editor

### DIFF
--- a/assets/js/base/components/cart-checkout/cart-line-items-table/style.scss
+++ b/assets/js/base/components/cart-checkout/cart-line-items-table/style.scss
@@ -26,6 +26,9 @@ table.wc-block-cart-items {
 			width: 100px;
 			text-align: right;
 		}
+		th {
+			font-weight: 700;
+		}
 	}
 	.wc-block-cart-items__row {
 		.wc-block-cart-item__image img {

--- a/assets/js/blocks/cart/style.scss
+++ b/assets/js/blocks/cart/style.scss
@@ -125,10 +125,14 @@
 		@include text-heading();
 		@include font-size( smaller );
 		display: block;
-		font-weight: 600;
+		font-weight: 700;
 		padding: 0.25rem 0;
 		text-align: right;
 		text-transform: uppercase;
+
+		textarea {
+			font-weight: 700; // Ensure correct font-weight in site-editor.
+		}
 	}
 
 	.wc-block-components-sidebar {


### PR DESCRIPTION
## What

Fixes #11870

## Why

In #11870, @ralucaStan reported that when viewing the Cart block in the site editor, the title `Cart totals` is using a different font weight than the titles `Product` and `Total`.

The reason behind that is that the titles `Product` and `Total` are displayed in a `<th>` element. By default, the `<th>` element is using `font-weight: bold` which translates to `font-weight: 700`, see https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#syntax.

The `Cart totals` title, however, is a `<textarea>` to enable merchants to customise the text of this title. By default, the `<textarea>` element is using `font-weight: normal` which translates to `font-weight: 400`. 

In the initial report (#11870), the issue was observed in the Twenty Twenty-Four theme. Upon further investigation, I noticed that this issue not only affected the Twenty Twenty-Four theme, but all block themes, including Twenty Twenty-Three and Twenty Twenty-Two. This broader impact was due to the nature of the issue.

I also noticed that in the frontend, the title `Cart totals` was using `font-weight: 600`. To ensure a consistent font weight, this PR changes the corresponding definition to `font-weight: 700`.

## Testing Instructions

_Please consider any edge cases this change may have, and also other areas of the product this may impact._

1. Install the following themes:
  - [Twenty Twenty-Four](https://wordpress.org/themes/twentytwentyfour/)
  - [Twenty Twenty-Three](https://wordpress.org/themes/twentytwentythree)
  - [Twenty Twenty-Two](https://wordpress.org/themes/twentytwentytwo/)
2. Activate the Twenty Twenty-Four theme
3. Go to `/wp-admin/site-editor.php?path=%2Fpage` and open the Cart page.
4. Verify that the titles `Product`, `Total` and `Cart totals` are using `font-weight: bold` resp. `font-weight: 700`.
5. Go to `/wp-admin/site-editor.php?path=%2Fwp_template`.
6. Verify the expectation of step 4.
7. Go to the frontend, add a product to the cart and go to the cart page.
8. Verify the expectation of step 4. 
9. Repeat the steps 3. to 8. with the Twenty Twenty-Three and the Twenty Twenty-Two theme.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

### Site editor

<table>
<tr>
<td valign="top">Before:
<br><br>
<img width="1280" alt="Screenshot 2023-12-05 at 23 17 24" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/25dfd00f-fcae-4073-ba9d-4637d6bf13b2">
</td>
<td valign="top">After:
<br><br>
<img width="1281" alt="Screenshot 2023-12-05 at 23 40 27" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/c75cf5c4-9b12-4a49-a288-dfcd8bfd0f7e">
</td>
</tr>
</table>

### Frontend

<table>
<tr>
<td valign="top">Before:
<br><br>
<img width="1279" alt="Screenshot 2023-12-05 at 23 22 33" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/38161830-31ea-4cf4-88f7-5829774dd0db">
</td>
<td valign="top">After:
<br><br>
<img width="1279" alt="Screenshot 2023-12-05 at 23 38 27" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/37a29e09-4ebd-41bd-8118-fa96218b6b1a">

</td>
</tr>
</table>

### Cross-browser compatibility

<img width="2560" alt="Screenshot 2023-12-05 at 23 11 47" src="https://github.com/woocommerce/woocommerce-blocks/assets/3323310/3bfe6374-fa6c-4cdf-9c7c-2c0f502d2b93">

## WooCommerce Visibility

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:

* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:

* [x] This PR has a UI change and has been cross-browser tested at different viewport sizes on both the frontend and in the editor.
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog

> Fix: Ensure column headers of the Cart block are using the same font weight in the site editor and the frontend.
