### PR TITLE
Allow guests to view full order details on the order confirmation page

### DIFF
--- a/src/BlockTypes/OrderConfirmation/AdditionalInformation.php
+++ b/src/BlockTypes/OrderConfirmation/AdditionalInformation.php
@@ -17,10 +17,10 @@ class AdditionalInformation extends AbstractOrderConfirmationBlock {
 	/**
 	 * This renders the content of the block within the wrapper.
 	 *
-	 * @param \WC_Order $order Order object.
-	 * @param string    $permission Permission level for viewing order details.
-	 * @param array     $attributes Block attributes.
-	 * @param string    $content Original block content.
+	 * @param \WC_Order    $order Order object.
+	 * @param string|false $permission If the current user can view the order details or not.
+	 * @param array        $attributes Block attributes.
+	 * @param string       $content Original block content.
 	 * @return string
 	 */
 	protected function render_content( $order, $permission = false, $attributes = [], $content = '' ) {

--- a/src/BlockTypes/OrderConfirmation/BillingAddress.php
+++ b/src/BlockTypes/OrderConfirmation/BillingAddress.php
@@ -17,14 +17,14 @@ class BillingAddress extends AbstractOrderConfirmationBlock {
 	/**
 	 * This renders the content of the block within the wrapper.
 	 *
-	 * @param \WC_Order $order Order object.
-	 * @param string    $permission Permission level for viewing order details.
-	 * @param array     $attributes Block attributes.
-	 * @param string    $content Original block content.
+	 * @param \WC_Order    $order Order object.
+	 * @param string|false $permission If the current user can view the order details or not.
+	 * @param array        $attributes Block attributes.
+	 * @param string       $content Original block content.
 	 * @return string
 	 */
 	protected function render_content( $order, $permission = false, $attributes = [], $content = '' ) {
-		if ( 'full' !== $permission || ! $order->has_billing_address() ) {
+		if ( ! $permission || ! $order->has_billing_address() ) {
 			return '';
 		}
 

--- a/src/BlockTypes/OrderConfirmation/BillingWrapper.php
+++ b/src/BlockTypes/OrderConfirmation/BillingWrapper.php
@@ -17,13 +17,13 @@ class BillingWrapper extends AbstractOrderConfirmationBlock {
 	/**
 	 * This renders the content of the billing wrapper.
 	 *
-	 * @param \WC_Order $order Order object.
-	 * @param string    $permission Permission level for viewing order details.
-	 * @param array     $attributes Block attributes.
-	 * @param string    $content Original block content.
+	 * @param \WC_Order    $order Order object.
+	 * @param string|false $permission If the current user can view the order details or not.
+	 * @param array        $attributes Block attributes.
+	 * @param string       $content Original block content.
 	 */
 	protected function render_content( $order, $permission = false, $attributes = [], $content = '' ) {
-		if ( ! $order || ! $order->has_billing_address() || 'full' !== $permission ) {
+		if ( ! $order || ! $order->has_billing_address() || ! $permission ) {
 			return '';
 		}
 		return $content;

--- a/src/BlockTypes/OrderConfirmation/Downloads.php
+++ b/src/BlockTypes/OrderConfirmation/Downloads.php
@@ -19,10 +19,10 @@ class Downloads extends AbstractOrderConfirmationBlock {
 	/**
 	 * This renders the content of the block within the wrapper.
 	 *
-	 * @param \WC_Order $order Order object.
-	 * @param string    $permission Permission level for viewing order details.
-	 * @param array     $attributes Block attributes.
-	 * @param string    $content Original block content.
+	 * @param \WC_Order    $order Order object.
+	 * @param string|false $permission If the current user can view the order details or not.
+	 * @param array        $attributes Block attributes.
+	 * @param string       $content Original block content.
 	 * @return string
 	 */
 	protected function render_content( $order, $permission = false, $attributes = [], $content = '' ) {

--- a/src/BlockTypes/OrderConfirmation/DownloadsWrapper.php
+++ b/src/BlockTypes/OrderConfirmation/DownloadsWrapper.php
@@ -62,10 +62,10 @@ class DownloadsWrapper extends AbstractOrderConfirmationBlock {
 	/**
 	 * This renders the content of the downloads wrapper.
 	 *
-	 * @param \WC_Order $order Order object.
-	 * @param string    $permission Permission level for viewing order details.
-	 * @param array     $attributes Block attributes.
-	 * @param string    $content Original block content.
+	 * @param \WC_Order    $order Order object.
+	 * @param string|false $permission If the current user can view the order details or not.
+	 * @param array        $attributes Block attributes.
+	 * @param string       $content Original block content.
 	 */
 	protected function render_content( $order, $permission = false, $attributes = [], $content = '' ) {
 		$show_downloads = $order && $order->has_downloadable_item() && $order->is_download_permitted();

--- a/src/BlockTypes/OrderConfirmation/ShippingAddress.php
+++ b/src/BlockTypes/OrderConfirmation/ShippingAddress.php
@@ -17,10 +17,10 @@ class ShippingAddress extends AbstractOrderConfirmationBlock {
 	/**
 	 * This renders the content of the block within the wrapper.
 	 *
-	 * @param \WC_Order $order Order object.
-	 * @param string    $permission Permission level for viewing order details.
-	 * @param array     $attributes Block attributes.
-	 * @param string    $content Original block content.
+	 * @param \WC_Order    $order Order object.
+	 * @param string|false $permission If the current user can view the order details or not.
+	 * @param array        $attributes Block attributes.
+	 * @param string       $content Original block content.
 	 * @return string
 	 */
 	protected function render_content( $order, $permission = false, $attributes = [], $content = '' ) {
@@ -28,32 +28,9 @@ class ShippingAddress extends AbstractOrderConfirmationBlock {
 			return $this->render_content_fallback();
 		}
 
-		if ( 'full' === $permission ) {
-			$address = '<address>' . wp_kses_post( $order->get_formatted_shipping_address() ) . '</address>';
-			$phone   = $order->get_shipping_phone() ? '<p class="woocommerce-customer-details--phone">' . esc_html( $order->get_shipping_phone() ) . '</p>' : '';
+		$address = '<address>' . wp_kses_post( $order->get_formatted_shipping_address() ) . '</address>';
+		$phone   = $order->get_shipping_phone() ? '<p class="woocommerce-customer-details--phone">' . esc_html( $order->get_shipping_phone() ) . '</p>' : '';
 
-			return $address . $phone;
-		}
-
-		$states  = wc()->countries->get_states( $order->get_shipping_country() );
-		$address = esc_html(
-			sprintf(
-			/* translators: %s location. */
-				__( 'Shipping to %s', 'woo-gutenberg-products-block' ),
-				implode(
-					', ',
-					array_filter(
-						[
-							$order->get_shipping_postcode(),
-							$order->get_shipping_city(),
-							$states[ $order->get_shipping_state() ] ?? $order->get_shipping_state(),
-							wc()->countries->countries[ $order->get_shipping_country() ] ?? $order->get_shipping_country(),
-						]
-					)
-				)
-			)
-		);
-
-		return '<address>' . wp_kses_post( $address ) . '</address>';
+		return $address . $phone;
 	}
 }

--- a/src/BlockTypes/OrderConfirmation/ShippingWrapper.php
+++ b/src/BlockTypes/OrderConfirmation/ShippingWrapper.php
@@ -17,10 +17,10 @@ class ShippingWrapper extends AbstractOrderConfirmationBlock {
 	/**
 	 * This renders the content of the shipping wrapper.
 	 *
-	 * @param \WC_Order $order Order object.
-	 * @param string    $permission Permission level for viewing order details.
-	 * @param array     $attributes Block attributes.
-	 * @param string    $content Original block content.
+	 * @param \WC_Order    $order Order object.
+	 * @param string|false $permission If the current user can view the order details or not.
+	 * @param array        $attributes Block attributes.
+	 * @param string       $content Original block content.
 	 */
 	protected function render_content( $order, $permission = false, $attributes = [], $content = '' ) {
 		if ( ! $order || ! $order->has_shipping_address() || ! $order->needs_shipping_address() || ! $permission ) {

--- a/src/BlockTypes/OrderConfirmation/Status.php
+++ b/src/BlockTypes/OrderConfirmation/Status.php
@@ -52,10 +52,10 @@ class Status extends AbstractOrderConfirmationBlock {
 	/**
 	 * This renders the content of the block within the wrapper.
 	 *
-	 * @param \WC_Order $order Order object.
-	 * @param string    $permission Permission level for viewing order details.
-	 * @param array     $attributes Block attributes.
-	 * @param string    $content Original block content.
+	 * @param \WC_Order    $order Order object.
+	 * @param string|false $permission If the current user can view the order details or not.
+	 * @param array        $attributes Block attributes.
+	 * @param string       $content Original block content.
 	 * @return string
 	 */
 	protected function render_content( $order, $permission = false, $attributes = [], $content = '' ) {
@@ -106,11 +106,7 @@ class Status extends AbstractOrderConfirmationBlock {
 			case 'failed':
 				// phpcs:ignore WooCommerce.Commenting.CommentHooks.MissingHookComment
 				$order_received_text = apply_filters( 'woocommerce_thankyou_order_received_text', esc_html__( 'Your order cannot be processed as the originating bank/merchant has declined your transaction. Please attempt your purchase again.', 'woo-gutenberg-products-block' ), null );
-				$actions             = '';
-
-				if ( 'full' === $permission ) {
-					$actions .= '<a href="' . esc_url( $order->get_checkout_payment_url() ) . '" class="button">' . esc_html__( 'Try again', 'woo-gutenberg-products-block' ) . '</a> ';
-				}
+				$actions             = '<a href="' . esc_url( $order->get_checkout_payment_url() ) . '" class="button">' . esc_html__( 'Try again', 'woo-gutenberg-products-block' ) . '</a> ';
 
 				if ( wc_get_page_permalink( 'myaccount' ) ) {
 					$actions .= '<a href="' . esc_url( wc_get_page_permalink( 'myaccount' ) ) . '" class="button">' . esc_html__( 'My account', 'woo-gutenberg-products-block' ) . '</a> ';

--- a/src/BlockTypes/OrderConfirmation/Summary.php
+++ b/src/BlockTypes/OrderConfirmation/Summary.php
@@ -17,10 +17,10 @@ class Summary extends AbstractOrderConfirmationBlock {
 	/**
 	 * This renders the content of the block within the wrapper.
 	 *
-	 * @param \WC_Order $order Order object.
-	 * @param string    $permission Permission level for viewing order details.
-	 * @param array     $attributes Block attributes.
-	 * @param string    $content Original block content.
+	 * @param \WC_Order    $order Order object.
+	 * @param string|false $permission If the current user can view the order details or not.
+	 * @param array        $attributes Block attributes.
+	 * @param string       $content Original block content.
 	 * @return string
 	 */
 	protected function render_content( $order, $permission = false, $attributes = [], $content = '' ) {
@@ -32,10 +32,8 @@ class Summary extends AbstractOrderConfirmationBlock {
 		$content .= $this->render_summary_row( __( 'Order number:', 'woo-gutenberg-products-block' ), $order->get_order_number() );
 		$content .= $this->render_summary_row( __( 'Date:', 'woo-gutenberg-products-block' ), wc_format_datetime( $order->get_date_created() ) );
 		$content .= $this->render_summary_row( __( 'Total:', 'woo-gutenberg-products-block' ), $order->get_formatted_order_total() );
-		if ( 'full' === $permission ) {
-			$content .= $this->render_summary_row( __( 'Email:', 'woo-gutenberg-products-block' ), $order->get_billing_email() );
-			$content .= $this->render_summary_row( __( 'Payment method:', 'woo-gutenberg-products-block' ), $order->get_payment_method_title() );
-		}
+		$content .= $this->render_summary_row( __( 'Email:', 'woo-gutenberg-products-block' ), $order->get_billing_email() );
+		$content .= $this->render_summary_row( __( 'Payment method:', 'woo-gutenberg-products-block' ), $order->get_payment_method_title() );
 		$content .= '</ul>';
 
 		return $content;

--- a/src/BlockTypes/OrderConfirmation/Totals.php
+++ b/src/BlockTypes/OrderConfirmation/Totals.php
@@ -19,10 +19,10 @@ class Totals extends AbstractOrderConfirmationBlock {
 	/**
 	 * This renders the content of the block within the wrapper.
 	 *
-	 * @param \WC_Order $order Order object.
-	 * @param string    $permission Permission level for viewing order details.
-	 * @param array     $attributes Block attributes.
-	 * @param string    $content Original block content.
+	 * @param \WC_Order    $order Order object.
+	 * @param string|false $permission If the current user can view the order details or not.
+	 * @param array        $attributes Block attributes.
+	 * @param string       $content Original block content.
 	 * @return string
 	 */
 	protected function render_content( $order, $permission = false, $attributes = [], $content = '' ) {

--- a/src/BlockTypes/OrderConfirmation/TotalsWrapper.php
+++ b/src/BlockTypes/OrderConfirmation/TotalsWrapper.php
@@ -17,10 +17,10 @@ class TotalsWrapper extends AbstractOrderConfirmationBlock {
 	/**
 	 * This renders the content of the totals wrapper.
 	 *
-	 * @param \WC_Order $order Order object.
-	 * @param string    $permission Permission level for viewing order details.
-	 * @param array     $attributes Block attributes.
-	 * @param string    $content Original block content.
+	 * @param \WC_Order    $order Order object.
+	 * @param string|false $permission If the current user can view the order details or not.
+	 * @param array        $attributes Block attributes.
+	 * @param string       $content Original block content.
 	 */
 	protected function render_content( $order, $permission = false, $attributes = [], $content = '' ) {
 		if ( ! $permission ) {


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

This PR removes "limited" view capability and instead shows all information to guests after verifying email or within the grace period, or with a valid session. From the issue.

- [x] Display the following fields when the shopper completes the purchase as a guest checkout: email address, shipping address, billing address (if they're available).
- [x] This information is only available within the grace period of after email verification

In addition, if the current session holds the order ID still, details can still be viewed. 

Fixes #11723

## Why

Allows guest to confirm order details after placing an order.

## Screenshots

![Screenshot 2023-12-06 at 15 16 56](https://github.com/woocommerce/woocommerce-blocks/assets/90977/0a2d3391-6649-44e9-a702-c38c6997567d)

## Testing Instructions

Before testing, ensure you're using the block based order confirmation page.

1. As a logged out guest, add something to cart and place the order.
2. You should see the order details on the page.
3. Copy the page address and open a separate browser/incognito window.
4. Paste the order confirmation address. You should see the order details on the page (within grace period).
5. Let 10 minutes pass and refresh. Details are now hidden.
6. Enter the email address you used to place the order. Details are shown again.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:

* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:

* [ ] This PR has a UI change and has been cross-browser tested at different viewport sizes on both the frontend and in the editor.
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog

> Allow guests to view full order details on the order confirmation page
