### PR TITLE
Add Monorepo Merge Notice Workflow

### DIFF
--- a/.github/workflows/monorepo-merge-notices.yml
+++ b/.github/workflows/monorepo-merge-notices.yml
@@ -1,0 +1,32 @@
+name: 'Monorepo Merge Notices'
+on:
+  pull_request:
+    types: [ 'opened' ]
+  issues:
+    types: [ 'opened' ]
+jobs:
+  issue_block:
+    name: 'Block Issues & Pull Requests'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: 'Add Merge Notice'
+        uses: 'actions/github-script@v5'
+        with:
+          script: |
+              github.rest.issues.createComment( {
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: 'We have merged WooCommerce Blocks into the WooCommerce monorepo. Please open any issues or pull requests \
+                in the woocommerce/woocommerce repository.'
+              } );
+      - name: 'Close'
+        uses: 'actions/github-script@v5'
+        with:
+          script: |
+            octokit.rest.issues.update({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'closed'
+            });

--- a/.github/workflows/monorepo-merge-notices.yml
+++ b/.github/workflows/monorepo-merge-notices.yml
@@ -17,9 +17,9 @@ jobs:
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body: 'WooCommerce Blocks [has been merged into the WooCommerce Monorepo](https://developer.woo.com/2023/12/01/woocommerce-blocks-merging-into-the-woocommerce-monorepo/).\n\n\
-                From now on, please open any issues or pull requests in the [woocommerce/woocommerce](https://github.com/woocommerce/woocommerce) repository.\n\n\
-                Thank you!'
+                body: 'Thank you for your interest in contributing to WooCommerce!\n\n\
+                WooCommerce Blocks [has been merged into the WooCommerce Monorepo](https://developer.woo.com/2023/12/01/woocommerce-blocks-merging-into-the-woocommerce-monorepo/).\n\n\
+                From now on, please open any issues or pull requests in the [woocommerce/woocommerce](https://github.com/woocommerce/woocommerce) repository.'
               } );
       - name: 'Close'
         uses: 'actions/github-script@v7'

--- a/.github/workflows/monorepo-merge-notices.yml
+++ b/.github/workflows/monorepo-merge-notices.yml
@@ -1,6 +1,6 @@
 name: 'Monorepo Merge Notices'
 on:
-  pull_request:
+  pull_request_target:
     types: [ 'opened' ]
   issues:
     types: [ 'opened' ]

--- a/.github/workflows/monorepo-merge-notices.yml
+++ b/.github/workflows/monorepo-merge-notices.yml
@@ -24,7 +24,7 @@ jobs:
         uses: 'actions/github-script@v5'
         with:
           script: |
-            octokit.rest.issues.update({
+            github.rest.issues.update({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/monorepo-merge-notices.yml
+++ b/.github/workflows/monorepo-merge-notices.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Add Merge Notice'
-        uses: 'actions/github-script@v5'
+        uses: 'actions/github-script@v7'
         with:
           script: |
               github.rest.issues.createComment( {
@@ -22,7 +22,7 @@ jobs:
                 Thank you!'
               } );
       - name: 'Close'
-        uses: 'actions/github-script@v5'
+        uses: 'actions/github-script@v7'
         with:
           script: |
             github.rest.issues.update({

--- a/.github/workflows/monorepo-merge-notices.yml
+++ b/.github/workflows/monorepo-merge-notices.yml
@@ -17,8 +17,9 @@ jobs:
                 issue_number: context.issue.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body: 'We have merged WooCommerce Blocks into the WooCommerce monorepo. Please open any issues or pull requests \
-                in the woocommerce/woocommerce repository.'
+                body: 'WooCommerce Blocks [has been merged into the WooCommerce Monorepo](https://developer.woo.com/2023/12/01/woocommerce-blocks-merging-into-the-woocommerce-monorepo/).\n\n\
+                From now on, please open any issues or pull requests in the [woocommerce/woocommerce](https://github.com/woocommerce/woocommerce) repository.\n\n\
+                Thank you!'
               } );
       - name: 'Close'
         uses: 'actions/github-script@v5'


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What

This pull request adds a new GitHub Workflow that prevents issues and pull requests from being opened. It will leave a comment referencing the merge and inform them that they should open their pull requests or issues against the monorepo.

## Why

The Merge!

## Testing Instructions

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->

N/A

* [x] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [x] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

N/A

## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [x] N/A

## Checklist

Required:

* [x] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:

* [ ] This PR has a UI change and has been cross-browser tested at different viewport sizes on both the frontend and in the editor.
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

N/A
