### PR TITLE
resolved issue 42040 overlapping problem

### DIFF
--- a/packages/components/totals/item/style.scss
+++ b/packages/components/totals/item/style.scss
@@ -11,7 +11,7 @@
 
 .wc-block-components-totals-item__value {
 	font-weight: bold;
-	white-space: nowrap;
+	white-space: wrap;
 }
 
 .wc-block-components-totals-item__description {


### PR DESCRIPTION
<!-- Please do not remove any information from this pull request. Instead, add N/A or leave blank if not applicable -->

## What
Currently, the values within the cart and checkout sidebar occasionally exceed the width. 

Fixes #42040

## Why

<!-- Describe the reason for your changes. This will help the reviewer and future readers get additional context -->




## Testing Instructions
1. Go to /wp-admin/admin.php?page=wc-settings&tab=shipping&section=options and activate the option Enable the shipping calculator on the cart page.
2. Create a test page and add the Cart block.
3 .Create another test page and add the Checkout block.
4. Open the frontend in an incognito window.
5. Add a product to the cart and visit the test page with the Cart block.
6. Set the browser width to 840px.

<!-- Write these steps from the perspective of a "user" (merchant) familiar with WooCommerce. No need to spell out the steps for common setup scenarios (eg. "Create a product"), but do be specific about the thing being tested. Include screenshots demonstrating expectations where that will be helpful. -->


* [ ] Do not include in the Testing Notes <!-- Check this box if this PR can't be tested (ie: it makes changes to tests, coding standards, docblocks, etc.). -->
* [ ] Should be tested by the development team exclusively <!-- Check this box if this PR should be tested by the development team exclusively (ie: it doesn't include user-facing changes or it can't be tested without manually modifying the code). -->

## Screenshots or screencast

<!-- Any screenshots of UI changes will be helpful to include here. Leave blank if not applicable. -->

| Before | After |
| ------ | ----- |
|   
![image](https://github.com/woocommerce/woocommerce-blocks/assets/72392580/3eab6883-c2fe-4e39-9d0a-eb478007452a)
     |     ![image (1)](https://github.com/woocommerce/woocommerce-blocks/assets/72392580/dc3632db-ca64-4d52-a3d9-656dd5223440)  |



## WooCommerce Visibility

<!-- Check this documentation link (../docs/blocks/feature-flags-and-experimental-interfaces.md) to see if the change is visible in WooCommerce core, part of the feature plugin, or experimental. -->
Required:

* [ ] WooCommerce Core
* [ ] Feature plugin
* [ ] Experimental
* [ ] N/A

## Checklist

Required:

* [ ] This PR has either a `[type]` label or a `[skip-changelog]` label.
* [ ] This PR is assigned to a milestone.

Conditional:

* [ ] This PR has a UI change and has been cross-browser tested at different viewport sizes on both the frontend and in the editor.
* [ ] This PR has a changelog description (if `[skip-changelog]` label is not present).
* [ ] This PR adds/removes a feature flag & I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR adds/removes an experimental interfaces, and I've updated [this doc](https://github.com/woocommerce/woocommerce-blocks/blob/trunk/docs/internal-developers/blocks/feature-flags-and-experimental-interfaces.md).
* [ ] This PR has been accessibility tested.
* [ ] This PR has had any necessary documentation added/updated.

## Changelog
<!-- Provide a brief, descriptive summary of the changes in this PR. Include potential impacts on different parts of the product. Example: "Updated the checkout process to streamline the experience for users and reduce the number of steps." -->

> Add suggested changelog entry here.
