### PR TITLE
Reset array keys after filtering to prevent conversion to JSON object

### DIFF
--- a/src/BlockTypes/Checkout.php
+++ b/src/BlockTypes/Checkout.php
@@ -421,11 +421,13 @@ class Checkout extends AbstractBlock {
 
 		// Filter out payment methods that are not enabled.
 		foreach ( $payment_methods as $payment_method_group => $saved_payment_methods ) {
-			$payment_methods[ $payment_method_group ] = array_filter(
-				$saved_payment_methods,
-				function( $saved_payment_method ) use ( $payment_gateways ) {
-					return in_array( $saved_payment_method['method']['gateway'], array_keys( $payment_gateways ), true );
-				}
+			$payment_methods[ $payment_method_group ] = array_values(
+				array_filter(
+					$saved_payment_methods,
+					function( $saved_payment_method ) use ( $payment_gateways ) {
+						return in_array( $saved_payment_method['method']['gateway'], array_keys( $payment_gateways ), true );
+					}
+				)
 			);
 		}
 


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

This is the code from https://github.com/woocommerce/woocommerce-blocks/pull/11070#issue-1919154008 rebased.

Closes #11070

## Why

Allowing CI to complete fully.

## Testing Instructions

Enable 2 credit card gateways (e.g. stripe) with a saved payment method. Alternatively you can insert some invalid ones manually with code:

```php 
add_filter(
	'woocommerce_saved_payment_methods_list',
	function( $payment_methods ) {
		$payment_methods['cc'][] = array(
			'method'     => array(
				'gateway' => 'does-not-exist',
				'last4'   => '4243',
				'brand'   => 'Visa',
			),
			'expires'    => '12/32',
			'is_default' => false,
			'actions'    => array(
				'delete' => array(
					'url'  => 'https://store.local/checkout/delete-payment-method/2/?_wpnonce=7459158275',
					'name' => 'Delete',
				),
			),
			'tokenId'    => 2,
		);
		$payment_methods['cc'][] = array(
			'method'     => array(
				'gateway' => 'does-not-exist',
				'last4'   => '4244',
				'brand'   => 'Visa',
			),
			'expires'    => '12/32',
			'is_default' => true,
			'actions'    => array(
				'delete' => array(
					'url'  => 'https://store.local/checkout/delete-payment-method/3/?_wpnonce=7459158275',
					'name' => 'Delete',
				),
			),
			'tokenId'    => 3,
		);
		return $payment_methods;
	},
	5
);
```

1. Add an item to the cart and checkout
2. Ensure there are no errors in the saved payment method area

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

See https://github.com/woocommerce/woocommerce-blocks/pull/11070#issue-1919154008

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:

* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:

* [ ] This PR has a UI change and has been cross-browser tested at different viewport sizes on both the frontend and in the editor.
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog

> Address a JS error in checkout when customer has saved payment methods from multiple gateways and one of them is inactive
