### PR TITLE
Convert PaymentMethodErrorBoundary to Class component

### DIFF
--- a/assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-error-boundary.tsx
+++ b/assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-error-boundary.tsx
@@ -2,51 +2,68 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { CURRENT_USER_IS_ADMIN } from '@woocommerce/settings';
 import { StoreNoticesContainer } from '@woocommerce/blocks-components';
 import { noticeContexts } from '@woocommerce/base-context';
 import { NoticeType } from '@woocommerce/types';
+import {
+	DerivedStateReturn,
+	ReactError,
+} from '@woocommerce/base-components/block-error-boundary/types';
+
 interface PaymentMethodErrorBoundaryProps {
 	isEditor: boolean;
 	children: React.ReactNode;
+	expressPaymentMethodId?: string | undefined;
 }
-const PaymentMethodErrorBoundary = ( {
-	isEditor,
-	children,
-}: PaymentMethodErrorBoundaryProps ) => {
-	const [ errorMessage ] = useState( '' );
-	const [ hasError ] = useState( false );
-	if ( hasError ) {
-		let errorText = __(
-			'We are experiencing difficulties with this payment method. Please contact us for assistance.',
-			'woo-gutenberg-products-block'
-		);
-		if ( isEditor || CURRENT_USER_IS_ADMIN ) {
-			if ( errorMessage ) {
-				errorText = errorMessage;
-			} else {
-				errorText = __(
-					"There was an error with this payment method. Please verify it's configured correctly.",
-					'woo-gutenberg-products-block'
-				);
-			}
-		}
-		const notices: NoticeType[] = [
-			{
-				id: '0',
-				content: errorText,
-				isDismissible: false,
-				status: 'error',
-			},
-		];
-		return (
-			<StoreNoticesContainer
-				additionalNotices={ notices }
-				context={ noticeContexts.PAYMENTS }
-			/>
-		);
+
+class PaymentMethodErrorBoundary extends Component< PaymentMethodErrorBoundaryProps > {
+	state = { errorMessage: '', hasError: false };
+	expressPaymentMethodId = this.props.expressPaymentMethodId;
+	static getDerivedStateFromError( error: ReactError ): DerivedStateReturn {
+		return {
+			errorMessage: error.message,
+			hasError: true,
+		};
 	}
-	return <>{ children }</>;
-};
+
+	render() {
+		const { hasError, errorMessage } = this.state;
+		const { isEditor } = this.props;
+
+		if ( hasError ) {
+			let errorText = __(
+				'We are experiencing difficulties with this payment method. Please contact us for assistance.',
+				'woo-gutenberg-products-block'
+			);
+			if ( isEditor || CURRENT_USER_IS_ADMIN ) {
+				if ( errorMessage ) {
+					errorText = errorMessage;
+				} else {
+					errorText = __(
+						"There was an error with this payment method. Please verify it's configured correctly.",
+						'woo-gutenberg-products-block'
+					);
+				}
+			}
+			const notices: NoticeType[] = [
+				{
+					id: '0',
+					content: errorText,
+					isDismissible: false,
+					status: 'error',
+				},
+			];
+			return (
+				<StoreNoticesContainer
+					additionalNotices={ notices }
+					context={ noticeContexts.PAYMENTS }
+				/>
+			);
+		}
+
+		return this.props.children;
+	}
+}
 export default PaymentMethodErrorBoundary;

--- a/assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-error-boundary.tsx
+++ b/assets/js/blocks/cart-checkout-shared/payment-methods/payment-method-error-boundary.tsx
@@ -15,12 +15,10 @@ import {
 interface PaymentMethodErrorBoundaryProps {
 	isEditor: boolean;
 	children: React.ReactNode;
-	expressPaymentMethodId?: string | undefined;
 }
 
 class PaymentMethodErrorBoundary extends Component< PaymentMethodErrorBoundaryProps > {
 	state = { errorMessage: '', hasError: false };
-	expressPaymentMethodId = this.props.expressPaymentMethodId;
 	static getDerivedStateFromError( error: ReactError ): DerivedStateReturn {
 		return {
 			errorMessage: error.message,


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What
Related woocommerce/woocommerce#42256 

## Why

We converted the PaymentMethodErrorBoundary Class component to the function component, and it stopped working. The issue was introduced by https://github.com/woocommerce/woocommerce-blocks/pull/9817 PR.

As per the react docs:

>There is currently no way to write an error boundary as a function component. However, you don’t have to write the error boundary class yourself. For example, you can use react-error-boundary instead.

src: https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary

In this PR, we're converting the function component to the Class component. 

#### We will handle removing the entire express payment block if no valid express payment button exists in a different PR.

## Testing Instructions

1. Enable express checkout payment buttons
2. Go to line https://github.com/woocommerce/woocommerce-blocks/blob/trunk/assets/js/blocks/cart-checkout-shared/payment-methods/express-payment-methods.js#L166
3. Replace it with the below code:

```js
        const ErrorThrower = () => {
		throw new Error( 'Test error for PaymentMethodErrorBoundary' );
	};

	return (
		<PaymentMethodErrorBoundary isEditor={ isEditor }>
			<ul className="wc-block-components-express-payment__event-buttons">
				{ content }
			</ul>
			<ErrorThrower />
		</PaymentMethodErrorBoundary>
	);
```
5. Visit the checkout page
6. Confirm empty express checkout block is visible.
7. Check browser console and confirm error is visible in browser console.

* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [x] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|![image](https://github.com/woocommerce/woocommerce-blocks/assets/11503784/2aa03081-2e42-4a99-afb1-1de4f643a7f6)|![image](https://github.com/woocommerce/woocommerce-blocks/assets/11503784/b6bf6fff-f245-4103-920d-5a1767ba04c2)|

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [x] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:

* [ ] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:

* [ ] This PR has a UI change and has been cross-browser tested at different viewport sizes on both the frontend and in the editor.
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog

> Convert PaymentMethodErrorBoundary to Class component
